### PR TITLE
Add query creation time to MySQL event listener

### DIFF
--- a/docs/src/main/sphinx/admin/event-listeners-mysql.md
+++ b/docs/src/main/sphinx/admin/event-listeners-mysql.md
@@ -54,8 +54,9 @@ If another event listener is already configured, add the new value
 After this configuration and successful start of the Trino cluster, the table
 `trino_queries` is created in the MySQL database. From then on, any query
 processing event is captured by the event listener and a new row is inserted
-into the table. The table includes many columns, such as query identifier, query
-string, user, catalog, and others with information about the query processing.
+into the table. The table includes many columns, such as query identifier,
+query creation time, query string, user, catalog, and others with information
+about the query processing.
 
 ### Configuration properties
 

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListener.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListener.java
@@ -31,13 +31,17 @@ import io.trino.spi.eventlistener.QueryStatistics;
 import io.trino.spi.resourcegroups.QueryType;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import jakarta.annotation.PostConstruct;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 
+import java.sql.SQLException;
 import java.time.Duration;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static java.time.ZoneOffset.UTC;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -48,7 +52,10 @@ public class MysqlEventListener
 {
     private static final Logger log = Logger.get(MysqlEventListener.class);
 
+    private static final int MYSQL_DUPLICATE_COLUMN_ERROR_CODE = 1060;
     private static final long MAX_OPERATOR_SUMMARIES_JSON_LENGTH = 16 * 1024 * 1024;
+    private static final DateTimeFormatter MYSQL_TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSS")
+            .withZone(UTC);
 
     private final boolean terminateOnInitializationFailure;
     private final QueryDao dao;
@@ -82,6 +89,7 @@ public class MysqlEventListener
     {
         try {
             dao.createTable();
+            addCreateTimeColumnIfMissing();
         }
         catch (Exception e) {
             if (terminateOnInitializationFailure) {
@@ -90,6 +98,32 @@ public class MysqlEventListener
             // Log the error but do not terminate, allowing the listener to continue functioning
             log.warn(e, "Unexpected error while creating MySQL event listener schema at startup. Ignoring error.");
         }
+    }
+
+    private void addCreateTimeColumnIfMissing()
+    {
+        if (dao.countCreateTimeColumn() != 0) {
+            return;
+        }
+        try {
+            dao.addCreateTimeColumn();
+        }
+        catch (UnableToExecuteStatementException e) {
+            if (!isDuplicateColumnException(e)) {
+                throw e;
+            }
+        }
+    }
+
+    private static boolean isDuplicateColumnException(Throwable throwable)
+    {
+        while (throwable != null) {
+            if (throwable instanceof SQLException sqlException && sqlException.getErrorCode() == MYSQL_DUPLICATE_COLUMN_ERROR_CODE) {
+                return true;
+            }
+            throwable = throwable.getCause();
+        }
+        return false;
     }
 
     @Override
@@ -101,6 +135,7 @@ public class MysqlEventListener
         QueryStatistics stats = event.getStatistics();
         QueryEntity entity = new QueryEntity(
                 metadata.getQueryId(),
+                MYSQL_TIMESTAMP_FORMATTER.format(event.getCreateTime()),
                 metadata.getTransactionId(),
                 metadata.getQuery(),
                 metadata.getUpdateType(),

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/QueryDao.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/QueryDao.java
@@ -14,222 +14,241 @@
 package io.trino.plugin.eventlistener.mysql;
 
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 public interface QueryDao
 {
-    @SqlUpdate("CREATE TABLE IF NOT EXISTS trino_queries (\n" +
-            "  query_id VARCHAR(255) NOT NULL PRIMARY KEY,\n" +
-            "  transaction_id VARCHAR(255) NULL,\n" +
-            "  query MEDIUMTEXT NOT NULL,\n" +
-            "  update_type VARCHAR(255) NULL,\n" +
-            "  prepared_query MEDIUMTEXT NULL,\n" +
-            "  query_state VARCHAR(255) NOT NULL,\n" +
-            "  plan MEDIUMTEXT NULL,\n" +
-            "  stage_info_json MEDIUMTEXT NULL,\n" +
-            "  user VARCHAR(255) NOT NULL,\n" +
-            "  principal VARCHAR(255) NULL,\n" +
-            "  trace_token VARCHAR(255) NULL,\n" +
-            "  remote_client_address VARCHAR(255) NULL,\n" +
-            "  user_agent VARCHAR(255) NULL,\n" +
-            "  client_info MEDIUMTEXT NULL,\n" +
-            "  client_tags_json MEDIUMTEXT NOT NULL,\n" +
-            "  source VARCHAR(255) NULL,\n" +
-            "  catalog VARCHAR(255) NULL,\n" +
-            "  `schema` VARCHAR(255) NULL,\n" +
-            "  resource_group_id VARCHAR(255) NULL,\n" +
-            "  session_properties_json MEDIUMTEXT NOT NULL,\n" +
-            "  server_address VARCHAR(255) NOT NULL,\n" +
-            "  server_version VARCHAR(255) NOT NULL,\n" +
-            "  environment VARCHAR(255) NOT NULL,\n" +
-            "  query_type VARCHAR(255) NULL,\n" +
-            "  inputs_json MEDIUMTEXT NOT NULL,\n" +
-            "  output_json MEDIUMTEXT NULL,\n" +
-            "  error_code VARCHAR(255) NULL,\n" +
-            "  error_type VARCHAR(255) NULL,\n" +
-            "  failure_type VARCHAR(255) NULL,\n" +
-            "  failure_message MEDIUMTEXT NULL,\n" +
-            "  failure_task VARCHAR(255) NULL,\n" +
-            "  failure_host VARCHAR(255) NULL,\n" +
-            "  failures_json MEDIUMTEXT NULL,\n" +
-            "  warnings_json MEDIUMTEXT NOT NULL,\n" +
-            "  cpu_time_millis BIGINT NOT NULL,\n" +
-            "  failed_cpu_time_millis BIGINT NOT NULL,\n" +
-            "  wall_time_millis BIGINT NOT NULL,\n" +
-            "  queued_time_millis BIGINT NOT NULL,\n" +
-            "  scheduled_time_millis BIGINT NOT NULL,\n" +
-            "  failed_scheduled_time_millis BIGINT NOT NULL,\n" +
-            "  waiting_time_millis BIGINT NOT NULL,\n" +
-            "  analysis_time_millis BIGINT NOT NULL,\n" +
-            "  planning_time_millis BIGINT NOT NULL,\n" +
-            "  planning_cpu_time_millis BIGINT NOT NULL,\n" +
-            "  starting_time_millis BIGINT NOT NULL,\n" +
-            "  execution_time_millis BIGINT NOT NULL,\n" +
-            "  input_blocked_time_millis BIGINT NOT NULL,\n" +
-            "  failed_input_blocked_time_millis BIGINT NOT NULL,\n" +
-            "  output_blocked_time_millis BIGINT NOT NULL,\n" +
-            "  failed_output_blocked_time_millis BIGINT NOT NULL,\n" +
-            "  physical_input_read_time_millis BIGINT NOT NULL,\n" +
-            "  peak_memory_bytes BIGINT NOT NULL,\n" +
-            "  peak_task_memory_bytes BIGINT NOT NULL,\n" +
-            "  physical_input_bytes BIGINT NOT NULL,\n" +
-            "  physical_input_rows BIGINT NOT NULL,\n" +
-            "  internal_network_bytes BIGINT NOT NULL,\n" +
-            "  internal_network_rows BIGINT NOT NULL,\n" +
-            "  total_bytes BIGINT NOT NULL,\n" +
-            "  total_rows BIGINT NOT NULL,\n" +
-            "  output_bytes BIGINT NOT NULL,\n" +
-            "  output_rows BIGINT NOT NULL,\n" +
-            "  written_bytes BIGINT NOT NULL,\n" +
-            "  written_rows BIGINT NOT NULL,\n" +
-            "  cumulative_memory DOUBLE NOT NULL,\n" +
-            "  failed_cumulative_memory DOUBLE NOT NULL,\n" +
-            "  completed_splits BIGINT NOT NULL,\n" +
-            "  retry_policy VARCHAR(255) NOT NULL,\n" +
-            "  operator_summaries_json MEDIUMTEXT NOT NULL\n" +
-            ")\n" +
-            "DEFAULT CHARACTER SET utf8")
+    @SqlUpdate(
+            """
+            CREATE TABLE IF NOT EXISTS trino_queries (
+              query_id VARCHAR(255) NOT NULL PRIMARY KEY,
+              create_time DATETIME(3) NULL,
+              transaction_id VARCHAR(255) NULL,
+              query MEDIUMTEXT NOT NULL,
+              update_type VARCHAR(255) NULL,
+              prepared_query MEDIUMTEXT NULL,
+              query_state VARCHAR(255) NOT NULL,
+              plan MEDIUMTEXT NULL,
+              stage_info_json MEDIUMTEXT NULL,
+              user VARCHAR(255) NOT NULL,
+              principal VARCHAR(255) NULL,
+              trace_token VARCHAR(255) NULL,
+              remote_client_address VARCHAR(255) NULL,
+              user_agent VARCHAR(255) NULL,
+              client_info MEDIUMTEXT NULL,
+              client_tags_json MEDIUMTEXT NOT NULL,
+              source VARCHAR(255) NULL,
+              catalog VARCHAR(255) NULL,
+              `schema` VARCHAR(255) NULL,
+              resource_group_id VARCHAR(255) NULL,
+              session_properties_json MEDIUMTEXT NOT NULL,
+              server_address VARCHAR(255) NOT NULL,
+              server_version VARCHAR(255) NOT NULL,
+              environment VARCHAR(255) NOT NULL,
+              query_type VARCHAR(255) NULL,
+              inputs_json MEDIUMTEXT NOT NULL,
+              output_json MEDIUMTEXT NULL,
+              error_code VARCHAR(255) NULL,
+              error_type VARCHAR(255) NULL,
+              failure_type VARCHAR(255) NULL,
+              failure_message MEDIUMTEXT NULL,
+              failure_task VARCHAR(255) NULL,
+              failure_host VARCHAR(255) NULL,
+              failures_json MEDIUMTEXT NULL,
+              warnings_json MEDIUMTEXT NOT NULL,
+              cpu_time_millis BIGINT NOT NULL,
+              failed_cpu_time_millis BIGINT NOT NULL,
+              wall_time_millis BIGINT NOT NULL,
+              queued_time_millis BIGINT NOT NULL,
+              scheduled_time_millis BIGINT NOT NULL,
+              failed_scheduled_time_millis BIGINT NOT NULL,
+              waiting_time_millis BIGINT NOT NULL,
+              analysis_time_millis BIGINT NOT NULL,
+              planning_time_millis BIGINT NOT NULL,
+              planning_cpu_time_millis BIGINT NOT NULL,
+              starting_time_millis BIGINT NOT NULL,
+              execution_time_millis BIGINT NOT NULL,
+              input_blocked_time_millis BIGINT NOT NULL,
+              failed_input_blocked_time_millis BIGINT NOT NULL,
+              output_blocked_time_millis BIGINT NOT NULL,
+              failed_output_blocked_time_millis BIGINT NOT NULL,
+              physical_input_read_time_millis BIGINT NOT NULL,
+              peak_memory_bytes BIGINT NOT NULL,
+              peak_task_memory_bytes BIGINT NOT NULL,
+              physical_input_bytes BIGINT NOT NULL,
+              physical_input_rows BIGINT NOT NULL,
+              internal_network_bytes BIGINT NOT NULL,
+              internal_network_rows BIGINT NOT NULL,
+              total_bytes BIGINT NOT NULL,
+              total_rows BIGINT NOT NULL,
+              output_bytes BIGINT NOT NULL,
+              output_rows BIGINT NOT NULL,
+              written_bytes BIGINT NOT NULL,
+              written_rows BIGINT NOT NULL,
+              cumulative_memory DOUBLE NOT NULL,
+              failed_cumulative_memory DOUBLE NOT NULL,
+              completed_splits BIGINT NOT NULL,
+              retry_policy VARCHAR(255) NOT NULL,
+              operator_summaries_json MEDIUMTEXT NOT NULL
+            )
+            DEFAULT CHARACTER SET utf8""")
     void createTable();
 
-    @SqlUpdate("INSERT INTO trino_queries (\n" +
-            "  query_id,\n" +
-            "  transaction_id,\n" +
-            "  query,\n" +
-            "  update_type,\n" +
-            "  prepared_query,\n" +
-            "  query_state,\n" +
-            "  plan,\n" +
-            "  stage_info_json,\n" +
-            "  user,\n" +
-            "  principal,\n" +
-            "  trace_token,\n" +
-            "  remote_client_address,\n" +
-            "  user_agent,\n" +
-            "  client_info,\n" +
-            "  client_tags_json,\n" +
-            "  source,\n" +
-            "  catalog,\n" +
-            "  `schema`,\n" +
-            "  resource_group_id,\n" +
-            "  session_properties_json,\n" +
-            "  server_address,\n" +
-            "  server_version,\n" +
-            "  environment,\n" +
-            "  query_type,\n" +
-            "  inputs_json,\n" +
-            "  output_json,\n" +
-            "  error_code,\n" +
-            "  error_type,\n" +
-            "  failure_type,\n" +
-            "  failure_message,\n" +
-            "  failure_task,\n" +
-            "  failure_host,\n" +
-            "  failures_json,\n" +
-            "  warnings_json,\n" +
-            "  cpu_time_millis,\n" +
-            "  failed_cpu_time_millis,\n" +
-            "  wall_time_millis,\n" +
-            "  queued_time_millis,\n" +
-            "  scheduled_time_millis,\n" +
-            "  failed_scheduled_time_millis,\n" +
-            "  waiting_time_millis,\n" +
-            "  analysis_time_millis,\n" +
-            "  planning_time_millis,\n" +
-            "  planning_cpu_time_millis,\n" +
-            "  starting_time_millis,\n" +
-            "  execution_time_millis,\n" +
-            "  input_blocked_time_millis,\n" +
-            "  failed_input_blocked_time_millis,\n" +
-            "  output_blocked_time_millis,\n" +
-            "  failed_output_blocked_time_millis,\n" +
-            "  physical_input_read_time_millis,\n" +
-            "  peak_memory_bytes,\n" +
-            "  peak_task_memory_bytes,\n" +
-            "  physical_input_bytes,\n" +
-            "  physical_input_rows,\n" +
-            "  internal_network_bytes,\n" +
-            "  internal_network_rows,\n" +
-            "  total_bytes,\n" +
-            "  total_rows,\n" +
-            "  output_bytes,\n" +
-            "  output_rows,\n" +
-            "  written_bytes,\n" +
-            "  written_rows,\n" +
-            "  cumulative_memory,\n" +
-            "  failed_cumulative_memory,\n" +
-            "  completed_splits,\n" +
-            "  retry_policy,\n" +
-            "  operator_summaries_json\n" +
-            ")\n" +
-            "VALUES (\n" +
-            " :queryId,\n" +
-            " :transactionId,\n" +
-            " :query,\n" +
-            " :updateType,\n" +
-            " :preparedQuery,\n" +
-            " :queryState,\n" +
-            " :plan,\n" +
-            " :stageInfoJson,\n" +
-            " :user,\n" +
-            " :principal,\n" +
-            " :traceToken,\n" +
-            " :remoteClientAddress,\n" +
-            " :userAgent,\n" +
-            " :clientInfo,\n" +
-            " :clientTagsJson,\n" +
-            " :source,\n" +
-            " :catalog,\n" +
-            " :schema,\n" +
-            " :resourceGroupId,\n" +
-            " :sessionPropertiesJson,\n" +
-            " :serverAddress,\n" +
-            " :serverVersion,\n" +
-            " :environment,\n" +
-            " :queryType,\n" +
-            " :inputsJson,\n" +
-            " :outputJson,\n" +
-            " :errorCode,\n" +
-            " :errorType,\n" +
-            " :failureType,\n" +
-            " :failureMessage,\n" +
-            " :failureTask,\n" +
-            " :failureHost,\n" +
-            " :failuresJson,\n" +
-            " :warningsJson,\n" +
-            " :cpuTimeMillis,\n" +
-            " :failedCpuTimeMillis,\n" +
-            " :wallTimeMillis,\n" +
-            " :queuedTimeMillis,\n" +
-            " :scheduledTimeMillis,\n" +
-            " :failedScheduledTimeMillis,\n" +
-            " :waitingTimeMillis,\n" +
-            " :analysisTimeMillis,\n" +
-            " :planningTimeMillis,\n" +
-            " :planningCpuTimeMillis,\n" +
-            " :startingTimeMillis,\n" +
-            " :executionTimeMillis,\n" +
-            " :inputBlockedTimeMillis,\n" +
-            " :failedInputBlockedTimeMillis,\n" +
-            " :outputBlockedTimeMillis,\n" +
-            " :failedOutputBlockedTimeMillis,\n" +
-            " :physicalInputReadTimeMillis,\n" +
-            " :peakMemoryBytes,\n" +
-            " :peakTaskMemoryBytes,\n" +
-            " :physicalInputBytes,\n" +
-            " :physicalInputRows,\n" +
-            " :internalNetworkBytes,\n" +
-            " :internalNetworkRows,\n" +
-            " :totalBytes,\n" +
-            " :totalRows,\n" +
-            " :outputBytes,\n" +
-            " :outputRows,\n" +
-            " :writtenBytes,\n" +
-            " :writtenRows,\n" +
-            " :cumulativeMemory,\n" +
-            " :failedCumulativeMemory,\n" +
-            " :completedSplits,\n" +
-            " :retryPolicy,\n" +
-            " :operatorSummariesJson\n" +
-            ")")
+    @SqlQuery(
+            """
+            SELECT COUNT(*) FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'trino_queries'
+              AND column_name = 'create_time'""")
+    int countCreateTimeColumn();
+
+    @SqlUpdate("ALTER TABLE trino_queries ADD COLUMN create_time DATETIME(3) NULL AFTER query_id")
+    void addCreateTimeColumn();
+
+    @SqlUpdate(
+            """
+            INSERT INTO trino_queries (
+              query_id,
+              create_time,
+              transaction_id,
+              query,
+              update_type,
+              prepared_query,
+              query_state,
+              plan,
+              stage_info_json,
+              user,
+              principal,
+              trace_token,
+              remote_client_address,
+              user_agent,
+              client_info,
+              client_tags_json,
+              source,
+              catalog,
+              `schema`,
+              resource_group_id,
+              session_properties_json,
+              server_address,
+              server_version,
+              environment,
+              query_type,
+              inputs_json,
+              output_json,
+              error_code,
+              error_type,
+              failure_type,
+              failure_message,
+              failure_task,
+              failure_host,
+              failures_json,
+              warnings_json,
+              cpu_time_millis,
+              failed_cpu_time_millis,
+              wall_time_millis,
+              queued_time_millis,
+              scheduled_time_millis,
+              failed_scheduled_time_millis,
+              waiting_time_millis,
+              analysis_time_millis,
+              planning_time_millis,
+              planning_cpu_time_millis,
+              starting_time_millis,
+              execution_time_millis,
+              input_blocked_time_millis,
+              failed_input_blocked_time_millis,
+              output_blocked_time_millis,
+              failed_output_blocked_time_millis,
+              physical_input_read_time_millis,
+              peak_memory_bytes,
+              peak_task_memory_bytes,
+              physical_input_bytes,
+              physical_input_rows,
+              internal_network_bytes,
+              internal_network_rows,
+              total_bytes,
+              total_rows,
+              output_bytes,
+              output_rows,
+              written_bytes,
+              written_rows,
+              cumulative_memory,
+              failed_cumulative_memory,
+              completed_splits,
+              retry_policy,
+              operator_summaries_json
+            )
+            VALUES (
+              :queryId,
+              :createTime,
+              :transactionId,
+              :query,
+              :updateType,
+              :preparedQuery,
+              :queryState,
+              :plan,
+              :stageInfoJson,
+              :user,
+              :principal,
+              :traceToken,
+              :remoteClientAddress,
+              :userAgent,
+              :clientInfo,
+              :clientTagsJson,
+              :source,
+              :catalog,
+              :schema,
+              :resourceGroupId,
+              :sessionPropertiesJson,
+              :serverAddress,
+              :serverVersion,
+              :environment,
+              :queryType,
+              :inputsJson,
+              :outputJson,
+              :errorCode,
+              :errorType,
+              :failureType,
+              :failureMessage,
+              :failureTask,
+              :failureHost,
+              :failuresJson,
+              :warningsJson,
+              :cpuTimeMillis,
+              :failedCpuTimeMillis,
+              :wallTimeMillis,
+              :queuedTimeMillis,
+              :scheduledTimeMillis,
+              :failedScheduledTimeMillis,
+              :waitingTimeMillis,
+              :analysisTimeMillis,
+              :planningTimeMillis,
+              :planningCpuTimeMillis,
+              :startingTimeMillis,
+              :executionTimeMillis,
+              :inputBlockedTimeMillis,
+              :failedInputBlockedTimeMillis,
+              :outputBlockedTimeMillis,
+              :failedOutputBlockedTimeMillis,
+              :physicalInputReadTimeMillis,
+              :peakMemoryBytes,
+              :peakTaskMemoryBytes,
+              :physicalInputBytes,
+              :physicalInputRows,
+              :internalNetworkBytes,
+              :internalNetworkRows,
+              :totalBytes,
+              :totalRows,
+              :outputBytes,
+              :outputRows,
+              :writtenBytes,
+              :writtenRows,
+              :cumulativeMemory,
+              :failedCumulativeMemory,
+              :completedSplits,
+              :retryPolicy,
+              :operatorSummariesJson
+            )""")
     void store(@BindMethods QueryEntity entity);
 }

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/QueryEntity.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/QueryEntity.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 public record QueryEntity(
         String queryId,
+        String createTime,
         Optional<String> transactionId,
         String query,
         Optional<String> updateType,
@@ -90,6 +91,7 @@ public record QueryEntity(
     public QueryEntity
     {
         requireNonNull(queryId, "queryId is null");
+        requireNonNull(createTime, "createTime is null");
         requireNonNull(transactionId, "transactionId is null");
         requireNonNull(query, "query is null");
         requireNonNull(updateType, "updateType is null");

--- a/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListener.java
+++ b/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListener.java
@@ -66,11 +66,16 @@ import static java.time.Duration.ofMillis;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+import static org.testcontainers.mysql.MySQLContainer.MYSQL_PORT;
 
 @TestInstance(PER_CLASS)
 @Execution(CONCURRENT)
 final class TestMysqlEventListener
 {
+    private static final Instant FULL_QUERY_CREATE_TIME = Instant.parse("2025-07-08T09:10:11.123Z");
+    private static final Instant MINIMAL_QUERY_CREATE_TIME = Instant.parse("2025-07-09T10:11:12.456Z");
+    private static final Instant MIGRATION_QUERY_CREATE_TIME = Instant.parse("2025-07-10T11:12:13.789Z");
+
     private static final QueryMetadata FULL_QUERY_METADATA = new QueryMetadata(
             "full_query",
             Optional.of("transactionId"),
@@ -239,7 +244,7 @@ final class TestMysqlEventListener
             List.of(new TrinoWarning(
                     StandardWarningCode.TOO_MANY_STAGES,
                     "too many stages")),
-            Instant.now(),
+            FULL_QUERY_CREATE_TIME,
             Instant.now(),
             Instant.now());
 
@@ -354,7 +359,7 @@ final class TestMysqlEventListener
             Optional.empty(),
             Optional.empty(),
             List.of(),
-            Instant.now(),
+            MINIMAL_QUERY_CREATE_TIME,
             Instant.now(),
             Instant.now());
 
@@ -365,9 +370,14 @@ final class TestMysqlEventListener
 
     @BeforeAll
     void setup()
+            throws SQLException
     {
         mysqlContainer = new MySQLContainer("mysql:8.0.36");
         mysqlContainer.start();
+        try (Connection connection = DriverManager.getConnection(getJdbcUrlWithoutDatabase(mysqlContainer), "root", mysqlContainer.getPassword());
+                Statement statement = connection.createStatement()) {
+            statement.execute(format("GRANT ALL PRIVILEGES ON *.* TO '%s'", mysqlContainer.getUsername()));
+        }
         mysqlContainerUrl = getJdbcUrl(mysqlContainer);
         eventListener = new MysqlEventListenerFactory()
                 .create(Map.of("mysql-event-listener.db.url", mysqlContainerUrl), new TestingEventListenerContext());
@@ -388,11 +398,23 @@ final class TestMysqlEventListener
 
     private static String getJdbcUrl(MySQLContainer container)
     {
+        return getJdbcUrl(container, container.getDatabaseName());
+    }
+
+    private static String getJdbcUrl(MySQLContainer container, String database)
+    {
         return format(
-                "%s?user=%s&password=%s&useSSL=false&allowPublicKeyRetrieval=true",
-                container.getJdbcUrl(),
+                "jdbc:mysql://%s:%s/%s?user=%s&password=%s&useSSL=false&allowPublicKeyRetrieval=true",
+                container.getHost(),
+                container.getMappedPort(MYSQL_PORT),
+                database,
                 container.getUsername(),
                 container.getPassword());
+    }
+
+    private static String getJdbcUrlWithoutDatabase(MySQLContainer container)
+    {
+        return format("jdbc:mysql://%s:%s?useSSL=false&allowPublicKeyRetrieval=true", container.getHost(), container.getMappedPort(MYSQL_PORT));
     }
 
     @Test
@@ -407,6 +429,7 @@ final class TestMysqlEventListener
                 try (ResultSet resultSet = statement.getResultSet()) {
                     assertThat(resultSet.next()).isTrue();
                     assertThat(resultSet.getString("query_id")).isEqualTo("full_query");
+                    assertThat(resultSet.getString("create_time")).isEqualTo("2025-07-08 09:10:11.123");
                     assertThat(resultSet.getString("transaction_id")).isEqualTo("transactionId");
                     assertThat(resultSet.getString("query")).isEqualTo("query");
                     assertThat(resultSet.getString("update_type")).isEqualTo("updateType");
@@ -492,6 +515,7 @@ final class TestMysqlEventListener
                 try (ResultSet resultSet = statement.getResultSet()) {
                     assertThat(resultSet.next()).isTrue();
                     assertThat(resultSet.getString("query_id")).isEqualTo("minimal_query");
+                    assertThat(resultSet.getString("create_time")).isEqualTo("2025-07-09 10:11:12.456");
                     assertThat(resultSet.getString("transaction_id")).isNull();
                     assertThat(resultSet.getString("query")).isEqualTo("query");
                     assertThat(resultSet.getString("update_type")).isNull();
@@ -559,6 +583,65 @@ final class TestMysqlEventListener
                     assertThat(resultSet.getString("operator_summaries_json")).isEqualTo("[]");
                     assertThat(resultSet.next()).isFalse();
                 }
+            }
+        }
+    }
+
+    @Test
+    void testCreateTimeColumnAddedToExistingTable()
+            throws SQLException
+    {
+        String database = "migration_test";
+        try (Connection connection = DriverManager.getConnection(mysqlContainerUrl);
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE DATABASE IF NOT EXISTS " + database);
+        }
+
+        String migrationUrl = getJdbcUrl(mysqlContainer, database);
+        new MysqlEventListenerFactory()
+                .create(Map.of("mysql-event-listener.db.url", migrationUrl), new TestingEventListenerContext());
+
+        try (Connection connection = DriverManager.getConnection(migrationUrl);
+                Statement statement = connection.createStatement()) {
+            statement.execute("ALTER TABLE trino_queries DROP COLUMN create_time");
+        }
+
+        new MysqlEventListenerFactory()
+                .create(Map.of("mysql-event-listener.db.url", migrationUrl), new TestingEventListenerContext());
+        EventListener migratedEventListener = new MysqlEventListenerFactory()
+                .create(Map.of("mysql-event-listener.db.url", migrationUrl), new TestingEventListenerContext());
+        migratedEventListener.queryCompleted(new QueryCompletedEvent(
+                new QueryMetadata(
+                        "migration_query",
+                        Optional.empty(),
+                        Optional.empty(),
+                        "query",
+                        Optional.empty(),
+                        Optional.empty(),
+                        "queryState",
+                        List.of(),
+                        List.of(),
+                        URI.create("http://localhost"),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
+                MINIMAL_QUERY_STATISTICS,
+                MINIMAL_QUERY_CONTEXT,
+                MINIMAL_QUERY_IO_METADATA,
+                Optional.empty(),
+                Optional.empty(),
+                List.of(),
+                MIGRATION_QUERY_CREATE_TIME,
+                Instant.now(),
+                Instant.now()));
+
+        try (Connection connection = DriverManager.getConnection(migrationUrl);
+                Statement statement = connection.createStatement()) {
+            statement.execute("SELECT * FROM trino_queries WHERE query_id = 'migration_query'");
+            try (ResultSet resultSet = statement.getResultSet()) {
+                assertThat(resultSet.next()).isTrue();
+                assertThat(resultSet.getString("create_time")).isEqualTo("2025-07-10 11:12:13.789");
+                assertThat(resultSet.next()).isFalse();
             }
         }
     }


### PR DESCRIPTION
## Description

Adds a `create_time` column to the MySQL event listener `trino_queries` table and stores the query creation timestamp from `QueryCompletedEvent`.

For existing listener tables, startup adds the nullable column when it is missing. The migration is idempotent and tolerates a concurrent duplicate-column race.

## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/26153.

Related: https://github.com/trinodb/trino/pull/26179 was an earlier attempt by dc-orz to address this issue, and closed as stale.

Validation:

- `./mvnw -P gib -pl plugin/trino-mysql-event-listener -am test -Dtest=TestMysqlEventListener`
- `./mvnw -P gib -pl plugin/trino-mysql-event-listener -am test -Dtest=TestMysqlEventListenerConfig`
- `./mvnw -P gib,errorprone-compiler -pl plugin/trino-mysql-event-listener -am test-compile -DskipTests -Dair.check.skip-all=true -Dmaven.source.skip=true -Dgib.buildUpstream=never`
- `./mvnw -P gib -pl plugin/trino-mysql-event-listener -am validate`
- `docs/build`
- `./mvnw -P gib -pl plugin/trino-mysql-event-listener,docs -am validate`

## Release notes

(x) Release notes are required, with the following suggested text:

## MySQL Event Listener

* Add the `create_time` column to records stored by the MySQL event listener. (#26153)
