### PR TITLE
Allow pruning MySQL event listener payload columns

### DIFF
--- a/docs/src/main/sphinx/admin/event-listeners-mysql.md
+++ b/docs/src/main/sphinx/admin/event-listeners-mysql.md
@@ -41,6 +41,15 @@ parameters to the MySQL JDBC driver. The supported parameters for the URL are
 documented in the [MySQL Developer
 Guide](https://dev.mysql.com/doc/connector-j/en/connector-j-reference-configuration-properties.html).
 
+Large query events can require significant MySQL storage. Set
+`mysql-event-listener.excluded-columns` to a comma-separated list of supported
+`trino_queries` text columns to exclude selected payloads from stored records.
+The table schema is unchanged. Nullable columns are stored as `NULL`. Required
+columns use valid empty values: `query` is stored as an empty string, required
+JSON array columns are stored as `[]`, and `session_properties_json` is stored
+as `{}`. These replacement values are not distinguishable from actual empty
+payloads. Excluding `query` removes the SQL text from stored query history.
+
 And set `event-listener.config-files` to `etc/mysql-event-listener.properties`
 in {ref}`config-properties`:
 
@@ -67,6 +76,12 @@ string, user, catalog, and others with information about the query processing.
   - Description
 * - `mysql-event-listener.db.url`
   - JDBC connection URL to the database including credentials
+* - `mysql-event-listener.excluded-columns`
+  - Comma-separated list of text columns to exclude from stored query records.
+    Supported values are `client_info`, `client_tags_json`, `failure_message`,
+    `failures_json`, `inputs_json`, `operator_summaries_json`, `output_json`,
+    `plan`, `prepared_query`, `query`, `session_properties_json`,
+    `stage_info_json`, and `warnings_json`.
 * - `mysql-event-listener.terminate-on-initialization-failure`
   - MySQL event listener initialization can fail if the database is unavailable.
     This [boolean](prop-type-boolean) switch controls whether to throw an 

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/ExcludableColumn.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/ExcludableColumn.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.eventlistener.mysql;
+
+import jakarta.annotation.Nullable;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Arrays.stream;
+import static java.util.Locale.ENGLISH;
+
+enum ExcludableColumn
+{
+    CLIENT_INFO("client_info", null),
+    CLIENT_TAGS_JSON("client_tags_json", "[]"),
+    FAILURE_MESSAGE("failure_message", null),
+    FAILURES_JSON("failures_json", null),
+    INPUTS_JSON("inputs_json", "[]"),
+    OPERATOR_SUMMARIES_JSON("operator_summaries_json", "[]"),
+    OUTPUT_JSON("output_json", null),
+    PLAN("plan", null),
+    PREPARED_QUERY("prepared_query", null),
+    QUERY("query", ""),
+    SESSION_PROPERTIES_JSON("session_properties_json", "{}"),
+    STAGE_INFO_JSON("stage_info_json", null),
+    WARNINGS_JSON("warnings_json", "[]");
+
+    private static final Map<String, ExcludableColumn> COLUMNS = stream(values())
+            .collect(toImmutableMap(ExcludableColumn::columnName, column -> column));
+
+    private final String columnName;
+    @Nullable
+    private final String excludedValue;
+
+    ExcludableColumn(String columnName, @Nullable String excludedValue)
+    {
+        this.columnName = columnName;
+        this.excludedValue = excludedValue;
+    }
+
+    public String columnName()
+    {
+        return columnName;
+    }
+
+    public Optional<String> excludedValue()
+    {
+        return Optional.ofNullable(excludedValue);
+    }
+
+    public static boolean isSupported(String columnName)
+    {
+        return COLUMNS.containsKey(normalize(columnName));
+    }
+
+    public static ExcludableColumn fromColumnName(String columnName)
+    {
+        ExcludableColumn column = COLUMNS.get(normalize(columnName));
+        checkArgument(column != null, "Unsupported MySQL event listener column: %s", columnName);
+        return column;
+    }
+
+    public static String normalize(String columnName)
+    {
+        return columnName.trim().toLowerCase(ENGLISH);
+    }
+}

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListener.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListener.java
@@ -37,7 +37,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.plugin.eventlistener.mysql.ExcludableColumn.CLIENT_INFO;
+import static io.trino.plugin.eventlistener.mysql.ExcludableColumn.CLIENT_TAGS_JSON;
+import static io.trino.plugin.eventlistener.mysql.ExcludableColumn.FAILURES_JSON;
+import static io.trino.plugin.eventlistener.mysql.ExcludableColumn.FAILURE_MESSAGE;
+import static io.trino.plugin.eventlistener.mysql.ExcludableColumn.INPUTS_JSON;
+import static io.trino.plugin.eventlistener.mysql.ExcludableColumn.OPERATOR_SUMMARIES_JSON;
+import static io.trino.plugin.eventlistener.mysql.ExcludableColumn.OUTPUT_JSON;
+import static io.trino.plugin.eventlistener.mysql.ExcludableColumn.PLAN;
+import static io.trino.plugin.eventlistener.mysql.ExcludableColumn.PREPARED_QUERY;
+import static io.trino.plugin.eventlistener.mysql.ExcludableColumn.QUERY;
+import static io.trino.plugin.eventlistener.mysql.ExcludableColumn.SESSION_PROPERTIES_JSON;
+import static io.trino.plugin.eventlistener.mysql.ExcludableColumn.STAGE_INFO_JSON;
+import static io.trino.plugin.eventlistener.mysql.ExcludableColumn.WARNINGS_JSON;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -51,6 +67,7 @@ public class MysqlEventListener
     private static final long MAX_OPERATOR_SUMMARIES_JSON_LENGTH = 16 * 1024 * 1024;
 
     private final boolean terminateOnInitializationFailure;
+    private final Set<ExcludableColumn> excludedColumns;
     private final QueryDao dao;
     private final JsonCodec<Set<String>> clientTagsJsonCodec;
     private final JsonCodec<Map<String, String>> sessionPropertiesJsonCodec;
@@ -69,6 +86,9 @@ public class MysqlEventListener
             JsonCodec<List<TrinoWarning>> warningsJsonCodec)
     {
         this.terminateOnInitializationFailure = config.getTerminateOnInitializationFailure();
+        this.excludedColumns = config.getExcludedColumns().stream()
+                .map(ExcludableColumn::fromColumnName)
+                .collect(toImmutableSet());
         this.dao = requireNonNull(dao, "dao is null");
         this.clientTagsJsonCodec = requireNonNull(clientTagsJsonCodec, "clientTagsJsonCodec is null");
         this.sessionPropertiesJsonCodec = requireNonNull(sessionPropertiesJsonCodec, "sessionPropertiesJsonCodec is null");
@@ -102,38 +122,38 @@ public class MysqlEventListener
         QueryEntity entity = new QueryEntity(
                 metadata.getQueryId(),
                 metadata.getTransactionId(),
-                metadata.getQuery(),
+                requiredColumn(QUERY, metadata::getQuery),
                 metadata.getUpdateType(),
-                metadata.getPreparedQuery(),
+                optionalColumn(PREPARED_QUERY, metadata::getPreparedQuery),
                 metadata.getQueryState(),
-                metadata.getPlan(),
-                metadata.getPayload(),
+                optionalColumn(PLAN, metadata::getPlan),
+                optionalColumn(STAGE_INFO_JSON, metadata::getPayload),
                 context.getUser(),
                 context.getPrincipal(),
                 context.getTraceToken(),
                 context.getRemoteClientAddress(),
                 context.getUserAgent(),
-                context.getClientInfo(),
-                clientTagsJsonCodec.toJson(context.getClientTags()),
+                optionalColumn(CLIENT_INFO, context::getClientInfo),
+                requiredColumn(CLIENT_TAGS_JSON, () -> clientTagsJsonCodec.toJson(context.getClientTags())),
                 context.getSource(),
                 context.getCatalog(),
                 context.getSchema(),
                 context.getResourceGroupId().map(ResourceGroupId::toString),
-                sessionPropertiesJsonCodec.toJson(context.getSessionProperties()),
+                requiredColumn(SESSION_PROPERTIES_JSON, () -> sessionPropertiesJsonCodec.toJson(context.getSessionProperties())),
                 context.getServerAddress(),
                 context.getServerVersion(),
                 context.getEnvironment(),
                 context.getQueryType().map(QueryType::name),
-                inputsJsonCodec.toJson(event.getIoMetadata().getInputs()),
-                event.getIoMetadata().getOutput().map(outputJsonCodec::toJson),
+                requiredColumn(INPUTS_JSON, () -> inputsJsonCodec.toJson(event.getIoMetadata().getInputs())),
+                optionalColumn(OUTPUT_JSON, () -> event.getIoMetadata().getOutput().map(outputJsonCodec::toJson)),
                 failureInfo.map(QueryFailureInfo::getErrorCode).map(ErrorCode::getName),
                 failureInfo.map(QueryFailureInfo::getErrorCode).map(ErrorCode::getType).map(ErrorType::name),
                 failureInfo.flatMap(QueryFailureInfo::getFailureType),
-                failureInfo.flatMap(QueryFailureInfo::getFailureMessage),
+                optionalColumn(FAILURE_MESSAGE, () -> failureInfo.flatMap(QueryFailureInfo::getFailureMessage)),
                 failureInfo.flatMap(QueryFailureInfo::getFailureTask),
                 failureInfo.flatMap(QueryFailureInfo::getFailureHost),
-                failureInfo.map(QueryFailureInfo::getFailuresJson),
-                warningsJsonCodec.toJson(event.getWarnings()),
+                optionalColumn(FAILURES_JSON, () -> failureInfo.map(QueryFailureInfo::getFailuresJson)),
+                requiredColumn(WARNINGS_JSON, () -> warningsJsonCodec.toJson(event.getWarnings())),
                 stats.getCpuTime().toMillis(),
                 stats.getFailedCpuTime().toMillis(),
                 stats.getWallTime().toMillis(),
@@ -167,8 +187,25 @@ public class MysqlEventListener
                 stats.getFailedCumulativeMemory(),
                 stats.getCompletedSplits(),
                 context.getRetryPolicy(),
-                createOperatorSummariesJson(metadata.getQueryId(), stats.getOperatorSummaries()));
+                optionalColumn(OPERATOR_SUMMARIES_JSON, () -> createOperatorSummariesJson(metadata.getQueryId(), stats.getOperatorSummaries())));
         dao.store(entity);
+    }
+
+    private Optional<String> optionalColumn(ExcludableColumn column, Supplier<Optional<String>> valueSupplier)
+    {
+        if (excludedColumns.contains(column)) {
+            return column.excludedValue();
+        }
+        return requireNonNull(valueSupplier.get(), "value is null");
+    }
+
+    private String requiredColumn(ExcludableColumn column, Supplier<String> valueSupplier)
+    {
+        if (excludedColumns.contains(column)) {
+            return column.excludedValue()
+                    .orElseThrow(() -> new IllegalArgumentException(format("Excluded column %s does not have a replacement value", column.columnName())));
+        }
+        return requireNonNull(valueSupplier.get(), "value is null");
     }
 
     private Optional<String> createOperatorSummariesJson(String queryId, List<String> summaries)

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListenerConfig.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListenerConfig.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.eventlistener.mysql;
 
+import com.google.common.collect.ImmutableSet;
 import com.mysql.cj.jdbc.Driver;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
@@ -21,10 +22,15 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 
 import java.sql.SQLException;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
 
 public class MysqlEventListenerConfig
 {
     private String url;
+    private Set<String> excludedColumns = ImmutableSet.of();
     private boolean terminateOnInitializationFailure = true;
 
     @NotNull
@@ -50,6 +56,28 @@ public class MysqlEventListenerConfig
         catch (SQLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public Set<String> getExcludedColumns()
+    {
+        return excludedColumns;
+    }
+
+    @Config("mysql-event-listener.excluded-columns")
+    @ConfigDescription("Comma-separated list of trino_queries text columns to exclude from stored query events")
+    public MysqlEventListenerConfig setExcludedColumns(Set<String> excludedColumns)
+    {
+        this.excludedColumns = requireNonNull(excludedColumns, "excludedColumns is null").stream()
+                .filter(column -> !column.isBlank())
+                .map(ExcludableColumn::normalize)
+                .collect(toImmutableSet());
+        return this;
+    }
+
+    @AssertTrue(message = "Only supported MySQL event listener text columns can be excluded")
+    public boolean isValidExcludedColumns()
+    {
+        return excludedColumns.stream().allMatch(ExcludableColumn::isSupported);
     }
 
     public boolean getTerminateOnInitializationFailure()

--- a/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListener.java
+++ b/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListener.java
@@ -71,22 +71,22 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @Execution(CONCURRENT)
 final class TestMysqlEventListener
 {
-    private static final QueryMetadata FULL_QUERY_METADATA = new QueryMetadata(
-            "full_query",
-            Optional.of("transactionId"),
-            Optional.of("encoding"),
+    private static final String EXCLUDED_COLUMNS = String.join(
+            ",",
             "query",
-            Optional.of("updateType"),
-            Optional.of("preparedQuery"),
-            "queryState",
-            // not stored
-            List.of(),
-            // not stored
-            List.of(),
-            URI.create("http://localhost"),
-            Optional.of("plan"),
-            Optional.of("jsonplan"),
-            Optional.of("stageInfo"));
+            "prepared_query",
+            "plan",
+            "stage_info_json",
+            "client_info",
+            "client_tags_json",
+            "session_properties_json",
+            "inputs_json",
+            "output_json",
+            "failure_message",
+            "failures_json",
+            "warnings_json",
+            "operator_summaries_json");
+    private static final QueryMetadata FULL_QUERY_METADATA = fullQueryMetadata("full_query");
 
     private static final QueryStatistics FULL_QUERY_STATISTICS = new QueryStatistics(
             ofMillis(101),
@@ -561,5 +561,74 @@ final class TestMysqlEventListener
                 }
             }
         }
+    }
+
+    @Test
+    void testExcludedColumns()
+            throws SQLException
+    {
+        EventListener pruningEventListener = new MysqlEventListenerFactory()
+                .create(
+                        Map.of(
+                                "mysql-event-listener.db.url", mysqlContainerUrl,
+                                "mysql-event-listener.excluded-columns", EXCLUDED_COLUMNS),
+                        new TestingEventListenerContext());
+
+        pruningEventListener.queryCompleted(new QueryCompletedEvent(
+                fullQueryMetadata("pruned_query"),
+                FULL_QUERY_STATISTICS,
+                FULL_QUERY_CONTEXT,
+                FULL_QUERY_IO_METADATA,
+                Optional.empty(),
+                Optional.of(FULL_FAILURE_INFO),
+                FULL_QUERY_COMPLETED_EVENT.getWarnings(),
+                Instant.now(),
+                Instant.now(),
+                Instant.now()));
+
+        try (Connection connection = DriverManager.getConnection(mysqlContainerUrl)) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("SELECT * FROM trino_queries WHERE query_id = 'pruned_query'");
+                try (ResultSet resultSet = statement.getResultSet()) {
+                    assertThat(resultSet.next()).isTrue();
+                    assertThat(resultSet.getString("query_id")).isEqualTo("pruned_query");
+                    assertThat(resultSet.getString("query")).isEmpty();
+                    assertThat(resultSet.getString("prepared_query")).isNull();
+                    assertThat(resultSet.getString("plan")).isNull();
+                    assertThat(resultSet.getString("stage_info_json")).isNull();
+                    assertThat(resultSet.getString("client_info")).isNull();
+                    assertThat(resultSet.getString("client_tags_json")).isEqualTo("[]");
+                    assertThat(resultSet.getString("session_properties_json")).isEqualTo("{}");
+                    assertThat(resultSet.getString("inputs_json")).isEqualTo("[]");
+                    assertThat(resultSet.getString("output_json")).isNull();
+                    assertThat(resultSet.getString("failure_message")).isNull();
+                    assertThat(resultSet.getString("failures_json")).isNull();
+                    assertThat(resultSet.getString("warnings_json")).isEqualTo("[]");
+                    assertThat(resultSet.getString("operator_summaries_json")).isEqualTo("[]");
+                    assertThat(resultSet.getString("user")).isEqualTo("user");
+                    assertThat(resultSet.next()).isFalse();
+                }
+            }
+        }
+    }
+
+    private static QueryMetadata fullQueryMetadata(String queryId)
+    {
+        return new QueryMetadata(
+                queryId,
+                Optional.of("transactionId"),
+                Optional.of("encoding"),
+                "query",
+                Optional.of("updateType"),
+                Optional.of("preparedQuery"),
+                "queryState",
+                // not stored
+                List.of(),
+                // not stored
+                List.of(),
+                URI.create("http://localhost"),
+                Optional.of("plan"),
+                Optional.of("jsonplan"),
+                Optional.of("stageInfo"));
     }
 }

--- a/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListenerConfig.java
+++ b/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListenerConfig.java
@@ -13,14 +13,18 @@
  */
 package io.trino.plugin.eventlistener.mysql;
 
+import com.google.inject.ConfigurationException;
+import io.airlift.configuration.ConfigurationFactory;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.Set;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class TestMysqlEventListenerConfig
 {
@@ -29,6 +33,7 @@ final class TestMysqlEventListenerConfig
     {
         assertRecordedDefaults(recordDefaults(MysqlEventListenerConfig.class)
                 .setUrl(null)
+                .setExcludedColumns(Set.of())
                 .setTerminateOnInitializationFailure(true));
     }
 
@@ -37,13 +42,36 @@ final class TestMysqlEventListenerConfig
     {
         Map<String, String> properties = Map.of(
                 "mysql-event-listener.db.url", "jdbc:mysql://example.net:3306",
+                "mysql-event-listener.excluded-columns", "plan,stage_info_json,operator_summaries_json",
                 "mysql-event-listener.terminate-on-initialization-failure", "false");
 
         MysqlEventListenerConfig expected = new MysqlEventListenerConfig()
                 .setUrl("jdbc:mysql://example.net:3306")
+                .setExcludedColumns(Set.of("plan", "stage_info_json", "operator_summaries_json"))
                 .setTerminateOnInitializationFailure(false);
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    void testExcludedColumns()
+    {
+        MysqlEventListenerConfig config = new MysqlEventListenerConfig()
+                .setExcludedColumns(Set.of(" PLAN ", "", "stage_info_json"));
+        assertThat(config.getExcludedColumns()).containsExactlyInAnyOrder("plan", "stage_info_json");
+    }
+
+    @Test
+    void testInvalidExcludedColumns()
+    {
+        Map<String, String> properties = Map.of(
+                "mysql-event-listener.db.url", "jdbc:mysql://example.net:3306",
+                "mysql-event-listener.excluded-columns", "cpu_time_millis");
+
+        ConfigurationFactory configurationFactory = new ConfigurationFactory(properties);
+        assertThatThrownBy(() -> configurationFactory.build(MysqlEventListenerConfig.class))
+                .isInstanceOf(ConfigurationException.class)
+                .hasMessageContaining("Only supported MySQL event listener text columns can be excluded");
     }
 
     @Test


### PR DESCRIPTION
## Description

Adds a `mysql-event-listener.excluded-columns` configuration property for the MySQL event listener. The property allows selected supported text or JSON payload columns in `trino_queries` to be omitted from stored query records without changing the table schema.

Excluded nullable columns are stored as `NULL`. Required text or JSON columns are stored with empty values so inserts remain compatible with the existing schema.

## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/26199.

Validation:

- `./mvnw -P gib -pl plugin/trino-mysql-event-listener -am airstyle:format`
- `./mvnw -P gib -pl plugin/trino-mysql-event-listener -am test -Dtest=TestMysqlEventListenerConfig`
- `./mvnw -P gib -pl plugin/trino-mysql-event-listener -am test -Dtest=TestMysqlEventListener`
- `./mvnw -P gib -pl plugin/trino-mysql-event-listener,docs -am validate`
- `docs/build`
- `./mvnw -P gib,errorprone-compiler -pl plugin/trino-mysql-event-listener -am clean test-compile -DskipTests -Dair.check.skip-all=true -Dmaven.source.skip=true -Dgib.buildUpstream=never`

## Release notes

(x) Release notes are required, with the following suggested text:

## MySQL Event Listener

* Add support for excluding selected payload columns from records stored by the MySQL event listener. (#26199)
