### PR TITLE
Convert `IntList` to record

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/IntList.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/IntList.java
@@ -13,24 +13,21 @@
  */
 package io.trino.plugin.base.metrics;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.metrics.Metric;
 
 import java.util.List;
-import java.util.Objects;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
-public class IntList
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Do not add @class property
+@JsonSerialize
+public record IntList(List<Integer> integers)
         implements Metric<IntList>
 {
-    private final List<Integer> integers;
-
-    @JsonCreator
-    public IntList(List<Integer> integers)
+    public IntList
     {
-        this.integers = ImmutableList.copyOf(integers);
+        integers = ImmutableList.copyOf(integers);
     }
 
     @Override
@@ -40,32 +37,5 @@ public class IntList
                 .addAll(integers)
                 .addAll(other.integers)
                 .build());
-    }
-
-    @Override
-    public boolean equals(Object o)
-    {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        IntList count = (IntList) o;
-        return integers.equals(count.integers);
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(integers);
-    }
-
-    @Override
-    public String toString()
-    {
-        return toStringHelper(this)
-                .add("integers", integers)
-                .toString();
     }
 }

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/metrics/TestIntList.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/metrics/TestIntList.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.metrics;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonCodec;
+import io.trino.spi.metrics.Metrics;
+import org.junit.jupiter.api.Test;
+
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestIntList
+{
+    private final JsonCodec<IntList> codec = jsonCodec(IntList.class);
+    private final JsonCodec<Metrics> metricsCodec = jsonCodec(Metrics.class);
+
+    @Test
+    void testRoundTrip()
+    {
+        IntList expected = new IntList(ImmutableList.of(1));
+
+        String json = codec.toJson(expected);
+        IntList actual = codec.fromJson(json);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testRoundTripViaMetrics()
+    {
+        Metrics metrics = new Metrics(ImmutableMap.of("projected_fields", new IntList(ImmutableList.of(1, 2, 3))));
+
+        String json = metricsCodec.toJson(metrics);
+        Metrics actual = metricsCodec.fromJson(json);
+
+        assertThat(actual).isEqualTo(metrics);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Convert `IntList` to record to make code compact and clean.

Also fix a potential issue when the metrics involved in serialization/deserialization round trip:

`IntList` had no getter for its `integers` field, so Jackson serialized it as just the type discriminator with no data:
  ```json
  {"@class":"io.trino.plugin.base.metrics.IntList"}
  ```
  Deserialization then failed with MismatchedInputException because the single-parameter  `@JsonCreator`  (a delegating creator) had no value to consume.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
