### PR TITLE
Add MySQL event listener connection credentials

### DIFF
--- a/docs/src/main/sphinx/admin/event-listeners-mysql.md
+++ b/docs/src/main/sphinx/admin/event-listeners-mysql.md
@@ -33,11 +33,15 @@ as an example:
 ```properties
 event-listener.name=mysql
 mysql-event-listener.db.url=jdbc:mysql://example.net:3306
+mysql-event-listener.db.user=root
+mysql-event-listener.db.password=secret
 ```
 
 The `mysql-event-listener.db.url` defines the connection to a MySQL database
-available at the domain `example.net` on port 3306. You can pass further
-parameters to the MySQL JDBC driver. The supported parameters for the URL are
+available at the domain `example.net` on port 3306. You can provide the
+connection user and password with `mysql-event-listener.db.user` and
+`mysql-event-listener.db.password`, or as parameters in the JDBC URL. You can
+pass further parameters to the MySQL JDBC driver. The supported parameters are
 documented in the [MySQL Developer
 Guide](https://dev.mysql.com/doc/connector-j/en/connector-j-reference-configuration-properties.html).
 
@@ -66,7 +70,11 @@ string, user, catalog, and others with information about the query processing.
 * - Property name
   - Description
 * - `mysql-event-listener.db.url`
-  - JDBC connection URL to the database including credentials
+  - JDBC connection URL to the database
+* - `mysql-event-listener.db.user`
+  - User name for the JDBC connection
+* - `mysql-event-listener.db.password`
+  - Password for the JDBC connection
 * - `mysql-event-listener.terminate-on-initialization-failure`
   - MySQL event listener initialization can fail if the database is unavailable.
     This [boolean](prop-type-boolean) switch controls whether to throw an 

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListenerConfig.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListenerConfig.java
@@ -21,10 +21,13 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 
 import java.sql.SQLException;
+import java.util.Optional;
 
 public class MysqlEventListenerConfig
 {
     private String url;
+    private String user;
+    private String password;
     private boolean terminateOnInitializationFailure = true;
 
     @NotNull
@@ -35,6 +38,7 @@ public class MysqlEventListenerConfig
 
     @ConfigSecuritySensitive
     @Config("mysql-event-listener.db.url")
+    @ConfigDescription("JDBC connection URL for the MySQL event listener database")
     public MysqlEventListenerConfig setUrl(String url)
     {
         this.url = url;
@@ -50,6 +54,33 @@ public class MysqlEventListenerConfig
         catch (SQLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public Optional<String> getUser()
+    {
+        return Optional.ofNullable(user);
+    }
+
+    @Config("mysql-event-listener.db.user")
+    @ConfigDescription("User name for the MySQL event listener database")
+    public MysqlEventListenerConfig setUser(String user)
+    {
+        this.user = user;
+        return this;
+    }
+
+    public Optional<String> getPassword()
+    {
+        return Optional.ofNullable(password);
+    }
+
+    @ConfigSecuritySensitive
+    @Config("mysql-event-listener.db.password")
+    @ConfigDescription("Password for the MySQL event listener database")
+    public MysqlEventListenerConfig setPassword(String password)
+    {
+        this.password = password;
+        return this;
     }
 
     public boolean getTerminateOnInitializationFailure()

--- a/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListenerFactory.java
+++ b/plugin/trino-mysql-event-listener/src/main/java/io/trino/plugin/eventlistener/mysql/MysqlEventListenerFactory.java
@@ -92,7 +92,7 @@ public class MysqlEventListenerFactory
         @Provides
         public ConnectionFactory createConnectionFactory(MysqlEventListenerConfig config)
         {
-            return () -> new Driver().connect(config.getUrl(), new Properties());
+            return () -> new Driver().connect(config.getUrl(), connectionProperties(config));
         }
 
         @Singleton
@@ -102,6 +102,14 @@ public class MysqlEventListenerFactory
             return Jdbi.create(connectionFactory)
                     .installPlugin(new SqlObjectPlugin())
                     .installPlugin(new JdbiOpenTelemetryPlugin(openTelemetry));
+        }
+
+        private static Properties connectionProperties(MysqlEventListenerConfig config)
+        {
+            Properties properties = new Properties();
+            config.getUser().ifPresent(user -> properties.setProperty("user", user));
+            config.getPassword().ifPresent(password -> properties.setProperty("password", password));
+            return properties;
         }
     }
 

--- a/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListener.java
+++ b/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListener.java
@@ -243,23 +243,6 @@ final class TestMysqlEventListener
             Instant.now(),
             Instant.now());
 
-    private static final QueryMetadata MINIMAL_QUERY_METADATA = new QueryMetadata(
-            "minimal_query",
-            Optional.empty(),
-            Optional.empty(),
-            "query",
-            Optional.empty(),
-            Optional.empty(),
-            "queryState",
-            // not stored
-            List.of(),
-            // not stored
-            List.of(),
-            URI.create("http://localhost"),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty());
-
     private static final QueryStatistics MINIMAL_QUERY_STATISTICS = new QueryStatistics(
             ofMillis(101),
             ofMillis(102),
@@ -346,17 +329,7 @@ final class TestMysqlEventListener
 
     private static final QueryIOMetadata MINIMAL_QUERY_IO_METADATA = new QueryIOMetadata(List.of(), Optional.empty());
 
-    private static final QueryCompletedEvent MINIMAL_QUERY_COMPLETED_EVENT = new QueryCompletedEvent(
-            MINIMAL_QUERY_METADATA,
-            MINIMAL_QUERY_STATISTICS,
-            MINIMAL_QUERY_CONTEXT,
-            MINIMAL_QUERY_IO_METADATA,
-            Optional.empty(),
-            Optional.empty(),
-            List.of(),
-            Instant.now(),
-            Instant.now(),
-            Instant.now());
+    private static final QueryCompletedEvent MINIMAL_QUERY_COMPLETED_EVENT = minimalQueryCompletedEvent("minimal_query");
 
     private MySQLContainer mysqlContainer;
     private String mysqlContainerUrl;
@@ -393,6 +366,48 @@ final class TestMysqlEventListener
                 container.getJdbcUrl(),
                 container.getUsername(),
                 container.getPassword());
+    }
+
+    private static String getJdbcUrlWithoutCredentials(MySQLContainer container)
+    {
+        return format(
+                "%s?useSSL=false&allowPublicKeyRetrieval=true",
+                container.getJdbcUrl());
+    }
+
+    private static QueryCompletedEvent minimalQueryCompletedEvent(String queryId)
+    {
+        return new QueryCompletedEvent(
+                minimalQueryMetadata(queryId),
+                MINIMAL_QUERY_STATISTICS,
+                MINIMAL_QUERY_CONTEXT,
+                MINIMAL_QUERY_IO_METADATA,
+                Optional.empty(),
+                Optional.empty(),
+                List.of(),
+                Instant.now(),
+                Instant.now(),
+                Instant.now());
+    }
+
+    private static QueryMetadata minimalQueryMetadata(String queryId)
+    {
+        return new QueryMetadata(
+                queryId,
+                Optional.empty(),
+                Optional.empty(),
+                "query",
+                Optional.empty(),
+                Optional.empty(),
+                "queryState",
+                // not stored
+                List.of(),
+                // not stored
+                List.of(),
+                URI.create("http://localhost"),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
     }
 
     @Test
@@ -474,6 +489,33 @@ final class TestMysqlEventListener
                     assertThat(resultSet.getLong("completed_splits")).isEqualTo(130);
                     assertThat(resultSet.getString("retry_policy")).isEqualTo("TASK");
                     assertThat(resultSet.getString("operator_summaries_json")).isEqualTo("[{operator: \"operator1\"},{operator: \"operator2\"}]");
+                    assertThat(resultSet.next()).isFalse();
+                }
+            }
+        }
+    }
+
+    @Test
+    void testConnectionCredentials()
+            throws SQLException
+    {
+        EventListener credentialsEventListener = new MysqlEventListenerFactory()
+                .create(
+                        Map.of(
+                                "mysql-event-listener.db.url", getJdbcUrlWithoutCredentials(mysqlContainer),
+                                "mysql-event-listener.db.user", mysqlContainer.getUsername(),
+                                "mysql-event-listener.db.password", mysqlContainer.getPassword()),
+                        new TestingEventListenerContext());
+
+        credentialsEventListener.queryCompleted(minimalQueryCompletedEvent("connection_credentials_query"));
+
+        try (Connection connection = DriverManager.getConnection(mysqlContainerUrl)) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("SELECT * FROM trino_queries WHERE query_id = 'connection_credentials_query'");
+                try (ResultSet resultSet = statement.getResultSet()) {
+                    assertThat(resultSet.next()).isTrue();
+                    assertThat(resultSet.getString("query_id")).isEqualTo("connection_credentials_query");
+                    assertThat(resultSet.getString("query")).isEqualTo("query");
                     assertThat(resultSet.next()).isFalse();
                 }
             }

--- a/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListenerConfig.java
+++ b/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListenerConfig.java
@@ -29,6 +29,8 @@ final class TestMysqlEventListenerConfig
     {
         assertRecordedDefaults(recordDefaults(MysqlEventListenerConfig.class)
                 .setUrl(null)
+                .setUser(null)
+                .setPassword(null)
                 .setTerminateOnInitializationFailure(true));
     }
 
@@ -37,10 +39,14 @@ final class TestMysqlEventListenerConfig
     {
         Map<String, String> properties = Map.of(
                 "mysql-event-listener.db.url", "jdbc:mysql://example.net:3306",
+                "mysql-event-listener.db.user", "user",
+                "mysql-event-listener.db.password", "pa:ss/word",
                 "mysql-event-listener.terminate-on-initialization-failure", "false");
 
         MysqlEventListenerConfig expected = new MysqlEventListenerConfig()
                 .setUrl("jdbc:mysql://example.net:3306")
+                .setUser("user")
+                .setPassword("pa:ss/word")
                 .setTerminateOnInitializationFailure(false);
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
## Description

Adds `mysql-event-listener.db.user` and `mysql-event-listener.db.password` configuration properties for the MySQL event listener.

The listener now passes these values to the MySQL JDBC driver as connection properties, so credentials no longer need to be embedded or URL-encoded in `mysql-event-listener.db.url`. Credentials in the JDBC URL remain supported.

## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/25941.

Related: https://github.com/trinodb/trino/pull/26260 was an earlier implementation by danielbelchior for the same issue, and closed as stale after review.

Local verification:

* `./mvnw -P gib -pl plugin/trino-mysql-event-listener -am airstyle:format`
* `./mvnw -P gib -pl plugin/trino-mysql-event-listener test -Dtest=TestMysqlEventListenerConfig`
* `./mvnw -P gib -pl plugin/trino-mysql-event-listener test -Dtest=TestMysqlEventListener`
* `docs/build`
* `./mvnw -P gib -pl plugin/trino-mysql-event-listener,docs -am validate`

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## MySQL Event Listener

* Add support for configuring the database user and password separately from the JDBC URL. (#25941)
```
