### PR TITLE
Add HTTP event listener headers file

### DIFF
--- a/docs/src/main/sphinx/admin/event-listeners-http.md
+++ b/docs/src/main/sphinx/admin/event-listeners-http.md
@@ -71,6 +71,12 @@ event-listener.config-files=etc/http-event-listener.properties,...
     [](http-event-listener-custom-headers) for more details
   - Empty
 
+* - http-event-listener.connect-http-headers-file
+  - Path to a Java properties file containing custom HTTP headers to be sent
+    along with the events. See [](http-event-listener-custom-headers) for more
+    details
+  - Empty
+
 * - http-event-listener.connect-http-method
   - Specifies the HTTP method to use for the request. Supported values
     are POST and PUT.
@@ -112,11 +118,27 @@ event messages.
 Providing headers follows the pattern of `key:value` pairs separated by commas:
 
 ```text
-http-event-listener.connect-http-headers="Header-Name-1:header value 1,Header-Value-2:header value 2,..."
+http-event-listener.connect-http-headers="Header-Name-1:header value 1,Header-Name-2:header value 2,..."
 ```
 
-If you need to use a comma(`,`) or colon(`:`) in a header name or value,
-escape it using a backslash (`\`).
+The inline property is parsed as a comma-separated list. For header values that
+contain commas, use `http-event-listener.connect-http-headers-file` instead:
+
+```properties
+http-event-listener.connect-http-headers-file=etc/http-event-listener-headers.properties
+```
+
+The file uses Java properties format, where each property name is an HTTP header
+name and each property value is an HTTP header value:
+
+```properties
+Header-Name-1=header value 1
+Header-Name-2=header value with comma, and colon: ok
+```
+
+When both `http-event-listener.connect-http-headers` and
+`http-event-listener.connect-http-headers-file` are configured, headers from both
+sources are sent. Header names must be unique across both properties.
 
 Keep in mind that these are static, so they can not carry information
 taken from the event itself.

--- a/docs/src/main/sphinx/release/release-481.md
+++ b/docs/src/main/sphinx/release/release-481.md
@@ -14,6 +14,7 @@
 * Add support for persisting external authentication tokens to disk (in `~/.trino/`), allowing reuse across separate JDBC client processes. Set `externalAuthenticationTokenCache=SYSTEM` to enable. ({issue}`28783`)
 * Include connector split source metrics in 
   `io.trino.spi.eventlistener.QueryInputMetadata#connectorMetrics`. ({issue}`28870`)
+* Add support for configuring HTTP event listener headers in a properties file. ({issue}`26187`)
 * Replace the Esri geometry library with JTS to improve interoperability with the broader spatial ecosystem. ({issue}`27881`)
 * {{breaking}} Reject WKT input that does not conform to OGC standards. Some inputs that were silently accepted before will now fail. ({issue}`27881`)
 * {{breaking}} Change {func}`ST_Union` to return an empty geometry collection instead of `NULL` for empty inputs. ({issue}`27881`)

--- a/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListener.java
+++ b/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListener.java
@@ -31,8 +31,11 @@ import io.trino.spi.eventlistener.QueryCompletedEvent;
 import io.trino.spi.eventlistener.QueryCreatedEvent;
 import jakarta.annotation.PreDestroy;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -41,6 +44,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.net.MediaType.JSON_UTF_8;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
 import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
 import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
 import static io.airlift.http.client.StatusResponseHandler.StatusResponse;
@@ -97,7 +101,7 @@ public class HttpEventListener
         this.maxDelay = config.getMaxDelay();
         this.backoffBase = config.getBackoffBase();
         this.httpMethod = config.getHttpMethod();
-        this.httpHeaders = ImmutableMap.copyOf(config.getHttpHeaders())
+        this.httpHeaders = loadHttpHeaders(config)
                 .entrySet()
                 .stream()
                 .collect(toImmutableMap(entry -> HeaderName.of(entry.getKey()), Map.Entry::getValue));
@@ -268,5 +272,24 @@ public class HttpEventListener
     public void shutdown()
     {
         lifecycleManager.stop();
+    }
+
+    private static Map<String, String> loadHttpHeaders(HttpEventListenerConfig config)
+    {
+        ImmutableMap.Builder<String, String> httpHeaders = ImmutableMap.builder();
+        config.getHttpHeadersFile()
+                .ifPresent(path -> httpHeaders.putAll(loadHttpHeadersFromFile(path)));
+        httpHeaders.putAll(config.getHttpHeaders());
+        return httpHeaders.buildOrThrow();
+    }
+
+    private static Map<String, String> loadHttpHeadersFromFile(Path path)
+    {
+        try {
+            return loadPropertiesFrom(path.toString());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Error reading HTTP event listener headers file " + path, e);
+        }
     }
 }

--- a/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListenerConfig.java
+++ b/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListenerConfig.java
@@ -16,14 +16,18 @@ package io.trino.plugin.httpquery;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
+import io.airlift.configuration.validation.FileExists;
 import io.airlift.units.Duration;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
+import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @DefunctConfig("http-event-listener.log-split")
@@ -37,6 +41,7 @@ public class HttpEventListenerConfig
     private String ingestUri;
     private HttpEventListenerHttpMethod httpMethod = HttpEventListenerHttpMethod.POST;
     private Map<String, String> httpHeaders = ImmutableMap.of();
+    private Optional<Path> httpHeadersFile = Optional.empty();
 
     @ConfigDescription("Will log io.trino.spi.eventlistener.QueryCreatedEvent")
     @Config("http-event-listener.log-created")
@@ -101,7 +106,8 @@ public class HttpEventListenerConfig
         return httpHeaders;
     }
 
-    @ConfigDescription("List of custom custom HTTP headers provided as: \"Header-Name-1: header value 1, Header-Value-2: header value 2, ...\" ")
+    @ConfigDescription("List of custom HTTP headers provided as: \"Header-Name-1: header value 1, Header-Name-2: header value 2, ...\"")
+    @ConfigSecuritySensitive
     @Config("http-event-listener.connect-http-headers")
     public HttpEventListenerConfig setHttpHeaders(List<String> httpHeaders)
     {
@@ -112,8 +118,21 @@ public class HttpEventListenerConfig
         }
         catch (IndexOutOfBoundsException e) {
             throw new IllegalArgumentException(String.format("Cannot parse http headers from property http-event-listener.connect-http-headers; value provided was %s, " +
-                    "expected format is \"Header-Name-1: header value 1, Header-Value-2: header value 2, ...\"", String.join(", ", httpHeaders)), e);
+                    "expected format is \"Header-Name-1: header value 1, Header-Name-2: header value 2, ...\"", String.join(", ", httpHeaders)), e);
         }
+        return this;
+    }
+
+    public Optional<@FileExists Path> getHttpHeadersFile()
+    {
+        return httpHeadersFile;
+    }
+
+    @ConfigDescription("Properties file containing custom HTTP headers to be sent along with the events")
+    @Config("http-event-listener.connect-http-headers-file")
+    public HttpEventListenerConfig setHttpHeadersFile(Path httpHeadersFile)
+    {
+        this.httpHeadersFile = Optional.ofNullable(httpHeadersFile);
         return this;
     }
 

--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
@@ -40,6 +40,7 @@ import okhttp3.Handshake;
 import okhttp3.TlsVersion;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -50,6 +51,8 @@ import javax.net.ssl.X509TrustManager;
 
 import java.io.File;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyStore;
 import java.time.Duration;
 import java.time.Instant;
@@ -280,6 +283,37 @@ final class TestHttpEventListener
         checkRequest(server.takeRequest(5, TimeUnit.SECONDS), Map.of(
                 "Authorization", "Trust Me!",
                 "Cache-Control", "no-cache"), queryCompleteEventJson);
+    }
+
+    @Test
+    void testHttpHeadersFileShouldBePresent(@TempDir Path tempDir)
+            throws Exception
+    {
+        Path httpHeadersFile = tempDir.resolve("http-event-listener-headers.properties");
+        Files.writeString(httpHeadersFile,
+                """
+                Authorization=Trust Me!
+                Cache-Control=no-cache
+                X-List=a,b
+                X-Trace=value:with:colon
+                """);
+
+        EventListener eventListener = createEventListener(Map.of(
+                "http-event-listener.connect-ingest-uri", server.url("/").toString(),
+                "http-event-listener.log-completed", "true",
+                "http-event-listener.connect-http-headers", "X-Inline:inline value",
+                "http-event-listener.connect-http-headers-file", httpHeadersFile.toString()));
+
+        server.enqueue(new MockResponse.Builder().code(200).build());
+
+        eventListener.queryCompleted(queryCompleteEvent);
+
+        checkRequest(server.takeRequest(5, TimeUnit.SECONDS), Map.of(
+                "Authorization", "Trust Me!",
+                "Cache-Control", "no-cache",
+                "X-Inline", "inline value",
+                "X-List", "a,b",
+                "X-Trace", "value:with:colon"), queryCompleteEventJson);
     }
 
     @Test

--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListenerConfig.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListenerConfig.java
@@ -15,7 +15,10 @@ package io.trino.plugin.httpquery;
 
 import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -32,6 +35,7 @@ final class TestHttpEventListenerConfig
     {
         assertRecordedDefaults(recordDefaults(HttpEventListenerConfig.class)
                 .setHttpHeaders(List.of())
+                .setHttpHeadersFile(null)
                 .setIngestUri(null)
                 .setRetryCount(0)
                 .setRetryDelay(Duration.succinctDuration(1, TimeUnit.SECONDS))
@@ -43,14 +47,17 @@ final class TestHttpEventListenerConfig
     }
 
     @Test
-    void testExplicitPropertyMappings()
+    void testExplicitPropertyMappings(@TempDir Path tempDir)
             throws Exception
     {
+        Path httpHeadersFile = Files.createFile(tempDir.resolve("http-event-listener-headers.properties"));
+
         Map<String, String> properties = Map.of(
                 "http-event-listener.log-created", "true",
                 "http-event-listener.log-completed", "true",
                 "http-event-listener.connect-ingest-uri", "http://example.com:8080/api",
                 "http-event-listener.connect-http-headers", "Authorization: Trust Me, Cache-Control: no-cache",
+                "http-event-listener.connect-http-headers-file", httpHeadersFile.toString(),
                 "http-event-listener.connect-retry-count", "2",
                 "http-event-listener.connect-http-method", "PUT",
                 "http-event-listener.connect-retry-delay", "101s",
@@ -62,6 +69,7 @@ final class TestHttpEventListenerConfig
                 .setLogCreated(true)
                 .setIngestUri("http://example.com:8080/api")
                 .setHttpHeaders(List.of("Authorization: Trust Me", "Cache-Control: no-cache"))
+                .setHttpHeadersFile(httpHeadersFile)
                 .setRetryCount(2)
                 .setHttpMethod(HttpEventListenerHttpMethod.PUT)
                 .setRetryDelay(Duration.succinctDuration(101, TimeUnit.SECONDS))


### PR DESCRIPTION
## Description

Add `http-event-listener.connect-http-headers-file` for configuring custom HTTP event listener headers from a Java properties file. This provides a supported path for header values containing commas, which cannot be represented reliably with the existing comma-separated `http-event-listener.connect-http-headers` property.

The existing inline header property remains supported. When both properties are configured, headers from both sources are sent and duplicate header names are rejected.

## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/26187.

This follows the headers-file approach discussed in https://github.com/trinodb/trino/issues/26187 and previously attempted in https://github.com/trinodb/trino/pull/26415 by danielbelchior, which closed as stale.

## Release notes

```markdown
# General
* Add support for configuring HTTP event listener headers in a properties file. (#26187)
```
