### PR TITLE
Fix DESCRIBE OUTPUT returning number type without NUMBER client capability

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/DescribeOutputRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/DescribeOutputRewrite.java
@@ -16,6 +16,7 @@ package io.trino.sql.rewrite;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.trino.Session;
+import io.trino.client.ClientCapabilities;
 import io.trino.execution.querystats.PlanOptimizersStatsCollector;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.QualifiedObjectName;
@@ -50,6 +51,7 @@ import java.util.Optional;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.StandardTypes.NUMBER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.QueryUtil.aliased;
 import static io.trino.sql.QueryUtil.identifier;
@@ -191,12 +193,17 @@ public final class DescribeOutputRewrite
 
             Optional<QualifiedObjectName> originTable = field.getOriginTable();
 
+            String typeName = field.getType().getDisplayName();
+            if (typeName.equals(NUMBER) && !session.getClientCapabilities().contains(ClientCapabilities.NUMBER.toString())) {
+                typeName = VARCHAR.getDisplayName();
+            }
+
             return row(
                     new StringLiteral(columnName),
                     new StringLiteral(originTable.map(QualifiedObjectName::catalogName).orElse("")),
                     new StringLiteral(originTable.map(QualifiedObjectName::schemaName).orElse("")),
                     new StringLiteral(originTable.map(QualifiedObjectName::objectName).orElse("")),
-                    new StringLiteral(field.getType().getDisplayName()),
+                    new StringLiteral(typeName),
                     typeSize,
                     new BooleanLiteral(String.valueOf(field.isAliased())));
         }

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -27,6 +27,7 @@ import io.airlift.concurrent.MoreFutures;
 import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.SystemSessionProperties;
+import io.trino.client.ClientCapabilities;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.NumberType;
 import io.trino.spi.type.TimeZoneKey;
@@ -56,6 +57,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -1600,6 +1602,34 @@ public abstract class AbstractTestEngineOnlyQueries
         // Test inline query syntax
         MaterializedResult inlineResult = computeActual(session, format("DESCRIBE OUTPUT (%s)", sql));
         assertEqualsIgnoreOrder(inlineResult, expected);
+    }
+
+    @Test
+    public void testDescribeOutputNumberTypeWithCapability()
+    {
+        Session session = Session.builder(getSession())
+                .setClientCapabilities(Stream.of(ClientCapabilities.values())
+                        .map(ClientCapabilities::toString)
+                        .collect(toImmutableSet()))
+                .build();
+        String sql = "SELECT NUMBER '1.5'";
+        MaterializedResult expected = resultBuilder(session, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, BIGINT, BOOLEAN)
+                .row("_col0", "", "", "", "number", 0, false)
+                .build();
+        assertDescribeOutputWithBothSyntax(session, sql, expected);
+    }
+
+    @Test
+    public void testDescribeOutputNumberTypeWithoutCapability()
+    {
+        Session session = Session.builder(getSession())
+                .setClientCapabilities(ImmutableSet.of())
+                .build();
+        String sql = "SELECT NUMBER '1.5'";
+        MaterializedResult expected = resultBuilder(session, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, BIGINT, BOOLEAN)
+                .row("_col0", "", "", "", "varchar", 0, false)
+                .build();
+        assertDescribeOutputWithBothSyntax(session, sql, expected);
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/server/protocol/AbstractSpooledQueryDataDistributedQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/server/protocol/AbstractSpooledQueryDataDistributedQueries.java
@@ -147,7 +147,7 @@ public abstract class AbstractSpooledQueryDataDistributedQueries
                         .builder(clientSession)
                         .encoding(Optional.ofNullable(encoding))
                         .build();
-                return newStatementClient(httpClient, clientSessionSpooled, query, Optional.empty());
+                return newStatementClient(httpClient, clientSessionSpooled, query, Optional.of(session.getClientCapabilities()));
             }
         }, session, new OkHttpClient());
     }


### PR DESCRIPTION
## Description

`DESCRIBE OUTPUT` was returning `number` as the column type for `NUMBER` columns even when the client did not advertise the `NUMBER` capability in `X-Trino-Client-Capabilities`.

For regular `SELECT` queries, `ProtocolUtil` correctly downgrades `number` to `varchar` when the `NUMBER` capability is absent. However, `DESCRIBE OUTPUT` bypassed this check — it embeds the type name directly from `Type.getDisplayName()` as a string literal during AST rewrite in `DescribeOutputRewrite`, so the capability check in `ProtocolUtil` never applies to it.

Fixed `DescribeOutputRewrite.createDescribeOutputRow()` to apply the same capability-aware substitution: when the column type is `number` and the `NUMBER` capability is not present in the session's client capabilities, the type name is reported as `varchar` — consistent with `SELECT` behavior.

## Additional context and related issues

The `NUMBER` capability was introduced so that older clients (e.g. ODBC drivers) that don't understand the `number` type fall back to receiving it as `varchar`. The `DESCRIBE OUTPUT` inconsistency meant such clients would see `number` in describe output but `varchar` in actual query results for the same column.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.