### PR TITLE
Populate table credentials in TaskContext for PlanTester

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlStage.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlStage.java
@@ -27,24 +27,17 @@ import io.trino.execution.buffer.OutputBuffers;
 import io.trino.execution.scheduler.SplitSchedulerStats;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.Split;
-import io.trino.metadata.TableFunctionHandle;
-import io.trino.metadata.TableHandle;
 import io.trino.node.InternalNode;
 import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.metrics.Metrics;
+import io.trino.sql.planner.ConnectorTableCredentialsVisitor;
 import io.trino.sql.planner.PartitioningHandle;
 import io.trino.sql.planner.PlanFragment;
-import io.trino.sql.planner.SimplePlanVisitor;
 import io.trino.sql.planner.plan.DynamicFilterId;
 import io.trino.sql.planner.plan.ExchangeNode;
-import io.trino.sql.planner.plan.MergeWriterNode;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.SimplePlanRewriter;
-import io.trino.sql.planner.plan.TableExecuteNode;
-import io.trino.sql.planner.plan.TableFunctionProcessorNode;
-import io.trino.sql.planner.plan.TableScanNode;
-import io.trino.sql.planner.plan.TableWriterNode;
 
 import java.util.HashSet;
 import java.util.List;
@@ -449,72 +442,6 @@ public final class SqlStage
                     node.getSources(),
                     node.getInputs(),
                     node.getOrderingScheme());
-        }
-    }
-
-    private static final class ConnectorTableCredentialsVisitor
-            extends SimplePlanVisitor<Void>
-    {
-        private final Metadata metadata;
-        private final Session session;
-        private final ImmutableMap.Builder<PlanNodeId, ConnectorTableCredentials> builder;
-
-        public ConnectorTableCredentialsVisitor(Session session, Metadata metadata, ImmutableMap.Builder<PlanNodeId, ConnectorTableCredentials> builder)
-        {
-            this.session = requireNonNull(session, "session is null");
-            this.metadata = requireNonNull(metadata, "metadata is null");
-            this.builder = requireNonNull(builder, "builder is null");
-        }
-
-        @Override
-        public Void visitMergeWriter(MergeWriterNode node, Void context)
-        {
-            TableWriterNode.MergeTarget target = node.getTarget();
-            extract(builder, node, metadata.getTableCredentials(session, target.getHandle().catalogHandle(), target.getHandle().connectorHandle()));
-            return super.visitMergeWriter(node, context);
-        }
-
-        @Override
-        public Void visitTableExecute(TableExecuteNode node, Void context)
-        {
-            TableWriterNode.TableExecuteTarget target = node.getTarget();
-            extract(builder, node, metadata.getTableCredentials(session, target.getExecuteHandle().catalogHandle(), target.getExecuteHandle().connectorHandle()));
-            return super.visitTableExecute(node, context);
-        }
-
-        @Override
-        public Void visitTableWriter(TableWriterNode node, Void context)
-        {
-            switch (node.getTarget()) {
-                case TableWriterNode.MergeTarget mergeTarget -> extract(builder, node, metadata.getTableCredentials(session, mergeTarget.getHandle().catalogHandle(), mergeTarget.getHandle().connectorHandle()));
-                case TableWriterNode.RefreshMaterializedViewTarget materializedViewTarget -> extract(builder, node, metadata.getTableCredentials(session, materializedViewTarget.getTableHandle().catalogHandle(), materializedViewTarget.getTableHandle().connectorHandle()));
-                case TableWriterNode.TableExecuteTarget tableExecuteTarget -> extract(builder, node, metadata.getTableCredentials(session, tableExecuteTarget.getExecuteHandle().catalogHandle(), tableExecuteTarget.getExecuteHandle().connectorHandle()));
-                case TableWriterNode.CreateTarget createTarget -> extract(builder, node, metadata.getTableCredentials(session, createTarget.getHandle().catalogHandle(), createTarget.getHandle().connectorHandle()));
-                case TableWriterNode.InsertTarget insertTarget -> extract(builder, node, metadata.getTableCredentials(session, insertTarget.getHandle().catalogHandle(), insertTarget.getHandle().connectorHandle()));
-                default -> throw new IllegalArgumentException("Unsupported table writer node: " + node.getClass().getSimpleName());
-            }
-            return super.visitTableWriter(node, context);
-        }
-
-        @Override
-        public Void visitTableScan(TableScanNode node, Void context)
-        {
-            TableHandle table = node.getTable();
-            extract(builder, node, metadata.getTableCredentials(session, table.catalogHandle(), table.connectorHandle()));
-            return super.visitTableScan(node, context);
-        }
-
-        @Override
-        public Void visitTableFunctionProcessor(TableFunctionProcessorNode node, Void context)
-        {
-            TableFunctionHandle handle = node.getHandle();
-            extract(builder, node, metadata.getTableCredentials(session, handle.catalogHandle(), handle.functionHandle()));
-            return super.visitTableFunctionProcessor(node, context);
-        }
-
-        private static void extract(ImmutableMap.Builder<PlanNodeId, ConnectorTableCredentials> builder, PlanNode node, Optional<ConnectorTableCredentials> credentials)
-        {
-            credentials.ifPresent(connectorTableCredentials -> builder.put(node.getId(), connectorTableCredentials));
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorTableCredentialsVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorTableCredentialsVisitor.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.TableFunctionHandle;
+import io.trino.metadata.TableHandle;
+import io.trino.spi.connector.ConnectorTableCredentials;
+import io.trino.sql.planner.plan.MergeWriterNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.TableExecuteNode;
+import io.trino.sql.planner.plan.TableFunctionProcessorNode;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.plan.TableWriterNode;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ConnectorTableCredentialsVisitor
+        extends SimplePlanVisitor<Void>
+{
+    private final Metadata metadata;
+    private final Session session;
+    private final ImmutableMap.Builder<PlanNodeId, ConnectorTableCredentials> builder;
+
+    public ConnectorTableCredentialsVisitor(Session session, Metadata metadata, ImmutableMap.Builder<PlanNodeId, ConnectorTableCredentials> builder)
+    {
+        this.session = requireNonNull(session, "session is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.builder = requireNonNull(builder, "builder is null");
+    }
+
+    @Override
+    public Void visitMergeWriter(MergeWriterNode node, Void context)
+    {
+        TableWriterNode.MergeTarget target = node.getTarget();
+        extract(builder, node, metadata.getTableCredentials(session, target.getHandle().catalogHandle(), target.getHandle().connectorHandle()));
+        return super.visitMergeWriter(node, context);
+    }
+
+    @Override
+    public Void visitTableExecute(TableExecuteNode node, Void context)
+    {
+        TableWriterNode.TableExecuteTarget target = node.getTarget();
+        extract(builder, node, metadata.getTableCredentials(session, target.getExecuteHandle().catalogHandle(), target.getExecuteHandle().connectorHandle()));
+        return super.visitTableExecute(node, context);
+    }
+
+    @Override
+    public Void visitTableWriter(TableWriterNode node, Void context)
+    {
+        switch (node.getTarget()) {
+            case TableWriterNode.MergeTarget mergeTarget -> extract(builder, node, metadata.getTableCredentials(session, mergeTarget.getHandle().catalogHandle(), mergeTarget.getHandle().connectorHandle()));
+            case TableWriterNode.RefreshMaterializedViewTarget materializedViewTarget -> extract(builder, node, metadata.getTableCredentials(session, materializedViewTarget.getTableHandle().catalogHandle(), materializedViewTarget.getTableHandle().connectorHandle()));
+            case TableWriterNode.TableExecuteTarget tableExecuteTarget -> extract(builder, node, metadata.getTableCredentials(session, tableExecuteTarget.getExecuteHandle().catalogHandle(), tableExecuteTarget.getExecuteHandle().connectorHandle()));
+            case TableWriterNode.CreateTarget createTarget -> extract(builder, node, metadata.getTableCredentials(session, createTarget.getHandle().catalogHandle(), createTarget.getHandle().connectorHandle()));
+            case TableWriterNode.InsertTarget insertTarget -> extract(builder, node, metadata.getTableCredentials(session, insertTarget.getHandle().catalogHandle(), insertTarget.getHandle().connectorHandle()));
+            default -> throw new IllegalArgumentException("Unsupported table writer node: " + node.getClass().getSimpleName());
+        }
+        return super.visitTableWriter(node, context);
+    }
+
+    @Override
+    public Void visitTableScan(TableScanNode node, Void context)
+    {
+        TableHandle table = node.getTable();
+        extract(builder, node, metadata.getTableCredentials(session, table.catalogHandle(), table.connectorHandle()));
+        return super.visitTableScan(node, context);
+    }
+
+    @Override
+    public Void visitTableFunctionProcessor(TableFunctionProcessorNode node, Void context)
+    {
+        TableFunctionHandle handle = node.getHandle();
+        extract(builder, node, metadata.getTableCredentials(session, handle.catalogHandle(), handle.functionHandle()));
+        return super.visitTableFunctionProcessor(node, context);
+    }
+
+    private static void extract(ImmutableMap.Builder<PlanNodeId, ConnectorTableCredentials> builder, PlanNode node, Optional<ConnectorTableCredentials> credentials)
+    {
+        credentials.ifPresent(connectorTableCredentials -> builder.put(node.getId(), connectorTableCredentials));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -159,6 +159,7 @@ import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.spi.connector.ConnectorName;
+import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.function.FunctionBundle;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
@@ -186,6 +187,7 @@ import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.planner.AdaptivePlanner;
 import io.trino.sql.planner.CompilerConfig;
+import io.trino.sql.planner.ConnectorTableCredentialsVisitor;
 import io.trino.sql.planner.LocalExecutionPlanner;
 import io.trino.sql.planner.LocalExecutionPlanner.LocalExecutionPlan;
 import io.trino.sql.planner.LogicalPlanner;
@@ -789,7 +791,12 @@ public class PlanTester
             throw new AssertionError("Expected sub-plan to have no children");
         }
 
-        TaskContext taskContext = createTaskContext(notificationExecutor, yieldExecutor, session);
+        ImmutableMap.Builder<PlanNodeId, ConnectorTableCredentials> tableCredentialsBuilder = ImmutableMap.builder();
+        ConnectorTableCredentialsVisitor visitor = new ConnectorTableCredentialsVisitor(session, plannerContext.getMetadata(), tableCredentialsBuilder);
+        subplan.getFragment().getRoot().accept(visitor, null);
+        ImmutableMap<PlanNodeId, ConnectorTableCredentials> tableCredentials = tableCredentialsBuilder.buildOrThrow();
+
+        TaskContext taskContext = createTaskContext(notificationExecutor, yieldExecutor, session, tableCredentials);
         TableExecuteContextManager tableExecuteContextManager = new TableExecuteContextManager();
         tableExecuteContextManager.registerTableExecuteContextForQuery(taskContext.getQueryContext().getQueryId());
         LocalExecutionPlanner executionPlanner = new LocalExecutionPlanner(

--- a/core/trino-main/src/main/java/io/trino/testing/TestingTaskContext.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingTaskContext.java
@@ -25,8 +25,11 @@ import io.trino.memory.MemoryPool;
 import io.trino.memory.QueryContext;
 import io.trino.operator.TaskContext;
 import io.trino.spi.QueryId;
+import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spiller.SpillSpaceTracker;
+import io.trino.sql.planner.plan.PlanNodeId;
 
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -43,6 +46,13 @@ public final class TestingTaskContext
     public static TaskContext createTaskContext(Executor notificationExecutor, ScheduledExecutorService scheduledExecutor, Session session)
     {
         return builder(notificationExecutor, scheduledExecutor, session).build();
+    }
+
+    public static TaskContext createTaskContext(Executor notificationExecutor, ScheduledExecutorService scheduledExecutor, Session session, Map<PlanNodeId, ConnectorTableCredentials> tableCredentials)
+    {
+        return builder(notificationExecutor, scheduledExecutor, session)
+                .setTableCredentials(tableCredentials)
+                .build();
     }
 
     public static TaskContext createTaskContext(Executor notificationExecutor, ScheduledExecutorService scheduledExecutor, Session session, DataSize maxMemory)
@@ -66,9 +76,14 @@ public final class TestingTaskContext
 
     private static TaskContext createTaskContext(QueryContext queryContext, Session session, TaskStateMachine taskStateMachine)
     {
+        return createTaskContext(queryContext, session, taskStateMachine, ImmutableMap.of());
+    }
+
+    private static TaskContext createTaskContext(QueryContext queryContext, Session session, TaskStateMachine taskStateMachine, Map<PlanNodeId, ConnectorTableCredentials> tableCredentials)
+    {
         return queryContext.addTaskContext(
                 taskStateMachine,
-                ImmutableMap.of(),
+                tableCredentials,
                 session,
                 () -> {},
                 true,
@@ -91,6 +106,7 @@ public final class TestingTaskContext
         private DataSize memoryPoolSize = DataSize.of(1, GIGABYTE);
         private DataSize maxSpillSize = DataSize.of(1, GIGABYTE);
         private DataSize queryMaxSpillSize = DataSize.of(1, GIGABYTE);
+        private Map<PlanNodeId, ConnectorTableCredentials> tableCredentials = ImmutableMap.of();
 
         private Builder(Executor notificationExecutor, ScheduledExecutorService scheduledExecutor, Session session)
         {
@@ -135,6 +151,12 @@ public final class TestingTaskContext
             return this;
         }
 
+        public Builder setTableCredentials(Map<PlanNodeId, ConnectorTableCredentials> tableCredentials)
+        {
+            this.tableCredentials = tableCredentials;
+            return this;
+        }
+
         public TaskContext build()
         {
             if (taskStateMachine == null) {
@@ -155,7 +177,7 @@ public final class TestingTaskContext
                     queryMaxSpillSize,
                     spillSpaceTracker);
 
-            return createTaskContext(queryContext, session, taskStateMachine);
+            return createTaskContext(queryContext, session, taskStateMachine, tableCredentials);
         }
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -91,6 +91,7 @@ public class IcebergPageSinkProvider
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId)
     {
+        verify(tableCredentials.isPresent(), "tableCredentials must be present");
         IcebergWritableTableHandle tableHandle = (IcebergWritableTableHandle) outputTableHandle;
         return createPageSink(session, tableHandle, getFileIoProperties(tableCredentials));
     }
@@ -98,6 +99,7 @@ public class IcebergPageSinkProvider
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId)
     {
+        verify(tableCredentials.isPresent(), "tableCredentials must be present");
         IcebergWritableTableHandle tableHandle = (IcebergWritableTableHandle) insertTableHandle;
         return createPageSink(session, tableHandle, getFileIoProperties(tableCredentials));
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Use `ConnectorTableCredentialsVisitor` to collect per-node credentials
from the plan fragment and pass them to `TestingTaskContext`, so
`PlanTester`-based tests exercise the same credential path as production.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This PR represents scaffolding for https://github.com/trinodb/trino/pull/29641 and is a follow-up from 9b5bb512


While testing the above mentioned PR, I've stumbled into unexpected failures when requiring table credentials presence in `IcebergPageSinkProvider`

https://github.com/trinodb/trino/actions/runs/26637783620/job/78502983413?pr=29641


```
TestIcebergProjectionPushdownPlans.testDereferencePushdown:152 » Verify tableCredentials is empty
Error:    TestIcebergProjectionPushdownPlans.testProjectionPushdownInsideLambda:257 » Verify tableCredentials is empty
Error:    TestIcebergProjectionPushdownPlans.testPushdownDisabled:133 » Verify tableCredentials is empty
Error:    TestMetadataQueryOptimization.testOptimization:90 » Verify tableCredentials is empty
Error:    TestMetadataQueryOptimization.testOptimizationOnPartitionWithMultipleFiles:135 » Verify tableCredentials is empty
Error:    TestMetadataQueryOptimization.testOptimizationWithNullPartitions:162 » Verify tableCredentials is empty
Error:    TestConnectorPushdownRulesWithIceberg.testColumnPruningProjectionPushdown:293 » Verify tableCredentials is empty
Error:    TestConnectorPushdownRulesWithIceberg.testPredicatePushdown:240 » Verify tableCredentials is empty
Error:    TestConnectorPushdownRulesWithIceberg.testProjectionPushdown:148 » Verify tableCredentials is empty
Error:    TestConnectorPushdownRulesWithIceberg.testPushdownWithDuplicateExpressions:351 » Verify tableCredentials is empty
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
