### PR TITLE
Add Parquet row-group row-count limit

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -228,6 +228,9 @@ The following table describes {ref}`catalog session properties
 * - `parquet_writer_block_size`
   - The maximum block size created by the Parquet writer.
   - `128MB`
+* - `parquet_writer_row_group_max_row_count`
+  - The maximum row count of row groups created by the Parquet writer.
+  - `unlimited`
 * - `parquet_writer_page_size`
   - The maximum page size created by the Parquet writer.
   - `1MB`

--- a/docs/src/main/sphinx/object-storage/file-formats.md
+++ b/docs/src/main/sphinx/object-storage/file-formats.md
@@ -74,6 +74,10 @@ with Parquet files performed by supported object storage connectors:
   - Maximum size of row groups written by Parquet writer. The equivalent 
     catalog session property is `parquet_writer_block_size`.
   - `128 MB`
+* - `parquet.writer.row-group-max-row-count`
+  - Maximum number of rows in row groups written by Parquet writer. The
+    equivalent catalog session property is `parquet_writer_row_group_max_row_count`.
+  - `unlimited`
 * - `parquet.writer.batch-size`
   - Maximum number of rows processed by the parquet writer in a batch.
     The equivalent catalog session property is `parquet_writer_batch_size`.

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -178,7 +178,7 @@ public class ParquetWriter
 
         int writeOffset = 0;
         while (writeOffset < page.getPositionCount()) {
-            Page chunk = page.getRegion(writeOffset, min(page.getPositionCount() - writeOffset, writerOption.getBatchSize()));
+            Page chunk = page.getRegion(writeOffset, min(page.getPositionCount() - writeOffset, min(writerOption.getBatchSize(), writerOption.getMaxRowGroupRowCount() - rows)));
 
             // avoid chunk with huge logical size
             while (chunk.getPositionCount() > 1 && chunk.getSizeInBytes() > chunkMaxBytes) {
@@ -200,7 +200,7 @@ public class ParquetWriter
         rows += page.getPositionCount();
         updateEstimatedBufferedBytes();
 
-        if (estimatedBufferedBytes >= writerOption.getMaxRowGroupSize()) {
+        if (estimatedBufferedBytes >= writerOption.getMaxRowGroupSize() || rows >= writerOption.getMaxRowGroupRowCount()) {
             columnWriters.forEach(ColumnWriter::close);
             flush();
             initColumnWriters();

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriterOptions.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriterOptions.java
@@ -26,6 +26,7 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 public class ParquetWriterOptions
 {
     private static final DataSize DEFAULT_MAX_ROW_GROUP_SIZE = DataSize.of(128, MEGABYTE);
+    public static final int DEFAULT_MAX_ROW_GROUP_ROW_COUNT = Integer.MAX_VALUE;
     private static final DataSize DEFAULT_MAX_PAGE_SIZE = DataSize.ofBytes(ParquetProperties.DEFAULT_PAGE_SIZE);
     // org.apache.parquet.column.DEFAULT_PAGE_ROW_COUNT_LIMIT is 20_000 to improve selectivity of page indexes
     // This value should be revisited when TODO https://github.com/trinodb/trino/issues/9359 is implemented
@@ -41,6 +42,7 @@ public class ParquetWriterOptions
     }
 
     private final int maxRowGroupSize;
+    private final int maxRowGroupRowCount;
     private final int maxPageSize;
     private final int maxPageValueCount;
     private final int batchSize;
@@ -52,6 +54,7 @@ public class ParquetWriterOptions
 
     private ParquetWriterOptions(
             DataSize maxBlockSize,
+            int maxRowGroupRowCount,
             DataSize maxPageSize,
             int maxPageValueCount,
             int batchSize,
@@ -61,6 +64,7 @@ public class ParquetWriterOptions
             boolean useDeltaLengthByteArrayEncoding)
     {
         this.maxRowGroupSize = Ints.saturatedCast(maxBlockSize.toBytes());
+        this.maxRowGroupRowCount = maxRowGroupRowCount;
         this.maxPageSize = Ints.saturatedCast(maxPageSize.toBytes());
         this.maxPageValueCount = maxPageValueCount;
         this.batchSize = batchSize;
@@ -68,12 +72,18 @@ public class ParquetWriterOptions
         this.bloomFilterFpp = bloomFilterFpp;
         this.bloomFilterColumns = ImmutableSet.copyOf(bloomFilterColumns);
         this.useDeltaLengthByteArrayEncoding = useDeltaLengthByteArrayEncoding;
+        checkArgument(this.maxRowGroupRowCount >= 1, "maxRowGroupRowCount must be at least 1");
         checkArgument(this.bloomFilterFpp > 0.0 && this.bloomFilterFpp < 1.0, "bloomFilterFpp should be > 0.0 & < 1.0");
     }
 
     public int getMaxRowGroupSize()
     {
         return maxRowGroupSize;
+    }
+
+    public int getMaxRowGroupRowCount()
+    {
+        return maxRowGroupRowCount;
     }
 
     public int getMaxPageSize()
@@ -114,6 +124,7 @@ public class ParquetWriterOptions
     public static class Builder
     {
         private DataSize maxBlockSize = DEFAULT_MAX_ROW_GROUP_SIZE;
+        private int maxRowGroupRowCount = DEFAULT_MAX_ROW_GROUP_ROW_COUNT;
         private DataSize maxPageSize = DEFAULT_MAX_PAGE_SIZE;
         private int maxPageValueCount = DEFAULT_MAX_PAGE_VALUE_COUNT;
         private int batchSize = DEFAULT_BATCH_SIZE;
@@ -125,6 +136,12 @@ public class ParquetWriterOptions
         public Builder setMaxBlockSize(DataSize maxBlockSize)
         {
             this.maxBlockSize = maxBlockSize;
+            return this;
+        }
+
+        public Builder setMaxRowGroupRowCount(int maxRowGroupRowCount)
+        {
+            this.maxRowGroupRowCount = maxRowGroupRowCount;
             return this;
         }
 
@@ -174,6 +191,7 @@ public class ParquetWriterOptions
         {
             return new ParquetWriterOptions(
                     maxBlockSize,
+                    maxRowGroupRowCount,
                     maxPageSize,
                     maxPageValueCount,
                     batchSize,

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
@@ -242,6 +242,100 @@ public class TestParquetWriter
     }
 
     @Test
+    public void testDefaultMaxRowGroupRowCountDoesNotFlush()
+            throws IOException
+    {
+        List<String> columnNames = ImmutableList.of("column");
+        List<Type> types = ImmutableList.of(INTEGER);
+
+        List<BlockMetadata> rowGroups = writeParquetAndReadRowGroups(
+                ParquetWriterOptions.builder()
+                        .setMaxBlockSize(DataSize.of(64, MEGABYTE))
+                        .build(),
+                types,
+                columnNames,
+                generateInputPages(types, 1000, 3));
+
+        assertThat(rowGroups)
+                .hasSize(1)
+                .allSatisfy(rowGroup -> assertThat(rowGroup.rowCount()).isEqualTo(3000));
+    }
+
+    @Test
+    public void testMaxRowGroupRowCountFlushesRowGroups()
+            throws IOException
+    {
+        List<String> columnNames = ImmutableList.of("column");
+        List<Type> types = ImmutableList.of(INTEGER);
+
+        List<BlockMetadata> rowGroups = writeParquetAndReadRowGroups(
+                ParquetWriterOptions.builder()
+                        .setMaxBlockSize(DataSize.of(64, MEGABYTE))
+                        .setMaxRowGroupRowCount(300)
+                        .build(),
+                types,
+                columnNames,
+                generateInputPages(types, 1000, 2));
+
+        assertThat(rowGroups)
+                .hasSize(7)
+                .extracting(BlockMetadata::rowCount)
+                .containsExactly(300L, 300L, 300L, 300L, 300L, 300L, 200L);
+    }
+
+    @Test
+    public void testMaxRowGroupSizeFlushesRowGroups()
+            throws IOException
+    {
+        List<String> columnNames = ImmutableList.of("columnA", "columnB");
+        List<Type> types = ImmutableList.of(INTEGER, BIGINT);
+
+        List<BlockMetadata> rowGroups = writeParquetAndReadRowGroups(
+                ParquetWriterOptions.builder()
+                        .setMaxBlockSize(DataSize.ofBytes(1000))
+                        .build(),
+                types,
+                columnNames,
+                generateInputPages(types, 10, 100));
+
+        assertThat(rowGroups.size()).isGreaterThan(1);
+    }
+
+    @Test
+    public void testEarlierRowGroupLimitWins()
+            throws IOException
+    {
+        List<String> columnNames = ImmutableList.of("columnA", "columnB");
+        List<Type> types = ImmutableList.of(INTEGER, BIGINT);
+
+        List<BlockMetadata> rowGroups = writeParquetAndReadRowGroups(
+                ParquetWriterOptions.builder()
+                        .setMaxBlockSize(DataSize.ofBytes(1000))
+                        .setMaxRowGroupRowCount(500)
+                        .build(),
+                types,
+                columnNames,
+                generateInputPages(types, 10, 100));
+
+        assertThat(rowGroups.size()).isGreaterThan(1);
+        assertThat(rowGroups)
+                .allSatisfy(rowGroup -> assertThat(rowGroup.rowCount()).isLessThan(500));
+
+        rowGroups = writeParquetAndReadRowGroups(
+                ParquetWriterOptions.builder()
+                        .setMaxBlockSize(DataSize.of(64, MEGABYTE))
+                        .setMaxRowGroupRowCount(300)
+                        .build(),
+                types,
+                columnNames,
+                generateInputPages(types, 1000, 1));
+
+        assertThat(rowGroups)
+                .extracting(BlockMetadata::rowCount)
+                .containsExactly(300L, 300L, 300L, 100L);
+    }
+
+    @Test
     public void testLargeStringTruncation()
             throws IOException
     {
@@ -704,5 +798,18 @@ public class TestParquetWriter
             blocks[column] = blockBuilder.build();
         }
         return new Page(blocks);
+    }
+
+    private static List<BlockMetadata> writeParquetAndReadRowGroups(ParquetWriterOptions writerOptions, List<Type> types, List<String> columnNames, List<Page> inputPages)
+            throws IOException
+    {
+        ParquetDataSource dataSource = new TestingParquetDataSource(
+                writeParquetFile(
+                        writerOptions,
+                        types,
+                        columnNames,
+                        inputPages),
+                ParquetReaderOptions.defaultOptions());
+        return MetadataReader.readFooter(dataSource, Optional.empty()).getBlocks();
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
@@ -62,6 +62,7 @@ import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getCompressio
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterBlockSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageValueCount;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterRowGroupMaxRowCount;
 import static io.trino.plugin.deltalake.DeltaLakeTypes.toParquetType;
 import static io.trino.plugin.hive.HiveCompressionCodecs.toCompressionCodec;
 import static java.lang.String.format;
@@ -467,6 +468,7 @@ public abstract class AbstractDeltaLakePageSink
     {
         ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                 .setMaxBlockSize(getParquetWriterBlockSize(session))
+                .setMaxRowGroupRowCount(getParquetWriterRowGroupMaxRowCount(session))
                 .setMaxPageSize(getParquetWriterPageSize(session))
                 .setMaxPageValueCount(getParquetWriterPageValueCount(session))
                 .setUseDeltaLengthByteArrayEncoding(useDeltaLengthByteArrayEncoding)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -81,6 +81,7 @@ import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getCompressio
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterBlockSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageValueCount;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterRowGroupMaxRowCount;
 import static io.trino.plugin.deltalake.DeltaLakeTypes.toParquetType;
 import static io.trino.plugin.deltalake.DeltaLakeWriter.readStatistics;
 import static io.trino.plugin.deltalake.delete.DeletionVectors.readDeletionVectors;
@@ -518,6 +519,7 @@ public class DeltaLakeMergeSink
     {
         ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                 .setMaxBlockSize(getParquetWriterBlockSize(session))
+                .setMaxRowGroupRowCount(getParquetWriterRowGroupMaxRowCount(session))
                 .setMaxPageSize(getParquetWriterPageSize(session))
                 .setMaxPageValueCount(getParquetWriterPageValueCount(session))
                 .setUseDeltaLengthByteArrayEncoding(useDeltaLengthByteArrayEncoding)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
@@ -40,6 +40,7 @@ import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MA
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_VALUE_COUNT;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_VALUE_COUNT;
+import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT;
 import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.enumProperty;
@@ -60,6 +61,7 @@ public final class DeltaLakeSessionProperties
     private static final String PARQUET_IGNORE_STATISTICS = "parquet_ignore_statistics";
     private static final String PARQUET_VECTORIZED_DECODING_ENABLED = "parquet_vectorized_decoding_enabled";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
+    private static final String PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT = "parquet_writer_row_group_max_row_count";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_PAGE_VALUE_COUNT = "parquet_writer_page_value_count";
     private static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
@@ -146,6 +148,18 @@ public final class DeltaLakeSessionProperties
                         "Parquet: Writer block size",
                         parquetWriterConfig.getBlockSize(),
                         value -> validateMaxDataSize(PARQUET_WRITER_BLOCK_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_BLOCK_SIZE)),
+                        false),
+                integerProperty(
+                        PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT,
+                        "Parquet: The maximum row count of row groups created by the Parquet writer",
+                        parquetWriterConfig.getRowGroupMaxRowCount(),
+                        value -> {
+                            if (value < PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT) {
+                                throw new TrinoException(
+                                        INVALID_SESSION_PROPERTY,
+                                        format("%s must be at least %s: %s", PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT, PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT, value));
+                            }
+                        },
                         false),
                 dataSizeProperty(
                         PARQUET_WRITER_PAGE_SIZE,
@@ -293,6 +307,11 @@ public final class DeltaLakeSessionProperties
     public static DataSize getParquetWriterBlockSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_BLOCK_SIZE, DataSize.class);
+    }
+
+    public static int getParquetWriterRowGroupMaxRowCount(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT, Integer.class);
     }
 
     public static DataSize getParquetWriterPageSize(ConnectorSession session)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -47,6 +47,7 @@ import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MA
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_VALUE_COUNT;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_VALUE_COUNT;
+import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT;
 import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.doubleProperty;
@@ -99,6 +100,7 @@ public final class HiveSessionProperties
     private static final String PARQUET_SMALL_FILE_THRESHOLD = "parquet_small_file_threshold";
     private static final String PARQUET_VECTORIZED_DECODING_ENABLED = "parquet_vectorized_decoding_enabled";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
+    private static final String PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT = "parquet_writer_row_group_max_row_count";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_PAGE_VALUE_COUNT = "parquet_writer_page_value_count";
     private static final String PARQUET_WRITER_BATCH_SIZE = "parquet_writer_batch_size";
@@ -371,6 +373,18 @@ public final class HiveSessionProperties
                         "Parquet: Writer block size",
                         parquetWriterConfig.getBlockSize(),
                         value -> validateMaxDataSize(PARQUET_WRITER_BLOCK_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_BLOCK_SIZE)),
+                        false),
+                integerProperty(
+                        PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT,
+                        "Parquet: The maximum row count of row groups created by the Parquet writer",
+                        parquetWriterConfig.getRowGroupMaxRowCount(),
+                        value -> {
+                            if (value < PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT) {
+                                throw new TrinoException(
+                                        INVALID_SESSION_PROPERTY,
+                                        format("%s must be at least %s: %s", PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT, PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT, value));
+                            }
+                        },
                         false),
                 dataSizeProperty(
                         PARQUET_WRITER_PAGE_SIZE,
@@ -757,6 +771,11 @@ public final class HiveSessionProperties
     public static DataSize getParquetWriterBlockSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_BLOCK_SIZE, DataSize.class);
+    }
+
+    public static int getParquetWriterRowGroupMaxRowCount(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT, Integer.class);
     }
 
     public static DataSize getParquetWriterPageSize(ConnectorSession session)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -110,6 +110,7 @@ public class ParquetFileWriterFactory
                 .setMaxPageSize(HiveSessionProperties.getParquetWriterPageSize(session))
                 .setMaxPageValueCount(HiveSessionProperties.getParquetWriterPageValueCount(session))
                 .setMaxBlockSize(HiveSessionProperties.getParquetWriterBlockSize(session))
+                .setMaxRowGroupRowCount(HiveSessionProperties.getParquetWriterRowGroupMaxRowCount(session))
                 .setBatchSize(HiveSessionProperties.getParquetBatchSize(session))
                 .setBloomFilterColumns(getParquetBloomFilterColumns(schema))
                 .setUseDeltaLengthByteArrayEncoding(useDeltaLengthByteArrayEncoding)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetWriterConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetWriterConfig.java
@@ -43,8 +43,10 @@ public class ParquetWriterConfig
     public static final String PARQUET_WRITER_MAX_PAGE_SIZE = "8MB";
     public static final int PARQUET_WRITER_MIN_PAGE_VALUE_COUNT = 1000;
     public static final int PARQUET_WRITER_MAX_PAGE_VALUE_COUNT = 200_000;
+    public static final int PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT = PARQUET_WRITER_MIN_PAGE_VALUE_COUNT;
 
     private DataSize blockSize = DataSize.of(128, MEGABYTE);
+    private int rowGroupMaxRowCount = ParquetWriterOptions.DEFAULT_MAX_ROW_GROUP_ROW_COUNT;
     private DataSize pageSize = DataSize.ofBytes(ParquetProperties.DEFAULT_PAGE_SIZE);
     private int pageValueCount = ParquetWriterOptions.DEFAULT_MAX_PAGE_VALUE_COUNT;
     private int batchSize = ParquetWriterOptions.DEFAULT_BATCH_SIZE;
@@ -61,6 +63,20 @@ public class ParquetWriterConfig
     public ParquetWriterConfig setBlockSize(DataSize blockSize)
     {
         this.blockSize = blockSize;
+        return this;
+    }
+
+    @Min(PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT)
+    public int getRowGroupMaxRowCount()
+    {
+        return rowGroupMaxRowCount;
+    }
+
+    @Config("parquet.writer.row-group-max-row-count")
+    @ConfigDescription("Maximum row count of row groups created by the Parquet writer")
+    public ParquetWriterConfig setRowGroupMaxRowCount(int rowGroupMaxRowCount)
+    {
+        this.rowGroupMaxRowCount = rowGroupMaxRowCount;
         return this;
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetWriterConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetWriterConfig.java
@@ -32,6 +32,7 @@ public class TestParquetWriterConfig
     {
         assertRecordedDefaults(recordDefaults(ParquetWriterConfig.class)
                 .setBlockSize(DataSize.of(128, MEGABYTE))
+                .setRowGroupMaxRowCount(ParquetWriterOptions.DEFAULT_MAX_ROW_GROUP_ROW_COUNT)
                 .setPageSize(DataSize.ofBytes(ParquetProperties.DEFAULT_PAGE_SIZE))
                 .setPageValueCount(ParquetWriterOptions.DEFAULT_MAX_PAGE_VALUE_COUNT)
                 .setBatchSize(ParquetWriterOptions.DEFAULT_BATCH_SIZE)
@@ -44,6 +45,7 @@ public class TestParquetWriterConfig
     {
         Map<String, String> properties = Map.of(
                 "parquet.writer.block-size", "234MB",
+                "parquet.writer.row-group-max-row-count", "50000",
                 "parquet.writer.page-size", "6MB",
                 "parquet.writer.page-value-count", "10000",
                 "parquet.writer.batch-size", "100",
@@ -52,6 +54,7 @@ public class TestParquetWriterConfig
 
         ParquetWriterConfig expected = new ParquetWriterConfig()
                 .setBlockSize(DataSize.of(234, MEGABYTE))
+                .setRowGroupMaxRowCount(50_000)
                 .setPageSize(DataSize.of(6, MEGABYTE))
                 .setPageValueCount(10_000)
                 .setBatchSize(100)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -76,6 +76,7 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterB
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterDeltaLengthByteArrayEncodingEnabled;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterPageSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterPageValueCount;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterRowGroupMaxRowCount;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isOrcWriterValidate;
 import static io.trino.plugin.iceberg.IcebergTableProperties.ORC_BLOOM_FILTER_FPP_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergUtil.getHiveCompressionCodec;
@@ -180,6 +181,7 @@ public class IcebergFileWriterFactory
                     .setMaxPageSize(getParquetWriterPageSize(session))
                     .setMaxPageValueCount(getParquetWriterPageValueCount(session))
                     .setMaxBlockSize(getParquetWriterBlockSize(session))
+                    .setMaxRowGroupRowCount(getParquetWriterRowGroupMaxRowCount(session))
                     .setBatchSize(getParquetWriterBatchSize(session))
                     .setBloomFilterColumns(getParquetBloomFilterColumns(storageProperties))
                     .setUseDeltaLengthByteArrayEncoding(getParquetWriterDeltaLengthByteArrayEncodingEnabled(session))

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -47,6 +47,7 @@ import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MA
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_VALUE_COUNT;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_VALUE_COUNT;
+import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT;
 import static io.trino.plugin.iceberg.IcebergConfig.COLLECT_EXTENDED_STATISTICS_ON_WRITE_DESCRIPTION;
 import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
@@ -87,6 +88,7 @@ public final class IcebergSessionProperties
     private static final String PARQUET_IGNORE_STATISTICS = "parquet_ignore_statistics";
     private static final String PARQUET_VECTORIZED_DECODING_ENABLED = "parquet_vectorized_decoding_enabled";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
+    private static final String PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT = "parquet_writer_row_group_max_row_count";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_PAGE_VALUE_COUNT = "parquet_writer_page_value_count";
     private static final String PARQUET_WRITER_BATCH_SIZE = "parquet_writer_batch_size";
@@ -264,6 +266,18 @@ public final class IcebergSessionProperties
                         "Parquet: Writer block size",
                         parquetWriterConfig.getBlockSize(),
                         value -> validateMaxDataSize(PARQUET_WRITER_BLOCK_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_BLOCK_SIZE)),
+                        false))
+                .add(integerProperty(
+                        PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT,
+                        "Parquet: The maximum row count of row groups created by the Parquet writer",
+                        parquetWriterConfig.getRowGroupMaxRowCount(),
+                        value -> {
+                            if (value < PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT) {
+                                throw new TrinoException(
+                                        INVALID_SESSION_PROPERTY,
+                                        format("%s must be at least %s: %s", PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT, PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT, value));
+                            }
+                        },
                         false))
                 .add(dataSizeProperty(
                         PARQUET_WRITER_PAGE_SIZE,
@@ -546,6 +560,11 @@ public final class IcebergSessionProperties
     public static DataSize getParquetWriterBlockSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_BLOCK_SIZE, DataSize.class);
+    }
+
+    public static int getParquetWriterRowGroupMaxRowCount(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT, Integer.class);
     }
 
     public static int getParquetWriterBatchSize(ConnectorSession session)


### PR DESCRIPTION
## Description

Adds a Parquet writer row-group row-count limit. The writer can now flush a row group when either the existing buffered byte threshold is reached or the new row-count threshold is reached.

The new configuration property is `parquet.writer.block-row-count`, with matching catalog session property `parquet_writer_block_row_count`. The default is effectively unlimited, preserving existing byte-size-based behavior.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Hive, Iceberg, Delta Lake, Lakehouse
* Add support for limiting the number of rows in Parquet writer row groups with the `parquet.writer.block-row-count` configuration property or the `parquet_writer_block_row_count` session property. ({issue}`issuenumber`)