### PR TITLE
Add Iceberg Parquet footer cache

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -204,6 +204,13 @@ implementation is used:
   - Set to `false` to disable in-memory caching of metadata files on the
     coordinator. This cache is not used when `fs.cache.enabled` is set to true.
   - `true`
+* - `iceberg.parquet-footer-cache.type`
+  - Type of cache to use for Parquet file footers. Set to `memory` to enable a
+    bounded, in-memory cache.
+  - `none`
+* - `iceberg.parquet-footer-cache.memory.max-size`
+  - Maximum size of the in-memory Parquet footer cache.
+  - `10MB`
 * - `iceberg.object-store-layout.enabled`
   - Set to `true` to enable Iceberg's [object store file layout](https://iceberg.apache.org/docs/latest/aws/#object-store-file-layout). 
     Enabling the object store file layout appends a deterministic hash directly 

--- a/lib/trino-parquet/pom.xml
+++ b/lib/trino-parquet/pom.xml
@@ -52,6 +52,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-cache</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-memory-context</artifactId>
         </dependency>
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/cache/MemoryParquetFooterCache.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/cache/MemoryParquetFooterCache.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.cache;
+
+import com.google.common.cache.Cache;
+import io.airlift.slice.Slice;
+import io.airlift.units.DataSize;
+import io.trino.cache.EvictableCacheBuilder;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class MemoryParquetFooterCache
+        implements ParquetFooterCache
+{
+    private final Cache<ParquetFooterCacheKey, Slice> cache;
+    private final long maxSizeInBytes;
+
+    public MemoryParquetFooterCache(DataSize maxSize)
+    {
+        requireNonNull(maxSize, "maxSize is null");
+        this.maxSizeInBytes = maxSize.toBytes();
+        this.cache = EvictableCacheBuilder.newBuilder()
+                .maximumWeight(maxSizeInBytes)
+                .weigher((ParquetFooterCacheKey _, Slice footerBytes) -> toIntExact(footerBytes.length()))
+                .build();
+    }
+
+    @Override
+    public Optional<Slice> get(ParquetFooterCacheKey key)
+    {
+        return Optional.ofNullable(cache.getIfPresent(key));
+    }
+
+    @Override
+    public void put(ParquetFooterCacheKey key, Slice footerBytes)
+    {
+        if (footerBytes.length() > maxSizeInBytes) {
+            return;
+        }
+        try {
+            // Do not replace an existing value, and only copy footer bytes when the cache is missing this key.
+            cache.get(key, footerBytes::copy);
+        }
+        catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void invalidate(ParquetFooterCacheKey key)
+    {
+        cache.invalidate(key);
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/cache/NoOpParquetFooterCache.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/cache/NoOpParquetFooterCache.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.cache;
+
+import io.airlift.slice.Slice;
+
+import java.util.Optional;
+
+enum NoOpParquetFooterCache
+        implements ParquetFooterCache
+{
+    INSTANCE;
+
+    @Override
+    public Optional<Slice> get(ParquetFooterCacheKey key)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public void put(ParquetFooterCacheKey key, Slice footerBytes) {}
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/cache/ParquetFooterCache.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/cache/ParquetFooterCache.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.cache;
+
+import io.airlift.slice.Slice;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public interface ParquetFooterCache
+{
+    Optional<Slice> get(ParquetFooterCacheKey key)
+            throws IOException;
+
+    void put(ParquetFooterCacheKey key, Slice footerBytes);
+
+    default void invalidate(ParquetFooterCacheKey key) {}
+
+    static ParquetFooterCache noop()
+    {
+        return NoOpParquetFooterCache.INSTANCE;
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/cache/ParquetFooterCacheKey.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/cache/ParquetFooterCacheKey.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.cache;
+
+import static java.util.Objects.requireNonNull;
+
+public record ParquetFooterCacheKey(String location, long fileSize)
+{
+    public ParquetFooterCacheKey
+    {
+        requireNonNull(location, "location is null");
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/MetadataReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/MetadataReader.java
@@ -23,6 +23,8 @@ import io.trino.parquet.ParquetDataSource;
 import io.trino.parquet.ParquetDataSourceId;
 import io.trino.parquet.ParquetReaderOptions;
 import io.trino.parquet.ParquetWriteValidation;
+import io.trino.parquet.cache.ParquetFooterCache;
+import io.trino.parquet.cache.ParquetFooterCacheKey;
 import io.trino.parquet.crypto.AesCipherUtils;
 import io.trino.parquet.crypto.AesGcmEncryptor;
 import io.trino.parquet.crypto.FileDecryptionContext;
@@ -79,7 +81,58 @@ public final class MetadataReader
         return readFooter(dataSource, options.getFooterReadSize(), Optional.of(options.getMaxFooterReadSize()), parquetWriteValidation, fileDecryptionProperties);
     }
 
+    public static ParquetMetadata readFooter(
+            ParquetDataSource dataSource,
+            ParquetReaderOptions options,
+            Optional<ParquetWriteValidation> parquetWriteValidation,
+            Optional<FileDecryptionProperties> fileDecryptionProperties,
+            ParquetFooterCache parquetFooterCache,
+            ParquetFooterCacheKey cacheKey)
+            throws IOException
+    {
+        requireNonNull(parquetFooterCache, "parquetFooterCache is null");
+        requireNonNull(cacheKey, "cacheKey is null");
+
+        try {
+            Optional<Slice> footerBytes = parquetFooterCache.get(cacheKey);
+            if (footerBytes.isPresent()) {
+                try {
+                    return parseFooter(dataSource.getId(), dataSource.getEstimatedSize(), footerBytes.get(), parquetWriteValidation, fileDecryptionProperties);
+                }
+                catch (IOException | RuntimeException _) {
+                    invalidateParquetFooterCache(parquetFooterCache, cacheKey);
+                }
+            }
+        }
+        catch (IOException | RuntimeException _) {
+            invalidateParquetFooterCache(parquetFooterCache, cacheKey);
+        }
+
+        Slice footerBytes = readFooterBytes(dataSource, options);
+        ParquetMetadata parquetMetadata = parseFooter(dataSource.getId(), dataSource.getEstimatedSize(), footerBytes, parquetWriteValidation, fileDecryptionProperties);
+        try {
+            parquetFooterCache.put(cacheKey, footerBytes);
+        }
+        catch (RuntimeException _) {
+            // Footer cache failures should not affect reads.
+        }
+        return parquetMetadata;
+    }
+
     public static ParquetMetadata readFooter(ParquetDataSource dataSource, DataSize footerReadSize, Optional<DataSize> maxFooterReadSize, Optional<ParquetWriteValidation> parquetWriteValidation, Optional<FileDecryptionProperties> fileDecryptionProperties)
+            throws IOException
+    {
+        return parseFooter(dataSource.getId(), dataSource.getEstimatedSize(), readFooterBytes(dataSource, footerReadSize, maxFooterReadSize), parquetWriteValidation, fileDecryptionProperties);
+    }
+
+    public static Slice readFooterBytes(ParquetDataSource dataSource, ParquetReaderOptions options)
+            throws IOException
+    {
+        requireNonNull(options, "options is null");
+        return readFooterBytes(dataSource, options.getFooterReadSize(), Optional.of(options.getMaxFooterReadSize()));
+    }
+
+    private static Slice readFooterBytes(ParquetDataSource dataSource, DataSize footerReadSize, Optional<DataSize> maxFooterReadSize)
             throws IOException
     {
         // Parquet File Layout:
@@ -102,7 +155,6 @@ public final class MetadataReader
         Slice magic = buffer.slice(buffer.length() - MAGIC.length(), MAGIC.length());
         validateParquet(MAGIC.equals(magic) || EMAGIC.equals(magic), dataSource.getId(), "Expected magic number: %s or %s got: %s", MAGIC.toStringUtf8(), EMAGIC.toStringUtf8(), magic.toStringUtf8());
 
-        boolean encryptedFooterMode = EMAGIC.equals(magic);
         int metadataLength = buffer.getInt(buffer.length() - POST_SCRIPT_SIZE);
         long metadataIndex = estimatedFileSize - POST_SCRIPT_SIZE - metadataLength;
         validateParquet(
@@ -123,17 +175,57 @@ public final class MetadataReader
             // initial read was not large enough, so just read again with the correct size
             buffer = dataSource.readTail(completeFooterSize);
         }
-        SliceInput metadataStream = buffer.slice(buffer.length() - completeFooterSize, metadataLength).getInput();
+        return buffer.slice(buffer.length() - completeFooterSize, completeFooterSize);
+    }
+
+    private static void invalidateParquetFooterCache(ParquetFooterCache parquetFooterCache, ParquetFooterCacheKey cacheKey)
+    {
+        try {
+            parquetFooterCache.invalidate(cacheKey);
+        }
+        catch (RuntimeException _) {
+            // Footer cache failures should not affect reads.
+        }
+    }
+
+    public static ParquetMetadata parseFooter(
+            ParquetDataSourceId dataSourceId,
+            long estimatedFileSize,
+            Slice footerBytes,
+            Optional<ParquetWriteValidation> parquetWriteValidation,
+            Optional<FileDecryptionProperties> fileDecryptionProperties)
+            throws IOException
+    {
+        requireNonNull(dataSourceId, "dataSourceId is null");
+        requireNonNull(footerBytes, "footerBytes is null");
+        validateParquet(estimatedFileSize >= MAGIC.length() + POST_SCRIPT_SIZE, dataSourceId, "%s is not a valid Parquet File", dataSourceId);
+        validateParquet(footerBytes.length() >= POST_SCRIPT_SIZE, dataSourceId, "Footer is too small");
+
+        Slice magic = footerBytes.slice(footerBytes.length() - MAGIC.length(), MAGIC.length());
+        validateParquet(MAGIC.equals(magic) || EMAGIC.equals(magic), dataSourceId, "Expected magic number: %s or %s got: %s", MAGIC.toStringUtf8(), EMAGIC.toStringUtf8(), magic.toStringUtf8());
+
+        int metadataLength = footerBytes.getInt(footerBytes.length() - POST_SCRIPT_SIZE);
+        long metadataIndex = estimatedFileSize - POST_SCRIPT_SIZE - metadataLength;
+        validateParquet(
+                metadataIndex >= MAGIC.length() && metadataIndex < estimatedFileSize - POST_SCRIPT_SIZE,
+                dataSourceId,
+                "Metadata index: %s out of range",
+                metadataIndex);
+
+        int completeFooterSize = metadataLength + POST_SCRIPT_SIZE;
+        validateParquet(completeFooterSize <= footerBytes.length(), dataSourceId, "Footer bytes do not contain complete footer");
+        SliceInput metadataStream = footerBytes.slice(footerBytes.length() - completeFooterSize, metadataLength).getInput();
 
         Optional<FileDecryptionContext> decryptionContext = Optional.empty();
         Decryptor footerDecryptor = null;
         byte[] aad = null;
 
+        boolean encryptedFooterMode = EMAGIC.equals(magic);
         if (encryptedFooterMode) {
-            validateParquetCrypto(fileDecryptionProperties.isPresent(), dataSource.getId(), "fileDecryptionProperties cannot be null when encryptedFooterMode is true");
+            validateParquetCrypto(fileDecryptionProperties.isPresent(), dataSourceId, "fileDecryptionProperties cannot be null when encryptedFooterMode is true");
             FileCryptoMetaData fileCryptoMetaData = readFileCryptoMetaData(metadataStream);
-            validateParquetCrypto(fileCryptoMetaData != null, dataSource.getId(), "FileCryptoMetaData cannot be null when encryptedFooterMode is true");
-            decryptionContext = Optional.of(new FileDecryptionContext(dataSource.getId(), fileDecryptionProperties.get(), fileCryptoMetaData.getEncryption_algorithm(), Optional.ofNullable(fileCryptoMetaData.getKey_metadata())));
+            validateParquetCrypto(fileCryptoMetaData != null, dataSourceId, "FileCryptoMetaData cannot be null when encryptedFooterMode is true");
+            decryptionContext = Optional.of(new FileDecryptionContext(dataSourceId, fileDecryptionProperties.get(), fileCryptoMetaData.getEncryption_algorithm(), Optional.ofNullable(fileCryptoMetaData.getKey_metadata())));
             footerDecryptor = decryptionContext.get().getFooterDecryptor();
             aad = AesCipherUtils.createFooterAAD(decryptionContext.get().getFileAad());
         }
@@ -141,15 +233,15 @@ public final class MetadataReader
         FileMetaData fileMetaData = readFileMetaData(metadataStream, footerDecryptor, aad);
         if (!encryptedFooterMode && fileDecryptionProperties.isPresent() && fileMetaData.isSetEncryption_algorithm()) {
             // footer is not encrypted, but some columns might be encrypted
-            decryptionContext = Optional.of(new FileDecryptionContext(dataSource.getId(), fileDecryptionProperties.get(), fileMetaData.getEncryption_algorithm(), Optional.ofNullable(fileMetaData.getFooter_signing_key_metadata())));
+            decryptionContext = Optional.of(new FileDecryptionContext(dataSourceId, fileDecryptionProperties.get(), fileMetaData.getEncryption_algorithm(), Optional.ofNullable(fileMetaData.getFooter_signing_key_metadata())));
             if (fileDecryptionProperties.get().isCheckFooterIntegrity()) {
                 // verify footer integrity
-                verifyFooterIntegrity(dataSource, metadataStream, decryptionContext.get(), metadataLength);
+                verifyFooterIntegrity(dataSourceId, metadataStream, decryptionContext.get(), metadataLength);
             }
         }
 
-        ParquetMetadata parquetMetadata = new ParquetMetadata(fileMetaData, dataSource.getId(), decryptionContext);
-        validateFileMetadata(dataSource.getId(), parquetMetadata.getFileMetaData(), parquetWriteValidation);
+        ParquetMetadata parquetMetadata = new ParquetMetadata(fileMetaData, dataSourceId, decryptionContext);
+        validateFileMetadata(dataSourceId, parquetMetadata.getFileMetaData(), parquetWriteValidation);
         return parquetMetadata;
     }
 
@@ -261,7 +353,7 @@ public final class MetadataReader
         writeValidation.validateColumns(dataSourceId, fileMetaData.getSchema());
     }
 
-    private static void verifyFooterIntegrity(ParquetDataSource dataSource, SliceInput metadataStream, FileDecryptionContext decryptionContext, int metadataLength)
+    private static void verifyFooterIntegrity(ParquetDataSourceId dataSourceId, SliceInput metadataStream, FileDecryptionContext decryptionContext, int metadataLength)
     {
         byte[] nonce = new byte[NONCE_LENGTH];
         metadataStream.read(nonce);
@@ -280,6 +372,6 @@ public final class MetadataReader
         byte[] encryptedFooterBytes = footerSigner.encrypt(false, footer, nonce, signedFooterAAD);
         byte[] calculatedTag = new byte[GCM_TAG_LENGTH];
         arraycopy(encryptedFooterBytes, encryptedFooterBytes.length - GCM_TAG_LENGTH, calculatedTag, 0, GCM_TAG_LENGTH);
-        validateParquetCrypto(Arrays.equals(gcmTag, calculatedTag), dataSource.getId(), "Signature mismatch in plaintext footer");
+        validateParquetCrypto(Arrays.equals(gcmTag, calculatedTag), dataSourceId, "Signature mismatch in plaintext footer");
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReader.java
@@ -279,6 +279,28 @@ public class TestParquetReader
         assertThat(dataSource.getTailReadLengths()).startsWith(128);
     }
 
+    @Test
+    void testParseFooterFromSuppliedFooterBytes()
+            throws IOException
+    {
+        List<String> columnNames = ImmutableList.of("columna", "columnb");
+        List<Type> types = ImmutableList.of(INTEGER, BIGINT);
+        Slice parquetFile = writeParquetFile(
+                ParquetWriterOptions.builder()
+                        .setMaxBlockSize(DataSize.ofBytes(10))
+                        .build(),
+                types,
+                columnNames,
+                generateInputPages(types, 10, 50));
+
+        RecordingParquetDataSource source = new RecordingParquetDataSource(parquetFile);
+        Slice footerBytes = MetadataReader.readFooterBytes(source, ParquetReaderOptions.defaultOptions());
+
+        ParquetMetadata metadata = MetadataReader.parseFooter(new ParquetDataSourceId("test"), parquetFile.length(), footerBytes, Optional.empty(), Optional.empty());
+
+        assertThat(metadata.getBlocks().stream().mapToLong(BlockMetadata::rowCount).sum()).isEqualTo(500);
+    }
+
     private void testReadingOldParquetFiles(File file, List<String> columnNames, Type columnType, List<?> expectedValues)
             throws IOException
     {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -21,6 +21,7 @@ import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.airlift.units.MinDataSize;
 import io.trino.filesystem.Location;
 import io.trino.plugin.base.configuration.ThreadCountParser;
 import io.trino.plugin.hive.HiveCompressionOption;
@@ -42,6 +43,7 @@ import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.plugin.iceberg.CatalogType.HIVE_METASTORE;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
+import static io.trino.plugin.iceberg.ParquetFooterCacheType.NONE;
 import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
@@ -104,6 +106,8 @@ public class IcebergConfig
     private boolean objectStoreLayoutEnabled;
     private int metadataParallelism = 8;
     private boolean bucketExecutionEnabled = true;
+    private ParquetFooterCacheType parquetFooterCacheType = NONE;
+    private DataSize parquetFooterCacheMemoryMaxSize = DataSize.of(10, MEGABYTE);
 
     public CatalogType getCatalogType()
     {
@@ -680,6 +684,34 @@ public class IcebergConfig
     public IcebergConfig setBucketExecutionEnabled(boolean bucketExecutionEnabled)
     {
         this.bucketExecutionEnabled = bucketExecutionEnabled;
+        return this;
+    }
+
+    @NotNull
+    public ParquetFooterCacheType getParquetFooterCacheType()
+    {
+        return parquetFooterCacheType;
+    }
+
+    @Config("iceberg.parquet-footer-cache.type")
+    @ConfigDescription("Type of cache to use for Parquet footer metadata")
+    public IcebergConfig setParquetFooterCacheType(ParquetFooterCacheType parquetFooterCacheType)
+    {
+        this.parquetFooterCacheType = parquetFooterCacheType;
+        return this;
+    }
+
+    @MinDataSize("0B")
+    public DataSize getParquetFooterCacheMemoryMaxSize()
+    {
+        return parquetFooterCacheMemoryMaxSize;
+    }
+
+    @Config("iceberg.parquet-footer-cache.memory.max-size")
+    @ConfigDescription("Maximum size of the in-memory Parquet footer cache")
+    public IcebergConfig setParquetFooterCacheMemoryMaxSize(DataSize parquetFooterCacheMemoryMaxSize)
+    {
+        this.parquetFooterCacheMemoryMaxSize = parquetFooterCacheMemoryMaxSize;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -16,11 +16,15 @@ package io.trino.plugin.iceberg;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Module;
+import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
 import io.trino.filesystem.cache.CacheKeyProvider;
 import io.trino.metastore.HiveMetastoreFactory;
 import io.trino.metastore.RawHiveMetastoreFactory;
+import io.trino.parquet.cache.MemoryParquetFooterCache;
+import io.trino.parquet.cache.ParquetFooterCache;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSinkProvider;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSourceProviderFactory;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitManager;
@@ -147,5 +151,15 @@ public class IcebergModule
         binder.bind(IcebergConnector.class).in(Scopes.SINGLETON);
 
         binder.install(new IcebergExecutorModule());
+    }
+
+    @Provides
+    @Singleton
+    public static ParquetFooterCache createParquetFooterCache(IcebergConfig config)
+    {
+        return switch (config.getParquetFooterCacheType()) {
+            case NONE -> ParquetFooterCache.noop();
+            case MEMORY -> new MemoryParquetFooterCache(config.getParquetFooterCacheMemoryMaxSize());
+        };
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -41,6 +41,8 @@ import io.trino.parquet.ParquetCorruptionException;
 import io.trino.parquet.ParquetDataSource;
 import io.trino.parquet.ParquetDataSourceId;
 import io.trino.parquet.ParquetReaderOptions;
+import io.trino.parquet.cache.ParquetFooterCache;
+import io.trino.parquet.cache.ParquetFooterCacheKey;
 import io.trino.parquet.metadata.FileMetadata;
 import io.trino.parquet.metadata.ParquetMetadata;
 import io.trino.parquet.predicate.TupleDomainParquetPredicate;
@@ -227,6 +229,7 @@ public class IcebergPageSourceProvider
     private final OrcReaderOptions orcReaderOptions;
     private final ParquetReaderOptions parquetReaderOptions;
     private final TypeManager typeManager;
+    private final ParquetFooterCache parquetFooterCache;
     private final DeleteManager unpartitionedTableDeleteManager;
     private final Map<Integer, Function<PartitionData, PartitionKey>> partitionKeyFactories = new ConcurrentHashMap<>();
     private final Map<PartitionKey, DeleteManager> partitionedDeleteManagers = new ConcurrentHashMap<>();
@@ -237,7 +240,8 @@ public class IcebergPageSourceProvider
             FileFormatDataSourceStats fileFormatDataSourceStats,
             OrcReaderOptions orcReaderOptions,
             ParquetReaderOptions parquetReaderOptions,
-            TypeManager typeManager)
+            TypeManager typeManager,
+            ParquetFooterCache parquetFooterCache)
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.fileIoFactory = requireNonNull(fileIoFactory, "fileIoFactory is null");
@@ -245,6 +249,7 @@ public class IcebergPageSourceProvider
         this.orcReaderOptions = requireNonNull(orcReaderOptions, "orcReaderOptions is null");
         this.parquetReaderOptions = requireNonNull(parquetReaderOptions, "parquetReaderOptions is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.parquetFooterCache = requireNonNull(parquetFooterCache, "parquetFooterCache is null");
         this.unpartitionedTableDeleteManager = new DeleteManager(typeManager);
     }
 
@@ -613,6 +618,7 @@ public class IcebergPageSourceProvider
                             .build(),
                     predicate,
                     fileFormatDataSourceStats,
+                    parquetFooterCache,
                     nameMapping,
                     partition,
                     partitionKeys,
@@ -1005,6 +1011,7 @@ public class IcebergPageSourceProvider
             ParquetReaderOptions options,
             TupleDomain<IcebergColumnHandle> effectivePredicate,
             FileFormatDataSourceStats fileFormatDataSourceStats,
+            ParquetFooterCache parquetFooterCache,
             Optional<NameMapping> nameMapping,
             String partition,
             Map<Integer, Optional<String>> partitionKeys,
@@ -1016,7 +1023,7 @@ public class IcebergPageSourceProvider
         ParquetDataSource dataSource = null;
         try {
             dataSource = createDataSource(inputFile, OptionalLong.of(fileSize), options, memoryContext, fileFormatDataSourceStats);
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options, Optional.empty(), Optional.empty());
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, options, Optional.empty(), Optional.empty(), parquetFooterCache, new ParquetFooterCacheKey(inputFile.location().toString(), fileSize));
             FileMetadata fileMetaData = parquetMetadata.getFileMetaData();
             MessageType fileSchema = fileMetaData.getSchema();
             if (nameMapping.isPresent() && !ParquetSchemaUtil.hasIds(fileSchema)) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProviderFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProviderFactory.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg;
 import com.google.inject.Inject;
 import io.trino.orc.OrcReaderOptions;
 import io.trino.parquet.ParquetReaderOptions;
+import io.trino.parquet.cache.ParquetFooterCache;
 import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
 import io.trino.plugin.hive.orc.OrcReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
@@ -34,6 +35,7 @@ public class IcebergPageSourceProviderFactory
     private final OrcReaderOptions orcReaderOptions;
     private final ParquetReaderOptions parquetReaderOptions;
     private final TypeManager typeManager;
+    private final ParquetFooterCache parquetFooterCache;
 
     @Inject
     public IcebergPageSourceProviderFactory(
@@ -42,7 +44,8 @@ public class IcebergPageSourceProviderFactory
             FileFormatDataSourceStats fileFormatDataSourceStats,
             OrcReaderConfig orcReaderConfig,
             ParquetReaderConfig parquetReaderConfig,
-            TypeManager typeManager)
+            TypeManager typeManager,
+            ParquetFooterCache parquetFooterCache)
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.fileIoFactory = requireNonNull(fileIoFactory, "fileIoFactory is null");
@@ -50,11 +53,12 @@ public class IcebergPageSourceProviderFactory
         this.orcReaderOptions = orcReaderConfig.toOrcReaderOptions();
         this.parquetReaderOptions = parquetReaderConfig.toParquetReaderOptions();
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.parquetFooterCache = requireNonNull(parquetFooterCache, "parquetFooterCache is null");
     }
 
     @Override
     public IcebergPageSourceProvider createPageSourceProvider()
     {
-        return new IcebergPageSourceProvider(fileSystemFactory, fileIoFactory, fileFormatDataSourceStats, orcReaderOptions, parquetReaderOptions, typeManager);
+        return new IcebergPageSourceProvider(fileSystemFactory, fileIoFactory, fileFormatDataSourceStats, orcReaderOptions, parquetReaderOptions, typeManager, parquetFooterCache);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ParquetFooterCacheType.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ParquetFooterCacheType.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+public enum ParquetFooterCacheType
+{
+    NONE,
+    MEMORY,
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -36,6 +36,8 @@ import static io.trino.plugin.iceberg.CatalogType.GLUE;
 import static io.trino.plugin.iceberg.CatalogType.HIVE_METASTORE;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
+import static io.trino.plugin.iceberg.ParquetFooterCacheType.MEMORY;
+import static io.trino.plugin.iceberg.ParquetFooterCacheType.NONE;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -86,7 +88,9 @@ public class TestIcebergConfig
                 .setMaterializedViewRefreshSnapshotRetentionPeriod(new Duration(4, HOURS))
                 .setObjectStoreLayoutEnabled(false)
                 .setMetadataParallelism(8)
-                .setBucketExecutionEnabled(true));
+                .setBucketExecutionEnabled(true)
+                .setParquetFooterCacheType(NONE)
+                .setParquetFooterCacheMemoryMaxSize(DataSize.of(10, MEGABYTE)));
     }
 
     @Test
@@ -133,6 +137,8 @@ public class TestIcebergConfig
                 .put("iceberg.object-store-layout.enabled", "true")
                 .put("iceberg.metadata.parallelism", "10")
                 .put("iceberg.bucket-execution", "false")
+                .put("iceberg.parquet-footer-cache.type", "MEMORY")
+                .put("iceberg.parquet-footer-cache.memory.max-size", "42MB")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -176,7 +182,9 @@ public class TestIcebergConfig
                 .setMaterializedViewRefreshSnapshotRetentionPeriod(new Duration(1, HOURS))
                 .setObjectStoreLayoutEnabled(true)
                 .setMetadataParallelism(10)
-                .setBucketExecutionEnabled(false);
+                .setBucketExecutionEnabled(false)
+                .setParquetFooterCacheType(MEMORY)
+                .setParquetFooterCacheMemoryMaxSize(DataSize.of(42, MEGABYTE));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -28,6 +28,7 @@ import io.trino.orc.OrcWriter;
 import io.trino.orc.OrcWriterOptions;
 import io.trino.orc.OrcWriterStats;
 import io.trino.orc.OutputStreamOrcDataSink;
+import io.trino.parquet.cache.ParquetFooterCache;
 import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
 import io.trino.plugin.hive.HiveTransactionHandle;
 import io.trino.plugin.hive.orc.OrcReaderConfig;
@@ -573,7 +574,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 stats,
                 ORC_READER_CONFIG,
                 PARQUET_READER_CONFIG,
-                TESTING_TYPE_MANAGER);
+                TESTING_TYPE_MANAGER,
+                ParquetFooterCache.noop());
         return factory.createPageSourceProvider().createPageSource(
                 transaction,
                 getSession(icebergConfig),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPageSourceProvider.java
@@ -15,9 +15,22 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ListMultimap;
 import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.filesystem.local.LocalInputFile;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.parquet.DiskRange;
+import io.trino.parquet.ParquetDataSource;
+import io.trino.parquet.ParquetDataSourceId;
+import io.trino.parquet.cache.MemoryParquetFooterCache;
+import io.trino.parquet.cache.ParquetFooterCache;
+import io.trino.parquet.cache.ParquetFooterCacheKey;
+import io.trino.parquet.metadata.ParquetMetadata;
+import io.trino.parquet.reader.ChunkedInputStream;
+import io.trino.parquet.reader.MetadataReader;
 import io.trino.parquet.writer.ParquetWriterOptions;
 import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
 import io.trino.plugin.hive.orc.OrcReaderConfig;
@@ -44,10 +57,14 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 
+import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.trino.hdfs.HdfsTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.hdfs.HdfsTestUtils.HDFS_FILE_SYSTEM_STATS;
 import static io.trino.parquet.ParquetTestUtils.writeParquetFile;
@@ -57,6 +74,8 @@ import static io.trino.plugin.iceberg.IcebergTestUtils.FILE_IO_FACTORY;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -159,6 +178,69 @@ class TestIcebergPageSourceProvider
         }
     }
 
+    @Test
+    void testParquetFooterCacheMissAndHit()
+            throws IOException
+    {
+        Slice parquetBytes = writeParquetFile(
+                ParquetWriterOptions.builder().build(),
+                ImmutableList.of(BIGINT),
+                ImmutableList.of("regionkey"),
+                ImmutableList.of(new Page(createBigintBlock(1L, 2L, 3L))));
+        ParquetFooterCacheKey key = new ParquetFooterCacheKey("file:///data.parquet", parquetBytes.length());
+        TestingParquetFooterCache cache = new TestingParquetFooterCache();
+
+        RecordingParquetDataSource missDataSource = new RecordingParquetDataSource(parquetBytes);
+        ParquetMetadata missMetadata = MetadataReader.readFooter(missDataSource, PARQUET_READER_CONFIG.toParquetReaderOptions(), Optional.empty(), Optional.empty(), cache, key);
+
+        assertThat(cache.gets).isEqualTo(1);
+        assertThat(cache.puts).isEqualTo(1);
+        assertThat(missDataSource.tailReadLengths).isNotEmpty();
+
+        RecordingParquetDataSource hitDataSource = new RecordingParquetDataSource(parquetBytes);
+        ParquetMetadata hitMetadata = MetadataReader.readFooter(hitDataSource, PARQUET_READER_CONFIG.toParquetReaderOptions(), Optional.empty(), Optional.empty(), cache, key);
+
+        assertThat(cache.gets).isEqualTo(2);
+        assertThat(cache.puts).isEqualTo(1);
+        assertThat(hitDataSource.tailReadLengths).isEmpty();
+        assertThat(hitMetadata.getBlocks()).hasSameSizeAs(missMetadata.getBlocks());
+    }
+
+    @Test
+    void testCorruptParquetFooterCacheFallsBack()
+            throws IOException
+    {
+        Slice parquetBytes = writeParquetFile(
+                ParquetWriterOptions.builder().build(),
+                ImmutableList.of(BIGINT),
+                ImmutableList.of("regionkey"),
+                ImmutableList.of(new Page(createBigintBlock(1L, 2L, 3L))));
+        ParquetFooterCacheKey key = new ParquetFooterCacheKey("file:///data.parquet", parquetBytes.length());
+        TestingParquetFooterCache cache = new TestingParquetFooterCache();
+        cache.values.put(key, Slices.allocate(8));
+
+        RecordingParquetDataSource dataSource = new RecordingParquetDataSource(parquetBytes);
+        MetadataReader.readFooter(dataSource, PARQUET_READER_CONFIG.toParquetReaderOptions(), Optional.empty(), Optional.empty(), cache, key);
+
+        assertThat(cache.invalidations).isEqualTo(1);
+        assertThat(cache.puts).isEqualTo(1);
+        assertThat(dataSource.tailReadLengths).isNotEmpty();
+    }
+
+    @Test
+    void testMemoryParquetFooterCacheIsBoundedByBytes()
+    {
+        MemoryParquetFooterCache cache = new MemoryParquetFooterCache(DataSize.of(8, BYTE));
+        ParquetFooterCacheKey oversizedKey = new ParquetFooterCacheKey("file:///large.parquet", 100);
+        ParquetFooterCacheKey maxSizeKey = new ParquetFooterCacheKey("file:///max.parquet", 100);
+
+        cache.put(oversizedKey, Slices.allocate(9));
+        cache.put(maxSizeKey, Slices.allocate(8));
+
+        assertThat(cache.get(oversizedKey)).isEmpty();
+        assertThat(cache.get(maxSizeKey)).isPresent();
+    }
+
     private static void writeParquetFileToDisk(Path path, List<Type> types, List<String> columnNames, Page page)
             throws IOException
     {
@@ -192,6 +274,97 @@ class TestIcebergPageSourceProvider
                 new FileFormatDataSourceStats(),
                 ORC_READER_CONFIG.toOrcReaderOptions(),
                 PARQUET_READER_CONFIG.toParquetReaderOptions(),
-                TESTING_TYPE_MANAGER);
+                TESTING_TYPE_MANAGER,
+                ParquetFooterCache.noop());
+    }
+
+    private static class TestingParquetFooterCache
+            implements ParquetFooterCache
+    {
+        private final Map<ParquetFooterCacheKey, Slice> values = new HashMap<>();
+        private int gets;
+        private int puts;
+        private int invalidations;
+
+        @Override
+        public Optional<Slice> get(ParquetFooterCacheKey key)
+        {
+            gets++;
+            return Optional.ofNullable(values.get(key));
+        }
+
+        @Override
+        public void put(ParquetFooterCacheKey key, Slice footerBytes)
+        {
+            puts++;
+            values.put(key, footerBytes.copy());
+        }
+
+        @Override
+        public void invalidate(ParquetFooterCacheKey key)
+        {
+            invalidations++;
+            values.remove(key);
+        }
+    }
+
+    private static class RecordingParquetDataSource
+            implements ParquetDataSource
+    {
+        private final ParquetDataSourceId id = new ParquetDataSourceId("recording");
+        private final Slice input;
+        private final List<Integer> tailReadLengths = new ArrayList<>();
+        private long readBytes;
+
+        public RecordingParquetDataSource(Slice input)
+        {
+            this.input = input;
+        }
+
+        @Override
+        public ParquetDataSourceId getId()
+        {
+            return id;
+        }
+
+        @Override
+        public long getReadBytes()
+        {
+            return readBytes;
+        }
+
+        @Override
+        public long getReadTimeNanos()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return input.length();
+        }
+
+        @Override
+        public Slice readTail(int length)
+        {
+            tailReadLengths.add(length);
+            int readSize = toIntExact(min(input.length(), length));
+            readBytes += readSize;
+            return input.slice(input.length() - readSize, readSize);
+        }
+
+        @Override
+        public Slice readFully(long position, int length)
+        {
+            readBytes += length;
+            return input.slice(toIntExact(position), length);
+        }
+
+        @Override
+        public <K> Map<K, ChunkedInputStream> planRead(ListMultimap<K, DiskRange> diskRanges, AggregatedMemoryContext memoryContext)
+        {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/plugin/trino-lakehouse/pom.xml
+++ b/plugin/trino-lakehouse/pom.xml
@@ -42,6 +42,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-delta-lake</artifactId>
         </dependency>
@@ -69,6 +74,11 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-metastore</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-parquet</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseIcebergModule.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseIcebergModule.java
@@ -15,10 +15,14 @@ package io.trino.plugin.lakehouse;
 
 import com.google.inject.Binder;
 import com.google.inject.Key;
+import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import com.google.inject.Singleton;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.metastore.HiveMetastoreFactory;
 import io.trino.metastore.RawHiveMetastoreFactory;
+import io.trino.parquet.cache.MemoryParquetFooterCache;
+import io.trino.parquet.cache.ParquetFooterCache;
 import io.trino.plugin.hive.metastore.MetastoreTypeConfig;
 import io.trino.plugin.iceberg.CommitTaskData;
 import io.trino.plugin.iceberg.DefaultIcebergFileSystemFactory;
@@ -85,5 +89,15 @@ public class LakehouseIcebergModule
         });
 
         binder.install(new IcebergExecutorModule());
+    }
+
+    @Provides
+    @Singleton
+    public static ParquetFooterCache createParquetFooterCache(IcebergConfig config)
+    {
+        return switch (config.getParquetFooterCacheType()) {
+            case NONE -> ParquetFooterCache.noop();
+            case MEMORY -> new MemoryParquetFooterCache(config.getParquetFooterCacheMemoryMaxSize());
+        };
     }
 }


### PR DESCRIPTION
## Description

Parquet footer reads in the Iceberg connector currently happen during page-source construction and require a tail read per Parquet file. On object stores, that extra tail read can add high latency even though the footer is small, parsed file-level metadata.

This adds a narrowly scoped Parquet footer cache for Iceberg. The Parquet reader now exposes footer-tail reading separately from footer parsing, while Iceberg owns the cache policy, configuration, and file identity. The default remains disabled.

Iceberg can now use either no footer cache or a bounded in-memory cache through:

- `iceberg.parquet-footer-cache.type=none|memory`
- `iceberg.parquet-footer-cache.memory.max-size`

The cache stores footer-tail bytes and parses them through the existing Parquet metadata path. Cache misses, corrupt cached bytes, disabled caching, and cache failures all fall back to the normal footer read path.

## Additional context and related issues

The cache key is based on Iceberg data file location and file size. This is intentionally connector-local because Iceberg data files are immutable, while other Parquet readers may need different identity rules.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Add an optional in-memory cache for Parquet file footers. ({issue}`issuenumber`)