### PR TITLE
Rename Parquet writer block size

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -225,8 +225,8 @@ The following table describes {ref}`catalog session properties
 * - `parquet_max_read_block_size`
   - The maximum block size used when reading Parquet files.
   - `16MB`
-* - `parquet_writer_block_size`
-  - The maximum block size created by the Parquet writer.
+* - `parquet_writer_row_group_size`
+  - The maximum row group size created by the Parquet writer.
   - `128MB`
 * - `parquet_writer_row_group_max_row_count`
   - The maximum row count of row groups created by the Parquet writer.

--- a/docs/src/main/sphinx/object-storage/file-formats.md
+++ b/docs/src/main/sphinx/object-storage/file-formats.md
@@ -70,9 +70,9 @@ with Parquet files performed by supported object storage connectors:
   - Maximum values count of pages written by Parquet writer. The equivalent 
     catalog session property is `parquet_writer_page_value_count`.
   - `80000`
-* - `parquet.writer.block-size`
+* - `parquet.writer.row-group-size`
   - Maximum size of row groups written by Parquet writer. The equivalent 
-    catalog session property is `parquet_writer_block_size`.
+    catalog session property is `parquet_writer_row_group_size`.
   - `128 MB`
 * - `parquet.writer.row-group-max-row-count`
   - Maximum number of rows in row groups written by Parquet writer. The

--- a/lib/trino-parquet/src/test/resources/lineitem_sorted_by_shipdate/README.md
+++ b/lib/trino-parquet/src/test/resources/lineitem_sorted_by_shipdate/README.md
@@ -4,7 +4,7 @@ It required using release <= 422 because the new Trino parquet writer does not s
 ```sql
 set session hive.parquet_writer_batch_size=10;
 set session hive.parquet_writer_page_size='10Kb';
-set session hive.parquet_writer_block_size='1MB';
+set session hive.parquet_writer_row_group_size='1MB';
 set session hive.parquet_optimized_writer_enabled=false;
 
 create table lineitem with (format='parquet', sorted_by=array['l_shipdate'], bucketed_by=array['l_shipdate'], bucket_count=1) as select * from tpch.tiny.lineitem;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
@@ -59,10 +59,10 @@ import static io.trino.metastore.Partitions.HIVE_DEFAULT_DYNAMIC_PARTITION;
 import static io.trino.metastore.Partitions.escapePathName;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_BAD_WRITE;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getCompressionCodec;
-import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterBlockSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageValueCount;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterRowGroupMaxRowCount;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterRowGroupSize;
 import static io.trino.plugin.deltalake.DeltaLakeTypes.toParquetType;
 import static io.trino.plugin.hive.HiveCompressionCodecs.toCompressionCodec;
 import static java.lang.String.format;
@@ -467,7 +467,7 @@ public abstract class AbstractDeltaLakePageSink
     private ParquetFileWriter createParquetFileWriter(Location path)
     {
         ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
-                .setMaxBlockSize(getParquetWriterBlockSize(session))
+                .setMaxBlockSize(getParquetWriterRowGroupSize(session))
                 .setMaxRowGroupRowCount(getParquetWriterRowGroupMaxRowCount(session))
                 .setMaxPageSize(getParquetWriterPageSize(session))
                 .setMaxPageValueCount(getParquetWriterPageValueCount(session))

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -78,10 +78,10 @@ import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_FILESYSTEM
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.relativePath;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.toUriFormat;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getCompressionCodec;
-import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterBlockSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageValueCount;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterRowGroupMaxRowCount;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterRowGroupSize;
 import static io.trino.plugin.deltalake.DeltaLakeTypes.toParquetType;
 import static io.trino.plugin.deltalake.DeltaLakeWriter.readStatistics;
 import static io.trino.plugin.deltalake.delete.DeletionVectors.readDeletionVectors;
@@ -518,7 +518,7 @@ public class DeltaLakeMergeSink
     private ParquetFileWriter createParquetFileWriter(Location path, List<DeltaLakeColumnHandle> dataColumns)
     {
         ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
-                .setMaxBlockSize(getParquetWriterBlockSize(session))
+                .setMaxBlockSize(getParquetWriterRowGroupSize(session))
                 .setMaxRowGroupRowCount(getParquetWriterRowGroupMaxRowCount(session))
                 .setMaxPageSize(getParquetWriterPageSize(session))
                 .setMaxPageValueCount(getParquetWriterPageValueCount(session))

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
@@ -35,9 +35,9 @@ import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMaxDataS
 import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMinDataSize;
 import static io.trino.plugin.hive.HiveTimestampPrecision.MILLISECONDS;
 import static io.trino.plugin.hive.parquet.ParquetReaderConfig.PARQUET_READER_MAX_SMALL_FILE_THRESHOLD;
-import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_BLOCK_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_VALUE_COUNT;
+import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_ROW_GROUP_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_VALUE_COUNT;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT;
@@ -60,7 +60,8 @@ public final class DeltaLakeSessionProperties
     private static final String PARQUET_USE_COLUMN_INDEX = "parquet_use_column_index";
     private static final String PARQUET_IGNORE_STATISTICS = "parquet_ignore_statistics";
     private static final String PARQUET_VECTORIZED_DECODING_ENABLED = "parquet_vectorized_decoding_enabled";
-    private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
+    private static final String PARQUET_WRITER_ROW_GROUP_SIZE = "parquet_writer_row_group_size";
+    private static final String LEGACY_PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT = "parquet_writer_row_group_max_row_count";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_PAGE_VALUE_COUNT = "parquet_writer_page_value_count";
@@ -144,10 +145,10 @@ public final class DeltaLakeSessionProperties
                         parquetReaderConfig.isVectorizedDecodingEnabled(),
                         false),
                 dataSizeProperty(
-                        PARQUET_WRITER_BLOCK_SIZE,
-                        "Parquet: Writer block size",
-                        parquetWriterConfig.getBlockSize(),
-                        value -> validateMaxDataSize(PARQUET_WRITER_BLOCK_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_BLOCK_SIZE)),
+                        PARQUET_WRITER_ROW_GROUP_SIZE,
+                        "Parquet: Writer row group size",
+                        parquetWriterConfig.getRowGroupSize(),
+                        value -> validateMaxDataSize(PARQUET_WRITER_ROW_GROUP_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_ROW_GROUP_SIZE)),
                         false),
                 integerProperty(
                         PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT,
@@ -161,6 +162,12 @@ public final class DeltaLakeSessionProperties
                             }
                         },
                         false),
+                dataSizeProperty(
+                        LEGACY_PARQUET_WRITER_BLOCK_SIZE,
+                        "Deprecated. Use parquet_writer_row_group_size instead.",
+                        null,
+                        value -> validateMaxDataSize(LEGACY_PARQUET_WRITER_BLOCK_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_ROW_GROUP_SIZE)),
+                        true),
                 dataSizeProperty(
                         PARQUET_WRITER_PAGE_SIZE,
                         "Parquet: Writer page size",
@@ -304,9 +311,13 @@ public final class DeltaLakeSessionProperties
         return session.getProperty(PARQUET_VECTORIZED_DECODING_ENABLED, Boolean.class);
     }
 
-    public static DataSize getParquetWriterBlockSize(ConnectorSession session)
+    public static DataSize getParquetWriterRowGroupSize(ConnectorSession session)
     {
-        return session.getProperty(PARQUET_WRITER_BLOCK_SIZE, DataSize.class);
+        DataSize legacyValue = session.getProperty(LEGACY_PARQUET_WRITER_BLOCK_SIZE, DataSize.class);
+        if (legacyValue != null) {
+            return legacyValue;
+        }
+        return session.getProperty(PARQUET_WRITER_ROW_GROUP_SIZE, DataSize.class);
     }
 
     public static int getParquetWriterRowGroupMaxRowCount(ConnectorSession session)

--- a/plugin/trino-delta-lake/src/test/resources/databricks73/pushdown/custkey_15rowgroups/README.md
+++ b/plugin/trino-delta-lake/src/test/resources/databricks73/pushdown/custkey_15rowgroups/README.md
@@ -37,7 +37,7 @@ Some interesting or useful statistics:
 
 This table was created from Trino using the following statements:
 ```sql
-SET SESSION delta.parquet_writer_block_size = '500B';
+SET SESSION delta.parquet_writer_row_group_size = '500B';
 
 CREATE TABLE delta.default.custkey_15rowgroups
 WITH (location = 's3://TEST_BUCKET/custkey_15rowgroups')

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -42,9 +42,9 @@ import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty
 import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMaxDataSize;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMinDataSize;
 import static io.trino.plugin.hive.parquet.ParquetReaderConfig.PARQUET_READER_MAX_SMALL_FILE_THRESHOLD;
-import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_BLOCK_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_VALUE_COUNT;
+import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_ROW_GROUP_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_VALUE_COUNT;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT;
@@ -99,7 +99,8 @@ public final class HiveSessionProperties
     private static final String PARQUET_MAX_READ_BLOCK_ROW_COUNT = "parquet_max_read_block_row_count";
     private static final String PARQUET_SMALL_FILE_THRESHOLD = "parquet_small_file_threshold";
     private static final String PARQUET_VECTORIZED_DECODING_ENABLED = "parquet_vectorized_decoding_enabled";
-    private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
+    private static final String PARQUET_WRITER_ROW_GROUP_SIZE = "parquet_writer_row_group_size";
+    private static final String LEGACY_PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT = "parquet_writer_row_group_max_row_count";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_PAGE_VALUE_COUNT = "parquet_writer_page_value_count";
@@ -369,10 +370,10 @@ public final class HiveSessionProperties
                         parquetReaderConfig.isVectorizedDecodingEnabled(),
                         false),
                 dataSizeProperty(
-                        PARQUET_WRITER_BLOCK_SIZE,
-                        "Parquet: Writer block size",
-                        parquetWriterConfig.getBlockSize(),
-                        value -> validateMaxDataSize(PARQUET_WRITER_BLOCK_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_BLOCK_SIZE)),
+                        PARQUET_WRITER_ROW_GROUP_SIZE,
+                        "Parquet: Writer row group size",
+                        parquetWriterConfig.getRowGroupSize(),
+                        value -> validateMaxDataSize(PARQUET_WRITER_ROW_GROUP_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_ROW_GROUP_SIZE)),
                         false),
                 integerProperty(
                         PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT,
@@ -386,6 +387,12 @@ public final class HiveSessionProperties
                             }
                         },
                         false),
+                dataSizeProperty(
+                        LEGACY_PARQUET_WRITER_BLOCK_SIZE,
+                        "Deprecated. Use parquet_writer_row_group_size instead.",
+                        null,
+                        value -> validateMaxDataSize(LEGACY_PARQUET_WRITER_BLOCK_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_ROW_GROUP_SIZE)),
+                        true),
                 dataSizeProperty(
                         PARQUET_WRITER_PAGE_SIZE,
                         "Parquet: Writer page size",
@@ -768,9 +775,13 @@ public final class HiveSessionProperties
         return session.getProperty(PARQUET_VECTORIZED_DECODING_ENABLED, Boolean.class);
     }
 
-    public static DataSize getParquetWriterBlockSize(ConnectorSession session)
+    public static DataSize getParquetWriterRowGroupSize(ConnectorSession session)
     {
-        return session.getProperty(PARQUET_WRITER_BLOCK_SIZE, DataSize.class);
+        DataSize legacyValue = session.getProperty(LEGACY_PARQUET_WRITER_BLOCK_SIZE, DataSize.class);
+        if (legacyValue != null) {
+            return legacyValue;
+        }
+        return session.getProperty(PARQUET_WRITER_ROW_GROUP_SIZE, DataSize.class);
     }
 
     public static int getParquetWriterRowGroupMaxRowCount(ConnectorSession session)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -109,7 +109,7 @@ public class ParquetFileWriterFactory
         ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                 .setMaxPageSize(HiveSessionProperties.getParquetWriterPageSize(session))
                 .setMaxPageValueCount(HiveSessionProperties.getParquetWriterPageValueCount(session))
-                .setMaxBlockSize(HiveSessionProperties.getParquetWriterBlockSize(session))
+                .setMaxBlockSize(HiveSessionProperties.getParquetWriterRowGroupSize(session))
                 .setMaxRowGroupRowCount(HiveSessionProperties.getParquetWriterRowGroupMaxRowCount(session))
                 .setBatchSize(HiveSessionProperties.getParquetBatchSize(session))
                 .setBloomFilterColumns(getParquetBloomFilterColumns(schema))

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetWriterConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetWriterConfig.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hive.parquet;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
+import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
@@ -38,14 +39,14 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 })
 public class ParquetWriterConfig
 {
-    public static final String PARQUET_WRITER_MAX_BLOCK_SIZE = "2GB";
+    public static final String PARQUET_WRITER_MAX_ROW_GROUP_SIZE = "2GB";
     public static final String PARQUET_WRITER_MIN_PAGE_SIZE = "8kB";
     public static final String PARQUET_WRITER_MAX_PAGE_SIZE = "8MB";
     public static final int PARQUET_WRITER_MIN_PAGE_VALUE_COUNT = 1000;
     public static final int PARQUET_WRITER_MAX_PAGE_VALUE_COUNT = 200_000;
     public static final int PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT = PARQUET_WRITER_MIN_PAGE_VALUE_COUNT;
 
-    private DataSize blockSize = DataSize.of(128, MEGABYTE);
+    private DataSize rowGroupSize = DataSize.of(128, MEGABYTE);
     private int rowGroupMaxRowCount = ParquetWriterOptions.DEFAULT_MAX_ROW_GROUP_ROW_COUNT;
     private DataSize pageSize = DataSize.ofBytes(ParquetProperties.DEFAULT_PAGE_SIZE);
     private int pageValueCount = ParquetWriterOptions.DEFAULT_MAX_PAGE_VALUE_COUNT;
@@ -53,16 +54,17 @@ public class ParquetWriterConfig
     private double validationPercentage = 5;
     private boolean deltaLengthByteArrayEncodingEnabled = true;
 
-    @MaxDataSize(PARQUET_WRITER_MAX_BLOCK_SIZE)
-    public DataSize getBlockSize()
+    @MaxDataSize(PARQUET_WRITER_MAX_ROW_GROUP_SIZE)
+    public DataSize getRowGroupSize()
     {
-        return blockSize;
+        return rowGroupSize;
     }
 
-    @Config("parquet.writer.block-size")
-    public ParquetWriterConfig setBlockSize(DataSize blockSize)
+    @Config("parquet.writer.row-group-size")
+    @LegacyConfig("parquet.writer.block-size")
+    public ParquetWriterConfig setRowGroupSize(DataSize rowGroupSize)
     {
-        this.blockSize = blockSize;
+        this.rowGroupSize = rowGroupSize;
         return this;
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkipping.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkipping.java
@@ -350,7 +350,7 @@ public class TestParquetPageSkipping
         assertUpdate(
                 Session.builder(getSession())
                         .setCatalogSessionProperty(catalog, "parquet_writer_page_size", "10000B")
-                        .setCatalogSessionProperty(catalog, "parquet_writer_block_size", "2GB")
+                        .setCatalogSessionProperty(catalog, "parquet_writer_row_group_size", "2GB")
                         .build(),
                 format("INSERT INTO %s SELECT *, ARRAY[rand(), rand(), rand()] FROM tpch.tiny.orders", tableName),
                 15000);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetWriterConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetWriterConfig.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static io.airlift.configuration.testing.ConfigAssertions.assertDeprecatedEquivalence;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
@@ -31,7 +32,7 @@ public class TestParquetWriterConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(ParquetWriterConfig.class)
-                .setBlockSize(DataSize.of(128, MEGABYTE))
+                .setRowGroupSize(DataSize.of(128, MEGABYTE))
                 .setRowGroupMaxRowCount(ParquetWriterOptions.DEFAULT_MAX_ROW_GROUP_ROW_COUNT)
                 .setPageSize(DataSize.ofBytes(ParquetProperties.DEFAULT_PAGE_SIZE))
                 .setPageValueCount(ParquetWriterOptions.DEFAULT_MAX_PAGE_VALUE_COUNT)
@@ -44,7 +45,7 @@ public class TestParquetWriterConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = Map.of(
-                "parquet.writer.block-size", "234MB",
+                "parquet.writer.row-group-size", "234MB",
                 "parquet.writer.row-group-max-row-count", "50000",
                 "parquet.writer.page-size", "6MB",
                 "parquet.writer.page-value-count", "10000",
@@ -53,7 +54,7 @@ public class TestParquetWriterConfig
                 "parquet.writer.delta-length-byte-array-encoding-enabled", "false");
 
         ParquetWriterConfig expected = new ParquetWriterConfig()
-                .setBlockSize(DataSize.of(234, MEGABYTE))
+                .setRowGroupSize(DataSize.of(234, MEGABYTE))
                 .setRowGroupMaxRowCount(50_000)
                 .setPageSize(DataSize.of(6, MEGABYTE))
                 .setPageValueCount(10_000)
@@ -62,5 +63,15 @@ public class TestParquetWriterConfig
                 .setDeltaLengthByteArrayEncodingEnabled(false);
 
         assertFullMapping(properties, expected);
+
+        Map<String, String> oldProperties = Map.of(
+                "parquet.writer.block-size", "234MB",
+                "parquet.writer.row-group-max-row-count", "50000",
+                "parquet.writer.page-size", "6MB",
+                "parquet.writer.page-value-count", "10000",
+                "parquet.writer.batch-size", "100",
+                "parquet.writer.validation-percentage", "10",
+                "parquet.writer.delta-length-byte-array-encoding-enabled", "false");
+        assertDeprecatedEquivalence(ParquetWriterConfig.class, properties, oldProperties);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -72,11 +72,11 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterMaxSt
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterMinStripeSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterValidateMode;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterBatchSize;
-import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterBlockSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterDeltaLengthByteArrayEncodingEnabled;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterPageSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterPageValueCount;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterRowGroupMaxRowCount;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterRowGroupSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isOrcWriterValidate;
 import static io.trino.plugin.iceberg.IcebergTableProperties.ORC_BLOOM_FILTER_FPP_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergUtil.getHiveCompressionCodec;
@@ -180,7 +180,7 @@ public class IcebergFileWriterFactory
             ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                     .setMaxPageSize(getParquetWriterPageSize(session))
                     .setMaxPageValueCount(getParquetWriterPageValueCount(session))
-                    .setMaxBlockSize(getParquetWriterBlockSize(session))
+                    .setMaxBlockSize(getParquetWriterRowGroupSize(session))
                     .setMaxRowGroupRowCount(getParquetWriterRowGroupMaxRowCount(session))
                     .setBatchSize(getParquetWriterBatchSize(session))
                     .setBloomFilterColumns(getParquetBloomFilterColumns(storageProperties))

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -42,9 +42,9 @@ import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty
 import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMaxDataSize;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMinDataSize;
 import static io.trino.plugin.hive.parquet.ParquetReaderConfig.PARQUET_READER_MAX_SMALL_FILE_THRESHOLD;
-import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_BLOCK_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_VALUE_COUNT;
+import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_ROW_GROUP_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_VALUE_COUNT;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT;
@@ -87,7 +87,8 @@ public final class IcebergSessionProperties
     private static final String PARQUET_SMALL_FILE_THRESHOLD = "parquet_small_file_threshold";
     private static final String PARQUET_IGNORE_STATISTICS = "parquet_ignore_statistics";
     private static final String PARQUET_VECTORIZED_DECODING_ENABLED = "parquet_vectorized_decoding_enabled";
-    private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
+    private static final String PARQUET_WRITER_ROW_GROUP_SIZE = "parquet_writer_row_group_size";
+    private static final String LEGACY_PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT = "parquet_writer_row_group_max_row_count";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_PAGE_VALUE_COUNT = "parquet_writer_page_value_count";
@@ -262,10 +263,10 @@ public final class IcebergSessionProperties
                         parquetReaderConfig.isVectorizedDecodingEnabled(),
                         false))
                 .add(dataSizeProperty(
-                        PARQUET_WRITER_BLOCK_SIZE,
-                        "Parquet: Writer block size",
-                        parquetWriterConfig.getBlockSize(),
-                        value -> validateMaxDataSize(PARQUET_WRITER_BLOCK_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_BLOCK_SIZE)),
+                        PARQUET_WRITER_ROW_GROUP_SIZE,
+                        "Parquet: Writer row group size",
+                        parquetWriterConfig.getRowGroupSize(),
+                        value -> validateMaxDataSize(PARQUET_WRITER_ROW_GROUP_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_ROW_GROUP_SIZE)),
                         false))
                 .add(integerProperty(
                         PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT,
@@ -279,6 +280,12 @@ public final class IcebergSessionProperties
                             }
                         },
                         false))
+                .add(dataSizeProperty(
+                        LEGACY_PARQUET_WRITER_BLOCK_SIZE,
+                        "Deprecated. Use parquet_writer_row_group_size instead.",
+                        null,
+                        value -> validateMaxDataSize(LEGACY_PARQUET_WRITER_BLOCK_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_ROW_GROUP_SIZE)),
+                        true))
                 .add(dataSizeProperty(
                         PARQUET_WRITER_PAGE_SIZE,
                         "Parquet: Writer page size",
@@ -557,9 +564,13 @@ public final class IcebergSessionProperties
         return session.getProperty(PARQUET_WRITER_PAGE_VALUE_COUNT, Integer.class);
     }
 
-    public static DataSize getParquetWriterBlockSize(ConnectorSession session)
+    public static DataSize getParquetWriterRowGroupSize(ConnectorSession session)
     {
-        return session.getProperty(PARQUET_WRITER_BLOCK_SIZE, DataSize.class);
+        DataSize legacyValue = session.getProperty(LEGACY_PARQUET_WRITER_BLOCK_SIZE, DataSize.class);
+        if (legacyValue != null) {
+            return legacyValue;
+        }
+        return session.getProperty(PARQUET_WRITER_ROW_GROUP_SIZE, DataSize.class);
     }
 
     public static int getParquetWriterRowGroupMaxRowCount(ConnectorSession session)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -5497,7 +5497,7 @@ public abstract class BaseIcebergConnectorTest
     private static Session withSplitPruningRowGroups(Session session)
     {
         return Session.builder(withSmallRowGroups(session))
-                .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "256B")
+                .setCatalogSessionProperty("iceberg", "parquet_writer_row_group_size", "256B")
                 .build();
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergParquetConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergParquetConnectorTest.java
@@ -202,7 +202,7 @@ public abstract class BaseIcebergParquetConnectorTest
     protected Session withTableChangesRowGroups(Session session)
     {
         return Session.builder(withSmallRowGroups(session))
-                .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "256B")
+                .setCatalogSessionProperty("iceberg", "parquet_writer_row_group_size", "256B")
                 .build();
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
@@ -107,7 +107,7 @@ public final class IcebergTestUtils
     {
         return Session.builder(session)
                 .setCatalogSessionProperty("iceberg", "orc_writer_max_stripe_rows", "20")
-                .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "1kB")
+                .setCatalogSessionProperty("iceberg", "parquet_writer_row_group_size", "1kB")
                 .setCatalogSessionProperty("iceberg", "parquet_writer_batch_size", "20")
                 .build();
     }

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergParquetFaultTolerantExecutionConnectorTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergParquetFaultTolerantExecutionConnectorTest.java
@@ -98,7 +98,7 @@ public class TestIcebergParquetFaultTolerantExecutionConnectorTest
     protected Session withTableChangesRowGroups(Session session)
     {
         return Session.builder(withSmallRowGroups(session))
-                .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "16kB")
+                .setCatalogSessionProperty("iceberg", "parquet_writer_row_group_size", "16kB")
                 .build();
     }
 


### PR DESCRIPTION
## Description

The Parquet writer size property still used legacy “block size” terminology, even though the setting controls the maximum Parquet row group size. This is especially confusing because nearby Parquet reader properties also use “read block” terminology, but those settings control reader-side batching/chunking rather than Parquet row groups.

This renames the writer-facing properties to modern row group terminology:

Config properties:

- `parquet.writer.block-size` -> `parquet.writer.row-group-size`

Session properties:

- `parquet_writer_block_size` -> `parquet_writer_row_group_size`

The legacy property names remain supported for compatibility.

## Additional context and related issues

This keeps the rename scoped to the Parquet writer row group size setting. Read-side properties such as `parquet.max-read-block-size` and `parquet_max_read_block_size` are intentionally unchanged because they do not control Parquet row group sizing.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Hive, Iceberg, Delta Lake, Lakehouse
* Rename the Parquet writer row group size configuration property from `parquet.writer.block-size` to `parquet.writer.row-group-size`, and the corresponding session property from `parquet_writer_block_size` to `parquet_writer_row_group_size`. The old property names remain supported for compatibility. ({issue}`issuenumber`)