### PR TITLE
Add User-Agent to JWKS requests

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwkService.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwkService.java
@@ -21,6 +21,7 @@ import io.airlift.http.client.Request;
 import io.airlift.http.client.StringResponseHandler.StringResponse;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
+import io.trino.spi.NodeVersion;
 import jakarta.annotation.Generated;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -35,6 +36,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.airlift.http.client.HeaderNames.USER_AGENT;
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
 import static io.trino.server.security.jwt.JwkDecoder.decodeKeys;
@@ -44,26 +46,29 @@ import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 public final class JwkService
 {
     private static final Logger log = Logger.get(JwkService.class);
+    private static final Duration DEFAULT_REFRESH_DELAY = new Duration(15, TimeUnit.MINUTES);
 
     private final URI address;
     private final HttpClient httpClient;
     private final Duration refreshDelay;
+    private final String userAgent;
     private final AtomicReference<Map<String, PublicKey>> keys;
 
     @Generated("this")
     private Closer closer;
 
-    public JwkService(URI address, HttpClient httpClient)
+    public JwkService(URI address, HttpClient httpClient, NodeVersion nodeVersion)
     {
-        this(address, httpClient, new Duration(15, TimeUnit.MINUTES));
+        this(address, httpClient, DEFAULT_REFRESH_DELAY, nodeVersion);
     }
 
     @VisibleForTesting
-    public JwkService(URI address, HttpClient httpClient, Duration refreshDelay)
+    public JwkService(URI address, HttpClient httpClient, Duration refreshDelay, NodeVersion nodeVersion)
     {
         this.address = requireNonNull(address, "address is null");
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.refreshDelay = requireNonNull(refreshDelay, "refreshDelay is null");
+        this.userAgent = "Trino/" + requireNonNull(nodeVersion, "nodeVersion is null").version();
 
         this.keys = new AtomicReference<>(fetchKeys());
     }
@@ -130,7 +135,10 @@ public final class JwkService
     private Map<String, PublicKey> fetchKeys()
             throws RuntimeException
     {
-        Request request = prepareGet().setUri(address).build();
+        Request request = prepareGet()
+                .setUri(address)
+                .setHeader(USER_AGENT, userAgent)
+                .build();
         StringResponse response;
         try {
             response = httpClient.execute(request, createStringResponseHandler());

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorSupportModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorSupportModule.java
@@ -22,6 +22,7 @@ import com.google.inject.TypeLiteral;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.http.client.HttpClient;
 import io.jsonwebtoken.Locator;
+import io.trino.spi.NodeVersion;
 
 import java.net.URI;
 import java.security.Key;
@@ -62,9 +63,9 @@ public class JwtAuthenticatorSupportModule
         @Provides
         @Singleton
         @ForJwt
-        public static JwkService createJwkService(JwtAuthenticatorConfig config, @ForJwt HttpClient httpClient)
+        public static JwkService createJwkService(JwtAuthenticatorConfig config, @ForJwt HttpClient httpClient, NodeVersion nodeVersion)
         {
-            return new JwkService(URI.create(config.getKeyFile()), httpClient);
+            return new JwkService(URI.create(config.getKeyFile()), httpClient, nodeVersion);
         }
 
         @Provides

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/NimbusAirliftHttpClient.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/NimbusAirliftHttpClient.java
@@ -26,6 +26,7 @@ import io.airlift.http.client.Response;
 import io.airlift.http.client.ResponseHandler;
 import io.airlift.http.client.ResponseHandlerUtils;
 import io.airlift.http.client.StringResponseHandler;
+import io.trino.spi.NodeVersion;
 import jakarta.ws.rs.core.UriBuilder;
 
 import java.io.IOException;
@@ -37,6 +38,7 @@ import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.GET;
 import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.POST;
 import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.PUT;
 import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
+import static io.airlift.http.client.HeaderNames.USER_AGENT;
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
 import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
@@ -48,11 +50,18 @@ public class NimbusAirliftHttpClient
         implements NimbusHttpClient
 {
     private final HttpClient httpClient;
+    private final String userAgent;
+
+    public NimbusAirliftHttpClient(HttpClient httpClient)
+    {
+        this(httpClient, new NodeVersion("unknown"));
+    }
 
     @Inject
-    public NimbusAirliftHttpClient(@ForOAuth2 HttpClient httpClient)
+    public NimbusAirliftHttpClient(@ForOAuth2 HttpClient httpClient, NodeVersion nodeVersion)
     {
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.userAgent = "Trino/" + requireNonNull(nodeVersion, "nodeVersion is null").version();
     }
 
     @Override
@@ -61,7 +70,10 @@ public class NimbusAirliftHttpClient
     {
         try {
             StringResponseHandler.StringResponse response = httpClient.execute(
-                    prepareGet().setUri(url.toURI()).build(),
+                    prepareGet()
+                            .setUri(url.toURI())
+                            .setHeader(USER_AGENT, userAgent)
+                            .build(),
                     createStringResponseHandler());
             return new Resource(response.getBody(), response.getHeader(CONTENT_TYPE).orElse(null));
         }

--- a/core/trino-main/src/test/java/io/trino/server/security/jwt/TestJwkService.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/jwt/TestJwkService.java
@@ -18,6 +18,7 @@ import io.airlift.http.client.HttpStatus;
 import io.airlift.http.client.Response;
 import io.airlift.http.client.testing.TestingHttpClient;
 import io.airlift.units.Duration;
+import io.trino.spi.NodeVersion;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
@@ -27,6 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static com.google.common.net.MediaType.JSON_UTF_8;
+import static io.airlift.http.client.HeaderNames.USER_AGENT;
 import static io.airlift.http.client.testing.TestingResponse.mockResponse;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -35,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestJwkService
 {
+    private static final NodeVersion TEST_VERSION = new NodeVersion("test-version");
     private static final String EMPTY_KEYS = "{ \"keys\": [] }";
     private static final String TEST_JWK_RESPONSE = "" +
             "{\n" +
@@ -75,15 +78,30 @@ public class TestJwkService
     public void testSuccess()
     {
         HttpClient httpClient = new TestingHttpClient(_ -> mockResponse(HttpStatus.OK, JSON_UTF_8, TEST_JWK_RESPONSE));
-        JwkService service = new JwkService(URI.create("http://example.com"), httpClient, new Duration(1, DAYS));
+        JwkService service = new JwkService(URI.create("http://example.com"), httpClient, new Duration(1, DAYS), TEST_VERSION);
         assertTestKeys(service);
+    }
+
+    @Test
+    public void testUserAgentHeader()
+    {
+        JwkService service = new JwkService(
+                URI.create("http://example.com"),
+                new TestingHttpClient(request -> {
+                    assertThat(request.getHeader(USER_AGENT)).isEqualTo("Trino/" + TEST_VERSION.version());
+                    return mockResponse(HttpStatus.OK, JSON_UTF_8, EMPTY_KEYS);
+                }),
+                new Duration(1, DAYS),
+                TEST_VERSION);
+
+        assertEmptyKeys(service);
     }
 
     @Test
     public void testReload()
     {
         AtomicReference<Response> response = new AtomicReference<>(mockResponse(HttpStatus.OK, JSON_UTF_8, EMPTY_KEYS));
-        JwkService service = new JwkService(URI.create("http://example.com"), new TestingHttpClient(_ -> response.get()), new Duration(1, DAYS));
+        JwkService service = new JwkService(URI.create("http://example.com"), new TestingHttpClient(_ -> response.get()), new Duration(1, DAYS), TEST_VERSION);
         assertEmptyKeys(service);
 
         response.set(mockResponse(HttpStatus.OK, JSON_UTF_8, EMPTY_KEYS));
@@ -108,7 +126,7 @@ public class TestJwkService
             throws InterruptedException
     {
         AtomicReference<Supplier<Response>> response = new AtomicReference<>(() -> mockResponse(HttpStatus.OK, JSON_UTF_8, EMPTY_KEYS));
-        JwkService service = new JwkService(URI.create("http://example.com"), new TestingHttpClient(_ -> response.get().get()), new Duration(1, MILLISECONDS));
+        JwkService service = new JwkService(URI.create("http://example.com"), new TestingHttpClient(_ -> response.get().get()), new Duration(1, MILLISECONDS), TEST_VERSION);
         assertEmptyKeys(service);
 
         try {
@@ -145,7 +163,8 @@ public class TestJwkService
                     }
                     return value;
                 }),
-                new Duration(1, DAYS));
+                new Duration(1, DAYS),
+                TEST_VERSION);
         assertTestKeys(service);
 
         // request failure
@@ -165,7 +184,7 @@ public class TestJwkService
     public void testBadResponse()
     {
         AtomicReference<Response> response = new AtomicReference<>(mockResponse(HttpStatus.OK, JSON_UTF_8, TEST_JWK_RESPONSE));
-        JwkService service = new JwkService(URI.create("http://example.com"), new TestingHttpClient(_ -> response.get()), new Duration(1, DAYS));
+        JwkService service = new JwkService(URI.create("http://example.com"), new TestingHttpClient(_ -> response.get()), new Duration(1, DAYS), TEST_VERSION);
         assertTestKeys(service);
 
         // bad response code document

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/BaseOAuth2WebUiAuthenticationFilterTest.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/BaseOAuth2WebUiAuthenticationFilterTest.java
@@ -30,6 +30,7 @@ import io.trino.server.security.jwt.JwkSigningKeyLocator;
 import io.trino.server.testing.TestingTrinoServer;
 import io.trino.server.ui.OAuth2WebUiAuthenticationFilter;
 import io.trino.server.ui.WebUiModule;
+import io.trino.spi.NodeVersion;
 import okhttp3.Cookie;
 import okhttp3.CookieJar;
 import okhttp3.HttpUrl;
@@ -79,6 +80,8 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @Execution(CONCURRENT)
 public abstract class BaseOAuth2WebUiAuthenticationFilterTest
 {
+    private static final NodeVersion TEST_VERSION = new NodeVersion("test-version");
+
     protected static final Duration TTL_ACCESS_TOKEN_IN_SECONDS = Duration.ofSeconds(5);
 
     protected static final String TRINO_CLIENT_ID = "trino-client";
@@ -376,7 +379,8 @@ public abstract class BaseOAuth2WebUiAuthenticationFilterTest
             return newJwtParserBuilder()
                     .keyLocator(new JwkSigningKeyLocator(new JwkService(
                             URI.create("https://localhost:" + hydraIdP.getAuthPort() + "/.well-known/jwks.json"),
-                            httpClient)))
+                            httpClient,
+                            TEST_VERSION)))
                     .build()
                     .parseSignedClaims(claimsJws);
         }

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestNimbusAirliftHttpClient.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestNimbusAirliftHttpClient.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import com.nimbusds.jose.util.Resource;
+import io.airlift.http.client.HttpStatus;
+import io.airlift.http.client.testing.TestingHttpClient;
+import io.trino.spi.NodeVersion;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static io.airlift.http.client.HeaderNames.USER_AGENT;
+import static io.airlift.http.client.testing.TestingResponse.mockResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestNimbusAirliftHttpClient
+{
+    private static final NodeVersion TEST_VERSION = new NodeVersion("test-version");
+
+    @Test
+    public void testRetrieveResourceUserAgentHeader()
+            throws Exception
+    {
+        NimbusAirliftHttpClient client = new NimbusAirliftHttpClient(
+                new TestingHttpClient(request -> {
+                    assertThat(request.getHeader(USER_AGENT)).isEqualTo("Trino/" + TEST_VERSION.version());
+                    return mockResponse(HttpStatus.OK, JSON_UTF_8, "{}");
+                }),
+                TEST_VERSION);
+
+        Resource resource = client.retrieveResource(URI.create("http://example.com/jwks").toURL());
+
+        assertThat(resource.getContent()).isEqualTo("{}");
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilterWithRefreshTokens.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilterWithRefreshTokens.java
@@ -26,6 +26,7 @@ import io.trino.server.security.jwt.JwkSigningKeyLocator;
 import io.trino.server.testing.TestingTrinoServer;
 import io.trino.server.ui.OAuth2WebUiAuthenticationFilter;
 import io.trino.server.ui.WebUiModule;
+import io.trino.spi.NodeVersion;
 import okhttp3.JavaNetCookieJar;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -57,6 +58,8 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @Execution(CONCURRENT)
 public class TestOAuth2WebUiAuthenticationFilterWithRefreshTokens
 {
+    private static final NodeVersion TEST_VERSION = new NodeVersion("test-version");
+
     protected static final Duration TTL_ACCESS_TOKEN_IN_SECONDS = Duration.ofSeconds(5);
 
     protected static final String TRINO_CLIENT_ID = "trino-client";
@@ -209,7 +212,8 @@ public class TestOAuth2WebUiAuthenticationFilterWithRefreshTokens
             assertThatThrownBy(() -> newJwtParserBuilder()
                     .keyLocator(new JwkSigningKeyLocator(new JwkService(
                             URI.create("https://localhost:" + hydraIdP.getAuthPort() + "/.well-known/jwks.json"),
-                            httpClient)))
+                            httpClient,
+                            TEST_VERSION)))
                     .build()
                     .parseSignedClaims(claimsJws));
         }


### PR DESCRIPTION
## Description

Fixes #29669.

JWKS fetches for JWT authentication and OAuth2 token validation now send a `User-Agent` header. The value is derived from the server `NodeVersion` as `Trino/<version>`, avoiding a hard-coded release number.

## Root Cause

Airlift removes Jetty's default `User-Agent`, and these two JWKS request paths did not set one explicitly. Endpoints behind proxies, WAFs, or identity providers that require `User-Agent` could reject the requests.

## Reproduction and Tests

Added focused regression tests that reproduce the missing-header condition by inspecting the outbound `TestingHttpClient` request:

- `TestJwkService.testUserAgentHeader`
- `TestNimbusAirliftHttpClient.testRetrieveResourceUserAgentHeader`

## Validation

- `./mvnw -pl :trino-main -am -DskipTests install`
- `./mvnw -pl :trino-main -Dtest=TestJwkService,TestNimbusAirliftHttpClient test`
- `git diff --check`

The targeted test run passed: 7 tests, 0 failures.
