### PR TITLE
Add REST API table description supplier for Kafka connector

### DIFF
--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConfig.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConfig.java
@@ -100,7 +100,7 @@ public class KafkaConfig
     }
 
     @Config("kafka.table-description-supplier")
-    @ConfigDescription("The table description supplier to use, default is FILE")
+    @ConfigDescription("The table description supplier to use: file, rest, or confluent. Default is file")
     public KafkaConfig setTableDescriptionSupplier(String tableDescriptionSupplier)
     {
         this.tableDescriptionSupplier = tableDescriptionSupplier;

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorModule.java
@@ -26,6 +26,8 @@ import io.trino.plugin.kafka.schema.confluent.ConfluentModule;
 import io.trino.plugin.kafka.schema.confluent.ConfluentSchemaRegistryTableDescriptionSupplier;
 import io.trino.plugin.kafka.schema.file.FileTableDescriptionSupplier;
 import io.trino.plugin.kafka.schema.file.FileTableDescriptionSupplierModule;
+import io.trino.plugin.kafka.schema.rest.RestTableDescriptionSupplier;
+import io.trino.plugin.kafka.schema.rest.RestTableDescriptionSupplierModule;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorRecordSetProvider;
@@ -60,6 +62,7 @@ public class KafkaConnectorModule
         KafkaConfig kafkaConfig = buildConfigObject(KafkaConfig.class);
         switch (kafkaConfig.getTableDescriptionSupplier().toLowerCase(ENGLISH)) {
             case FileTableDescriptionSupplier.NAME -> install(new FileTableDescriptionSupplierModule());
+            case RestTableDescriptionSupplier.NAME -> install(new RestTableDescriptionSupplierModule());
             case ConfluentSchemaRegistryTableDescriptionSupplier.NAME -> install(new ConfluentModule());
         }
         newSetBinder(binder, SessionPropertiesProvider.class).addBinding().to(KafkaSessionProperties.class).in(Scopes.SINGLETON);

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTopicFieldGroup.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTopicFieldGroup.java
@@ -32,8 +32,8 @@ public record KafkaTopicFieldGroup(
     public KafkaTopicFieldGroup
     {
         requireNonNull(dataFormat, "dataFormat is null");
-        requireNonNull(dataSchema, "dataSchema is null");
-        requireNonNull(subject, "subject is null");
+        dataSchema = dataSchema != null ? dataSchema : Optional.empty();
+        subject = subject != null ? subject : Optional.empty();
         fields = ImmutableList.copyOf(requireNonNull(fields, "fields is null"));
     }
 }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/rest/RestPlainAvroDecoderModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/rest/RestPlainAvroDecoderModule.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.rest;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.multibindings.MapBinder;
+import io.trino.decoder.DispatchingRowDecoderFactory;
+import io.trino.decoder.RowDecoderFactory;
+import io.trino.decoder.avro.AvroBytesDeserializer;
+import io.trino.decoder.avro.AvroDeserializer;
+import io.trino.decoder.avro.AvroReaderSupplier;
+import io.trino.decoder.avro.AvroRowDecoderFactory;
+import io.trino.decoder.avro.FixedSchemaAvroReaderSupplier;
+import io.trino.decoder.csv.CsvRowDecoder;
+import io.trino.decoder.csv.CsvRowDecoderFactory;
+import io.trino.decoder.dummy.DummyRowDecoder;
+import io.trino.decoder.dummy.DummyRowDecoderFactory;
+import io.trino.decoder.json.JsonRowDecoder;
+import io.trino.decoder.json.JsonRowDecoderFactory;
+import io.trino.decoder.protobuf.ProtobufDecoderModule;
+import io.trino.decoder.raw.RawRowDecoder;
+import io.trino.decoder.raw.RawRowDecoderFactory;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.multibindings.MapBinder.newMapBinder;
+
+/**
+ * Decoder bindings for Kafka topics that use plain Avro binary (no Confluent wire-format header).
+ * Use when {@code kafka.confluent-schema-registry-url} is not set: the default
+ * {@link io.trino.decoder.DecoderModule} binds {@link io.trino.decoder.avro.AvroFileDeserializer},
+ * which expects Avro object-container files, not
+ * per-message Kafka payloads.
+ */
+public class RestPlainAvroDecoderModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        MapBinder<String, RowDecoderFactory> mapBinder =
+                newMapBinder(binder, String.class, RowDecoderFactory.class);
+        mapBinder.addBinding(DummyRowDecoder.NAME).to(DummyRowDecoderFactory.class).in(SINGLETON);
+        mapBinder.addBinding(CsvRowDecoder.NAME).to(CsvRowDecoderFactory.class).in(SINGLETON);
+        mapBinder.addBinding(JsonRowDecoder.NAME).to(JsonRowDecoderFactory.class).in(SINGLETON);
+        mapBinder.addBinding(RawRowDecoder.NAME).to(RawRowDecoderFactory.class).in(SINGLETON);
+        mapBinder.addBinding(AvroRowDecoderFactory.NAME).to(AvroRowDecoderFactory.class).in(SINGLETON);
+
+        binder.bind(AvroReaderSupplier.Factory.class).to(FixedSchemaAvroReaderSupplier.Factory.class).in(SINGLETON);
+        binder.bind(AvroDeserializer.Factory.class).to(AvroBytesDeserializer.Factory.class).in(SINGLETON);
+
+        binder.install(new ProtobufDecoderModule());
+        binder.bind(DispatchingRowDecoderFactory.class).in(SINGLETON);
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/rest/RestTableDescriptionSupplier.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/rest/RestTableDescriptionSupplier.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.airlift.json.JsonCodec;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import io.trino.plugin.kafka.KafkaConfig;
+import io.trino.plugin.kafka.KafkaTopicDescription;
+import io.trino.plugin.kafka.schema.TableDescriptionSupplier;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaTableName;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Fetches table and schema descriptions from a REST API instead of the file system.
+ * The API must return a JSON array of KafkaTopicDescription objects (same structure as file-based JSON).
+ * Only the configured API URL is called; no external or user-supplied URLs are used.
+ */
+public class RestTableDescriptionSupplier
+        implements TableDescriptionSupplier
+{
+    public static final String NAME = "rest";
+
+    private static final Logger log = Logger.get(RestTableDescriptionSupplier.class);
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    private final URI tableDescriptionApiUrl;
+    private final String defaultSchema;
+    private final JsonCodec<KafkaTopicDescription> topicDescriptionCodec;
+    private final long refreshIntervalMillis;
+
+    private final AtomicReference<CachedDescriptions> cache = new AtomicReference<>();
+    private final ReentrantLock refreshLock = new ReentrantLock();
+    private final HttpClient httpClient;
+
+    @Inject
+    public RestTableDescriptionSupplier(
+            RestTableDescriptionSupplierConfig config,
+            KafkaConfig kafkaConfig,
+            JsonCodec<KafkaTopicDescription> topicDescriptionCodec)
+    {
+        this.tableDescriptionApiUrl = requireNonNull(config.getTableDescriptionApiUrl(), "tableDescriptionApiUrl is null");
+        this.defaultSchema = requireNonNull(kafkaConfig.getDefaultSchema(), "defaultSchema is null");
+        this.topicDescriptionCodec = requireNonNull(topicDescriptionCodec, "topicDescriptionCodec is null");
+        Duration refresh = config.getRefreshInterval();
+        this.refreshIntervalMillis = refresh == null ? 0 : refresh.toMillis();
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(java.time.Duration.ofSeconds(10))
+                .build();
+    }
+
+    @Override
+    public Set<SchemaTableName> listTables()
+    {
+        return loadDescriptions().keySet();
+    }
+
+    @Override
+    public Optional<KafkaTopicDescription> getTopicDescription(ConnectorSession session, SchemaTableName schemaTableName)
+    {
+        KafkaTopicDescription description = loadDescriptions().get(schemaTableName);
+        if (description == null) {
+            return Optional.empty();
+        }
+        return Optional.of(description);
+    }
+
+    private Map<SchemaTableName, KafkaTopicDescription> loadDescriptions()
+    {
+        long now = System.currentTimeMillis();
+        CachedDescriptions cached = cache.get();
+        if (cached != null && refreshIntervalMillis > 0 && (now - cached.loadedAtMillis) < refreshIntervalMillis) {
+            return cached.descriptions;
+        }
+
+        if (refreshIntervalMillis > 0) {
+            refreshLock.lock();
+            try {
+                cached = cache.get();
+                if (cached != null && (now - cached.loadedAtMillis) < refreshIntervalMillis) {
+                    return cached.descriptions;
+                }
+                return fetchAndCacheDescriptions();
+            }
+            finally {
+                refreshLock.unlock();
+            }
+        }
+        return fetchAndCacheDescriptions();
+    }
+
+    private Map<SchemaTableName, KafkaTopicDescription> fetchAndCacheDescriptions()
+    {
+        ImmutableMap.Builder<SchemaTableName, KafkaTopicDescription> builder = ImmutableMap.builder();
+
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(tableDescriptionApiUrl)
+                    .GET()
+                    .timeout(java.time.Duration.ofSeconds(30))
+                    .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+
+            if (response.statusCode() != 200) {
+                throw new IllegalStateException("Table description API returned status " + response.statusCode());
+            }
+
+            String body = response.body();
+            if (body == null || body.isBlank()) {
+                log.debug("Table description API returned empty body");
+                return builder.buildOrThrow();
+            }
+
+            JsonNode root = JSON_MAPPER.readTree(body);
+            if (!root.isArray()) {
+                throw new IllegalStateException("Table description API must return a JSON array of table descriptions");
+            }
+
+            for (JsonNode node : root) {
+                KafkaTopicDescription table = topicDescriptionCodec.fromJson(node.toString());
+                String schemaName = table.schemaName().orElse(defaultSchema);
+                SchemaTableName schemaTableName = new SchemaTableName(schemaName, table.tableName());
+                builder.put(schemaTableName, table);
+            }
+
+            ImmutableMap<SchemaTableName, KafkaTopicDescription> descriptions = builder.buildOrThrow();
+            cache.set(new CachedDescriptions(descriptions, System.currentTimeMillis()));
+            log.debug("Loaded %s table descriptions from REST API", descriptions.size());
+            return descriptions;
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while fetching table descriptions from API", e);
+        }
+        catch (Exception e) {
+            CachedDescriptions existing = cache.get();
+            if (existing != null) {
+                log.warn(e, "Failed to refresh table descriptions from API, using cached data");
+                return existing.descriptions;
+            }
+            throw new RuntimeException("Failed to load table descriptions from REST API: " + tableDescriptionApiUrl, e);
+        }
+    }
+
+    private static final class CachedDescriptions
+    {
+        final Map<SchemaTableName, KafkaTopicDescription> descriptions;
+        final long loadedAtMillis;
+
+        CachedDescriptions(Map<SchemaTableName, KafkaTopicDescription> descriptions, long loadedAtMillis)
+        {
+            this.descriptions = descriptions;
+            this.loadedAtMillis = loadedAtMillis;
+        }
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/rest/RestTableDescriptionSupplierConfig.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/rest/RestTableDescriptionSupplierConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.rest;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
+import io.airlift.units.MaxDuration;
+import io.airlift.units.MinDuration;
+import jakarta.validation.constraints.NotNull;
+
+import java.net.URI;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class RestTableDescriptionSupplierConfig
+{
+    private URI tableDescriptionApiUrl;
+    private Duration refreshInterval = new Duration(30, SECONDS);
+
+    @NotNull(message = "kafka.table-description-api-url is required when using rest table description supplier")
+    public URI getTableDescriptionApiUrl()
+    {
+        return tableDescriptionApiUrl;
+    }
+
+    @Config("kafka.table-description-api-url")
+    @ConfigDescription("Base URL of the REST API that returns Kafka table and schema descriptions (JSON array of table description objects)")
+    public RestTableDescriptionSupplierConfig setTableDescriptionApiUrl(String tableDescriptionApiUrl)
+    {
+        this.tableDescriptionApiUrl = tableDescriptionApiUrl == null || tableDescriptionApiUrl.isBlank()
+                ? null
+                : URI.create(tableDescriptionApiUrl.trim());
+        return this;
+    }
+
+    @MinDuration("1s")
+    @MaxDuration("1h")
+    public Duration getRefreshInterval()
+    {
+        return refreshInterval;
+    }
+
+    @Config("kafka.table-description-api-refresh-interval")
+    @ConfigDescription("How often to refresh table list from the REST API")
+    public RestTableDescriptionSupplierConfig setRefreshInterval(Duration refreshInterval)
+    {
+        this.refreshInterval = refreshInterval;
+        return this;
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/rest/RestTableDescriptionSupplierModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/rest/RestTableDescriptionSupplierModule.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.rest;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.decoder.protobuf.DescriptorProvider;
+import io.trino.decoder.protobuf.FileDescriptorProvider;
+import io.trino.plugin.kafka.encoder.EncoderModule;
+import io.trino.plugin.kafka.schema.ContentSchemaProvider;
+import io.trino.plugin.kafka.schema.ProtobufAnySupportConfig;
+import io.trino.plugin.kafka.schema.TableDescriptionSupplier;
+import io.trino.plugin.kafka.schema.file.FileReadContentSchemaProvider;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class RestTableDescriptionSupplierModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(RestTableDescriptionSupplierConfig.class);
+
+        binder.bind(TableDescriptionSupplier.class).to(RestTableDescriptionSupplier.class).in(SINGLETON);
+
+        install(new RestPlainAvroDecoderModule());
+        binder.bind(ContentSchemaProvider.class).to(FileReadContentSchemaProvider.class).in(SINGLETON);
+
+        install(new EncoderModule());
+
+        configBinder(binder).bindConfig(ProtobufAnySupportConfig.class);
+        if (buildConfigObject(ProtobufAnySupportConfig.class).isProtobufAnySupportEnabled()) {
+            install(new FileDescriptorProviderModule());
+        }
+    }
+
+    private static class FileDescriptorProviderModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            binder.bind(DescriptorProvider.class).to(FileDescriptorProvider.class).in(SINGLETON);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `rest` table description supplier for the Kafka connector that fetches topic and schema definitions from a REST API endpoint instead of the local file system. This enables dynamic table discovery in environments where schema metadata is managed centrally (e.g. a data catalog or metadata service).

**New classes** in `plugin/trino-kafka/schema/rest/`:
- `RestTableDescriptionSupplier` — fetches and caches `KafkaTopicDescription` objects from a configured HTTP endpoint (GET, JSON array response). Falls back to the last successful cache if the API is temporarily unavailable
- `RestTableDescriptionSupplierConfig` — config for the new supplier
- `RestTableDescriptionSupplierModule` — Guice wiring
- `RestPlainAvroDecoderModule` — plain binary Avro decoder bindings (no Confluent wire-format)

**Existing file changes:**
- `KafkaConnectorModule` — adds `rest` case to the supplier switch
- `KafkaConfig` — updates `kafka.table-description-supplier` description to mention `rest`
- `KafkaTopicFieldGroup` — makes `dataSchema`/`subject` null-safe via `Optional.empty()` fallback so topic descriptions that omit these fields don't throw at construction time

## Configuration

```properties
kafka.table-description-supplier=rest
kafka.table-description-api-url=http://metadata-service/api/topics
kafka.table-description-api-refresh-interval=30s   # optional, default 30s
```

## Test plan

- [ ] `kafka.table-description-supplier=rest` wires up `RestTableDescriptionSupplier` via `KafkaConnectorModule`
- [ ] API fetch, JSON parsing, and caching behaviour with a local mock HTTP server
- [ ] Config validation: missing `kafka.table-description-api-url` fails startup with a clear message
- [ ] Refresh interval: cached descriptions expire and re-fetch after the configured interval
- [ ] Stale-cache fallback: API failure returns last successful result instead of throwing