### PR TITLE
Throw EOFException for reads past end of file in AlluxioInput

### DIFF
--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInput.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInput.java
@@ -71,11 +71,11 @@ public class AlluxioInput
         if (length == 0) {
             return;
         }
+        if (length > fileLength - position) {
+            throw new EOFException("Read past end of file %s: position %s, length %s, file length %s".formatted(inputFile.location(), position, length, fileLength));
+        }
 
         int bytesRead = helper.doCacheRead(position, buffer, offset, length);
-        if (length > bytesRead && position + bytesRead == fileLength) {
-            throw new EOFException("Read %s of %s requested bytes: %s".formatted(bytesRead, length, inputFile.location()));
-        }
         doExternalRead(position + bytesRead, buffer, offset + bytesRead, length - bytesRead);
     }
 

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystem.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystem.java
@@ -18,13 +18,17 @@ import io.airlift.units.DataSize;
 import io.trino.filesystem.AbstractTestTrinoFileSystem;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInput;
 import io.trino.filesystem.cache.CacheFileSystem;
 import io.trino.filesystem.cache.DefaultCacheKeyProvider;
 import io.trino.filesystem.memory.MemoryFileSystem;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
+import java.io.EOFException;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
@@ -33,6 +37,7 @@ import java.util.stream.Stream;
 
 import static io.airlift.tracing.Tracing.noopTracer;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestAlluxioCacheFileSystem
         extends AbstractTestTrinoFileSystem
@@ -80,6 +85,23 @@ public class TestAlluxioCacheFileSystem
                 }
             }
         }
+    }
+
+    @Test
+    void testReadFullyPastEndOfFile()
+            throws IOException
+    {
+        Location location = getRootLocation().appendPath("testReadFullyPastEndOfFile");
+        byte[] content = new byte[64];
+        try (OutputStream output = fileSystem.newOutputFile(location).create()) {
+            output.write(content);
+        }
+        // cold-cache positioned read starting beyond the file length takes the external read path
+        try (TrinoInput input = fileSystem.newInputFile(location).newInput()) {
+            assertThatThrownBy(() -> input.readFully(content.length + 16, new byte[16], 0, 16))
+                    .isInstanceOf(EOFException.class);
+        }
+        fileSystem.deleteFile(location);
     }
 
     @Override


### PR DESCRIPTION
## Description

`AlluxioInput.readFully` signalled end of file only when a cache read landed exactly on the file length. A cold-cache read starting past the end of the file instead failed with `ArrayIndexOutOfBoundsException` from the page-aligned external read, rather than the expected `EOFException`.

This guards the requested length against the remaining bytes up front, so any past-end read throws `EOFException` regardless of cache state. The added test reproduces the original `ArrayIndexOutOfBoundsException` and verifies the corrected behavior.

## Additional context and related issues

## Release notes

(x) This is not user-visible or is an internal change, and no release notes are required.