### PR TITLE
Clean up equi-join hash strategy codegen

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/index/IndexSnapshotBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/IndexSnapshotBuilder.java
@@ -33,6 +33,7 @@ import java.util.OptionalInt;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.trino.operator.join.JoinUtils.rowContainsNull;
 import static java.util.Objects.requireNonNull;
 
 public class IndexSnapshotBuilder
@@ -136,7 +137,8 @@ public class IndexSnapshotBuilder
         while (indexKeysRecordCursor.advanceNextPosition()) {
             Page page = indexKeysRecordCursor.getPage();
             int position = indexKeysRecordCursor.getPosition();
-            if (lookupSource.getJoinPosition(position, page, page) < 0) {
+            // getJoinPosition requires non-null keys; a null key matches nothing, so record it as missing.
+            if (rowContainsNull(page, position) || lookupSource.getJoinPosition(position, page, page) < 0) {
                 missingKeysPageBuilder.declarePosition();
                 for (int i = 0; i < page.getChannelCount(); i++) {
                     Block block = page.getBlock(i);

--- a/core/trino-main/src/main/java/io/trino/operator/index/UnloadedIndexKeyRecordSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/UnloadedIndexKeyRecordSet.java
@@ -21,7 +21,6 @@ import io.trino.operator.FlatHashStrategyCompiler;
 import io.trino.operator.GroupByHash;
 import io.trino.operator.Work;
 import io.trino.spi.Page;
-import io.trino.spi.block.Block;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.RecordSet;
 import io.trino.spi.type.Type;
@@ -39,6 +38,7 @@ import static com.google.common.base.Verify.verify;
 import static io.trino.operator.GroupByHash.createGroupByHash;
 import static io.trino.operator.UpdateMemory.NOOP;
 import static io.trino.operator.index.IndexSnapshot.UNLOADED_INDEX_KEY;
+import static io.trino.operator.join.JoinUtils.rowContainsNull;
 import static java.util.Objects.requireNonNull;
 
 public class UnloadedIndexKeyRecordSet
@@ -82,7 +82,7 @@ public class UnloadedIndexKeyRecordSet
             IntList positions = new IntArrayList(groupCount);
             for (int position = 0; position < positionCount; position++) {
                 // We are reading ahead in the cursors, so we need to filter any nulls since they cannot join
-                if (!containsNullValue(position, page)) {
+                if (!rowContainsNull(page, position)) {
                     // Only include the key if it is not already in the index
                     if (existingSnapshot.getJoinPosition(position, page) == UNLOADED_INDEX_KEY) {
                         // Only add the position if we have not seen this tuple before (based on the distinct channels)
@@ -113,17 +113,6 @@ public class UnloadedIndexKeyRecordSet
     public UnloadedIndexKeyRecordCursor cursor()
     {
         return new UnloadedIndexKeyRecordCursor(types, pageAndPositions);
-    }
-
-    private static boolean containsNullValue(int position, Page page)
-    {
-        for (int channel = 0; channel < page.getChannelCount(); channel++) {
-            Block block = page.getBlock(channel);
-            if (block.isNull(position)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     public static class UnloadedIndexKeyRecordCursor

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinUtils.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinUtils.java
@@ -77,6 +77,26 @@ public final class JoinUtils
         return OptionalInt.empty();
     }
 
+    public static boolean pageMayHaveNull(Page page)
+    {
+        for (int channel = 0; channel < page.getChannelCount(); channel++) {
+            if (page.getBlock(channel).mayHaveNull()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean rowContainsNull(Page page, int position)
+    {
+        for (int channel = 0; channel < page.getChannelCount(); channel++) {
+            if (page.getBlock(channel).isNull(position)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static boolean isBuildSideReplicated(PlanNode node)
     {
         checkArgument(node instanceof JoinNode || node instanceof SemiJoinNode);

--- a/core/trino-main/src/main/java/io/trino/operator/join/spilling/JoinProbe.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/spilling/JoinProbe.java
@@ -20,6 +20,8 @@ import io.trino.spi.Page;
 import java.util.List;
 
 import static com.google.common.base.Verify.verify;
+import static io.trino.operator.join.JoinUtils.pageMayHaveNull;
+import static io.trino.operator.join.JoinUtils.rowContainsNull;
 
 public class JoinProbe
 {
@@ -54,7 +56,7 @@ public class JoinProbe
         this.positionCount = page.getPositionCount();
         this.page = page;
         this.probePage = probePage;
-        this.probeMayHaveNull = probeMayHaveNull(probePage);
+        this.probeMayHaveNull = pageMayHaveNull(probePage);
     }
 
     public int[] getOutputChannels()
@@ -75,7 +77,7 @@ public class JoinProbe
 
     public long getCurrentJoinPosition(LookupSource lookupSource)
     {
-        if (probeMayHaveNull && currentRowContainsNull()) {
+        if (probeMayHaveNull && rowContainsNull(probePage, position)) {
             return -1;
         }
         return lookupSource.getJoinPosition(position, probePage, page);
@@ -89,25 +91,5 @@ public class JoinProbe
     public Page getPage()
     {
         return page;
-    }
-
-    private boolean currentRowContainsNull()
-    {
-        for (int i = 0; i < probePage.getChannelCount(); i++) {
-            if (probePage.getBlock(i).isNull(position)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean probeMayHaveNull(Page probePage)
-    {
-        for (int i = 0; i < probePage.getChannelCount(); i++) {
-            if (probePage.getBlock(i).mayHaveNull()) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
@@ -540,7 +540,7 @@ public class JoinCompiler
                     .cast(Block.class);
 
             BytecodeExpression rightBlock = rightPage.invoke("getBlock", Block.class, constantInt(index));
-            BytecodeNode equalityCondition = typeEqualsIgnoreNulls(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightPosition);
+            BytecodeNode equalityCondition = typeEqualsBothNotNull(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightPosition);
 
             LabelNode checkNextField = new LabelNode("checkNextField");
             positionEqualsRowMethod
@@ -715,7 +715,7 @@ public class JoinCompiler
                     .invoke("get", Object.class, rightBlockIndex)
                     .cast(Block.class);
 
-            BytecodeNode equalityCondition = typeEqualsIgnoreNulls(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
+            BytecodeNode equalityCondition = typeEqualsBothNotNull(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
 
             LabelNode checkNextField = new LabelNode("checkNextField");
             positionEqualsPositionMethod
@@ -879,7 +879,10 @@ public class JoinCompiler
                 .append(isNull);
     }
 
-    private BytecodeNode typeEqualsIgnoreNulls(
+    // Both inputs are non-null on every equi-join key, so the equal operator skips its internal isNull checks.
+    // Callers guarantee this: DefaultPagesHash.indexPages skips null build positions, JoinProbe filters null
+    // probe rows, IndexSnapshotBuilder skips null index keys.
+    private BytecodeNode typeEqualsBothNotNull(
             CallSiteBinder callSiteBinder,
             Type type,
             BytecodeExpression leftBlock,
@@ -887,7 +890,7 @@ public class JoinCompiler
             BytecodeExpression rightBlock,
             BytecodeExpression rightBlockPosition)
     {
-        MethodHandle equalOperator = typeOperators.getEqualOperator(type, simpleConvention(DEFAULT_ON_NULL, BLOCK_POSITION, BLOCK_POSITION));
+        MethodHandle equalOperator = typeOperators.getEqualOperator(type, simpleConvention(DEFAULT_ON_NULL, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL));
         return invokeDynamic(
                 BOOTSTRAP_METHOD,
                 ImmutableList.of(callSiteBinder.bind(equalOperator).getBindingId()),

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
@@ -492,6 +492,7 @@ public class JoinCompiler
             rowIdenticalToRowMethod
                     .getBody()
                     .append(typeIdentical(
+                            rowIdenticalToRowMethod.getScope(),
                             callSiteBinder,
                             type,
                             leftBlock,
@@ -592,7 +593,7 @@ public class JoinCompiler
             LabelNode checkNextField = new LabelNode("checkNextField");
             positionIdenticalToRowPosition
                     .getBody()
-                    .append(typeIdentical(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightPosition))
+                    .append(typeIdentical(positionIdenticalToRowPosition.getScope(), callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightPosition))
                     .ifTrueGoto(checkNextField)
                     .push(false)
                     .retBoolean()
@@ -640,13 +641,14 @@ public class JoinCompiler
             Type type = joinChannelTypes.get(index);
 
             body.append(new IfStatement()
-                    .condition(typeIdentical(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightPosition))
+                    .condition(typeIdentical(scope, callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightPosition))
                     .ifFalse(constantFalse().ret()));
         }
         body.append(constantTrue().ret());
     }
 
     private BytecodeNode typeIdentical(
+            Scope scope,
             CallSiteBinder callSiteBinder,
             Type type,
             BytecodeExpression leftBlock,
@@ -654,12 +656,19 @@ public class JoinCompiler
             BytecodeExpression rightBlock,
             BytecodeExpression rightBlockPosition)
     {
-        return new IfStatement()
-                .condition(BytecodeExpressions.or(leftBlock.invoke("isNull", boolean.class, leftBlockPosition), rightBlock.invoke("isNull", boolean.class, rightBlockPosition)))
-                .ifTrue(BytecodeExpressions.and(
-                        leftBlock.invoke("isNull", boolean.class, leftBlockPosition),
-                        rightBlock.invoke("isNull", boolean.class, rightBlockPosition)))
-                .ifFalse(typeIdenticalIgnoreNulls(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightBlockPosition));
+        Variable leftBlockVariable = scope.createTempVariable(Block.class);
+        Variable rightBlockVariable = scope.createTempVariable(Block.class);
+        Variable leftNull = scope.createTempVariable(boolean.class);
+        Variable rightNull = scope.createTempVariable(boolean.class);
+        return new BytecodeBlock()
+                .append(leftBlockVariable.set(leftBlock))
+                .append(rightBlockVariable.set(rightBlock))
+                .append(leftNull.set(leftBlockVariable.invoke("isNull", boolean.class, leftBlockPosition)))
+                .append(rightNull.set(rightBlockVariable.invoke("isNull", boolean.class, rightBlockPosition)))
+                .append(new IfStatement()
+                        .condition(BytecodeExpressions.or(leftNull, rightNull))
+                        .ifTrue(BytecodeExpressions.and(leftNull, rightNull))
+                        .ifFalse(typeIdenticalIgnoreNulls(callSiteBinder, type, leftBlockVariable, leftBlockPosition, rightBlockVariable, rightBlockPosition)));
     }
 
     // Both inputs are non-null here; the isNull guard in typeIdentical handles the null cases, so the
@@ -771,7 +780,7 @@ public class JoinCompiler
             LabelNode checkNextField = new LabelNode("checkNextField");
             positionIdenticalToPositionMethod
                     .getBody()
-                    .append(typeIdentical(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightBlockPosition))
+                    .append(typeIdentical(positionIdenticalToPositionMethod.getScope(), callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightBlockPosition))
                     .ifTrueGoto(checkNextField)
                     .push(false)
                     .retBoolean()

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
@@ -662,6 +662,8 @@ public class JoinCompiler
                 .ifFalse(typeIdenticalIgnoreNulls(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightBlockPosition));
     }
 
+    // Both inputs are non-null here; the isNull guard in typeIdentical handles the null cases, so the
+    // identical operator can skip its internal isNull checks.
     private BytecodeExpression typeIdenticalIgnoreNulls(
             CallSiteBinder callSiteBinder,
             Type type,
@@ -670,7 +672,7 @@ public class JoinCompiler
             BytecodeExpression rightBlock,
             BytecodeExpression rightBlockPosition)
     {
-        MethodHandle identicalOperator = typeOperators.getIdenticalOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION));
+        MethodHandle identicalOperator = typeOperators.getIdenticalOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL));
         return invokeDynamic(
                 BOOTSTRAP_METHOD,
                 ImmutableList.of(callSiteBinder.bind(identicalOperator).getBindingId()),

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
@@ -242,10 +242,10 @@ public class JoinCompiler
         generateHashPositionMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields);
         generateHashRowMethod(classDefinition, callSiteBinder, joinChannelTypes);
         generateRowIdenticalToRowMethod(classDefinition, callSiteBinder, joinChannelTypes);
-        generatePositionEqualsRowMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields, true);
+        generatePositionEqualsRowMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields);
         generatePositionIdenticalRowMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields);
         generatePositionIdenticalToRowWithPageMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields);
-        generatePositionEqualsPositionMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields, true);
+        generatePositionEqualsPositionMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields);
         generatePositionIdenticalToPositionMethod(classDefinition, callSiteBinder, joinChannelTypes, joinChannelFields);
         generateIsPositionNull(classDefinition, joinChannelFields);
         generateCompareSortChannelPositionsMethod(classDefinition, callSiteBinder, types, channelFields, sortChannel);
@@ -514,8 +514,7 @@ public class JoinCompiler
             ClassDefinition classDefinition,
             CallSiteBinder callSiteBinder,
             List<Type> joinChannelTypes,
-            List<FieldDefinition> joinChannelFields,
-            boolean ignoreNulls)
+            List<FieldDefinition> joinChannelFields)
     {
         Parameter leftBlockIndex = arg("leftBlockIndex", int.class);
         Parameter leftBlockPosition = arg("leftBlockPosition", int.class);
@@ -523,7 +522,7 @@ public class JoinCompiler
         Parameter rightPage = arg("rightPage", Page.class);
         MethodDefinition positionEqualsRowMethod = classDefinition.declareMethod(
                 a(PUBLIC),
-                ignoreNulls ? "positionEqualsRowIgnoreNulls" : "positionEqualsRow",
+                "positionEqualsRowIgnoreNulls",
                 type(boolean.class),
                 leftBlockIndex,
                 leftBlockPosition,
@@ -541,13 +540,7 @@ public class JoinCompiler
                     .cast(Block.class);
 
             BytecodeExpression rightBlock = rightPage.invoke("getBlock", Block.class, constantInt(index));
-            BytecodeNode equalityCondition;
-            if (ignoreNulls) {
-                equalityCondition = typeEqualsIgnoreNulls(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightPosition);
-            }
-            else {
-                equalityCondition = typeEquals(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightPosition);
-            }
+            BytecodeNode equalityCondition = typeEqualsIgnoreNulls(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightPosition);
 
             LabelNode checkNextField = new LabelNode("checkNextField");
             positionEqualsRowMethod
@@ -693,8 +686,7 @@ public class JoinCompiler
             ClassDefinition classDefinition,
             CallSiteBinder callSiteBinder,
             List<Type> joinChannelTypes,
-            List<FieldDefinition> joinChannelFields,
-            boolean ignoreNulls)
+            List<FieldDefinition> joinChannelFields)
     {
         Parameter leftBlockIndex = arg("leftBlockIndex", int.class);
         Parameter leftBlockPosition = arg("leftBlockPosition", int.class);
@@ -702,7 +694,7 @@ public class JoinCompiler
         Parameter rightBlockPosition = arg("rightBlockPosition", int.class);
         MethodDefinition positionEqualsPositionMethod = classDefinition.declareMethod(
                 a(PUBLIC),
-                ignoreNulls ? "positionEqualsPositionIgnoreNulls" : "positionEqualsPosition",
+                "positionEqualsPositionIgnoreNulls",
                 type(boolean.class),
                 leftBlockIndex,
                 leftBlockPosition,
@@ -723,13 +715,7 @@ public class JoinCompiler
                     .invoke("get", Object.class, rightBlockIndex)
                     .cast(Block.class);
 
-            BytecodeNode equalityCondition;
-            if (ignoreNulls) {
-                equalityCondition = typeEqualsIgnoreNulls(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
-            }
-            else {
-                equalityCondition = typeEquals(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
-            }
+            BytecodeNode equalityCondition = typeEqualsIgnoreNulls(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
 
             LabelNode checkNextField = new LabelNode("checkNextField");
             positionEqualsPositionMethod
@@ -891,30 +877,6 @@ public class JoinCompiler
         isSortChannelPositionNullMethod
                 .getBody()
                 .append(isNull);
-    }
-
-    private BytecodeNode typeEquals(
-            CallSiteBinder callSiteBinder,
-            Type type,
-            BytecodeExpression leftBlock,
-            BytecodeExpression leftBlockPosition,
-            BytecodeExpression rightBlock,
-            BytecodeExpression rightBlockPosition)
-    {
-        IfStatement ifStatement = new IfStatement();
-        ifStatement.condition()
-                .append(leftBlock.invoke("isNull", boolean.class, leftBlockPosition))
-                .append(rightBlock.invoke("isNull", boolean.class, rightBlockPosition))
-                .append(OpCode.IOR);
-
-        ifStatement.ifTrue()
-                .append(leftBlock.invoke("isNull", boolean.class, leftBlockPosition))
-                .append(rightBlock.invoke("isNull", boolean.class, rightBlockPosition))
-                .append(OpCode.IAND);
-
-        ifStatement.ifFalse().append(typeEqualsIgnoreNulls(callSiteBinder, type, leftBlock, leftBlockPosition, rightBlock, rightBlockPosition));
-
-        return ifStatement;
     }
 
     private BytecodeNode typeEqualsIgnoreNulls(

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestJoinCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestJoinCompiler.java
@@ -21,6 +21,7 @@ import io.trino.operator.SimplePagesHashStrategy;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
 import io.trino.sql.gen.JoinCompiler.PagesHashStrategyFactory;
@@ -42,6 +43,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJoinCompiler
@@ -267,6 +269,49 @@ public class TestJoinCompiler
                     doubleChannel.get(leftBlockIndex),
                     booleanChannel.get(leftBlockIndex),
                     extraChannel.get(leftBlockIndex)));
+        }
+    }
+
+    @Test
+    void testStructuralChannel()
+    {
+        // ARRAY equality has a nullable return; compiling the hash strategy must adapt it to DEFAULT_ON_NULL.
+        Type arrayType = new ArrayType(BIGINT);
+        List<Integer> joinChannels = Ints.asList(0);
+
+        PagesHashStrategyFactory pagesHashStrategyFactory = joinCompiler.compilePagesHashStrategyFactory(ImmutableList.of(arrayType), joinChannels);
+
+        ObjectArrayList<Block> channel = new ObjectArrayList<>();
+        channel.add(BlockAssertions.createArrayBigintBlock(asList(
+                asList(1L, 2L),
+                asList(1L, null),
+                null,
+                asList(1L, 2L),
+                asList(3L))));
+
+        PagesHashStrategy hashStrategy = pagesHashStrategyFactory.createPagesHashStrategy(ImmutableList.of(channel));
+
+        assertThat(hashStrategy.getChannelCount()).isEqualTo(1);
+
+        BlockTypeOperators blockTypeOperators = new BlockTypeOperators();
+        BlockPositionEqual equalOperator = blockTypeOperators.getEqualOperator(arrayType);
+        BlockPositionIsIdentical identicalOperator = blockTypeOperators.getIdenticalOperator(arrayType);
+
+        Block block = channel.get(0);
+        for (int leftPosition = 0; leftPosition < block.getPositionCount(); leftPosition++) {
+            for (int rightPosition = 0; rightPosition < block.getPositionCount(); rightPosition++) {
+                boolean expectedIdentical = identicalOperator.isIdentical(block, leftPosition, block, rightPosition);
+                assertThat(hashStrategy.positionIdenticalToPosition(0, leftPosition, 0, rightPosition)).isEqualTo(expectedIdentical);
+                assertThat(hashStrategy.positionIdenticalToRow(0, leftPosition, rightPosition, new Page(block))).isEqualTo(expectedIdentical);
+                assertThat(hashStrategy.rowIdenticalToRow(leftPosition, new Page(block), rightPosition, new Page(block))).isEqualTo(expectedIdentical);
+
+                // positionEquals*IgnoreNulls callers guarantee non-null inputs; a non-null array with a null element compares as no match.
+                if (!block.isNull(leftPosition) && !block.isNull(rightPosition)) {
+                    boolean expected = equalOperator.equal(block, leftPosition, block, rightPosition);
+                    assertThat(hashStrategy.positionEqualsPositionIgnoreNulls(0, leftPosition, 0, rightPosition)).isEqualTo(expected);
+                    assertThat(hashStrategy.positionEqualsRowIgnoreNulls(0, leftPosition, rightPosition, new Page(block))).isEqualTo(expected);
+                }
+            }
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
@@ -348,4 +348,31 @@ public class TestJoin
                 """))
                 .returnsEmptyResult();
     }
+
+    @Test
+    void testNullKeysInEquiJoin()
+    {
+        // Multi-column varchar keys route through DefaultPagesHash, whose equality codegen assumes non-null keys.
+        // EQUAL excludes rows with any null key.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM (VALUES ('a', 'x'), ('b', CAST(null AS varchar)), (CAST(null AS varchar), 'z')) t(a, b)
+                JOIN (VALUES ('a', 'x'), ('b', CAST(null AS varchar)), (CAST(null AS varchar), 'z')) u(a, b)
+                  ON t.a = u.a AND t.b = u.b
+                """))
+                .skippingTypesCheck()
+                .matches("VALUES ('a', 'x', 'a', 'x')");
+
+        // IS NOT DISTINCT FROM matches null to null and stays in the join filter, not the equi-join keys.
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM (VALUES ('a', 'x'), ('b', CAST(null AS varchar)), (CAST(null AS varchar), 'z')) t(a, b)
+                JOIN (VALUES ('a', 'x'), ('b', CAST(null AS varchar)), (CAST(null AS varchar), 'z')) u(a, b)
+                  ON t.a IS NOT DISTINCT FROM u.a AND t.b IS NOT DISTINCT FROM u.b
+                """))
+                .skippingTypesCheck()
+                .matches("VALUES ('a', 'x', 'a', 'x'), ('b', null, 'b', null), (null, 'z', null, 'z')");
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Code cleanup in the equi-join hash strategy codegen (`JoinCompiler`):

- Drop dead code: the `ignoreNulls` parameter (always passed `true`) and the `typeEquals` helper it selected. `PagesHashStrategy` declares only the `IgnoreNulls` variants.
- In the branches where both inputs are already proven non-null, request the equal/identical operators with the `BLOCK_POSITION_NOT_NULL` convention so they skip their internal `isNull` checks.
- Evaluate each identical-comparison block and its null flag once instead of re-emitting them per use.

No functional change.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Split into four self-contained commits for review. The generated `identical` methods are exercised by window functions, streaming aggregation, and table functions (peer-group/framing boundary detection); equality methods by the join hash path.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
