### PR TITLE
Extend optimized aggregation decorrelation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/AggregationDecorrelation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/AggregationDecorrelation.java
@@ -15,7 +15,6 @@ package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.Symbol;
@@ -29,7 +28,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.trino.metadata.GlobalFunctionCatalog.isBuiltinFunctionName;
+import static io.trino.sql.planner.plan.AggregationNode.Step.SINGLE;
 
 final class AggregationDecorrelation
 {
@@ -55,37 +54,15 @@ final class AggregationDecorrelation
      */
     public static boolean isNullRowInsensitiveAggregation(AggregationNode node)
     {
+        // For PARTIAL/FINAL/INTERMEDIATE steps, the aggregation.getResolvedFunction() inspected below does not carry the @InputFunction attributes
+        checkArgument(node.getStep() == SINGLE, "Expected SINGLE step aggregation, got %s", node.getStep());
+
         for (Aggregation aggregation : node.getAggregations().values()) {
-            // TODO pre-existing (moved), but probably redundant check
-            if (aggregation.getFilter().isPresent() || aggregation.getMask().isPresent()) {
+            if (!aggregation.getArguments().stream().allMatch(AggregationDecorrelation::isNullOnNullInput)) {
                 return false;
             }
-            CatalogSchemaFunctionName name = aggregation.getResolvedFunction().name();
-            if (!isBuiltinFunctionName(name)) {
-                // Unrecognized
+            if (aggregation.getResolvedFunction().functionNullability().getArgumentNullable().stream().allMatch(nullable -> nullable)) {
                 return false;
-            }
-            switch (name.functionName()) {
-                // TODO this should be determined from aggregation function metadata
-                case "min", "max", "sum", "avg", "bool_and", "bool_or" -> {
-                    if (!aggregation.getArguments().stream().allMatch(AggregationDecorrelation::isNullOnNullInput)) {
-                        return false;
-                    }
-                }
-                case "count" -> {
-                    if (aggregation.getArguments().isEmpty()) {
-                        // count(*)
-                        return false;
-                    }
-                    // count(a...)
-                    if (!aggregation.getArguments().stream().allMatch(AggregationDecorrelation::isNullOnNullInput)) {
-                        return false;
-                    }
-                }
-                default -> {
-                    // Unrecognized
-                    return false;
-                }
             }
         }
         return true;

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithProjection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithProjection.java
@@ -22,7 +22,6 @@ import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
-import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
@@ -38,7 +37,6 @@ import static io.trino.sql.ir.Booleans.FALSE;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.Comparison.Operator.EQUAL;
 import static io.trino.sql.ir.Comparison.Operator.GREATER_THAN;
-import static io.trino.sql.ir.Logical.Operator.AND;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregationFunction;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.assignUniqueId;
@@ -282,17 +280,14 @@ public class TestTransformCorrelatedGlobalAggregationWithProjection
                                         singleGroupingSet("unique", "corr"),
                                         ImmutableMap.of(Optional.of("sum_1"), aggregationFunction("sum", ImmutableList.of("a"))),
                                         ImmutableList.of(),
-                                        ImmutableList.of("new_mask"),
+                                        ImmutableList.of("mask"),
                                         Optional.empty(),
                                         SINGLE,
-                                        project(
-                                                ImmutableMap.of("new_mask", expression(new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "mask"), new Reference(BOOLEAN, "non_null"))))),
-                                                join(LEFT, builder -> builder
-                                                        .left(assignUniqueId(
-                                                                "unique",
-                                                                values(ImmutableMap.of("corr", 0))))
-                                                        .right(project(ImmutableMap.of("non_null", expression(TRUE)),
-                                                                values(ImmutableMap.of("a", 0, "mask", 1)))))))));
+                                        join(LEFT, builder -> builder
+                                                .left(assignUniqueId(
+                                                        "unique",
+                                                        values(ImmutableMap.of("corr", 0))))
+                                                .right(values(ImmutableMap.of("a", 0, "mask", 1)))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithoutProjection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedGlobalAggregationWithoutProjection.java
@@ -21,7 +21,6 @@ import io.trino.spi.function.OperatorType;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
-import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
@@ -32,11 +31,11 @@ import java.util.Optional;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.Comparison.Operator.EQUAL;
 import static io.trino.sql.ir.Comparison.Operator.GREATER_THAN;
-import static io.trino.sql.ir.Logical.Operator.AND;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregationFunction;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.assignUniqueId;
@@ -204,6 +203,84 @@ public class TestTransformCorrelatedGlobalAggregationWithoutProjection
     }
 
     @Test
+    public void skipsMaskForStddev()
+    {
+        tester().assertThat(new TransformCorrelatedGlobalAggregationWithoutProjection(tester().getPlannerContext()))
+                .on(p -> p.correlatedJoin(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.aggregation(ab -> ab
+                                .source(p.values(p.symbol("a"), p.symbol("b")))
+                                .addAggregation(p.symbol("stddev_agg", DOUBLE), PlanBuilder.aggregation("stddev", ImmutableList.of(new Reference(BIGINT, "a"))), ImmutableList.of(BIGINT))
+                                .globalGrouping())))
+                .matches(
+                        project(ImmutableMap.of("stddev_agg", expression(new Reference(DOUBLE, "stddev_agg")), "corr", expression(new Reference(BIGINT, "corr"))),
+                                aggregation(ImmutableMap.of("stddev_agg", aggregationFunction("stddev", ImmutableList.of("a"))),
+                                        join(LEFT, builder -> builder
+                                                .left(assignUniqueId(
+                                                        "unique",
+                                                        values(ImmutableMap.of("corr", 0))))
+                                                .right(values(ImmutableMap.of("a", 0, "b", 1)))))));
+    }
+
+    @Test
+    public void skipsMaskForCorrelation()
+    {
+        tester().assertThat(new TransformCorrelatedGlobalAggregationWithoutProjection(tester().getPlannerContext()))
+                .on(p -> p.correlatedJoin(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.aggregation(ab -> ab
+                                .source(p.values(p.symbol("a", DOUBLE), p.symbol("b", DOUBLE)))
+                                .addAggregation(
+                                        p.symbol("corr_agg", DOUBLE),
+                                        PlanBuilder.aggregation("corr", ImmutableList.of(new Reference(DOUBLE, "a"), new Reference(DOUBLE, "b"))),
+                                        ImmutableList.of(DOUBLE, DOUBLE))
+                                .globalGrouping())))
+                .matches(
+                        project(ImmutableMap.of("corr_agg", expression(new Reference(DOUBLE, "corr_agg")), "corr", expression(new Reference(BIGINT, "corr"))),
+                                aggregation(ImmutableMap.of("corr_agg", aggregationFunction("corr", ImmutableList.of("a", "b"))),
+                                        join(LEFT, builder -> builder
+                                                .left(assignUniqueId(
+                                                        "unique",
+                                                        values(ImmutableMap.of("corr", 0))))
+                                                .right(values(ImmutableMap.of("a", 0, "b", 1)))))));
+    }
+
+    @Test
+    public void skipsMaskForApproxPercentileWithProjectedConstant()
+    {
+        tester().assertThat(new TransformCorrelatedGlobalAggregationWithoutProjection(tester().getPlannerContext()))
+                .on(p -> p.correlatedJoin(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        p.aggregation(ab -> ab
+                                .source(p.project(
+                                        Assignments.builder()
+                                                .put(p.symbol("a", DOUBLE), new Reference(DOUBLE, "a"))
+                                                .put(p.symbol("lit_0_5", DOUBLE), new Constant(DOUBLE, 0.5))
+                                                .build(),
+                                        p.values(p.symbol("a", DOUBLE))))
+                                .addAggregation(
+                                        p.symbol("percentile_agg", DOUBLE),
+                                        PlanBuilder.aggregation("approx_percentile", ImmutableList.of(new Reference(DOUBLE, "a"), new Reference(DOUBLE, "lit_0_5"))),
+                                        ImmutableList.of(DOUBLE, DOUBLE))
+                                .globalGrouping())))
+                .matches(
+                        project(ImmutableMap.of("percentile_agg", expression(new Reference(DOUBLE, "percentile_agg")), "corr", expression(new Reference(BIGINT, "corr"))),
+                                aggregation(ImmutableMap.of("percentile_agg", aggregationFunction("approx_percentile", ImmutableList.of("a", "lit_0_5"))),
+                                        join(LEFT, builder -> builder
+                                                .left(assignUniqueId(
+                                                        "unique",
+                                                        values(ImmutableMap.of("corr", 0))))
+                                                .right(project(
+                                                        ImmutableMap.of(
+                                                                "a", expression(new Reference(DOUBLE, "a")),
+                                                                "lit_0_5", expression(new Constant(DOUBLE, 0.5))),
+                                                        values(ImmutableMap.of("a", 0))))))));
+    }
+
+    @Test
     public void testSubqueryWithCount()
     {
         tester().assertThat(new TransformCorrelatedGlobalAggregationWithoutProjection(tester().getPlannerContext()))
@@ -335,16 +412,13 @@ public class TestTransformCorrelatedGlobalAggregationWithoutProjection
                                         singleGroupingSet("corr", "unique"),
                                         ImmutableMap.of(Optional.of("count_non_null_values"), aggregationFunction("count", ImmutableList.of("a"))),
                                         ImmutableList.of(),
-                                        ImmutableList.of("new_mask"),
+                                        ImmutableList.of("mask"),
                                         Optional.empty(),
                                         SINGLE,
-                                        project(
-                                                ImmutableMap.of("new_mask", expression(new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "mask"), new Reference(BOOLEAN, "non_null"))))),
-                                                join(LEFT, builder -> builder
-                                                        .left(assignUniqueId(
-                                                                "unique",
-                                                                values(ImmutableMap.of("corr", 0))))
-                                                        .right(project(ImmutableMap.of("non_null", expression(TRUE)),
-                                                                values(ImmutableMap.of("a", 0, "mask", 1)))))))));
+                                        join(LEFT, builder -> builder
+                                                .left(assignUniqueId(
+                                                        "unique",
+                                                        values(ImmutableMap.of("corr", 0))))
+                                                .right(values(ImmutableMap.of("a", 0, "mask", 1)))))));
     }
 }


### PR DESCRIPTION
Extend logic in `TransformCorrelatedGlobalAggregation*Projection` so that it avoids redundant mask symbols for more aggregations.
