### PR TITLE
Keep CLA workflow green when CLA is missing

### DIFF
--- a/.github/bin/check-cla.js
+++ b/.github/bin/check-cla.js
@@ -351,8 +351,7 @@ async function main() {
         await setStatus(target.statusSha, 'failure', 'CLA is missing for one or more commit authors');
         await bestEffortUpdatePullRequests(() => markTargetFailed(target, result.message));
         const missing = result.unidentified || result.missing;
-        console.error(`CLA check failed for ${describeTarget(target)}: ${missing.join(', ')}`);
-        process.exitCode = 1;
+        console.log(`CLA status for ${describeTarget(target)} is failure: ${missing.join(', ')}`);
         return;
     }
     catch (error) {


### PR DESCRIPTION
Missing CLA results are now reported through `verification/cla-signed` without failing the CLA workflow job.

The workflow still fails when the checker cannot complete.