### PR TITLE
Support concrete aggregation state type parameters

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/TypeSignatureMapping.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/TypeSignatureMapping.java
@@ -14,7 +14,6 @@
 package io.trino.operator.aggregation;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedMap;
 import io.trino.operator.annotations.CastImplementationDependency;
 import io.trino.operator.annotations.FunctionImplementationDependency;
 import io.trino.operator.annotations.ImplementationDependency;
@@ -30,16 +29,20 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSortedMap.toImmutableSortedMap;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.parseTypeSignature;
 
 class TypeSignatureMapping
 {
-    private final Map<String, String> mapping;
+    private final Map<String, TypeSignature> mapping;
 
     public TypeSignatureMapping(Map<String, String> mapping)
     {
-        this.mapping = ImmutableSortedMap.<String, String>orderedBy(String.CASE_INSENSITIVE_ORDER)
-                .putAll(mapping)
-                .build();
+        this.mapping = mapping.entrySet().stream()
+                .collect(toImmutableSortedMap(
+                        String.CASE_INSENSITIVE_ORDER,
+                        Map.Entry::getKey,
+                        entry -> parseTypeSignature(entry.getValue(), ImmutableSet.of())));
     }
 
     public Set<String> getTypeParameters()
@@ -93,7 +96,7 @@ class TypeSignatureMapping
         }
         if (mapping.containsKey(typeSignature.getBase())) {
             checkArgument(typeSignature.getParameters().isEmpty(), "Type variable can not have type parameters: %s", typeSignature);
-            return new TypeSignature(mapping.get(typeSignature.getBase()));
+            return mapping.get(typeSignature.getBase());
         }
         return new TypeSignature(
                 typeSignature.getBase(),

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestConcreteAggregationStateTypeParameters.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestConcreteAggregationStateTypeParameters.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.MapBlockBuilder;
+import io.trino.spi.block.ValueBlock;
+import io.trino.spi.function.AggregationFunction;
+import io.trino.spi.function.AggregationState;
+import io.trino.spi.function.BlockIndex;
+import io.trino.spi.function.BlockPosition;
+import io.trino.spi.function.CombineFunction;
+import io.trino.spi.function.InputFunction;
+import io.trino.spi.function.OutputFunction;
+import io.trino.spi.function.SqlType;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.block.BlockAssertions.createLongsBlock;
+import static io.trino.metadata.InternalFunctionBundle.extractFunctions;
+import static io.trino.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestConcreteAggregationStateTypeParameters
+{
+    private static final TestingFunctionResolution FUNCTION_RESOLUTION =
+            new TestingFunctionResolution(extractFunctions(FixedMapAggregation.class));
+
+    @Test
+    public void testConcreteMapAggregationStateTypeParameters()
+    {
+        TestingAggregationFunction function = FUNCTION_RESOLUTION.getAggregateFunction("test_fixed_map_agg", fromTypes(BIGINT, BIGINT));
+        assertThat(function.getFinalType().getTypeSignature().toString()).isEqualTo("map(varchar,bigint)");
+        assertThat(function.getIntermediateType().getTypeSignature().toString()).isEqualTo("map(varchar,bigint)");
+
+        assertAggregation(
+                FUNCTION_RESOLUTION,
+                "test_fixed_map_agg",
+                fromTypes(BIGINT, BIGINT),
+                ImmutableMap.of("11", 1L, "22", 2L, "33", 3L),
+                createLongsBlock(11L, 22L, 33L),
+                createLongsBlock(1L, 2L, 3L));
+    }
+
+    @AggregationFunction("test_fixed_map_agg")
+    public static final class FixedMapAggregation
+    {
+        private FixedMapAggregation() {}
+
+        @InputFunction
+        public static void input(
+                @AggregationState({"varchar", "bigint"}) MapAggregationState state,
+                @SqlType("bigint") long key,
+                @BlockPosition @SqlType("bigint") ValueBlock value,
+                @BlockIndex int valuePosition)
+        {
+            BlockBuilder keyBlockBuilder = VARCHAR.createBlockBuilder(null, 1);
+            VARCHAR.writeString(keyBlockBuilder, Long.toString(key));
+            state.add(keyBlockBuilder.buildValueBlock(), 0, value, valuePosition);
+        }
+
+        @CombineFunction
+        public static void combine(
+                @AggregationState({"varchar", "bigint"}) MapAggregationState state,
+                @AggregationState({"varchar", "bigint"}) MapAggregationState otherState)
+        {
+            state.merge(otherState);
+        }
+
+        @OutputFunction("map(varchar, bigint)")
+        public static void output(
+                @AggregationState({"varchar", "bigint"}) MapAggregationState state,
+                BlockBuilder out)
+        {
+            state.writeAll((MapBlockBuilder) out);
+        }
+    }
+}


### PR DESCRIPTION
Allow easily reusing generic aggregation states with concrete types.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
