### PR TITLE
Fix spooled protocol serialization of custom types

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/JsonQueryDataEncoder.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/encoding/JsonQueryDataEncoder.java
@@ -15,6 +15,7 @@ package io.trino.server.protocol.spooling.encoding;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.io.CountingOutputStream;
 import com.google.inject.Inject;
 import io.trino.Session;
@@ -34,7 +35,6 @@ import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.client.spooling.DataAttribute.SEGMENT_SIZE;
-import static io.trino.plugin.base.util.JsonUtils.jsonFactory;
 import static io.trino.server.protocol.JsonEncodingUtils.createTypeEncoders;
 import static io.trino.server.protocol.JsonEncodingUtils.writePagesToJsonGenerator;
 import static java.lang.Math.toIntExact;
@@ -100,9 +100,10 @@ public class JsonQueryDataEncoder
     {
         protected final JsonFactory factory;
 
-        public Factory()
+        @Inject
+        public Factory(JsonMapper mapper)
         {
-            this.factory = jsonFactory();
+            this.factory = mapper.getFactory();
         }
 
         @Override
@@ -124,8 +125,9 @@ public class JsonQueryDataEncoder
         private final int compressionThreshold;
 
         @Inject
-        public ZstdFactory(QueryDataEncodingConfig config)
+        public ZstdFactory(QueryDataEncodingConfig config, JsonMapper mapper)
         {
+            super(mapper);
             this.compressionThreshold = toIntExact(config.getCompressionThreshold().toBytes());
         }
 
@@ -148,8 +150,9 @@ public class JsonQueryDataEncoder
         private final int compressionThreshold;
 
         @Inject
-        public Lz4Factory(QueryDataEncodingConfig config)
+        public Lz4Factory(QueryDataEncodingConfig config, JsonMapper mapper)
         {
+            super(mapper);
             this.compressionThreshold = toIntExact(config.getCompressionThreshold().toBytes());
         }
 

--- a/core/trino-main/src/test/java/io/trino/server/protocol/TestJsonEncodingUtils.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/TestJsonEncodingUtils.java
@@ -13,6 +13,8 @@
  */
 package io.trino.server.protocol;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.client.ClientCapabilities;
@@ -31,12 +33,14 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.MapBlockBuilder;
 import io.trino.spi.block.RowBlockBuilder;
+import io.trino.spi.type.AbstractIntType;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
+import io.trino.spi.type.TypeSignature;
 import io.trino.spi.variant.Variant;
 import org.junit.jupiter.api.Test;
 
@@ -89,7 +93,7 @@ public class TestJsonEncodingUtils
 
     protected QueryDataEncoder createEncoder(Session session, List<OutputColumn> columns)
     {
-        return new JsonQueryDataEncoder.Factory().create(session, columns);
+        return new JsonQueryDataEncoder.Factory(new JsonMapper()).create(session, columns);
     }
 
     @Test
@@ -725,6 +729,24 @@ public class TestJsonEncodingUtils
                                 .build()));
     }
 
+    @Test
+    public void testTypeObjectSerialization()
+            throws IOException
+    {
+        CustomType customType = new CustomType();
+        BlockBuilder blockBuilder = customType.createBlockBuilder(null, 2);
+        customType.writeInt(blockBuilder, 42);
+        blockBuilder.appendNull();
+        Page page = page(blockBuilder.build());
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        QueryDataEncoder encoder = new JsonQueryDataEncoder.Factory(new JsonMapper())
+                .create(TEST_SESSION, ImmutableList.of(new OutputColumn(0, "custom", customType)));
+
+        encoder.encodeTo(output, List.of(page));
+        assertThat(output.toString(UTF_8)).isEqualTo("[[{\"value\":42}],[null]]");
+    }
+
     protected List<List<Object>> roundTrip(List<TypedColumn> columns, Page page, String expectedJson)
             throws IOException
     {
@@ -896,6 +918,32 @@ public class TestJsonEncodingUtils
     {
         // Allow nulls
     }
+
+    private static final class CustomType
+            extends AbstractIntType
+    {
+        private CustomType()
+        {
+            super(new TypeSignature("custom"));
+        }
+
+        @Override
+        public String getDisplayName()
+        {
+            return "custom";
+        }
+
+        @Override
+        public Object getObjectValue(Block block, int position)
+        {
+            if (block.isNull(position)) {
+                return null;
+            }
+            return new Custom(getInt(block, position));
+        }
+    }
+
+    private record Custom(@JsonProperty("value") int value) {}
 
     static <K, V> Entry<K, V> entry(K key, V value)
     {

--- a/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestPreferredQueryDataEncoderSelector.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestPreferredQueryDataEncoderSelector.java
@@ -13,6 +13,7 @@
  */
 package io.trino.server.protocol.spooling;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.airlift.log.Level;
 import io.airlift.log.Logging;
 import io.trino.server.protocol.spooling.QueryDataEncoder.EncoderSelector;
@@ -34,7 +35,7 @@ class TestPreferredQueryDataEncoderSelector
     @Test
     public void testNoEncoderWhenNoneIsMatching()
     {
-        EncoderSelector selector = new PreferredQueryDataEncoderSelector(new QueryDataEncoders(new SpoolingEnabledConfig().setEnabled(true), Set.of(new JsonQueryDataEncoder.Factory())));
+        EncoderSelector selector = new PreferredQueryDataEncoderSelector(new QueryDataEncoders(new SpoolingEnabledConfig().setEnabled(true), Set.of(new JsonQueryDataEncoder.Factory(new JsonMapper()))));
 
         assertThat(selector.select(List.of())).isEmpty();
         assertThat(selector.select(List.of("json+zstd"))).isEmpty();
@@ -52,7 +53,7 @@ class TestPreferredQueryDataEncoderSelector
     @Test
     public void testSingleMatchingEncoderIsPicked()
     {
-        JsonQueryDataEncoder.Factory factory = new JsonQueryDataEncoder.Factory();
+        JsonQueryDataEncoder.Factory factory = new JsonQueryDataEncoder.Factory(new JsonMapper());
         EncoderSelector selector = new PreferredQueryDataEncoderSelector(new QueryDataEncoders(new SpoolingEnabledConfig().setEnabled(true), Set.of(factory)));
 
         assertThat(selector.select(List.of("json+zstd", "json"))).hasValue(factory);
@@ -61,8 +62,8 @@ class TestPreferredQueryDataEncoderSelector
     @Test
     public void testSingleMatchingEncoderFromMultipleIsPicked()
     {
-        JsonQueryDataEncoder.Factory factory = new JsonQueryDataEncoder.Factory();
-        EncoderSelector selector = new PreferredQueryDataEncoderSelector(new QueryDataEncoders(new SpoolingEnabledConfig().setEnabled(true), Set.of(factory, new JsonQueryDataEncoder.ZstdFactory(new QueryDataEncodingConfig()))));
+        JsonQueryDataEncoder.Factory factory = new JsonQueryDataEncoder.Factory(new JsonMapper());
+        EncoderSelector selector = new PreferredQueryDataEncoderSelector(new QueryDataEncoders(new SpoolingEnabledConfig().setEnabled(true), Set.of(factory, new JsonQueryDataEncoder.ZstdFactory(new QueryDataEncodingConfig(), new JsonMapper()))));
 
         assertThat(selector.select(List.of("protobuf", "json", "json+zstd"))).hasValue(factory);
     }
@@ -70,8 +71,8 @@ class TestPreferredQueryDataEncoderSelector
     @Test
     public void testSingleMatchingEncoderFromMultipleIsPickedInOrder()
     {
-        JsonQueryDataEncoder.Factory factory = new JsonQueryDataEncoder.Factory();
-        JsonQueryDataEncoder.ZstdFactory zstdFactory = new JsonQueryDataEncoder.ZstdFactory(new QueryDataEncodingConfig());
+        JsonQueryDataEncoder.Factory factory = new JsonQueryDataEncoder.Factory(new JsonMapper());
+        JsonQueryDataEncoder.ZstdFactory zstdFactory = new JsonQueryDataEncoder.ZstdFactory(new QueryDataEncodingConfig(), new JsonMapper());
 
         EncoderSelector selector = new PreferredQueryDataEncoderSelector(new QueryDataEncoders(new SpoolingEnabledConfig().setEnabled(true), Set.of(factory, zstdFactory)));
 


### PR DESCRIPTION
Serialization of custom types in the spooling protocol requires an object mapper that knows how to serialize Jackson annotatied POJOs

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix serialization of SPI provided types in spooling protocol ({issue}`issuenumber`)
```
