### PR TITLE
Fix domain translation for `starts_with` calls

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -1010,7 +1010,7 @@ public final class DomainTranslator
             }
 
             Expression prefix = args.get(1);
-            if (!(prefix instanceof Constant literal && literal.type().equals(VarcharType.VARCHAR))) {
+            if (!(prefix instanceof Constant literal && literal.type() instanceof VarcharType)) {
                 // dynamic pattern
                 return Optional.empty();
             }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.spi.predicate.Domain;
@@ -67,6 +68,7 @@ import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.ir.Booleans.FALSE;
 import static io.trino.sql.ir.Booleans.TRUE;
@@ -1424,7 +1426,7 @@ public class TestDomainTranslator
                         false));
 
         // dynamic escape
-        assertUnsupportedPredicate(like(C_VARCHAR, stringLiteral("abc\\_def"), C_VARCHAR_1.toSymbolReference()));
+        assertUnsupportedPredicate(like(C_VARCHAR, new Constant(VARCHAR, utf8Slice("abc\\_def")), C_VARCHAR_1.toSymbolReference()));
 
         // negation with literal
         testSimpleComparison(
@@ -1491,9 +1493,10 @@ public class TestDomainTranslator
         assertUnsupportedPredicate(new Call(
                 functionResolution.resolveFunction("length", fromTypes(VARCHAR)),
                 ImmutableList.of(C_VARCHAR.toSymbolReference())));
+        Constant replaceArgument = stringLiteral("abc");
         assertUnsupportedPredicate(new Call(
-                functionResolution.resolveFunction("replace", fromTypes(VARCHAR, VARCHAR)),
-                ImmutableList.of(C_VARCHAR.toSymbolReference(), stringLiteral("abc"))));
+                functionResolution.resolveFunction("replace", fromTypes(C_VARCHAR.type(), replaceArgument.type())),
+                ImmutableList.of(C_VARCHAR.toSymbolReference(), replaceArgument)));
     }
 
     @Test
@@ -1630,7 +1633,7 @@ public class TestDomainTranslator
     private Call startsWith(Symbol symbol, Expression expression)
     {
         return new Call(
-                functionResolution.resolveFunction("starts_with", fromTypes(VARCHAR, VARCHAR)),
+                functionResolution.resolveFunction("starts_with", fromTypes(symbol.type(), expression.type())),
                 ImmutableList.of(symbol.toSymbolReference(), expression));
     }
 
@@ -1732,7 +1735,8 @@ public class TestDomainTranslator
 
     private static Constant stringLiteral(String value)
     {
-        return new Constant(VARCHAR, utf8Slice(value));
+        Slice slice = utf8Slice(value);
+        return new Constant(createVarcharType(slice.length()), slice);
     }
 
     private static Expression nullLiteral(Type type)


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

An incorrect type check of the prefix argument caused the domain translation for `starts_with` calls to fail in practice.

Fixes #29712

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Tests failed to catch this because they use a `stringLiteral` helper that does not behave as Trino SQL. It always created an unbounded varchar type, whereas string literals in practice are bounded.

 ```sql
select typeof('foo')
-- 3
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* ({issue}`issuenumber`)
```
