### PR TITLE
Vectorize block null bit packing using VectorMask

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/BlockEncodingManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/BlockEncodingManager.java
@@ -50,18 +50,18 @@ public final class BlockEncodingManager
     {
         // add the built-in BlockEncodings
         SimdSupport simdSupport = blockEncodingSimdSupport.getSimdSupport();
-        addBlockEncoding(new VariableWidthBlockEncoding(simdSupport.vectorizeNullBitPacking()));
-        addBlockEncoding(new ByteArrayBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.compressByte(), simdSupport.expandByte()));
-        addBlockEncoding(new ShortArrayBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.compressShort(), simdSupport.expandShort()));
-        addBlockEncoding(new IntArrayBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.compressInt(), simdSupport.expandInt()));
-        addBlockEncoding(new LongArrayBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.compressLong(), simdSupport.expandLong()));
-        addBlockEncoding(new Fixed12BlockEncoding(simdSupport.vectorizeNullBitPacking()));
-        addBlockEncoding(new Int128ArrayBlockEncoding(simdSupport.vectorizeNullBitPacking()));
-        addBlockEncoding(new VariantBlockEncoding(simdSupport.vectorizeNullBitPacking()));
+        addBlockEncoding(new VariableWidthBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.useVectorMaskFromLong()));
+        addBlockEncoding(new ByteArrayBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.compressByte(), simdSupport.expandByte(), simdSupport.useVectorMaskFromLong()));
+        addBlockEncoding(new ShortArrayBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.compressShort(), simdSupport.expandShort(), simdSupport.useVectorMaskFromLong()));
+        addBlockEncoding(new IntArrayBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.compressInt(), simdSupport.expandInt(), simdSupport.useVectorMaskFromLong()));
+        addBlockEncoding(new LongArrayBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.compressLong(), simdSupport.expandLong(), simdSupport.useVectorMaskFromLong()));
+        addBlockEncoding(new Fixed12BlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.useVectorMaskFromLong()));
+        addBlockEncoding(new Int128ArrayBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.useVectorMaskFromLong()));
+        addBlockEncoding(new VariantBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.useVectorMaskFromLong()));
         addBlockEncoding(new DictionaryBlockEncoding());
-        addBlockEncoding(new ArrayBlockEncoding(simdSupport.vectorizeNullBitPacking()));
-        addBlockEncoding(new MapBlockEncoding(simdSupport.vectorizeNullBitPacking()));
-        addBlockEncoding(new RowBlockEncoding(simdSupport.vectorizeNullBitPacking()));
+        addBlockEncoding(new ArrayBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.useVectorMaskFromLong()));
+        addBlockEncoding(new MapBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.useVectorMaskFromLong()));
+        addBlockEncoding(new RowBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.useVectorMaskFromLong()));
         addBlockEncoding(new RunLengthBlockEncoding());
     }
 

--- a/core/trino-main/src/main/java/io/trino/simd/BlockEncodingSimdSupport.java
+++ b/core/trino-main/src/main/java/io/trino/simd/BlockEncodingSimdSupport.java
@@ -56,10 +56,11 @@ public final class BlockEncodingSimdSupport
             boolean compressInt,
             boolean expandInt,
             boolean compressLong,
-            boolean expandLong)
+            boolean expandLong,
+            boolean useVectorMaskFromLong)
     {
-        public static final SimdSupport NONE = new SimdSupport(false, false, false, false, false, false, false, false, false);
-        public static final SimdSupport ALL = new SimdSupport(true, true, true, true, true, true, true, true, true);
+        public static final SimdSupport NONE = new SimdSupport(false, false, false, false, false, false, false, false, false, false);
+        public static final SimdSupport ALL = new SimdSupport(true, true, true, true, true, true, true, true, true, true);
     }
 
     private static final SimdSupport AUTO_DETECTED_SUPPORT = detectSimd();
@@ -152,6 +153,7 @@ public final class BlockEncodingSimdSupport
         boolean expandAndCompressShort = x86Flags.contains(X86SimdInstructionSet.avx512vbmi2);
         boolean expandAndCompressInt = x86Flags.contains(X86SimdInstructionSet.avx512f);
         boolean expandAndCompressLong = x86Flags.contains(X86SimdInstructionSet.avx512f);
+        boolean useVectorMaskFromLong = true; // no known x86_64 platforms regress with this approach
         return new SimdSupport(
                 packIsNullBits,
                 expandAndCompressByte,
@@ -161,7 +163,8 @@ public final class BlockEncodingSimdSupport
                 expandAndCompressInt,
                 expandAndCompressInt,
                 expandAndCompressLong,
-                expandAndCompressLong);
+                expandAndCompressLong,
+                useVectorMaskFromLong);
     }
 
     private static SimdSupport detectArmSimdSupport(int preferredVectorBitWidth, Set<String> flags)
@@ -199,6 +202,7 @@ public final class BlockEncodingSimdSupport
         boolean expandInt = armFlags.contains(ArmSimdInstructionSet.sve2);
         boolean expandLong = armFlags.contains(ArmSimdInstructionSet.sve2) && preferredVectorBitWidth > 128; // ensure minimum register width for long
         boolean expandByteAndShort = false; // no intrinsics in JDK 25
+        boolean useVectorMaskFromLong = armFlags.contains(ArmSimdInstructionSet.sve2); // intrinsics only available in SVE2
         return new SimdSupport(
                 packIsNullBits,
                 compressAll,
@@ -208,7 +212,8 @@ public final class BlockEncodingSimdSupport
                 compressAll,
                 expandInt,
                 compressLong,
-                expandLong);
+                expandLong,
+                useVectorMaskFromLong);
     }
 
     public SimdSupport getSimdSupport()

--- a/core/trino-main/src/test/java/io/trino/metadata/TestInternalBlockEncodingSerde.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestInternalBlockEncodingSerde.java
@@ -34,8 +34,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestInternalBlockEncodingSerde
 {
-    private final Map<String, BlockEncoding> blockEncodings = ImmutableMap.of(VariableWidthBlockEncoding.NAME, new VariableWidthBlockEncoding(true));
-    private final Map<Class<? extends Block>, BlockEncoding> blockNames = ImmutableMap.of(VariableWidthBlock.class, new VariableWidthBlockEncoding(true));
+    private final Map<String, BlockEncoding> blockEncodings = ImmutableMap.of(VariableWidthBlockEncoding.NAME, new VariableWidthBlockEncoding(true, false));
+    private final Map<Class<? extends Block>, BlockEncoding> blockNames = ImmutableMap.of(VariableWidthBlock.class, new VariableWidthBlockEncoding(true, false));
     private final BlockEncodingSerde blockEncodingSerde = new InternalBlockEncodingSerde(blockEncodings::get, blockNames::get, TESTING_TYPE_MANAGER::getType);
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/simd/TestBlockEncodingSimdSupport.java
+++ b/core/trino-main/src/test/java/io/trino/simd/TestBlockEncodingSimdSupport.java
@@ -38,7 +38,8 @@ final class TestBlockEncodingSimdSupport
                         true, // compressInt
                         true, // expandInt
                         true, // compressLong
-                        true));
+                        true, // expandLong
+                        true)); // useVectorMaskFromLong
         // Support compress / expand for all types with avx512vbmi2
         assertThat(determineSimdSupport(osArch, vectorBitsPreferred, Set.of("avx512f", "avx512vbmi2")))
                 .isEqualTo(BlockEncodingSimdSupport.SimdSupport.ALL);
@@ -59,7 +60,8 @@ final class TestBlockEncodingSimdSupport
                 true, // compressInt
                 false, // expandInt - no intrinsic for SVE 1 in JDK 25
                 true, // compressLong
-                false); // expandLong - no intrinsic for SVE1 in JDK 25
+                false, // expandLong - no intrinsic for SVE1 in JDK 25
+                false); // useVectorMaskFromLong - no intrinsic for SVE1
         assertThat(determineSimdSupport(osArch, vectorBitsPreferred, flags)).isEqualTo(expected);
     }
 
@@ -78,7 +80,8 @@ final class TestBlockEncodingSimdSupport
                 true, // compressInt
                 true, // expandInt
                 false, // compressLong - not worthwhile on 128 bit vectors
-                false); // expandLong - not worthwhile on 128 bit vectors
+                false, // expandLong - not worthwhile on 128 bit vectors
+                true); // useVectorMaskFromLong - intrinsics available in SVE2 and optimized in JDK26
         assertThat(determineSimdSupport(osArch, vectorBitsPreferred, flags)).isEqualTo(expected);
     }
 }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -271,6 +271,83 @@
                                     <justification>Add hasNonDeterministicFunctions parameter to detect stale materialized views</justification>
                                 </item>
                                 <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.block.ArrayBlockEncoding::&lt;init&gt;(boolean)</old>
+                                    <new>method void io.trino.spi.block.ArrayBlockEncoding::&lt;init&gt;(boolean, boolean)</new>
+                                    <justification>Added parameter to ArrayBlockEncoding constructor to enable SIMD support</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.block.ByteArrayBlockEncoding::&lt;init&gt;(boolean, boolean, boolean)</old>
+                                    <new>method void io.trino.spi.block.ByteArrayBlockEncoding::&lt;init&gt;(boolean, boolean, boolean, boolean)</new>
+                                    <justification>Added parameter to ByteArrayBlockEncoding constructor to enable SIMD support</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.block.Fixed12BlockEncoding::&lt;init&gt;(boolean)</old>
+                                    <new>method void io.trino.spi.block.Fixed12BlockEncoding::&lt;init&gt;(boolean, boolean)</new>
+                                    <justification>Added parameter to Fixed12BlockEncoding constructor to enable SIMD support</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.block.Int128ArrayBlockEncoding::&lt;init&gt;(boolean)</old>
+                                    <new>method void io.trino.spi.block.Int128ArrayBlockEncoding::&lt;init&gt;(boolean, boolean)</new>
+                                    <justification>Added parameter to Int128ArrayBlockEncoding constructor to enable SIMD support</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.block.IntArrayBlockEncoding::&lt;init&gt;(boolean, boolean, boolean)</old>
+                                    <new>method void io.trino.spi.block.IntArrayBlockEncoding::&lt;init&gt;(boolean, boolean, boolean, boolean)</new>
+                                    <justification>Added parameter to IntArrayBlockEncoding constructor to enable SIMD support</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.block.LongArrayBlockEncoding::&lt;init&gt;(boolean, boolean, boolean)</old>
+                                    <new>method void io.trino.spi.block.LongArrayBlockEncoding::&lt;init&gt;(boolean, boolean, boolean, boolean)</new>
+                                    <justification>Added parameter to LongArrayBlockEncoding constructor to enable SIMD support</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.block.MapBlockEncoding::&lt;init&gt;(boolean)</old>
+                                    <new>method void io.trino.spi.block.MapBlockEncoding::&lt;init&gt;(boolean, boolean)</new>
+                                    <justification>Added parameter to MapBlockEncoding constructor to enable SIMD support</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.block.RowBlockEncoding::&lt;init&gt;(boolean)</old>
+                                    <new>method void io.trino.spi.block.RowBlockEncoding::&lt;init&gt;(boolean, boolean)</new>
+                                    <justification>Added parameter to RowBlockEncoding constructor to enable SIMD support</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.block.ShortArrayBlockEncoding::&lt;init&gt;(boolean, boolean, boolean)</old>
+                                    <new>method void io.trino.spi.block.ShortArrayBlockEncoding::&lt;init&gt;(boolean, boolean, boolean, boolean)</new>
+                                    <justification>Added parameter to ShortArrayBlockEncoding constructor to enable SIMD support</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.block.VariableWidthBlockEncoding::&lt;init&gt;(boolean)</old>
+                                    <new>method void io.trino.spi.block.VariableWidthBlockEncoding::&lt;init&gt;(boolean, boolean)</new>
+                                    <justification>Added parameter to VariableWidthBlockEncoding constructor to enable SIMD support</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.block.VariantBlockEncoding::&lt;init&gt;(boolean)</old>
+                                    <new>method void io.trino.spi.block.VariantBlockEncoding::&lt;init&gt;(boolean, boolean)</new>
+                                    <justification>Added parameter to VariantBlockEncoding constructor to enable SIMD support</justification>
+                                </item>
+                                <item>
                                     <code>java.field.removed</code>
                                     <old>field io.trino.spi.function.OperatorType.MODULUS</old>
                                     <justification>Renamed to MODULO</justification>

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockEncoding.java
@@ -28,10 +28,12 @@ public class ArrayBlockEncoding
     public static final String NAME = "ARRAY";
 
     private final boolean vectorizeNullBitPacking;
+    private final boolean useVectorMaskFromLong;
 
-    public ArrayBlockEncoding(boolean vectorizeNullBitPacking)
+    public ArrayBlockEncoding(boolean vectorizeNullBitPacking, boolean useVectorMaskFromLong)
     {
         this.vectorizeNullBitPacking = vectorizeNullBitPacking;
+        this.useVectorMaskFromLong = useVectorMaskFromLong;
     }
 
     @Override
@@ -84,7 +86,7 @@ public class ArrayBlockEncoding
         sliceInput.readInts(offsets);
         boolean[] valueIsNull;
         if (vectorizeNullBitPacking) {
-            valueIsNull = decodeNullBitsVectorized(sliceInput, positionCount).orElse(null);
+            valueIsNull = decodeNullBitsVectorized(sliceInput, positionCount, useVectorMaskFromLong).orElse(null);
         }
         else {
             valueIsNull = decodeNullBitsScalar(sliceInput, positionCount).orElse(null);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlockEncoding.java
@@ -38,12 +38,14 @@ public class ByteArrayBlockEncoding
     private final boolean vectorizeNullBitPacking;
     private final boolean vectorizeNullCompress;
     private final boolean vectorizeNullExpand;
+    private final boolean useVectorMaskFromLong;
 
-    public ByteArrayBlockEncoding(boolean vectorizeNullBitPacking, boolean vectorizeNullCompress, boolean vectorizeNullExpand)
+    public ByteArrayBlockEncoding(boolean vectorizeNullBitPacking, boolean vectorizeNullCompress, boolean vectorizeNullExpand, boolean useVectorMaskFromLong)
     {
         this.vectorizeNullBitPacking = vectorizeNullBitPacking;
         this.vectorizeNullCompress = vectorizeNullCompress;
         this.vectorizeNullExpand = vectorizeNullExpand;
+        this.useVectorMaskFromLong = useVectorMaskFromLong;
     }
 
     @Override
@@ -105,7 +107,7 @@ public class ByteArrayBlockEncoding
 
         boolean[] valueIsNull;
         if (vectorizeNullBitPacking) {
-            valueIsNull = decodeNullBitsVectorized(valueIsNullPacked, positionCount);
+            valueIsNull = decodeNullBitsVectorized(valueIsNullPacked, positionCount, useVectorMaskFromLong);
         }
         else {
             valueIsNull = decodeNullBitsScalar(valueIsNullPacked, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/EncoderUtil.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/EncoderUtil.java
@@ -17,6 +17,7 @@ import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 import jakarta.annotation.Nullable;
 import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorOperators;
 
 import java.io.IOException;
@@ -86,7 +87,18 @@ final class EncoderUtil
         byte[] packedIsNull = new byte[(length + 7) / 8];
         int currentByte = 0;
         int position = 0;
-        while (position < ByteVector.SPECIES_64.loopBound(length)) {
+
+        // process 16 nulls at a time
+        while (position < ByteVector.SPECIES_128.loopBound(length)) {
+            VectorMask<Byte> mask = VectorMask.fromArray(ByteVector.SPECIES_128, isNull, position + offset);
+            int intMask = Integer.reverse((int) mask.toLong());
+            packedIsNull[currentByte++] = (byte) (intMask >>> 24);
+            packedIsNull[currentByte++] = (byte) (intMask >>> 16);
+            position += ByteVector.SPECIES_128.length();
+        }
+
+        // process 8 nulls at a time
+        if (position < ByteVector.SPECIES_64.loopBound(length)) {
             packedIsNull[currentByte++] = ByteVector.fromBooleanArray(ByteVector.SPECIES_64, isNull, position + offset)
                     .lanewise(VectorOperators.LSHL, NULL_BIT_SHIFTS)
                     .reduceLanes(VectorOperators.OR);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/EncoderUtil.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/EncoderUtil.java
@@ -161,18 +161,30 @@ final class EncoderUtil
     /**
      * Implementation of {@link EncoderUtil#decodeNullBitsScalar(SliceInput, int)} that uses the vector API
      */
-    public static Optional<boolean[]> decodeNullBitsVectorized(SliceInput sliceInput, int positionCount)
+    public static Optional<boolean[]> decodeNullBitsVectorized(SliceInput sliceInput, int positionCount, boolean useVectorMaskFromLong)
     {
         return Optional.ofNullable(retrieveNullBits(sliceInput, positionCount))
-                .map(packedIsNull -> decodeNullBitsVectorized(packedIsNull, positionCount));
+                .map(packedIsNull -> decodeNullBitsVectorized(packedIsNull, positionCount, useVectorMaskFromLong));
     }
 
-    public static boolean[] decodeNullBitsVectorized(byte[] packedIsNull, int positionCount)
+    public static boolean[] decodeNullBitsVectorized(byte[] packedIsNull, int positionCount, boolean useVectorMaskFromLong)
     {
-        // read null bits 8 at a time
         boolean[] valueIsNull = new boolean[positionCount];
         int currentByte = 0;
         int position = 0;
+
+        // read null bits 16 at a time, if required API can be used
+        if (useVectorMaskFromLong) {
+            while (position < ByteVector.SPECIES_128.loopBound(positionCount)) {
+                int shiftedByte1 = (packedIsNull[currentByte++] & 0xFF) << 24;
+                int shiftedByte2 = (packedIsNull[currentByte++] & 0xFF) << 16;
+                VectorMask.fromLong(ByteVector.SPECIES_128, Integer.reverse(shiftedByte1 | shiftedByte2))
+                        .intoArray(valueIsNull, position);
+                position += ByteVector.SPECIES_128.length();
+            }
+        }
+
+        // read null bits 8 at a time
         while (position < ByteVector.SPECIES_64.loopBound(positionCount)) {
             // equivalent of ((value >>> shift) & 1) != 0
             ByteVector.broadcast(ByteVector.SPECIES_64, packedIsNull[currentByte++])

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12BlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12BlockEncoding.java
@@ -29,10 +29,12 @@ public class Fixed12BlockEncoding
     public static final String NAME = "FIXED12";
 
     private final boolean vectorizeNullBitPacking;
+    private final boolean useVectorMaskFromLong;
 
-    public Fixed12BlockEncoding(boolean vectorizeNullBitPacking)
+    public Fixed12BlockEncoding(boolean vectorizeNullBitPacking, boolean useVectorMaskFromLong)
     {
         this.vectorizeNullBitPacking = vectorizeNullBitPacking;
+        this.useVectorMaskFromLong = useVectorMaskFromLong;
     }
 
     @Override
@@ -93,7 +95,7 @@ public class Fixed12BlockEncoding
 
         boolean[] valueIsNull;
         if (vectorizeNullBitPacking) {
-            valueIsNull = decodeNullBitsVectorized(sliceInput, positionCount).orElse(null);
+            valueIsNull = decodeNullBitsVectorized(sliceInput, positionCount, useVectorMaskFromLong).orElse(null);
         }
         else {
             valueIsNull = decodeNullBitsScalar(sliceInput, positionCount).orElse(null);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockEncoding.java
@@ -29,10 +29,12 @@ public class Int128ArrayBlockEncoding
     public static final String NAME = "INT128_ARRAY";
 
     private final boolean vectorizeNullBitPacking;
+    private final boolean useVectorMaskFromLong;
 
-    public Int128ArrayBlockEncoding(boolean vectorizeNullBitPacking)
+    public Int128ArrayBlockEncoding(boolean vectorizeNullBitPacking, boolean useVectorMaskFromLong)
     {
         this.vectorizeNullBitPacking = vectorizeNullBitPacking;
+        this.useVectorMaskFromLong = useVectorMaskFromLong;
     }
 
     @Override
@@ -92,7 +94,7 @@ public class Int128ArrayBlockEncoding
 
         boolean[] valueIsNull;
         if (vectorizeNullBitPacking) {
-            valueIsNull = decodeNullBitsVectorized(sliceInput, positionCount).orElse(null);
+            valueIsNull = decodeNullBitsVectorized(sliceInput, positionCount, useVectorMaskFromLong).orElse(null);
         }
         else {
             valueIsNull = decodeNullBitsScalar(sliceInput, positionCount).orElse(null);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockEncoding.java
@@ -37,12 +37,14 @@ public class IntArrayBlockEncoding
     private final boolean vectorizeNullBitPacking;
     private final boolean vectorizeNullCompress;
     private final boolean vectorizeNullExpand;
+    private final boolean useVectorMaskFromLong;
 
-    public IntArrayBlockEncoding(boolean vectorizeNullBitPacking, boolean vectorizeNullCompress, boolean vectorizeNullExpand)
+    public IntArrayBlockEncoding(boolean vectorizeNullBitPacking, boolean vectorizeNullCompress, boolean vectorizeNullExpand, boolean useVectorMaskFromLong)
     {
         this.vectorizeNullBitPacking = vectorizeNullBitPacking;
         this.vectorizeNullCompress = vectorizeNullCompress;
         this.vectorizeNullExpand = vectorizeNullExpand;
+        this.useVectorMaskFromLong = useVectorMaskFromLong;
     }
 
     @Override
@@ -103,7 +105,7 @@ public class IntArrayBlockEncoding
 
         boolean[] valueIsNull;
         if (vectorizeNullBitPacking) {
-            valueIsNull = decodeNullBitsVectorized(valueIsNullPacked, positionCount);
+            valueIsNull = decodeNullBitsVectorized(valueIsNullPacked, positionCount, useVectorMaskFromLong);
         }
         else {
             valueIsNull = decodeNullBitsScalar(valueIsNullPacked, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockEncoding.java
@@ -37,12 +37,14 @@ public class LongArrayBlockEncoding
     private final boolean vectorizeNullBitPacking;
     private final boolean vectorizeNullCompress;
     private final boolean vectorizeNullExpand;
+    private final boolean useVectorMaskFromLong;
 
-    public LongArrayBlockEncoding(boolean vectorizeNullBitPacking, boolean vectorizeNullCompress, boolean vectorizeNullExpand)
+    public LongArrayBlockEncoding(boolean vectorizeNullBitPacking, boolean vectorizeNullCompress, boolean vectorizeNullExpand, boolean useVectorMaskFromLong)
     {
         this.vectorizeNullBitPacking = vectorizeNullBitPacking;
         this.vectorizeNullCompress = vectorizeNullCompress;
         this.vectorizeNullExpand = vectorizeNullExpand;
+        this.useVectorMaskFromLong = useVectorMaskFromLong;
     }
 
     @Override
@@ -103,7 +105,7 @@ public class LongArrayBlockEncoding
 
         boolean[] valueIsNull;
         if (vectorizeNullBitPacking) {
-            valueIsNull = decodeNullBitsVectorized(valueIsNullPacked, positionCount);
+            valueIsNull = decodeNullBitsVectorized(valueIsNullPacked, positionCount, useVectorMaskFromLong);
         }
         else {
             valueIsNull = decodeNullBitsScalar(valueIsNullPacked, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockEncoding.java
@@ -35,10 +35,12 @@ public class MapBlockEncoding
     public static final String NAME = "MAP";
 
     private final boolean vectorizeNullBitPacking;
+    private final boolean useVectorMaskFromLong;
 
-    public MapBlockEncoding(boolean vectorizeNullBitPacking)
+    public MapBlockEncoding(boolean vectorizeNullBitPacking, boolean useVectorMaskFromLong)
     {
         this.vectorizeNullBitPacking = vectorizeNullBitPacking;
+        this.useVectorMaskFromLong = useVectorMaskFromLong;
     }
 
     @Override
@@ -129,7 +131,7 @@ public class MapBlockEncoding
         sliceInput.readInts(offsets);
         Optional<boolean[]> mapIsNull;
         if (vectorizeNullBitPacking) {
-            mapIsNull = decodeNullBitsVectorized(sliceInput, positionCount);
+            mapIsNull = decodeNullBitsVectorized(sliceInput, positionCount, useVectorMaskFromLong);
         }
         else {
             mapIsNull = decodeNullBitsScalar(sliceInput, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockEncoding.java
@@ -31,10 +31,12 @@ public class RowBlockEncoding
     public static final String NAME = "ROW";
 
     private final boolean vectorizeNullBitPacking;
+    private final boolean useVectorMaskFromLong;
 
-    public RowBlockEncoding(boolean vectorizeNullBitPacking)
+    public RowBlockEncoding(boolean vectorizeNullBitPacking, boolean useVectorMaskFromLong)
     {
         this.vectorizeNullBitPacking = vectorizeNullBitPacking;
+        this.useVectorMaskFromLong = useVectorMaskFromLong;
     }
 
     @Override
@@ -83,7 +85,7 @@ public class RowBlockEncoding
 
         Optional<boolean[]> rowIsNull;
         if (vectorizeNullBitPacking) {
-            rowIsNull = decodeNullBitsVectorized(sliceInput, positionCount);
+            rowIsNull = decodeNullBitsVectorized(sliceInput, positionCount, useVectorMaskFromLong);
         }
         else {
             rowIsNull = decodeNullBitsScalar(sliceInput, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockEncoding.java
@@ -37,12 +37,14 @@ public class ShortArrayBlockEncoding
     private final boolean vectorizeNullBitPacking;
     private final boolean vectorizeNullCompress;
     private final boolean vectorizeNullExpand;
+    private final boolean useVectorMaskFromLong;
 
-    public ShortArrayBlockEncoding(boolean vectorizeNullBitPacking, boolean vectorizeNullCompress, boolean vectorizeNullExpand)
+    public ShortArrayBlockEncoding(boolean vectorizeNullBitPacking, boolean vectorizeNullCompress, boolean vectorizeNullExpand, boolean useVectorMaskFromLong)
     {
         this.vectorizeNullBitPacking = vectorizeNullBitPacking;
         this.vectorizeNullCompress = vectorizeNullCompress;
         this.vectorizeNullExpand = vectorizeNullExpand;
+        this.useVectorMaskFromLong = useVectorMaskFromLong;
     }
 
     @Override
@@ -104,7 +106,7 @@ public class ShortArrayBlockEncoding
 
         boolean[] valueIsNull;
         if (vectorizeNullBitPacking) {
-            valueIsNull = decodeNullBitsVectorized(valueIsNullPacked, positionCount);
+            valueIsNull = decodeNullBitsVectorized(valueIsNullPacked, positionCount, useVectorMaskFromLong);
         }
         else {
             valueIsNull = decodeNullBitsScalar(valueIsNullPacked, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockEncoding.java
@@ -32,10 +32,12 @@ public class VariableWidthBlockEncoding
     public static final String NAME = "VARIABLE_WIDTH";
 
     private final boolean vectorizeNullBitPacking;
+    private final boolean useVectorMaskFromLong;
 
-    public VariableWidthBlockEncoding(boolean vectorizeNullBitPacking)
+    public VariableWidthBlockEncoding(boolean vectorizeNullBitPacking, boolean useVectorMaskFromLong)
     {
         this.vectorizeNullBitPacking = vectorizeNullBitPacking;
+        this.useVectorMaskFromLong = useVectorMaskFromLong;
     }
 
     @Override
@@ -85,7 +87,7 @@ public class VariableWidthBlockEncoding
 
         boolean[] valueIsNull;
         if (vectorizeNullBitPacking) {
-            valueIsNull = decodeNullBitsVectorized(sliceInput, positionCount).orElse(null);
+            valueIsNull = decodeNullBitsVectorized(sliceInput, positionCount, useVectorMaskFromLong).orElse(null);
         }
         else {
             valueIsNull = decodeNullBitsScalar(sliceInput, positionCount).orElse(null);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariantBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariantBlockEncoding.java
@@ -28,10 +28,12 @@ public class VariantBlockEncoding
     public static final String NAME = "VARIANT";
 
     private final boolean vectorizeNullBitPacking;
+    private final boolean useVectorMaskFromLong;
 
-    public VariantBlockEncoding(boolean vectorizeNullBitPacking)
+    public VariantBlockEncoding(boolean vectorizeNullBitPacking, boolean useVectorMaskFromLong)
     {
         this.vectorizeNullBitPacking = vectorizeNullBitPacking;
+        this.useVectorMaskFromLong = useVectorMaskFromLong;
     }
 
     @Override
@@ -74,7 +76,7 @@ public class VariantBlockEncoding
 
         boolean[] variantIsNull;
         if (vectorizeNullBitPacking) {
-            variantIsNull = decodeNullBitsVectorized(sliceInput, positionCount).orElse(null);
+            variantIsNull = decodeNullBitsVectorized(sliceInput, positionCount, useVectorMaskFromLong).orElse(null);
         }
         else {
             variantIsNull = decodeNullBitsScalar(sliceInput, positionCount).orElse(null);

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestByteArrayBlockEncoding.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestByteArrayBlockEncoding.java
@@ -65,7 +65,7 @@ final class TestByteArrayBlockEncoding
                     byte[] compressedVectorized = compressBytesVectorized(values, isNull, offset, length);
                     assertThat(compressedVectorized).as("bytes: compressedScalar and vector outputs differ").isEqualTo(compressedScalar);
                     byte[] packedIsNullBits = getEncodedNullsAsBits(isNull, offset, length);
-                    boolean[] decodedIsNull = decodeNullBitsVectorized(packedIsNullBits, length);
+                    boolean[] decodedIsNull = decodeNullBitsVectorized(packedIsNullBits, length, false);
                     assertThat(decodedIsNull).as("decodedIsNull must match input isNull").isEqualTo(Arrays.copyOfRange(isNull, offset, offset + length));
                     ByteArrayBlock scalarBlock = expandBytesWithNullsScalar(Slices.wrappedBuffer(compressedScalar).getInput(), length, packedIsNullBits, decodedIsNull);
                     ByteArrayBlock vectorBlock = expandBytesWithNullsVectorized(Slices.wrappedBuffer(compressedScalar).getInput(), length, decodedIsNull);

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestEncoderUtil.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestEncoderUtil.java
@@ -55,7 +55,7 @@ final class TestEncoderUtil
                     Slice vectorSlice = vectorOutput.slice();
                     assertThat(scalarSlice).as("scalar and vector encode results differ").isEqualTo(vectorSlice);
                     boolean[] scalarDecode = EncoderUtil.decodeNullBitsScalar(scalarSlice.getInput(), length).orElseThrow();
-                    boolean[] vectorDecode = EncoderUtil.decodeNullBitsVectorized(scalarSlice.getInput(), length).orElseThrow();
+                    boolean[] vectorDecode = EncoderUtil.decodeNullBitsVectorized(scalarSlice.getInput(), length, true).orElseThrow();
                     assertThat(scalarDecode).as("scalar and vector decode results differ").isEqualTo(vectorDecode);
                     assertThat(scalarDecode).as("decode boolean[] differs from input value").isEqualTo(Arrays.copyOfRange(isNull, offset, offset + length));
                 }

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestIntegerArrayBlockEncoding.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestIntegerArrayBlockEncoding.java
@@ -64,7 +64,7 @@ final class TestIntegerArrayBlockEncoding
                     byte[] vector = compressIntsVectorized(values, isNull, offset, length);
                     assertThat(vector).as("ints: scalar and vector outputs differ").isEqualTo(scalar);
                     byte[] packedIsNullBits = getEncodedNullsAsBits(isNull, offset, length);
-                    boolean[] decodedIsNull = decodeNullBitsVectorized(packedIsNullBits, length);
+                    boolean[] decodedIsNull = decodeNullBitsVectorized(packedIsNullBits, length, false);
                     assertThat(decodedIsNull).as("decodedIsNull must match input isNull").isEqualTo(Arrays.copyOfRange(isNull, offset, offset + length));
                     IntArrayBlock scalarBlock = expandIntsWithNullsScalar(Slices.wrappedBuffer(scalar).getInput(), length, packedIsNullBits, decodedIsNull);
                     IntArrayBlock vectorBlock = expandIntsWithNullsVectorized(Slices.wrappedBuffer(vector).getInput(), length, decodedIsNull);

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestLongArrayBlockEncoding.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestLongArrayBlockEncoding.java
@@ -64,7 +64,7 @@ final class TestLongArrayBlockEncoding
                     byte[] vector = compressLongsVectorized(values, isNull, offset, length);
                     assertThat(vector).as("longs: scalar and vector outputs differ").isEqualTo(scalar);
                     byte[] packedIsNullBits = getEncodedNullsAsBits(isNull, offset, length);
-                    boolean[] decodedIsNull = decodeNullBitsVectorized(packedIsNullBits, length);
+                    boolean[] decodedIsNull = decodeNullBitsVectorized(packedIsNullBits, length, false);
                     assertThat(decodedIsNull).as("decodedIsNull must match input isNull").isEqualTo(Arrays.copyOfRange(isNull, offset, offset + length));
                     LongArrayBlock scalarBlock = expandLongsWithNullsScalar(Slices.wrappedBuffer(scalar).getInput(), length, packedIsNullBits, decodedIsNull);
                     LongArrayBlock vectorBlock = expandLongsWithNullsVectorized(Slices.wrappedBuffer(scalar).getInput(), length, decodedIsNull);

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestShortArrayBlockEncoding.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestShortArrayBlockEncoding.java
@@ -64,7 +64,7 @@ final class TestShortArrayBlockEncoding
                     byte[] vector = compressShortsVectorized(values, isNull, offset, length);
                     assertThat(vector).as("shorts: scalar and vector outputs differ").isEqualTo(scalar);
                     byte[] packedIsNullBits = getEncodedNullsAsBits(isNull, offset, length);
-                    boolean[] decodedIsNull = decodeNullBitsVectorized(packedIsNullBits, length);
+                    boolean[] decodedIsNull = decodeNullBitsVectorized(packedIsNullBits, length, false);
                     assertThat(decodedIsNull).as("decodedIsNull must match input isNull").isEqualTo(Arrays.copyOfRange(isNull, offset, offset + length));
                     ShortArrayBlock scalarBlock = expandShortsWithNullsScalar(Slices.wrappedBuffer(scalar).getInput(), length, packedIsNullBits, decodedIsNull);
                     ShortArrayBlock vectorBlock = expandShortsWithNullsVectorized(Slices.wrappedBuffer(scalar).getInput(), length, decodedIsNull);

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestingBlockEncodingSerde.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestingBlockEncodingSerde.java
@@ -50,18 +50,18 @@ public final class TestingBlockEncodingSerde
     {
         this.types = requireNonNull(types, "types is null");
         // add the built-in BlockEncodings
-        addBlockEncoding(new VariableWidthBlockEncoding(true));
-        addBlockEncoding(new ByteArrayBlockEncoding(true, true, true));
-        addBlockEncoding(new ShortArrayBlockEncoding(true, true, true));
-        addBlockEncoding(new IntArrayBlockEncoding(true, true, true));
-        addBlockEncoding(new LongArrayBlockEncoding(true, true, true));
-        addBlockEncoding(new Fixed12BlockEncoding(true));
-        addBlockEncoding(new Int128ArrayBlockEncoding(true));
-        addBlockEncoding(new VariantBlockEncoding(true));
+        addBlockEncoding(new VariableWidthBlockEncoding(true, true));
+        addBlockEncoding(new ByteArrayBlockEncoding(true, true, true, true));
+        addBlockEncoding(new ShortArrayBlockEncoding(true, true, true, true));
+        addBlockEncoding(new IntArrayBlockEncoding(true, true, true, true));
+        addBlockEncoding(new LongArrayBlockEncoding(true, true, true, true));
+        addBlockEncoding(new Fixed12BlockEncoding(true, true));
+        addBlockEncoding(new Int128ArrayBlockEncoding(true, true));
+        addBlockEncoding(new VariantBlockEncoding(true, true));
         addBlockEncoding(new DictionaryBlockEncoding());
-        addBlockEncoding(new ArrayBlockEncoding(true));
-        addBlockEncoding(new MapBlockEncoding(true));
-        addBlockEncoding(new RowBlockEncoding(true));
+        addBlockEncoding(new ArrayBlockEncoding(true, true));
+        addBlockEncoding(new MapBlockEncoding(true, true));
+        addBlockEncoding(new RowBlockEncoding(true, true));
         addBlockEncoding(new RunLengthBlockEncoding());
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This PR extends the SIMD support for null bit packing in BlockSerde, introduced in #27674, by leveraging VectorMask methods in Vector API.

The bit-packing optimization (encodeNullsAsBits method) is enabled on all x86_64 platforms and on all ARM platforms that support SVE or SVE2.

For bit unpacking (decodeNullBits method), the VectorMask API relies on BitPerm intrinsics, which are only available in SVE2. Therefore, on AArch64 platforms, we check whether the target machine supports SVE2 before using the VectorMask implementation. No such limitation exists on x86_64 platforms.

### Note
VectorMask.fromLong/toLong() performance for SVE was improved in JDK 26 as part of [openjdk/jdk#27481](https://github.com/openjdk/jdk/pull/27481). Using JDK 25 or earlier may result in performance degradation on AArch64 platforms.

### Benchmark
We used the same benchmark as in #27586 and #27674

#### Graviton 3 (m7g.4xlarge instance)

- ~90% improvement in deserializeSliceDirect.
- ~10% improvement in serializeByte and serializeInteger.
- ~5-7% improvement in other datatypes.

#### Graviton 4 (c8g.4xlarge instance)

- ~115% improvement in deserializeSliceDirect.
- ~13% improvement in deserializeInteger and serializeInteger.
- ~5-10% improvement in other datatypes.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: