### PR TITLE
Document `ConnectorSplitSource` batch contract

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplitSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplitSource.java
@@ -30,6 +30,24 @@ import static java.util.Objects.requireNonNull;
 public interface ConnectorSplitSource
         extends Closeable
 {
+    /**
+     * Returns the next batch of splits.
+     * <p>
+     * Callers must not invoke this method again until the returned future is done.
+     * In other words, each split source supports at most one outstanding batch request.
+     * Implementations are not required to support concurrent invocations of this method.
+     * <p>
+     * The returned future may complete with an empty batch when no splits are currently
+     * available. This does not necessarily mean the split source is finished unless the
+     * returned batch has {@code noMoreSplits} set.
+     * <p>
+     * The {@link #close()} method may be called concurrently while a batch request is
+     * outstanding.
+     * If this method observes that the split source has already been closed, it should
+     * preferably fail the request, such as by returning an exceptionally completed
+     * future. Since close may race with a batch request, it is also acceptable to return
+     * a normal batch result.
+     */
     default CompletableFuture<ConnectorSplitBatch> getNextBatch(int maxSize)
     {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
## Description

Clarify the existing usage contract for `ConnectorSplitSource#getNextBatch`. The method already operates as a single outstanding request contract in practice: callers must wait for the returned future to complete before requesting another batch, while `close()` may be called concurrently.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)