### PR TITLE
Model SIMD support as an enum set instead of boolean flags

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/BlockEncodingManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/BlockEncodingManager.java
@@ -36,6 +36,15 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.simd.SimdCapability.COMPRESS_BYTE;
+import static io.trino.simd.SimdCapability.COMPRESS_INT;
+import static io.trino.simd.SimdCapability.COMPRESS_LONG;
+import static io.trino.simd.SimdCapability.COMPRESS_SHORT;
+import static io.trino.simd.SimdCapability.EXPAND_BYTE;
+import static io.trino.simd.SimdCapability.EXPAND_INT;
+import static io.trino.simd.SimdCapability.EXPAND_LONG;
+import static io.trino.simd.SimdCapability.EXPAND_SHORT;
+import static io.trino.simd.SimdCapability.NULL_BIT_PACKING;
 import static java.util.Objects.requireNonNull;
 
 public final class BlockEncodingManager
@@ -50,18 +59,18 @@ public final class BlockEncodingManager
     {
         // add the built-in BlockEncodings
         SimdSupport simdSupport = blockEncodingSimdSupport.getSimdSupport();
-        addBlockEncoding(new VariableWidthBlockEncoding(simdSupport.vectorizeNullBitPacking()));
-        addBlockEncoding(new ByteArrayBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.compressByte(), simdSupport.expandByte()));
-        addBlockEncoding(new ShortArrayBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.compressShort(), simdSupport.expandShort()));
-        addBlockEncoding(new IntArrayBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.compressInt(), simdSupport.expandInt()));
-        addBlockEncoding(new LongArrayBlockEncoding(simdSupport.vectorizeNullBitPacking(), simdSupport.compressLong(), simdSupport.expandLong()));
-        addBlockEncoding(new Fixed12BlockEncoding(simdSupport.vectorizeNullBitPacking()));
-        addBlockEncoding(new Int128ArrayBlockEncoding(simdSupport.vectorizeNullBitPacking()));
-        addBlockEncoding(new VariantBlockEncoding(simdSupport.vectorizeNullBitPacking()));
+        addBlockEncoding(new VariableWidthBlockEncoding(simdSupport.supports(NULL_BIT_PACKING)));
+        addBlockEncoding(new ByteArrayBlockEncoding(simdSupport.supports(NULL_BIT_PACKING), simdSupport.supports(COMPRESS_BYTE), simdSupport.supports(EXPAND_BYTE)));
+        addBlockEncoding(new ShortArrayBlockEncoding(simdSupport.supports(NULL_BIT_PACKING), simdSupport.supports(COMPRESS_SHORT), simdSupport.supports(EXPAND_SHORT)));
+        addBlockEncoding(new IntArrayBlockEncoding(simdSupport.supports(NULL_BIT_PACKING), simdSupport.supports(COMPRESS_INT), simdSupport.supports(EXPAND_INT)));
+        addBlockEncoding(new LongArrayBlockEncoding(simdSupport.supports(NULL_BIT_PACKING), simdSupport.supports(COMPRESS_LONG), simdSupport.supports(EXPAND_LONG)));
+        addBlockEncoding(new Fixed12BlockEncoding(simdSupport.supports(NULL_BIT_PACKING)));
+        addBlockEncoding(new Int128ArrayBlockEncoding(simdSupport.supports(NULL_BIT_PACKING)));
+        addBlockEncoding(new VariantBlockEncoding(simdSupport.supports(NULL_BIT_PACKING)));
         addBlockEncoding(new DictionaryBlockEncoding());
-        addBlockEncoding(new ArrayBlockEncoding(simdSupport.vectorizeNullBitPacking()));
-        addBlockEncoding(new MapBlockEncoding(simdSupport.vectorizeNullBitPacking()));
-        addBlockEncoding(new RowBlockEncoding(simdSupport.vectorizeNullBitPacking()));
+        addBlockEncoding(new ArrayBlockEncoding(simdSupport.supports(NULL_BIT_PACKING)));
+        addBlockEncoding(new MapBlockEncoding(simdSupport.supports(NULL_BIT_PACKING)));
+        addBlockEncoding(new RowBlockEncoding(simdSupport.supports(NULL_BIT_PACKING)));
         addBlockEncoding(new RunLengthBlockEncoding());
     }
 

--- a/core/trino-main/src/main/java/io/trino/simd/BlockEncodingSimdSupport.java
+++ b/core/trino-main/src/main/java/io/trino/simd/BlockEncodingSimdSupport.java
@@ -15,6 +15,7 @@ package io.trino.simd;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.StandardSystemProperty;
+import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.airlift.log.Logger;
@@ -24,6 +25,15 @@ import jdk.incubator.vector.VectorShape;
 import java.util.EnumSet;
 import java.util.Set;
 
+import static io.trino.simd.SimdCapability.COMPRESS_BYTE;
+import static io.trino.simd.SimdCapability.COMPRESS_INT;
+import static io.trino.simd.SimdCapability.COMPRESS_LONG;
+import static io.trino.simd.SimdCapability.COMPRESS_SHORT;
+import static io.trino.simd.SimdCapability.EXPAND_BYTE;
+import static io.trino.simd.SimdCapability.EXPAND_INT;
+import static io.trino.simd.SimdCapability.EXPAND_LONG;
+import static io.trino.simd.SimdCapability.EXPAND_SHORT;
+import static io.trino.simd.SimdCapability.NULL_BIT_PACKING;
 import static io.trino.util.MachineInfo.readCpuFlags;
 import static java.util.Locale.ENGLISH;
 
@@ -47,19 +57,20 @@ public final class BlockEncodingSimdSupport
 {
     private static final Logger log = Logger.get(BlockEncodingSimdSupport.class);
 
-    public record SimdSupport(
-            boolean vectorizeNullBitPacking,
-            boolean compressByte,
-            boolean expandByte,
-            boolean compressShort,
-            boolean expandShort,
-            boolean compressInt,
-            boolean expandInt,
-            boolean compressLong,
-            boolean expandLong)
+    public record SimdSupport(Set<SimdCapability> capabilities)
     {
-        public static final SimdSupport NONE = new SimdSupport(false, false, false, false, false, false, false, false, false);
-        public static final SimdSupport ALL = new SimdSupport(true, true, true, true, true, true, true, true, true);
+        public static final SimdSupport NONE = new SimdSupport(EnumSet.noneOf(SimdCapability.class));
+        public static final SimdSupport ALL = new SimdSupport(EnumSet.allOf(SimdCapability.class));
+
+        public SimdSupport
+        {
+            capabilities = Sets.immutableEnumSet(capabilities);
+        }
+
+        public boolean supports(SimdCapability capability)
+        {
+            return capabilities.contains(capability);
+        }
     }
 
     private static final SimdSupport AUTO_DETECTED_SUPPORT = detectSimd();
@@ -147,21 +158,20 @@ public final class BlockEncodingSimdSupport
         }
 
         // Always vectorize valueIsNull bit packing, no known x86_64 platforms regress with this approach
-        boolean packIsNullBits = true;
-        boolean expandAndCompressByte = x86Flags.contains(X86SimdInstructionSet.avx512vbmi2);
-        boolean expandAndCompressShort = x86Flags.contains(X86SimdInstructionSet.avx512vbmi2);
-        boolean expandAndCompressInt = x86Flags.contains(X86SimdInstructionSet.avx512f);
-        boolean expandAndCompressLong = x86Flags.contains(X86SimdInstructionSet.avx512f);
-        return new SimdSupport(
-                packIsNullBits,
-                expandAndCompressByte,
-                expandAndCompressByte,
-                expandAndCompressShort,
-                expandAndCompressShort,
-                expandAndCompressInt,
-                expandAndCompressInt,
-                expandAndCompressLong,
-                expandAndCompressLong);
+        EnumSet<SimdCapability> capabilities = EnumSet.of(NULL_BIT_PACKING);
+        if (x86Flags.contains(X86SimdInstructionSet.avx512vbmi2)) {
+            capabilities.add(COMPRESS_BYTE);
+            capabilities.add(EXPAND_BYTE);
+            capabilities.add(COMPRESS_SHORT);
+            capabilities.add(EXPAND_SHORT);
+        }
+        if (x86Flags.contains(X86SimdInstructionSet.avx512f)) {
+            capabilities.add(COMPRESS_INT);
+            capabilities.add(EXPAND_INT);
+            capabilities.add(COMPRESS_LONG);
+            capabilities.add(EXPAND_LONG);
+        }
+        return new SimdSupport(capabilities);
     }
 
     private static SimdSupport detectArmSimdSupport(int preferredVectorBitWidth, Set<String> flags)
@@ -188,27 +198,25 @@ public final class BlockEncodingSimdSupport
         }
 
         // Vectorized null bit packing has no known aarch64 platforms that regress compared to scalar code
-        boolean packIsNullBits = true;
+        EnumSet<SimdCapability> capabilities = EnumSet.of(NULL_BIT_PACKING);
         // SVE 1 is sufficient to have Vector#compress(VectorMask) intrinsics for all primitive types
-        boolean compressAll = true;
-        boolean compressLong = preferredVectorBitWidth > 128; // only vectorize long compression if we can handle more than 2 values per instruction
+        capabilities.add(COMPRESS_BYTE);
+        capabilities.add(COMPRESS_SHORT);
+        capabilities.add(COMPRESS_INT);
+        if (preferredVectorBitWidth > 128) { // only vectorize long compression if we can handle more than 2 values per instruction
+            capabilities.add(COMPRESS_LONG);
+        }
 
         // As of JDK 25, SVE 2 intrinsics for Vector#expand(VectorMask) over int and long, but not byte or short. JDK 26 add intrinsics
         // for byte and short on SVE 2, SVE 1, and NEON in https://bugs.openjdk.org/browse/JDK-8363989. We can reconsider enabling vectorized
-        // expansion for those types at some point in the future
-        boolean expandInt = armFlags.contains(ArmSimdInstructionSet.sve2);
-        boolean expandLong = armFlags.contains(ArmSimdInstructionSet.sve2) && preferredVectorBitWidth > 128; // ensure minimum register width for long
-        boolean expandByteAndShort = false; // no intrinsics in JDK 25
-        return new SimdSupport(
-                packIsNullBits,
-                compressAll,
-                expandByteAndShort,
-                compressAll,
-                expandByteAndShort,
-                compressAll,
-                expandInt,
-                compressLong,
-                expandLong);
+        // expansion for those types at some point in the future. Expansion for byte and short therefore stays disabled here.
+        if (armFlags.contains(ArmSimdInstructionSet.sve2)) {
+            capabilities.add(EXPAND_INT);
+            if (preferredVectorBitWidth > 128) { // ensure minimum register width for long
+                capabilities.add(EXPAND_LONG);
+            }
+        }
+        return new SimdSupport(capabilities);
     }
 
     public SimdSupport getSimdSupport()

--- a/core/trino-main/src/main/java/io/trino/simd/SimdCapability.java
+++ b/core/trino-main/src/main/java/io/trino/simd/SimdCapability.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.simd;
+
+/**
+ * A single block-encoding operation that can be vectorized when the underlying
+ * hardware advertises native support for it.
+ */
+public enum SimdCapability
+{
+    NULL_BIT_PACKING,
+    COMPRESS_BYTE,
+    EXPAND_BYTE,
+    COMPRESS_SHORT,
+    EXPAND_SHORT,
+    COMPRESS_INT,
+    EXPAND_INT,
+    COMPRESS_LONG,
+    EXPAND_LONG,
+}

--- a/core/trino-main/src/test/java/io/trino/simd/TestBlockEncodingSimdSupport.java
+++ b/core/trino-main/src/test/java/io/trino/simd/TestBlockEncodingSimdSupport.java
@@ -15,9 +15,17 @@ package io.trino.simd;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.EnumSet;
 import java.util.Set;
 
 import static io.trino.simd.BlockEncodingSimdSupport.determineSimdSupport;
+import static io.trino.simd.SimdCapability.COMPRESS_BYTE;
+import static io.trino.simd.SimdCapability.COMPRESS_INT;
+import static io.trino.simd.SimdCapability.COMPRESS_LONG;
+import static io.trino.simd.SimdCapability.COMPRESS_SHORT;
+import static io.trino.simd.SimdCapability.EXPAND_INT;
+import static io.trino.simd.SimdCapability.EXPAND_LONG;
+import static io.trino.simd.SimdCapability.NULL_BIT_PACKING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestBlockEncodingSimdSupport
@@ -29,16 +37,12 @@ final class TestBlockEncodingSimdSupport
         int vectorBitsPreferred = 256;
         // Only compress and expand int and long, no byte or short support with only avx512f
         assertThat(determineSimdSupport(osArch, vectorBitsPreferred, Set.of("avx512f")))
-                .isEqualTo(new BlockEncodingSimdSupport.SimdSupport(
-                        true, // vectorizeNullBitPacking
-                        false, // compressByte
-                        false, // expandByte
-                        false, // compressShort
-                        false, // expandShort
-                        true, // compressInt
-                        true, // expandInt
-                        true, // compressLong
-                        true));
+                .isEqualTo(new BlockEncodingSimdSupport.SimdSupport(EnumSet.of(
+                        NULL_BIT_PACKING,
+                        COMPRESS_INT,
+                        EXPAND_INT,
+                        COMPRESS_LONG,
+                        EXPAND_LONG)));
         // Support compress / expand for all types with avx512vbmi2
         assertThat(determineSimdSupport(osArch, vectorBitsPreferred, Set.of("avx512f", "avx512vbmi2")))
                 .isEqualTo(BlockEncodingSimdSupport.SimdSupport.ALL);
@@ -50,16 +54,13 @@ final class TestBlockEncodingSimdSupport
         String osArch = "aarch64";
         int vectorBitsPreferred = 256;
         Set<String> flags = Set.of("sve");
-        BlockEncodingSimdSupport.SimdSupport expected = new BlockEncodingSimdSupport.SimdSupport(
-                true, // vectorizeNullBitPacking
-                true, // compressByte
-                false, // expandByte - no intrinsic support in JDK 25
-                true, // compressShort
-                false, // expandShort - not intrinsic support in JDK 25
-                true, // compressInt
-                false, // expandInt - no intrinsic for SVE 1 in JDK 25
-                true, // compressLong
-                false); // expandLong - no intrinsic for SVE1 in JDK 25
+        // SVE 1 supports compress for all primitive types, but no expand intrinsics in JDK 25
+        BlockEncodingSimdSupport.SimdSupport expected = new BlockEncodingSimdSupport.SimdSupport(EnumSet.of(
+                NULL_BIT_PACKING,
+                COMPRESS_BYTE,
+                COMPRESS_SHORT,
+                COMPRESS_INT,
+                COMPRESS_LONG));
         assertThat(determineSimdSupport(osArch, vectorBitsPreferred, flags)).isEqualTo(expected);
     }
 
@@ -69,16 +70,13 @@ final class TestBlockEncodingSimdSupport
         String osArch = "aarch64";
         int vectorBitsPreferred = 128;
         Set<String> flags = Set.of("sve", "sve2");
-        BlockEncodingSimdSupport.SimdSupport expected = new BlockEncodingSimdSupport.SimdSupport(
-                true, // vectorizeNullBitPacking
-                true, // compressByte
-                false, // expandByte - no intrinsic support in JDK 25
-                true, // compressShort
-                false, // expandShort - no intrinsic support in JDK 25
-                true, // compressInt
-                true, // expandInt
-                false, // compressLong - not worthwhile on 128 bit vectors
-                false); // expandLong - not worthwhile on 128 bit vectors
+        // SVE 2 adds expand for int; long compress/expand stay off because they are not worthwhile on 128 bit vectors
+        BlockEncodingSimdSupport.SimdSupport expected = new BlockEncodingSimdSupport.SimdSupport(EnumSet.of(
+                NULL_BIT_PACKING,
+                COMPRESS_BYTE,
+                COMPRESS_SHORT,
+                COMPRESS_INT,
+                EXPAND_INT));
         assertThat(determineSimdSupport(osArch, vectorBitsPreferred, flags)).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
## Description

`BlockEncodingSimdSupport.SimdSupport` carried nine positional `boolean` fields, one per vectorizable block-encoding operation. Constructing it required getting nine bare booleans in the right order, which was error-prone and forced every call site and test to annotate each literal with an inline comment to stay legible.

This change models the capabilities as a flat `SimdCapability` enum held in an `EnumSet`, wrapped by a thin `SimdSupport` record. Construction and queries are now order-independent and self-describing.

- New `SimdCapability` enum — flat, 9 values (`NULL_BIT_PACKING`, `COMPRESS_BYTE`/`EXPAND_BYTE`, … `COMPRESS_LONG`/`EXPAND_LONG`).
- `SimdSupport` is now `record SimdSupport(Set<SimdCapability> capabilities)`; the compact constructor normalizes to `Sets.immutableEnumSet`, and `NONE`/`ALL` become empty / `allOf`. Added `supports(SimdCapability)`.
- Detection (x86 + ARM paths) builds an `EnumSet` with named, flag-guarded `.add(...)` calls instead of nine positional booleans; arch comments preserved.
- `BlockEncodingManager` reads via `supports(...)`; the `BlockEncoding` constructors keep their `boolean` params.
- Tests assert with `EnumSet.of(...)` instead of commented positional booleans.

No behavioral change: the detection logic produces the same capability set for every architecture/flag/width combination as before.

## Additional context and related issues

Pure internal refactor of recently added SIMD block-encoding support.

## Release notes

(x) This is not user-visible or is an internal change.