### PR TITLE
Preserve zero-channel unnest page positions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/unnest/UnnestOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/unnest/UnnestOperator.java
@@ -234,7 +234,7 @@ public class UnnestOperator
         int batchSize = calculateNextBatchSize();
         Block[] outputBlocks = buildOutputBlocks(batchSize);
 
-        return new Page(outputBlocks);
+        return new Page(currentBatchOutputRowCount, outputBlocks);
     }
 
     private int calculateNextBatchSize()

--- a/core/trino-main/src/test/java/io/trino/operator/unnest/TestUnnestOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/unnest/TestUnnestOperator.java
@@ -315,6 +315,21 @@ public class TestUnnestOperator
     }
 
     @Test
+    public void testZeroChannelOuterUnnest()
+    {
+        Operator unnestOperator = new UnnestOperator.UnnestOperatorFactory(
+                0, new PlanNodeId("test"), ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), false, true)
+                .createOperator(createDriverContext());
+
+        unnestOperator.addInput(new Page(3));
+
+        Page output = unnestOperator.getOutput();
+        assertThat(output.getChannelCount()).isEqualTo(0);
+        assertThat(output.getPositionCount()).isEqualTo(3);
+        assertThat(unnestOperator.getOutput()).isNull();
+    }
+
+    @Test
     public void testUnnestSingleArray()
     {
         testUnnest(


### PR DESCRIPTION
## Description

Preserve the output row count when `UnnestOperator` builds a page with no output channels. The operator already tracks the batch output row count in `currentBatchOutputRowCount`; passing it to the `Page` constructor avoids inferring the position count from an empty `Block[]`.

Added a regression test for an outer zero-channel unnest output page.

## Additional context and related issues

This fixes the same class of zero-channel `Page` reconstruction issue as DSCVR-472.

Validation:

- `./mvnw -pl core/trino-main airstyle:format '-Dincludes=**/UnnestOperator.java,**/TestUnnestOperator.java'` passed.
- `./mvnw -pl core/trino-main -Dtest=TestUnnestOperator#testZeroChannelOuterUnnest test` could not resolve local same-version modules without `-am`.
- `./mvnw -pl core/trino-main -am -Dtest=TestUnnestOperator#testZeroChannelOuterUnnest -DfailIfNoTests=false test` was blocked before compilation by Trino's Java vendor enforcer because this machine has Homebrew OpenJDK 26.0.1, not Temurin or Oracle JDK.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```