### PR TITLE
Reuse SessionContext for nested REST namespace listing

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -190,7 +190,7 @@ public class TrinoRestCatalog
     public List<String> listNamespaces(ConnectorSession session)
     {
         if (nestedNamespaceEnabled) {
-            return collectNamespaces(session, Namespace.empty());
+            return collectNamespaces(convert(session), Namespace.empty());
         }
         try {
             return restSessionCatalog.listNamespaces(convert(session)).stream()
@@ -202,11 +202,11 @@ public class TrinoRestCatalog
         }
     }
 
-    private List<String> collectNamespaces(ConnectorSession session, Namespace parentNamespace)
+    private List<String> collectNamespaces(SessionContext sessionContext, Namespace parentNamespace)
     {
         try {
-            return restSessionCatalog.listNamespaces(convert(session), parentNamespace).stream()
-                    .flatMap(childNamespace -> collectNamespaceIfExists(session, childNamespace).stream())
+            return restSessionCatalog.listNamespaces(sessionContext, parentNamespace).stream()
+                    .flatMap(childNamespace -> collectNamespaceIfExists(sessionContext, childNamespace).stream())
                     .collect(toImmutableList());
         }
         catch (RESTException e) {
@@ -214,12 +214,12 @@ public class TrinoRestCatalog
         }
     }
 
-    private List<String> collectNamespaceIfExists(ConnectorSession session, Namespace namespace)
+    private List<String> collectNamespaceIfExists(SessionContext sessionContext, Namespace namespace)
     {
         try {
             return Stream.concat(
                             Stream.of(namespace.toString()),
-                            collectNamespaces(session, namespace).stream())
+                            collectNamespaces(sessionContext, namespace).stream())
                     .collect(toImmutableList());
         }
         catch (NoSuchNamespaceException e) {
@@ -1070,24 +1070,29 @@ public class TrinoRestCatalog
 
     private List<Namespace> listNamespaces(ConnectorSession session, Namespace parentNamespace)
     {
-        List<Namespace> childNamespaces;
-        try {
-            childNamespaces = restSessionCatalog.listNamespaces(convert(session), parentNamespace);
-        }
-        catch (RESTException e) {
-            throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to list namespaces", e);
-        }
-        return childNamespaces.stream().flatMap(childNamespace -> listNamespaceIfExists(session, childNamespace).stream()).toList();
+        return listNamespaces(convert(session), parentNamespace);
     }
 
-    private List<Namespace> listNamespaceIfExists(ConnectorSession session, Namespace namespace)
+    private List<Namespace> listNamespaceIfExists(SessionContext sessionContext, Namespace namespace)
     {
         try {
-            return Stream.concat(Stream.of(namespace), listNamespaces(session, namespace).stream()).toList();
+            return Stream.concat(Stream.of(namespace), listNamespaces(sessionContext, namespace).stream()).toList();
         }
         catch (NoSuchNamespaceException e) {
             return ImmutableList.of();
         }
+    }
+
+    private List<Namespace> listNamespaces(SessionContext sessionContext, Namespace parentNamespace)
+    {
+        List<Namespace> childNamespaces;
+        try {
+            childNamespaces = restSessionCatalog.listNamespaces(sessionContext, parentNamespace);
+        }
+        catch (RESTException e) {
+            throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to list namespaces", e);
+        }
+        return childNamespaces.stream().flatMap(childNamespace -> listNamespaceIfExists(sessionContext, childNamespace).stream()).toList();
     }
 
     private static Namespace toTrinoNamespace(Namespace namespace)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -48,6 +48,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -69,6 +70,7 @@ import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.INTEGER;
 
 public class TestTrinoRestCatalog
         extends BaseTrinoCatalogTest
@@ -222,6 +224,27 @@ public class TestTrinoRestCatalog
         TrinoCatalog catalog = createTrinoRestCatalog(false, new NamespaceDeletedDuringRecursiveListingCatalog(), false, true);
 
         assertThat(catalog.namespaceExists(SESSION, "existing")).isTrue();
+    }
+
+    @Test
+    public void testNestedListNamespacesReusesSessionContext()
+    {
+        Map<String, Integer> sessionIdCounts = new ConcurrentHashMap<>();
+        RESTSessionCatalog restSessionCatalog = new NamespaceDeletedDuringRecursiveListingCatalog()
+        {
+            @Override
+            public List<Namespace> listNamespaces(SessionContext context, Namespace namespace)
+            {
+                sessionIdCounts.merge(context.sessionId(), 1, Integer::sum);
+                return super.listNamespaces(context, namespace);
+            }
+        };
+
+        TrinoRestCatalog catalog = createTrinoRestCatalog(false, restSessionCatalog, true, false);
+
+        catalog.listNamespaces(SESSION);
+
+        assertThat(sessionIdCounts.values()).singleElement(INTEGER).isGreaterThan(1);
     }
 
     @Test


### PR DESCRIPTION
## Description

When `iceberg.rest-catalog.nested-namespace-enabled` is true and `iceberg.rest-catalog.session` is `NONE`, recursive namespace listing in `TrinoRestCatalog` created a new Iceberg `SessionContext` on every REST `listNamespaces` call via `convert(session)`.

With OAuth2 credentials configured, Iceberg's `OAuth2Manager` treats each new session id as a separate client session and may fetch a new access token from the identity provider. A single `SHOW SCHEMAS` against a catalog with nested namespaces can therefore trigger many OAuth token requests.

Reuse a single `SessionContext` for the full recursive namespace listing, including the case-insensitive namespace resolution path.

Fixes #29722

## Additional context and related issues

Relates to #25122. Concrete failure reported in apache/gravitino#11077 when listing schemas from a Gravitino Iceberg REST catalog with `session=NONE` and OAuth2 client credentials.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Fix excessive OAuth token requests when listing nested namespaces on Iceberg REST catalogs with `session=NONE`. ({issue}`29722`)
```