### PR TITLE
Trino Datasketches plugin: Fix boxed-type mismatch and add integration tests

### DIFF
--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/UnionWithParams.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/UnionWithParams.java
@@ -25,15 +25,17 @@ import io.trino.spi.function.OutputFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
+import static java.lang.Math.toIntExact;
+
 @AggregationFunction("theta_sketch_union")
 public final class UnionWithParams
 {
     private UnionWithParams() {}
 
     @InputFunction
-    public static void input(@AggregationState SketchState state, @SqlType(StandardTypes.VARBINARY) Slice inputValue, @SqlType(StandardTypes.INTEGER) Integer nominalEntries, @SqlType(StandardTypes.BIGINT) Long seed)
+    public static void input(@AggregationState SketchState state, @SqlType(StandardTypes.VARBINARY) Slice inputValue, @SqlType(StandardTypes.INTEGER) long nominalEntries, @SqlType(StandardTypes.BIGINT) long seed)
     {
-        state.setNominalEntries(nominalEntries);
+        state.setNominalEntries(toIntExact(nominalEntries));
         state.setSeed(seed);
         state.addSketch(inputValue);
     }

--- a/plugin/trino-datasketches/src/test/java/io/trino/plugin/datasketches/TestDataSketches.java
+++ b/plugin/trino-datasketches/src/test/java/io/trino/plugin/datasketches/TestDataSketches.java
@@ -197,6 +197,39 @@ public class TestDataSketches
         assertThat(estimate).isEqualTo(3d);
     }
 
+    @Test
+    public void testCardinalityExactWithLargeNominalEntries()
+    {
+        int nominalEntries = 2 * DEFAULT_NOMINAL_ENTRIES;
+        String hexSketch = toHexSketch(0, nominalEntries, nominalEntries);
+
+        double estimate = (double) computeScalar(
+                """
+                SELECT theta_sketch_cardinality(theta_sketch_union(sketch, %d, CAST(%d AS BIGINT)))
+                FROM (VALUES (X'%s')) t(sketch)
+                """.formatted(nominalEntries, DEFAULT_UPDATE_SEED, hexSketch));
+
+        assertThat(estimate).isEqualTo(nominalEntries);
+    }
+
+    @Test
+    public void testUnionExactWithLargeNominalEntries()
+    {
+        // Two disjoint sketches, each with DEFAULT_NOMINAL_ENTRIES elements; unioning with K=2*DEFAULT_NOMINAL_ENTRIES
+        // gives enough capacity to retain all values without sampling
+        int unionNominalEntries = 2 * DEFAULT_NOMINAL_ENTRIES;
+        String sketchA = toHexSketch(0, DEFAULT_NOMINAL_ENTRIES, DEFAULT_NOMINAL_ENTRIES);
+        String sketchB = toHexSketch(DEFAULT_NOMINAL_ENTRIES, unionNominalEntries, DEFAULT_NOMINAL_ENTRIES);
+
+        double estimate = (double) computeScalar(
+                """
+                SELECT theta_sketch_cardinality(theta_sketch_union(sketch, %d, CAST(%d AS BIGINT)))
+                FROM (VALUES (X'%s'), (X'%s')) t(sketch)
+                """.formatted(unionNominalEntries, DEFAULT_UPDATE_SEED, sketchA, sketchB));
+
+        assertThat(estimate).isEqualTo(unionNominalEntries);
+    }
+
     private String toHexSketch(int[] data)
     {
         UpdatableThetaSketch sketch = UpdatableThetaSketch.builder()
@@ -205,6 +238,18 @@ public class TestDataSketches
                 .build();
         Arrays.stream(data).forEach(sketch::update);
 
+        return base16().lowerCase().encode(sketch.compact().toByteArray());
+    }
+
+    private static String toHexSketch(int from, int to, int nominalEntries)
+    {
+        UpdatableThetaSketch sketch = UpdatableThetaSketch.builder()
+                .setNominalEntries(nominalEntries)
+                .setSeed(DEFAULT_UPDATE_SEED)
+                .build();
+        for (int i = from; i < to; i++) {
+            sketch.update(i);
+        }
         return base16().lowerCase().encode(sketch.compact().toByteArray());
     }
 


### PR DESCRIPTION
## Summary

- **Bug fix:** `UnionWithParams.input()` declared extra params as boxed `Integer nominalEntries` and `Long seed`. Trino SPI passes `INTEGER`/`BIGINT` column values as primitive `long` via `(ValueBlock,int)long` method handles. `MethodHandles.filterArguments` failed at runtime:

  ```
  java.lang.IllegalArgumentException: target and filter types do not match:
    (SketchState,ValueBlock,int,Integer,Long)void, (ValueBlock,int)long
  ```

  Fix: change both params to primitive `long`; cast `nominalEntries` to `int` at the call site since `SketchState.setNominalEntries` takes `int`.

  ```java
  // before
  @SqlType(StandardTypes.INTEGER) Integer nominalEntries,
  @SqlType(StandardTypes.BIGINT)  Long seed

  // after
  @SqlType(StandardTypes.INTEGER) long nominalEntries,
  @SqlType(StandardTypes.BIGINT)  long seed
  ```

- **Tests:** Two new tests exercise `theta_sketch_union(sketch, nominalEntries, seed)` with explicit `K=8192`, verifying exact cardinality when all values fit within the sketch capacity.

## Test plan

- [x] `TestDataSketches#testCardinalityExactWithLargeNominalEntries` — single sketch K=8192, 8192 distinct values → exact 8192.0
- [x] `TestDataSketches#testUnionExactWithLargeNominalEntries` — two disjoint sketches (4096 elements each at default K=4096) unioned with K=8192 → exact 8192.0
