### PR TITLE
Extract HiveFormatsModule shared by Hive and Lakehouse

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveFormatsModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveFormatsModule.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.hive.avro.AvroFileWriterFactory;
+import io.trino.plugin.hive.avro.AvroPageSourceFactory;
+import io.trino.plugin.hive.crypto.ParquetEncryptionModule;
+import io.trino.plugin.hive.esri.EsriPageSourceFactory;
+import io.trino.plugin.hive.line.CsvFileWriterFactory;
+import io.trino.plugin.hive.line.CsvPageSourceFactory;
+import io.trino.plugin.hive.line.JsonFileWriterFactory;
+import io.trino.plugin.hive.line.JsonPageSourceFactory;
+import io.trino.plugin.hive.line.OpenXJsonFileWriterFactory;
+import io.trino.plugin.hive.line.OpenXJsonPageSourceFactory;
+import io.trino.plugin.hive.line.ProtobufSequenceFilePageSourceFactory;
+import io.trino.plugin.hive.line.RegexFileWriterFactory;
+import io.trino.plugin.hive.line.RegexPageSourceFactory;
+import io.trino.plugin.hive.line.SimpleSequenceFilePageSourceFactory;
+import io.trino.plugin.hive.line.SimpleSequenceFileWriterFactory;
+import io.trino.plugin.hive.line.SimpleTextFilePageSourceFactory;
+import io.trino.plugin.hive.line.SimpleTextFileWriterFactory;
+import io.trino.plugin.hive.orc.OrcFileWriterFactory;
+import io.trino.plugin.hive.orc.OrcPageSourceFactory;
+import io.trino.plugin.hive.parquet.ParquetFileWriterFactory;
+import io.trino.plugin.hive.parquet.ParquetPageSourceFactory;
+import io.trino.plugin.hive.rcfile.RcFilePageSourceFactory;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class HiveFormatsModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        Multibinder<HivePageSourceFactory> pageSourceFactoryBinder = newSetBinder(binder, HivePageSourceFactory.class);
+        pageSourceFactoryBinder.addBinding().to(CsvPageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(JsonPageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(OpenXJsonPageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(EsriPageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(RegexPageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(SimpleTextFilePageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(SimpleSequenceFilePageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(OrcPageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(ParquetPageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(RcFilePageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(AvroPageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(ProtobufSequenceFilePageSourceFactory.class).in(Scopes.SINGLETON);
+
+        binder.bind(OrcFileWriterFactory.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(OrcFileWriterFactory.class).withGeneratedName();
+
+        Multibinder<HiveFileWriterFactory> fileWriterFactoryBinder = newSetBinder(binder, HiveFileWriterFactory.class);
+        fileWriterFactoryBinder.addBinding().to(CsvFileWriterFactory.class).in(Scopes.SINGLETON);
+        fileWriterFactoryBinder.addBinding().to(JsonFileWriterFactory.class).in(Scopes.SINGLETON);
+        fileWriterFactoryBinder.addBinding().to(RegexFileWriterFactory.class).in(Scopes.SINGLETON);
+        fileWriterFactoryBinder.addBinding().to(OpenXJsonFileWriterFactory.class).in(Scopes.SINGLETON);
+        fileWriterFactoryBinder.addBinding().to(SimpleTextFileWriterFactory.class).in(Scopes.SINGLETON);
+        fileWriterFactoryBinder.addBinding().to(SimpleSequenceFileWriterFactory.class).in(Scopes.SINGLETON);
+        fileWriterFactoryBinder.addBinding().to(OrcFileWriterFactory.class).in(Scopes.SINGLETON);
+        fileWriterFactoryBinder.addBinding().to(RcFileFileWriterFactory.class).in(Scopes.SINGLETON);
+        fileWriterFactoryBinder.addBinding().to(AvroFileWriterFactory.class).in(Scopes.SINGLETON);
+        fileWriterFactoryBinder.addBinding().to(ParquetFileWriterFactory.class).in(Scopes.SINGLETON);
+
+        install(new ParquetEncryptionModule());
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
@@ -20,36 +20,14 @@ import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
-import io.trino.plugin.hive.avro.AvroFileWriterFactory;
-import io.trino.plugin.hive.avro.AvroPageSourceFactory;
-import io.trino.plugin.hive.crypto.ParquetEncryptionModule;
-import io.trino.plugin.hive.esri.EsriPageSourceFactory;
 import io.trino.plugin.hive.fs.CachingDirectoryLister;
 import io.trino.plugin.hive.fs.DirectoryLister;
 import io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryListerFactory;
-import io.trino.plugin.hive.line.CsvFileWriterFactory;
-import io.trino.plugin.hive.line.CsvPageSourceFactory;
-import io.trino.plugin.hive.line.JsonFileWriterFactory;
-import io.trino.plugin.hive.line.JsonPageSourceFactory;
-import io.trino.plugin.hive.line.OpenXJsonFileWriterFactory;
-import io.trino.plugin.hive.line.OpenXJsonPageSourceFactory;
-import io.trino.plugin.hive.line.ProtobufSequenceFilePageSourceFactory;
-import io.trino.plugin.hive.line.RegexFileWriterFactory;
-import io.trino.plugin.hive.line.RegexPageSourceFactory;
-import io.trino.plugin.hive.line.SimpleSequenceFilePageSourceFactory;
-import io.trino.plugin.hive.line.SimpleSequenceFileWriterFactory;
-import io.trino.plugin.hive.line.SimpleTextFilePageSourceFactory;
-import io.trino.plugin.hive.line.SimpleTextFileWriterFactory;
 import io.trino.plugin.hive.metastore.HiveMetastoreConfig;
-import io.trino.plugin.hive.orc.OrcFileWriterFactory;
-import io.trino.plugin.hive.orc.OrcPageSourceFactory;
 import io.trino.plugin.hive.orc.OrcReaderConfig;
 import io.trino.plugin.hive.orc.OrcWriterConfig;
-import io.trino.plugin.hive.parquet.ParquetFileWriterFactory;
-import io.trino.plugin.hive.parquet.ParquetPageSourceFactory;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
-import io.trino.plugin.hive.rcfile.RcFilePageSourceFactory;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
@@ -103,41 +81,13 @@ public class HiveModule
         binder.bind(FileFormatDataSourceStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(FileFormatDataSourceStats.class).withGeneratedName();
 
-        Multibinder<HivePageSourceFactory> pageSourceFactoryBinder = newSetBinder(binder, HivePageSourceFactory.class);
-        pageSourceFactoryBinder.addBinding().to(CsvPageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(JsonPageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(OpenXJsonPageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(EsriPageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(RegexPageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(SimpleTextFilePageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(SimpleSequenceFilePageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(OrcPageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(ParquetPageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(RcFilePageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(AvroPageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(ProtobufSequenceFilePageSourceFactory.class).in(Scopes.SINGLETON);
-
-        Multibinder<HiveFileWriterFactory> fileWriterFactoryBinder = newSetBinder(binder, HiveFileWriterFactory.class);
-        binder.bind(OrcFileWriterFactory.class).in(Scopes.SINGLETON);
-        newExporter(binder).export(OrcFileWriterFactory.class).withGeneratedName();
         configBinder(binder).bindConfig(OrcReaderConfig.class);
         configBinder(binder).bindConfig(OrcWriterConfig.class);
-        fileWriterFactoryBinder.addBinding().to(CsvFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(JsonFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(RegexFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(OpenXJsonFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(SimpleTextFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(SimpleSequenceFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(OrcFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(RcFileFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(AvroFileWriterFactory.class).in(Scopes.SINGLETON);
-
         configBinder(binder).bindConfig(ParquetReaderConfig.class);
         configBinder(binder).bindConfig(ParquetWriterConfig.class);
-        fileWriterFactoryBinder.addBinding().to(ParquetFileWriterFactory.class).in(Scopes.SINGLETON);
 
+        install(new HiveFormatsModule());
         binder.install(new HiveExecutorModule());
-        install(new ParquetEncryptionModule());
     }
 
     @Provides

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseHiveModule.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseHiveModule.java
@@ -18,12 +18,11 @@ import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.hive.HiveConfig;
 import io.trino.plugin.hive.HiveExecutorModule;
-import io.trino.plugin.hive.HiveFileWriterFactory;
+import io.trino.plugin.hive.HiveFormatsModule;
 import io.trino.plugin.hive.HiveLocationService;
 import io.trino.plugin.hive.HiveMetadataFactory;
 import io.trino.plugin.hive.HiveNodePartitioningProvider;
 import io.trino.plugin.hive.HivePageSinkProvider;
-import io.trino.plugin.hive.HivePageSourceFactory;
 import io.trino.plugin.hive.HivePageSourceProvider;
 import io.trino.plugin.hive.HivePartitionManager;
 import io.trino.plugin.hive.HiveSessionProperties;
@@ -35,34 +34,13 @@ import io.trino.plugin.hive.LocationService;
 import io.trino.plugin.hive.PartitionUpdate;
 import io.trino.plugin.hive.PartitionsSystemTableProvider;
 import io.trino.plugin.hive.PropertiesSystemTableProvider;
-import io.trino.plugin.hive.RcFileFileWriterFactory;
 import io.trino.plugin.hive.SystemTableProvider;
 import io.trino.plugin.hive.TransactionalMetadataFactory;
-import io.trino.plugin.hive.avro.AvroFileWriterFactory;
-import io.trino.plugin.hive.avro.AvroPageSourceFactory;
-import io.trino.plugin.hive.crypto.ParquetEncryptionModule;
 import io.trino.plugin.hive.fs.CachingDirectoryLister;
 import io.trino.plugin.hive.fs.DirectoryLister;
 import io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryListerFactory;
-import io.trino.plugin.hive.line.CsvFileWriterFactory;
-import io.trino.plugin.hive.line.CsvPageSourceFactory;
-import io.trino.plugin.hive.line.JsonFileWriterFactory;
-import io.trino.plugin.hive.line.JsonPageSourceFactory;
-import io.trino.plugin.hive.line.OpenXJsonFileWriterFactory;
-import io.trino.plugin.hive.line.OpenXJsonPageSourceFactory;
-import io.trino.plugin.hive.line.RegexFileWriterFactory;
-import io.trino.plugin.hive.line.RegexPageSourceFactory;
-import io.trino.plugin.hive.line.SimpleSequenceFilePageSourceFactory;
-import io.trino.plugin.hive.line.SimpleSequenceFileWriterFactory;
-import io.trino.plugin.hive.line.SimpleTextFilePageSourceFactory;
-import io.trino.plugin.hive.line.SimpleTextFileWriterFactory;
 import io.trino.plugin.hive.metastore.HiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.HiveMetastoreModule;
-import io.trino.plugin.hive.orc.OrcFileWriterFactory;
-import io.trino.plugin.hive.orc.OrcPageSourceFactory;
-import io.trino.plugin.hive.parquet.ParquetFileWriterFactory;
-import io.trino.plugin.hive.parquet.ParquetPageSourceFactory;
-import io.trino.plugin.hive.rcfile.RcFilePageSourceFactory;
 
 import java.util.Optional;
 
@@ -105,38 +83,11 @@ class LakehouseHiveModule
         newExporter(binder).export(CachingDirectoryLister.class).withGeneratedName();
         binder.bind(DirectoryLister.class).to(CachingDirectoryLister.class).in(Scopes.SINGLETON);
 
-        binder.bind(OrcFileWriterFactory.class).in(Scopes.SINGLETON);
-        newExporter(binder).export(OrcFileWriterFactory.class).withGeneratedName();
-
         var systemTableProviders = newSetBinder(binder, SystemTableProvider.class);
         systemTableProviders.addBinding().to(PartitionsSystemTableProvider.class).in(Scopes.SINGLETON);
         systemTableProviders.addBinding().to(PropertiesSystemTableProvider.class).in(Scopes.SINGLETON);
 
-        var pageSourceFactoryBinder = newSetBinder(binder, HivePageSourceFactory.class);
-        pageSourceFactoryBinder.addBinding().to(CsvPageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(JsonPageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(OpenXJsonPageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(RegexPageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(SimpleTextFilePageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(SimpleSequenceFilePageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(OrcPageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(ParquetPageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(RcFilePageSourceFactory.class).in(Scopes.SINGLETON);
-        pageSourceFactoryBinder.addBinding().to(AvroPageSourceFactory.class).in(Scopes.SINGLETON);
-
-        var fileWriterFactoryBinder = newSetBinder(binder, HiveFileWriterFactory.class);
-        fileWriterFactoryBinder.addBinding().to(CsvFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(JsonFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(RegexFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(OpenXJsonFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(SimpleTextFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(SimpleSequenceFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(OrcFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(RcFileFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(AvroFileWriterFactory.class).in(Scopes.SINGLETON);
-        fileWriterFactoryBinder.addBinding().to(ParquetFileWriterFactory.class).in(Scopes.SINGLETON);
-
+        install(new HiveFormatsModule());
         binder.install(new HiveExecutorModule());
-        install(new ParquetEncryptionModule());
     }
 }


### PR DESCRIPTION
LakehouseHiveModule was a copy of the page-source and file-writer factory lists from HiveModule, with the result that file formats added to HiveModule after the Lakehouse connector landed in 4def327122e were never registered for the Lakehouse Hive table type:

* native ESRI reader (f819b922d68)
* Twitter Elephantbird protobuf sequence file reader (9505e4f6016)

Neither commit message indicates the omission was intentional, and neither factory has a Lakehouse-specific reason to be excluded — both just need TrinoFileSystemFactory (and the protobuf one a HiveConfig). The drift is the failure mode that copying invites.

Extract the shared multibinder lists, the OrcFileWriterFactory binding and JMX export, and ParquetEncryptionModule into HiveFormatsModule, and have both HiveModule and LakehouseHiveModule install it. This adds support for reading ESRI GeoJson and protobuf sequence files in the Lakehouse connector's Hive table type, and makes the shared format catalog the place future formats are added once.
