### PR TITLE
Reuse existing view location when replacing view in Iceberg REST Catalog

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.cache.Cache;
@@ -674,12 +675,19 @@ public class TrinoRestCatalog
         definition.getComment().ifPresent(comment -> properties.put(COMMENT, comment));
         Schema schema = IcebergUtil.schemaFromViewColumns(typeManager, definition.getColumns());
         ViewBuilder viewBuilder = restSessionCatalog.buildView(convert(session), toRemoteView(session, schemaViewName, true));
+        String viewLocation = defaultTableLocation(session, schemaViewName);
+        if (replace) {
+            Optional<View> view = getIcebergView(session, schemaViewName, true);
+            if (view.isPresent()) {
+                viewLocation = view.get().location();
+            }
+        }
         viewBuilder = viewBuilder.withSchema(schema)
                 .withQuery("trino", definition.getOriginalSql())
                 .withDefaultNamespace(toRemoteNamespace(session, toNamespace(schemaViewName.getSchemaName())))
                 .withDefaultCatalog(definition.getCatalog().orElse(null))
                 .withProperties(properties.buildOrThrow())
-                .withLocation(defaultTableLocation(session, schemaViewName));
+                .withLocation(viewLocation);
         try {
             if (replace) {
                 viewBuilder.createOrReplace();
@@ -777,7 +785,8 @@ public class TrinoRestCatalog
         });
     }
 
-    private Optional<View> getIcebergView(ConnectorSession session, SchemaTableName viewName, boolean getCached)
+    @VisibleForTesting
+    Optional<View> getIcebergView(ConnectorSession session, SchemaTableName viewName, boolean getCached)
     {
         if (!viewEndpointsEnabled) {
             return Optional.empty();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.cache.EvictableCacheBuilder;
 import io.trino.metastore.TableInfo;
@@ -27,14 +28,18 @@ import io.trino.spi.NodeVersion;
 import io.trino.spi.TrinoException;
 import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.connector.ConnectorViewDefinition.ViewColumn;
+import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
 import org.apache.iceberg.catalog.Namespace;
-import org.apache.iceberg.catalog.SessionCatalog.SessionContext;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.rest.DelegatingRestSessionCatalog;
 import org.apache.iceberg.rest.RESTSessionCatalog;
+import org.apache.iceberg.view.View;
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -55,6 +60,8 @@ import static io.trino.plugin.iceberg.IcebergTestUtils.TABLE_STATISTICS_READER;
 import static io.trino.plugin.iceberg.catalog.rest.IcebergRestCatalogConfig.SessionType.NONE;
 import static io.trino.plugin.iceberg.catalog.rest.RestCatalogTestUtils.backendCatalog;
 import static io.trino.plugin.iceberg.delete.DeletionVectorWriter.UNSUPPORTED_DELETION_VECTOR_WRITER;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
@@ -88,7 +95,6 @@ public class TestTrinoRestCatalog
             throws IOException
     {
         Path warehouseLocation = Files.createTempDirectory(null);
-        warehouseLocation.toFile().deleteOnExit();
 
         String catalogName = "iceberg_rest";
         RESTSessionCatalog restSessionCatalog = DelegatingRestSessionCatalog
@@ -278,5 +284,57 @@ public class TestTrinoRestCatalog
     protected TableInfo.ExtendedRelationType getViewType()
     {
         return OTHER_VIEW;
+    }
+
+    @Test
+    public void testReplaceViewReuseExistingLocation()
+            throws IOException
+    {
+        TrinoRestCatalog catalog = createTrinoRestCatalog(true, ImmutableMap.of());
+
+        String namespace = "test_create_replace_view_" + randomNameSuffix();
+        SchemaTableName viewName = new SchemaTableName(namespace, "test_view");
+        ConnectorViewDefinition viewDefinition = viewDefinition(
+                "SELECT name FROM local.tiny.nation",
+                new ViewColumn("name", VARCHAR.getTypeId(), Optional.empty()));
+
+        catalog.createNamespace(SESSION, namespace, defaultNamespaceProperties(namespace), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
+
+        catalog.createView(SESSION, viewName, viewDefinition, false);
+        assertViewDefinition(catalog.getView(SESSION, viewName).orElseThrow(), viewDefinition);
+
+        View initialView = catalog.getIcebergView(SESSION, viewName, false).orElse(null);
+        assertThat(initialView).isNotNull();
+        assertThat(initialView.location()).isNotNull();
+
+        ConnectorViewDefinition updatedViewDefinition = viewDefinition(
+                "SELECT regionkey, name, comment FROM local.tiny.region",
+                new ViewColumn("regionkey", BIGINT.getTypeId(), Optional.empty()),
+                new ViewColumn("name", VARCHAR.getTypeId(), Optional.empty()),
+                new ViewColumn("comment", VARCHAR.getTypeId(), Optional.empty()));
+
+        catalog.createView(SESSION, viewName, updatedViewDefinition, true);
+        assertViewDefinition(catalog.getView(SESSION, viewName).orElseThrow(), updatedViewDefinition);
+
+        View updatedView = catalog.getIcebergView(SESSION, viewName, false).orElse(null);
+        assertThat(updatedView).isNotNull();
+        assertThat(updatedView.location()).isEqualTo(initialView.location());
+        assertThat(updatedView.currentVersion().versionId()).isEqualTo(initialView.currentVersion().versionId() + 1);
+
+        catalog.dropView(SESSION, viewName);
+        catalog.dropNamespace(SESSION, namespace);
+    }
+
+    private static ConnectorViewDefinition viewDefinition(@Language("SQL") String sql, ViewColumn... columns)
+    {
+        return new ConnectorViewDefinition(
+                sql,
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.copyOf(columns),
+                Optional.empty(),
+                Optional.of(SESSION.getUser()),
+                false,
+                ImmutableList.of());
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Final tweaks of the initial PR https://github.com/trinodb/trino/pull/26736

Thank you @codluca 

Fixes https://github.com/trinodb/trino/issues/25425

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Reuse existing view location when replacing view in Iceberg REST Catalog. ({issue}`29729`)
```
