### PR TITLE
Fix creating multiple delete files per data file for Iceberg tables only partitioned with identity transforms

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -3231,7 +3231,11 @@ public class IcebergMetadata
     @Override
     public Optional<ConnectorPartitioningHandle> getUpdateLayout(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        return getInsertLayout(session, tableHandle)
+        IcebergTableHandle table = (IcebergTableHandle) tableHandle;
+        Schema schema = SchemaParser.fromJson(table.getTableSchemaJson());
+        int specId = table.getSpecId().orElseThrow(() -> new VerifyException("Partition spec missing in the table handle"));
+        PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, table.getPartitionSpecJsons().get(specId));
+        return getWriteLayout(schema, partitionSpec, true)
                 .flatMap(ConnectorTableLayout::getPartitioning)
                 .map(IcebergPartitioningHandle.class::cast)
                 .map(IcebergPartitioningHandle::forUpdate);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -6008,6 +6008,37 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testDeleteOnIdentityPartitionedTableProducesOneDeleteEntryPerDataFile()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(TASK_MIN_WRITER_COUNT, "4")
+                .setSystemProperty(TASK_MAX_WRITER_COUNT, "4")
+                .build();
+
+        try (TestTable table = newTrinoTable(
+                "test_identity_partitioned_deletes_",
+                """
+                WITH (partitioning = ARRAY['regionkey']) AS
+                SELECT id, id % 5 regionkey
+                FROM UNNEST(sequence(0, 499)) t(id)""")) {
+            assertQuery(
+                    "SELECT content, count(*) FROM \"" + table.getName() + "$files\" GROUP BY content",
+                    "VALUES (0, 5)");
+
+            assertUpdate(session, "DELETE FROM " + table.getName() + " WHERE id % 2 = 0", 250);
+
+            assertThat(query("SELECT count(*) FROM \"" + table.getName() + "$files\" WHERE content = 1"))
+                    .matches("VALUES BIGINT '5'");
+            assertQuery(
+                    "SELECT count(*) FROM " + table.getName(),
+                    "VALUES 250");
+            assertQuery(
+                    "SELECT count(*) FROM " + table.getName() + " WHERE id % 2 = 0",
+                    "VALUES 0");
+        }
+    }
+
+    @Test
     public void testOptimizeFilesDoNotInheritSequenceNumber()
             throws IOException
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fixes #28276 

An optimization in `getWriteLayout` caused `getUpdateLayout` to return an empty partitioning handle when all partition column are identity transforms. This works for insert, but not update, which ideally would add deletes to a single delete file per data file.

The fix is very simple: instead of invoking `getInsertLayout` from `getUpdateLayout`, we instead duplicate a small bit of code, and invoke `getWriteLayout` with `forceRepartitioning` set to true. This will bypass the previously mentioned optimization and correctly populate a partitioning handle.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
