### PR TITLE
Respect namespace argument in Iceberg JDBC catalog getViews

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -281,7 +281,10 @@ public class TrinoJdbcCatalog
 
     private List<String> listNamespaces(ConnectorSession session, Optional<String> namespace)
     {
-        if (namespace.isPresent() && namespaceExists(session, namespace.get())) {
+        if (namespace.isPresent()) {
+            if (!namespaceExists(session, namespace.get())) {
+                return ImmutableList.of();
+            }
             return ImmutableList.of(namespace.get());
         }
         return listNamespaces(session);
@@ -522,11 +525,11 @@ public class TrinoJdbcCatalog
     public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, Optional<String> namespace)
     {
         ImmutableMap.Builder<SchemaTableName, ConnectorViewDefinition> views = ImmutableMap.builder();
-        for (Namespace ns : jdbcCatalog.listNamespaces()) {
-            for (TableIdentifier restView : jdbcCatalog.listViews(ns)) {
-                SchemaTableName schemaTableName = SchemaTableName.schemaTableName(restView.namespace().toString(), restView.name());
+        for (String ns : listNamespaces(session, namespace)) {
+            for (TableIdentifier view : jdbcCatalog.listViews(Namespace.of(ns))) {
+                SchemaTableName schemaTableName = SchemaTableName.schemaTableName(view.namespace().toString(), view.name());
                 try {
-                    getView(session, schemaTableName).ifPresent(view -> views.put(schemaTableName, view));
+                    getView(session, schemaTableName).ifPresent(viewDefinition -> views.put(schemaTableName, viewDefinition));
                 }
                 catch (TrinoException e) {
                     if (e.getErrorCode().equals(ICEBERG_UNSUPPORTED_VIEW_DIALECT.toErrorCode())) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -750,7 +750,7 @@ public class TrinoRestCatalog
                 restViews = restSessionCatalog.listViews(sessionContext, toRemoteNamespace(session, restNamespace));
             }
             catch (NoSuchNamespaceException e) {
-                return ImmutableMap.of();
+                continue;
             }
             catch (RESTException e) {
                 throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to list views", e);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -749,6 +749,9 @@ public class TrinoRestCatalog
             try {
                 restViews = restSessionCatalog.listViews(sessionContext, toRemoteNamespace(session, restNamespace));
             }
+            catch (NoSuchNamespaceException e) {
+                return ImmutableMap.of();
+            }
             catch (RESTException e) {
                 throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to list views", e);
             }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
@@ -475,6 +475,102 @@ public abstract class BaseTrinoCatalogTest
     }
 
     @Test
+    public void testTableNamespaceFilter()
+            throws Exception
+    {
+        TrinoCatalog catalog = createTrinoCatalog(false);
+        TrinoPrincipal principal = new TrinoPrincipal(PrincipalType.USER, SESSION.getUser());
+
+        try (AutoCloseableCloser closer = AutoCloseableCloser.create()) {
+            String namespace1 = "test_table_namespace1_filter_" + randomNameSuffix();
+            String namespace2 = "test_table_namespace2_filter_" + randomNameSuffix();
+            catalog.createNamespace(SESSION, namespace1, defaultNamespaceProperties(namespace1), principal);
+            closer.register(() -> catalog.dropNamespace(SESSION, namespace1));
+            catalog.createNamespace(SESSION, namespace2, defaultNamespaceProperties(namespace2), principal);
+            closer.register(() -> catalog.dropNamespace(SESSION, namespace2));
+
+            SchemaTableName tableName1 = new SchemaTableName(namespace1, "table1");
+            SchemaTableName tableName2 = new SchemaTableName(namespace2, "table2");
+            createTable(catalog, tableName1, closer);
+            createTable(catalog, tableName2, closer);
+
+            // listTables without a filter returns tables from all namespaces
+            assertThat(catalog.listTables(SESSION, Optional.empty()))
+                    .contains(new TableInfo(tableName1, TABLE), new TableInfo(tableName2, TABLE));
+            // listTables with a filter only returns tables from the requested namespace
+            assertThat(catalog.listTables(SESSION, Optional.of(namespace1)))
+                    .contains(new TableInfo(tableName1, TABLE))
+                    .doesNotContain(new TableInfo(tableName2, TABLE));
+
+            // listIcebergTables without a filter returns tables from all namespaces
+            assertThat(catalog.listIcebergTables(SESSION, ImmutableList.of()))
+                    .contains(tableName1, tableName2);
+            // listIcebergTables with a filter only returns tables from the requested namespace
+            assertThat(catalog.listIcebergTables(SESSION, ImmutableList.of(namespace1)))
+                    .contains(tableName1)
+                    .doesNotContain(tableName2);
+
+            // a non-existent namespace filter yields no tables
+            assertThat(catalog.listTables(SESSION, Optional.of("non_existing"))).isEmpty();
+            assertThat(catalog.listIcebergTables(SESSION, ImmutableList.of("non_existing"))).isEmpty();
+        }
+    }
+
+    @Test
+    public void testViewNamespaceFilter()
+            throws Exception
+    {
+        TrinoCatalog catalog = createTrinoCatalog(false);
+        TrinoPrincipal principal = new TrinoPrincipal(PrincipalType.USER, SESSION.getUser());
+
+        try (AutoCloseableCloser closer = AutoCloseableCloser.create()) {
+            String namespace1 = "test_view_namespace_filter_" + randomNameSuffix();
+            String namespace2 = "test_view_namespace_filter_" + randomNameSuffix();
+            catalog.createNamespace(SESSION, namespace1, defaultNamespaceProperties(namespace1), principal);
+            closer.register(() -> catalog.dropNamespace(SESSION, namespace1));
+            catalog.createNamespace(SESSION, namespace2, defaultNamespaceProperties(namespace2), principal);
+            closer.register(() -> catalog.dropNamespace(SESSION, namespace2));
+
+            SchemaTableName viewName1 = new SchemaTableName(namespace1, "view1");
+            SchemaTableName viewName2 = new SchemaTableName(namespace2, "view2");
+            ConnectorViewDefinition viewDefinition = new ConnectorViewDefinition(
+                    "SELECT name FROM local.tiny.nation",
+                    Optional.empty(),
+                    Optional.empty(),
+                    ImmutableList.of(
+                            new ConnectorViewDefinition.ViewColumn("name", VarcharType.createUnboundedVarcharType().getTypeId(), Optional.empty())),
+                    Optional.empty(),
+                    Optional.of(SESSION.getUser()),
+                    false,
+                    ImmutableList.of());
+            catalog.createView(SESSION, viewName1, viewDefinition, ImmutableMap.of(), false);
+            closer.register(() -> catalog.dropView(SESSION, viewName1));
+            catalog.createView(SESSION, viewName2, viewDefinition, ImmutableMap.of(), false);
+            closer.register(() -> catalog.dropView(SESSION, viewName2));
+
+            // getViews without a filter returns views from all namespaces
+            assertThat(catalog.getViews(SESSION, Optional.empty()))
+                    .containsKeys(viewName1, viewName2);
+            // getViews with a filter only returns views from the requested namespace
+            Map<SchemaTableName, ConnectorViewDefinition> filteredViews = catalog.getViews(SESSION, Optional.of(namespace1));
+            assertThat(filteredViews).containsOnlyKeys(viewName1);
+            assertViewDefinition(filteredViews.get(viewName1), viewDefinition);
+
+            // listViews without a filter returns views from all namespaces
+            assertThat(catalog.listViews(SESSION, Optional.empty()))
+                    .contains(viewName1, viewName2);
+            // listViews with a filter only returns views from the requested namespace
+            assertThat(catalog.listViews(SESSION, Optional.of(namespace1)))
+                    .contains(viewName1)
+                    .doesNotContain(viewName2);
+
+            // a non-existent namespace filter yields no views
+            assertThat(catalog.listViews(SESSION, Optional.of("non_existing"))).isEmpty();
+            assertThat(catalog.getViews(SESSION, Optional.of("non_existing"))).isEmpty();
+        }
+    }
+
+    @Test
     public void testListTables()
             throws Exception
     {
@@ -645,6 +741,21 @@ public abstract class BaseTrinoCatalogTest
         Path tmpDirectory = Files.createTempDirectory("iceberg_catalog_test_arbitrary_location");
         tmpDirectory.toFile().deleteOnExit();
         return tmpDirectory.toString();
+    }
+
+    private void createTable(TrinoCatalog catalog, SchemaTableName tableName, AutoCloseableCloser closer)
+            throws Exception
+    {
+        catalog.newCreateTableTransaction(
+                        SESSION,
+                        tableName,
+                        new Schema(Types.NestedField.optional(1, "col1", Types.LongType.get())),
+                        PartitionSpec.unpartitioned(),
+                        SortOrder.unsorted(),
+                        Optional.of(arbitraryTableLocation(catalog, SESSION, tableName)),
+                        ImmutableMap.of())
+                .commitTransaction();
+        closer.register(() -> catalog.dropTable(SESSION, tableName));
     }
 
     private void assertViewColumnDefinition(ConnectorViewDefinition.ViewColumn actualViewColumn, ConnectorViewDefinition.ViewColumn expectedViewColumn)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
@@ -94,6 +94,8 @@ public abstract class BaseTrinoCatalogTest
                     .getSessionProperties())
             .build();
 
+    protected abstract void createNamespaceWithProperties(TrinoCatalog catalog, String namespace, Map<String, String> properties);
+
     protected abstract TrinoCatalog createTrinoCatalog(boolean useUniqueTableLocations)
             throws IOException;
 
@@ -472,11 +474,6 @@ public abstract class BaseTrinoCatalogTest
         }
     }
 
-    protected ExtendedRelationType getViewType()
-    {
-        return TRINO_VIEW;
-    }
-
     @Test
     public void testListTables()
             throws Exception
@@ -586,7 +583,10 @@ public abstract class BaseTrinoCatalogTest
         }
     }
 
-    protected abstract void createNamespaceWithProperties(TrinoCatalog catalog, String namespace, Map<String, String> properties);
+    protected ExtendedRelationType getViewType()
+    {
+        return TRINO_VIEW;
+    }
 
     protected void createMaterializedView(
             ConnectorSession session,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestTrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestTrinoJdbcCatalog.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.metastore.TableInfo.ExtendedRelationType;
+import io.trino.plugin.base.util.AutoCloseableCloser;
+import io.trino.plugin.iceberg.catalog.BaseTrinoCatalogTest;
+import io.trino.plugin.iceberg.catalog.TrinoCatalog;
+import io.trino.spi.catalog.CatalogName;
+import io.trino.spi.security.PrincipalType;
+import io.trino.spi.security.TrinoPrincipal;
+import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.postgresql.Driver;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.hdfs.HdfsTestUtils.HDFS_FILE_SYSTEM_FACTORY;
+import static io.trino.plugin.iceberg.IcebergTestUtils.FILE_IO_FACTORY;
+import static io.trino.plugin.iceberg.catalog.jdbc.IcebergJdbcCatalogConfig.SchemaVersion.V1;
+import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.PASSWORD;
+import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.USER;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static java.util.Locale.ENGLISH;
+import static org.apache.iceberg.CatalogProperties.CATALOG_IMPL;
+import static org.apache.iceberg.CatalogProperties.URI;
+import static org.apache.iceberg.CatalogProperties.WAREHOUSE_LOCATION;
+import static org.apache.iceberg.CatalogUtil.buildIcebergCatalog;
+import static org.apache.iceberg.jdbc.JdbcCatalog.PROPERTY_PREFIX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+final class TestTrinoJdbcCatalog
+        extends BaseTrinoCatalogTest
+{
+    private static final String CATALOG_NAME = "iceberg_jdbc";
+
+    private final AutoCloseableCloser closer = AutoCloseableCloser.create();
+    private TestingIcebergJdbcServer server;
+
+    @BeforeAll
+    void setUp()
+    {
+        server = closer.register(new TestingIcebergJdbcServer());
+    }
+
+    @AfterAll
+    void tearDown()
+            throws Exception
+    {
+        closer.close();
+    }
+
+    @Override
+    protected TrinoCatalog createTrinoCatalog(boolean useUniqueTableLocations)
+            throws IOException
+    {
+        Path warehouseLocation = Files.createTempDirectory(null);
+        warehouseLocation.toFile().deleteOnExit();
+        JdbcCatalog jdbcCatalog = createJdbcCatalog(server.getJdbcUrl(), warehouseLocation);
+        closer.register(jdbcCatalog);
+        return createTrinoJdbcCatalog(useUniqueTableLocations, warehouseLocation, server.getJdbcUrl(), jdbcCatalog);
+    }
+
+    private static TrinoJdbcCatalog createTrinoJdbcCatalog(boolean useUniqueTableLocations, Path warehouseLocation, String jdbcUrl, JdbcCatalog jdbcCatalog)
+    {
+        IcebergJdbcClient jdbcClient = new IcebergJdbcClient(
+                new IcebergJdbcConnectionFactory(new Driver(), jdbcUrl, Optional.of(USER), Optional.of(PASSWORD)),
+                CATALOG_NAME,
+                V1);
+        return new TrinoJdbcCatalog(
+                new CatalogName(CATALOG_NAME),
+                TESTING_TYPE_MANAGER,
+                new IcebergJdbcTableOperationsProvider(HDFS_FILE_SYSTEM_FACTORY, FILE_IO_FACTORY, jdbcClient),
+                jdbcCatalog,
+                jdbcClient,
+                HDFS_FILE_SYSTEM_FACTORY,
+                FILE_IO_FACTORY,
+                useUniqueTableLocations,
+                warehouseLocation.toAbsolutePath().toString(),
+                V1);
+    }
+
+    private static JdbcCatalog createJdbcCatalog(String jdbcUrl, Path warehouseLocation)
+    {
+        return (JdbcCatalog) buildIcebergCatalog(
+                CATALOG_NAME,
+                ImmutableMap.<String, String>builder()
+                        .put(CATALOG_IMPL, JdbcCatalog.class.getName())
+                        .put(URI, jdbcUrl)
+                        .put(PROPERTY_PREFIX + "user", USER)
+                        .put(PROPERTY_PREFIX + "password", PASSWORD)
+                        .put(PROPERTY_PREFIX + "schema-version", V1.toString())
+                        .put(WAREHOUSE_LOCATION, warehouseLocation.toAbsolutePath().toString())
+                        .buildOrThrow(),
+                null);
+    }
+
+    @Override
+    protected void createNamespaceWithProperties(TrinoCatalog catalog, String namespace, Map<String, String> properties)
+    {
+        catalog.createNamespace(
+                SESSION,
+                namespace,
+                ImmutableMap.copyOf(properties),
+                new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
+    }
+
+    @Override
+    protected ExtendedRelationType getViewType()
+    {
+        return ExtendedRelationType.OTHER_VIEW;
+    }
+
+    @Test
+    @Override
+    public void testNonLowercaseNamespace()
+            throws Exception
+    {
+        TrinoCatalog catalog = createTrinoCatalog(false);
+
+        String namespace = "testNonLowercaseNamespace";
+        String schema = namespace.toLowerCase(ENGLISH);
+
+        catalog.createNamespace(SESSION, namespace, defaultNamespaceProperties(namespace), new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
+        try {
+            assertThat(catalog.namespaceExists(SESSION, namespace)).as("catalog.namespaceExists(namespace)")
+                    .isTrue();
+            assertThat(catalog.namespaceExists(SESSION, schema)).as("catalog.namespaceExists(schema)")
+                    .isFalse();
+            assertThat(catalog.listNamespaces(SESSION)).as("catalog.listNamespaces")
+                    // JDBC catalog lowercases namespaces returned from listNamespaces
+                    .doesNotContain(namespace)
+                    .contains(schema);
+        }
+        finally {
+            catalog.dropNamespace(SESSION, namespace);
+        }
+    }
+
+    @Test
+    @Override
+    public void testSchemaWithInvalidProperties()
+    {
+        // JDBC catalog preserves arbitrary namespace properties
+        // https://github.com/trinodb/trino/issues/29769
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
@@ -181,6 +181,14 @@ public class TestTrinoNessieCatalog
 
     @Test
     @Override
+    public void testViewNamespaceFilter()
+    {
+        assertThatThrownBy(super::testViewNamespaceFilter)
+                .hasMessageContaining("createView is not supported for Iceberg Nessie catalogs");
+    }
+
+    @Test
+    @Override
     public void testNonLowercaseNamespace()
     {
         TrinoCatalog catalog = createTrinoCatalog(false);

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/snowflake/TestTrinoSnowflakeCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/snowflake/TestTrinoSnowflakeCatalog.java
@@ -368,6 +368,22 @@ public class TestTrinoSnowflakeCatalog
 
     @Test
     @Override
+    public void testTableNamespaceFilter()
+    {
+        assertThatThrownBy(super::testTableNamespaceFilter)
+                .hasMessageContaining("Iceberg Snowflake catalog schemas do not support modifications");
+    }
+
+    @Test
+    @Override
+    public void testViewNamespaceFilter()
+    {
+        assertThatThrownBy(super::testViewNamespaceFilter)
+                .hasMessageContaining("Iceberg Snowflake catalog schemas do not support modifications");
+    }
+
+    @Test
+    @Override
     public void testListTables()
     {
         TrinoCatalog catalog = createTrinoCatalog(false);


### PR DESCRIPTION
## Description

TrinoJdbcCatalog.getViews iterated over every namespace in the catalog, ignoring the namespace argument it was given. Route it through the listNamespaces helper so it only scans the requested namespace.

While here, make that helper return an empty list when a specific but non-existent namespace is requested, instead of falling back to listing all namespaces. This also fixes listTables, listIcebergTables and listViews returning relations from unrelated namespaces in that case.

Add TestTrinoJdbcCatalog, a BaseTrinoCatalogTest implementation backed by the Postgres-based TestingIcebergJdbcServer, and extend the shared testView case to cover views across multiple namespaces.

## Additional context and related issues

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
