### PR TITLE
Parallelize and bulk-resolve getViews in the Iceberg JDBC catalog

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcClient.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcClient.java
@@ -51,10 +51,11 @@ public class IcebergJdbcClient
     private void createTableV0(String schemaName, String tableName, String metadataLocation)
     {
         try (Handle handle = Jdbi.open(connectionFactory)) {
-            handle.createUpdate("" +
-                            "INSERT INTO iceberg_tables " +
-                            "(catalog_name, table_namespace, table_name, metadata_location, previous_metadata_location) " +
-                            "VALUES (:catalog, :schema, :table, :metadata_location, null)")
+            handle.createUpdate(
+                            """
+                            INSERT INTO iceberg_tables
+                            (catalog_name, table_namespace, table_name, metadata_location, previous_metadata_location)
+                            VALUES (:catalog, :schema, :table, :metadata_location, null)""")
                     .bind("catalog", catalogName)
                     .bind("schema", schemaName)
                     .bind("table", tableName)
@@ -66,10 +67,11 @@ public class IcebergJdbcClient
     private void createTableV1(String schemaName, String tableName, String metadataLocation)
     {
         try (Handle handle = Jdbi.open(connectionFactory)) {
-            handle.createUpdate("" +
-                            "INSERT INTO iceberg_tables " +
-                            "(catalog_name, table_namespace, table_name, metadata_location, previous_metadata_location, iceberg_type) " +
-                            "VALUES (:catalog, :schema, :table, :metadata_location, null, 'TABLE')")
+            handle.createUpdate(
+                            """
+                            INSERT INTO iceberg_tables
+                            (catalog_name, table_namespace, table_name, metadata_location, previous_metadata_location, iceberg_type)
+                            VALUES (:catalog, :schema, :table, :metadata_location, null, 'TABLE')""")
                     .bind("catalog", catalogName)
                     .bind("schema", schemaName)
                     .bind("table", tableName)
@@ -81,10 +83,11 @@ public class IcebergJdbcClient
     public void alterTable(String schemaName, String tableName, String newMetadataLocation, String previousMetadataLocation)
     {
         try (Handle handle = Jdbi.open(connectionFactory)) {
-            int updatedRecords = handle.createUpdate("" +
-                            "UPDATE iceberg_tables " +
-                            "SET metadata_location = :metadata_location, previous_metadata_location = :previous_metadata_location " +
-                            "WHERE catalog_name = :catalog AND table_namespace = :schema AND table_name = :table AND metadata_location = :previous_metadata_location")
+            int updatedRecords = handle.createUpdate(
+                            """
+                            UPDATE iceberg_tables
+                            SET metadata_location = :metadata_location, previous_metadata_location = :previous_metadata_location
+                            WHERE catalog_name = :catalog AND table_namespace = :schema AND table_name = :table AND metadata_location = :previous_metadata_location""")
                     .bind("metadata_location", newMetadataLocation)
                     .bind("previous_metadata_location", previousMetadataLocation)
                     .bind("catalog", catalogName)
@@ -100,10 +103,11 @@ public class IcebergJdbcClient
     public Optional<String> getMetadataLocation(String schemaName, String tableName)
     {
         try (Handle handle = Jdbi.open(connectionFactory)) {
-            return handle.createQuery("" +
-                            "SELECT metadata_location " +
-                            "FROM iceberg_tables " +
-                            "WHERE catalog_name = :catalog AND table_namespace = :schema AND table_name = :table")
+            return handle.createQuery(
+                            """
+                            SELECT metadata_location
+                            FROM iceberg_tables
+                            WHERE catalog_name = :catalog AND table_namespace = :schema AND table_name = :table""")
                     .bind("catalog", catalogName)
                     .bind("schema", schemaName)
                     .bind("table", tableName)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcClient.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcClient.java
@@ -18,8 +18,11 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.iceberg.catalog.jdbc.IcebergJdbcCatalogConfig.SchemaVersion.V0;
 import static io.trino.plugin.iceberg.catalog.jdbc.IcebergJdbcCatalogConfig.SchemaVersion.V1;
 import static java.util.Objects.requireNonNull;
@@ -106,6 +109,22 @@ public class IcebergJdbcClient
                     .bind("table", tableName)
                     .mapTo(String.class)
                     .findOne();
+        }
+    }
+
+    public Map<String, String> getViewMetadataLocations(String schemaName)
+    {
+        try (Handle handle = Jdbi.open(connectionFactory)) {
+            return handle.createQuery(
+                            """
+                            SELECT table_name, metadata_location
+                            FROM iceberg_tables
+                            WHERE catalog_name = :catalog AND table_namespace = :schema AND iceberg_type = 'VIEW'""")
+                    .bind("catalog", catalogName)
+                    .bind("schema", schemaName)
+                    .map((rs, _) -> Map.entry(rs.getString("table_name"), rs.getString("metadata_location")))
+                    .stream()
+                    .collect(toImmutableMap(Entry::getKey, Entry::getValue));
         }
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.jdbc.UncheckedInterruptedException;
 import org.apache.iceberg.jdbc.UncheckedSQLException;
@@ -60,6 +61,8 @@ import org.apache.iceberg.view.SQLViewRepresentation;
 import org.apache.iceberg.view.UpdateViewProperties;
 import org.apache.iceberg.view.View;
 import org.apache.iceberg.view.ViewBuilder;
+import org.apache.iceberg.view.ViewMetadata;
+import org.apache.iceberg.view.ViewMetadataParser;
 import org.apache.iceberg.view.ViewRepresentation;
 import org.apache.iceberg.view.ViewVersion;
 
@@ -91,6 +94,7 @@ import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_UNSUPPORTED_VIEW_DIALECT;
 import static io.trino.plugin.iceberg.IcebergSchemaProperties.LOCATION_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergSchemaProperties.SUPPORTED_SCHEMA_PROPERTIES;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.isUseFileSizeFromMetadata;
 import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableWithMetadata;
 import static io.trino.plugin.iceberg.IcebergUtil.loadIcebergTable;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -541,11 +545,11 @@ public class TrinoJdbcCatalog
 
         List<Callable<Optional<Map.Entry<SchemaTableName, ConnectorViewDefinition>>>> tasks = new ArrayList<>();
         for (String ns : listNamespaces(session, namespace)) {
-            for (TableIdentifier view : jdbcCatalog.listViews(Namespace.of(ns))) {
-                SchemaTableName schemaTableName = SchemaTableName.schemaTableName(view.namespace().toString(), view.name());
+            jdbcClient.getViewMetadataLocations(ns).forEach((viewName, metadataLocation) -> {
+                SchemaTableName schemaTableName = SchemaTableName.schemaTableName(ns, viewName);
                 tasks.add(() -> {
                     try {
-                        return loadViewDefinition(schemaTableName).map(definition -> Map.entry(schemaTableName, definition));
+                        return loadViewDefinition(session, schemaTableName, metadataLocation).map(definition -> Map.entry(schemaTableName, definition));
                     }
                     catch (TrinoException e) {
                         if (e.getErrorCode().equals(ICEBERG_UNSUPPORTED_VIEW_DIALECT.toErrorCode())) {
@@ -555,7 +559,7 @@ public class TrinoJdbcCatalog
                         throw e;
                     }
                 });
-            }
+            });
         }
 
         ImmutableMap.Builder<SchemaTableName, ConnectorViewDefinition> views = ImmutableMap.builder();
@@ -594,17 +598,45 @@ public class TrinoJdbcCatalog
         if (!sqlView.dialect().equalsIgnoreCase("trino")) {
             throw new TrinoException(ICEBERG_UNSUPPORTED_VIEW_DIALECT, "Cannot read unsupported dialect '%s' for view '%s'".formatted(sqlView.dialect(), viewIdentifier));
         }
+        return createViewDefinition(viewIdentifier, view.currentVersion(), view.schema(), view.properties());
+    }
 
-        Optional<String> comment = Optional.ofNullable(view.properties().get(COMMENT));
-        List<ConnectorViewDefinition.ViewColumn> viewColumns = IcebergUtil.viewColumnsFromSchema(typeManager, view.schema());
-        ViewVersion currentVersion = view.currentVersion();
+    private Optional<ConnectorViewDefinition> loadViewDefinition(ConnectorSession session, SchemaTableName viewIdentifier, String metadataLocation)
+    {
+        ViewMetadata viewMetadata;
+        try {
+            viewMetadata = ViewMetadataParser.read(fileIoFactory.create(fileSystemFactory.create(session), isUseFileSizeFromMetadata(session)), metadataLocation);
+        }
+        catch (NotFoundException e) {
+            // View may have been dropped concurrently with listing
+            return Optional.empty();
+        }
+        return createViewDefinition(viewIdentifier, viewMetadata.currentVersion(), viewMetadata.schema(), viewMetadata.properties());
+    }
+
+    private Optional<ConnectorViewDefinition> createViewDefinition(SchemaTableName viewIdentifier, ViewVersion currentVersion, Schema viewSchema, Map<String, String> properties)
+    {
+        List<SQLViewRepresentation> sqlRepresentations = currentVersion.representations().stream()
+                .filter(SQLViewRepresentation.class::isInstance)
+                .map(SQLViewRepresentation.class::cast)
+                .collect(toImmutableList());
+        SQLViewRepresentation sqlView = sqlRepresentations.stream()
+                .filter(representation -> representation.dialect().equalsIgnoreCase("trino"))
+                .findFirst()
+                .orElseThrow(() -> {
+                    String dialect = sqlRepresentations.stream().findFirst().map(SQLViewRepresentation::dialect).orElse("unknown");
+                    return new TrinoException(ICEBERG_UNSUPPORTED_VIEW_DIALECT, "Cannot read unsupported dialect '%s' for view '%s'".formatted(dialect, viewIdentifier));
+                });
+
+        Optional<String> comment = Optional.ofNullable(properties.get(COMMENT));
+        List<ConnectorViewDefinition.ViewColumn> viewColumns = IcebergUtil.viewColumnsFromSchema(typeManager, viewSchema);
         Optional<String> catalog = Optional.ofNullable(currentVersion.defaultCatalog());
         Optional<String> schema = Optional.empty();
         if (catalog.isPresent() && !currentVersion.defaultNamespace().isEmpty()) {
             schema = Optional.of(currentVersion.defaultNamespace().toString());
         }
 
-        Optional<String> owner = Optional.ofNullable(view.properties().get(ICEBERG_VIEW_RUN_AS_OWNER));
+        Optional<String> owner = Optional.ofNullable(properties.get(ICEBERG_VIEW_RUN_AS_OWNER));
         return Optional.of(new ConnectorViewDefinition(sqlView.sql(), catalog, schema, viewColumns, comment, owner, owner.isEmpty(), null));
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -63,6 +63,7 @@ import org.apache.iceberg.view.ViewBuilder;
 import org.apache.iceberg.view.ViewRepresentation;
 import org.apache.iceberg.view.ViewVersion;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -70,6 +71,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
@@ -81,6 +85,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Maps.transformValues;
 import static io.trino.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.filesystem.Locations.appendPath;
+import static io.trino.plugin.base.util.ExecutorUtil.processWithAdditionalThreads;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_CATALOG_ERROR;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_UNSUPPORTED_VIEW_DIALECT;
@@ -107,6 +112,7 @@ public class TrinoJdbcCatalog
     private final IcebergJdbcClient jdbcClient;
     private final String defaultWarehouseDir;
     private final SchemaVersion schemaVersion;
+    private final Executor metadataFetchingExecutor;
 
     private final Cache<SchemaTableName, TableMetadata> tableMetadataCache = EvictableCacheBuilder.newBuilder()
             .maximumSize(PER_QUERY_CACHE_SIZE)
@@ -122,13 +128,15 @@ public class TrinoJdbcCatalog
             ForwardingFileIoFactory fileIoFactory,
             boolean useUniqueTableLocation,
             String defaultWarehouseDir,
-            SchemaVersion schemaVersion)
+            SchemaVersion schemaVersion,
+            Executor metadataFetchingExecutor)
     {
         super(catalogName, useUniqueTableLocation, typeManager, tableOperationsProvider, fileSystemFactory, fileIoFactory);
         this.jdbcCatalog = requireNonNull(jdbcCatalog, "jdbcCatalog is null");
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         this.defaultWarehouseDir = requireNonNull(defaultWarehouseDir, "defaultWarehouseDir is null");
         this.schemaVersion = requireNonNull(schemaVersion, "schemaVersion is null");
+        this.metadataFetchingExecutor = requireNonNull(metadataFetchingExecutor, "metadataFetchingExecutor is null");
     }
 
     @Override
@@ -526,23 +534,40 @@ public class TrinoJdbcCatalog
     @Override
     public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, Optional<String> namespace)
     {
-        ImmutableMap.Builder<SchemaTableName, ConnectorViewDefinition> views = ImmutableMap.builder();
+        if (schemaVersion == SchemaVersion.V0) {
+            // V0 doesn't support views
+            return ImmutableMap.of();
+        }
+
+        List<Callable<Optional<Map.Entry<SchemaTableName, ConnectorViewDefinition>>>> tasks = new ArrayList<>();
         for (String ns : listNamespaces(session, namespace)) {
             for (TableIdentifier view : jdbcCatalog.listViews(Namespace.of(ns))) {
                 SchemaTableName schemaTableName = SchemaTableName.schemaTableName(view.namespace().toString(), view.name());
-                try {
-                    getView(session, schemaTableName).ifPresent(viewDefinition -> views.put(schemaTableName, viewDefinition));
-                }
-                catch (TrinoException e) {
-                    if (e.getErrorCode().equals(ICEBERG_UNSUPPORTED_VIEW_DIALECT.toErrorCode())) {
-                        LOG.debug(e, "Skip unsupported view dialect: %s", schemaTableName);
-                        continue;
+                tasks.add(() -> {
+                    try {
+                        return loadViewDefinition(schemaTableName).map(definition -> Map.entry(schemaTableName, definition));
                     }
-                    throw e;
-                }
+                    catch (TrinoException e) {
+                        if (e.getErrorCode().equals(ICEBERG_UNSUPPORTED_VIEW_DIALECT.toErrorCode())) {
+                            LOG.debug(e, "Skip unsupported view dialect: %s", schemaTableName);
+                            return Optional.empty();
+                        }
+                        throw e;
+                    }
+                });
             }
         }
 
+        ImmutableMap.Builder<SchemaTableName, ConnectorViewDefinition> views = ImmutableMap.builder();
+        try {
+            for (Optional<Map.Entry<SchemaTableName, ConnectorViewDefinition>> result : processWithAdditionalThreads(tasks, metadataFetchingExecutor)) {
+                result.ifPresent(entry -> views.put(entry.getKey(), entry.getValue()));
+            }
+        }
+        catch (ExecutionException e) {
+            throwIfUnchecked(e.getCause());
+            throw new RuntimeException(e.getCause());
+        }
         return views.buildOrThrow();
     }
 
@@ -558,7 +583,13 @@ public class TrinoJdbcCatalog
             return Optional.empty();
         }
 
+        return loadViewDefinition(viewIdentifier);
+    }
+
+    private Optional<ConnectorViewDefinition> loadViewDefinition(SchemaTableName viewIdentifier)
+    {
         View view = loadIcebergView(viewIdentifier);
+
         SQLViewRepresentation sqlView = view.sqlFor("trino");
         if (!sqlView.dialect().equalsIgnoreCase("trino")) {
             throw new TrinoException(ICEBERG_UNSUPPORTED_VIEW_DIALECT, "Cannot read unsupported dialect '%s' for view '%s'".formatted(sqlView.dialect(), viewIdentifier));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
@@ -15,7 +15,9 @@ package io.trino.plugin.iceberg.catalog.jdbc;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import io.airlift.concurrent.BoundedExecutor;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.plugin.iceberg.ForIcebergMetadata;
 import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
@@ -29,7 +31,10 @@ import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.jdbc.JdbcClientPool;
 
 import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.CatalogProperties.URI;
 import static org.apache.iceberg.CatalogProperties.WAREHOUSE_LOCATION;
@@ -50,6 +55,7 @@ public class TrinoJdbcCatalogFactory
     private final boolean isUniqueTableLocation;
     private final Map<String, String> catalogProperties;
     private final JdbcClientPool clientPool;
+    private final Executor metadataFetchingExecutor;
 
     @Inject
     public TrinoJdbcCatalogFactory(
@@ -60,7 +66,8 @@ public class TrinoJdbcCatalogFactory
             ForwardingFileIoFactory fileIoFactory,
             IcebergJdbcClient jdbcClient,
             IcebergJdbcCatalogConfig jdbcConfig,
-            IcebergConfig icebergConfig)
+            IcebergConfig icebergConfig,
+            @ForIcebergMetadata ExecutorService metadataExecutorService)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -83,6 +90,13 @@ public class TrinoJdbcCatalogFactory
         this.catalogProperties = properties.buildOrThrow();
 
         this.clientPool = new JdbcClientPool(jdbcConfig.getConnectionUrl(), catalogProperties);
+
+        if (icebergConfig.getMetadataParallelism() == 1) {
+            this.metadataFetchingExecutor = directExecutor();
+        }
+        else {
+            this.metadataFetchingExecutor = new BoundedExecutor(metadataExecutorService, icebergConfig.getMetadataParallelism());
+        }
     }
 
     @PreDestroy
@@ -111,6 +125,7 @@ public class TrinoJdbcCatalogFactory
                 fileIoFactory,
                 isUniqueTableLocation,
                 defaultWarehouseDir,
-                schemaVersion);
+                schemaVersion,
+                metadataFetchingExecutor);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestTrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestTrinoJdbcCatalog.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.trino.hdfs.HdfsTestUtils.HDFS_FILE_SYSTEM_FACTORY;
 import static io.trino.plugin.iceberg.IcebergTestUtils.ENCRYPTION_MANAGER_FACTORY;
 import static io.trino.plugin.iceberg.IcebergTestUtils.FILE_IO_FACTORY;
@@ -99,7 +100,8 @@ final class TestTrinoJdbcCatalog
                 FILE_IO_FACTORY,
                 useUniqueTableLocations,
                 warehouseLocation.toAbsolutePath().toString(),
-                V1);
+                V1,
+                directExecutor());
     }
 
     private static JdbcCatalog createJdbcCatalog(String jdbcUrl, Path warehouseLocation)


### PR DESCRIPTION
## Description

### Problem
Listing views in the Iceberg JDBC catalog (e.g. querying information_schema.views) was slow and got linearly worse as the number of views grew.

Loading each view requires two network round trips:

1. A query to the metastore database to resolve where the view's metadata file lives.
2. A read of that metadata file from the underlying file system (e.g. an S3 GET).

For a schema with N views, this meant N database queries plus N file reads, all performed one after another. Listing views in a busy schema therefore hammered the metastore DB and stacked up file-read latency serially.

### Solution
Two changes, one per commit:

1. Load views in parallel.
Instead of loading views one at a time, the per-view loads are fanned out across the shared metadata executor (bounded by iceberg.metadata-parallelism). The file reads now happen concurrently rather than back-to-back.

2. Resolve all view metadata pointers in a single bulk query.
Parallelizing still left one separate database query per view. This adds a bulk lookup that resolves every view's metadata location for a schema in one query, replacing the N per-view queries.
## Additional context and related issues

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
