### PR TITLE
Map Ignite high-precision DECIMAL to Trino NUMBER

### DIFF
--- a/docs/src/main/sphinx/connector/ignite.md
+++ b/docs/src/main/sphinx/connector/ignite.md
@@ -131,8 +131,9 @@ The following are supported Ignite SQL data types from [https://ignite.apache.or
   - `BIGINT`
   - `-9223372036854775808`, `9223372036854775807`, etc.
 * - `DECIMAL`
-  - `DECIMAL`
-  - Data type with fixed precision and scale
+  - `DECIMAL` or `NUMBER`
+  - Maps to Trino `DECIMAL` when the declared precision and scale can be
+    represented as a Trino `DECIMAL`. Otherwise, maps to `NUMBER`.
 * - `DOUBLE`
   - `DOUBLE`
   - `3.14`, `-10.24`, etc.

--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
@@ -91,7 +91,6 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.ignite.IgniteTableProperties.PRIMARY_KEY_PROPERTY;
 import static io.trino.plugin.jdbc.ColumnMapping.longMapping;
-import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRounding;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRoundingMode;
@@ -107,6 +106,7 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.doubleWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.integerColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.integerWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.numberColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.realColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.realWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.shortDecimalWriteFunction;
@@ -118,6 +118,8 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.varbinaryColumnMapping
 import static io.trino.plugin.jdbc.StandardColumnMappings.varbinaryWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
+import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsupportedTypeHandling;
+import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
 import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -230,23 +232,36 @@ public class IgniteClient
             case Types.FLOAT -> Optional.of(realColumnMapping());
             case Types.DOUBLE -> Optional.of(doubleColumnMapping());
             case Types.DECIMAL -> {
-                int decimalDigits = typeHandle.requiredDecimalDigits();
-                int precision = typeHandle.requiredColumnSize();
-                if (getDecimalRounding(session) == ALLOW_OVERFLOW && precision > Decimals.MAX_PRECISION) {
-                    int scale = min(decimalDigits, getDecimalDefaultScale(session));
-                    yield Optional.of(decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, scale), getDecimalRoundingMode(session)));
+                int scale = typeHandle.requiredDecimalDigits();
+                // Map decimal(p, -s) (negative scale) to decimal(p+s, 0).
+                // Map decimal(p, s) with s>p, to decimal(s, s).
+                int precision = max(typeHandle.requiredColumnSize() + max(-scale, 0), scale);
+                scale = max(scale, 0);
+                if (precision <= Decimals.MAX_PRECISION) {
+                    yield Optional.of(decimalColumnMapping(createDecimalType(precision, scale)));
                 }
-                precision = precision + max(-decimalDigits, 0); // Map decimal(p, -s) (negative scale) to decimal(p+s, 0).
-                if (precision > Decimals.MAX_PRECISION) {
-                    yield Optional.empty();
-                }
-                yield Optional.of(decimalColumnMapping(createDecimalType(precision, max(decimalDigits, 0))));
+                yield switch (getDecimalRounding(session)) {
+                    case MAP_TO_NUMBER -> Optional.of(numberColumnMapping());
+                    case STRICT -> unsupportedTypeMapping(session, typeHandle);
+                    case ALLOW_OVERFLOW -> {
+                        int overflowScale = min(scale, getDecimalDefaultScale(session));
+                        yield Optional.of(decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, overflowScale), getDecimalRoundingMode(session)));
+                    }
+                };
             }
             case Types.VARCHAR -> Optional.of(varcharColumnMapping(typeHandle.columnSize()));
             case Types.DATE -> Optional.of(longMapping(DATE, dateReadFunction(), dateWriteFunction()));
             case Types.BINARY -> Optional.of(varbinaryColumnMapping());
             default -> Optional.empty();
         };
+    }
+
+    private Optional<ColumnMapping> unsupportedTypeMapping(ConnectorSession session, JdbcTypeHandle typeHandle)
+    {
+        if (getUnsupportedTypeHandling(session) == CONVERT_TO_VARCHAR) {
+            return mapToUnboundedVarchar(typeHandle);
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClientModule.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClientModule.java
@@ -31,6 +31,7 @@ import org.apache.ignite.IgniteJdbcThinDriver;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.plugin.jdbc.DecimalModule.MappingToNumber.ON_BY_DEFAULT;
 import static io.trino.plugin.jdbc.JdbcModule.bindTablePropertiesProvider;
 
 public class IgniteClientModule
@@ -43,7 +44,7 @@ public class IgniteClientModule
         newOptionalBinder(binder, JdbcMetadataFactory.class).setBinding().to(IgniteJdbcMetadataFactory.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(IgniteJdbcConfig.class);
         bindTablePropertiesProvider(binder, IgniteTableProperties.class);
-        binder.install(new DecimalModule());
+        binder.install(DecimalModule.withNumberMapping(ON_BY_DEFAULT));
     }
 
     @Provides

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
@@ -15,6 +15,7 @@ package io.trino.plugin.ignite;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
+import io.trino.plugin.jdbc.UnsupportedTypeHandling;
 import io.trino.spi.type.TimeZoneKey;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
@@ -30,12 +31,21 @@ import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
+import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.STRICT;
+import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.DECIMAL_DEFAULT_SCALE;
+import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.DECIMAL_MAPPING;
+import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.DECIMAL_ROUNDING_MODE;
+import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.UNSUPPORTED_TYPE_HANDLING;
+import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
+import static io.trino.plugin.jdbc.UnsupportedTypeHandling.IGNORE;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
@@ -49,7 +59,9 @@ import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.lang.String.format;
+import static java.math.RoundingMode.UNNECESSARY;
 import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestIgniteTypeMapping
@@ -259,6 +271,65 @@ public class TestIgniteTypeMapping
     }
 
     @Test
+    public void testDecimalExceedingPrecisionMax()
+    {
+        try (TestTable table = new TestTable(
+                igniteServer::execute,
+                "test_decimal_exceeding_precision_max",
+                "(id int primary key, d40 decimal(40, 5), d50 decimal(50, 0))",
+                List.of(
+                        "1, CAST('12345678901234567890123456789012345.12345' AS decimal(40, 5)), CAST('12345678901234567890123456789012345678901234567890' AS decimal(50, 0))",
+                        "2, CAST('-12345678901234567890123456789012345.12345' AS decimal(40, 5)), CAST('-12345678901234567890123456789012345678901234567890' AS decimal(50, 0))",
+                        "3, CAST('123.45' AS decimal(40, 5)), CAST(NULL AS decimal(50, 0))",
+                        "4, CAST(NULL AS decimal(40, 5)), CAST('0' AS decimal(50, 0))"))) {
+            assertThat(query(format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = '%s' ORDER BY ordinal_position", table.getName())))
+                    .skippingTypesCheck()
+                    .matches("VALUES ('id', 'integer'), ('d40', 'number'), ('d50', 'number')");
+            assertThat(query(format("SELECT d40, d50 FROM %s ORDER BY id", table.getName())))
+                    .matches("VALUES " +
+                            "(NUMBER '12345678901234567890123456789012345.12345', NUMBER '12345678901234567890123456789012345678901234567890'), " +
+                            "(NUMBER '-12345678901234567890123456789012345.12345', NUMBER '-12345678901234567890123456789012345678901234567890'), " +
+                            "(NUMBER '123.45', CAST(NULL AS NUMBER)), " +
+                            "(CAST(NULL AS NUMBER), NUMBER '0')");
+        }
+    }
+
+    @Test
+    public void testDecimalExceedingPrecisionMaxWithLegacyDecimalMapping()
+    {
+        try (TestTable table = new TestTable(
+                igniteServer::execute,
+                "test_decimal_exceeding_precision_max_allow_overflow",
+                "(id int primary key, d_col decimal(40, 0))",
+                List.of("1, CAST('12345678901234567890123456789012345678' AS decimal(40, 0))"))) {
+            assertThat(query(
+                    sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
+                    format("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = '%s' ORDER BY ordinal_position", table.getName())))
+                    .skippingTypesCheck()
+                    .matches("VALUES ('id', 'integer'), ('d_col', 'decimal(38,0)')");
+            assertThat(query(sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0), format("SELECT d_col FROM %s", table.getName())))
+                    .matches("VALUES DECIMAL '12345678901234567890123456789012345678'");
+        }
+
+        try (TestTable table = new TestTable(
+                igniteServer::execute,
+                "test_decimal_exceeding_precision_max_strict",
+                "(id int primary key, d_col decimal(40, 5))",
+                List.of("1, CAST('123.45' AS decimal(40, 5))"))) {
+            String columnInfoSql = format(
+                    "SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = 'public' AND table_name = '%s' ORDER BY ordinal_position",
+                    table.getName());
+
+            assertThat(query(sessionWithDecimalMappingStrict(IGNORE), columnInfoSql))
+                    .skippingTypesCheck()
+                    .matches("VALUES ('id', 'integer')");
+            assertThat(query(sessionWithDecimalMappingStrict(CONVERT_TO_VARCHAR), columnInfoSql))
+                    .skippingTypesCheck()
+                    .matches("VALUES ('id', 'integer'), ('d_col', 'varchar')");
+        }
+    }
+
+    @Test
     public void testBinary()
     {
         binaryTest("binary")
@@ -429,6 +500,23 @@ public class TestIgniteTypeMapping
     private DataSetup trinoCreateAsSelect(String tableNamePrefix)
     {
         return new CreateAsSelectDataSetup(new TrinoSqlExecutor(getQueryRunner()), tableNamePrefix);
+    }
+
+    private Session sessionWithDecimalMappingAllowOverflow(RoundingMode roundingMode, int scale)
+    {
+        return Session.builder(getSession())
+                .setCatalogSessionProperty("ignite", DECIMAL_MAPPING, ALLOW_OVERFLOW.name())
+                .setCatalogSessionProperty("ignite", DECIMAL_ROUNDING_MODE, roundingMode.name())
+                .setCatalogSessionProperty("ignite", DECIMAL_DEFAULT_SCALE, Integer.valueOf(scale).toString())
+                .build();
+    }
+
+    private Session sessionWithDecimalMappingStrict(UnsupportedTypeHandling unsupportedTypeHandling)
+    {
+        return Session.builder(getSession())
+                .setCatalogSessionProperty("ignite", DECIMAL_MAPPING, STRICT.name())
+                .setCatalogSessionProperty("ignite", UNSUPPORTED_TYPE_HANDLING, unsupportedTypeHandling.name())
+                .build();
     }
 
     private DataSetup igniteCreateAndInsert(String tableNamePrefix)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/ignite/TestIgnite.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/ignite/TestIgnite.java
@@ -18,9 +18,11 @@ import io.trino.tempto.query.QueryResult;
 import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tests.product.TestGroups.IGNITE;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestIgnite
@@ -37,6 +39,30 @@ public class TestIgnite
         }
         finally {
             onTrino().executeQuery("DROP TABLE nation");
+        }
+    }
+
+    @Test(groups = {IGNITE, PROFILE_SPECIFIC_TESTS})
+    public void testHighPrecisionDecimalMapsToNumber()
+    {
+        String tableName = "test_decimal_number_" + randomNameSuffix();
+        onTrino().executeQuery(format("CALL system.execute('CREATE TABLE %s (id int primary key, d40 decimal(40, 5), d50 decimal(50, 0))')", tableName));
+        try {
+            onTrino().executeQuery(format(
+                    "CALL system.execute('INSERT INTO %s VALUES (1, CAST(''12345678901234567890123456789012345.12345'' AS decimal(40, 5)), CAST(''12345678901234567890123456789012345678901234567890'' AS decimal(50, 0)))')",
+                    tableName));
+
+            assertThat(onTrino().executeQuery(format(
+                    "SELECT typeof(d40), d40 = NUMBER '12345678901234567890123456789012345.12345', typeof(d50), d50 = NUMBER '12345678901234567890123456789012345678901234567890' FROM %s",
+                    tableName)))
+                    .containsOnly(row(
+                            "number",
+                            true,
+                            "number",
+                            true));
+        }
+        finally {
+            onTrino().executeQuery("DROP TABLE " + tableName);
         }
     }
 }


### PR DESCRIPTION
  ## Description

  Migrate the Ignite connector decimal read mapping to use Trino `NUMBER` for high-precision Ignite `DECIMAL` columns.

  This changes the Ignite connector to install `DecimalModule.withNumberMapping(ON_BY_DEFAULT)` and updates `IgniteClient.toColumnMapping()` so that:

  - Ignite `DECIMAL` values that fit in Trino `DECIMAL` continue to map to Trino `DECIMAL`.
  - Ignite `DECIMAL` values whose precision exceeds Trino `DECIMAL` capability map to Trino `NUMBER` by default.
  - Explicit legacy `decimal-mapping=STRICT` and `decimal-mapping=ALLOW_OVERFLOW` behavior is preserved.
  - Trino `NUMBER` write mapping is not added for Ignite.

  The Ignite connector documentation is updated to describe the new `DECIMAL` / `NUMBER` mapping behavior.

  ## Additional context and related issues
  - #28405 

  This follows the same migration approach as the PostgreSQL connector's change, adapted for Ignite's fixed precision/scale `DECIMAL` type.

  Additional tests cover:

  - high-precision Ignite `DECIMAL` mapping to Trino `NUMBER`
  - preserving existing `DECIMAL` behavior for values within Trino precision limits
  - legacy `STRICT` and `ALLOW_OVERFLOW` decimal mapping behavior
  - product test coverage for high-precision `DECIMAL` reads

  ## Release notes

  ( ) This is not user-visible or is docs only, and no release notes are required.
  ( ) Release notes are required. Please propose a release note for me.
  (x) Release notes are required, with the following suggested text:

  ```markdown
  ## Ignite
  * Map high-precision `DECIMAL` columns to `NUMBER` by default.