### PR TITLE
Reuse existing view location when replacing view in Iceberg JDBC Catalog

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.jdbc.UncheckedInterruptedException;
 import org.apache.iceberg.jdbc.UncheckedSQLException;
+import org.apache.iceberg.util.LocationUtil;
 import org.apache.iceberg.view.ReplaceViewVersion;
 import org.apache.iceberg.view.SQLViewRepresentation;
 import org.apache.iceberg.view.UpdateViewProperties;
@@ -91,7 +92,6 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.CatalogUtil.dropTableData;
-import static org.apache.iceberg.util.LocationUtil.stripTrailingSlash;
 import static org.apache.iceberg.view.ViewProperties.COMMENT;
 
 public class TrinoJdbcCatalog
@@ -477,7 +477,8 @@ public class TrinoJdbcCatalog
         definition.getOwner().ifPresent(owner -> properties.put(ICEBERG_VIEW_RUN_AS_OWNER, owner));
         definition.getComment().ifPresent(comment -> properties.put(COMMENT, comment));
         Schema schema = IcebergUtil.schemaFromViewColumns(typeManager, definition.getColumns());
-        String viewLocation = stripTrailingSlash(IcebergViewProperties.getLocation(viewProperties).orElse(defaultTableLocation(session, schemaViewName)));
+        Optional<String> locationProperty = IcebergViewProperties.getLocation(viewProperties);
+        String viewLocation = locationProperty.map(LocationUtil::stripTrailingSlash).orElse(defaultTableLocation(session, schemaViewName));
         ViewBuilder viewBuilder = jdbcCatalog.buildView(toIdentifier(schemaViewName));
         viewBuilder = viewBuilder.withSchema(schema)
                 .withQuery("trino", definition.getOriginalSql())

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -480,6 +480,9 @@ public class TrinoJdbcCatalog
         Optional<String> locationProperty = IcebergViewProperties.getLocation(viewProperties);
         String viewLocation = locationProperty.map(LocationUtil::stripTrailingSlash).orElse(defaultTableLocation(session, schemaViewName));
         ViewBuilder viewBuilder = jdbcCatalog.buildView(toIdentifier(schemaViewName));
+        if (replace && jdbcCatalog.viewExists(toIdentifier(schemaViewName))) {
+            viewLocation = loadIcebergView(schemaViewName).location();
+        }
         viewBuilder = viewBuilder.withSchema(schema)
                 .withQuery("trino", definition.getOriginalSql())
                 .withDefaultNamespace(Namespace.of(schemaViewName.getSchemaName()))

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/BaseIcebergJdbcCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/BaseIcebergJdbcCatalogConnectorSmokeTest.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.view.View;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -158,6 +159,25 @@ public abstract class BaseIcebergJdbcCatalogConnectorSmokeTest
 
         assertThat(jdbcCatalog.viewExists(sparkViewIdentifier)).isFalse();
         assertThat(jdbcCatalog.viewExists(trinoViewIdentifier)).isFalse();
+    }
+
+    @Test
+    void testReplaceViewReuseExistingLocation()
+    {
+        String viewName = "test_replace_view_reuse_location_" + randomNameSuffix();
+        TableIdentifier identifier = toIdentifier(viewName);
+
+        assertUpdate("CREATE VIEW " + viewName + " AS SELECT nationkey FROM nation");
+        View initialView = jdbcCatalog.loadView(identifier);
+        assertThat(initialView.location()).isNotNull();
+
+        assertUpdate("CREATE OR REPLACE VIEW " + viewName + " AS SELECT nationkey, name FROM nation");
+        View replacedView = jdbcCatalog.loadView(identifier);
+
+        assertThat(replacedView.location()).isEqualTo(initialView.location());
+        assertThat(replacedView.currentVersion().versionId()).isEqualTo(initialView.currentVersion().versionId() + 1);
+
+        assertUpdate("DROP VIEW " + viewName);
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogV0SchemaConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogV0SchemaConnectorSmokeTest.java
@@ -52,6 +52,14 @@ final class TestIcebergJdbcCatalogV0SchemaConnectorSmokeTest
 
     @Test
     @Override
+    void testReplaceViewReuseExistingLocation()
+    {
+        assertThatThrownBy(super::testReplaceViewReuseExistingLocation)
+                .hasMessageContaining("Schema version V0 does not support views");
+    }
+
+    @Test
+    @Override
     void testUnsupportedViewDialect()
     {
         assertThatThrownBy(super::testUnsupportedViewDialect)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Reuse the existing Iceberg view location when replacing a view in the JDBC catalog.

This changes the JDBC Iceberg catalog so `CREATE OR REPLACE VIEW` preserves the existing Iceberg view location instead of assigning a new default location. This aligns the JDBC behavior with the earlier REST catalog fix for the same issue.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes #29755.

This is a follow-up to the REST catalog fix described in #29729.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Reuse existing view location when replacing view in Iceberg JDBC Catalog. ({issue}`29755`)
```
