### PR TITLE
Reuse existing view location in Iceberg JDBC catalog

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -475,13 +475,18 @@ public class TrinoJdbcCatalog
         definition.getOwner().ifPresent(owner -> properties.put(ICEBERG_VIEW_RUN_AS_OWNER, owner));
         definition.getComment().ifPresent(comment -> properties.put(COMMENT, comment));
         Schema schema = IcebergUtil.schemaFromViewColumns(typeManager, definition.getColumns());
-        ViewBuilder viewBuilder = jdbcCatalog.buildView(toIdentifier(schemaViewName));
+        TableIdentifier viewIdentifier = toIdentifier(schemaViewName);
+        ViewBuilder viewBuilder = jdbcCatalog.buildView(viewIdentifier);
+        String viewLocation = defaultTableLocation(session, schemaViewName);
+        if (replace && jdbcCatalog.viewExists(viewIdentifier)) {
+            viewLocation = jdbcCatalog.loadView(viewIdentifier).location();
+        }
         viewBuilder = viewBuilder.withSchema(schema)
                 .withQuery("trino", definition.getOriginalSql())
                 .withDefaultNamespace(Namespace.of(schemaViewName.getSchemaName()))
                 .withDefaultCatalog(definition.getCatalog().orElse(null))
                 .withProperties(properties.buildOrThrow())
-                .withLocation(defaultTableLocation(session, schemaViewName));
+                .withLocation(viewLocation);
 
         if (replace) {
             viewBuilder.createOrReplace();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/BaseIcebergJdbcCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/BaseIcebergJdbcCatalogConnectorSmokeTest.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.view.View;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -187,6 +188,24 @@ public abstract class BaseIcebergJdbcCatalogConnectorSmokeTest
         assertQueryFails("SELECT * FROM " + viewName, "Cannot read unsupported dialect 'spark' for view '.*'");
 
         jdbcCatalog.dropView(identifier);
+    }
+
+    @Test
+    void testReplaceViewReuseExistingLocation()
+    {
+        String viewName = "test_replace_view_location_" + randomNameSuffix();
+        TableIdentifier identifier = TableIdentifier.of("tpch", viewName);
+
+        assertUpdate("CREATE VIEW " + viewName + " AS SELECT name FROM nation");
+        View initialView = jdbcCatalog.loadView(identifier);
+        assertThat(initialView.location()).isNotNull();
+
+        assertUpdate("CREATE OR REPLACE VIEW " + viewName + " AS SELECT regionkey, name FROM region");
+        View updatedView = jdbcCatalog.loadView(identifier);
+        assertThat(updatedView.location()).isEqualTo(initialView.location());
+        assertThat(updatedView.currentVersion().versionId()).isEqualTo(initialView.currentVersion().versionId() + 1);
+
+        assertUpdate("DROP VIEW " + viewName);
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogV0SchemaConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogV0SchemaConnectorSmokeTest.java
@@ -57,4 +57,12 @@ final class TestIcebergJdbcCatalogV0SchemaConnectorSmokeTest
         assertThatThrownBy(super::testUnsupportedViewDialect)
                 .hasMessageContaining("Error processing metadata");
     }
+
+    @Test
+    @Override
+    void testReplaceViewReuseExistingLocation()
+    {
+        assertThatThrownBy(super::testReplaceViewReuseExistingLocation)
+                .hasMessageContaining("Schema version V0 does not support views");
+    }
 }


### PR DESCRIPTION
## Description

Fixes #29755.

This mirrors the Iceberg REST catalog behavior from #29729 for the JDBC catalog. When replacing an existing Iceberg view, the JDBC catalog now reuses the current view location instead of assigning a new default table location. New JDBC smoke coverage verifies that `CREATE OR REPLACE VIEW` keeps the original Iceberg view location while advancing the view version.

## Additional context and related issues

Follow-up to #29729.

Local test execution is limited by the machine's Java toolchain. `java -version` and `./mvnw -version` both report Java 8, while current Trino requires a modern JDK. A focused Maven test command was started but not run to completion after Maven began redownloading the dependency graph with the Java 8 environment.

Checks completed locally:

- `git diff --check`

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Reuse existing view location when replacing view in Iceberg JDBC Catalog. ({issue}`29755`)
```
