### PR TITLE
Fix "Multiple entries with same key error" with Iceberg equality deletes

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -93,6 +93,7 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -498,8 +499,18 @@ public final class IcebergUtil
 
     public static StructType structTypeFromHandles(List<IcebergColumnHandle> columns)
     {
-        List<NestedField> icebergColumns = columns.stream()
-                .map(column -> NestedField.optional(column.getId(), column.getName(), toIcebergType(column.getType(), column.getColumnIdentity())))
+        // Deduplicate by base column ID to handle nested field projections where multiple
+        // nested fields from the same base struct appear (e.g., root.a, root.b both reference base column "root")
+        Map<Integer, IcebergColumnHandle> columnsByBaseId = new LinkedHashMap<>();
+        for (IcebergColumnHandle column : columns) {
+            columnsByBaseId.putIfAbsent(column.getBaseColumnIdentity().getId(), column);
+        }
+
+        List<NestedField> icebergColumns = columnsByBaseId.values().stream()
+                .map(column -> NestedField.optional(
+                        column.getBaseColumnIdentity().getId(),
+                        column.getBaseColumnIdentity().getName(),
+                        toIcebergType(column.getBaseType(), column.getBaseColumnIdentity())))
                 .collect(toImmutableList());
         return StructType.of(icebergColumns);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -643,6 +643,14 @@ public class TestIcebergV2
             // verify that the equality delete is effective also when not specifying the corresponding column in the projection list
             assertThat(query("SELECT id FROM " + tableName))
                     .matches("VALUES BIGINT '1'");
+
+            // verify equality deletes work with nested field in projection and WHERE clause
+            assertThat(query("SELECT root.nested FROM " + tableName))
+                    .matches("VALUES BIGINT '10'");
+            assertThat(query("SELECT id FROM " + tableName + " WHERE root.nested = 10"))
+                    .matches("VALUES BIGINT '1'");
+            assertThat(query("SELECT id FROM " + tableName + " WHERE root.nested = 20"))
+                    .returnsEmptyResult();
         }
     }
 


### PR DESCRIPTION
## Description

Fix `Multiple entries with same key error` when equality delete files contain nested fields and SELECT statement specify it in projection or where condition:
```
io.trino.testing.QueryFailedException: Multiple entries with same key: 3=3: nested: optional long and 3=3: nested: optional long

	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:591)
	at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:574)
	at io.trino.sql.query.QueryAssertions$QueryAssert.lambda$new$1(QueryAssertions.java:289)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:194)
	at io.trino.sql.query.QueryAssertions$QueryAssert.result(QueryAssertions.java:414)
	at io.trino.sql.query.QueryAssertions$QueryAssert.matches(QueryAssertions.java:335)
	at io.trino.sql.query.QueryAssertions$QueryAssert.matches(QueryAssertions.java:329)
	at io.trino.plugin.iceberg.TestIcebergV2.testMultipleEqualityDeletesWithNestedFields(TestIcebergV2.java:649)
	Suppressed: java.lang.Exception: SQL: SELECT root.nested FROM test_multiple_equality_deletes_nested_fields_mbzkirhmqc
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:598)
		... 7 more
Caused by: io.trino.spi.TrinoException: Multiple entries with same key: 3=3: nested: optional long and 3=3: nested: optional long
	at io.trino.plugin.iceberg.IcebergPageSourceProvider.lambda$createPageSource$6(IcebergPageSourceProvider.java:425)
	at io.trino.plugin.hive.TransformConnectorPageSource.getNextSourcePage(TransformConnectorPageSource.java:92)
	at io.trino.operator.TableScanOperator.getOutput(TableScanOperator.java:274)
	at io.trino.operator.OutputValidatingSourceOperator.getOutput(OutputValidatingSourceOperator.java:70)
	at io.trino.operator.Driver.processInternal(Driver.java:403)
	at io.trino.operator.Driver.lambda$process$0(Driver.java:306)
	at io.trino.operator.Driver.tryWithLock(Driver.java:709)
	at io.trino.operator.Driver.process(Driver.java:298)
	at io.trino.operator.Driver.processForDuration(Driver.java:269)
	at io.trino.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:852)
	at io.trino.execution.executor.dedicated.SplitProcessor.run(SplitProcessor.java:77)
	at io.trino.execution.executor.dedicated.TaskEntry$VersionEmbedderBridge.lambda$run$0(TaskEntry.java:205)
	at io.trino.$gen.Trino_testversion____20260605_021609_360.run(Unknown Source)
	at io.trino.execution.executor.dedicated.TaskEntry$VersionEmbedderBridge.run(TaskEntry.java:206)
	at io.trino.execution.executor.scheduler.FairScheduler.runTask(FairScheduler.java:177)
	at io.trino.execution.executor.scheduler.FairScheduler.lambda$submit$0(FairScheduler.java:164)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: java.lang.IllegalArgumentException: Multiple entries with same key: 3=3: nested: optional long and 3=3: nested: optional long
	at org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap.conflictException(ImmutableMap.java:382)
	at org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap.checkNoConflict(ImmutableMap.java:376)
	at org.apache.iceberg.relocated.com.google.common.collect.RegularImmutableMap.checkNoConflictInKeyBucket(RegularImmutableMap.java:246)
	at org.apache.iceberg.relocated.com.google.common.collect.RegularImmutableMap.fromEntryArrayCheckingBucketOverflow(RegularImmutableMap.java:135)
	at org.apache.iceberg.relocated.com.google.common.collect.RegularImmutableMap.fromEntryArray(RegularImmutableMap.java:97)
	at org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:579)
	at org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap$Builder.buildOrThrow(ImmutableMap.java:607)
	at org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap$Builder.build(ImmutableMap.java:594)
	at org.apache.iceberg.types.Types$StructType.lazyFieldsById(Types.java:1142)
	at org.apache.iceberg.types.Types$StructType.field(Types.java:1040)
	at io.trino.plugin.iceberg.delete.EqualityDeleteFilter.lambda$createPredicate$1(EqualityDeleteFilter.java:69)
	at java.base/java.util.stream.MatchOps$1MatchSink.accept(MatchOps.java:90)
	at java.base/java.util.Collections$2.tryAdvance(Collections.java:5182)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:147)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:588)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:574)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:668)
	at io.trino.plugin.iceberg.delete.EqualityDeleteFilter.createPredicate(EqualityDeleteFilter.java:69)
	at io.trino.plugin.iceberg.delete.DeleteManager.lambda$getDeletePredicate$5(DeleteManager.java:123)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:214)
	at java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:722)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.reduce(ReferencePipeline.java:698)
	at io.trino.plugin.iceberg.delete.DeleteManager.getDeletePredicate(DeleteManager.java:124)
	at io.trino.plugin.iceberg.IcebergPageSourceProvider.lambda$createPageSource$3(IcebergPageSourceProvider.java:404)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:194)
	at io.trino.plugin.iceberg.IcebergPageSourceProvider.lambda$createPageSource$6(IcebergPageSourceProvider.java:416)
	... 22 more
```

## Release notes

```markdown
## Iceberg
* Fix `Multiple entries with same key error` when reading tables with equality delete files. ({issue}`issuenumber`)
```
