### PR TITLE
Document Iceberg view location property

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -2108,6 +2108,27 @@ CREATE TABLE example_table (
 When trying to insert/update data in the table, the query fails if trying to set
 `NULL` value on a column having the `NOT NULL` constraint.
 
+(iceberg-views)=
+### Views
+
+The Iceberg connector supports {ref}`sql-view-management`.
+
+View properties supply or set metadata for the underlying views. View properties
+are passed to the connector using a `WITH` clause in {doc}`/sql/create-view`
+statements.
+
+:::{list-table} Iceberg view properties
+:width: 100%
+:widths: 40, 60
+:header-rows: 1
+
+* - Property name
+  - Description
+* - `location`
+  - Optionally specifies the file system location URI for the view metadata
+    files.
+:::
+
 (iceberg-materialized-views)=
 ### Materialized views
 


### PR DESCRIPTION
## Description

Document the Iceberg `location` view property for catalogs that support it.

This adds an Iceberg views section with a view properties table, a `CREATE VIEW ... WITH (location = ...)` example, and a note that `SHOW CREATE VIEW` shows the current `location`.

## Additional context and related issues

- #29739

This is a documentation follow-up for #29724, which adds support for the `location` view property in Iceberg JDBC catalogs using schema version `V1` and REST catalogs with view endpoints enabled.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)