### PR TITLE
Remove lenient byte[]/String handling from TypeUtils.writeNativeValue 

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -51,6 +51,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.connector.informationschema.InformationSchemaMetadata.defaultPrefixes;
 import static io.trino.connector.informationschema.InformationSchemaMetadata.isTablesEnumeratingTable;
 import static io.trino.metadata.MetadataListing.getRelationTypes;
@@ -380,7 +381,7 @@ public class InformationSchemaPageSource
     {
         pageBuilder.declarePosition();
         for (int i = 0; i < types.size(); i++) {
-            writeNativeValue(types.get(i), pageBuilder.getBlockBuilder(i), values[i]);
+            writeNativeValue(types.get(i), pageBuilder.getBlockBuilder(i), values[i] instanceof String string ? utf8Slice(string) : values[i]);
         }
         if (pageBuilder.isFull()) {
             flushPageBuilder();

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineHash.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineHash.java
@@ -23,7 +23,6 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.BlockEncodingSerde;
 import io.trino.spi.function.BoundSignature;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeUtils;
 import io.trino.sql.ir.Array;
 import io.trino.sql.ir.Between;
 import io.trino.sql.ir.Bind;
@@ -58,6 +57,7 @@ import io.trino.sql.routine.ir.IrStatement;
 import io.trino.sql.routine.ir.IrVariable;
 import io.trino.sql.routine.ir.IrWhile;
 
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static java.lang.Math.toIntExact;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -229,7 +229,7 @@ public final class SqlRoutineHash
                         default -> {
                             // For complex types (e.g., Block-backed arrays/rows/maps), serialize canonically
                             BlockBuilder blockBuilder = constant.type().createBlockBuilder(null, 1);
-                            TypeUtils.writeNativeValue(constant.type(), blockBuilder, value);
+                            writeNativeValue(constant.type(), blockBuilder, value);
                             Block block = blockBuilder.build();
                             SliceOutput output = new DynamicSliceOutput(toIntExact(blockEncodingSerde.estimatedWriteSize(block)));
                             blockEncodingSerde.writeBlock(output, block);

--- a/core/trino-main/src/main/java/io/trino/util/variant/ArrayVariantWriter.java
+++ b/core/trino-main/src/main/java/io/trino/util/variant/ArrayVariantWriter.java
@@ -18,6 +18,8 @@ import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.Type;
 import io.trino.spi.variant.Metadata;
 
+import static io.trino.spi.type.TypeUtils.readNativeValue;
+
 record ArrayVariantWriter(ArrayType type, VariantWriter elementWriter)
         implements VariantWriter
 {
@@ -32,7 +34,7 @@ record ArrayVariantWriter(ArrayType type, VariantWriter elementWriter)
         Block array = (Block) value;
         PlannedValue[] planned = new PlannedValue[array.getPositionCount()];
         for (int position = 0; position < array.getPositionCount(); position++) {
-            planned[position] = elementWriter.plan(metadataBuilder, elementType.getObject(array, position));
+            planned[position] = elementWriter.plan(metadataBuilder, readNativeValue(elementType, array, position));
         }
         return new PlannedArrayValue(planned);
     }

--- a/core/trino-main/src/main/java/io/trino/util/variant/MapVariantWriter.java
+++ b/core/trino-main/src/main/java/io/trino/util/variant/MapVariantWriter.java
@@ -19,6 +19,7 @@ import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
 import io.trino.spi.variant.Metadata;
 
+import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.util.variant.PrimitiveMapVariantWriter.getMapKeys;
 
 public record MapVariantWriter(MapType type, VariantWriter valueWriter)
@@ -40,7 +41,7 @@ public record MapVariantWriter(MapType type, VariantWriter valueWriter)
         Block valueBlock = sqlMap.getRawValueBlock();
         int valueBlockOffset = sqlMap.getRawOffset();
         for (int entry = 0; entry < sqlMap.getSize(); entry++) {
-            plannedValues[entry] = valueWriter.plan(metadataBuilder, valueType.getObject(valueBlock, valueBlockOffset + entry));
+            plannedValues[entry] = valueWriter.plan(metadataBuilder, readNativeValue(valueType, valueBlock, valueBlockOffset + entry));
         }
 
         return new PlannedObjectValue(fieldIds, plannedValues);

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/minmaxbyn/TestTypedKeyValueHeap.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/minmaxbyn/TestTypedKeyValueHeap.java
@@ -20,7 +20,6 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.ValueBlock;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
-import io.trino.spi.type.TypeUtils;
 import org.junit.jupiter.api.Test;
 
 import java.lang.invoke.MethodHandle;
@@ -42,6 +41,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Comparator.comparing;
 
@@ -231,7 +231,7 @@ public class TestTypedKeyValueHeap
     private static <T> ValueBlock toBlock(Type type, List<T> inputStream)
     {
         BlockBuilder blockBuilder = type.createBlockBuilder(null, INPUT_SIZE);
-        inputStream.forEach(value -> TypeUtils.writeNativeValue(type, blockBuilder, value));
+        inputStream.forEach(value -> writeNativeValue(type, blockBuilder, value));
         return blockBuilder.buildValueBlock();
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/minmaxn/TestTypedHeap.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/minmaxn/TestTypedHeap.java
@@ -19,7 +19,6 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.ValueBlock;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
-import io.trino.spi.type.TypeUtils;
 import org.junit.jupiter.api.Test;
 
 import java.lang.invoke.MethodHandle;
@@ -37,6 +36,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FLAT_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 
@@ -157,7 +157,7 @@ public class TestTypedHeap
     private static <T> ValueBlock toBlock(Type type, List<T> inputStream)
     {
         BlockBuilder blockBuilder = type.createBlockBuilder(null, INPUT_SIZE);
-        inputStream.forEach(value -> TypeUtils.writeNativeValue(type, blockBuilder, value));
+        inputStream.forEach(value -> writeNativeValue(type, blockBuilder, value));
         return blockBuilder.buildValueBlock();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestDynamicPageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestDynamicPageFilter.java
@@ -114,7 +114,7 @@ public class TestDynamicPageFilter
 
         filterEvaluator = createDynamicFilterEvaluator(
                 TupleDomain.withColumnDomains(ImmutableMap.of(
-                        column, multipleValues(VARCHAR, ImmutableList.of("bc", "cd")))),
+                        column, multipleValues(VARCHAR, ImmutableList.of(utf8Slice("bc"), utf8Slice("cd"))))),
                 ImmutableMap.of(column, 0));
         verifySelectedPositions(filterPage(page, filterEvaluator), new int[] {1, 3});
 

--- a/core/trino-main/src/test/java/io/trino/type/TestVariantOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestVariantOperators.java
@@ -842,6 +842,57 @@ class TestVariantOperators
     }
 
     @Test
+    void testCastArrayWithNullNestedElementsToVariant()
+    {
+        // Array of arrays with a null element
+        assertThat(assertions.expression("CAST(CAST(a AS VARIANT) AS JSON)")
+                .binding("a", "ARRAY[ARRAY[1, 2], NULL, ARRAY[3]]"))
+                .isEqualTo("[[1,2],null,[3]]");
+
+        // Array of maps with a null element
+        assertThat(assertions.expression("CAST(CAST(a AS VARIANT) AS JSON)")
+                .binding("a", "ARRAY[MAP(ARRAY['a'], ARRAY[1]), NULL]"))
+                .isEqualTo("[{\"a\":1},null]");
+
+        // Array of rows with a null element
+        assertThat(assertions.expression("CAST(CAST(a AS VARIANT) AS JSON)")
+                .binding("a", "ARRAY[CAST(ROW(1, 'x') AS ROW(i INTEGER, s VARCHAR)), NULL]"))
+                .isEqualTo("[{\"i\":1,\"s\":\"x\"},null]");
+    }
+
+    @Test
+    void testCastMapWithNullNestedValuesToVariant()
+    {
+        // Map with a null array value
+        assertThat(assertions.expression("CAST(CAST(a AS VARIANT) AS JSON)")
+                .binding("a", "MAP(ARRAY['k1', 'k2'], ARRAY[ARRAY[1, 2], NULL])"))
+                .isEqualTo("{\"k1\":[1,2],\"k2\":null}");
+
+        // Map with a null map value
+        assertThat(assertions.expression("CAST(CAST(a AS VARIANT) AS JSON)")
+                .binding("a", "MAP(ARRAY['k1', 'k2'], ARRAY[MAP(ARRAY['x'], ARRAY[1]), NULL])"))
+                .isEqualTo("{\"k1\":{\"x\":1},\"k2\":null}");
+    }
+
+    @Test
+    void testCastArrayOfRealToVariant()
+    {
+        // ARRAY(REAL) — element type is primitive with java type long.
+        // type.getObject(block, position) is the wrong API here: RealType inherits
+        // the default which throws.
+        assertThat(assertions.expression("CAST(CAST(a AS VARIANT) AS JSON)")
+                .binding("a", "ARRAY[REAL '1.5', REAL '2.5', NULL]"))
+                .isEqualTo("[1.5,2.5,null]");
+
+        // Nested: ARRAY(ARRAY(REAL)) routes the outer through ArrayVariantWriter
+        // with element type ARRAY(REAL); the inner array then routes through
+        // PrimitiveArrayVariantWriter. Element nulls at the outer level matter.
+        assertThat(assertions.expression("CAST(CAST(a AS VARIANT) AS JSON)")
+                .binding("a", "ARRAY[ARRAY[REAL '1.5', REAL '2.5'], NULL, ARRAY[REAL '3.5']]"))
+                .isEqualTo("[[1.5,2.5],null,[3.5]]");
+    }
+
+    @Test
     void testCastJsonToVariantMetadataAndFieldOrdering()
     {
         // Top-level array of objects with different field sets and order

--- a/core/trino-main/src/test/java/io/trino/util/variant/TestVariantWriter.java
+++ b/core/trino-main/src/test/java/io/trino/util/variant/TestVariantWriter.java
@@ -56,7 +56,7 @@ class TestVariantWriter
         assertPrimitiveWrite(REAL, (long) floatToRawIntBits(12.5f), Variant.ofFloat(12.5f));
         assertPrimitiveWrite(DOUBLE, 12.5, Variant.ofDouble(12.5));
         assertPrimitiveWrite(DATE, 20_000L, Variant.ofDate(20_000));
-        assertPrimitiveWrite(VARCHAR, "hello", Variant.ofString("hello"));
+        assertPrimitiveWrite(VARCHAR, utf8Slice("hello"), Variant.ofString("hello"));
 
         Slice binary = utf8Slice("hello");
         assertPrimitiveWrite(VARBINARY, binary, Variant.ofBinary(binary));

--- a/core/trino-spi/src/main/java/io/trino/spi/procedure/Primitives.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/procedure/Primitives.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.procedure;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+// Note: this code was forked from com.google.common.primitives.Primitives
+// Copyright (C) 2007 The Guava Authors
+final class Primitives
+{
+    private Primitives() {}
+
+    private static final Map<Class<?>, Class<?>> WRAPPERS = new HashMap<>();
+
+    static {
+        WRAPPERS.put(boolean.class, Boolean.class);
+        WRAPPERS.put(byte.class, Byte.class);
+        WRAPPERS.put(char.class, Character.class);
+        WRAPPERS.put(double.class, Double.class);
+        WRAPPERS.put(float.class, Float.class);
+        WRAPPERS.put(int.class, Integer.class);
+        WRAPPERS.put(long.class, Long.class);
+        WRAPPERS.put(short.class, Short.class);
+    }
+
+    public static <T> Class<T> wrap(Class<T> type)
+    {
+        requireNonNull(type);
+
+        // cast is safe: long.class and Long.class are both of type Class<Long>
+        @SuppressWarnings("unchecked")
+        Class<T> wrapped = (Class<T>) WRAPPERS.get(type);
+        return (wrapped == null) ? type : wrapped;
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/procedure/Procedure.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/procedure/Procedure.java
@@ -138,6 +138,9 @@ public class Procedure
             }
             this.type = requireNonNull(type, "type is null");
             this.required = required;
+            if (defaultValue != null && !Primitives.wrap(type.getJavaType()).isInstance(defaultValue)) {
+                throw new IllegalArgumentException(format("Unexpected value class for type %s, expected %s, got %s", type, type.getJavaType(), defaultValue.getClass()));
+            }
             this.defaultValue = defaultValue;
         }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeUtils.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeUtils.java
@@ -14,7 +14,6 @@
 package io.trino.spi.type;
 
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -93,16 +92,7 @@ public final class TypeUtils
             type.writeLong(blockBuilder, ((long) value));
         }
         else if (type.getJavaType() == Slice.class) {
-            Slice slice;
-            if (value instanceof byte[] bytes) {
-                slice = Slices.wrappedBuffer(bytes);
-            }
-            else if (value instanceof String string) {
-                slice = Slices.utf8Slice(string);
-            }
-            else {
-                slice = (Slice) value;
-            }
+            Slice slice = (Slice) value;
             type.writeSlice(blockBuilder, slice, 0, slice.length());
         }
         else {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
@@ -16,6 +16,7 @@ package io.trino.plugin.deltalake.transactionlog.checkpoint;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Primitives;
 import io.trino.filesystem.TrinoOutputFile;
 import io.trino.parquet.writer.ParquetSchemaConverter;
 import io.trino.parquet.writer.ParquetWriter;
@@ -55,6 +56,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.alwaysTrue;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -512,6 +514,7 @@ public class CheckpointWriter
                                             // This is TIMESTAMP_NTZ type in Delta Lake
                                             return value;
                                         }
+                                        checkState(Primitives.wrap(type.getJavaType()).isInstance(value), "Unexpected value class for type %s, expected %s, got %s", type, type.getJavaType(), value.getClass());
                                         return value;
                                     }));
                 });

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
@@ -525,7 +525,7 @@ public class TestCheckpointEntryIterator
                         .collect(toImmutableMap("intcol%s"::formatted, _ -> random.nextLong(0, 1000))))
                 .putAll(IntStream.rangeClosed(1, countStringColumns)
                         .boxed()
-                        .collect(toImmutableMap("stringcol%s"::formatted, _ -> "A".repeat(random.nextInt(1, 10)) + UUID.randomUUID())))
+                        .collect(toImmutableMap("stringcol%s"::formatted, _ -> utf8Slice("A".repeat(random.nextInt(1, 10)) + UUID.randomUUID()))))
                 .buildOrThrow();
         Map<String, Object> maxValues = ImmutableMap.<String, Object>builder()
                 .putAll(IntStream.rangeClosed(1, countIntegerColumns)
@@ -533,7 +533,7 @@ public class TestCheckpointEntryIterator
                         .collect(toImmutableMap("intcol%s"::formatted, _ -> 1000L + random.nextLong(0, 1000))))
                 .putAll(IntStream.rangeClosed(1, countStringColumns)
                         .boxed()
-                        .collect(toImmutableMap("stringcol%s"::formatted, _ -> "Z".repeat(random.nextInt(1, 10)) + UUID.randomUUID())))
+                        .collect(toImmutableMap("stringcol%s"::formatted, _ -> utf8Slice("Z".repeat(random.nextInt(1, 10)) + UUID.randomUUID()))))
                 .buildOrThrow();
         Map<String, Object> nullCount = ImmutableMap.<String, Object>builder()
                 .putAll(IntStream.rangeClosed(1, countIntegerColumns)

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchQueryBuilder.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchQueryBuilder.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.elasticsearch.ElasticsearchQueryBuilder.buildSearchQuery;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -70,7 +71,7 @@ public class TestElasticsearchQueryBuilder
 
         // List
         assertQueryBuilder(
-                ImmutableMap.of(NAME, Domain.multipleValues(VARCHAR, ImmutableList.of("alice", "bob"))),
+                ImmutableMap.of(NAME, Domain.multipleValues(VARCHAR, ImmutableList.of(utf8Slice("alice"), utf8Slice("bob")))),
                 new BoolQueryBuilder().filter(
                         new BoolQueryBuilder()
                                 .should(new TermQueryBuilder(NAME.name(), "alice"))

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaRecordSet.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaRecordSet.java
@@ -43,6 +43,8 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.decoder.FieldValueProviders.booleanValueProvider;
 import static io.trino.decoder.FieldValueProviders.bytesValueProvider;
 import static io.trino.decoder.FieldValueProviders.longValueProvider;
@@ -281,10 +283,10 @@ public class KafkaRecordSet
                 headerMap.size(),
                 (keyBuilder, valueBuilder) -> {
                     for (String headerKey : headerMap.keySet()) {
-                        writeNativeValue(keyType, keyBuilder, headerKey);
+                        writeNativeValue(keyType, keyBuilder, utf8Slice(headerKey));
                         ((ArrayBlockBuilder) valueBuilder).buildEntry(elementBuilder -> {
                             for (byte[] value : headerMap.get(headerKey)) {
-                                writeNativeValue(valueType, elementBuilder, value);
+                                writeNativeValue(valueType, elementBuilder, value == null ? null : wrappedBuffer(value));
                             }
                         });
                     }

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/protobuf/TestProtobufEncoder.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/protobuf/TestProtobufEncoder.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Timestamp;
-import io.airlift.slice.Slices;
 import io.trino.plugin.kafka.KafkaColumnHandle;
 import io.trino.plugin.kafka.encoder.EncoderColumnHandle;
 import io.trino.plugin.kafka.encoder.RowEncoder;
@@ -270,9 +269,9 @@ public class TestProtobufEncoder
             writeNativeValue(DOUBLE, fieldBuilders.get(3), doubleData);
             writeNativeValue(REAL, fieldBuilders.get(4), (long) floatToIntBits(floatData));
             writeNativeValue(BOOLEAN, fieldBuilders.get(5), booleanData);
-            writeNativeValue(VARCHAR, fieldBuilders.get(6), enumData);
+            writeNativeValue(VARCHAR, fieldBuilders.get(6), utf8Slice(enumData));
             writeNativeValue(createTimestampType(6), fieldBuilders.get(7), sqlTimestamp.getEpochMicros());
-            writeNativeValue(VARBINARY, fieldBuilders.get(8), bytesData);
+            writeNativeValue(VARBINARY, fieldBuilders.get(8), wrappedBuffer(bytesData));
         });
         rowEncoder.appendColumnValue(rowBlockBuilder.build(), 0);
 
@@ -377,15 +376,15 @@ public class TestProtobufEncoder
 
         RowBlockBuilder rowBlockBuilder = rowType.createBlockBuilder(null, 1);
         rowBlockBuilder.buildEntry(fieldBuilders -> {
-            writeNativeValue(VARCHAR, fieldBuilders.get(0), Slices.utf8Slice(stringData));
+            writeNativeValue(VARCHAR, fieldBuilders.get(0), utf8Slice(stringData));
             writeNativeValue(INTEGER, fieldBuilders.get(1), integerData.longValue());
             writeNativeValue(BIGINT, fieldBuilders.get(2), longData);
             writeNativeValue(DOUBLE, fieldBuilders.get(3), doubleData);
             writeNativeValue(REAL, fieldBuilders.get(4), (long) floatToIntBits(floatData));
             writeNativeValue(BOOLEAN, fieldBuilders.get(5), booleanData);
-            writeNativeValue(VARCHAR, fieldBuilders.get(6), enumData);
+            writeNativeValue(VARCHAR, fieldBuilders.get(6), utf8Slice(enumData));
             writeNativeValue(createTimestampType(6), fieldBuilders.get(7), sqlTimestamp.getEpochMicros());
-            writeNativeValue(VARBINARY, fieldBuilders.get(8), bytesData);
+            writeNativeValue(VARBINARY, fieldBuilders.get(8), wrappedBuffer(bytesData));
         });
 
         RowType nestedRowType = (RowType) columnHandles.get(0).getType();

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiRecordCursor.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiRecordCursor.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.loki;
 
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import io.trino.spi.block.SqlMap;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.type.MapType;
@@ -27,6 +26,7 @@ import java.util.Map;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.block.MapValueBuilder.buildMapValue;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
@@ -103,7 +103,7 @@ public class LokiRecordCursor
     public Slice getSlice(int field)
     {
         checkFieldType(field, createUnboundedVarcharType());
-        return Slices.utf8Slice((String) requireNonNull(getFieldValue(field)));
+        return utf8Slice((String) requireNonNull(getFieldValue(field)));
     }
 
     @Override
@@ -153,8 +153,8 @@ public class LokiRecordCursor
 
         return buildMapValue(mapType, labels.size(), (keyBuilder, valueBuilder) -> {
             labels.forEach((key, value) -> {
-                writeNativeValue(keyType, keyBuilder, key);
-                writeNativeValue(valueType, valueBuilder, value);
+                writeNativeValue(keyType, keyBuilder, utf8Slice(key));
+                writeNativeValue(valueType, valueBuilder, utf8Slice(value));
             });
         });
     }

--- a/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiRecordCursor.java
+++ b/plugin/trino-loki/src/main/java/io/trino/plugin/loki/LokiRecordCursor.java
@@ -19,7 +19,6 @@ import io.trino.spi.block.SqlMap;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeUtils;
 
 import java.util.Comparator;
 import java.util.List;
@@ -31,6 +30,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.block.MapValueBuilder.buildMapValue;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Objects.requireNonNull;
 
@@ -153,8 +153,8 @@ public class LokiRecordCursor
 
         return buildMapValue(mapType, labels.size(), (keyBuilder, valueBuilder) -> {
             labels.forEach((key, value) -> {
-                TypeUtils.writeNativeValue(keyType, keyBuilder, key);
-                TypeUtils.writeNativeValue(valueType, valueBuilder, value);
+                writeNativeValue(keyType, keyBuilder, key);
+                writeNativeValue(valueType, valueBuilder, value);
             });
         });
     }

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/TestOpenSearchQueryBuilder.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/TestOpenSearchQueryBuilder.java
@@ -34,6 +34,7 @@ import org.opensearch.index.query.TermQueryBuilder;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -69,7 +70,7 @@ public class TestOpenSearchQueryBuilder
 
         // List
         assertQueryBuilder(
-                ImmutableMap.of(NAME, Domain.multipleValues(VARCHAR, ImmutableList.of("alice", "bob"))),
+                ImmutableMap.of(NAME, Domain.multipleValues(VARCHAR, ImmutableList.of(utf8Slice("alice"), utf8Slice("bob")))),
                 new BoolQueryBuilder().filter(
                         new BoolQueryBuilder()
                                 .should(new TermQueryBuilder(NAME.name(), "alice"))

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusRecordCursor.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusRecordCursor.java
@@ -54,6 +54,7 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Objects.requireNonNull;
 
@@ -256,7 +257,7 @@ public class PrometheusRecordCursor
                     || BIGINT.equals(type)
                     || DOUBLE.equals(type)
                     || type instanceof VarcharType) {
-                TypeUtils.writeNativeValue(type, builder, obj);
+                writeNativeValue(type, builder, obj);
             }
         }
     }

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusRecordCursor.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusRecordCursor.java
@@ -16,7 +16,6 @@ package io.trino.plugin.prometheus;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CountingInputStream;
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.ArrayBlockBuilder;
 import io.trino.spi.block.Block;
@@ -44,6 +43,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.prometheus.PrometheusClient.TIMESTAMP_COLUMN_TYPE;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.block.MapValueBuilder.buildMapValue;
@@ -162,7 +162,7 @@ public class PrometheusRecordCursor
     public Slice getSlice(int field)
     {
         checkFieldType(field, createUnboundedVarcharType());
-        return Slices.utf8Slice((String) requireNonNull(getFieldValue(field)));
+        return utf8Slice((String) requireNonNull(getFieldValue(field)));
     }
 
     @Override
@@ -255,9 +255,11 @@ public class PrometheusRecordCursor
                     || SMALLINT.equals(type)
                     || INTEGER.equals(type)
                     || BIGINT.equals(type)
-                    || DOUBLE.equals(type)
-                    || type instanceof VarcharType) {
+                    || DOUBLE.equals(type)) {
                 writeNativeValue(type, builder, obj);
+            }
+            else if (type instanceof VarcharType) {
+                writeNativeValue(type, builder, obj == null ? null : utf8Slice((String) obj));
             }
         }
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/TestingProcedures.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/TestingProcedures.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -157,26 +158,26 @@ public final class TestingProcedures
                 .add(procedure(schema, "test_session_last", "sessionLast", ImmutableList.of(
                         new Argument("X", VARCHAR))))
                 .add(procedure(schema, "test_optionals", "optionals", ImmutableList.of(
-                        new Argument("X", VARCHAR, false, "hello"))))
+                        new Argument("X", VARCHAR, false, utf8Slice("hello")))))
                 .add(procedure(schema, "test_optionals2", "optionals2", ImmutableList.of(
                         new Argument("X", VARCHAR),
-                        new Argument("Y", VARCHAR, false, "world"))))
+                        new Argument("Y", VARCHAR, false, utf8Slice("world")))))
                 .add(procedure(schema, "test_optionals3", "optionals3", ImmutableList.of(
-                        new Argument("X", VARCHAR, false, "this"),
-                        new Argument("Y", VARCHAR, false, "is"),
-                        new Argument("Z", VARCHAR, false, "default"))))
+                        new Argument("X", VARCHAR, false, utf8Slice("this")),
+                        new Argument("Y", VARCHAR, false, utf8Slice("is")),
+                        new Argument("Z", VARCHAR, false, utf8Slice("default")))))
                 .add(procedure(schema, "test_optionals4", "optionals4", ImmutableList.of(
                         new Argument("X", VARCHAR),
                         new Argument("Y", VARCHAR),
-                        new Argument("Z", VARCHAR, false, "z default"),
-                        new Argument("V", VARCHAR, false, "v default"))))
+                        new Argument("Z", VARCHAR, false, utf8Slice("z default")),
+                        new Argument("V", VARCHAR, false, utf8Slice("v default")))))
                 .add(procedure(schema, "test_exception", "exception", ImmutableList.of()))
                 .add(procedure(schema, "test_error", "error", ImmutableList.of()))
                 .add(procedure(schema, "test_argument_names", "names", ImmutableList.of(
-                        new Argument("lower", true, VARCHAR, false, "a"),
-                        new Argument("UPPER", true, VARCHAR, false, "b"),
-                        new Argument("MixeD", true, VARCHAR, false, "c"),
-                        new Argument("with space", true, VARCHAR, false, "d"))))
+                        new Argument("lower", true, VARCHAR, false, utf8Slice("a")),
+                        new Argument("UPPER", true, VARCHAR, false, utf8Slice("b")),
+                        new Argument("MixeD", true, VARCHAR, false, utf8Slice("c")),
+                        new Argument("with space", true, VARCHAR, false, utf8Slice("d")))))
                 .build();
     }
 

--- a/testing/trino-tests/pom.xml
+++ b/testing/trino-tests/pom.xml
@@ -95,6 +95,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>tracing</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
@@ -15,6 +15,7 @@ package io.trino.execution;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
 import io.trino.Session;
 import io.trino.operator.RetryPolicy;
 import io.trino.plugin.memory.MemoryPlugin;
@@ -65,6 +66,7 @@ import java.util.function.Consumer;
 import java.util.stream.LongStream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.SystemSessionProperties.FILTERING_SEMI_JOIN_TO_INNER;
 import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.trino.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
@@ -257,9 +259,9 @@ public abstract class AbstractTestCoordinatorDynamicFiltering
 
         computeActual("CREATE TABLE memory.default.supplier_varchar AS SELECT name, CAST(address as varchar(42)) address FROM tpch.tiny.supplier");
 
-        List<String> values = computeActual("SELECT address FROM memory.default.supplier_varchar WHERE name >= 'Supplier#000000080'")
+        List<Slice> values = computeActual("SELECT address FROM memory.default.supplier_varchar WHERE name >= 'Supplier#000000080'")
                 .getOnlyColumn()
-                .map(Object::toString)
+                .map(value -> utf8Slice((String) value))
                 .collect(toImmutableList());
 
         assertQueryDynamicFilters(


### PR DESCRIPTION
Just do what `writeNativeValue` promises to do: write the native value.
Accepting e.g. a String for every Slice-backed type is error-prone.

- fixes https://github.com/trinodb/trino/issues/29767