### PR TITLE
Cleanup RunLengthEncodedBlock

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -182,9 +182,6 @@ public final class RunLengthEncodedBlock
     @Override
     public boolean isNull(int position)
     {
-        if (!mayHaveNull()) {
-            return false;
-        }
         checkValidPosition(position, positionCount);
         return value.isNull(0);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -32,10 +32,7 @@ public final class RunLengthEncodedBlock
 
     public static Block create(Type type, Object value, int positionCount)
     {
-        Block block = writeNativeValue(type, value);
-        if (block instanceof RunLengthEncodedBlock) {
-            block = ((RunLengthEncodedBlock) block).getValue();
-        }
+        ValueBlock block = writeNativeValue(type, value);
         return create(block, positionCount);
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -170,13 +170,13 @@ public final class RunLengthEncodedBlock
     @Override
     public boolean mayHaveNull()
     {
-        return positionCount > 0 && value.isNull(0);
+        return hasNull();
     }
 
     @Override
     public boolean hasNull()
     {
-        return mayHaveNull();
+        return value.isNull(0);
     }
 
     @Override


### PR DESCRIPTION
## Description
Three minor cleanups:
- Avoid checking whether a `ValueBlock` is a `RunLengthEncodedBlock` in `RunLengthEncodedBlock#create` (this check is always false and therefore unnecessary)
- Optimize `RunLengthEncodedBlock#isNull` and make it more strict when checking for illegal position arguments. Previously, it would accept any position argument when the block has no nulls- but the more strict version is cheaper in the case of `RunLengthEncodedBlock` when the value _is_ null by not calling `value.isNull(0)` twice and no more expensive when there are no nulls.
- Move the concrete logic from `#mayHaveNull()` to the `hasNull()` method, since the logic was always precise and better aligns with that method naming scheme. Also removes the `positionCount > 0` check since `RunLengthEncodedBlock` instances are validated by their constructor to always have `positionCount >= 2` positions.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
