### PR TITLE
Cache reusable native GCS clients

### DIFF
--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsInput.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsInput.java
@@ -30,6 +30,9 @@ import static io.trino.filesystem.gcs.GcsUtils.encodedKey;
 import static io.trino.filesystem.gcs.GcsUtils.getBlobOrThrow;
 import static io.trino.filesystem.gcs.GcsUtils.getReadChannel;
 import static io.trino.filesystem.gcs.GcsUtils.handleGcsException;
+import static java.lang.Math.addExact;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 import static java.util.Objects.checkFromIndexSize;
 import static java.util.Objects.requireNonNull;
 
@@ -63,7 +66,9 @@ final class GcsInput
             return;
         }
 
-        try (ReadChannel readChannel = getReadChannel(getBlobOrThrow(storage, location, blobGetOptions()), location, position, bufferLength, length, key)) {
+        Blob blob = getBlobOrThrow(storage, location, blobGetOptions());
+        OptionalLong limit = readLimit(position, bufferLength, length);
+        try (ReadChannel readChannel = getReadChannel(blob, location, position, bufferLength, limit, key)) {
             int readSize = readNBytes(readChannel, buffer, bufferOffset, bufferLength);
             if (readSize != bufferLength) {
                 throw new EOFException("End of file reached before reading fully: " + location);
@@ -80,9 +85,14 @@ final class GcsInput
     {
         ensureOpen();
         checkFromIndexSize(bufferOffset, bufferLength, buffer.length);
+        if (bufferLength == 0) {
+            return 0;
+        }
+
         Blob blob = getBlobOrThrow(storage, location, blobGetOptions());
-        long offset = Math.max(0, length.orElse(blob.getSize()) - bufferLength);
-        try (ReadChannel readChannel = getReadChannel(blob, location, offset, bufferLength, length, key)) {
+        long offset = max(0, length.orElse(blob.getSize()) - bufferLength);
+        OptionalLong limit = readLimit(offset, bufferLength, OptionalLong.of(blob.getSize()));
+        try (ReadChannel readChannel = getReadChannel(blob, location, offset, bufferLength, limit, key)) {
             return readNBytes(readChannel, buffer, bufferOffset, bufferLength);
         }
         catch (RuntimeException e) {
@@ -130,5 +140,14 @@ final class GcsInput
         return key
                 .map(encryption -> new BlobGetOption[] {BlobGetOption.decryptionKey(encodedKey(encryption))})
                 .orElseGet(() -> new BlobGetOption[0]);
+    }
+
+    private static OptionalLong readLimit(long position, int length, OptionalLong fileSize)
+    {
+        long limit = addExact(position, length);
+        if (fileSize.isPresent()) {
+            limit = min(limit, fileSize.getAsLong());
+        }
+        return OptionalLong.of(limit);
     }
 }

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsStorageFactory.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsStorageFactory.java
@@ -20,6 +20,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.inject.Inject;
 import io.trino.spi.security.ConnectorIdentity;
+import jakarta.annotation.PreDestroy;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -31,6 +32,7 @@ import java.util.Optional;
 
 import static com.google.cloud.storage.StorageRetryStrategy.getUniformStorageRetryStrategy;
 import static com.google.common.net.HttpHeaders.USER_AGENT;
+import static io.trino.filesystem.gcs.GcsFileSystemConfig.AuthType.ACCESS_TOKEN;
 import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY;
 import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY;
 import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY;
@@ -39,6 +41,7 @@ import static java.util.Objects.requireNonNull;
 public class GcsStorageFactory
 {
     public static final String GCS_OAUTH_KEY = "gcs.oauth";
+    private final GcsFileSystemConfig.AuthType authType;
     private final String projectId;
     private final Optional<String> endpoint;
     private final int maxRetries;
@@ -48,11 +51,13 @@ public class GcsStorageFactory
     private final Duration maxBackoffDelay;
     private final String applicationId;
     private final GcsAuth gcsAuth;
+    private volatile Storage cachedStorage;
 
     @Inject
     public GcsStorageFactory(GcsFileSystemConfig config, GcsAuth gcsAuth)
     {
         this.gcsAuth = requireNonNull(gcsAuth, "gcsAuth is null");
+        authType = config.getAuthType();
         projectId = config.getProjectId();
         endpoint = config.getEndpoint();
         this.maxRetries = config.getMaxRetries();
@@ -64,6 +69,40 @@ public class GcsStorageFactory
     }
 
     public Storage create(ConnectorIdentity identity)
+    {
+        if (isCacheable(identity)) {
+            Storage storage = cachedStorage;
+            if (storage == null) {
+                synchronized (this) {
+                    storage = cachedStorage;
+                    if (storage == null) {
+                        storage = createStorage(identity);
+                        cachedStorage = storage;
+                    }
+                }
+            }
+            return storage;
+        }
+        return createStorage(identity);
+    }
+
+    @PreDestroy
+    public void stop()
+            throws Exception
+    {
+        Storage storage = cachedStorage;
+        cachedStorage = null;
+        if (storage != null) {
+            storage.close();
+        }
+    }
+
+    private boolean isCacheable(ConnectorIdentity identity)
+    {
+        return authType != ACCESS_TOKEN && !identity.getExtraCredentials().containsKey(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY);
+    }
+
+    private Storage createStorage(ConnectorIdentity identity)
     {
         try {
             StorageOptions.Builder storageOptionsBuilder = StorageOptions.newBuilder();

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsInput.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsInput.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.gcs;
+
+import com.google.cloud.storage.Storage;
+import io.trino.filesystem.Location;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static java.lang.reflect.Proxy.newProxyInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestGcsInput
+{
+    @Test
+    void testZeroLengthReadTailDoesNotRead()
+            throws Exception
+    {
+        Storage storage = (Storage) newProxyInstance(
+                TestGcsInput.class.getClassLoader(),
+                new Class<?>[] {Storage.class},
+                (_, method, _) -> {
+                    throw new AssertionError("Storage should not be accessed: " + method);
+                });
+        GcsInput input = new GcsInput(
+                new GcsLocation(Location.of("gs://bucket/key")),
+                storage,
+                OptionalLong.empty(),
+                Optional.empty());
+
+        assertThat(input.readTail(new byte[0], 0, 0)).isEqualTo(0);
+    }
+}

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsStorageFactory.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsStorageFactory.java
@@ -37,12 +37,14 @@ final class TestGcsStorageFactory
         GcsFileSystemConfig config = new GcsFileSystemConfig().setAuthType(AuthType.APPLICATION_DEFAULT);
         GcsStorageFactory storageFactory = new GcsStorageFactory(config, new ApplicationDefaultAuth());
 
-        Credentials actualCredentials;
-        try (Storage storage = storageFactory.create(ConnectorIdentity.ofUser("test"))) {
-            actualCredentials = storage.getOptions().getCredentials();
+        try {
+            Storage storage = storageFactory.create(ConnectorIdentity.ofUser("test"));
+            Credentials actualCredentials = storage.getOptions().getCredentials();
+            assertThat(actualCredentials).isNotNull();
         }
-
-        assertThat(actualCredentials).isEqualTo(NoCredentials.getInstance());
+        finally {
+            storageFactory.stop();
+        }
     }
 
     @Test
@@ -64,6 +66,59 @@ final class TestGcsStorageFactory
             AccessToken accessToken = googleCredentials.getAccessToken();
             assertThat(accessToken).isNotNull();
             assertThat(accessToken.getTokenValue()).isEqualTo("ya29.test-token");
+        }
+    }
+
+    @Test
+    void testStaticCredentialsAreCached()
+            throws Exception
+    {
+        GcsFileSystemConfig config = new GcsFileSystemConfig().setAuthType(AuthType.APPLICATION_DEFAULT);
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new ApplicationDefaultAuth());
+
+        try {
+            Storage first = storageFactory.create(ConnectorIdentity.ofUser("test"));
+            Storage second = storageFactory.create(ConnectorIdentity.ofUser("test"));
+
+            assertThat(second).isSameAs(first);
+        }
+        finally {
+            storageFactory.stop();
+        }
+    }
+
+    @Test
+    void testVendedOAuthTokenCredentialsAreNotCached()
+            throws Exception
+    {
+        GcsFileSystemConfig config = new GcsFileSystemConfig().setAuthType(AuthType.APPLICATION_DEFAULT);
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new ApplicationDefaultAuth());
+
+        ConnectorIdentity firstIdentity = ConnectorIdentity.forUser("test")
+                .withExtraCredentials(ImmutableMap.of(
+                        EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, "ya29.first-token"))
+                .build();
+        ConnectorIdentity secondIdentity = ConnectorIdentity.forUser("test")
+                .withExtraCredentials(ImmutableMap.of(
+                        EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, "ya29.second-token"))
+                .build();
+
+        try (Storage first = storageFactory.create(firstIdentity);
+                Storage second = storageFactory.create(secondIdentity)) {
+            assertThat(second).isNotSameAs(first);
+        }
+    }
+
+    @Test
+    void testAccessTokenCredentialsAreNotCached()
+            throws Exception
+    {
+        GcsFileSystemConfig config = new GcsFileSystemConfig().setAuthType(AuthType.ACCESS_TOKEN);
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, (builder, _) -> builder.setCredentials(NoCredentials.getInstance()));
+
+        try (Storage first = storageFactory.create(ConnectorIdentity.ofUser("test"));
+                Storage second = storageFactory.create(ConnectorIdentity.ofUser("test"))) {
+            assertThat(second).isNotSameAs(first);
         }
     }
 
@@ -121,9 +176,13 @@ final class TestGcsStorageFactory
                 .setProjectId("static-project");
         GcsStorageFactory storageFactory = new GcsStorageFactory(config, new ApplicationDefaultAuth());
 
-        try (Storage storage = storageFactory.create(ConnectorIdentity.ofUser("test"))) {
+        try {
+            Storage storage = storageFactory.create(ConnectorIdentity.ofUser("test"));
             assertThat(storage.getOptions().getProjectId()).isEqualTo("static-project");
-            assertThat(storage.getOptions().getCredentials()).isEqualTo(NoCredentials.getInstance());
+            assertThat(storage.getOptions().getCredentials()).isNotNull();
+        }
+        finally {
+            storageFactory.stop();
         }
     }
 }


### PR DESCRIPTION
## Description

- Native GCS rebuilds a `Storage` service whenever a filesystem wrapper is created, and the switching filesystem can create those wrappers for ordinary file operations.
- On GCE and GKE, rebuilding application-default credentials can repeatedly hit the metadata-server token path instead of reusing the SDK credential/client state.
- OAuth-token based credentials can be short-lived and refreshed by Iceberg REST vending, so they must not be pinned in a shared client.

## Approach
- Reuse the GCS `Storage` service for static service-account and application-default authentication.
- Keep configured access-token auth and vended OAuth-token identities uncached so refreshed credentials still take effect.
- Bound positional `readFully` and `readTail` channels to the requested byte range while leaving streaming reads unchanged.

## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
## GCS
* Improve native GCS read performance by reusing storage clients for static credentials. ({issue}`issuenumber`)
```
