### PR TITLE
Enhance GCS File System Integration with Analytics Core Support

### DIFF
--- a/lib/trino-filesystem-gcs/pom.xml
+++ b/lib/trino-filesystem-gcs/pom.xml
@@ -60,6 +60,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.cloud.gcs.analytics</groupId>
+            <artifactId>client</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud.gcs.analytics</groupId>
+            <artifactId>gcs-analytics-core</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -188,6 +200,8 @@
                             <excludes>
                                 <exclude>**/TestGcsFileSystem.java</exclude>
                                 <exclude>**/TestGcsFileSystemWithEncryption.java</exclude>
+                                <exclude>**/TestGcsFileSystemWithAnalyticsCore.java</exclude>
+                                <exclude>**/TestGcsFileSystemWithAnalyticsCoreAndEncryption.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -206,6 +220,8 @@
                             <includes>
                                 <include>**/TestGcsFileSystem.java</include>
                                 <include>**/TestGcsFileSystemWithEncryption.java</include>
+                                <include>**/TestGcsFileSystemWithAnalyticsCore.java</include>
+                                <include>**/TestGcsFileSystemWithAnalyticsCoreAndEncryption.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/AnalyticsCoreGcsFileSystemFactory.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/AnalyticsCoreGcsFileSystemFactory.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.gcs;
+
+import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
+import com.google.cloud.gcs.analyticscore.client.GcsFileSystemImpl;
+import com.google.cloud.gcs.analyticscore.core.GcsAnalyticsCoreOptions;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.airlift.units.DataSize;
+
+import java.util.Optional;
+
+public class AnalyticsCoreGcsFileSystemFactory
+{
+    private final String projectId;
+    private final Optional<String> userProject;
+    private final Optional<String> decryptionKey;
+    private final DataSize channelReadChunkSize;
+    private final Optional<String> clientLibToken;
+    private final Optional<String> serviceHost;
+    private final String userAgent;
+    private final GcsFileSystemConfig.FileAccessPattern fileAccessPattern;
+    private final boolean footerPrefetchEnabled;
+    private final int readThreadCount;
+
+    @Inject
+    public AnalyticsCoreGcsFileSystemFactory(GcsFileSystemConfig config)
+    {
+        projectId = config.getProjectId();
+        userProject = config.getUserProject();
+        decryptionKey = config.getDecryptionKey();
+        channelReadChunkSize = config.getReadBlockSize();
+        clientLibToken = config.getClientLibToken();
+        serviceHost = config.getEndpoint();
+        userAgent = config.getApplicationId();
+        fileAccessPattern = config.getAnalyticsCoreFileAccessPattern();
+        footerPrefetchEnabled = config.isAnalyticsCoreFooterPrefetchEnabled();
+        readThreadCount = config.getAnalyticsCoreReadThreadCount();
+    }
+
+    public GcsFileSystem create(Storage storage)
+    {
+        StorageOptions storageOptions = storage.getOptions();
+        ImmutableMap.Builder<String, String> optionMap = ImmutableMap.<String, String>builder()
+                .put("gcs.user-agent", userAgent)
+                .put("gcs.channel.read.chunk-size-bytes", String.valueOf(channelReadChunkSize.toBytes()))
+                .put("gcs.analytics-core.read.file-access-pattern", fileAccessPattern.name())
+                .put("gcs.analytics-core.footer.prefetch.enabled", String.valueOf(footerPrefetchEnabled))
+                .put("gcs.analytics-core.read.thread.count", String.valueOf(readThreadCount));
+
+        if (projectId != null) {
+            optionMap.put("gcs.project-id", projectId);
+        }
+        else {
+            optionMap.put("gcs.project-id", storageOptions.getProjectId());
+        }
+
+        decryptionKey.ifPresent(key -> optionMap.put("gcs.decryption-key", key));
+        userProject.ifPresent(project -> optionMap.put("gcs.user-project", project));
+        serviceHost.ifPresent(host -> optionMap.put("gcs.service-host", host));
+        clientLibToken.ifPresent(token -> optionMap.put("gcs.client-lib-token", token));
+        GcsAnalyticsCoreOptions options = new GcsAnalyticsCoreOptions("gcs.", optionMap.buildOrThrow());
+
+        return new GcsFileSystemImpl(storage.getOptions().getCredentials(), options.getGcsFileSystemOptions());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "AnalyticsCoreGcsFileSystemFactory{" +
+                "projectId='" + projectId + '\'' +
+                ", userProject=" + userProject +
+                ", decryptionKey=" + decryptionKey +
+                ", channelReadChunkSize=" + channelReadChunkSize +
+                ", clientLibToken=" + clientLibToken +
+                ", serviceHost=" + serviceHost +
+                ", userAgent='" + userAgent + '\'' +
+                ", fileAccessPattern=" + fileAccessPattern +
+                ", footerPrefetchEnabled=" + footerPrefetchEnabled +
+                ", readThreadCount=" + readThreadCount +
+                '}';
+    }
+}

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/AnalyticsCoreGcsInput.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/AnalyticsCoreGcsInput.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.gcs;
+
+import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
+import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageInputStream;
+import com.google.cloud.storage.Storage;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.encryption.EncryptionKey;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static io.trino.filesystem.gcs.GcsUtils.findEncryptionKey;
+import static io.trino.filesystem.gcs.GcsUtils.handleGcsException;
+import static io.trino.filesystem.gcs.GcsUtils.mapFileNotFound;
+import static io.trino.filesystem.gcs.GcsUtils.openGcsInputStream;
+import static io.trino.filesystem.gcs.GcsUtils.pathHasSpecialCharacters;
+import static java.util.Objects.checkFromIndexSize;
+import static java.util.Objects.requireNonNull;
+
+final class AnalyticsCoreGcsInput
+        implements TrinoInput
+{
+    private final GcsLocation location;
+    private final Storage storage;
+    private final GcsFileSystem gcsFileSystem;
+    private final boolean useSpecialCharactersFallback;
+
+    // Lazily initialized and reused across reads to avoid stream creation overhead
+    private GoogleCloudStorageInputStream cachedStream;
+    private boolean closed;
+
+    public AnalyticsCoreGcsInput(GcsLocation location, Storage storage, GcsFileSystem gcsFileSystem)
+    {
+        this.location = requireNonNull(location, "location is null");
+        this.storage = requireNonNull(storage, "storage is null");
+        this.gcsFileSystem = requireNonNull(gcsFileSystem, "gcsFileSystem is null");
+        // Check once at construction - path won't change
+        this.useSpecialCharactersFallback = pathHasSpecialCharacters(location.path());
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
+            throws IOException
+    {
+        ensureOpen();
+        if (position < 0) {
+            throw new IOException("Negative seek offset");
+        }
+        checkFromIndexSize(bufferOffset, bufferLength, buffer.length);
+        if (bufferLength == 0) {
+            return;
+        }
+
+        // Fall back to legacy GCS API for paths with special characters
+        // The gcs-analytics-core library internally uses URI.create() which fails for these
+        if (useSpecialCharactersFallback) {
+            try (GcsInput fallback = new GcsInput(location, storage, OptionalLong.empty(), getFallbackEncryptionKey())) {
+                fallback.readFully(position, buffer, bufferOffset, bufferLength);
+                return;
+            }
+        }
+
+        try {
+            getOrCreateStream().readFully(position, buffer, bufferOffset, bufferLength);
+        }
+        catch (EOFException e) {
+            throw new EOFException("%s: %s".formatted(e.getMessage(), location));
+        }
+        catch (IOException e) {
+            throw mapFileNotFound(e, location);
+        }
+        catch (RuntimeException e) {
+            throw handleGcsException(e, "reading file", location);
+        }
+    }
+
+    @Override
+    public int readTail(byte[] buffer, int bufferOffset, int bufferLength)
+            throws IOException
+    {
+        ensureOpen();
+        checkFromIndexSize(bufferOffset, bufferLength, buffer.length);
+
+        // Fall back to legacy GCS API for paths with special characters
+        // The gcs-analytics-core library internally uses URI.create() which fails for these
+        if (useSpecialCharactersFallback) {
+            try (GcsInput fallback = new GcsInput(location, storage, OptionalLong.empty(), getFallbackEncryptionKey())) {
+                return fallback.readTail(buffer, bufferOffset, bufferLength);
+            }
+        }
+
+        try {
+            return Math.max(0, getOrCreateStream().readTail(buffer, bufferOffset, bufferLength));
+        }
+        catch (IOException e) {
+            throw mapFileNotFound(e, location);
+        }
+        catch (RuntimeException e) {
+            throw handleGcsException(e, "reading file", location);
+        }
+    }
+
+    private GoogleCloudStorageInputStream getOrCreateStream()
+            throws IOException
+    {
+        if (cachedStream == null) {
+            cachedStream = openGcsInputStream(gcsFileSystem, location);
+        }
+        return cachedStream;
+    }
+
+    private Optional<EncryptionKey> getFallbackEncryptionKey()
+    {
+        return findEncryptionKey(gcsFileSystem).map(GcsUtils::decodeKey);
+    }
+
+    private void ensureOpen()
+            throws IOException
+    {
+        if (closed) {
+            throw new IOException("Input stream closed: " + location);
+        }
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        closed = true;
+        if (cachedStream != null) {
+            cachedStream.close();
+            cachedStream = null;
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return location.toString();
+    }
+}

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/AnalyticsCoreGcsInputFile.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/AnalyticsCoreGcsInputFile.java
@@ -13,6 +13,8 @@
  */
 package io.trino.filesystem.gcs;
 
+import com.google.cloud.gcs.analyticscore.client.GcsFileInfo;
+import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
 import io.trino.filesystem.Location;
@@ -27,48 +29,61 @@ import java.util.Optional;
 import java.util.OptionalLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static io.trino.filesystem.gcs.GcsUtils.blobGetOptions;
+import static io.trino.filesystem.gcs.GcsUtils.blobGetOptionsFromEncodedKey;
+import static io.trino.filesystem.gcs.GcsUtils.findEncryptionKey;
 import static io.trino.filesystem.gcs.GcsUtils.getBlob;
 import static io.trino.filesystem.gcs.GcsUtils.getBlobOrThrow;
+import static io.trino.filesystem.gcs.GcsUtils.getGcsFileInfoOrThrow;
 import static io.trino.filesystem.gcs.GcsUtils.handleGcsException;
+import static io.trino.filesystem.gcs.GcsUtils.pathHasSpecialCharacters;
 import static java.util.Objects.requireNonNull;
 
-public class GcsInputFile
+final class AnalyticsCoreGcsInputFile
         implements TrinoInputFile
 {
     private final GcsLocation location;
     private final Storage storage;
-    private final int readBlockSize;
+    private final GcsFileSystem gcsFileSystem;
     private final OptionalLong predeclaredLength;
-    private final Optional<EncryptionKey> key;
+    private final int readBlockSizeBytes;
     private OptionalLong length;
     private Optional<Instant> lastModified;
 
-    public GcsInputFile(GcsLocation location, Storage storage, int readBockSize, OptionalLong predeclaredLength, Optional<Instant> lastModified, Optional<EncryptionKey> key)
+    public AnalyticsCoreGcsInputFile(GcsLocation location, Storage storage, GcsFileSystem gcsFileSystem, OptionalLong predeclaredLength, Optional<Instant> lastModified, int readBlockSizeBytes)
     {
         this.location = requireNonNull(location, "location is null");
         this.storage = requireNonNull(storage, "storage is null");
-        this.readBlockSize = readBockSize;
+        this.gcsFileSystem = requireNonNull(gcsFileSystem, "gcsFileSystem is null");
         this.predeclaredLength = requireNonNull(predeclaredLength, "length is null");
+        this.readBlockSizeBytes = readBlockSizeBytes;
         this.length = OptionalLong.empty();
         this.lastModified = requireNonNull(lastModified, "lastModified is null");
-        this.key = requireNonNull(key, "key is null");
     }
 
     @Override
     public TrinoInput newInput()
             throws IOException
     {
-        // Note: Only pass predeclared length, to keep the contract of TrinoFileSystem.newInputFile
-        return new GcsInput(location, storage, predeclaredLength, key);
+        return new AnalyticsCoreGcsInput(location, storage, gcsFileSystem);
     }
 
     @Override
     public TrinoInputStream newStream()
             throws IOException
     {
-        Blob blob = getBlobOrThrow(storage, location, blobGetOptions(key));
-        return new GcsInputStream(location, blob, readBlockSize, predeclaredLength, key);
+        // Fall back to legacy GCS API for paths with special characters
+        // The gcs-analytics-core library internally uses URI.create() which fails for these
+        if (pathHasSpecialCharacters(location.path())) {
+            Blob blob = getBlobOrThrow(storage, location, blobGetOptionsFromEncodedKey(findEncryptionKey(gcsFileSystem)));
+            return new GcsInputStream(location, blob, readBlockSizeBytes, predeclaredLength, getFallbackEncryptionKey());
+        }
+        GcsFileInfo fileInfo = getGcsFileInfoOrThrow(gcsFileSystem, location);
+        return new AnalyticsCoreGcsInputStream(location, storage, fileInfo, gcsFileSystem, predeclaredLength);
+    }
+
+    private Optional<EncryptionKey> getFallbackEncryptionKey()
+    {
+        return findEncryptionKey(gcsFileSystem).map(GcsUtils::decodeKey);
     }
 
     @Override
@@ -98,7 +113,7 @@ public class GcsInputFile
     public boolean exists()
             throws IOException
     {
-        Optional<Blob> blob = getBlob(storage, location, blobGetOptions(key));
+        Optional<Blob> blob = getBlob(storage, location, blobGetOptionsFromEncodedKey(findEncryptionKey(gcsFileSystem)));
         return blob.isPresent() && blob.get().exists();
     }
 
@@ -122,7 +137,36 @@ public class GcsInputFile
     private void loadProperties()
             throws IOException
     {
-        Blob blob = getBlobOrThrow(storage, location, blobGetOptions(key));
+        // Fall back to legacy GCS API for paths with special characters
+        // The gcs-analytics-core library internally uses URI.create() which fails for these
+        if (pathHasSpecialCharacters(location.path())) {
+            loadPropertiesFromBlob();
+            return;
+        }
+
+        GcsFileInfo fileInfo = getGcsFileInfoOrThrow(gcsFileSystem, location);
+        try {
+            length = OptionalLong.of(fileInfo.getItemInfo().getSize());
+            if (lastModified.isEmpty()) {
+                Blob blob = getBlobOrThrow(
+                        storage,
+                        location,
+                        blobGetOptionsFromEncodedKey(findEncryptionKey(gcsFileSystem)));
+                lastModified = Optional.of(Instant.from(blob.getUpdateTimeOffsetDateTime()));
+            }
+        }
+        catch (RuntimeException e) {
+            throw handleGcsException(e, "fetching properties for file", location);
+        }
+    }
+
+    private void loadPropertiesFromBlob()
+            throws IOException
+    {
+        Blob blob = getBlobOrThrow(
+                storage,
+                location,
+                blobGetOptionsFromEncodedKey(findEncryptionKey(gcsFileSystem)));
         try {
             length = OptionalLong.of(blob.getSize());
             if (lastModified.isEmpty()) {

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/AnalyticsCoreGcsInputStream.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/AnalyticsCoreGcsInputStream.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.gcs;
+
+import com.google.cloud.gcs.analyticscore.client.GcsFileInfo;
+import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
+import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageInputStream;
+import com.google.cloud.storage.Storage;
+import io.trino.filesystem.TrinoInputStream;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.OptionalLong;
+
+import static io.trino.filesystem.gcs.GcsUtils.handleGcsException;
+import static io.trino.filesystem.gcs.GcsUtils.openGcsInputStream;
+import static java.lang.Math.clamp;
+import static java.util.Objects.checkFromIndexSize;
+import static java.util.Objects.requireNonNull;
+
+final class AnalyticsCoreGcsInputStream
+        extends TrinoInputStream
+{
+    private final GcsLocation location;
+    private final GcsFileInfo fileInfo;
+    private final long fileSize;
+    private final GcsFileSystem gcsFileSystem;
+    private GoogleCloudStorageInputStream stream;
+    private boolean closed;
+
+    public AnalyticsCoreGcsInputStream(GcsLocation location, Storage storage, GcsFileInfo fileInfo, GcsFileSystem gcsFileSystem, OptionalLong predeclaredLength)
+            throws IOException
+    {
+        this.location = requireNonNull(location, "location is null");
+        requireNonNull(storage, "storage is null");
+        this.fileInfo = requireNonNull(fileInfo, "fileInfo is null");
+        this.fileSize = predeclaredLength.orElse(fileInfo.getItemInfo().getSize());
+        this.gcsFileSystem = requireNonNull(gcsFileSystem, "gcsFileSystem is null");
+        openStream();
+    }
+
+    @Override
+    public int available()
+            throws IOException
+    {
+        ensureOpen();
+        return stream.available();
+    }
+
+    @Override
+    public long getPosition()
+            throws IOException
+    {
+        ensureOpen();
+        return stream.getPos();
+    }
+
+    @Override
+    public void seek(long newPosition)
+            throws IOException
+    {
+        ensureOpen();
+        if (newPosition < 0) {
+            throw new IOException("Negative seek offset");
+        }
+        if (newPosition > fileSize) {
+            throw new IOException("Cannot seek to %s. File size is %s: %s".formatted(newPosition, fileSize, location));
+        }
+        stream.seek(newPosition);
+    }
+
+    @Override
+    public int read()
+            throws IOException
+    {
+        ensureOpen();
+        try {
+            return stream.read();
+        }
+        catch (IOException e) {
+            throw new IOException("Error reading file: " + location, e);
+        }
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        checkFromIndexSize(offset, length, buffer.length);
+        ensureOpen();
+        try {
+            return stream.read(buffer, offset, length);
+        }
+        catch (IOException e) {
+            throw new IOException("Error reading file: " + location, e);
+        }
+    }
+
+    @Override
+    public long skip(long n)
+            throws IOException
+    {
+        ensureOpen();
+        long skipSize = clamp(n, 0, fileSize - stream.getPos());
+        stream.seek(stream.getPos() + skipSize);
+        return skipSize;
+    }
+
+    @Override
+    public void skipNBytes(long n)
+            throws IOException
+    {
+        ensureOpen();
+        if (n <= 0) {
+            return;
+        }
+
+        long position = stream.getPos() + n;
+        if ((position < 0) || (position > fileSize)) {
+            throw new EOFException("Unable to skip %s bytes (position=%s, fileSize=%s): %s".formatted(n, stream.getPos(), fileSize, location));
+        }
+        stream.seek(position);
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        if (!closed) {
+            closed = true;
+            try {
+                stream.close();
+            }
+            catch (RuntimeException e) {
+                throw handleGcsException(e, "closing file", location);
+            }
+        }
+    }
+
+    private void ensureOpen()
+            throws IOException
+    {
+        if (closed) {
+            throw new IOException("Input stream closed: " + location);
+        }
+    }
+
+    private void openStream()
+            throws IOException
+    {
+        this.stream = openGcsInputStream(gcsFileSystem, fileInfo, location);
+    }
+}

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/ApplicationDefaultAuth.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/ApplicationDefaultAuth.java
@@ -17,26 +17,49 @@ import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.storage.StorageOptions;
+import com.google.inject.Inject;
 import io.trino.spi.security.ConnectorIdentity;
 
 import java.io.IOException;
 
+import static java.util.Objects.requireNonNull;
+
 public class ApplicationDefaultAuth
         implements GcsAuth
 {
+    private final CredentialsProvider credentialsProvider;
+
+    @Inject
+    public ApplicationDefaultAuth()
+    {
+        this(GoogleCredentials::getApplicationDefault);
+    }
+
+    ApplicationDefaultAuth(CredentialsProvider credentialsProvider)
+    {
+        this.credentialsProvider = requireNonNull(credentialsProvider, "credentialsProvider is null");
+    }
+
     @Override
     public void setAuth(StorageOptions.Builder builder, ConnectorIdentity identity)
     {
         builder.setCredentials(getCredentials());
     }
 
-    private static Credentials getCredentials()
+    private Credentials getCredentials()
     {
         try {
-            return GoogleCredentials.getApplicationDefault();
+            return credentialsProvider.getCredentials();
         }
         catch (IOException e) {
             return NoCredentials.getInstance();
         }
+    }
+
+    @FunctionalInterface
+    interface CredentialsProvider
+    {
+        Credentials getCredentials()
+                throws IOException;
     }
 }

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystem.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystem.java
@@ -78,8 +78,16 @@ public class GcsFileSystem
     private final long writeBlockSizeBytes;
     private final int pageSize;
     private final int batchSize;
+    private final Optional<com.google.cloud.gcs.analyticscore.client.GcsFileSystem> analyticsFileSystem;
 
-    public GcsFileSystem(ListeningExecutorService executorService, Storage storage, int readBlockSizeBytes, long writeBlockSizeBytes, int pageSize, int batchSize)
+    public GcsFileSystem(
+            ListeningExecutorService executorService,
+            Storage storage,
+            int readBlockSizeBytes,
+            long writeBlockSizeBytes,
+            int pageSize,
+            int batchSize,
+            Optional<com.google.cloud.gcs.analyticscore.client.GcsFileSystem> analyticsFileSystem)
     {
         this.executorService = requireNonNull(executorService, "executorService is null");
         this.storage = requireNonNull(storage, "storage is null");
@@ -87,6 +95,7 @@ public class GcsFileSystem
         this.writeBlockSizeBytes = writeBlockSizeBytes;
         this.pageSize = pageSize;
         this.batchSize = batchSize;
+        this.analyticsFileSystem = analyticsFileSystem;
     }
 
     @Override
@@ -94,7 +103,7 @@ public class GcsFileSystem
     {
         GcsLocation gcsLocation = new GcsLocation(location);
         checkIsValidFile(gcsLocation);
-        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.empty(), Optional.empty(), Optional.empty());
+        return createInputFile(gcsLocation, OptionalLong.empty(), Optional.empty(), Optional.empty());
     }
 
     @Override
@@ -102,7 +111,7 @@ public class GcsFileSystem
     {
         GcsLocation gcsLocation = new GcsLocation(location);
         checkIsValidFile(gcsLocation);
-        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.empty(), Optional.empty(), Optional.of(key));
+        return createInputFile(gcsLocation, OptionalLong.empty(), Optional.empty(), Optional.of(key));
     }
 
     @Override
@@ -110,7 +119,7 @@ public class GcsFileSystem
     {
         GcsLocation gcsLocation = new GcsLocation(location);
         checkIsValidFile(gcsLocation);
-        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.of(length), Optional.empty(), Optional.empty());
+        return createInputFile(gcsLocation, OptionalLong.of(length), Optional.empty(), Optional.empty());
     }
 
     @Override
@@ -118,7 +127,7 @@ public class GcsFileSystem
     {
         GcsLocation gcsLocation = new GcsLocation(location);
         checkIsValidFile(gcsLocation);
-        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.of(length), Optional.empty(), Optional.of(key));
+        return createInputFile(gcsLocation, OptionalLong.of(length), Optional.empty(), Optional.of(key));
     }
 
     @Override
@@ -126,7 +135,7 @@ public class GcsFileSystem
     {
         GcsLocation gcsLocation = new GcsLocation(location);
         checkIsValidFile(gcsLocation);
-        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.of(length), Optional.of(lastModified), Optional.empty());
+        return createInputFile(gcsLocation, OptionalLong.of(length), Optional.of(lastModified), Optional.empty());
     }
 
     @Override
@@ -134,7 +143,19 @@ public class GcsFileSystem
     {
         GcsLocation gcsLocation = new GcsLocation(location);
         checkIsValidFile(gcsLocation);
-        return new GcsInputFile(gcsLocation, storage, readBlockSizeBytes, OptionalLong.of(length), Optional.of(lastModified), Optional.of(key));
+        return createInputFile(gcsLocation, OptionalLong.of(length), Optional.of(lastModified), Optional.of(key));
+    }
+
+    private TrinoInputFile createInputFile(GcsLocation location, OptionalLong length, Optional<Instant> lastModified, Optional<EncryptionKey> key)
+    {
+        if (analyticsFileSystem.isPresent()) {
+            com.google.cloud.gcs.analyticscore.client.GcsFileSystem analytics = analyticsFileSystem.get();
+            if (key.isPresent() && analytics.getFileSystemOptions().getGcsClientOptions().getGcsReadOptions().getDecryptionKey().isEmpty()) {
+                throw new IllegalStateException("Encrypted GCS read requested, but gcs.client.decryption-key is not configured");
+            }
+            return new AnalyticsCoreGcsInputFile(location, storage, analytics, length, lastModified, readBlockSizeBytes);
+        }
+        return new GcsInputFile(location, storage, readBlockSizeBytes, length, lastModified, key);
     }
 
     @Override
@@ -294,9 +315,17 @@ public class GcsFileSystem
 
         GcsLocation gcsLocation = new GcsLocation(location);
         if (gcsLocation.path().isEmpty()) {
+            // Only check bucket existence when the path is the bucket root
+            // This requires storage.buckets.get permission
             return Optional.of(bucketExists(gcsLocation.bucket()));
         }
         if (listFiles(location).hasNext()) {
+            return Optional.of(true);
+        }
+        // For paths explicitly marked as directories (ending with /), return true
+        // This handles the case where an empty directory prefix is used as a root location
+        // We don't check bucket existence here to avoid requiring storage.buckets.get permission
+        if (location.path().endsWith("/")) {
             return Optional.of(true);
         }
         return Optional.empty();

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystemConfig.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystemConfig.java
@@ -15,6 +15,7 @@ package io.trino.filesystem.gcs;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -25,6 +26,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+import java.util.Base64;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -40,13 +42,23 @@ public class GcsFileSystemConfig
         APPLICATION_DEFAULT,
     }
 
+    public enum FileAccessPattern
+    {
+        RANDOM,
+        SEQUENTIAL,
+        AUTO_SEQUENTIAL,
+        AUTO_RANDOM,
+    }
+
     private DataSize readBlockSize = DataSize.of(2, MEGABYTE);
     private DataSize writeBlockSize = DataSize.of(16, MEGABYTE);
     private int pageSize = 100;
     private int batchSize = 100;
 
     private String projectId;
+    private Optional<String> userProject = Optional.empty();
     private Optional<String> endpoint = Optional.empty();
+    private Optional<String> clientLibToken = Optional.empty();
 
     private AuthType authType = AuthType.SERVICE_ACCOUNT;
     private int maxRetries = 20;
@@ -56,6 +68,11 @@ public class GcsFileSystemConfig
     // Note: there is no benefit to setting this much higher as the rpc quota is 1x per second: https://cloud.google.com/storage/docs/retry-strategy#java
     private Duration maxBackoffDelay = new Duration(2000, TimeUnit.MILLISECONDS);
     private String applicationId = "Trino";
+    private boolean analyticsCoreEnabled;
+    private FileAccessPattern analyticsCoreFileAccessPattern = FileAccessPattern.AUTO_RANDOM;
+    private boolean analyticsCoreFooterPrefetchEnabled = true;
+    private int analyticsCoreReadThreadCount = 16;
+    private Optional<String> decryptionKey = Optional.empty();
 
     @NotNull
     public DataSize getReadBlockSize()
@@ -126,6 +143,19 @@ public class GcsFileSystemConfig
         return this;
     }
 
+    public Optional<String> getUserProject()
+    {
+        return userProject;
+    }
+
+    @ConfigDescription("Project ID whose Google Cloud Project's billing account should be charged for the operation being executed.")
+    @Config("gcs.user-project")
+    public GcsFileSystemConfig setUserProject(Optional<String> userProject)
+    {
+        this.userProject = userProject;
+        return this;
+    }
+
     public Optional<String> getEndpoint()
     {
         return endpoint;
@@ -136,6 +166,18 @@ public class GcsFileSystemConfig
     public GcsFileSystemConfig setEndpoint(Optional<String> endpoint)
     {
         this.endpoint = endpoint;
+        return this;
+    }
+
+    public Optional<String> getClientLibToken()
+    {
+        return clientLibToken;
+    }
+
+    @Config("gcs.client-lib-token")
+    public GcsFileSystemConfig setClientLibToken(Optional<String> clientLibToken)
+    {
+        this.clientLibToken = clientLibToken;
         return this;
     }
 
@@ -239,9 +281,91 @@ public class GcsFileSystemConfig
         return this;
     }
 
+    public boolean isAnalyticsCoreEnabled()
+    {
+        return analyticsCoreEnabled;
+    }
+
+    @Config("gcs.analytics-core.enabled")
+    @ConfigDescription("Enable Google Cloud Storage Analytics Core, which provides read implementations optimized for analytics workloads")
+    public GcsFileSystemConfig setAnalyticsCoreEnabled(boolean analyticsCoreEnabled)
+    {
+        this.analyticsCoreEnabled = analyticsCoreEnabled;
+        return this;
+    }
+
+    @NotNull
+    public FileAccessPattern getAnalyticsCoreFileAccessPattern()
+    {
+        return analyticsCoreFileAccessPattern;
+    }
+
+    @Config("gcs.analytics-core.file-access-pattern")
+    @ConfigDescription("File access pattern hint for Analytics Core reads. RANDOM is best for Parquet/columnar formats, SEQUENTIAL for full file scans, AUTO_RANDOM adapts but prefers random access")
+    public GcsFileSystemConfig setAnalyticsCoreFileAccessPattern(FileAccessPattern analyticsCoreFileAccessPattern)
+    {
+        this.analyticsCoreFileAccessPattern = analyticsCoreFileAccessPattern;
+        return this;
+    }
+
+    public boolean isAnalyticsCoreFooterPrefetchEnabled()
+    {
+        return analyticsCoreFooterPrefetchEnabled;
+    }
+
+    @Config("gcs.analytics-core.footer-prefetch-enabled")
+    @ConfigDescription("Enable prefetching of file footer data for Analytics Core reads")
+    public GcsFileSystemConfig setAnalyticsCoreFooterPrefetchEnabled(boolean analyticsCoreFooterPrefetchEnabled)
+    {
+        this.analyticsCoreFooterPrefetchEnabled = analyticsCoreFooterPrefetchEnabled;
+        return this;
+    }
+
+    @Min(1)
+    public int getAnalyticsCoreReadThreadCount()
+    {
+        return analyticsCoreReadThreadCount;
+    }
+
+    @Config("gcs.analytics-core.read-thread-count")
+    @ConfigDescription("Number of threads used for Analytics Core parallel reads")
+    public GcsFileSystemConfig setAnalyticsCoreReadThreadCount(int analyticsCoreReadThreadCount)
+    {
+        this.analyticsCoreReadThreadCount = analyticsCoreReadThreadCount;
+        return this;
+    }
+
+    public Optional<String> getDecryptionKey()
+    {
+        return decryptionKey;
+    }
+
+    @Config("gcs.client.decryption-key")
+    @ConfigSecuritySensitive
+    @ConfigDescription("Decryption key for Google Cloud Storage")
+    public GcsFileSystemConfig setDecryptionKey(Optional<String> decryptionKey)
+    {
+        this.decryptionKey = decryptionKey;
+        return this;
+    }
+
     @AssertTrue(message = "gcs.client.min-backoff-delay must be less than or equal to gcs.client.max-backoff-delay")
     public boolean isRetryDelayValid()
     {
         return minBackoffDelay.compareTo(maxBackoffDelay) <= 0;
+    }
+
+    @AssertTrue(message = "gcs.client.decryption-key must be base64 encoded")
+    public boolean isDecryptionKeyValid()
+    {
+        try {
+            decryptionKey.ifPresent(key -> {
+                Base64.getDecoder().decode(key);
+            });
+            return true;
+        }
+        catch (IllegalArgumentException _) {
+            return false;
+        }
     }
 }

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystemFactory.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystemFactory.java
@@ -13,12 +13,15 @@
  */
 package io.trino.filesystem.gcs;
 
+import com.google.cloud.storage.Storage;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.inject.Inject;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.spi.security.ConnectorIdentity;
 import jakarta.annotation.PreDestroy;
+
+import java.util.Optional;
 
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
@@ -33,17 +36,21 @@ public class GcsFileSystemFactory
     private final long writeBlockSizeBytes;
     private final int pageSize;
     private final int batchSize;
+    private final boolean analyticsCoreEnabled;
     private final ListeningExecutorService executorService;
     private final GcsStorageFactory storageFactory;
+    private final AnalyticsCoreGcsFileSystemFactory analyticsCoreGcsFileSystemFactory;
 
     @Inject
-    public GcsFileSystemFactory(GcsFileSystemConfig config, GcsStorageFactory storageFactory)
+    public GcsFileSystemFactory(GcsFileSystemConfig config, GcsStorageFactory storageFactory, AnalyticsCoreGcsFileSystemFactory analyticsCoreGcsFileSystemFactory)
     {
         this.readBlockSizeBytes = toIntExact(config.getReadBlockSize().toBytes());
         this.writeBlockSizeBytes = config.getWriteBlockSize().toBytes();
         this.pageSize = config.getPageSize();
         this.batchSize = config.getBatchSize();
+        this.analyticsCoreEnabled = config.isAnalyticsCoreEnabled();
         this.storageFactory = requireNonNull(storageFactory, "storageFactory is null");
+        this.analyticsCoreGcsFileSystemFactory = requireNonNull(analyticsCoreGcsFileSystemFactory, "analyticsCoreGcsFileSystemFactory is null");
         this.executorService = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("trino-filesystem-gcs-%S")));
     }
 
@@ -56,6 +63,11 @@ public class GcsFileSystemFactory
     @Override
     public TrinoFileSystem create(ConnectorIdentity identity)
     {
-        return new GcsFileSystem(executorService, storageFactory.create(identity), readBlockSizeBytes, writeBlockSizeBytes, pageSize, batchSize);
+        Storage storage = storageFactory.create(identity);
+        Optional<com.google.cloud.gcs.analyticscore.client.GcsFileSystem> analyticsFileSystem = Optional.empty();
+        if (analyticsCoreEnabled) {
+            analyticsFileSystem = Optional.of(analyticsCoreGcsFileSystemFactory.create(storage));
+        }
+        return new GcsFileSystem(executorService, storage, readBlockSizeBytes, writeBlockSizeBytes, pageSize, batchSize, analyticsFileSystem);
     }
 }

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystemModule.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystemModule.java
@@ -28,6 +28,7 @@ public class GcsFileSystemModule
         configBinder(binder).bindConfig(GcsFileSystemConfig.class);
         binder.bind(GcsStorageFactory.class).in(Scopes.SINGLETON);
         binder.bind(GcsFileSystemFactory.class).in(Scopes.SINGLETON);
+        binder.bind(AnalyticsCoreGcsFileSystemFactory.class).in(Scopes.SINGLETON);
 
         switch (buildConfigObject(GcsFileSystemConfig.class).getAuthType()) {
             case ACCESS_TOKEN -> binder.bind(GcsAuth.class).to(GcsAccessTokenAuth.class).in(Scopes.SINGLETON);

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsLocation.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsLocation.java
@@ -15,12 +15,15 @@ package io.trino.filesystem.gcs;
 
 import io.trino.filesystem.Location;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-record GcsLocation(Location location)
+public record GcsLocation(Location location)
 {
-    GcsLocation
+    public GcsLocation
     {
         // Note: Underscores are allowed in bucket names, see https://cloud.google.com/storage/docs/buckets#naming.
 
@@ -56,5 +59,15 @@ record GcsLocation(Location location)
     public String toString()
     {
         return location.toString();
+    }
+
+    public URI toUri()
+    {
+        try {
+            return new URI(scheme(), bucket(), "/" + path(), null);
+        }
+        catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid GCS location: " + location, e);
+        }
     }
 }

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsStorageFactory.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsStorageFactory.java
@@ -20,6 +20,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.inject.Inject;
 import io.trino.spi.security.ConnectorIdentity;
+import jakarta.annotation.PreDestroy;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -49,6 +50,10 @@ public class GcsStorageFactory
     private final String applicationId;
     private final GcsAuth gcsAuth;
 
+    // Cached Storage instance for the default auth case (no per-identity OAuth token).
+    // Storage is thread-safe and can be shared across threads.
+    private volatile Storage sharedStorage;
+
     @Inject
     public GcsStorageFactory(GcsFileSystemConfig config, GcsAuth gcsAuth)
     {
@@ -63,7 +68,47 @@ public class GcsStorageFactory
         this.applicationId = config.getApplicationId();
     }
 
+    @PreDestroy
+    public void shutdown()
+    {
+        Storage storage = sharedStorage;
+        if (storage != null) {
+            try {
+                storage.close();
+            }
+            catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
     public Storage create(ConnectorIdentity identity)
+    {
+        // If identity has OAuth credentials, create a new Storage instance for that identity
+        if (hasOAuthCredentials(identity)) {
+            return createStorage(identity);
+        }
+
+        // Otherwise, use the shared cached Storage instance
+        Storage storage = sharedStorage;
+        if (storage == null) {
+            synchronized (this) {
+                storage = sharedStorage;
+                if (storage == null) {
+                    storage = createStorage(identity);
+                    sharedStorage = storage;
+                }
+            }
+        }
+        return storage;
+    }
+
+    private boolean hasOAuthCredentials(ConnectorIdentity identity)
+    {
+        return identity.getExtraCredentials().containsKey(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY);
+    }
+
+    private Storage createStorage(ConnectorIdentity identity)
     {
         try {
             StorageOptions.Builder storageOptionsBuilder = StorageOptions.newBuilder();

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsUtils.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsUtils.java
@@ -15,6 +15,10 @@ package io.trino.filesystem.gcs;
 
 import com.google.cloud.BaseServiceException;
 import com.google.cloud.ReadChannel;
+import com.google.cloud.gcs.analyticscore.client.GcsFileInfo;
+import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
+import com.google.cloud.gcs.analyticscore.client.GcsItemId;
+import com.google.cloud.gcs.analyticscore.core.GoogleCloudStorageInputStream;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
@@ -77,8 +81,13 @@ public class GcsUtils
 
     private static Blob.BlobSourceOption[] blobSourceOptions(Optional<EncryptionKey> key)
     {
-        return key.map(encryption -> new Blob.BlobSourceOption[] {Blob.BlobSourceOption.decryptionKey(encodedKey(encryption)), shouldReturnRawInputStream(true)})
-                .orElse(new Blob.BlobSourceOption[] {shouldReturnRawInputStream(true)});
+        return key.map(encryption -> new Blob.BlobSourceOption[] {
+                        Blob.BlobSourceOption.decryptionKey(encodedKey(encryption)),
+                        shouldReturnRawInputStream(true),
+                })
+                .orElseGet(() -> new Blob.BlobSourceOption[] {
+                        shouldReturnRawInputStream(true),
+                });
     }
 
     public static Optional<Blob> getBlob(Storage storage, GcsLocation location, Storage.BlobGetOption... blobGetOptions)
@@ -93,9 +102,99 @@ public class GcsUtils
         return getBlob(storage, location, blobGetOptions).orElseThrow(() -> new FileNotFoundException("File %s not found".formatted(location)));
     }
 
+    public static Optional<GcsFileInfo> getGcsFileInfo(GcsFileSystem gcsFileSystem, GcsLocation location)
+    {
+        checkArgument(!location.path().isEmpty(), "Path for location %s is empty", location);
+        try {
+            return Optional.ofNullable(gcsFileSystem.getFileInfo(toGcsItemId(location)));
+        }
+        catch (IOException e) {
+            return Optional.empty();
+        }
+    }
+
+    public static GcsFileInfo getGcsFileInfoOrThrow(GcsFileSystem gcsFileSystem, GcsLocation location)
+            throws IOException
+    {
+        return getGcsFileInfo(gcsFileSystem, location).orElseThrow(() -> new FileNotFoundException("File %s not found".formatted(location)));
+    }
+
+    public static GoogleCloudStorageInputStream openGcsInputStream(GcsFileSystem gcsFileSystem, GcsLocation location)
+            throws IOException
+    {
+        try {
+            return GoogleCloudStorageInputStream.create(gcsFileSystem, toGcsItemId(location));
+        }
+        catch (IOException e) {
+            throw mapFileNotFound(e, location);
+        }
+        catch (RuntimeException e) {
+            throw handleGcsException(e, "reading file", location);
+        }
+    }
+
+    public static GoogleCloudStorageInputStream openGcsInputStream(GcsFileSystem gcsFileSystem, GcsFileInfo fileInfo, GcsLocation location)
+            throws IOException
+    {
+        try {
+            return GoogleCloudStorageInputStream.create(gcsFileSystem, fileInfo);
+        }
+        catch (IOException e) {
+            throw mapFileNotFound(e, location);
+        }
+        catch (RuntimeException e) {
+            throw handleGcsException(e, "reading file", location);
+        }
+    }
+
+    public static IOException mapFileNotFound(IOException exception, GcsLocation location)
+    {
+        if (exception instanceof FileNotFoundException) {
+            return exception;
+        }
+        String message = exception.getMessage();
+        if (message != null) {
+            if (message.startsWith("Object not found:")) {
+                return new FileNotFoundException("File %s not found".formatted(location));
+            }
+            // Handle Analytics Core library exceptions that wrap StorageException 404
+            if (message.contains("404 Not Found") || message.contains("No such object:")) {
+                return new FileNotFoundException("File %s not found".formatted(location));
+            }
+        }
+        return exception;
+    }
+
     public static String encodedKey(EncryptionKey key)
     {
         return Base64.getEncoder().encodeToString(key.key());
+    }
+
+    public static Storage.BlobGetOption[] blobGetOptions(Optional<EncryptionKey> key)
+    {
+        return key
+                .map(encryption -> new Storage.BlobGetOption[] {
+                        Storage.BlobGetOption.decryptionKey(encodedKey(encryption)),
+                })
+                .orElseGet(() -> new Storage.BlobGetOption[0]);
+    }
+
+    public static Storage.BlobGetOption[] blobGetOptionsFromEncodedKey(Optional<String> key)
+    {
+        return key
+                .map(encryption -> new Storage.BlobGetOption[] {
+                        Storage.BlobGetOption.decryptionKey(encryption),
+                })
+                .orElseGet(() -> new Storage.BlobGetOption[0]);
+    }
+
+    public static Optional<String> findEncryptionKey(GcsFileSystem gcsFileSystem)
+    {
+        String key = gcsFileSystem.getFileSystemOptions().getGcsClientOptions().getGcsReadOptions().getDecryptionKey().orElse("");
+        if (key.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(key);
     }
 
     public static String keySha256Checksum(EncryptionKey key)
@@ -108,5 +207,38 @@ public class GcsUtils
         catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Creates a GcsItemId from a GcsLocation using the bucket and path directly,
+     * avoiding URI encoding issues with special characters.
+     */
+    public static GcsItemId toGcsItemId(GcsLocation location)
+    {
+        return GcsItemId.builder()
+                .setBucketName(location.bucket())
+                .setObjectName(location.path())
+                .build();
+    }
+
+    /**
+     * Checks if the path contains characters that cause issues with URI handling in
+     * Analytics Core.
+     * The gcs-analytics-core library internally uses URI.create() which fails for
+     * these characters.
+     * When detected, callers should fall back to the legacy GCS Storage API.
+     */
+    public static boolean pathHasSpecialCharacters(String path)
+    {
+        return path.contains(" ") || path.contains("#") || path.contains("?") || path.contains("[") || path.contains("]") || path.contains("*");
+    }
+
+    /**
+     * Decodes a Base64-encoded encryption key string to an EncryptionKey.
+     */
+    public static EncryptionKey decodeKey(String base64Key)
+    {
+        byte[] keyBytes = Base64.getDecoder().decode(base64Key);
+        return new EncryptionKey(keyBytes, "AES256");
     }
 }

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/AbstractTestGcsFileSystem.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/AbstractTestGcsFileSystem.java
@@ -36,9 +36,12 @@ import org.junit.jupiter.api.TestInstance;
 
 import java.io.IOException;
 import java.util.Base64;
+import java.util.UUID;
+import java.util.function.Consumer;
 
 import static com.google.cloud.storage.Storage.BlobTargetOption.doesNotExist;
 import static io.trino.filesystem.encryption.EncryptionKey.randomAes256;
+import static io.trino.filesystem.gcs.GcsFileSystemConfig.AuthType.APPLICATION_DEFAULT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,23 +54,73 @@ public abstract class AbstractTestGcsFileSystem
     private Location rootLocation;
     private Storage storage;
     private GcsFileSystemFactory gcsFileSystemFactory;
+    private boolean ownsBucket;
 
     protected void initialize(String gcpCredentialKey)
+            throws IOException
+    {
+        initialize(gcpCredentialKey, null);
+    }
+
+    protected void initialize(String gcpCredentialKey, String staticBucket)
+            throws IOException
+    {
+        initialize(gcpCredentialKey, staticBucket, _ -> {});
+    }
+
+    protected void initialize(String gcpCredentialKey, String staticBucket, Consumer<GcsFileSystemConfig> configCustomizer)
             throws IOException
     {
         // Note: the account needs the following permissions:
         // create/get/delete bucket
         // create/get/list/delete blob
-        // For gcp testing this corresponds to the Cluster Storage Admin and Cluster Storage Object Admin roles
+        // For gcp testing this corresponds to the Cluster Storage Admin and Cluster
+        // Storage Object
+        // Admin roles
         byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
         GcsFileSystemConfig config = new GcsFileSystemConfig();
-        GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig().setJsonKey(new String(jsonKeyBytes, UTF_8));
+        configCustomizer.accept(config);
+        GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig()
+                .setJsonKey(new String(jsonKeyBytes, UTF_8));
         GcsStorageFactory storageFactory = new GcsStorageFactory(config, new GcsServiceAccountAuth(authConfig));
-        this.gcsFileSystemFactory = new GcsFileSystemFactory(config, storageFactory);
+        AnalyticsCoreGcsFileSystemFactory analyticsCoreGcsFileSystemFactory = new AnalyticsCoreGcsFileSystemFactory(config);
+        initializeStorage(config, storageFactory, analyticsCoreGcsFileSystemFactory, staticBucket);
+    }
+
+    protected void initializeWithApplicationDefault(String staticBucket, Consumer<GcsFileSystemConfig> configCustomizer)
+            throws IOException
+    {
+        GcsFileSystemConfig config = new GcsFileSystemConfig()
+                .setAuthType(APPLICATION_DEFAULT);
+        configCustomizer.accept(config);
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new ApplicationDefaultAuth());
+        AnalyticsCoreGcsFileSystemFactory analyticsCoreGcsFileSystemFactory = new AnalyticsCoreGcsFileSystemFactory(config);
+        initializeStorage(config, storageFactory, analyticsCoreGcsFileSystemFactory, staticBucket);
+    }
+
+    private void initializeStorage(
+            GcsFileSystemConfig config,
+            GcsStorageFactory storageFactory,
+            AnalyticsCoreGcsFileSystemFactory analyticsCoreGcsFileSystemFactory,
+            String staticBucket)
+            throws IOException
+    {
+        this.gcsFileSystemFactory = new GcsFileSystemFactory(
+                config,
+                storageFactory,
+                analyticsCoreGcsFileSystemFactory);
         this.storage = storageFactory.create(ConnectorIdentity.ofUser("test"));
-        String bucket = RemoteStorageHelper.generateBucketName();
-        storage.create(BucketInfo.of(bucket));
-        this.rootLocation = Location.of("gs://%s/".formatted(bucket));
+        if (staticBucket != null && !staticBucket.isEmpty()) {
+            String uniquePath = UUID.randomUUID().toString();
+            this.rootLocation = Location.of("gs://%s/%s/".formatted(staticBucket, uniquePath));
+            this.ownsBucket = false;
+        }
+        else {
+            String bucket = RemoteStorageHelper.generateBucketName();
+            storage.create(BucketInfo.of(bucket));
+            this.rootLocation = Location.of("gs://%s/".formatted(bucket));
+            this.ownsBucket = true;
+        }
         this.fileSystem = gcsFileSystemFactory.create(ConnectorIdentity.ofUser("test"));
         cleanupFiles();
     }
@@ -76,11 +129,20 @@ public abstract class AbstractTestGcsFileSystem
     void tearDown()
     {
         try {
-            Bucket bucket = storage.get(new GcsLocation(rootLocation).bucket());
-            for (Blob blob : bucket.list().iterateAll()) {
-                storage.delete(blob.getBlobId());
+            String bucketName = new GcsLocation(rootLocation).bucket();
+            if (ownsBucket) {
+                Bucket bucket = storage.get(bucketName);
+                for (Blob blob : bucket.list().iterateAll()) {
+                    storage.delete(blob.getBlobId());
+                }
+                bucket.delete();
             }
-            bucket.delete();
+            else {
+                String prefix = new GcsLocation(rootLocation).path();
+                for (Blob blob : storage.list(bucketName, Storage.BlobListOption.prefix(prefix)).iterateAll()) {
+                    storage.delete(blob.getBlobId());
+                }
+            }
         }
         finally {
             fileSystem = null;
@@ -133,7 +195,14 @@ public abstract class AbstractTestGcsFileSystem
     protected void verifyFileSystemIsEmpty()
     {
         String bucket = new GcsLocation(rootLocation).bucket();
-        assertThat(storage.list(bucket).iterateAll()).isEmpty();
+        String prefix = new GcsLocation(rootLocation).path();
+        if (prefix.isEmpty()) {
+            assertThat(storage.list(bucket).iterateAll()).isEmpty();
+        }
+        else {
+            assertThat(storage.list(bucket, Storage.BlobListOption.prefix(prefix)).iterateAll())
+                    .isEmpty();
+        }
     }
 
     @Override
@@ -152,7 +221,8 @@ public abstract class AbstractTestGcsFileSystem
     void testExistingFileWithTrailingSlash()
             throws IOException
     {
-        BlobId blobId = BlobId.of(new GcsLocation(rootLocation).bucket(), "data/file/");
+        GcsLocation gcsRootLocation = new GcsLocation(rootLocation);
+        BlobId blobId = BlobId.of(gcsRootLocation.bucket(), gcsRootLocation.path() + "data/file/");
         storage.create(BlobInfo.newBuilder(blobId).build(), new byte[0], doesNotExist());
         try {
             assertThat(fileSystem.listFiles(getRootLocation()).hasNext()).isFalse();
@@ -161,7 +231,8 @@ public abstract class AbstractTestGcsFileSystem
             assertThat(fileSystem.listDirectories(getRootLocation())).containsExactly(data);
             assertThat(fileSystem.listDirectories(data)).containsExactly(data.appendPath("file/"));
 
-            // blobs ending in slash are deleted, even though they are not visible to listings
+            // blobs ending in slash are deleted, even though they are not visible to
+            // listings
             fileSystem.deleteDirectory(data);
             assertThat(fileSystem.listDirectories(getRootLocation())).isEmpty();
         }
@@ -174,8 +245,11 @@ public abstract class AbstractTestGcsFileSystem
     void testRoundTripFileWithDiscouragedCharsName()
             throws Exception
     {
-        // According to https://docs.cloud.google.com/storage/docs/objects#recommendations some chars ([*]#?) are discouraged
-        // because they are specially treated in gcloud cli. But they are not directly prohibited.
+        // According to
+        // https://docs.cloud.google.com/storage/docs/objects#recommendations some chars
+        // ([*]#?) are discouraged
+        // because they are specially treated in gcloud cli. But they are not directly
+        // prohibited.
         byte[] buffer = new byte[8];
         String stringToWrite = "test";
         Location fileLocation = getRootLocation().appendPath("[*]#?");

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystem.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystem.java
@@ -19,8 +19,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
-import static io.trino.testing.SystemEnvironmentUtils.requireEnv;
+import static io.airlift.units.Duration.succinctDuration;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -31,7 +32,24 @@ public class TestGcsFileSystem
     void setup()
             throws IOException
     {
-        initialize(requireEnv("GCP_CREDENTIALS_KEY"));
+        String staticBucket = System.getenv("GCS_TEST_BUCKET");
+        String gcpCredentialsKey = System.getenv("GCP_CREDENTIALS_KEY");
+        if (gcpCredentialsKey == null || gcpCredentialsKey.isBlank()) {
+            initializeWithApplicationDefault(staticBucket, this::configureRetrySettings);
+            return;
+        }
+
+        initialize(gcpCredentialsKey, staticBucket, this::configureRetrySettings);
+    }
+
+    private void configureRetrySettings(GcsFileSystemConfig config)
+    {
+        // This cloud test intentionally triggers retry behavior via repeated writes.
+        // Use a larger retry budget to absorb transient GCS throttling in shared CI environments.
+        config.setMaxRetries(100)
+                .setMaxRetryTime(succinctDuration(2, TimeUnit.MINUTES))
+                .setMinBackoffDelay(succinctDuration(50, TimeUnit.MILLISECONDS))
+                .setMaxBackoffDelay(succinctDuration(10, TimeUnit.SECONDS));
     }
 
     @Test

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemConfig.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemConfig.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.filesystem.gcs.GcsFileSystemConfig.AuthType;
+import io.trino.filesystem.gcs.GcsFileSystemConfig.FileAccessPattern;
 import jakarta.validation.constraints.AssertTrue;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +34,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestGcsFileSystemConfig
 {
+    private static final String BASE64_KEY = "YmFzZTY0LWtleQ==";
+
     @Test
     void testDefaults()
     {
@@ -42,14 +45,21 @@ public class TestGcsFileSystemConfig
                 .setPageSize(100)
                 .setBatchSize(100)
                 .setProjectId(null)
+                .setUserProject(Optional.empty())
                 .setEndpoint(Optional.empty())
+                .setClientLibToken(Optional.empty())
                 .setAuthType(AuthType.SERVICE_ACCOUNT)
                 .setMaxRetries(20)
                 .setBackoffScaleFactor(3.0)
                 .setMaxRetryTime(new Duration(25, SECONDS))
                 .setMinBackoffDelay(new Duration(10, MILLISECONDS))
                 .setMaxBackoffDelay(new Duration(2000, MILLISECONDS))
-                .setApplicationId("Trino"));
+                .setApplicationId("Trino")
+                .setAnalyticsCoreEnabled(false)
+                .setAnalyticsCoreFileAccessPattern(FileAccessPattern.AUTO_RANDOM)
+                .setAnalyticsCoreFooterPrefetchEnabled(true)
+                .setAnalyticsCoreReadThreadCount(16)
+                .setDecryptionKey(Optional.empty()));
     }
 
     @Test
@@ -61,7 +71,9 @@ public class TestGcsFileSystemConfig
                 .put("gcs.page-size", "10")
                 .put("gcs.batch-size", "11")
                 .put("gcs.project-id", "project")
+                .put("gcs.user-project", "billing-project")
                 .put("gcs.endpoint", "http://custom.dns.org:8000")
+                .put("gcs.client-lib-token", "client-lib-token")
                 .put("gcs.auth-type", "access_token")
                 .put("gcs.client.max-retries", "10")
                 .put("gcs.client.backoff-scale-factor", "4.0")
@@ -69,6 +81,11 @@ public class TestGcsFileSystemConfig
                 .put("gcs.client.min-backoff-delay", "20ms")
                 .put("gcs.client.max-backoff-delay", "20ms")
                 .put("gcs.application-id", "application id")
+                .put("gcs.analytics-core.enabled", "true")
+                .put("gcs.analytics-core.file-access-pattern", "RANDOM")
+                .put("gcs.analytics-core.footer-prefetch-enabled", "false")
+                .put("gcs.analytics-core.read-thread-count", "8")
+                .put("gcs.client.decryption-key", BASE64_KEY)
                 .buildOrThrow();
 
         GcsFileSystemConfig expected = new GcsFileSystemConfig()
@@ -77,14 +94,21 @@ public class TestGcsFileSystemConfig
                 .setPageSize(10)
                 .setBatchSize(11)
                 .setProjectId("project")
+                .setUserProject(Optional.of("billing-project"))
                 .setEndpoint(Optional.of("http://custom.dns.org:8000"))
+                .setClientLibToken(Optional.of("client-lib-token"))
                 .setAuthType(AuthType.ACCESS_TOKEN)
                 .setMaxRetries(10)
                 .setBackoffScaleFactor(4.0)
                 .setMaxRetryTime(new Duration(10, SECONDS))
                 .setMinBackoffDelay(new Duration(20, MILLISECONDS))
                 .setMaxBackoffDelay(new Duration(20, MILLISECONDS))
-                .setApplicationId("application id");
+                .setApplicationId("application id")
+                .setAnalyticsCoreEnabled(true)
+                .setAnalyticsCoreFileAccessPattern(FileAccessPattern.RANDOM)
+                .setAnalyticsCoreFooterPrefetchEnabled(false)
+                .setAnalyticsCoreReadThreadCount(8)
+                .setDecryptionKey(Optional.of(BASE64_KEY));
         assertFullMapping(properties, expected);
     }
 
@@ -97,6 +121,13 @@ public class TestGcsFileSystemConfig
                         .setMaxBackoffDelay(new Duration(19, MILLISECONDS)),
                 "retryDelayValid",
                 "gcs.client.min-backoff-delay must be less than or equal to gcs.client.max-backoff-delay",
+                AssertTrue.class);
+
+        assertFailsValidation(
+                new GcsFileSystemConfig()
+                        .setDecryptionKey(Optional.of("not-base64")),
+                "decryptionKeyValid",
+                "gcs.client.decryption-key must be base64 encoded",
                 AssertTrue.class);
     }
 }

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemWithAnalyticsCore.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemWithAnalyticsCore.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.gcs;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestGcsFileSystemWithAnalyticsCore
+        extends AbstractTestGcsFileSystem
+{
+    @BeforeAll
+    void setup()
+            throws IOException
+    {
+        String staticBucket = System.getenv("GCS_TEST_BUCKET");
+        String gcpCredentialsKey = System.getenv("GCP_CREDENTIALS_KEY");
+        if (gcpCredentialsKey == null || gcpCredentialsKey.isBlank()) {
+            initializeWithApplicationDefault(staticBucket, config -> config.setAnalyticsCoreEnabled(true));
+            return;
+        }
+
+        initialize(gcpCredentialsKey, staticBucket, config -> config.setAnalyticsCoreEnabled(true));
+    }
+}

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemWithAnalyticsCoreAndEncryption.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemWithAnalyticsCoreAndEncryption.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.gcs;
+
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static io.trino.filesystem.gcs.GcsUtils.encodedKey;
+
+public class TestGcsFileSystemWithAnalyticsCoreAndEncryption
+        extends TestGcsFileSystemWithAnalyticsCore
+{
+    @Override
+    @BeforeAll
+    void setup()
+            throws IOException
+    {
+        String staticBucket = System.getenv("GCS_TEST_BUCKET");
+        String gcpCredentialsKey = System.getenv("GCP_CREDENTIALS_KEY");
+
+        if (gcpCredentialsKey == null || gcpCredentialsKey.isBlank()) {
+            initializeWithApplicationDefault(staticBucket, config -> config
+                    .setAnalyticsCoreEnabled(true)
+                    .setDecryptionKey(Optional.of(encodedKey(randomEncryptionKey))));
+            return;
+        }
+
+        initialize(gcpCredentialsKey, staticBucket, config -> config
+                .setAnalyticsCoreEnabled(true)
+                .setDecryptionKey(Optional.of(encodedKey(randomEncryptionKey))));
+    }
+
+    @Override
+    protected boolean useServerSideEncryptionWithCustomerKey()
+    {
+        return true;
+    }
+
+    protected boolean encryptionDelegateHasDecryptionKey()
+    {
+        // With Analytics Core, the decryption key is configured globally in GcsReadOptions,
+        // so the delegate file system also has access to the key for decryption
+        return true;
+    }
+}

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsStorageFactory.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsStorageFactory.java
@@ -19,10 +19,10 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.gcs.GcsFileSystemConfig.AuthType;
 import io.trino.spi.security.ConnectorIdentity;
 import org.junit.jupiter.api.Test;
 
-import static io.trino.filesystem.gcs.GcsFileSystemConfig.AuthType;
 import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_EXPIRES_AT_PROPERTY;
 import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY;
 import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_PROJECT_ID_PROPERTY;
@@ -30,12 +30,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestGcsStorageFactory
 {
+    private static final ApplicationDefaultAuth TEST_APPLICATION_DEFAULT_AUTH = new ApplicationDefaultAuth(NoCredentials::getInstance);
+
     @Test
     void testApplicationDefaultCredentials()
             throws Exception
     {
         GcsFileSystemConfig config = new GcsFileSystemConfig().setAuthType(AuthType.APPLICATION_DEFAULT);
-        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new ApplicationDefaultAuth());
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, TEST_APPLICATION_DEFAULT_AUTH);
 
         Credentials actualCredentials;
         try (Storage storage = storageFactory.create(ConnectorIdentity.ofUser("test"))) {
@@ -50,7 +52,7 @@ final class TestGcsStorageFactory
             throws Exception
     {
         GcsFileSystemConfig config = new GcsFileSystemConfig().setAuthType(AuthType.APPLICATION_DEFAULT);
-        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new ApplicationDefaultAuth());
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, TEST_APPLICATION_DEFAULT_AUTH);
 
         ConnectorIdentity identity = ConnectorIdentity.forUser("test")
                 .withExtraCredentials(ImmutableMap.of(
@@ -72,7 +74,7 @@ final class TestGcsStorageFactory
             throws Exception
     {
         GcsFileSystemConfig config = new GcsFileSystemConfig().setAuthType(AuthType.APPLICATION_DEFAULT);
-        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new ApplicationDefaultAuth());
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, TEST_APPLICATION_DEFAULT_AUTH);
 
         ConnectorIdentity identity = ConnectorIdentity.forUser("test")
                 .withExtraCredentials(ImmutableMap.of(
@@ -99,7 +101,7 @@ final class TestGcsStorageFactory
         GcsFileSystemConfig config = new GcsFileSystemConfig()
                 .setAuthType(AuthType.APPLICATION_DEFAULT)
                 .setProjectId("static-project");
-        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new ApplicationDefaultAuth());
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, TEST_APPLICATION_DEFAULT_AUTH);
 
         ConnectorIdentity identity = ConnectorIdentity.forUser("test")
                 .withExtraCredentials(ImmutableMap.of(
@@ -119,11 +121,57 @@ final class TestGcsStorageFactory
         GcsFileSystemConfig config = new GcsFileSystemConfig()
                 .setAuthType(AuthType.APPLICATION_DEFAULT)
                 .setProjectId("static-project");
-        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new ApplicationDefaultAuth());
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, TEST_APPLICATION_DEFAULT_AUTH);
 
         try (Storage storage = storageFactory.create(ConnectorIdentity.ofUser("test"))) {
             assertThat(storage.getOptions().getProjectId()).isEqualTo("static-project");
             assertThat(storage.getOptions().getCredentials()).isEqualTo(NoCredentials.getInstance());
         }
+    }
+
+    @Test
+    void testSharedStorageInstanceForDefaultAuth()
+    {
+        GcsFileSystemConfig config = new GcsFileSystemConfig().setAuthType(AuthType.APPLICATION_DEFAULT);
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, TEST_APPLICATION_DEFAULT_AUTH);
+
+        // Multiple calls without OAuth credentials should return the same cached instance
+        Storage storage1 = storageFactory.create(ConnectorIdentity.ofUser("user1"));
+        Storage storage2 = storageFactory.create(ConnectorIdentity.ofUser("user2"));
+
+        assertThat(storage1).isSameAs(storage2);
+
+        storageFactory.shutdown();
+    }
+
+    @Test
+    void testSeparateStorageInstancesForOAuthCredentials()
+    {
+        GcsFileSystemConfig config = new GcsFileSystemConfig().setAuthType(AuthType.APPLICATION_DEFAULT);
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, TEST_APPLICATION_DEFAULT_AUTH);
+
+        ConnectorIdentity oauthIdentity1 = ConnectorIdentity.forUser("user1")
+                .withExtraCredentials(ImmutableMap.of(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, "token1"))
+                .build();
+        ConnectorIdentity oauthIdentity2 = ConnectorIdentity.forUser("user2")
+                .withExtraCredentials(ImmutableMap.of(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, "token2"))
+                .build();
+
+        // OAuth requests should get separate instances
+        Storage oauthStorage1 = storageFactory.create(oauthIdentity1);
+        Storage oauthStorage2 = storageFactory.create(oauthIdentity2);
+
+        assertThat(oauthStorage1).isNotSameAs(oauthStorage2);
+
+        // Default auth should get the shared instance
+        Storage defaultStorage = storageFactory.create(ConnectorIdentity.ofUser("default"));
+        assertThat(defaultStorage).isNotSameAs(oauthStorage1);
+        assertThat(defaultStorage).isNotSameAs(oauthStorage2);
+
+        // Second default auth call should return the same cached instance
+        Storage defaultStorage2 = storageFactory.create(ConnectorIdentity.ofUser("default2"));
+        assertThat(defaultStorage).isSameAs(defaultStorage2);
+
+        storageFactory.shutdown();
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogStorageCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogStorageCredentialsRefresh.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.gcs.AnalyticsCoreGcsFileSystemFactory;
 import io.trino.filesystem.gcs.GcsFileSystemConfig;
 import io.trino.filesystem.gcs.GcsFileSystemFactory;
 import io.trino.filesystem.gcs.GcsServiceAccountAuth;
@@ -71,7 +72,7 @@ final class TestIcebergGcsRestCatalogStorageCredentialsRefresh
         GcsFileSystemConfig config = new GcsFileSystemConfig();
         GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig().setJsonKey(new String(jsonKeyBytes, UTF_8));
         GcsStorageFactory storageFactory = new GcsStorageFactory(config, new GcsServiceAccountAuth(authConfig));
-        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
+        fileSystem = new GcsFileSystemFactory(config, storageFactory, new AnalyticsCoreGcsFileSystemFactory(config)).create(SESSION);
     }
 
     @AfterAll

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.gcs.AnalyticsCoreGcsFileSystemFactory;
 import io.trino.filesystem.gcs.GcsFileSystemConfig;
 import io.trino.filesystem.gcs.GcsFileSystemFactory;
 import io.trino.filesystem.gcs.GcsServiceAccountAuth;
@@ -69,7 +70,8 @@ final class TestIcebergGcsRestCatalogVendedCredentialsRefresh
         catch (IOException e) {
             throw new RuntimeException(e);
         }
-        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
+        AnalyticsCoreGcsFileSystemFactory analyticsCoreFactory = new AnalyticsCoreGcsFileSystemFactory(config);
+        fileSystem = new GcsFileSystemFactory(config, storageFactory, analyticsCoreFactory).create(SESSION);
     }
 
     @AfterAll

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java
@@ -20,6 +20,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.filesystem.Location;
+import io.trino.filesystem.gcs.AnalyticsCoreGcsFileSystemFactory;
 import io.trino.filesystem.gcs.GcsFileSystemConfig;
 import io.trino.filesystem.gcs.GcsFileSystemFactory;
 import io.trino.filesystem.gcs.GcsServiceAccountAuth;
@@ -79,9 +80,7 @@ final class TestIcebergGcsVendingRestCatalogConnectorSmokeTest
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
     {
         return switch (connectorBehavior) {
-            case SUPPORTS_CREATE_MATERIALIZED_VIEW,
-                 SUPPORTS_RENAME_MATERIALIZED_VIEW,
-                 SUPPORTS_RENAME_SCHEMA -> false;
+            case SUPPORTS_CREATE_MATERIALIZED_VIEW, SUPPORTS_RENAME_MATERIALIZED_VIEW, SUPPORTS_RENAME_SCHEMA -> false;
             default -> super.hasBehavior(connectorBehavior);
         };
     }
@@ -137,7 +136,8 @@ final class TestIcebergGcsVendingRestCatalogConnectorSmokeTest
         catch (IOException e) {
             throw new RuntimeException(e);
         }
-        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
+        AnalyticsCoreGcsFileSystemFactory analyticsCoreFactory = new AnalyticsCoreGcsFileSystemFactory(config);
+        fileSystem = new GcsFileSystemFactory(config, storageFactory, analyticsCoreFactory).create(SESSION);
     }
 
     @AfterAll


### PR DESCRIPTION
## Description
Integrates the [gcs-analytics-core library ](https://github.com/GoogleCloudPlatform/gcs-analytics-core/tree/main)
for optimizing reads for analytic workloads. The ultimate goal of this PR is to try and close the performance gap between the removed hadoop based gcs storage connector and the current connector. The changes in this PR include:

- Added AnalyticsCoreGcsFileSystemFactory binding in GcsFileSystemModule.
- Implemented shared Storage instance caching in GcsStorageFactory for default auth.
- Enhanced GcsUtils with methods for GcsFileInfo retrieval and encryption key handling.
- Updated tests to cover Analytics Core functionality and encryption scenarios.
- Refactored TestGcsFileSystem to support application default credentials and retry settings.
- Updated Iceberg tests to utilize AnalyticsCoreGcsFileSystemFactory. -Misc. Fixes for running GCS tests in a GCP environment


## Additional context and related issues
I've been running benchmarks and tests extensively in a GCP environment. A number of the changes around auth account for running trino on GCE/GKE and using instance/workload identity.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
