### PR TITLE
fix minio test container failures on amd64

### DIFF
--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/BaseTestContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/BaseTestContainer.java
@@ -28,6 +28,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -118,6 +119,11 @@ public abstract class BaseTestContainer
     protected void mountDirectory(String hostPath, String dockerPath)
     {
         container.addFileSystemBind(hostPath, dockerPath, BindMode.READ_WRITE);
+    }
+
+    protected void waitingFor(WaitStrategy waitStrategy)
+    {
+        container.waitingFor(waitStrategy);
     }
 
     protected void withCreateContainerModifier(Consumer<CreateContainerCmd> modifier)

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/Minio.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/Minio.java
@@ -23,6 +23,7 @@ import dev.failsafe.RetryPolicy;
 import io.airlift.log.Logger;
 import io.trino.testing.minio.MinioClient;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.IOException;
@@ -90,6 +91,10 @@ public class Minio
                         "--console-address",
                         "0.0.0.0:" + MINIO_CONSOLE_PORT,
                         "/data"));
+        // The Chainguard minio image is distroless on amd64 (no /bin/sh), so the default
+        // Wait.forListeningPort() fails because Testcontainers 2.x also execs a shell inside
+        // the container to verify the port. Use the HTTP health endpoint instead.
+        waitingFor(Wait.forHttp("/minio/health/live").forPort(MINIO_API_PORT));
     }
 
     @Override


### PR DESCRIPTION
## Description
The chainguard amd64 image is distroless which causes the default mechanism testcontainers uses to verify port availability to fail. Configure it to wait for the http port to be available externally instead.

## Additional context and related issues



## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: