### PR TITLE
Remove BlockUtil.checkReadablePosition

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
@@ -21,7 +21,7 @@ import java.util.function.ObjLongConsumer;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
-import static io.trino.spi.block.BlockUtil.checkReadablePosition;
+import static io.trino.spi.block.BlockUtil.checkValidPosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactIsNull;
 import static io.trino.spi.block.BlockUtil.compactOffsets;
@@ -239,7 +239,7 @@ public final class ArrayBlock
         IntArrayList valuesPositions = new IntArrayList();
         for (int i = 0; i < length; i++) {
             int position = positions[offset + i];
-            checkReadablePosition(this, position);
+            checkValidPosition(position, positionCount);
             if (valueIsNull != null && valueIsNull[position + arrayOffset]) {
                 hasNull = true;
                 newValueIsNull[i] = true;
@@ -308,7 +308,7 @@ public final class ArrayBlock
 
     public Block getArray(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         int startValueOffset = offsets[position + arrayOffset];
         int endValueOffset = offsets[position + 1 + arrayOffset];
         return values.getRegion(startValueOffset, endValueOffset - startValueOffset);
@@ -317,7 +317,7 @@ public final class ArrayBlock
     @Override
     public ArrayBlock getSingleValueBlock(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
 
         int startValueOffset = offsets[position + arrayOffset];
         int valueLength = offsets[position + 1 + arrayOffset] - startValueOffset;
@@ -334,7 +334,7 @@ public final class ArrayBlock
     @Override
     public long getEstimatedDataSizeForStats(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
 
         if (isNull(position)) {
             return 0;
@@ -357,7 +357,7 @@ public final class ArrayBlock
         if (!mayHaveNull()) {
             return false;
         }
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return valueIsNull[position + arrayOffset];
     }
 
@@ -375,7 +375,7 @@ public final class ArrayBlock
 
     public <T> T apply(ArrayBlockFunction<T> function, int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
 
         int startValueOffset = offsets[position + arrayOffset];
         int endValueOffset = offsets[position + 1 + arrayOffset];

--- a/core/trino-spi/src/main/java/io/trino/spi/block/BlockUtil.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/BlockUtil.java
@@ -65,11 +65,6 @@ final class BlockUtil
         }
     }
 
-    static void checkReadablePosition(Block block, int position)
-    {
-        checkValidPosition(position, block.getPositionCount());
-    }
-
     static int calculateNewArraySize(int currentSize)
     {
         return calculateNewArraySize(currentSize, DEFAULT_CAPACITY);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
@@ -23,7 +23,7 @@ import java.util.function.ObjLongConsumer;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
-import static io.trino.spi.block.BlockUtil.checkReadablePosition;
+import static io.trino.spi.block.BlockUtil.checkValidPosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.compactIsNull;
@@ -131,7 +131,7 @@ public final class ByteArrayBlock
 
     public byte getByte(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return values[position + arrayOffset];
     }
 
@@ -161,14 +161,14 @@ public final class ByteArrayBlock
         if (!mayHaveNull()) {
             return false;
         }
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return valueIsNull[position + arrayOffset];
     }
 
     @Override
     public ByteArrayBlock getSingleValueBlock(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return new ByteArrayBlock(
                 0,
                 1,
@@ -189,7 +189,7 @@ public final class ByteArrayBlock
         byte[] newValues = new byte[length];
         for (int i = 0; i < length; i++) {
             int position = positions[offset + i];
-            checkReadablePosition(this, position);
+            checkValidPosition(position, positionCount);
             if (valueIsNull != null) {
                 boolean isNull = valueIsNull[position + arrayOffset];
                 newValueIsNull[i] = isNull;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
@@ -21,7 +21,7 @@ import java.util.function.ObjLongConsumer;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
-import static io.trino.spi.block.BlockUtil.checkReadablePosition;
+import static io.trino.spi.block.BlockUtil.checkValidPosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.compactIsNull;
@@ -114,7 +114,7 @@ public final class Fixed12Block
 
     public int getInt(int position, int offset)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         if (offset == 0) {
             return values[(position + positionOffset) * 3];
         }
@@ -129,7 +129,7 @@ public final class Fixed12Block
 
     public long getFixed12First(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return decodeFixed12First(values, position + positionOffset);
     }
 
@@ -164,14 +164,14 @@ public final class Fixed12Block
         if (!mayHaveNull()) {
             return false;
         }
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return valueIsNull[position + positionOffset];
     }
 
     @Override
     public Fixed12Block getSingleValueBlock(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         int index = (position + positionOffset) * 3;
         return new Fixed12Block(
                 0,
@@ -193,7 +193,7 @@ public final class Fixed12Block
         int[] newValues = new int[length * 3];
         for (int i = 0; i < length; i++) {
             int position = positions[offset + i];
-            checkReadablePosition(this, position);
+            checkValidPosition(position, positionCount);
             if (valueIsNull != null) {
                 boolean isNull = valueIsNull[position + positionOffset];
                 newValueIsNull[i] = isNull;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
@@ -22,7 +22,7 @@ import java.util.function.ObjLongConsumer;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
-import static io.trino.spi.block.BlockUtil.checkReadablePosition;
+import static io.trino.spi.block.BlockUtil.checkValidPosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.compactIsNull;
@@ -115,20 +115,20 @@ public final class Int128ArrayBlock
 
     public Int128 getInt128(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         int offset = (position + positionOffset) * 2;
         return Int128.valueOf(values[offset], values[offset + 1]);
     }
 
     public long getInt128High(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return values[(position + positionOffset) * 2];
     }
 
     public long getInt128Low(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return values[((position + positionOffset) * 2) + 1];
     }
 
@@ -158,14 +158,14 @@ public final class Int128ArrayBlock
         if (!mayHaveNull()) {
             return false;
         }
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return valueIsNull[position + positionOffset];
     }
 
     @Override
     public Int128ArrayBlock getSingleValueBlock(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return new Int128ArrayBlock(
                 0,
                 1,
@@ -189,7 +189,7 @@ public final class Int128ArrayBlock
         long[] newValues = new long[length * 2];
         for (int i = 0; i < length; i++) {
             int position = positions[offset + i];
-            checkReadablePosition(this, position);
+            checkValidPosition(position, positionCount);
             if (valueIsNull != null) {
                 boolean isNull = valueIsNull[position + positionOffset];
                 newValueIsNull[i] = isNull;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
@@ -21,7 +21,7 @@ import java.util.function.ObjLongConsumer;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
-import static io.trino.spi.block.BlockUtil.checkReadablePosition;
+import static io.trino.spi.block.BlockUtil.checkValidPosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.compactIsNull;
@@ -113,7 +113,7 @@ public final class IntArrayBlock
 
     public int getInt(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return values[position + arrayOffset];
     }
 
@@ -143,14 +143,14 @@ public final class IntArrayBlock
         if (!mayHaveNull()) {
             return false;
         }
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return valueIsNull[position + arrayOffset];
     }
 
     @Override
     public IntArrayBlock getSingleValueBlock(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return new IntArrayBlock(
                 0,
                 1,
@@ -171,7 +171,7 @@ public final class IntArrayBlock
         int[] newValues = new int[length];
         for (int i = 0; i < length; i++) {
             int position = positions[offset + i];
-            checkReadablePosition(this, position);
+            checkValidPosition(position, positionCount);
             if (valueIsNull != null) {
                 boolean isNull = valueIsNull[position + arrayOffset];
                 newValueIsNull[i] = isNull;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
@@ -21,7 +21,7 @@ import java.util.function.ObjLongConsumer;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
-import static io.trino.spi.block.BlockUtil.checkReadablePosition;
+import static io.trino.spi.block.BlockUtil.checkValidPosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.compactIsNull;
@@ -113,7 +113,7 @@ public final class LongArrayBlock
 
     public long getLong(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return values[position + arrayOffset];
     }
 
@@ -143,14 +143,14 @@ public final class LongArrayBlock
         if (!mayHaveNull()) {
             return false;
         }
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return valueIsNull[position + arrayOffset];
     }
 
     @Override
     public LongArrayBlock getSingleValueBlock(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return new LongArrayBlock(
                 0,
                 1,
@@ -171,7 +171,7 @@ public final class LongArrayBlock
         long[] newValues = new long[length];
         for (int i = 0; i < length; i++) {
             int position = positions[offset + i];
-            checkReadablePosition(this, position);
+            checkValidPosition(position, positionCount);
             if (valueIsNull != null) {
                 boolean isNull = valueIsNull[position + arrayOffset];
                 newValueIsNull[i] = isNull;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
@@ -24,7 +24,7 @@ import java.util.function.ObjLongConsumer;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
-import static io.trino.spi.block.BlockUtil.checkReadablePosition;
+import static io.trino.spi.block.BlockUtil.checkValidPosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.compactIsNull;
@@ -467,7 +467,7 @@ public final class MapBlock
 
     public SqlMap getMap(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         int startEntryOffset = getOffset(position);
         int endEntryOffset = getOffset(position + 1);
         return new SqlMap(
@@ -482,7 +482,7 @@ public final class MapBlock
     @Override
     public MapBlock getSingleValueBlock(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
 
         int startValueOffset = getOffset(position);
         int endValueOffset = getOffset(position + 1);
@@ -509,7 +509,7 @@ public final class MapBlock
     @Override
     public long getEstimatedDataSizeForStats(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
 
         if (isNull(position)) {
             return 0;
@@ -534,7 +534,7 @@ public final class MapBlock
         if (!mayHaveNull()) {
             return false;
         }
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return mapIsNull[position + startOffset];
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -24,7 +24,7 @@ import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.arraySame;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
-import static io.trino.spi.block.BlockUtil.checkReadablePosition;
+import static io.trino.spi.block.BlockUtil.checkValidPosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static java.lang.String.format;
@@ -334,7 +334,7 @@ public final class RowBlock
 
     public SqlRow getRow(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         if (isNull(position)) {
             throw new IllegalStateException("Position is null");
         }
@@ -344,7 +344,7 @@ public final class RowBlock
     @Override
     public RowBlock getSingleValueBlock(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
 
         Block[] newBlocks = new Block[fieldBlocks.length];
         for (int i = 0; i < fieldBlocks.length; i++) {
@@ -357,7 +357,7 @@ public final class RowBlock
     @Override
     public long getEstimatedDataSizeForStats(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
 
         if (isNull(position)) {
             return 0;
@@ -376,7 +376,7 @@ public final class RowBlock
         if (!mayHaveNull()) {
             return false;
         }
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return rowIsNull[startOffset + position];
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -19,7 +19,6 @@ import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
-import static io.trino.spi.block.BlockUtil.checkReadablePosition;
 import static io.trino.spi.block.BlockUtil.checkValidPosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
@@ -167,7 +166,7 @@ public final class RunLengthEncodedBlock
     @Override
     public ValueBlock getSingleValueBlock(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return value;
     }
 
@@ -189,7 +188,7 @@ public final class RunLengthEncodedBlock
         if (!mayHaveNull()) {
             return false;
         }
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return value.isNull(0);
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
@@ -21,7 +21,7 @@ import java.util.function.ObjLongConsumer;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
-import static io.trino.spi.block.BlockUtil.checkReadablePosition;
+import static io.trino.spi.block.BlockUtil.checkValidPosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.compactIsNull;
@@ -113,7 +113,7 @@ public final class ShortArrayBlock
 
     public short getShort(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return values[position + arrayOffset];
     }
 
@@ -143,14 +143,14 @@ public final class ShortArrayBlock
         if (!mayHaveNull()) {
             return false;
         }
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return valueIsNull[position + arrayOffset];
     }
 
     @Override
     public ShortArrayBlock getSingleValueBlock(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return new ShortArrayBlock(
                 0,
                 1,
@@ -171,7 +171,7 @@ public final class ShortArrayBlock
         short[] newValues = new short[length];
         for (int i = 0; i < length; i++) {
             int position = positions[offset + i];
-            checkReadablePosition(this, position);
+            checkValidPosition(position, positionCount);
             if (valueIsNull != null) {
                 boolean isNull = valueIsNull[position + arrayOffset];
                 newValueIsNull[i] = isNull;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
@@ -25,7 +25,7 @@ import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
-import static io.trino.spi.block.BlockUtil.checkReadablePosition;
+import static io.trino.spi.block.BlockUtil.checkValidPosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactIsNull;
 import static io.trino.spi.block.BlockUtil.compactOffsets;
@@ -96,7 +96,7 @@ public final class VariableWidthBlock
      */
     public int getRawSliceOffset(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return getPositionOffset(position);
     }
 
@@ -107,7 +107,7 @@ public final class VariableWidthBlock
 
     public int getSliceLength(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return getPositionOffset(position + 1) - getPositionOffset(position);
     }
 
@@ -154,7 +154,7 @@ public final class VariableWidthBlock
 
     public Slice getSlice(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         int offset = offsets[position + arrayOffset];
         int length = offsets[position + 1 + arrayOffset] - offset;
         return slice.slice(offset, length);
@@ -186,7 +186,7 @@ public final class VariableWidthBlock
         if (!mayHaveNull()) {
             return false;
         }
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return valueIsNull[position + arrayOffset];
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariantBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariantBlock.java
@@ -25,7 +25,7 @@ import java.util.function.ObjLongConsumer;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
-import static io.trino.spi.block.BlockUtil.checkReadablePosition;
+import static io.trino.spi.block.BlockUtil.checkValidPosition;
 import static io.trino.spi.block.BlockUtil.checkValidRegion;
 import static io.trino.spi.block.BlockUtil.compactArray;
 import static java.util.Objects.requireNonNull;
@@ -320,7 +320,7 @@ public final class VariantBlock
 
     public Variant getVariant(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         if (isNull(position)) {
             throw new IllegalStateException("Position is null");
         }
@@ -337,7 +337,7 @@ public final class VariantBlock
     @Override
     public VariantBlock getSingleValueBlock(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
 
         Block newMetadata = metadata.getSingleValueBlock(startOffset + position);
         Block newValues = values.getSingleValueBlock(startOffset + position);
@@ -348,7 +348,7 @@ public final class VariantBlock
     @Override
     public long getEstimatedDataSizeForStats(int position)
     {
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
 
         if (isNull(position)) {
             return 0;
@@ -364,7 +364,7 @@ public final class VariantBlock
         if (!mayHaveNull()) {
             return false;
         }
-        checkReadablePosition(this, position);
+        checkValidPosition(position, positionCount);
         return isNull[startOffset + position];
     }
 


### PR DESCRIPTION
## Description
Removes the method and replaces all usages with `BlockUtil.checkValidPosition`, which was always directly called by the former anyway. Removing this extra call avoids an unnecessary virtual call if inlining has not (yet) occurred and reduces inlining depth after inlining.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
