### PR TITLE
Compare candidate return types by signature, not by resolved Type

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.FunctionNullability;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeSignature;
 import io.trino.sql.analyzer.TypeSignatureProvider;
 
 import java.util.ArrayList;
@@ -285,8 +286,8 @@ class FunctionBinder
 
     private boolean returnTypeIsTheSame(List<ApplicableFunction> applicableFunctions)
     {
-        Set<Type> returnTypes = applicableFunctions.stream()
-                .map(function -> typeManager.getType(function.boundSignature().getReturnType()))
+        Set<TypeSignature> returnTypes = applicableFunctions.stream()
+                .map(function -> function.boundSignature().getReturnType())
                 .collect(Collectors.toSet());
         return returnTypes.size() == 1;
     }


### PR DESCRIPTION
When several functions are applicable to a call, `FunctionBinder.returnTypeIsTheSame` deduplicates their return types to decide whether the result type is unambiguous. It did this by resolving each bound return `TypeSignature` to a `Type` through the type manager and collecting the `Type`s into a set.

A bound return type already has a single canonical `TypeSignature`, so two candidates return the same type exactly when their return signatures are equal. Comparing the signatures directly is equivalent and avoids the type-resolution round-trip on a function-resolution hot path.