### PR TITLE
Support non-standard Azure ABFS hosts

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
@@ -94,6 +94,7 @@ public class AzureFileSystem
     private final int maxWriteConcurrency;
     private final long maxSingleUploadSizeBytes;
     private final boolean multipartWriteEnabled;
+    private final boolean allowNonStandardHosts;
 
     public AzureFileSystem(
             HttpClient httpClient,
@@ -106,7 +107,8 @@ public class AzureFileSystem
             DataSize writeBlockSize,
             int maxWriteConcurrency,
             DataSize maxSingleUploadSize,
-            boolean multipartWriteEnabled)
+            boolean multipartWriteEnabled,
+            boolean allowNonStandardHosts)
     {
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.concurrencyPolicy = requireNonNull(concurrencyPolicy, "concurrencyPolicy is null");
@@ -120,6 +122,7 @@ public class AzureFileSystem
         this.maxWriteConcurrency = maxWriteConcurrency;
         this.maxSingleUploadSizeBytes = maxSingleUploadSize.toBytes();
         this.multipartWriteEnabled = multipartWriteEnabled;
+        this.allowNonStandardHosts = allowNonStandardHosts;
     }
 
     @Override
@@ -666,10 +669,38 @@ public class AzureFileSystem
 
     private String validatedEndpoint(AzureLocation location)
     {
-        if (!location.endpoint().equals(endpoint)) {
+        // For non-standard hosts (e.g., Microsoft Fabric OneLake) the endpoint is fully
+        // specified in the URL itself; skip the check against the configured default endpoint.
+        if (!location.isStandardFormat()) {
+            if (!allowNonStandardHosts) {
+                throw new IllegalArgumentException("Location does not match configured Azure endpoint: " + location);
+            }
+            return location.endpoint();
+        }
+        if (!location.endpoint().equals(endpoint) && !allowNonStandardHosts) {
             throw new IllegalArgumentException("Location does not match configured Azure endpoint: " + location);
         }
         return location.endpoint();
+    }
+
+    private String blobServiceUrl(AzureLocation location)
+    {
+        String ep = validatedEndpoint(location);
+        if (location.isStandardFormat()) {
+            return "https://%s.blob.%s".formatted(location.account(), ep);
+        }
+        // Non-standard host (e.g., Microsoft Fabric OneLake): no .blob. infix
+        return "https://%s.%s".formatted(location.account(), ep);
+    }
+
+    private String dfsServiceUrl(AzureLocation location)
+    {
+        String ep = validatedEndpoint(location);
+        if (location.isStandardFormat()) {
+            return "https://%s.dfs.%s".formatted(location.account(), ep);
+        }
+        // Non-standard host (e.g., Microsoft Fabric OneLake): no .dfs. infix
+        return "https://%s.%s".formatted(location.account(), ep);
     }
 
     private BlobClient createBlobClient(AzureLocation location, Optional<EncryptionKey> key)
@@ -685,7 +716,7 @@ public class AzureFileSystem
                 .httpClient(httpClient)
                 .addPolicy(concurrencyPolicy)
                 .clientOptions(new ClientOptions().setTracingOptions(tracingOptions))
-                .endpoint("https://%s.blob.%s".formatted(location.account(), validatedEndpoint(location)));
+                .endpoint(blobServiceUrl(location));
 
         key.ifPresent(encryption -> builder.customerProvidedKey(blobCustomerProvidedKey(encryption)));
 
@@ -702,7 +733,7 @@ public class AzureFileSystem
                 .httpClient(httpClient)
                 .addPolicy(concurrencyPolicy)
                 .clientOptions(new ClientOptions().setTracingOptions(tracingOptions))
-                .endpoint("https://%s.dfs.%s".formatted(location.account(), validatedEndpoint(location)));
+                .endpoint(dfsServiceUrl(location));
         key.ifPresent(encryption -> builder.customerProvidedKey(lakeCustomerProvidedKey(encryption)));
         azureAuth.setAuth(location.account(), builder);
         DataLakeServiceClient client = builder.buildClient();

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemConfig.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemConfig.java
@@ -52,6 +52,7 @@ public class AzureFileSystemConfig
     private Duration httpRequestTimeout = new Duration(10, TimeUnit.MINUTES);
     private String applicationId = "Trino";
     private boolean multipartWriteEnabled;
+    private boolean allowNonStandardHosts;
 
     @NotNull
     public AuthType getAuthType()
@@ -212,6 +213,19 @@ public class AzureFileSystemConfig
     public AzureFileSystemConfig setMultipartWriteEnabled(boolean multipartWriteEnabled)
     {
         this.multipartWriteEnabled = multipartWriteEnabled;
+        return this;
+    }
+
+    public boolean isAllowNonStandardHosts()
+    {
+        return allowNonStandardHosts;
+    }
+
+    @Config("azure.allow-non-standard-hosts")
+    @ConfigDescription("Allow ABFS URIs whose hostname does not contain \".dfs.\", e.g., for Microsoft Fabric OneLake workspaces")
+    public AzureFileSystemConfig setAllowNonStandardHosts(boolean allowNonStandardHosts)
+    {
+        this.allowNonStandardHosts = allowNonStandardHosts;
         return this;
     }
 }

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemFactory.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemFactory.java
@@ -60,6 +60,7 @@ public class AzureFileSystemFactory
     private final ConnectionProvider connectionProvider;
     private final EventLoopGroup eventLoopGroup;
     private final boolean multipart;
+    private final boolean allowNonStandardHosts;
     private final HttpPipelinePolicy concurrencyPolicy;
 
     @Inject
@@ -77,7 +78,8 @@ public class AzureFileSystemFactory
                 config.getConnectionPoolMaxIdleTime(),
                 config.getHttpRequestTimeout(),
                 config.getApplicationId(),
-                config.isMultipartWriteEnabled());
+                config.isMultipartWriteEnabled(),
+                config.isAllowNonStandardHosts());
     }
 
     public AzureFileSystemFactory(
@@ -93,7 +95,8 @@ public class AzureFileSystemFactory
             Duration connectionPoolMaxIdleTime,
             Duration httpRequestTimeout,
             String applicationId,
-            boolean multipart)
+            boolean multipart,
+            boolean allowNonStandardHosts)
     {
         this.auth = requireNonNull(azureAuth, "azureAuth is null");
         this.endpoint = requireNonNull(endpoint, "endpoint is null");
@@ -116,6 +119,7 @@ public class AzureFileSystemFactory
         clientOptions.setMaximumConnectionPoolSize(maxHttpConnections);
         httpClient = createAzureHttpClient(connectionProvider, eventLoopGroup, clientOptions);
         this.multipart = multipart;
+        this.allowNonStandardHosts = allowNonStandardHosts;
         this.concurrencyPolicy = new ConcurrencyLimitHttpPipelinePolicy(
                 maxHttpRequests,
                 httpRequestTimeout.toJavaTime());
@@ -147,7 +151,7 @@ public class AzureFileSystemFactory
     public TrinoFileSystem create(ConnectorIdentity identity)
     {
         AzureAuth effectiveAuth = getEffectiveAuth(identity);
-        return new AzureFileSystem(httpClient, concurrencyPolicy, uploadExecutor, tracingOptions, effectiveAuth, endpoint, readBlockSize, writeBlockSize, maxWriteConcurrency, maxSingleUploadSize, multipart);
+        return new AzureFileSystem(httpClient, concurrencyPolicy, uploadExecutor, tracingOptions, effectiveAuth, endpoint, readBlockSize, writeBlockSize, maxWriteConcurrency, maxSingleUploadSize, multipart, allowNonStandardHosts);
     }
 
     private AzureAuth getEffectiveAuth(ConnectorIdentity identity)

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureLocation.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureLocation.java
@@ -34,6 +34,7 @@ class AzureLocation
     private final String scheme;
     private final String account;
     private final String endpoint;
+    private final boolean standardFormat;
 
     /**
      * Creates a new location based on the endpoint, storage account, container and blob path parsed from the location.
@@ -86,16 +87,25 @@ class AzureLocation
                 this.location);
         this.account = host.substring(0, accountSplit);
 
-        // abfs[s] host must contain ".dfs.", and wasb[s] host must contain ".blob." before endpoint
+        // abfs[s] host must contain ".dfs." (standard Azure), or may use a non-standard host (e.g., Microsoft Fabric OneLake).
+        // wasb[s] host must contain ".blob." before endpoint.
         if (scheme.equals("abfs") || scheme.equals("abfss")) {
-            checkArgument(host.substring(accountSplit).startsWith(".dfs."), invalidLocationMessage, location);
-            // endpoint does not include dfs
-            this.endpoint = host.substring(accountSplit + ".dfs.".length());
+            if (host.substring(accountSplit).startsWith(".dfs.")) {
+                // Standard Azure Data Lake Storage: account.dfs.<endpoint>
+                this.endpoint = host.substring(accountSplit + ".dfs.".length());
+                this.standardFormat = true;
+            }
+            else {
+                // Non-standard host (e.g., Microsoft Fabric OneLake): account.<endpoint>
+                this.endpoint = host.substring(accountSplit + 1);
+                this.standardFormat = false;
+            }
         }
         else {
             checkArgument(host.substring(accountSplit).startsWith(".blob."), invalidLocationMessage, location);
             // endpoint does not include blob
             this.endpoint = host.substring(accountSplit + ".blob.".length());
+            this.standardFormat = true;
         }
         checkArgument(!endpoint.isEmpty(), invalidLocationMessage, location);
 
@@ -125,6 +135,11 @@ class AzureLocation
         return endpoint;
     }
 
+    public boolean isStandardFormat()
+    {
+        return standardFormat;
+    }
+
     public String path()
     {
         return location.path();
@@ -147,7 +162,15 @@ class AzureLocation
 
     public Location baseLocation()
     {
-        return Location.of("%s://%s%s.dfs.%s/".formatted(
+        if (standardFormat) {
+            return Location.of("%s://%s%s.dfs.%s/".formatted(
+                    scheme,
+                    container().map(container -> container + "@").orElse(""),
+                    account(),
+                    endpoint));
+        }
+        // Non-standard host (e.g., Microsoft Fabric OneLake): no .dfs. infix
+        return Location.of("%s://%s%s.%s/".formatted(
                 scheme,
                 container().map(container -> container + "@").orElse(""),
                 account(),

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemConfig.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemConfig.java
@@ -45,7 +45,8 @@ class TestAzureFileSystemConfig
                 .setConnectionPoolMaxIdleTime(new Duration(5, MINUTES))
                 .setHttpRequestTimeout(new Duration(10, MINUTES))
                 .setApplicationId("Trino")
-                .setMultipartWriteEnabled(false));
+                .setMultipartWriteEnabled(false)
+                .setAllowNonStandardHosts(false));
     }
 
     @Test
@@ -64,6 +65,7 @@ class TestAzureFileSystemConfig
                 .put("azure.http-request-timeout", "1m")
                 .put("azure.application-id", "application id")
                 .put("azure.multipart-write-enabled", "true")
+                .put("azure.allow-non-standard-hosts", "true")
                 .buildOrThrow();
 
         AzureFileSystemConfig expected = new AzureFileSystemConfig()
@@ -78,7 +80,8 @@ class TestAzureFileSystemConfig
                 .setConnectionPoolMaxIdleTime(new Duration(1, MINUTES))
                 .setHttpRequestTimeout(new Duration(1, MINUTES))
                 .setApplicationId("application id")
-                .setMultipartWriteEnabled(true);
+                .setMultipartWriteEnabled(true)
+                .setAllowNonStandardHosts(true);
 
         assertFullMapping(properties, expected);
     }

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureLocation.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureLocation.java
@@ -45,12 +45,12 @@ class TestAzureLocation
         assertValid("wasb://container@account.blob.core.usgovcloudapi.net/some/path/file", "account", "container", "some/path/file", "wasb", "core.usgovcloudapi.net");
         assertValid("wasbs://container@account.blob.core.usgovcloudapi.net/some/path/file", "account", "container", "some/path/file", "wasbs", "core.usgovcloudapi.net");
 
-        // abfs[s] host must contain ".dfs.", and wasb[s] host must contain ".blob." before endpoint
-        assertInvalid("abfs://container@account.invalid.core.usgovcloudapi.net/some/path/file");
-        assertInvalid("abfss://container@account.invalid.core.usgovcloudapi.net/some/path/file");
+        // abfs[s] non-standard hosts (no .dfs. after account) are accepted; wasb[s] still requires .blob.
+        assertNonStandard("abfs://container@account.invalid.core.usgovcloudapi.net/some/path/file", "account", "container", "some/path/file", "abfs", "invalid.core.usgovcloudapi.net");
+        assertNonStandard("abfss://container@account.invalid.core.usgovcloudapi.net/some/path/file", "account", "container", "some/path/file", "abfss", "invalid.core.usgovcloudapi.net");
         assertInvalid("wasb://container@account.invalid.core.usgovcloudapi.net/some/path/file");
-        assertInvalid("abfs://container@account.blob.core.usgovcloudapi.net/some/path/file");
-        assertInvalid("abfss://container@account.blob.core.usgovcloudapi.net/some/path/file");
+        assertNonStandard("abfs://container@account.blob.core.usgovcloudapi.net/some/path/file", "account", "container", "some/path/file", "abfs", "blob.core.usgovcloudapi.net");
+        assertNonStandard("abfss://container@account.blob.core.usgovcloudapi.net/some/path/file", "account", "container", "some/path/file", "abfss", "blob.core.usgovcloudapi.net");
         assertInvalid("wasb://container@account.dfs.core.usgovcloudapi.net/some/path/file");
         assertInvalid("wasbs://container@account.dfs.core.usgovcloudapi.net/some/path/file");
 
@@ -79,8 +79,8 @@ class TestAzureLocation
         assertInvalid("abfs://container@ac$count.dfs.core.windows.net/some/path/file");
 
         // host must contain .dfs. after account
-        assertInvalid("abfs://container@account.example.com/some/path/file");
-        assertInvalid("abfs://container@account.fake.dfs.core.windows.net/some/path/file");
+        assertNonStandard("abfs://container@account.example.com/some/path/file", "account", "container", "some/path/file", "abfs", "example.com");
+        assertNonStandard("abfs://container@account.fake.dfs.core.windows.net/some/path/file", "account", "container", "some/path/file", "abfs", "fake.dfs.core.windows.net");
     }
 
     private static void assertValid(String uri, String expectedAccount, String expectedContainer, String expectedPath, String expectedScheme, String expectedEndpoint)
@@ -93,6 +93,19 @@ class TestAzureLocation
         assertThat(azureLocation.container()).isEqualTo(Optional.ofNullable(expectedContainer));
         assertThat(azureLocation.path()).contains(expectedPath);
         assertThat(azureLocation.baseLocation().scheme()).isEqualTo(Optional.of(expectedScheme));
+    }
+
+    private static void assertNonStandard(String uri, String expectedAccount, String expectedContainer, String expectedPath, String expectedScheme, String expectedEndpoint)
+    {
+        Location location = Location.of(uri);
+        AzureLocation azureLocation = new AzureLocation(location);
+        assertThat(azureLocation.location()).isEqualTo(location);
+        assertThat(azureLocation.account()).isEqualTo(expectedAccount);
+        assertThat(azureLocation.endpoint()).isEqualTo(expectedEndpoint);
+        assertThat(azureLocation.container()).isEqualTo(Optional.ofNullable(expectedContainer));
+        assertThat(azureLocation.path()).contains(expectedPath);
+        assertThat(azureLocation.baseLocation().scheme()).isEqualTo(Optional.of(expectedScheme));
+        assertThat(azureLocation.isStandardFormat()).isFalse();
     }
 
     private static void assertInvalid(String uri)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Add an opt-in config property azure.allow-non-standard-hosts (default false) that allows ABFS URIs whose hostname does not follow the standard account.dfs.<endpoint> pattern, e.g. Microsoft Fabric OneLake workspaces.

When enabled:
- AzureLocation accepts non-standard abfs/abfss hosts (standardFormat=false) and extracts the full host suffix as the endpoint
- AzureFileSystem skips the configured-endpoint equality check for such locations
- blobServiceUrl/dfsServiceUrl omit the .blob./.dfs. infixes for non-standard hosts so the correct service URL is reconstructed from the original hostname
- baseLocation() likewise omits the .dfs. infix for non-standard hosts

wasb/wasbs URIs are unaffected and still require .blob. in the hostname.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Microsoft Fabric is Microsoft's big data platform. Its underlying storage is also ADLS Gen2, but uses another domain which differs from the hardcoded one in the ADLS FS provider here.

Fabric does not provide Hive Metastore, so I use its Iceberg compatibility layer. The location property in the metadata of a lakehouse looks like:
`"location": "abfs://544e....c045@544e....c045.z54.onelake.fabric.microsoft.com/2355....e400/Tables/dbo/some_test_table",`

It's neither *.blob.* nor *.dfs.*, and thus such exception is thrown (even I have configured azure.endpoint in properties file):
```
2026-06-09T01:55:35.916Z        DEBUG   stage-scheduler io.trino.execution.QueryStateMachine    Query 20260609_015523_00000_2uv9h failed
java.util.concurrent.CompletionException: io.trino.spi.TrinoException: Error processing metadata for table dbo.*****
        at java.base/java.util.concurrent.CompletableFuture.wrapInCompletionException(CompletableFuture.java:323)
        at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:359)
        at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:364)
        at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:1015)
        at java.base/java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(CompletableFuture.java:995)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:531)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2221)
        at io.airlift.concurrent.MoreFutures$2.onFailure(MoreFutures.java:495)
        at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1111)
        at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:30)
        at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1021)
        at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:784)
        at com.google.common.util.concurrent.AbstractFuture.setException(AbstractFuture.java:533)
        at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.afterRanInterruptiblyFailure(TrustedListenableFutureTask.java:138)
        at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:89)
        at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
        at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: io.trino.spi.TrinoException: Error processing metadata for table dbo.*****
        at io.trino.plugin.iceberg.IcebergExceptions.translateMetadataException(IcebergExceptions.java:54)
        at io.trino.plugin.iceberg.IcebergSplitSource.lambda$getNextBatch$2(IcebergSplitSource.java:270)
        at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:1011)
        ... 15 more
Caused by: java.lang.IllegalArgumentException: Location does not match configured Azure endpoint: abfs://***@***.z54.onelake.fabric.microsoft.com/***/Tables/dbo/***/metadata/***.avro
        at io.trino.filesystem.azure.AzureFileSystem.validatedEndpoint(AzureFileSystem.java:676)
        at io.trino.filesystem.azure.AzureFileSystem.blobServiceUrl(AzureFileSystem.java:688)
        at io.trino.filesystem.azure.AzureFileSystem.createBlobContainerClient(AzureFileSystem.java:719)
        at io.trino.filesystem.azure.AzureFileSystem.createBlobClient(AzureFileSystem.java:708)
        at io.trino.filesystem.azure.AzureFileSystem.newInputFile(AzureFileSystem.java:148)
        at io.trino.filesystem.switching.SwitchingFileSystem.newInputFile(SwitchingFileSystem.java:66)
        at io.trino.filesystem.tracing.TracingFileSystem.newInputFile(TracingFileSystem.java:57)
        at io.trino.filesystem.cache.CacheFileSystem.newInputFile(CacheFileSystem.java:64)
        at io.trino.plugin.iceberg.fileio.ForwardingFileIo.newInputFile(ForwardingFileIo.java:85)
        at org.apache.iceberg.io.FileIO.newInputFile(FileIO.java:70)
        at io.trino.plugin.iceberg.fileio.ForwardingFileIo.newInputFile(ForwardingFileIo.java:137)
        at org.apache.iceberg.ManifestFiles.newInputFile(ManifestFiles.java:424)
        at org.apache.iceberg.ManifestFiles.read(ManifestFiles.java:131)
        at org.apache.iceberg.ManifestGroup$1.iterator(ManifestGroup.java:311)
        at org.apache.iceberg.io.CloseableIterable$ConcatCloseableIterable$ConcatCloseableIterator.hasNext(CloseableIterable.java:274)
        at io.trino.plugin.iceberg.IcebergSplitSource.getNextBatchInternal(IcebergSplitSource.java:321)
        at io.trino.plugin.iceberg.IcebergSplitSource.lambda$getNextBatch$1(IcebergSplitSource.java:265)
        at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)
        at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
        ... 4 more
```

So I added a switch azure.allow-non-standard-hosts to bypass this hardcoded validation.
Now with this switch set to true, the query can be executed well against Iceberg from Fabric.
```
trino> SELECT * FROM fabric.dbo.*****LIMIT 10;
  dateid  |    date    | datecode | fiscalperiodcode | yearno | yearfirstdate | yearlastdate | monthno | monthfirstdate>
----------+------------+----------+------------------+--------+---------------+--------------+---------+--------------->
        0 | 1900-01-01 |       -1 |               -1 |     -1 | 1900-01-01    | 1900-01-01   |      -1 | 1900-01-01    >
 20040201 | 2004-02-01 | 20040201 |                0 |   2004 | 2004-01-01    | 2004-12-31   |       2 | 2004-02-01    >
 20040202 | 2004-02-02 | 20040202 |                0 |   2004 | 2004-01-01    | 2004-12-31   |       2 | 2004-02-01    >
 20040203 | 2004-02-03 | 20040203 |                0 |   2004 | 2004-01-01    | 2004-12-31   |       2 | 2004-02-01    >
 20040204 | 2004-02-04 | 20040204 |                0 |   2004 | 2004-01-01    | 2004-12-31   |       2 | 2004-02-01    >
 20040205 | 2004-02-05 | 20040205 |                0 |   2004 | 2004-01-01    | 2004-12-31   |       2 | 2004-02-01    >
 20040206 | 2004-02-06 | 20040206 |                0 |   2004 | 2004-01-01    | 2004-12-31   |       2 | 2004-02-01    >
 20040207 | 2004-02-07 | 20040207 |                0 |   2004 | 2004-01-01    | 2004-12-31   |       2 | 2004-02-01    >
 20040208 | 2004-02-08 | 20040208 |                0 |   2004 | 2004-01-01    | 2004-12-31   |       2 | 2004-02-01    >
 20040209 | 2004-02-09 | 20040209 |                0 |   2004 | 2004-01-01    | 2004-12-31   |       2 | 2004-02-01    >
(10 rows)

Query 20260609_015659_00000_qnwn4, FINISHED, 1 node
Splits: 10 total, 10 done (100.00%)
13.48 [15 rows, 656KiB] [1 rows/s, 48.7KiB/s]
```

If not set, the usual validation is still in effect.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(*) Release notes are required, with the following suggested text:

```markdown
## File System
* Add support for non-standard hostname on ADFS Gen2 filesystem provider
```
