### PR TITLE
Name type-variable and numeric-variable construction in function signatures

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/GlobalFunctionCatalog.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/GlobalFunctionCatalog.java
@@ -42,7 +42,6 @@ import io.trino.spi.function.WindowFunctionSupplier;
 import io.trino.spi.function.table.ConnectorTableFunctionHandle;
 import io.trino.spi.function.table.TableFunctionProcessorProvider;
 import io.trino.spi.type.TypeManager;
-import io.trino.spi.type.TypeSignature;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -64,6 +63,7 @@ import static io.trino.spi.function.FunctionKind.AGGREGATE;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
@@ -120,7 +120,7 @@ public class GlobalFunctionCatalog
         // so we only these exact signatures to be registered.  Since, only a single function with
         // a specific signature can be registered, it prevents others from being registered.
         Signature.Builder expectedSignature = Signature.builder()
-                .argumentTypes(Collections.nCopies(operatorType.getArgumentCount(), new TypeSignature("T")));
+                .argumentTypes(Collections.nCopies(operatorType.getArgumentCount(), typeVariable("T")));
 
         switch (operatorType) {
             case EQUAL, IDENTICAL, INDETERMINATE -> {

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ReduceAggregationFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ReduceAggregationFunction.java
@@ -34,7 +34,6 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.lambda.BinaryFunctionInterface;
 
 import java.lang.invoke.MethodHandle;
@@ -43,6 +42,7 @@ import static io.trino.operator.aggregation.AggregationFunctionAdapter.Aggregati
 import static io.trino.operator.aggregation.AggregationFunctionAdapter.AggregationParameterKind.STATE;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.TypeSignature.functionType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.util.Reflection.methodHandle;
 import static java.lang.String.format;
 
@@ -79,16 +79,16 @@ public class ReduceAggregationFunction
                         .signature(Signature.builder()
                                 .typeVariable("T")
                                 .typeVariable("S")
-                                .returnType(new TypeSignature("S"))
-                                .argumentType(new TypeSignature("T"))
-                                .argumentType(new TypeSignature("S"))
-                                .argumentType(functionType(new TypeSignature("S"), new TypeSignature("T"), new TypeSignature("S")))
-                                .argumentType(functionType(new TypeSignature("S"), new TypeSignature("S"), new TypeSignature("S")))
+                                .returnType(typeVariable("S"))
+                                .argumentType(typeVariable("T"))
+                                .argumentType(typeVariable("S"))
+                                .argumentType(functionType(typeVariable("S"), typeVariable("T"), typeVariable("S")))
+                                .argumentType(functionType(typeVariable("S"), typeVariable("S"), typeVariable("S")))
                                 .build())
                         .description("Reduce input elements into a single value")
                         .build(),
                 AggregationFunctionMetadata.builder()
-                        .intermediateType(new TypeSignature("S"))
+                        .intermediateType(typeVariable("S"))
                         .build());
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/AbstractGreatestLeast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/AbstractGreatestLeast.java
@@ -31,7 +31,6 @@ import io.trino.spi.function.FunctionDependencyDeclaration;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.CallSiteBinder;
 
 import java.lang.invoke.MethodHandle;
@@ -58,6 +57,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.sql.gen.Bootstrap.BOOTSTRAP_METHOD;
 import static io.trino.util.CompilerUtils.defineClass;
 import static io.trino.util.CompilerUtils.makeClassName;
@@ -79,8 +79,8 @@ public abstract class AbstractGreatestLeast
         super(FunctionMetadata.scalarBuilder(min ? "least" : "greatest")
                 .signature(Signature.builder()
                         .orderableTypeParameter("E")
-                        .returnType(new TypeSignature("E"))
-                        .argumentType(new TypeSignature("E"))
+                        .returnType(typeVariable("E"))
+                        .argumentType(typeVariable("E"))
                         .variableArity()
                         .build())
                 .nullable()
@@ -94,7 +94,7 @@ public abstract class AbstractGreatestLeast
     @Override
     public FunctionDependencyDeclaration getFunctionDependencies()
     {
-        return getMinMaxCompareFunctionDependencies(new TypeSignature("E"), min);
+        return getMinMaxCompareFunctionDependencies(typeVariable("E"), min);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ApplyFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ApplyFunction.java
@@ -21,7 +21,6 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.lambda.UnaryFunctionInterface;
 
 import java.lang.invoke.MethodHandle;
@@ -31,6 +30,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.FUNCTION;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.type.TypeSignature.functionType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.util.Reflection.methodHandle;
 
 /**
@@ -49,9 +49,9 @@ public final class ApplyFunction
                 .signature(Signature.builder()
                         .typeVariable("T")
                         .typeVariable("U")
-                        .returnType(new TypeSignature("U"))
-                        .argumentType(new TypeSignature("T"))
-                        .argumentType(functionType(new TypeSignature("T"), new TypeSignature("U")))
+                        .returnType(typeVariable("U"))
+                        .argumentType(typeVariable("T"))
+                        .argumentType(functionType(typeVariable("T"), typeVariable("U")))
                         .build())
                 .nullable()
                 .argumentNullability(true, false)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayConcatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayConcatFunction.java
@@ -22,7 +22,6 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.ArrayType;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.VarArgsToArrayAdapterGenerator;
 
 import java.lang.invoke.MethodHandle;
@@ -33,6 +32,7 @@ import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.TypeSignature.arrayType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.sql.gen.VarArgsToArrayAdapterGenerator.generateVarArgsToArrayAdapter;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.lang.invoke.MethodType.methodType;
@@ -65,8 +65,8 @@ public final class ArrayConcatFunction
         super(FunctionMetadata.scalarBuilder(FUNCTION_NAME)
                 .signature(Signature.builder()
                         .typeVariable("E")
-                        .returnType(arrayType(new TypeSignature("E")))
-                        .argumentType(arrayType(new TypeSignature("E")))
+                        .returnType(arrayType(typeVariable("E")))
+                        .argumentType(arrayType(typeVariable("E")))
                         .variableArity()
                         .build())
                 .description(DESCRIPTION)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayFlattenFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayFlattenFunction.java
@@ -22,13 +22,13 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.TypeSignature.arrayType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.util.Reflection.methodHandle;
 import static java.lang.Math.toIntExact;
 
@@ -44,8 +44,8 @@ public class ArrayFlattenFunction
         super(FunctionMetadata.scalarBuilder(FUNCTION_NAME)
                 .signature(Signature.builder()
                         .typeVariable("E")
-                        .returnType(arrayType(new TypeSignature("E")))
-                        .argumentType(arrayType(arrayType(new TypeSignature("E"))))
+                        .returnType(arrayType(typeVariable("E")))
+                        .argumentType(arrayType(arrayType(typeVariable("E"))))
                         .build())
                 .description("Flattens the given array")
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayReduceFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayReduceFunction.java
@@ -22,7 +22,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.lambda.BinaryFunctionInterface;
 import io.trino.sql.gen.lambda.UnaryFunctionInterface;
 
@@ -35,6 +34,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.spi.type.TypeSignature.functionType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.util.Reflection.methodHandle;
 
@@ -52,11 +52,11 @@ public final class ArrayReduceFunction
                         .typeVariable("T")
                         .typeVariable("S")
                         .typeVariable("R")
-                        .returnType(new TypeSignature("R"))
-                        .argumentType(arrayType(new TypeSignature("T")))
-                        .argumentType(new TypeSignature("S"))
-                        .argumentType(functionType(new TypeSignature("S"), new TypeSignature("T"), new TypeSignature("S")))
-                        .argumentType(functionType(new TypeSignature("S"), new TypeSignature("R")))
+                        .returnType(typeVariable("R"))
+                        .argumentType(arrayType(typeVariable("T")))
+                        .argumentType(typeVariable("S"))
+                        .argumentType(functionType(typeVariable("S"), typeVariable("T"), typeVariable("S")))
+                        .argumentType(functionType(typeVariable("S"), typeVariable("R")))
                         .build())
                 .nullable()
                 .argumentNullability(false, true, false, false)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArraySubscriptOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArraySubscriptOperator.java
@@ -23,7 +23,6 @@ import io.trino.spi.function.FunctionDependencyDeclaration;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
@@ -37,6 +36,7 @@ import static io.trino.spi.function.OperatorType.READ_VALUE;
 import static io.trino.spi.function.OperatorType.SUBSCRIPT;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.TypeSignature.arrayType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.lang.invoke.MethodHandles.collectArguments;
@@ -70,8 +70,8 @@ public class ArraySubscriptOperator
         super(FunctionMetadata.operatorBuilder(SUBSCRIPT)
                 .signature(Signature.builder()
                         .typeVariable("E")
-                        .returnType(new TypeSignature("E"))
-                        .argumentType(arrayType(new TypeSignature("E")))
+                        .returnType(typeVariable("E"))
+                        .argumentType(arrayType(typeVariable("E")))
                         .argumentType(BIGINT)
                         .build())
                 .nullable()
@@ -82,7 +82,7 @@ public class ArraySubscriptOperator
     public FunctionDependencyDeclaration getFunctionDependencies()
     {
         return FunctionDependencyDeclaration.builder()
-                .addOperatorSignature(READ_VALUE, ImmutableList.of(new TypeSignature("E")))
+                .addOperatorSignature(READ_VALUE, ImmutableList.of(typeVariable("E")))
                 .build();
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayToElementConcatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayToElementConcatFunction.java
@@ -21,13 +21,13 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.TypeSignature.arrayType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.util.Reflection.methodHandle;
 
 public class ArrayToElementConcatFunction
@@ -47,9 +47,9 @@ public class ArrayToElementConcatFunction
         super(FunctionMetadata.scalarBuilder(FUNCTION_NAME)
                 .signature(Signature.builder()
                         .typeVariable("E")
-                        .returnType(arrayType(new TypeSignature("E")))
-                        .argumentType(arrayType(new TypeSignature("E")))
-                        .argumentType(new TypeSignature("E"))
+                        .returnType(arrayType(typeVariable("E")))
+                        .argumentType(arrayType(typeVariable("E")))
+                        .argumentType(typeVariable("E"))
                         .build())
                 .description("Concatenates an array to an element")
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayToJsonCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayToJsonCast.java
@@ -25,7 +25,6 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.ArrayType;
-import io.trino.spi.type.TypeSignature;
 import io.trino.util.JsonUtil.JsonGeneratorWriter;
 
 import java.io.IOException;
@@ -36,6 +35,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.TypeSignature.arrayType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.type.JsonType.JSON;
 import static io.trino.util.Failures.checkCondition;
 import static io.trino.util.JsonUtil.canCastToJson;
@@ -58,7 +58,7 @@ public class ArrayToJsonCast
                 .signature(Signature.builder()
                         .castableToTypeParameter("T", JSON.getTypeSignature())
                         .returnType(JSON)
-                        .argumentType(arrayType(new TypeSignature("T")))
+                        .argumentType(arrayType(typeVariable("T")))
                         .build())
                 .build());
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayToVariantCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayToVariantCast.java
@@ -20,7 +20,6 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.ArrayType;
-import io.trino.spi.type.TypeSignature;
 import io.trino.spi.variant.Variant;
 import io.trino.util.variant.VariantWriter;
 
@@ -32,6 +31,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.TypeSignature.arrayType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.VariantType.VARIANT;
 import static io.trino.util.Failures.checkCondition;
 import static io.trino.util.variant.VariantUtil.canCastToVariant;
@@ -59,7 +59,7 @@ public class ArrayToVariantCast
                 .signature(Signature.builder()
                         .castableToTypeParameter("T", VARIANT.getTypeSignature())
                         .returnType(VARIANT)
-                        .argumentType(arrayType(new TypeSignature("T")))
+                        .argumentType(arrayType(typeVariable("T")))
                         .build())
                 .build());
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayTransformFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayTransformFunction.java
@@ -36,7 +36,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.CallSiteBinder;
 import io.trino.sql.gen.lambda.UnaryFunctionInterface;
 
@@ -62,6 +61,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.spi.type.TypeSignature.functionType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.sql.gen.LambdaMetafactoryGenerator.generateMetafactory;
 import static io.trino.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static io.trino.type.UnknownType.UNKNOWN;
@@ -92,9 +92,9 @@ public final class ArrayTransformFunction
                 .signature(Signature.builder()
                         .typeVariable("T")
                         .typeVariable("U")
-                        .returnType(arrayType(new TypeSignature("U")))
-                        .argumentType(arrayType(new TypeSignature("T")))
-                        .argumentType(functionType(new TypeSignature("T"), new TypeSignature("U")))
+                        .returnType(arrayType(typeVariable("U")))
+                        .argumentType(arrayType(typeVariable("T")))
+                        .argumentType(functionType(typeVariable("T"), typeVariable("U")))
                         .build())
                 .description("Apply lambda to each element of the array")
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/CastFromUnknownOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/CastFromUnknownOperator.java
@@ -20,13 +20,13 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.CAST;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.type.UnknownType.UNKNOWN;
 import static io.trino.util.Reflection.methodHandle;
 
@@ -41,7 +41,7 @@ public final class CastFromUnknownOperator
         super(FunctionMetadata.operatorBuilder(CAST)
                 .signature(Signature.builder()
                         .typeVariable("E")
-                        .returnType(new TypeSignature("E"))
+                        .returnType(typeVariable("E"))
                         .argumentType(UNKNOWN)
                         .build())
                 .neverFails()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ElementToArrayConcatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ElementToArrayConcatFunction.java
@@ -21,13 +21,13 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.TypeSignature.arrayType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.util.Reflection.methodHandle;
 
 public class ElementToArrayConcatFunction
@@ -47,9 +47,9 @@ public class ElementToArrayConcatFunction
         super(FunctionMetadata.scalarBuilder(FUNCTION_NAME)
                 .signature(Signature.builder()
                         .typeVariable("E")
-                        .returnType(arrayType(new TypeSignature("E")))
-                        .argumentType(new TypeSignature("E"))
-                        .argumentType(arrayType(new TypeSignature("E")))
+                        .returnType(arrayType(typeVariable("E")))
+                        .argumentType(typeVariable("E"))
+                        .argumentType(arrayType(typeVariable("E")))
                         .build())
                 .description("Concatenates an element to an array")
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/FormatFunction.java
@@ -36,7 +36,6 @@ import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.VarcharType;
 
 import java.lang.invoke.MethodHandle;
@@ -65,6 +64,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.Timestamps.roundDiv;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.type.DateTimes.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.type.DateTimes.toLocalDateTime;
@@ -91,7 +91,7 @@ public final class FormatFunction
                 .signature(Signature.builder()
                         .rowTypeParameter("T")
                         .argumentType(VARCHAR.getTypeSignature())
-                        .argumentType(new TypeSignature("T"))
+                        .argumentType(typeVariable("T"))
                         .returnType(VARCHAR.getTypeSignature())
                         .build())
                 .hidden()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedFirstOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedFirstOperator.java
@@ -20,12 +20,12 @@ import io.trino.spi.function.ScalarFunctionImplementation;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_FIRST;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static java.util.Objects.requireNonNull;
 
 public class GenericComparisonUnorderedFirstOperator
@@ -39,8 +39,8 @@ public class GenericComparisonUnorderedFirstOperator
                 .signature(Signature.builder()
                         .orderableTypeParameter("T")
                         .returnType(INTEGER)
-                        .argumentType(new TypeSignature("T"))
-                        .argumentType(new TypeSignature("T"))
+                        .argumentType(typeVariable("T"))
+                        .argumentType(typeVariable("T"))
                         .build())
                 .neverFails()
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedLastOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedLastOperator.java
@@ -20,12 +20,12 @@ import io.trino.spi.function.ScalarFunctionImplementation;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static java.util.Objects.requireNonNull;
 
 public class GenericComparisonUnorderedLastOperator
@@ -39,8 +39,8 @@ public class GenericComparisonUnorderedLastOperator
                 .signature(Signature.builder()
                         .orderableTypeParameter("T")
                         .returnType(INTEGER)
-                        .argumentType(new TypeSignature("T"))
-                        .argumentType(new TypeSignature("T"))
+                        .argumentType(typeVariable("T"))
+                        .argumentType(typeVariable("T"))
                         .build())
                 .neverFails()
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericEqualOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericEqualOperator.java
@@ -20,12 +20,12 @@ import io.trino.spi.function.ScalarFunctionImplementation;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static java.util.Objects.requireNonNull;
 
 public class GenericEqualOperator
@@ -39,8 +39,8 @@ public class GenericEqualOperator
                 .signature(Signature.builder()
                         .comparableTypeParameter("T")
                         .returnType(BOOLEAN)
-                        .argumentType(new TypeSignature("T"))
-                        .argumentType(new TypeSignature("T"))
+                        .argumentType(typeVariable("T"))
+                        .argumentType(typeVariable("T"))
                         .build())
                 .nullable()
                 .neverFails()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericHashCodeOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericHashCodeOperator.java
@@ -20,12 +20,12 @@ import io.trino.spi.function.ScalarFunctionImplementation;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static java.util.Objects.requireNonNull;
 
 public class GenericHashCodeOperator
@@ -39,7 +39,7 @@ public class GenericHashCodeOperator
                 .signature(Signature.builder()
                         .comparableTypeParameter("T")
                         .returnType(BIGINT)
-                        .argumentType(new TypeSignature("T"))
+                        .argumentType(typeVariable("T"))
                         .build())
                 .neverFails()
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericIdenticalOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericIdenticalOperator.java
@@ -20,12 +20,12 @@ import io.trino.spi.function.ScalarFunctionImplementation;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.OperatorType.IDENTICAL;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static java.util.Objects.requireNonNull;
 
 public class GenericIdenticalOperator
@@ -39,8 +39,8 @@ public class GenericIdenticalOperator
                 .signature(Signature.builder()
                         .comparableTypeParameter("T")
                         .returnType(BOOLEAN)
-                        .argumentType(new TypeSignature("T"))
-                        .argumentType(new TypeSignature("T"))
+                        .argumentType(typeVariable("T"))
+                        .argumentType(typeVariable("T"))
                         .build())
                 .argumentNullability(true, true)
                 .neverFails()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericIndeterminateOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericIndeterminateOperator.java
@@ -20,12 +20,12 @@ import io.trino.spi.function.ScalarFunctionImplementation;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.OperatorType.INDETERMINATE;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static java.util.Objects.requireNonNull;
 
 public class GenericIndeterminateOperator
@@ -39,7 +39,7 @@ public class GenericIndeterminateOperator
                 .signature(Signature.builder()
                         .comparableTypeParameter("T")
                         .returnType(BOOLEAN)
-                        .argumentType(new TypeSignature("T"))
+                        .argumentType(typeVariable("T"))
                         .build())
                 .argumentNullability(true)
                 .neverFails()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOperator.java
@@ -20,12 +20,12 @@ import io.trino.spi.function.ScalarFunctionImplementation;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static java.util.Objects.requireNonNull;
 
 public class GenericLessThanOperator
@@ -39,8 +39,8 @@ public class GenericLessThanOperator
                 .signature(Signature.builder()
                         .orderableTypeParameter("T")
                         .returnType(BOOLEAN)
-                        .argumentType(new TypeSignature("T"))
-                        .argumentType(new TypeSignature("T"))
+                        .argumentType(typeVariable("T"))
+                        .argumentType(typeVariable("T"))
                         .build())
                 .neverFails()
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOrEqualOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOrEqualOperator.java
@@ -20,12 +20,12 @@ import io.trino.spi.function.ScalarFunctionImplementation;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static java.util.Objects.requireNonNull;
 
 public class GenericLessThanOrEqualOperator
@@ -39,8 +39,8 @@ public class GenericLessThanOrEqualOperator
                 .signature(Signature.builder()
                         .orderableTypeParameter("T")
                         .returnType(BOOLEAN)
-                        .argumentType(new TypeSignature("T"))
-                        .argumentType(new TypeSignature("T"))
+                        .argumentType(typeVariable("T"))
+                        .argumentType(typeVariable("T"))
                         .build())
                 .neverFails()
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericReadValueOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericReadValueOperator.java
@@ -20,11 +20,11 @@ import io.trino.spi.function.ScalarFunctionImplementation;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static java.util.Objects.requireNonNull;
 
 public class GenericReadValueOperator
@@ -37,8 +37,8 @@ public class GenericReadValueOperator
         super(FunctionMetadata.operatorBuilder(READ_VALUE)
                 .signature(Signature.builder()
                         .typeVariable("T")
-                        .returnType(new TypeSignature("T"))
-                        .argumentType(new TypeSignature("T"))
+                        .returnType(typeVariable("T"))
+                        .argumentType(typeVariable("T"))
                         .build())
                 .neverFails()
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericXxHash64Operator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericXxHash64Operator.java
@@ -20,12 +20,12 @@ import io.trino.spi.function.ScalarFunctionImplementation;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static java.util.Objects.requireNonNull;
 
 public class GenericXxHash64Operator
@@ -39,7 +39,7 @@ public class GenericXxHash64Operator
                 .signature(Signature.builder()
                         .comparableTypeParameter("T")
                         .returnType(BIGINT)
-                        .argumentType(new TypeSignature("T"))
+                        .argumentType(typeVariable("T"))
                         .build())
                 .neverFails()
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/IdentityCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/IdentityCast.java
@@ -19,7 +19,6 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -27,6 +26,7 @@ import java.lang.invoke.MethodHandles;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.CAST;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 
 public class IdentityCast
         extends SqlScalarFunction
@@ -38,8 +38,8 @@ public class IdentityCast
         super(FunctionMetadata.operatorBuilder(CAST)
                 .signature(Signature.builder()
                         .typeVariable("T")
-                        .returnType(new TypeSignature("T"))
-                        .argumentType(new TypeSignature("T"))
+                        .returnType(typeVariable("T"))
+                        .argumentType(typeVariable("T"))
                         .build())
                 .neverFails()
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/InvokeFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/InvokeFunction.java
@@ -20,7 +20,6 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.lambda.LambdaFunctionInterface;
 
 import java.lang.invoke.MethodHandle;
@@ -29,6 +28,7 @@ import java.util.Optional;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.FUNCTION;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.type.TypeSignature.functionType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.util.Reflection.methodHandle;
 
 /**
@@ -46,8 +46,8 @@ public final class InvokeFunction
         super(FunctionMetadata.scalarBuilder("invoke")
                 .signature(Signature.builder()
                         .typeVariable("T")
-                        .returnType(new TypeSignature("T"))
-                        .argumentType(functionType(new TypeSignature("T")))
+                        .returnType(typeVariable("T"))
+                        .argumentType(functionType(typeVariable("T")))
                         .build())
                 .nullable()
                 .hidden()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringArrayExtractScalar.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringArrayExtractScalar.java
@@ -41,7 +41,7 @@ import static com.fasterxml.jackson.core.JsonToken.START_ARRAY;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
-import static io.trino.spi.type.TypeParameter.typeVariable;
+import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.util.JsonUtil.createJsonFactory;
@@ -64,7 +64,7 @@ public final class JsonStringArrayExtractScalar
     {
         super(FunctionMetadata.scalarBuilder(JSON_STRING_ARRAY_EXTRACT_SCALAR_NAME)
                 .signature(Signature.builder()
-                        .argumentType(new TypeSignature("varchar", typeVariable("N")))
+                        .argumentType(new TypeSignature("varchar", numericVariable("N")))
                         .longVariable("N")
                         .argumentType(new TypeSignature(JsonPathType.NAME))
                         .returnType(arrayType(VARCHAR.getTypeSignature()))

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToArrayCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToArrayCast.java
@@ -22,6 +22,7 @@ import io.trino.spi.type.TypeSignature;
 import static io.trino.operator.scalar.JsonToArrayCast.JSON_TO_ARRAY;
 import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeSignature.arrayType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 
 public final class JsonStringToArrayCast
         extends SqlScalarFunction
@@ -35,7 +36,7 @@ public final class JsonStringToArrayCast
                 .signature(Signature.builder()
                         .typeVariable("T")
                         .longVariable("N")
-                        .returnType(arrayType(new TypeSignature("T")))
+                        .returnType(arrayType(typeVariable("T")))
                         .argumentType(new TypeSignature("varchar", numericVariable("N")))
                         .build())
                 .nullable()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToArrayCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToArrayCast.java
@@ -20,7 +20,7 @@ import io.trino.spi.function.Signature;
 import io.trino.spi.type.TypeSignature;
 
 import static io.trino.operator.scalar.JsonToArrayCast.JSON_TO_ARRAY;
-import static io.trino.spi.type.TypeParameter.typeVariable;
+import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeSignature.arrayType;
 
 public final class JsonStringToArrayCast
@@ -36,7 +36,7 @@ public final class JsonStringToArrayCast
                         .typeVariable("T")
                         .longVariable("N")
                         .returnType(arrayType(new TypeSignature("T")))
-                        .argumentType(new TypeSignature("varchar", typeVariable("N")))
+                        .argumentType(new TypeSignature("varchar", numericVariable("N")))
                         .build())
                 .nullable()
                 .hidden()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToMapCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToMapCast.java
@@ -20,7 +20,7 @@ import io.trino.spi.function.Signature;
 import io.trino.spi.type.TypeSignature;
 
 import static io.trino.operator.scalar.JsonToMapCast.JSON_TO_MAP;
-import static io.trino.spi.type.TypeParameter.typeVariable;
+import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeSignature.mapType;
 
 public final class JsonStringToMapCast
@@ -37,7 +37,7 @@ public final class JsonStringToMapCast
                         .typeVariable("V")
                         .longVariable("N")
                         .returnType(mapType(new TypeSignature("K"), new TypeSignature("V")))
-                        .argumentType(new TypeSignature("varchar", typeVariable("N")))
+                        .argumentType(new TypeSignature("varchar", numericVariable("N")))
                         .build())
                 .nullable()
                 .hidden()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToMapCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToMapCast.java
@@ -22,6 +22,7 @@ import io.trino.spi.type.TypeSignature;
 import static io.trino.operator.scalar.JsonToMapCast.JSON_TO_MAP;
 import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 
 public final class JsonStringToMapCast
         extends SqlScalarFunction
@@ -36,7 +37,7 @@ public final class JsonStringToMapCast
                         .comparableTypeParameter("K")
                         .typeVariable("V")
                         .longVariable("N")
-                        .returnType(mapType(new TypeSignature("K"), new TypeSignature("V")))
+                        .returnType(mapType(typeVariable("K"), typeVariable("V")))
                         .argumentType(new TypeSignature("varchar", numericVariable("N")))
                         .build())
                 .nullable()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToRowCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToRowCast.java
@@ -21,6 +21,7 @@ import io.trino.spi.type.TypeSignature;
 
 import static io.trino.operator.scalar.JsonToRowCast.JSON_TO_ROW;
 import static io.trino.spi.type.TypeParameter.numericVariable;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 
 public final class JsonStringToRowCast
         extends SqlScalarFunction
@@ -34,7 +35,7 @@ public final class JsonStringToRowCast
                 .signature(Signature.builder()
                         .longVariable("N")
                         .rowTypeParameter("T")
-                        .returnType(new TypeSignature("T"))
+                        .returnType(typeVariable("T"))
                         .argumentType(new TypeSignature("varchar", numericVariable("N")))
                         .build())
                 .nullable()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToRowCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToRowCast.java
@@ -20,7 +20,7 @@ import io.trino.spi.function.Signature;
 import io.trino.spi.type.TypeSignature;
 
 import static io.trino.operator.scalar.JsonToRowCast.JSON_TO_ROW;
-import static io.trino.spi.type.TypeParameter.typeVariable;
+import static io.trino.spi.type.TypeParameter.numericVariable;
 
 public final class JsonStringToRowCast
         extends SqlScalarFunction
@@ -35,7 +35,7 @@ public final class JsonStringToRowCast
                         .longVariable("N")
                         .rowTypeParameter("T")
                         .returnType(new TypeSignature("T"))
-                        .argumentType(new TypeSignature("varchar", typeVariable("N")))
+                        .argumentType(new TypeSignature("varchar", numericVariable("N")))
                         .build())
                 .nullable()
                 .hidden()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonToArrayCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonToArrayCast.java
@@ -27,7 +27,6 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.ArrayType;
-import io.trino.spi.type.TypeSignature;
 import io.trino.util.JsonCastException;
 import io.trino.util.JsonUtil.BlockBuilderAppender;
 
@@ -39,6 +38,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.TypeSignature.arrayType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.type.JsonType.JSON;
 import static io.trino.util.Failures.checkCondition;
 import static io.trino.util.JsonUtil.canCastFromJson;
@@ -61,7 +61,7 @@ public class JsonToArrayCast
         super(FunctionMetadata.operatorBuilder(CAST)
                 .signature(Signature.builder()
                         .castableFromTypeParameter("T", JSON.getTypeSignature())
-                        .returnType(arrayType(new TypeSignature("T")))
+                        .returnType(arrayType(typeVariable("T")))
                         .argumentType(JSON)
                         .build())
                 .nullable()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonToMapCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonToMapCast.java
@@ -28,7 +28,6 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.MapType;
-import io.trino.spi.type.TypeSignature;
 import io.trino.util.JsonCastException;
 import io.trino.util.JsonUtil.BlockBuilderAppender;
 
@@ -40,6 +39,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.type.JsonType.JSON;
 import static io.trino.util.Failures.checkCondition;
@@ -65,7 +65,7 @@ public class JsonToMapCast
                 .signature(Signature.builder()
                         .castableFromTypeParameter("K", VARCHAR.getTypeSignature())
                         .castableFromTypeParameter("V", JSON.getTypeSignature())
-                        .returnType(mapType(new TypeSignature("K"), new TypeSignature("V")))
+                        .returnType(mapType(typeVariable("K"), typeVariable("V")))
                         .argumentType(JSON)
                         .build())
                 .nullable()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonToRowCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonToRowCast.java
@@ -29,7 +29,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.function.TypeVariableConstraint;
 import io.trino.spi.type.RowType;
-import io.trino.spi.type.TypeSignature;
 import io.trino.util.JsonCastException;
 import io.trino.util.JsonUtil.BlockBuilderAppender;
 
@@ -39,6 +38,7 @@ import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.OperatorType.CAST;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.type.JsonType.JSON;
 import static io.trino.util.Failures.checkCondition;
 import static io.trino.util.JsonUtil.BlockBuilderAppender.createBlockBuilderAppender;
@@ -66,7 +66,7 @@ public class JsonToRowCast
                                 TypeVariableConstraint.builder("T")
                                         .rowType()
                                         .build())
-                        .returnType(new TypeSignature("T"))
+                        .returnType(typeVariable("T"))
                         .argumentType(JSON)
                         .build())
                 .nullable()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapConcatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapConcatFunction.java
@@ -25,7 +25,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.VarArgsToArrayAdapterGenerator.MethodHandleAndConstructor;
 import io.trino.type.BlockTypeOperators;
 import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
@@ -39,6 +38,7 @@ import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.sql.gen.VarArgsToArrayAdapterGenerator.generateVarArgsToArrayAdapter;
 import static io.trino.util.Reflection.methodHandle;
 import static java.lang.Math.min;
@@ -68,8 +68,8 @@ public final class MapConcatFunction
                 .signature(Signature.builder()
                         .typeVariable("K")
                         .typeVariable("V")
-                        .returnType(mapType(new TypeSignature("K"), new TypeSignature("V")))
-                        .argumentType(mapType(new TypeSignature("K"), new TypeSignature("V")))
+                        .returnType(mapType(typeVariable("K"), typeVariable("V")))
+                        .argumentType(mapType(typeVariable("K"), typeVariable("V")))
                         .variableArity()
                         .build())
                 .description(DESCRIPTION)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapConstructor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapConstructor.java
@@ -28,7 +28,6 @@ import io.trino.spi.function.FunctionDependencyDeclaration;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.MapType;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 import java.util.Optional;
@@ -44,6 +43,7 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.INDETERMINATE;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.util.Failures.checkCondition;
 import static io.trino.util.Failures.internalError;
 import static io.trino.util.Reflection.constructorMethodHandle;
@@ -72,9 +72,9 @@ public final class MapConstructor
                 .signature(Signature.builder()
                         .comparableTypeParameter("K")
                         .typeVariable("V")
-                        .returnType(mapType(new TypeSignature("K"), new TypeSignature("V")))
-                        .argumentType(arrayType(new TypeSignature("K")))
-                        .argumentType(arrayType(new TypeSignature("V")))
+                        .returnType(mapType(typeVariable("K"), typeVariable("V")))
+                        .argumentType(arrayType(typeVariable("K")))
+                        .argumentType(arrayType(typeVariable("V")))
                         .build())
                 .description(DESCRIPTION)
                 .build());
@@ -84,9 +84,9 @@ public final class MapConstructor
     public FunctionDependencyDeclaration getFunctionDependencies()
     {
         return FunctionDependencyDeclaration.builder()
-                .addOperatorSignature(HASH_CODE, ImmutableList.of(new TypeSignature("K")))
-                .addOperatorSignature(EQUAL, ImmutableList.of(new TypeSignature("K"), new TypeSignature("K")))
-                .addOperatorSignature(INDETERMINATE, ImmutableList.of(new TypeSignature("K")))
+                .addOperatorSignature(HASH_CODE, ImmutableList.of(typeVariable("K")))
+                .addOperatorSignature(EQUAL, ImmutableList.of(typeVariable("K"), typeVariable("K")))
+                .addOperatorSignature(INDETERMINATE, ImmutableList.of(typeVariable("K")))
                 .build();
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapElementAtFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapElementAtFunction.java
@@ -25,7 +25,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
@@ -33,6 +32,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.util.Reflection.methodHandle;
 
@@ -52,9 +52,9 @@ public class MapElementAtFunction
                 .signature(Signature.builder()
                         .typeVariable("K")
                         .typeVariable("V")
-                        .returnType(new TypeSignature("V"))
-                        .argumentType(mapType(new TypeSignature("K"), new TypeSignature("V")))
-                        .argumentType(new TypeSignature("K"))
+                        .returnType(typeVariable("V"))
+                        .argumentType(mapType(typeVariable("K"), typeVariable("V")))
+                        .argumentType(typeVariable("K"))
                         .build())
                 .nullable()
                 .description("Get value for the given key, or null if it does not exist")
@@ -65,7 +65,7 @@ public class MapElementAtFunction
     public FunctionDependencyDeclaration getFunctionDependencies()
     {
         return FunctionDependencyDeclaration.builder()
-                .addOperatorSignature(EQUAL, ImmutableList.of(new TypeSignature("K"), new TypeSignature("K")))
+                .addOperatorSignature(EQUAL, ImmutableList.of(typeVariable("K"), typeVariable("K")))
                 .build();
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapFilterFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapFilterFunction.java
@@ -38,7 +38,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.CallSiteBinder;
 import io.trino.sql.gen.SqlTypeBytecodeExpression;
 import io.trino.sql.gen.lambda.BinaryFunctionInterface;
@@ -65,6 +64,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.TypeSignature.functionType;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.sql.gen.LambdaMetafactoryGenerator.generateMetafactory;
 import static io.trino.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static io.trino.type.UnknownType.UNKNOWN;
@@ -84,9 +84,9 @@ public final class MapFilterFunction
                 .signature(Signature.builder()
                         .typeVariable("K")
                         .typeVariable("V")
-                        .returnType(mapType(new TypeSignature("K"), new TypeSignature("V")))
-                        .argumentType(mapType(new TypeSignature("K"), new TypeSignature("V")))
-                        .argumentType(functionType(new TypeSignature("K"), new TypeSignature("V"), BOOLEAN.getTypeSignature()))
+                        .returnType(mapType(typeVariable("K"), typeVariable("V")))
+                        .argumentType(mapType(typeVariable("K"), typeVariable("V")))
+                        .argumentType(functionType(typeVariable("K"), typeVariable("V"), BOOLEAN.getTypeSignature()))
                         .build())
                 .description("return map containing entries that match the given predicate")
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapSubscriptOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapSubscriptOperator.java
@@ -29,7 +29,6 @@ import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -40,6 +39,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.OperatorType.SUBSCRIPT;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.util.Reflection.methodHandle;
@@ -58,9 +58,9 @@ public class MapSubscriptOperator
                 .signature(Signature.builder()
                         .typeVariable("K")
                         .typeVariable("V")
-                        .returnType(new TypeSignature("V"))
-                        .argumentType(mapType(new TypeSignature("K"), new TypeSignature("V")))
-                        .argumentType(new TypeSignature("K"))
+                        .returnType(typeVariable("V"))
+                        .argumentType(mapType(typeVariable("K"), typeVariable("V")))
+                        .argumentType(typeVariable("K"))
                         .build())
                 .nullable()
                 .build());
@@ -70,7 +70,7 @@ public class MapSubscriptOperator
     public FunctionDependencyDeclaration getFunctionDependencies()
     {
         return FunctionDependencyDeclaration.builder()
-                .addOptionalCastSignature(new TypeSignature("K"), VARCHAR.getTypeSignature())
+                .addOptionalCastSignature(typeVariable("K"), VARCHAR.getTypeSignature())
                 .build();
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapToJsonCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapToJsonCast.java
@@ -28,7 +28,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandle;
@@ -41,6 +40,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.type.JsonType.JSON;
 import static io.trino.util.Failures.checkCondition;
@@ -66,7 +66,7 @@ public class MapToJsonCast
                         .castableToTypeParameter("K", VARCHAR.getTypeSignature())
                         .castableToTypeParameter("V", JSON.getTypeSignature())
                         .returnType(JSON)
-                        .argumentType(mapType(new TypeSignature("K"), new TypeSignature("V")))
+                        .argumentType(mapType(typeVariable("K"), typeVariable("V")))
                         .build())
                 .build());
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapToMapCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapToMapCast.java
@@ -32,7 +32,6 @@ import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.type.BlockTypeOperators;
 import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
 import io.trino.type.BlockTypeOperators.BlockPositionIsIdentical;
@@ -49,6 +48,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.util.Failures.internalError;
 import static io.trino.util.Reflection.methodHandle;
 import static java.lang.invoke.MethodHandles.dropArguments;
@@ -88,12 +88,12 @@ public final class MapToMapCast
     {
         super(FunctionMetadata.operatorBuilder(CAST)
                 .signature(Signature.builder()
-                        .castableToTypeParameter("FK", new TypeSignature("TK"))
-                        .castableToTypeParameter("FV", new TypeSignature("TV"))
+                        .castableToTypeParameter("FK", typeVariable("TK"))
+                        .castableToTypeParameter("FV", typeVariable("TV"))
                         .typeVariable("TK")
                         .typeVariable("TV")
-                        .returnType(mapType(new TypeSignature("TK"), new TypeSignature("TV")))
-                        .argumentType(mapType(new TypeSignature("FK"), new TypeSignature("FV")))
+                        .returnType(mapType(typeVariable("TK"), typeVariable("TV")))
+                        .argumentType(mapType(typeVariable("FK"), typeVariable("FV")))
                         .build())
                 .nullable()
                 .build());
@@ -104,8 +104,8 @@ public final class MapToMapCast
     public FunctionDependencyDeclaration getFunctionDependencies()
     {
         return FunctionDependencyDeclaration.builder()
-                .addCastSignature(new TypeSignature("FK"), new TypeSignature("TK"))
-                .addCastSignature(new TypeSignature("FV"), new TypeSignature("TV"))
+                .addCastSignature(typeVariable("FK"), typeVariable("TK"))
+                .addCastSignature(typeVariable("FV"), typeVariable("TV"))
                 .build();
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapToVariantCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapToVariantCast.java
@@ -33,6 +33,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.VariantType.VARIANT;
 import static io.trino.util.Failures.checkCondition;
 import static io.trino.util.variant.VariantUtil.canCastToVariant;
@@ -60,7 +61,7 @@ public class MapToVariantCast
                         .longVariable("N")
                         .castableToTypeParameter("V", VARIANT.getTypeSignature())
                         .returnType(VARIANT)
-                        .argumentType(mapType(new TypeSignature("varchar", numericVariable("N")), new TypeSignature("V")))
+                        .argumentType(mapType(new TypeSignature("varchar", numericVariable("N")), typeVariable("V")))
                         .build())
                 .build());
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapToVariantCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapToVariantCast.java
@@ -31,7 +31,7 @@ import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.CAST;
-import static io.trino.spi.type.TypeParameter.typeVariable;
+import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeSignature.mapType;
 import static io.trino.spi.type.VariantType.VARIANT;
 import static io.trino.util.Failures.checkCondition;
@@ -60,7 +60,7 @@ public class MapToVariantCast
                         .longVariable("N")
                         .castableToTypeParameter("V", VARIANT.getTypeSignature())
                         .returnType(VARIANT)
-                        .argumentType(mapType(new TypeSignature("varchar", typeVariable("N")), new TypeSignature("V")))
+                        .argumentType(mapType(new TypeSignature("varchar", numericVariable("N")), new TypeSignature("V")))
                         .build())
                 .build());
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapTransformKeysFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapTransformKeysFunction.java
@@ -43,7 +43,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.CallSiteBinder;
 import io.trino.sql.gen.SqlTypeBytecodeExpression;
 import io.trino.sql.gen.lambda.BinaryFunctionInterface;
@@ -73,6 +72,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.TypeSignature.functionType;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.sql.gen.LambdaMetafactoryGenerator.generateMetafactory;
 import static io.trino.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static io.trino.type.UnknownType.UNKNOWN;
@@ -93,9 +93,9 @@ public final class MapTransformKeysFunction
                         .typeVariable("K1")
                         .typeVariable("K2")
                         .typeVariable("V")
-                        .returnType(mapType(new TypeSignature("K2"), new TypeSignature("V")))
-                        .argumentType(mapType(new TypeSignature("K1"), new TypeSignature("V")))
-                        .argumentType(functionType(new TypeSignature("K1"), new TypeSignature("V"), new TypeSignature("K2")))
+                        .returnType(mapType(typeVariable("K2"), typeVariable("V")))
+                        .argumentType(mapType(typeVariable("K1"), typeVariable("V")))
+                        .argumentType(functionType(typeVariable("K1"), typeVariable("V"), typeVariable("K2")))
                         .build())
                 .description("Apply lambda to each entry of the map and transform the key")
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapTransformValuesFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapTransformValuesFunction.java
@@ -42,7 +42,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.CallSiteBinder;
 import io.trino.sql.gen.SqlTypeBytecodeExpression;
 import io.trino.sql.gen.lambda.BinaryFunctionInterface;
@@ -72,6 +71,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.TypeSignature.functionType;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.sql.gen.LambdaMetafactoryGenerator.generateMetafactory;
 import static io.trino.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static io.trino.type.UnknownType.UNKNOWN;
@@ -92,9 +92,9 @@ public final class MapTransformValuesFunction
                         .typeVariable("K")
                         .typeVariable("V1")
                         .typeVariable("V2")
-                        .returnType(mapType(new TypeSignature("K"), new TypeSignature("V2")))
-                        .argumentType(mapType(new TypeSignature("K"), new TypeSignature("V1")))
-                        .argumentType(functionType(new TypeSignature("K"), new TypeSignature("V1"), new TypeSignature("V2")))
+                        .returnType(mapType(typeVariable("K"), typeVariable("V2")))
+                        .argumentType(mapType(typeVariable("K"), typeVariable("V1")))
+                        .argumentType(functionType(typeVariable("K"), typeVariable("V1"), typeVariable("V2")))
                         .build())
                 .description("Apply lambda to each entry of the map and transform the value")
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapZipWithFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapZipWithFunction.java
@@ -24,7 +24,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.lambda.LambdaFunctionInterface;
 
 import java.lang.invoke.MethodHandle;
@@ -35,6 +34,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.TypeSignature.functionType;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.util.Reflection.methodHandle;
@@ -55,10 +55,10 @@ public final class MapZipWithFunction
                         .typeVariable("V1")
                         .typeVariable("V2")
                         .typeVariable("V3")
-                        .returnType(mapType(new TypeSignature("K"), new TypeSignature("V3")))
-                        .argumentType(mapType(new TypeSignature("K"), new TypeSignature("V1")))
-                        .argumentType(mapType(new TypeSignature("K"), new TypeSignature("V2")))
-                        .argumentType(functionType(new TypeSignature("K"), new TypeSignature("V1"), new TypeSignature("V2"), new TypeSignature("V3")))
+                        .returnType(mapType(typeVariable("K"), typeVariable("V3")))
+                        .argumentType(mapType(typeVariable("K"), typeVariable("V1")))
+                        .argumentType(mapType(typeVariable("K"), typeVariable("V2")))
+                        .argumentType(functionType(typeVariable("K"), typeVariable("V1"), typeVariable("V2"), typeVariable("V3")))
                         .build())
                 .description("Merge two maps into a single map by applying the lambda function to the pair of values with the same key")
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/RowToJsonCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/RowToJsonCast.java
@@ -28,7 +28,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.function.TypeVariableConstraint;
 import io.trino.spi.type.RowType;
-import io.trino.spi.type.TypeSignature;
 import io.trino.util.JsonUtil.JsonGeneratorWriter;
 
 import java.io.IOException;
@@ -39,6 +38,7 @@ import java.util.List;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.CAST;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.type.JsonType.JSON;
 import static io.trino.util.JsonUtil.JsonGeneratorWriter.createJsonGeneratorWriter;
 import static io.trino.util.JsonUtil.createJsonFactory;
@@ -64,7 +64,7 @@ public class RowToJsonCast
                                         .rowType()
                                         .build())
                         .returnType(JSON)
-                        .argumentType(new TypeSignature("T"))
+                        .argumentType(typeVariable("T"))
                         .build())
                 .build());
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/RowToRowCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/RowToRowCast.java
@@ -41,7 +41,6 @@ import io.trino.spi.function.Signature;
 import io.trino.spi.function.TypeVariableConstraint;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.CallSiteBinder;
 
 import java.lang.invoke.MethodHandle;
@@ -65,6 +64,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.OperatorType.CAST;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.sql.gen.Bootstrap.BOOTSTRAP_METHOD;
 import static io.trino.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static io.trino.type.UnknownType.UNKNOWN;
@@ -117,11 +117,11 @@ public class RowToRowCast
                                 // this is technically a recursive constraint for cast, but SignatureBinder has explicit handling for row-to-row cast
                                 TypeVariableConstraint.builder("F")
                                         .rowType()
-                                        .castableTo(new TypeSignature("T"))
+                                        .castableTo(typeVariable("T"))
                                         .build())
                         .rowTypeParameter("T")
-                        .returnType(new TypeSignature("T"))
-                        .argumentType(new TypeSignature("F"))
+                        .returnType(typeVariable("T"))
+                        .argumentType(typeVariable("F"))
                         .build())
                 .build());
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/RowToVariantCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/RowToVariantCast.java
@@ -22,7 +22,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.function.TypeVariableConstraint;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.spi.variant.Variant;
 import io.trino.util.variant.VariantWriter;
 
@@ -32,6 +31,7 @@ import java.lang.invoke.MethodHandles;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.CAST;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.VariantType.VARIANT;
 import static java.lang.invoke.MethodType.methodType;
 
@@ -61,7 +61,7 @@ public class RowToVariantCast
                                         .rowType()
                                         .build())
                         .returnType(VARIANT)
-                        .argumentType(new TypeSignature("T"))
+                        .argumentType(typeVariable("T"))
                         .build())
                 .build());
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/TryCastFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/TryCastFunction.java
@@ -22,13 +22,13 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 
 import java.lang.invoke.MethodHandle;
 
 import static com.google.common.primitives.Primitives.wrap;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static java.lang.invoke.MethodHandles.catchException;
 import static java.lang.invoke.MethodHandles.constant;
 import static java.lang.invoke.MethodHandles.dropArguments;
@@ -43,10 +43,10 @@ public class TryCastFunction
     {
         super(FunctionMetadata.scalarBuilder("$try_cast")
                 .signature(Signature.builder()
-                        .castableToTypeParameter("F", new TypeSignature("T"))
+                        .castableToTypeParameter("F", typeVariable("T"))
                         .typeVariable("T")
-                        .returnType(new TypeSignature("T"))
-                        .argumentType(new TypeSignature("F"))
+                        .returnType(typeVariable("T"))
+                        .argumentType(typeVariable("F"))
                         .build())
                 .nullable()
                 .hidden()
@@ -59,7 +59,7 @@ public class TryCastFunction
     public FunctionDependencyDeclaration getFunctionDependencies()
     {
         return FunctionDependencyDeclaration.builder()
-                .addCastSignature(new TypeSignature("F"), new TypeSignature("T"))
+                .addCastSignature(typeVariable("F"), typeVariable("T"))
                 .build();
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/VariantToArrayCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/VariantToArrayCast.java
@@ -24,7 +24,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.spi.variant.Variant;
 import io.trino.util.variant.VariantUtil.BlockBuilderAppender;
 
@@ -37,6 +36,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.TypeSignature.arrayType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.VariantType.VARIANT;
 import static io.trino.util.Failures.checkCondition;
 import static io.trino.util.variant.VariantUtil.canCastFromVariant;
@@ -63,7 +63,7 @@ public class VariantToArrayCast
         super(FunctionMetadata.operatorBuilder(CAST)
                 .signature(Signature.builder()
                         .castableFromTypeParameter("T", VARIANT.getTypeSignature())
-                        .returnType(arrayType(new TypeSignature("T")))
+                        .returnType(arrayType(typeVariable("T")))
                         .argumentType(VARIANT)
                         .build())
                 .nullable()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/VariantToMapCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/VariantToMapCast.java
@@ -24,7 +24,6 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.MapType;
-import io.trino.spi.type.TypeSignature;
 import io.trino.spi.variant.Variant;
 import io.trino.util.variant.VariantUtil.BlockBuilderAppender;
 
@@ -37,6 +36,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VariantType.VARIANT;
 import static io.trino.util.Failures.checkCondition;
@@ -64,7 +64,7 @@ public class VariantToMapCast
                 .signature(Signature.builder()
                         .castableFromTypeParameter("K", VARCHAR.getTypeSignature())
                         .castableFromTypeParameter("V", VARIANT.getTypeSignature())
-                        .returnType(mapType(new TypeSignature("K"), new TypeSignature("V")))
+                        .returnType(mapType(typeVariable("K"), typeVariable("V")))
                         .argumentType(VARIANT)
                         .build())
                 .nullable()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/VariantToRowCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/VariantToRowCast.java
@@ -25,7 +25,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.function.TypeVariableConstraint;
 import io.trino.spi.type.RowType;
-import io.trino.spi.type.TypeSignature;
 import io.trino.spi.variant.Variant;
 import io.trino.util.variant.VariantUtil.BlockBuilderAppender;
 
@@ -36,6 +35,7 @@ import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.OperatorType.CAST;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.VariantType.VARIANT;
 import static io.trino.util.Failures.checkCondition;
 import static io.trino.util.variant.VariantUtil.BlockBuilderAppender.createBlockBuilderAppender;
@@ -66,7 +66,7 @@ public class VariantToRowCast
                                 TypeVariableConstraint.builder("T")
                                         .rowType()
                                         .build())
-                        .returnType(new TypeSignature("T"))
+                        .returnType(typeVariable("T"))
                         .argumentType(VARIANT)
                         .build())
                 .nullable()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ZipWithFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ZipWithFunction.java
@@ -22,7 +22,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.lambda.BinaryFunctionInterface;
 
 import java.lang.invoke.MethodHandle;
@@ -33,6 +32,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.spi.type.TypeSignature.functionType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.util.Reflection.methodHandle;
@@ -53,10 +53,10 @@ public final class ZipWithFunction
                         .typeVariable("T")
                         .typeVariable("U")
                         .typeVariable("R")
-                        .returnType(arrayType(new TypeSignature("R")))
-                        .argumentType(arrayType(new TypeSignature("T")))
-                        .argumentType(arrayType(new TypeSignature("U")))
-                        .argumentType(functionType(new TypeSignature("T"), new TypeSignature("U"), new TypeSignature("R")))
+                        .returnType(arrayType(typeVariable("R")))
+                        .argumentType(arrayType(typeVariable("T")))
+                        .argumentType(arrayType(typeVariable("U")))
+                        .argumentType(functionType(typeVariable("T"), typeVariable("U"), typeVariable("R")))
                         .build())
                 .description("Merge two arrays, element-wise, into a single array using the lambda function")
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonArrayFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonArrayFunction.java
@@ -44,6 +44,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.StandardTypes.BOOLEAN;
 import static io.trino.spi.type.StandardTypes.JSON_2016;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.sql.analyzer.ExpressionAnalyzer.JSON_NO_PARAMETERS_ROW_TYPE;
 import static io.trino.util.Reflection.methodHandle;
@@ -62,7 +63,7 @@ public class JsonArrayFunction
                 .signature(Signature.builder()
                         .typeVariable("E")
                         .returnType(new TypeSignature(JSON_2016))
-                        .argumentTypes(ImmutableList.of(new TypeSignature("E"), new TypeSignature(BOOLEAN)))
+                        .argumentTypes(ImmutableList.of(typeVariable("E"), new TypeSignature(BOOLEAN)))
                         .build())
                 .argumentNullability(true, false)
                 .hidden()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonExistsFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonExistsFunction.java
@@ -50,6 +50,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.StandardTypes.JSON_2016;
 import static io.trino.spi.type.StandardTypes.TINYINT;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.util.Reflection.constructorMethodHandle;
 import static io.trino.util.Reflection.methodHandle;
 import static java.util.Objects.requireNonNull;
@@ -70,7 +71,7 @@ public class JsonExistsFunction
                 .signature(Signature.builder()
                         .typeVariable("T")
                         .returnType(BOOLEAN)
-                        .argumentTypes(ImmutableList.of(new TypeSignature(JSON_2016), new TypeSignature(JsonPath2016Type.NAME), new TypeSignature("T"), new TypeSignature(TINYINT)))
+                        .argumentTypes(ImmutableList.of(new TypeSignature(JSON_2016), new TypeSignature(JsonPath2016Type.NAME), typeVariable("T"), new TypeSignature(TINYINT)))
                         .build())
                 .nullable()
                 .argumentNullability(false, false, true, false)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonObjectFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonObjectFunction.java
@@ -49,6 +49,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.StandardTypes.BOOLEAN;
 import static io.trino.spi.type.StandardTypes.JSON_2016;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.sql.analyzer.ExpressionAnalyzer.JSON_NO_PARAMETERS_ROW_TYPE;
 import static io.trino.util.Reflection.methodHandle;
@@ -68,7 +69,7 @@ public class JsonObjectFunction
                         .typeVariable("K")
                         .typeVariable("V")
                         .returnType(new TypeSignature(JSON_2016))
-                        .argumentTypes(ImmutableList.of(new TypeSignature("K"), new TypeSignature("V"), new TypeSignature(BOOLEAN), new TypeSignature(BOOLEAN)))
+                        .argumentTypes(ImmutableList.of(typeVariable("K"), typeVariable("V"), new TypeSignature(BOOLEAN), new TypeSignature(BOOLEAN)))
                         .build())
                 .argumentNullability(true, true, false, false)
                 .hidden()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonQueryFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonQueryFunction.java
@@ -55,6 +55,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.type.StandardTypes.JSON_2016;
 import static io.trino.spi.type.StandardTypes.TINYINT;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.util.Reflection.constructorMethodHandle;
 import static io.trino.util.Reflection.methodHandle;
 import static java.lang.String.format;
@@ -81,7 +82,7 @@ public class JsonQueryFunction
                         .argumentTypes(ImmutableList.of(
                                 new TypeSignature(JSON_2016),
                                 new TypeSignature(JsonPath2016Type.NAME),
-                                new TypeSignature("T"),
+                                typeVariable("T"),
                                 new TypeSignature(TINYINT),
                                 new TypeSignature(TINYINT),
                                 new TypeSignature(TINYINT)))

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonValueFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonValueFunction.java
@@ -68,6 +68,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.type.StandardTypes.JSON_2016;
 import static io.trino.spi.type.StandardTypes.TINYINT;
 import static io.trino.spi.type.TypeSignature.functionType;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.util.Reflection.constructorMethodHandle;
 import static io.trino.util.Reflection.methodHandle;
 import static java.lang.String.format;
@@ -96,16 +97,16 @@ public class JsonValueFunction
                         .typeVariable("T")
                         .typeVariable("E")
                         .typeVariable("D")
-                        .returnType(new TypeSignature("R"))
+                        .returnType(typeVariable("R"))
                         .argumentTypes(ImmutableList.of(
                                 new TypeSignature(JSON_2016),
                                 new TypeSignature(JsonPath2016Type.NAME),
-                                new TypeSignature("T"),
-                                new TypeSignature("R"),
+                                typeVariable("T"),
+                                typeVariable("R"),
                                 new TypeSignature(TINYINT),
-                                functionType(new TypeSignature("E")),
+                                functionType(typeVariable("E")),
                                 new TypeSignature(TINYINT),
-                                functionType(new TypeSignature("D"))))
+                                functionType(typeVariable("D"))))
                         .build())
                 .nullable()
                 .argumentNullability(false, false, true, true, false, false, false, false)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/TypeSignatureTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/TypeSignatureTranslator.java
@@ -58,8 +58,8 @@ import static io.trino.spi.type.StandardTypes.TIMESTAMP_WITH_TIME_ZONE;
 import static io.trino.spi.type.StandardTypes.TIME_WITH_TIME_ZONE;
 import static io.trino.spi.type.StandardTypes.VARCHAR;
 import static io.trino.spi.type.TypeParameter.numericParameter;
+import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeParameter.typeParameter;
-import static io.trino.spi.type.TypeParameter.typeVariable;
 import static io.trino.spi.type.VarcharType.UNBOUNDED_LENGTH;
 import static io.trino.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
 import static io.trino.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
@@ -150,7 +150,7 @@ public final class TypeSignatureTranslator
                     if (value instanceof GenericDataType genericDataType &&
                             genericDataType.getArguments().isEmpty() &&
                             typeVariables.contains(genericDataType.getName().getValue())) {
-                        parameters.add(typeVariable(genericDataType.getName().getValue()));
+                        parameters.add(numericVariable(genericDataType.getName().getValue()));
                     }
                     else {
                         parameters.add(typeParameter(toTypeSignature(value, typeVariables)));
@@ -222,7 +222,7 @@ public final class TypeSignatureTranslator
                 }
                 String variable = genericDataType.getName().getValue();
                 checkArgument(typeVariables.contains(variable), "Parameter to datetime type must be either a number or a type variable: %s", variable);
-                parameters.add(typeVariable(variable));
+                parameters.add(numericVariable(variable));
             }
         }
         return parameters;

--- a/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
@@ -62,7 +62,7 @@ import static io.trino.spi.type.NumberType.NUMBER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
-import static io.trino.spi.type.TypeParameter.typeVariable;
+import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.VarcharType.UNBOUNDED_LENGTH;
 import static io.trino.spi.type.VariantType.VARIANT;
 import static io.trino.type.JsonType.JSON;
@@ -100,7 +100,7 @@ public final class DecimalCasts
     public static final SqlScalarFunction REAL_TO_DECIMAL_CAST = castFunctionToDecimalFrom(REAL.getTypeSignature(), true, "realToShortDecimal", "realToLongDecimal");
     public static final SqlScalarFunction DECIMAL_TO_NUMBER_CAST = castFunctionFromDecimalTo(NUMBER.getTypeSignature(), true, "shortDecimalToNumber", "longDecimalToNumber");
     public static final SqlScalarFunction NUMBER_TO_DECIMAL_CAST = castFunctionToDecimalFrom(NUMBER.getTypeSignature(), false, "numberToShortDecimal", "numberToLongDecimal");
-    public static final SqlScalarFunction VARCHAR_TO_DECIMAL_CAST = castFunctionToDecimalFrom(new TypeSignature("varchar", typeVariable("x")), false, "varcharToShortDecimal", "varcharToLongDecimal");
+    public static final SqlScalarFunction VARCHAR_TO_DECIMAL_CAST = castFunctionToDecimalFrom(new TypeSignature("varchar", numericVariable("x")), false, "varcharToShortDecimal", "varcharToLongDecimal");
     // Despite decimalToJson having a catch inside that suggests that function can fail, IOException comes from the Jackson writing to an OutputStream
     // that never happens for SliceOutput.
     public static final SqlScalarFunction DECIMAL_TO_JSON_CAST = castFunctionFromDecimalTo(JSON.getTypeSignature(), true, "shortDecimalToJson", "longDecimalToJson");
@@ -113,7 +113,7 @@ public final class DecimalCasts
     private static SqlScalarFunction castFunctionFromDecimalTo(TypeSignature to, boolean neverFails, String... methodNames)
     {
         Signature signature = Signature.builder()
-                .argumentType(new TypeSignature("decimal", typeVariable("precision"), typeVariable("scale")))
+                .argumentType(new TypeSignature("decimal", numericVariable("precision"), numericVariable("scale")))
                 .returnType(to)
                 .build();
         return new PolymorphicScalarFunctionBuilder(CAST, DecimalCasts.class)
@@ -147,7 +147,7 @@ public final class DecimalCasts
     {
         Signature signature = Signature.builder()
                 .argumentType(from)
-                .returnType(new TypeSignature("decimal", typeVariable("precision"), typeVariable("scale")))
+                .returnType(new TypeSignature("decimal", numericVariable("precision"), numericVariable("scale")))
                 .build();
         return new PolymorphicScalarFunctionBuilder(CAST, DecimalCasts.class)
                 .signature(signature)
@@ -173,8 +173,8 @@ public final class DecimalCasts
 
     public static final SqlScalarFunction DECIMAL_TO_VARCHAR_CAST = new PolymorphicScalarFunctionBuilder(CAST, DecimalCasts.class)
             .signature(Signature.builder()
-                    .argumentType(new TypeSignature("decimal", typeVariable("precision"), typeVariable("scale")))
-                    .returnType(new TypeSignature("varchar", typeVariable("x")))
+                    .argumentType(new TypeSignature("decimal", numericVariable("precision"), numericVariable("scale")))
+                    .returnType(new TypeSignature("varchar", numericVariable("x")))
                     .build())
             .deterministic(true)
             .choice(choice -> choice

--- a/core/trino-main/src/main/java/io/trino/type/DecimalOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalOperators.java
@@ -47,7 +47,7 @@ import static io.trino.spi.type.Int128Math.negateExact;
 import static io.trino.spi.type.Int128Math.remainder;
 import static io.trino.spi.type.Int128Math.rescale;
 import static io.trino.spi.type.Int128Math.subtract;
-import static io.trino.spi.type.TypeParameter.typeVariable;
+import static io.trino.spi.type.TypeParameter.numericVariable;
 import static java.lang.Integer.max;
 import static java.lang.Long.signum;
 import static java.lang.Math.abs;
@@ -70,9 +70,9 @@ public final class DecimalOperators
 
     private static SqlScalarFunction decimalAddOperator(boolean legacyTypeCalculation)
     {
-        TypeSignature decimalLeftSignature = new TypeSignature("decimal", typeVariable("a_precision"), typeVariable("a_scale"));
-        TypeSignature decimalRightSignature = new TypeSignature("decimal", typeVariable("b_precision"), typeVariable("b_scale"));
-        TypeSignature decimalResultSignature = new TypeSignature("decimal", typeVariable("r_precision"), typeVariable("r_scale"));
+        TypeSignature decimalLeftSignature = new TypeSignature("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
+        TypeSignature decimalRightSignature = new TypeSignature("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
+        TypeSignature decimalResultSignature = new TypeSignature("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
 
         Signature.Builder signature = Signature.builder();
 
@@ -167,9 +167,9 @@ public final class DecimalOperators
 
     private static SqlScalarFunction decimalSubtractOperator(boolean legacyTypeCalculation)
     {
-        TypeSignature decimalLeftSignature = new TypeSignature("decimal", typeVariable("a_precision"), typeVariable("a_scale"));
-        TypeSignature decimalRightSignature = new TypeSignature("decimal", typeVariable("b_precision"), typeVariable("b_scale"));
-        TypeSignature decimalResultSignature = new TypeSignature("decimal", typeVariable("r_precision"), typeVariable("r_scale"));
+        TypeSignature decimalLeftSignature = new TypeSignature("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
+        TypeSignature decimalRightSignature = new TypeSignature("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
+        TypeSignature decimalResultSignature = new TypeSignature("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
 
         Signature.Builder signature = Signature.builder();
 
@@ -262,9 +262,9 @@ public final class DecimalOperators
 
     private static SqlScalarFunction decimalMultiplyOperator(boolean legacyTypeCalculation)
     {
-        TypeSignature decimalLeftSignature = new TypeSignature("decimal", typeVariable("a_precision"), typeVariable("a_scale"));
-        TypeSignature decimalRightSignature = new TypeSignature("decimal", typeVariable("b_precision"), typeVariable("b_scale"));
-        TypeSignature decimalResultSignature = new TypeSignature("decimal", typeVariable("r_precision"), typeVariable("r_scale"));
+        TypeSignature decimalLeftSignature = new TypeSignature("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
+        TypeSignature decimalRightSignature = new TypeSignature("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
+        TypeSignature decimalResultSignature = new TypeSignature("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
 
         Signature.Builder signature = Signature.builder();
 
@@ -366,9 +366,9 @@ public final class DecimalOperators
 
     private static SqlScalarFunction decimalDivideOperator(boolean legacyTypeCalculation)
     {
-        TypeSignature decimalLeftSignature = new TypeSignature("decimal", typeVariable("a_precision"), typeVariable("a_scale"));
-        TypeSignature decimalRightSignature = new TypeSignature("decimal", typeVariable("b_precision"), typeVariable("b_scale"));
-        TypeSignature decimalResultSignature = new TypeSignature("decimal", typeVariable("r_precision"), typeVariable("r_scale"));
+        TypeSignature decimalLeftSignature = new TypeSignature("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
+        TypeSignature decimalRightSignature = new TypeSignature("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
+        TypeSignature decimalResultSignature = new TypeSignature("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
 
         Signature.Builder signature = Signature.builder();
 
@@ -552,9 +552,9 @@ public final class DecimalOperators
 
     private static SqlScalarFunction moduloScalarFunction(PolymorphicScalarFunctionBuilder builder)
     {
-        TypeSignature decimalLeftSignature = new TypeSignature("decimal", typeVariable("a_precision"), typeVariable("a_scale"));
-        TypeSignature decimalRightSignature = new TypeSignature("decimal", typeVariable("b_precision"), typeVariable("b_scale"));
-        TypeSignature decimalResultSignature = new TypeSignature("decimal", typeVariable("r_precision"), typeVariable("r_scale"));
+        TypeSignature decimalLeftSignature = new TypeSignature("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
+        TypeSignature decimalRightSignature = new TypeSignature("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
+        TypeSignature decimalResultSignature = new TypeSignature("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
 
         Signature signature = Signature.builder()
                 .longVariable("r_precision", "min(b_precision - b_scale, a_precision - a_scale) + max(a_scale, b_scale)")

--- a/core/trino-main/src/main/java/io/trino/type/DecimalSaturatedFloorCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalSaturatedFloorCasts.java
@@ -32,7 +32,7 @@ import static io.trino.spi.type.Int128Math.subtract;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
-import static io.trino.spi.type.TypeParameter.typeVariable;
+import static io.trino.spi.type.TypeParameter.numericVariable;
 import static java.lang.Math.toIntExact;
 
 public final class DecimalSaturatedFloorCasts
@@ -41,8 +41,8 @@ public final class DecimalSaturatedFloorCasts
 
     public static final SqlScalarFunction DECIMAL_TO_DECIMAL_SATURATED_FLOOR_CAST = new PolymorphicScalarFunctionBuilder(SATURATED_FLOOR_CAST, DecimalSaturatedFloorCasts.class)
             .signature(Signature.builder()
-                    .argumentType(new TypeSignature("decimal", typeVariable("source_precision"), typeVariable("source_scale")))
-                    .returnType(new TypeSignature("decimal", typeVariable("result_precision"), typeVariable("result_scale")))
+                    .argumentType(new TypeSignature("decimal", numericVariable("source_precision"), numericVariable("source_scale")))
+                    .returnType(new TypeSignature("decimal", numericVariable("result_precision"), numericVariable("result_scale")))
                     .build())
             .deterministic(true)
             .choice(choice -> choice
@@ -111,7 +111,7 @@ public final class DecimalSaturatedFloorCasts
     {
         return new PolymorphicScalarFunctionBuilder(SATURATED_FLOOR_CAST, DecimalSaturatedFloorCasts.class)
                 .signature(Signature.builder()
-                        .argumentType(new TypeSignature("decimal", typeVariable("source_precision"), typeVariable("source_scale")))
+                        .argumentType(new TypeSignature("decimal", numericVariable("source_precision"), numericVariable("source_scale")))
                         .returnType(type.getTypeSignature())
                         .build())
                 .deterministic(true)
@@ -163,7 +163,7 @@ public final class DecimalSaturatedFloorCasts
         return new PolymorphicScalarFunctionBuilder(SATURATED_FLOOR_CAST, DecimalSaturatedFloorCasts.class)
                 .signature(Signature.builder()
                         .argumentType(integerType)
-                        .returnType(new TypeSignature("decimal", typeVariable("result_precision"), typeVariable("result_scale")))
+                        .returnType(new TypeSignature("decimal", numericVariable("result_precision"), numericVariable("result_scale")))
                         .build())
                 .deterministic(true)
                 .choice(choice -> choice

--- a/core/trino-main/src/test/java/io/trino/metadata/TestPolymorphicScalarFunction.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestPolymorphicScalarFunction.java
@@ -45,7 +45,7 @@ import static io.trino.spi.function.OperatorType.IDENTICAL;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.Decimals.MAX_SHORT_PRECISION;
-import static io.trino.spi.type.TypeParameter.typeVariable;
+import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.util.Arrays.asList;
@@ -58,7 +58,7 @@ public class TestPolymorphicScalarFunction
     private static final String FUNCTION_NAME = "foo";
     private static final Signature SIGNATURE = Signature.builder()
             .returnType(BIGINT)
-            .argumentType(new TypeSignature("varchar", typeVariable("x")))
+            .argumentType(new TypeSignature("varchar", numericVariable("x")))
             .build();
     private static final int INPUT_VARCHAR_LENGTH = 10;
     private static final Slice INPUT_SLICE = Slices.allocate(INPUT_VARCHAR_LENGTH);
@@ -68,7 +68,7 @@ public class TestPolymorphicScalarFunction
             BIGINT,
             ImmutableList.of(createVarcharType(INPUT_VARCHAR_LENGTH)));
 
-    private static final TypeSignature DECIMAL_SIGNATURE = new TypeSignature("decimal", typeVariable("a_precision"), typeVariable("a_scale"));
+    private static final TypeSignature DECIMAL_SIGNATURE = new TypeSignature("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
 
     private static final DecimalType LONG_DECIMAL_BOUND_TYPE = DecimalType.createDecimalType(MAX_SHORT_PRECISION + 1, 2);
 
@@ -174,8 +174,8 @@ public class TestPolymorphicScalarFunction
             throws Throwable
     {
         Signature signature = Signature.builder()
-                .returnType(new TypeSignature("varchar", typeVariable("x")))
-                .argumentType(new TypeSignature("varchar", typeVariable("x")))
+                .returnType(new TypeSignature("varchar", numericVariable("x")))
+                .argumentType(new TypeSignature("varchar", numericVariable("x")))
                 .build();
 
         SqlScalarFunction function = new PolymorphicScalarFunctionBuilder(FUNCTION_NAME, TestMethods.class)
@@ -233,8 +233,8 @@ public class TestPolymorphicScalarFunction
     public void testSetsHiddenToTrueForOperators()
     {
         Signature signature = Signature.builder()
-                .returnType(new TypeSignature("varchar", typeVariable("x")))
-                .argumentType(new TypeSignature("varchar", typeVariable("x")))
+                .returnType(new TypeSignature("varchar", numericVariable("x")))
+                .argumentType(new TypeSignature("varchar", numericVariable("x")))
                 .build();
 
         SqlScalarFunction function = new PolymorphicScalarFunctionBuilder(ADD, TestMethods.class)

--- a/core/trino-main/src/test/java/io/trino/metadata/TestSignatureBinder.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestSignatureBinder.java
@@ -67,8 +67,8 @@ public class TestSignatureBinder
     @Test
     public void testBindLiteralForDecimal()
     {
-        TypeSignature leftType = new TypeSignature("decimal", TypeParameter.typeVariable("p1"), TypeParameter.typeVariable("s1"));
-        TypeSignature rightType = new TypeSignature("decimal", TypeParameter.typeVariable("p2"), TypeParameter.typeVariable("s2"));
+        TypeSignature leftType = new TypeSignature("decimal", TypeParameter.numericVariable("p1"), TypeParameter.numericVariable("s1"));
+        TypeSignature rightType = new TypeSignature("decimal", TypeParameter.numericVariable("p2"), TypeParameter.numericVariable("s2"));
 
         Signature function = functionSignature()
                 .returnType(BOOLEAN)
@@ -91,7 +91,7 @@ public class TestSignatureBinder
     {
         Signature function = functionSignature()
                 .returnType(BOOLEAN)
-                .argumentType(new TypeSignature("decimal", numericParameter(4), TypeParameter.typeVariable("s")))
+                .argumentType(new TypeSignature("decimal", numericParameter(4), TypeParameter.numericVariable("s")))
                 .build();
 
         assertThat(function)
@@ -103,7 +103,7 @@ public class TestSignatureBinder
 
         function = functionSignature()
                 .returnType(BOOLEAN)
-                .argumentType(new TypeSignature("decimal", TypeParameter.typeVariable("p"), numericParameter(1)))
+                .argumentType(new TypeSignature("decimal", TypeParameter.numericVariable("p"), numericParameter(1)))
                 .build();
 
         assertThat(function)
@@ -130,8 +130,8 @@ public class TestSignatureBinder
     @Test
     public void testBindLiteralForVarchar()
     {
-        TypeSignature leftType = new TypeSignature("varchar", TypeParameter.typeVariable("x"));
-        TypeSignature rightType = new TypeSignature("varchar", TypeParameter.typeVariable("y"));
+        TypeSignature leftType = new TypeSignature("varchar", TypeParameter.numericVariable("x"));
+        TypeSignature rightType = new TypeSignature("varchar", TypeParameter.numericVariable("y"));
 
         Signature function = functionSignature()
                 .returnType(BOOLEAN)
@@ -158,8 +158,8 @@ public class TestSignatureBinder
     @Test
     public void testBindLiteralForRepeatedVarcharWithReturn()
     {
-        TypeSignature leftType = new TypeSignature("varchar", TypeParameter.typeVariable("x"));
-        TypeSignature rightType = new TypeSignature("varchar", TypeParameter.typeVariable("x"));
+        TypeSignature leftType = new TypeSignature("varchar", TypeParameter.numericVariable("x"));
+        TypeSignature rightType = new TypeSignature("varchar", TypeParameter.numericVariable("x"));
 
         Signature function = functionSignature()
                 .returnType(BOOLEAN)
@@ -195,8 +195,8 @@ public class TestSignatureBinder
     @Test
     public void testBindLiteralForRepeatedDecimal()
     {
-        TypeSignature leftType = new TypeSignature("decimal", TypeParameter.typeVariable("p"), TypeParameter.typeVariable("s"));
-        TypeSignature rightType = new TypeSignature("decimal", TypeParameter.typeVariable("p"), TypeParameter.typeVariable("s"));
+        TypeSignature leftType = new TypeSignature("decimal", TypeParameter.numericVariable("p"), TypeParameter.numericVariable("s"));
+        TypeSignature rightType = new TypeSignature("decimal", TypeParameter.numericVariable("p"), TypeParameter.numericVariable("s"));
 
         Signature function = functionSignature()
                 .returnType(BOOLEAN)
@@ -236,9 +236,9 @@ public class TestSignatureBinder
     @Test
     public void testBindLiteralForRepeatedVarchar()
     {
-        TypeSignature leftType = new TypeSignature("varchar", TypeParameter.typeVariable("x"));
-        TypeSignature rightType = new TypeSignature("varchar", TypeParameter.typeVariable("x"));
-        TypeSignature returnType = new TypeSignature("varchar", TypeParameter.typeVariable("x"));
+        TypeSignature leftType = new TypeSignature("varchar", TypeParameter.numericVariable("x"));
+        TypeSignature rightType = new TypeSignature("varchar", TypeParameter.numericVariable("x"));
+        TypeSignature returnType = new TypeSignature("varchar", TypeParameter.numericVariable("x"));
 
         Signature function = functionSignature()
                 .returnType(returnType)
@@ -266,7 +266,7 @@ public class TestSignatureBinder
     {
         Signature function = functionSignature()
                 .returnType(BOOLEAN)
-                .argumentType(new TypeSignature("varchar", TypeParameter.typeVariable("x")))
+                .argumentType(new TypeSignature("varchar", TypeParameter.numericVariable("x")))
                 .build();
 
         assertThat(function)
@@ -286,7 +286,7 @@ public class TestSignatureBinder
                 .returnType(BOOLEAN)
                 .typeVariable("T")
                 .argumentType(arrayType(new TypeSignature("T")))
-                .argumentType(arrayType(new TypeSignature("decimal", TypeParameter.typeVariable("p"), TypeParameter.typeVariable("s"))))
+                .argumentType(arrayType(new TypeSignature("decimal", TypeParameter.numericVariable("p"), TypeParameter.numericVariable("s"))))
                 .build();
 
         assertThat(function)
@@ -302,7 +302,7 @@ public class TestSignatureBinder
     @Test
     public void testBindDifferentLiteralParameters()
     {
-        TypeSignature argType = new TypeSignature("decimal", TypeParameter.typeVariable("p"), TypeParameter.typeVariable("s"));
+        TypeSignature argType = new TypeSignature("decimal", TypeParameter.numericVariable("p"), TypeParameter.numericVariable("s"));
 
         Signature function = functionSignature()
                 .returnType(BOOLEAN)
@@ -318,8 +318,8 @@ public class TestSignatureBinder
     @Test
     public void testNoVariableReuseAcrossTypes()
     {
-        TypeSignature leftType = new TypeSignature("decimal", TypeParameter.typeVariable("p1"), TypeParameter.typeVariable("s"));
-        TypeSignature rightType = new TypeSignature("decimal", TypeParameter.typeVariable("p2"), TypeParameter.typeVariable("s"));
+        TypeSignature leftType = new TypeSignature("decimal", TypeParameter.numericVariable("p1"), TypeParameter.numericVariable("s"));
+        TypeSignature rightType = new TypeSignature("decimal", TypeParameter.numericVariable("p2"), TypeParameter.numericVariable("s"));
 
         Signature function = functionSignature()
                 .returnType(BOOLEAN)
@@ -339,7 +339,7 @@ public class TestSignatureBinder
     {
         Signature function = functionSignature()
                 .returnType(BOOLEAN)
-                .argumentType(new TypeSignature("decimal", TypeParameter.typeVariable("p"), TypeParameter.typeVariable("s")))
+                .argumentType(new TypeSignature("decimal", TypeParameter.numericVariable("p"), TypeParameter.numericVariable("s")))
                 .build();
 
         assertThat(function)
@@ -485,7 +485,7 @@ public class TestSignatureBinder
     {
         Signature function = functionSignature()
                 .returnType(BOOLEAN)
-                .argumentType(new TypeSignature("varchar", TypeParameter.typeVariable("x")))
+                .argumentType(new TypeSignature("varchar", TypeParameter.numericVariable("x")))
                 .build();
 
         assertThat(function)
@@ -1048,7 +1048,7 @@ public class TestSignatureBinder
         Signature varcharApply = functionSignature()
                 .returnType(VARCHAR)
                 .argumentType(VARCHAR)
-                .argumentType(functionType(VARCHAR.getTypeSignature(), new TypeSignature("varchar", TypeParameter.typeVariable("x"))))
+                .argumentType(functionType(VARCHAR.getTypeSignature(), new TypeSignature("varchar", TypeParameter.numericVariable("x"))))
                 .build();
         assertThat(varcharApply)
                 .withCoercion()

--- a/core/trino-main/src/test/java/io/trino/operator/TestAnnotationEngineForAggregates.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestAnnotationEngineForAggregates.java
@@ -93,7 +93,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.type.StandardTypes.DOUBLE;
-import static io.trino.spi.type.TypeParameter.typeVariable;
+import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypeSignatures;
@@ -905,8 +905,8 @@ public class TestAnnotationEngineForAggregates
     public void testInjectLiteralAggregateParse()
     {
         Signature expectedSignature = Signature.builder()
-                .returnType(new TypeSignature("varchar", typeVariable("x")))
-                .argumentType(new TypeSignature("varchar", typeVariable("x")))
+                .returnType(new TypeSignature("varchar", numericVariable("x")))
+                .argumentType(new TypeSignature("varchar", numericVariable("x")))
                 .build();
 
         ParametricAggregation aggregation = getOnlyElement(parseFunctionDefinitions(InjectLiteralAggregateFunction.class));
@@ -971,9 +971,9 @@ public class TestAnnotationEngineForAggregates
     {
         Signature expectedSignature = Signature.builder()
                 .longVariable("z", "x + y")
-                .returnType(new TypeSignature("varchar", typeVariable("z")))
-                .argumentType(new TypeSignature("varchar", typeVariable("x")))
-                .argumentType(new TypeSignature("varchar", typeVariable("y")))
+                .returnType(new TypeSignature("varchar", numericVariable("z")))
+                .argumentType(new TypeSignature("varchar", numericVariable("x")))
+                .argumentType(new TypeSignature("varchar", numericVariable("y")))
                 .build();
 
         ParametricAggregation aggregation = getOnlyElement(parseFunctionDefinitions(LongConstraintAggregateFunction.class));

--- a/core/trino-main/src/test/java/io/trino/operator/TestAnnotationEngineForScalars.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestAnnotationEngineForScalars.java
@@ -376,7 +376,7 @@ public class TestAnnotationEngineForScalars
     {
         Signature expectedSignature = Signature.builder()
                 .returnType(BOOLEAN)
-                .argumentType(arrayType(new TypeSignature("varchar", TypeParameter.typeVariable("x"))))
+                .argumentType(arrayType(new TypeSignature("varchar", TypeParameter.numericVariable("x"))))
                 .build();
 
         Signature exactSignature = Signature.builder()
@@ -416,7 +416,7 @@ public class TestAnnotationEngineForScalars
     {
         Signature expectedSignature = Signature.builder()
                 .returnType(BIGINT)
-                .argumentType(new TypeSignature("varchar", TypeParameter.typeVariable("x")))
+                .argumentType(new TypeSignature("varchar", TypeParameter.numericVariable("x")))
                 .build();
 
         List<SqlScalarFunction> functions = ScalarFromAnnotationsParser.parseFunctionDefinition(SimpleInjectionScalarFunction.class);

--- a/core/trino-main/src/test/java/io/trino/operator/TestTypeSignature.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTypeSignature.java
@@ -31,7 +31,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.TypeParameter.namedField;
 import static io.trino.spi.type.TypeParameter.numericParameter;
-import static io.trino.spi.type.TypeParameter.typeVariable;
+import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.spi.type.TypeSignature.mapType;
 import static io.trino.spi.type.TypeSignature.rowType;
@@ -48,7 +48,7 @@ public class TestTypeSignature
     @Test
     public void parseSignatureWithLiterals()
     {
-        TypeSignature result = new TypeSignature("decimal", typeVariable("X"), numericParameter(42));
+        TypeSignature result = new TypeSignature("decimal", numericVariable("X"), numericParameter(42));
         assertThat(result.getParameters()).hasSize(2);
         assertThat(result.getParameters().get(0)).isInstanceOf(TypeParameter.Variable.class);
         assertThat(result.getParameters().get(1)).isInstanceOf(TypeParameter.Numeric.class);
@@ -184,7 +184,7 @@ public class TestTypeSignature
     private TypeSignature decimal(String precisionVariable, String scaleVariable)
     {
         return new TypeSignature(StandardTypes.DECIMAL, ImmutableList.of(
-                typeVariable(precisionVariable), typeVariable(scaleVariable)));
+                numericVariable(precisionVariable), numericVariable(scaleVariable)));
     }
 
     private static TypeSignature rowSignature(Field... fields)
@@ -280,13 +280,13 @@ public class TestTypeSignature
     public void testIsCalculated()
     {
         assertThat(BIGINT.getTypeSignature().isCalculated()).isFalse();
-        assertThat(new TypeSignature("decimal", typeVariable("p"), typeVariable("s")).isCalculated()).isTrue();
+        assertThat(new TypeSignature("decimal", numericVariable("p"), numericVariable("s")).isCalculated()).isTrue();
         assertThat(createDecimalType(2, 1).getTypeSignature().isCalculated()).isFalse();
-        assertThat(arrayType(new TypeSignature("decimal", typeVariable("p"), typeVariable("s"))).isCalculated()).isTrue();
+        assertThat(arrayType(new TypeSignature("decimal", numericVariable("p"), numericVariable("s"))).isCalculated()).isTrue();
         assertThat(arrayType(createDecimalType(2, 1).getTypeSignature()).isCalculated()).isFalse();
-        assertThat(mapType(new TypeSignature("decimal", typeVariable("p1"), typeVariable("s1")), new TypeSignature("decimal", typeVariable("p2"), typeVariable("s2"))).isCalculated()).isTrue();
+        assertThat(mapType(new TypeSignature("decimal", numericVariable("p1"), numericVariable("s1")), new TypeSignature("decimal", numericVariable("p2"), numericVariable("s2"))).isCalculated()).isTrue();
         assertThat(mapType(createDecimalType(2, 1).getTypeSignature(), createDecimalType(3, 1).getTypeSignature()).isCalculated()).isFalse();
-        assertThat(rowType(List.of(namedField("a", new TypeSignature("decimal", typeVariable("p1"), typeVariable("s1"))), namedField("b", new TypeSignature("decimal", typeVariable("p2"), typeVariable("s2"))))).isCalculated()).isTrue();
+        assertThat(rowType(List.of(namedField("a", new TypeSignature("decimal", numericVariable("p1"), numericVariable("s1"))), namedField("b", new TypeSignature("decimal", numericVariable("p2"), numericVariable("s2"))))).isCalculated()).isTrue();
     }
 
     private static void assertRowSignature(

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -224,6 +224,12 @@
                                 <item>
                                     <ignore>true</ignore>
                                     <code>java.method.removed</code>
+                                    <old>method io.trino.spi.type.TypeParameter io.trino.spi.type.TypeParameter::typeVariable(java.lang.String)</old>
+                                    <justification>Renamed to numericVariable; the factory builds a numeric parameter variable, not a type variable.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
                                     <old>method io.trino.spi.block.Block io.trino.spi.predicate.Utils::nativeValueToBlock(io.trino.spi.type.Type, java.lang.Object)</old>
                                 </item>
                                 <item>

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeParameter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeParameter.java
@@ -50,7 +50,7 @@ public sealed interface TypeParameter
         return new Type(Optional.empty(), type);
     }
 
-    static TypeParameter typeVariable(String variable)
+    static TypeParameter numericVariable(String variable)
     {
         return new Variable(variable);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeSignature.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeSignature.java
@@ -167,6 +167,16 @@ public final class TypeSignature
 
     // Type signature constructors for common types
 
+    /// Constructs a reference to the named type variable.
+    ///
+    /// A type variable is written as a parameterless type name whose base is the variable's
+    /// name; this factory makes that intent explicit instead of constructing a bare
+    /// [TypeSignature] that is indistinguishable from a concrete no-argument type.
+    public static TypeSignature typeVariable(String name)
+    {
+        return new TypeSignature(name);
+    }
+
     public static TypeSignature arrayType(TypeSignature elementType)
     {
         return new TypeSignature(StandardTypes.ARRAY, typeParameter(elementType));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/IcebergFunctionProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/IcebergFunctionProvider.java
@@ -43,7 +43,6 @@ import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 import org.apache.iceberg.transforms.Transforms;
@@ -61,6 +60,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.TypeSignature.typeVariable;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.lang.invoke.MethodType.methodType;
 import static java.util.Collections.nCopies;
@@ -76,7 +76,7 @@ public class IcebergFunctionProvider
                     .signature(Signature.builder()
                             .typeVariable("T")
                             .returnType(INTEGER)
-                            .argumentTypes(ImmutableList.of(new TypeSignature("T"), INTEGER.getTypeSignature()))
+                            .argumentTypes(ImmutableList.of(typeVariable("T"), INTEGER.getTypeSignature()))
                             .build())
                     .nullable()
                     .build())


### PR DESCRIPTION
A function `Signature` references two kinds of variable, and neither was named clearly at the construction site:

- A **numeric** variable — the length in `varchar(N)`, the precision/scale in `decimal(p, s)` — was built with `TypeParameter.typeVariable(String)`. That factory is misnamed: it produces a numeric parameter variable, not a type variable.
- A **type** variable — the `E` in `array(E)` — was built as a naked `new TypeSignature("E")`, a parameterless signature whose base *is* the variable name, indistinguishable at a glance from a concrete no-argument type.

This gives both a clear factory:

- Rename `TypeParameter.typeVariable` to `numericVariable`, pairing with the existing `numericParameter(long)`.
- Add `TypeSignature.typeVariable(String)` and migrate the type-variable construction sites to it.

Both commits are pure refactors; the constructed signatures are unchanged.