### PR TITLE
Fix NaN query progress under fault-tolerant execution

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -907,7 +907,7 @@ public class QueryStateMachine
                     StageInfo stage = queue.poll();
                     StageStats stageStats = stage.stageStats();
                     totalStages++;
-                    if (stage.state().isScheduled()) {
+                    if (stage.state().isScheduled() && stageStats.getTotalDrivers() != 0) {
                         completedPercentageSum += 100.0 * stageStats.getCompletedDrivers() / stageStats.getTotalDrivers();
                         runningPercentageSum += 100.0 * stageStats.getRunningDrivers() / stageStats.getTotalDrivers();
                     }


### PR DESCRIPTION
## Description
Fix https://github.com/trinodb/trino/issues/29791 Under fault-tolerant execution (retry_policy=TASK), a query's progressPercentage and runningPercentage can be reported as NaN.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
 `QueryStateMachine.getQueryStats()` computes progress by averaging the completion of each *scheduled* stage:
  ```java
  if (stage.state().isScheduled()) {
      completedPercentageSum += 100.0 * stageStats.getCompletedDrivers() / stageStats.getTotalDrivers();
      runningPercentageSum  += 100.0 * stageStats.getRunningDrivers()  / stageStats.getTotalDrivers();
  }
```
  StageState.isScheduled() returns true for PENDING and RUNNING stages. In fault-tolerant execution stages run in waves, so a downstream stage routinely sits in PENDING with totalDrivers == 0 while an upstream stage runs. That gives 100.0 * 0 / 0 = NaN, and because the sum is shared, one such stage makes the whole result NaN (min(100, NaN) == NaN).


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix stage progress. ({issue}`https://github.com/trinodb/trino/issues/29791`)
```
