### PR TITLE
Fix stage running percentage in StageStats.toBasicStageStats

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/StageStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStats.java
@@ -625,7 +625,7 @@ public class StageStats
         }
         OptionalDouble runningPercentage = OptionalDouble.empty();
         if (isScheduled && totalDrivers != 0) {
-            progressPercentage = OptionalDouble.of(min(100, (runningDrivers * 100.0) / totalDrivers));
+            runningPercentage = OptionalDouble.of(min(100, (runningDrivers * 100.0) / totalDrivers));
         }
 
         return new BasicStageStats(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Fix https://github.com/trinodb/trino/issues/29793
  `StageStats.toBasicStageStats()` populates the `BasicStageStats` progress and running percentages incorrectly:

  - `progressPercentage` reports the running-driver ratio instead of the
    completed-driver ratio.
  - `runningPercentage` is always empty.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
N.A


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix incorrect runningPercentage in basic stage stats. ({issue}`29793`)
```
