### PR TITLE
Clean up function signature construction helpers

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
@@ -22,7 +22,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.spi.function.FunctionId;
-import io.trino.spi.function.LongVariableConstraint;
+import io.trino.spi.function.NumericVariableConstraint;
 import io.trino.spi.function.Signature;
 import io.trino.spi.function.TypeVariableConstraint;
 import io.trino.spi.type.FunctionType;
@@ -535,9 +535,9 @@ public class SignatureBinder
 
     private void calculateVariableValuesForLongConstraints(BindingsBuilder variableBinder)
     {
-        for (LongVariableConstraint longVariableConstraint : declaredSignature.getLongVariableConstraints()) {
-            String calculation = longVariableConstraint.getExpression();
-            String variableName = longVariableConstraint.getName();
+        for (NumericVariableConstraint numericVariableConstraint : declaredSignature.getNumericVariableConstraints()) {
+            String calculation = numericVariableConstraint.getExpression();
+            String variableName = numericVariableConstraint.getName();
             Long calculatedValue = calculateLiteralValue(calculation, variableBinder.getLongVariables());
             if (variableBinder.containsLongVariable(variableName)) {
                 Long currentValue = variableBinder.getLongVariable(variableName);
@@ -661,7 +661,7 @@ public class SignatureBinder
         }
 
         // there must be exactly one type variable constraint and no long variable constraints
-        if (signature.getTypeVariableConstraints().size() != 1 || !signature.getLongVariableConstraints().isEmpty()) {
+        if (signature.getTypeVariableConstraints().size() != 1 || !signature.getNumericVariableConstraints().isEmpty()) {
             return false;
         }
         TypeVariableConstraint typeVariableConstraint = signature.getTypeVariableConstraints().getFirst();
@@ -689,7 +689,7 @@ public class SignatureBinder
         }
 
         // there must be exactly one type variable constraint and no long variable constraints
-        if (signature.getTypeVariableConstraints().size() != 1 || !signature.getLongVariableConstraints().isEmpty()) {
+        if (signature.getTypeVariableConstraints().size() != 1 || !signature.getNumericVariableConstraints().isEmpty()) {
             return false;
         }
         TypeVariableConstraint typeVariableConstraint = signature.getTypeVariableConstraints().getFirst();

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ParametricAggregationImplementation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ParametricAggregationImplementation.java
@@ -59,7 +59,7 @@ import static io.trino.operator.aggregation.AggregationFunctionAdapter.Aggregati
 import static io.trino.operator.annotations.FunctionsParserHelper.containsAnnotation;
 import static io.trino.operator.annotations.FunctionsParserHelper.createTypeVariableConstraints;
 import static io.trino.operator.annotations.FunctionsParserHelper.parseLiteralParameters;
-import static io.trino.operator.annotations.FunctionsParserHelper.parseLongVariableConstraints;
+import static io.trino.operator.annotations.FunctionsParserHelper.parseNumericVariableConstraints;
 import static io.trino.operator.annotations.ImplementationDependency.Factory.createDependency;
 import static io.trino.operator.annotations.ImplementationDependency.getImplementationDependencyAnnotation;
 import static io.trino.operator.annotations.ImplementationDependency.isImplementationDependencyAnnotation;
@@ -250,7 +250,7 @@ public class ParametricAggregationImplementation
             inputParameterKinds = parseInputParameterKinds(inputFunction);
 
             // parse constraints
-            parseLongVariableConstraints(inputFunction, signatureBuilder);
+            parseNumericVariableConstraints(inputFunction, signatureBuilder);
             List<ImplementationDependency> allDependencies =
                     Stream.of(
                                     stateDetails.stream().map(AccumulatorStateDetails::getDependencies).flatMap(Collection::stream),

--- a/core/trino-main/src/main/java/io/trino/operator/annotations/FunctionsParserHelper.java
+++ b/core/trino-main/src/main/java/io/trino/operator/annotations/FunctionsParserHelper.java
@@ -283,10 +283,10 @@ public final class FunctionsParserHelper
         return (description == null) ? Optional.empty() : Optional.of(description.value());
     }
 
-    public static void parseLongVariableConstraints(Method inputFunction, Builder signatureBuilder)
+    public static void parseNumericVariableConstraints(Method inputFunction, Builder signatureBuilder)
     {
         Stream.of(inputFunction.getAnnotationsByType(Constraint.class))
-                .forEach(annotation -> signatureBuilder.longVariable(annotation.variable(), annotation.expression()));
+                .forEach(annotation -> signatureBuilder.numericVariable(annotation.variable(), annotation.expression()));
     }
 
     public static Map<String, Class<?>> getDeclaredSpecializedTypeParameters(Method method, Set<io.trino.spi.function.TypeParameter> typeParameters)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringArrayExtractScalar.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringArrayExtractScalar.java
@@ -29,7 +29,6 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.ArrayType;
-import io.trino.spi.type.TypeSignature;
 import io.trino.type.JsonPathType;
 import io.trino.util.JsonCastException;
 
@@ -43,6 +42,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeSignature.arrayType;
+import static io.trino.spi.type.TypeSignature.type;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.util.JsonUtil.createJsonFactory;
 import static io.trino.util.JsonUtil.createJsonParser;
@@ -64,9 +64,9 @@ public final class JsonStringArrayExtractScalar
     {
         super(FunctionMetadata.scalarBuilder(JSON_STRING_ARRAY_EXTRACT_SCALAR_NAME)
                 .signature(Signature.builder()
-                        .argumentType(new TypeSignature("varchar", numericVariable("N")))
+                        .argumentType(type("varchar", numericVariable("N")))
                         .numericVariable("N")
-                        .argumentType(new TypeSignature(JsonPathType.NAME))
+                        .argumentType(type(JsonPathType.NAME))
                         .returnType(arrayType(VARCHAR.getTypeSignature()))
                         .build())
                 .nullable()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringArrayExtractScalar.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringArrayExtractScalar.java
@@ -65,7 +65,7 @@ public final class JsonStringArrayExtractScalar
         super(FunctionMetadata.scalarBuilder(JSON_STRING_ARRAY_EXTRACT_SCALAR_NAME)
                 .signature(Signature.builder()
                         .argumentType(new TypeSignature("varchar", numericVariable("N")))
-                        .longVariable("N")
+                        .numericVariable("N")
                         .argumentType(new TypeSignature(JsonPathType.NAME))
                         .returnType(arrayType(VARCHAR.getTypeSignature()))
                         .build())

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToArrayCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToArrayCast.java
@@ -17,11 +17,11 @@ import io.trino.metadata.SqlScalarFunction;
 import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
-import io.trino.spi.type.TypeSignature;
 
 import static io.trino.operator.scalar.JsonToArrayCast.JSON_TO_ARRAY;
 import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeSignature.arrayType;
+import static io.trino.spi.type.TypeSignature.type;
 import static io.trino.spi.type.TypeSignature.typeVariable;
 
 public final class JsonStringToArrayCast
@@ -37,7 +37,7 @@ public final class JsonStringToArrayCast
                         .typeVariable("T")
                         .numericVariable("N")
                         .returnType(arrayType(typeVariable("T")))
-                        .argumentType(new TypeSignature("varchar", numericVariable("N")))
+                        .argumentType(type("varchar", numericVariable("N")))
                         .build())
                 .nullable()
                 .hidden()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToArrayCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToArrayCast.java
@@ -35,7 +35,7 @@ public final class JsonStringToArrayCast
         super(FunctionMetadata.scalarBuilder(JSON_STRING_TO_ARRAY_NAME)
                 .signature(Signature.builder()
                         .typeVariable("T")
-                        .longVariable("N")
+                        .numericVariable("N")
                         .returnType(arrayType(typeVariable("T")))
                         .argumentType(new TypeSignature("varchar", numericVariable("N")))
                         .build())

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToMapCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToMapCast.java
@@ -36,7 +36,7 @@ public final class JsonStringToMapCast
                 .signature(Signature.builder()
                         .comparableTypeParameter("K")
                         .typeVariable("V")
-                        .longVariable("N")
+                        .numericVariable("N")
                         .returnType(mapType(typeVariable("K"), typeVariable("V")))
                         .argumentType(new TypeSignature("varchar", numericVariable("N")))
                         .build())

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToMapCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToMapCast.java
@@ -17,11 +17,11 @@ import io.trino.metadata.SqlScalarFunction;
 import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
-import io.trino.spi.type.TypeSignature;
 
 import static io.trino.operator.scalar.JsonToMapCast.JSON_TO_MAP;
 import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.type;
 import static io.trino.spi.type.TypeSignature.typeVariable;
 
 public final class JsonStringToMapCast
@@ -38,7 +38,7 @@ public final class JsonStringToMapCast
                         .typeVariable("V")
                         .numericVariable("N")
                         .returnType(mapType(typeVariable("K"), typeVariable("V")))
-                        .argumentType(new TypeSignature("varchar", numericVariable("N")))
+                        .argumentType(type("varchar", numericVariable("N")))
                         .build())
                 .nullable()
                 .hidden()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToRowCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToRowCast.java
@@ -17,10 +17,10 @@ import io.trino.metadata.SqlScalarFunction;
 import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
-import io.trino.spi.type.TypeSignature;
 
 import static io.trino.operator.scalar.JsonToRowCast.JSON_TO_ROW;
 import static io.trino.spi.type.TypeParameter.numericVariable;
+import static io.trino.spi.type.TypeSignature.type;
 import static io.trino.spi.type.TypeSignature.typeVariable;
 
 public final class JsonStringToRowCast
@@ -36,7 +36,7 @@ public final class JsonStringToRowCast
                         .numericVariable("N")
                         .rowTypeParameter("T")
                         .returnType(typeVariable("T"))
-                        .argumentType(new TypeSignature("varchar", numericVariable("N")))
+                        .argumentType(type("varchar", numericVariable("N")))
                         .build())
                 .nullable()
                 .hidden()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToRowCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JsonStringToRowCast.java
@@ -33,7 +33,7 @@ public final class JsonStringToRowCast
     {
         super(FunctionMetadata.scalarBuilder(JSON_STRING_TO_ROW_NAME)
                 .signature(Signature.builder()
-                        .longVariable("N")
+                        .numericVariable("N")
                         .rowTypeParameter("T")
                         .returnType(typeVariable("T"))
                         .argumentType(new TypeSignature("varchar", numericVariable("N")))

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapToVariantCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapToVariantCast.java
@@ -58,7 +58,7 @@ public class MapToVariantCast
     {
         super(FunctionMetadata.operatorBuilder(CAST)
                 .signature(Signature.builder()
-                        .longVariable("N")
+                        .numericVariable("N")
                         .castableToTypeParameter("V", VARIANT.getTypeSignature())
                         .returnType(VARIANT)
                         .argumentType(mapType(new TypeSignature("varchar", numericVariable("N")), typeVariable("V")))

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapToVariantCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapToVariantCast.java
@@ -20,7 +20,6 @@ import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.MapType;
-import io.trino.spi.type.TypeSignature;
 import io.trino.spi.variant.Variant;
 import io.trino.util.variant.VariantWriter;
 
@@ -33,6 +32,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeSignature.mapType;
+import static io.trino.spi.type.TypeSignature.type;
 import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.VariantType.VARIANT;
 import static io.trino.util.Failures.checkCondition;
@@ -61,7 +61,7 @@ public class MapToVariantCast
                         .numericVariable("N")
                         .castableToTypeParameter("V", VARIANT.getTypeSignature())
                         .returnType(VARIANT)
-                        .argumentType(mapType(new TypeSignature("varchar", numericVariable("N")), typeVariable("V")))
+                        .argumentType(mapType(type("varchar", numericVariable("N")), typeVariable("V")))
                         .build())
                 .build());
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/ParametricScalarImplementation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/ParametricScalarImplementation.java
@@ -72,7 +72,7 @@ import static io.trino.operator.annotations.FunctionsParserHelper.containsLegacy
 import static io.trino.operator.annotations.FunctionsParserHelper.createTypeVariableConstraints;
 import static io.trino.operator.annotations.FunctionsParserHelper.getDeclaredSpecializedTypeParameters;
 import static io.trino.operator.annotations.FunctionsParserHelper.parseLiteralParameters;
-import static io.trino.operator.annotations.FunctionsParserHelper.parseLongVariableConstraints;
+import static io.trino.operator.annotations.FunctionsParserHelper.parseNumericVariableConstraints;
 import static io.trino.operator.annotations.ImplementationDependency.Factory.createDependency;
 import static io.trino.operator.annotations.ImplementationDependency.checkTypeParameters;
 import static io.trino.operator.annotations.ImplementationDependency.getImplementationDependencyAnnotation;
@@ -504,7 +504,7 @@ public class ParametricScalarImplementation
                 checkArgument(!nullable, "Method [%s] annotated with @SqlNullable has primitive return type %s", method, actualReturnType.getSimpleName());
             }
 
-            parseLongVariableConstraints(method, signatureBuilder);
+            parseNumericVariableConstraints(method, signatureBuilder);
 
             this.specializedTypeParameters = getDeclaredSpecializedTypeParameters(method, typeParameters);
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonArrayFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonArrayFunction.java
@@ -30,7 +30,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.type.Json2016Type;
 
 import java.lang.invoke.MethodHandle;
@@ -44,6 +43,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.StandardTypes.BOOLEAN;
 import static io.trino.spi.type.StandardTypes.JSON_2016;
+import static io.trino.spi.type.TypeSignature.type;
 import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.sql.analyzer.ExpressionAnalyzer.JSON_NO_PARAMETERS_ROW_TYPE;
@@ -62,8 +62,8 @@ public class JsonArrayFunction
         super(FunctionMetadata.scalarBuilder(JSON_ARRAY_FUNCTION_NAME)
                 .signature(Signature.builder()
                         .typeVariable("E")
-                        .returnType(new TypeSignature(JSON_2016))
-                        .argumentTypes(ImmutableList.of(typeVariable("E"), new TypeSignature(BOOLEAN)))
+                        .returnType(type(JSON_2016))
+                        .argumentTypes(ImmutableList.of(typeVariable("E"), type(BOOLEAN)))
                         .build())
                 .argumentNullability(true, false)
                 .hidden()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonExistsFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonExistsFunction.java
@@ -33,7 +33,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.tree.JsonExists.ErrorBehavior;
 import io.trino.type.JsonPath2016Type;
 
@@ -50,6 +49,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.StandardTypes.JSON_2016;
 import static io.trino.spi.type.StandardTypes.TINYINT;
+import static io.trino.spi.type.TypeSignature.type;
 import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.util.Reflection.constructorMethodHandle;
 import static io.trino.util.Reflection.methodHandle;
@@ -71,7 +71,7 @@ public class JsonExistsFunction
                 .signature(Signature.builder()
                         .typeVariable("T")
                         .returnType(BOOLEAN)
-                        .argumentTypes(ImmutableList.of(new TypeSignature(JSON_2016), new TypeSignature(JsonPath2016Type.NAME), typeVariable("T"), new TypeSignature(TINYINT)))
+                        .argumentTypes(ImmutableList.of(type(JSON_2016), type(JsonPath2016Type.NAME), typeVariable("T"), type(TINYINT)))
                         .build())
                 .nullable()
                 .argumentNullability(false, false, true, false)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonObjectFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonObjectFunction.java
@@ -31,7 +31,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 import io.trino.type.Json2016Type;
 
 import java.lang.invoke.MethodHandle;
@@ -49,6 +48,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.StandardTypes.BOOLEAN;
 import static io.trino.spi.type.StandardTypes.JSON_2016;
+import static io.trino.spi.type.TypeSignature.type;
 import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.sql.analyzer.ExpressionAnalyzer.JSON_NO_PARAMETERS_ROW_TYPE;
@@ -68,8 +68,8 @@ public class JsonObjectFunction
                 .signature(Signature.builder()
                         .typeVariable("K")
                         .typeVariable("V")
-                        .returnType(new TypeSignature(JSON_2016))
-                        .argumentTypes(ImmutableList.of(typeVariable("K"), typeVariable("V"), new TypeSignature(BOOLEAN), new TypeSignature(BOOLEAN)))
+                        .returnType(type(JSON_2016))
+                        .argumentTypes(ImmutableList.of(typeVariable("K"), typeVariable("V"), type(BOOLEAN), type(BOOLEAN)))
                         .build())
                 .argumentNullability(true, true, false, false)
                 .hidden()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonQueryFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonQueryFunction.java
@@ -37,7 +37,6 @@ import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.tree.JsonQuery.ArrayWrapperBehavior;
 import io.trino.sql.tree.JsonQuery.EmptyOrErrorBehavior;
 import io.trino.type.JsonPath2016Type;
@@ -55,6 +54,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.type.StandardTypes.JSON_2016;
 import static io.trino.spi.type.StandardTypes.TINYINT;
+import static io.trino.spi.type.TypeSignature.type;
 import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.util.Reflection.constructorMethodHandle;
 import static io.trino.util.Reflection.methodHandle;
@@ -78,14 +78,14 @@ public class JsonQueryFunction
         super(FunctionMetadata.scalarBuilder(JSON_QUERY_FUNCTION_NAME)
                 .signature(Signature.builder()
                         .typeVariable("T")
-                        .returnType(new TypeSignature(JSON_2016))
+                        .returnType(type(JSON_2016))
                         .argumentTypes(ImmutableList.of(
-                                new TypeSignature(JSON_2016),
-                                new TypeSignature(JsonPath2016Type.NAME),
+                                type(JSON_2016),
+                                type(JsonPath2016Type.NAME),
                                 typeVariable("T"),
-                                new TypeSignature(TINYINT),
-                                new TypeSignature(TINYINT),
-                                new TypeSignature(TINYINT)))
+                                type(TINYINT),
+                                type(TINYINT),
+                                type(TINYINT)))
                         .build())
                 .nullable()
                 .argumentNullability(false, false, true, false, false, false)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonValueFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonValueFunction.java
@@ -43,7 +43,6 @@ import io.trino.spi.function.Signature;
 import io.trino.spi.type.FunctionType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
-import io.trino.spi.type.TypeSignature;
 import io.trino.sql.InterpretedFunctionInvoker;
 import io.trino.sql.gen.lambda.LambdaFunctionInterface;
 import io.trino.sql.tree.JsonValue.EmptyOrErrorBehavior;
@@ -68,6 +67,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.type.StandardTypes.JSON_2016;
 import static io.trino.spi.type.StandardTypes.TINYINT;
 import static io.trino.spi.type.TypeSignature.functionType;
+import static io.trino.spi.type.TypeSignature.type;
 import static io.trino.spi.type.TypeSignature.typeVariable;
 import static io.trino.util.Reflection.constructorMethodHandle;
 import static io.trino.util.Reflection.methodHandle;
@@ -99,13 +99,13 @@ public class JsonValueFunction
                         .typeVariable("D")
                         .returnType(typeVariable("R"))
                         .argumentTypes(ImmutableList.of(
-                                new TypeSignature(JSON_2016),
-                                new TypeSignature(JsonPath2016Type.NAME),
+                                type(JSON_2016),
+                                type(JsonPath2016Type.NAME),
                                 typeVariable("T"),
                                 typeVariable("R"),
-                                new TypeSignature(TINYINT),
+                                type(TINYINT),
                                 functionType(typeVariable("E")),
-                                new TypeSignature(TINYINT),
+                                type(TINYINT),
                                 functionType(typeVariable("D"))))
                         .build())
                 .nullable()

--- a/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
@@ -63,6 +63,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.TypeParameter.numericVariable;
+import static io.trino.spi.type.TypeSignature.type;
 import static io.trino.spi.type.VarcharType.UNBOUNDED_LENGTH;
 import static io.trino.spi.type.VariantType.VARIANT;
 import static io.trino.type.JsonType.JSON;
@@ -100,7 +101,7 @@ public final class DecimalCasts
     public static final SqlScalarFunction REAL_TO_DECIMAL_CAST = castFunctionToDecimalFrom(REAL.getTypeSignature(), true, "realToShortDecimal", "realToLongDecimal");
     public static final SqlScalarFunction DECIMAL_TO_NUMBER_CAST = castFunctionFromDecimalTo(NUMBER.getTypeSignature(), true, "shortDecimalToNumber", "longDecimalToNumber");
     public static final SqlScalarFunction NUMBER_TO_DECIMAL_CAST = castFunctionToDecimalFrom(NUMBER.getTypeSignature(), false, "numberToShortDecimal", "numberToLongDecimal");
-    public static final SqlScalarFunction VARCHAR_TO_DECIMAL_CAST = castFunctionToDecimalFrom(new TypeSignature("varchar", numericVariable("x")), false, "varcharToShortDecimal", "varcharToLongDecimal");
+    public static final SqlScalarFunction VARCHAR_TO_DECIMAL_CAST = castFunctionToDecimalFrom(type("varchar", numericVariable("x")), false, "varcharToShortDecimal", "varcharToLongDecimal");
     // Despite decimalToJson having a catch inside that suggests that function can fail, IOException comes from the Jackson writing to an OutputStream
     // that never happens for SliceOutput.
     public static final SqlScalarFunction DECIMAL_TO_JSON_CAST = castFunctionFromDecimalTo(JSON.getTypeSignature(), true, "shortDecimalToJson", "longDecimalToJson");
@@ -113,7 +114,7 @@ public final class DecimalCasts
     private static SqlScalarFunction castFunctionFromDecimalTo(TypeSignature to, boolean neverFails, String... methodNames)
     {
         Signature signature = Signature.builder()
-                .argumentType(new TypeSignature("decimal", numericVariable("precision"), numericVariable("scale")))
+                .argumentType(type("decimal", numericVariable("precision"), numericVariable("scale")))
                 .returnType(to)
                 .build();
         return new PolymorphicScalarFunctionBuilder(CAST, DecimalCasts.class)
@@ -147,7 +148,7 @@ public final class DecimalCasts
     {
         Signature signature = Signature.builder()
                 .argumentType(from)
-                .returnType(new TypeSignature("decimal", numericVariable("precision"), numericVariable("scale")))
+                .returnType(type("decimal", numericVariable("precision"), numericVariable("scale")))
                 .build();
         return new PolymorphicScalarFunctionBuilder(CAST, DecimalCasts.class)
                 .signature(signature)
@@ -173,8 +174,8 @@ public final class DecimalCasts
 
     public static final SqlScalarFunction DECIMAL_TO_VARCHAR_CAST = new PolymorphicScalarFunctionBuilder(CAST, DecimalCasts.class)
             .signature(Signature.builder()
-                    .argumentType(new TypeSignature("decimal", numericVariable("precision"), numericVariable("scale")))
-                    .returnType(new TypeSignature("varchar", numericVariable("x")))
+                    .argumentType(type("decimal", numericVariable("precision"), numericVariable("scale")))
+                    .returnType(type("varchar", numericVariable("x")))
                     .build())
             .deterministic(true)
             .choice(choice -> choice

--- a/core/trino-main/src/main/java/io/trino/type/DecimalOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalOperators.java
@@ -48,6 +48,7 @@ import static io.trino.spi.type.Int128Math.remainder;
 import static io.trino.spi.type.Int128Math.rescale;
 import static io.trino.spi.type.Int128Math.subtract;
 import static io.trino.spi.type.TypeParameter.numericVariable;
+import static io.trino.spi.type.TypeSignature.type;
 import static java.lang.Integer.max;
 import static java.lang.Long.signum;
 import static java.lang.Math.abs;
@@ -70,9 +71,9 @@ public final class DecimalOperators
 
     private static SqlScalarFunction decimalAddOperator(boolean legacyTypeCalculation)
     {
-        TypeSignature decimalLeftSignature = new TypeSignature("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
-        TypeSignature decimalRightSignature = new TypeSignature("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
-        TypeSignature decimalResultSignature = new TypeSignature("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
+        TypeSignature decimalLeftSignature = type("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
+        TypeSignature decimalRightSignature = type("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
+        TypeSignature decimalResultSignature = type("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
 
         Signature.Builder signature = Signature.builder();
 
@@ -167,9 +168,9 @@ public final class DecimalOperators
 
     private static SqlScalarFunction decimalSubtractOperator(boolean legacyTypeCalculation)
     {
-        TypeSignature decimalLeftSignature = new TypeSignature("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
-        TypeSignature decimalRightSignature = new TypeSignature("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
-        TypeSignature decimalResultSignature = new TypeSignature("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
+        TypeSignature decimalLeftSignature = type("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
+        TypeSignature decimalRightSignature = type("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
+        TypeSignature decimalResultSignature = type("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
 
         Signature.Builder signature = Signature.builder();
 
@@ -262,9 +263,9 @@ public final class DecimalOperators
 
     private static SqlScalarFunction decimalMultiplyOperator(boolean legacyTypeCalculation)
     {
-        TypeSignature decimalLeftSignature = new TypeSignature("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
-        TypeSignature decimalRightSignature = new TypeSignature("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
-        TypeSignature decimalResultSignature = new TypeSignature("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
+        TypeSignature decimalLeftSignature = type("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
+        TypeSignature decimalRightSignature = type("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
+        TypeSignature decimalResultSignature = type("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
 
         Signature.Builder signature = Signature.builder();
 
@@ -366,9 +367,9 @@ public final class DecimalOperators
 
     private static SqlScalarFunction decimalDivideOperator(boolean legacyTypeCalculation)
     {
-        TypeSignature decimalLeftSignature = new TypeSignature("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
-        TypeSignature decimalRightSignature = new TypeSignature("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
-        TypeSignature decimalResultSignature = new TypeSignature("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
+        TypeSignature decimalLeftSignature = type("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
+        TypeSignature decimalRightSignature = type("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
+        TypeSignature decimalResultSignature = type("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
 
         Signature.Builder signature = Signature.builder();
 
@@ -552,9 +553,9 @@ public final class DecimalOperators
 
     private static SqlScalarFunction moduloScalarFunction(PolymorphicScalarFunctionBuilder builder)
     {
-        TypeSignature decimalLeftSignature = new TypeSignature("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
-        TypeSignature decimalRightSignature = new TypeSignature("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
-        TypeSignature decimalResultSignature = new TypeSignature("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
+        TypeSignature decimalLeftSignature = type("decimal", numericVariable("a_precision"), numericVariable("a_scale"));
+        TypeSignature decimalRightSignature = type("decimal", numericVariable("b_precision"), numericVariable("b_scale"));
+        TypeSignature decimalResultSignature = type("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
 
         Signature signature = Signature.builder()
                 .numericVariable("r_precision", "min(b_precision - b_scale, a_precision - a_scale) + max(a_scale, b_scale)")

--- a/core/trino-main/src/main/java/io/trino/type/DecimalOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalOperators.java
@@ -77,8 +77,8 @@ public final class DecimalOperators
         Signature.Builder signature = Signature.builder();
 
         if (legacyTypeCalculation) {
-            signature.longVariable("r_precision", "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
-                    .longVariable("r_scale", "max(a_scale, b_scale)");
+            signature.numericVariable("r_precision", "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
+                    .numericVariable("r_scale", "max(a_scale, b_scale)");
         }
         else {
             // The precision and scale calculations are modeled after MSSQL (https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql),
@@ -87,8 +87,8 @@ public final class DecimalOperators
             //    raw_scale = max(a_scale, b_scale);
             //    r_precision = min(raw_scale + integral + 1, 38);
             //    r_scale = min(raw_scale, precision - integral);
-            signature.longVariable("r_precision", "min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38)")
-                    .longVariable("r_scale", "min(max(a_scale, b_scale), min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38) - max(a_precision - a_scale, b_precision - b_scale))");
+            signature.numericVariable("r_precision", "min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38)")
+                    .numericVariable("r_scale", "min(max(a_scale, b_scale), min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38) - max(a_precision - a_scale, b_precision - b_scale))");
         }
 
         return new PolymorphicScalarFunctionBuilder(ADD, DecimalOperators.class)
@@ -174,8 +174,8 @@ public final class DecimalOperators
         Signature.Builder signature = Signature.builder();
 
         if (legacyTypeCalculation) {
-            signature.longVariable("r_precision", "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
-                    .longVariable("r_scale", "max(a_scale, b_scale)");
+            signature.numericVariable("r_precision", "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
+                    .numericVariable("r_scale", "max(a_scale, b_scale)");
         }
         else {
             // The precision and scale calculations are modeled after MSSQL (https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql),
@@ -184,8 +184,8 @@ public final class DecimalOperators
             //    raw_scale = max(a_scale, b_scale);
             //    r_precision = min(raw_scale + integral + 1, 38);
             //    r_scale = min(raw_scale, precision - integral);
-            signature.longVariable("r_precision", "min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38)")
-                    .longVariable("r_scale", "min(max(a_scale, b_scale), min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38) - max(a_precision - a_scale, b_precision - b_scale))");
+            signature.numericVariable("r_precision", "min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38)")
+                    .numericVariable("r_scale", "min(max(a_scale, b_scale), min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38) - max(a_precision - a_scale, b_precision - b_scale))");
         }
 
         return new PolymorphicScalarFunctionBuilder(SUBTRACT, DecimalOperators.class)
@@ -270,8 +270,8 @@ public final class DecimalOperators
 
         if (legacyTypeCalculation) {
             signature
-                    .longVariable("r_precision", "min(38, a_precision + b_precision)")
-                    .longVariable("r_scale", "a_scale + b_scale");
+                    .numericVariable("r_precision", "min(38, a_precision + b_precision)")
+                    .numericVariable("r_scale", "a_scale + b_scale");
         }
         else {
             // The precision and scale calculations are modeled after MSSQL (https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql),
@@ -285,8 +285,8 @@ public final class DecimalOperators
             //     precision = min(raw_precision, 38);
             //     scale = min(raw_scale, integral > 32 ? 6 : 38 - integral);
             signature
-                    .longVariable("r_precision", "min(a_precision + b_precision, 38)")
-                    .longVariable("r_scale", "min(a_scale + b_scale, if(a_precision + b_precision - (a_scale + b_scale) > 32, 6, 38 - (a_precision + b_precision - (a_scale + b_scale))))");
+                    .numericVariable("r_precision", "min(a_precision + b_precision, 38)")
+                    .numericVariable("r_scale", "min(a_scale + b_scale, if(a_precision + b_precision - (a_scale + b_scale) > 32, 6, 38 - (a_precision + b_precision - (a_scale + b_scale))))");
         }
 
         return new PolymorphicScalarFunctionBuilder(MULTIPLY, DecimalOperators.class)
@@ -373,8 +373,8 @@ public final class DecimalOperators
         Signature.Builder signature = Signature.builder();
 
         if (legacyTypeCalculation) {
-            signature.longVariable("r_precision", "min(38, a_precision + b_scale + max(b_scale - a_scale, 0))")
-                    .longVariable("r_scale", "max(a_scale, b_scale)");
+            signature.numericVariable("r_precision", "min(38, a_precision + b_scale + max(b_scale - a_scale, 0))")
+                    .numericVariable("r_scale", "max(a_scale, b_scale)");
         }
         else {
             // The precision and scale calculations are modeled after MSSQL (https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql),
@@ -386,8 +386,8 @@ public final class DecimalOperators
             //     integral = raw_precision - raw_scale;
             //     precision = min(raw_precision, 38);
             //     scale = min(raw_scale, integral > 32 ? 6 : 38 - integral);
-            signature.longVariable("r_precision", "min(a_precision - a_scale + b_scale + max(6, a_scale + b_precision + 1), 38)")
-                    .longVariable("r_scale", "min(max(6, a_scale + b_precision + 1), if(a_precision - a_scale + b_scale + max(6, a_scale + b_precision + 1) - max(6, a_scale + b_precision + 1) > 32, 6, 38 - (a_precision - a_scale + b_scale + max(6, a_scale + b_precision + 1) - max(6, a_scale + b_precision + 1))))");
+            signature.numericVariable("r_precision", "min(a_precision - a_scale + b_scale + max(6, a_scale + b_precision + 1), 38)")
+                    .numericVariable("r_scale", "min(max(6, a_scale + b_precision + 1), if(a_precision - a_scale + b_scale + max(6, a_scale + b_precision + 1) - max(6, a_scale + b_precision + 1) > 32, 6, 38 - (a_precision - a_scale + b_scale + max(6, a_scale + b_precision + 1) - max(6, a_scale + b_precision + 1))))");
         }
 
         return new PolymorphicScalarFunctionBuilder(DIVIDE, DecimalOperators.class)
@@ -557,8 +557,8 @@ public final class DecimalOperators
         TypeSignature decimalResultSignature = new TypeSignature("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
 
         Signature signature = Signature.builder()
-                .longVariable("r_precision", "min(b_precision - b_scale, a_precision - a_scale) + max(a_scale, b_scale)")
-                .longVariable("r_scale", "max(a_scale, b_scale)")
+                .numericVariable("r_precision", "min(b_precision - b_scale, a_precision - a_scale) + max(a_scale, b_scale)")
+                .numericVariable("r_scale", "max(a_scale, b_scale)")
                 .argumentType(decimalLeftSignature)
                 .argumentType(decimalRightSignature)
                 .returnType(decimalResultSignature)

--- a/core/trino-main/src/main/java/io/trino/type/DecimalSaturatedFloorCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalSaturatedFloorCasts.java
@@ -20,7 +20,6 @@ import io.trino.metadata.SqlScalarFunction;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeSignature;
 
 import static io.trino.spi.function.OperatorType.SATURATED_FLOOR_CAST;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -33,6 +32,7 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.TypeParameter.numericVariable;
+import static io.trino.spi.type.TypeSignature.type;
 import static java.lang.Math.toIntExact;
 
 public final class DecimalSaturatedFloorCasts
@@ -41,8 +41,8 @@ public final class DecimalSaturatedFloorCasts
 
     public static final SqlScalarFunction DECIMAL_TO_DECIMAL_SATURATED_FLOOR_CAST = new PolymorphicScalarFunctionBuilder(SATURATED_FLOOR_CAST, DecimalSaturatedFloorCasts.class)
             .signature(Signature.builder()
-                    .argumentType(new TypeSignature("decimal", numericVariable("source_precision"), numericVariable("source_scale")))
-                    .returnType(new TypeSignature("decimal", numericVariable("result_precision"), numericVariable("result_scale")))
+                    .argumentType(type("decimal", numericVariable("source_precision"), numericVariable("source_scale")))
+                    .returnType(type("decimal", numericVariable("result_precision"), numericVariable("result_scale")))
                     .build())
             .deterministic(true)
             .choice(choice -> choice
@@ -111,7 +111,7 @@ public final class DecimalSaturatedFloorCasts
     {
         return new PolymorphicScalarFunctionBuilder(SATURATED_FLOOR_CAST, DecimalSaturatedFloorCasts.class)
                 .signature(Signature.builder()
-                        .argumentType(new TypeSignature("decimal", numericVariable("source_precision"), numericVariable("source_scale")))
+                        .argumentType(type("decimal", numericVariable("source_precision"), numericVariable("source_scale")))
                         .returnType(type.getTypeSignature())
                         .build())
                 .deterministic(true)
@@ -163,7 +163,7 @@ public final class DecimalSaturatedFloorCasts
         return new PolymorphicScalarFunctionBuilder(SATURATED_FLOOR_CAST, DecimalSaturatedFloorCasts.class)
                 .signature(Signature.builder()
                         .argumentType(integerType)
-                        .returnType(new TypeSignature("decimal", numericVariable("result_precision"), numericVariable("result_scale")))
+                        .returnType(type("decimal", numericVariable("result_precision"), numericVariable("result_scale")))
                         .build())
                 .deterministic(true)
                 .choice(choice -> choice

--- a/core/trino-main/src/test/java/io/trino/operator/TestAnnotationEngineForAggregates.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestAnnotationEngineForAggregates.java
@@ -970,7 +970,7 @@ public class TestAnnotationEngineForAggregates
     public void testLongConstraintAggregateFunctionParse()
     {
         Signature expectedSignature = Signature.builder()
-                .longVariable("z", "x + y")
+                .numericVariable("z", "x + y")
                 .returnType(new TypeSignature("varchar", numericVariable("z")))
                 .argumentType(new TypeSignature("varchar", numericVariable("x")))
                 .argumentType(new TypeSignature("varchar", numericVariable("y")))

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -235,6 +235,30 @@
                                 </item>
                                 <item>
                                     <ignore>true</ignore>
+                                    <code>java.class.removed</code>
+                                    <old>class io.trino.spi.function.LongVariableConstraint</old>
+                                    <justification>Renamed to NumericVariableConstraint.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method io.trino.spi.function.Signature.Builder io.trino.spi.function.Signature.Builder::longVariable(java.lang.String)</old>
+                                    <justification>Renamed to numericVariable.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method io.trino.spi.function.Signature.Builder io.trino.spi.function.Signature.Builder::longVariable(java.lang.String, java.lang.String)</old>
+                                    <justification>Renamed to numericVariable.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.List&lt;io.trino.spi.function.LongVariableConstraint&gt; io.trino.spi.function.Signature::getLongVariableConstraints()</old>
+                                    <justification>Renamed to getNumericVariableConstraints.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
                                     <code>java.method.removed</code>
                                     <old>method io.trino.spi.block.Block io.trino.spi.predicate.Utils::nativeValueToBlock(io.trino.spi.type.Type, java.lang.Object)</old>
                                 </item>

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -260,6 +260,24 @@
                                 <item>
                                     <ignore>true</ignore>
                                     <code>java.method.removed</code>
+                                    <old>method io.trino.spi.type.TypeSignature io.trino.spi.type.TypeSignature::parametricType(java.lang.String, io.trino.spi.type.TypeSignature[])</old>
+                                    <justification>Renamed parametricType to type; the parameterless type(name) is the degenerate case.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
+                                    <new>method io.trino.spi.type.TypeSignature io.trino.spi.type.TypeSignature::type(java.lang.String, io.trino.spi.type.TypeSignature[])</new>
+                                    <justification>The type factory deliberately overloads on TypeSignature... and TypeParameter... varargs so callers avoid wrapping homogeneous parameters.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
+                                    <new>method io.trino.spi.type.TypeSignature io.trino.spi.type.TypeSignature::type(java.lang.String, io.trino.spi.type.TypeParameter[])</new>
+                                    <justification>The type factory deliberately overloads on TypeSignature... and TypeParameter... varargs so callers avoid wrapping homogeneous parameters.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.removed</code>
                                     <old>method io.trino.spi.block.Block io.trino.spi.predicate.Utils::nativeValueToBlock(io.trino.spi.type.Type, java.lang.Object)</old>
                                 </item>
                                 <item>

--- a/core/trino-spi/src/main/java/io/trino/spi/function/NumericVariableConstraint.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/NumericVariableConstraint.java
@@ -21,12 +21,12 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
-public class LongVariableConstraint
+public class NumericVariableConstraint
 {
     private final String name;
     private final String expression;
 
-    LongVariableConstraint(String name, String expression)
+    NumericVariableConstraint(String name, String expression)
     {
         this.name = requireNonNull(name, "name is null");
         this.expression = requireNonNull(expression, "expression is null");
@@ -59,7 +59,7 @@ public class LongVariableConstraint
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        LongVariableConstraint that = (LongVariableConstraint) o;
+        NumericVariableConstraint that = (NumericVariableConstraint) o;
         return Objects.equals(name, that.name) &&
                 Objects.equals(expression, that.expression);
     }
@@ -73,10 +73,10 @@ public class LongVariableConstraint
     @JsonCreator
     @DoNotCall // For JSON deserialization only
     @Deprecated // Discourage usages in SPI consumers
-    public static LongVariableConstraint fromJson(
+    public static NumericVariableConstraint fromJson(
             @JsonProperty("name") String name,
             @JsonProperty("expression") String expression)
     {
-        return new LongVariableConstraint(name, expression);
+        return new NumericVariableConstraint(name, expression);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/function/Signature.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/Signature.java
@@ -43,20 +43,20 @@ public class Signature
     }
 
     private final List<TypeVariableConstraint> typeVariableConstraints;
-    private final List<LongVariableConstraint> longVariableConstraints;
+    private final List<NumericVariableConstraint> numericVariableConstraints;
     private final TypeSignature returnType;
     private final List<Argument> arguments;
     private final boolean variableArity;
 
     private Signature(
             List<TypeVariableConstraint> typeVariableConstraints,
-            List<LongVariableConstraint> longVariableConstraints,
+            List<NumericVariableConstraint> numericVariableConstraints,
             TypeSignature returnType,
             List<Argument> arguments,
             boolean variableArity)
     {
         this.typeVariableConstraints = List.copyOf(typeVariableConstraints);
-        this.longVariableConstraints = List.copyOf(longVariableConstraints);
+        this.numericVariableConstraints = List.copyOf(numericVariableConstraints);
         this.returnType = requireNonNull(returnType, "returnType is null");
         this.arguments = List.copyOf(arguments);
         this.variableArity = variableArity;
@@ -97,15 +97,15 @@ public class Signature
         return typeVariableConstraints;
     }
 
-    public List<LongVariableConstraint> getLongVariableConstraints()
+    public List<NumericVariableConstraint> getNumericVariableConstraints()
     {
-        return longVariableConstraints;
+        return numericVariableConstraints;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(typeVariableConstraints, longVariableConstraints, returnType, arguments, variableArity);
+        return Objects.hash(typeVariableConstraints, numericVariableConstraints, returnType, arguments, variableArity);
     }
 
     @Override
@@ -118,7 +118,7 @@ public class Signature
             return false;
         }
         return Objects.equals(this.typeVariableConstraints, other.typeVariableConstraints) &&
-                Objects.equals(this.longVariableConstraints, other.longVariableConstraints) &&
+                Objects.equals(this.numericVariableConstraints, other.numericVariableConstraints) &&
                 Objects.equals(this.returnType, other.returnType) &&
                 Objects.equals(this.arguments, other.arguments) &&
                 this.variableArity == other.variableArity;
@@ -129,7 +129,7 @@ public class Signature
     {
         List<String> allConstraints = concat(
                 typeVariableConstraints.stream().map(TypeVariableConstraint::toString),
-                longVariableConstraints.stream().map(LongVariableConstraint::toString))
+                numericVariableConstraints.stream().map(NumericVariableConstraint::toString))
                 .collect(Collectors.toList());
 
         return (allConstraints.isEmpty() ? "" : allConstraints.stream().collect(joining(",", "<", ">"))) +
@@ -146,7 +146,7 @@ public class Signature
     {
         Builder builder = new Builder()
                 .typeVariableConstraints(base.typeVariableConstraints)
-                .longVariableConstraints(base.longVariableConstraints)
+                .numericVariableConstraints(base.numericVariableConstraints)
                 .returnType(base.returnType)
                 .arguments(base.arguments);
         if (base.variableArity) {
@@ -158,7 +158,7 @@ public class Signature
     public static final class Builder
     {
         private final List<TypeVariableConstraint> typeVariableConstraints = new ArrayList<>();
-        private final List<LongVariableConstraint> longVariableConstraints = new ArrayList<>();
+        private final List<NumericVariableConstraint> numericVariableConstraints = new ArrayList<>();
         private TypeSignature returnType;
         private final List<Argument> arguments = new ArrayList<>();
         private boolean variableArity;
@@ -234,21 +234,21 @@ public class Signature
             return this;
         }
 
-        public Builder longVariable(String name, String expression)
+        public Builder numericVariable(String name, String expression)
         {
-            this.longVariableConstraints.add(new LongVariableConstraint(name, expression));
+            this.numericVariableConstraints.add(new NumericVariableConstraint(name, expression));
             return this;
         }
 
-        public Builder longVariable(String name)
+        public Builder numericVariable(String name)
         {
-            this.longVariableConstraints.add(new LongVariableConstraint(name, name));
+            this.numericVariableConstraints.add(new NumericVariableConstraint(name, name));
             return this;
         }
 
-        public Builder longVariableConstraints(List<LongVariableConstraint> longVariableConstraints)
+        public Builder numericVariableConstraints(List<NumericVariableConstraint> numericVariableConstraints)
         {
-            this.longVariableConstraints.addAll(longVariableConstraints);
+            this.numericVariableConstraints.addAll(numericVariableConstraints);
             return this;
         }
 
@@ -297,7 +297,7 @@ public class Signature
 
         public Signature build()
         {
-            return new Signature(typeVariableConstraints, longVariableConstraints, returnType, arguments, variableArity);
+            return new Signature(typeVariableConstraints, numericVariableConstraints, returnType, arguments, variableArity);
         }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeSignature.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeSignature.java
@@ -192,13 +192,23 @@ public final class TypeSignature
         return new TypeSignature(StandardTypes.MAP, typeParameter(keyType), typeParameter(valueType));
     }
 
-    public static TypeSignature parametricType(String name, TypeSignature... parameters)
+    public static TypeSignature type(String base)
+    {
+        return new TypeSignature(base);
+    }
+
+    public static TypeSignature type(String name, TypeSignature... parameters)
     {
         return new TypeSignature(
                 name,
                 Arrays.stream(parameters)
                         .map(TypeParameter::typeParameter)
                         .collect(toUnmodifiableList()));
+    }
+
+    public static TypeSignature type(String base, TypeParameter... parameters)
+    {
+        return new TypeSignature(base, parameters);
     }
 
     public static TypeSignature functionType(TypeSignature first, TypeSignature... rest)


### PR DESCRIPTION
## Description

Two small, independent cleanups to how function signatures are constructed, each self-contained.

**Rename `longVariable` to `numericVariable`.** A `Signature`'s long/literal variable — the length in `varchar(N)`, the precision and scale in `decimal(p, s)` — is a numeric variable; "long" names the Java storage type, not the concept. Renames `LongVariableConstraint` to `NumericVariableConstraint` and the `Signature.Builder.longVariable` / `getLongVariableConstraints` accessors to the `numericVariable` terminology. Behavior is unchanged.

**Introduce a `type(...)` factory for named and parametric types.** Function signatures construct types either parameterless (`new TypeSignature(JSON_2016)`) or parametric (`new TypeSignature("decimal", numericVariable(p), numericVariable(s))`). This collapses both into a single `type(base, parameters...)` factory — the no-argument call being the degenerate case — replacing the `parametricType` factory and the raw `TypeSignature` constructor at the signature-construction sites.

Both are server-side SPI changes; the accepted revapi differences are included. The client wire format (`ClientTypeSignature`) is untouched.

## Additional context and related issues

These are preparatory cleanups extracted ahead of a larger function-signature refactor, but each stands on its own.

## Release notes

(x) This is not user-visible or is an internal change, and no release notes are required.
