### PR TITLE
Simplify Signature's variable and calculated-expression representation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
@@ -26,6 +26,8 @@ import io.trino.spi.function.NumericVariableConstraint;
 import io.trino.spi.function.Signature;
 import io.trino.spi.function.TypeVariableConstraint;
 import io.trino.spi.type.FunctionType;
+import io.trino.spi.type.NumericExpression;
+import io.trino.spi.type.NumericExpressions;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
@@ -56,7 +58,6 @@ import static io.trino.metadata.SignatureBinder.RelationshipType.EXPLICIT_COERCI
 import static io.trino.metadata.SignatureBinder.RelationshipType.IMPLICIT_COERCION;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
-import static io.trino.type.TypeCalculation.calculateLiteralValue;
 import static io.trino.type.TypeCoercion.isCovariantTypeBase;
 import static io.trino.type.UnknownType.UNKNOWN;
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
@@ -536,9 +537,9 @@ public class SignatureBinder
     private void calculateVariableValuesForLongConstraints(BindingsBuilder variableBinder)
     {
         for (NumericVariableConstraint numericVariableConstraint : declaredSignature.getNumericVariableConstraints()) {
-            String calculation = numericVariableConstraint.getExpression();
+            NumericExpression calculation = numericVariableConstraint.getExpression();
             String variableName = numericVariableConstraint.getName();
-            Long calculatedValue = calculateLiteralValue(calculation, variableBinder.getLongVariables());
+            Long calculatedValue = NumericExpressions.evaluate(calculation, variableBinder.getLongVariables()).longValueExact();
             if (variableBinder.containsLongVariable(variableName)) {
                 Long currentValue = variableBinder.getLongVariable(variableName);
                 checkState(Objects.equals(currentValue, calculatedValue),

--- a/core/trino-main/src/main/java/io/trino/operator/annotations/FunctionsParserHelper.java
+++ b/core/trino-main/src/main/java/io/trino/operator/annotations/FunctionsParserHelper.java
@@ -65,6 +65,7 @@ import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.parseTypeSignature;
+import static io.trino.type.TypeCalculation.parseNumericExpression;
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static java.util.Comparator.comparing;
 
@@ -286,7 +287,7 @@ public final class FunctionsParserHelper
     public static void parseNumericVariableConstraints(Method inputFunction, Builder signatureBuilder)
     {
         Stream.of(inputFunction.getAnnotationsByType(Constraint.class))
-                .forEach(annotation -> signatureBuilder.numericVariable(annotation.variable(), annotation.expression()));
+                .forEach(annotation -> signatureBuilder.numericVariable(annotation.variable(), parseNumericExpression(annotation.expression())));
     }
 
     public static Map<String, Class<?>> getDeclaredSpecializedTypeParameters(Method method, Set<io.trino.spi.function.TypeParameter> typeParameters)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonArrayFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonArrayFunction.java
@@ -63,7 +63,7 @@ public class JsonArrayFunction
                 .signature(Signature.builder()
                         .typeVariable("E")
                         .returnType(type(JSON_2016))
-                        .argumentTypes(ImmutableList.of(typeVariable("E"), type(BOOLEAN)))
+                        .argumentTypes(typeVariable("E"), type(BOOLEAN))
                         .build())
                 .argumentNullability(true, false)
                 .hidden()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonExistsFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonExistsFunction.java
@@ -71,7 +71,7 @@ public class JsonExistsFunction
                 .signature(Signature.builder()
                         .typeVariable("T")
                         .returnType(BOOLEAN)
-                        .argumentTypes(ImmutableList.of(type(JSON_2016), type(JsonPath2016Type.NAME), typeVariable("T"), type(TINYINT)))
+                        .argumentTypes(type(JSON_2016), type(JsonPath2016Type.NAME), typeVariable("T"), type(TINYINT))
                         .build())
                 .nullable()
                 .argumentNullability(false, false, true, false)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonObjectFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonObjectFunction.java
@@ -69,7 +69,7 @@ public class JsonObjectFunction
                         .typeVariable("K")
                         .typeVariable("V")
                         .returnType(type(JSON_2016))
-                        .argumentTypes(ImmutableList.of(typeVariable("K"), typeVariable("V"), type(BOOLEAN), type(BOOLEAN)))
+                        .argumentTypes(typeVariable("K"), typeVariable("V"), type(BOOLEAN), type(BOOLEAN))
                         .build())
                 .argumentNullability(true, true, false, false)
                 .hidden()

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonQueryFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonQueryFunction.java
@@ -79,13 +79,13 @@ public class JsonQueryFunction
                 .signature(Signature.builder()
                         .typeVariable("T")
                         .returnType(type(JSON_2016))
-                        .argumentTypes(ImmutableList.of(
+                        .argumentTypes(
                                 type(JSON_2016),
                                 type(JsonPath2016Type.NAME),
                                 typeVariable("T"),
                                 type(TINYINT),
                                 type(TINYINT),
-                                type(TINYINT)))
+                                type(TINYINT))
                         .build())
                 .nullable()
                 .argumentNullability(false, false, true, false, false, false)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonValueFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/json/JsonValueFunction.java
@@ -98,7 +98,7 @@ public class JsonValueFunction
                         .typeVariable("E")
                         .typeVariable("D")
                         .returnType(typeVariable("R"))
-                        .argumentTypes(ImmutableList.of(
+                        .argumentTypes(
                                 type(JSON_2016),
                                 type(JsonPath2016Type.NAME),
                                 typeVariable("T"),
@@ -106,7 +106,7 @@ public class JsonValueFunction
                                 type(TINYINT),
                                 functionType(typeVariable("E")),
                                 type(TINYINT),
-                                functionType(typeVariable("D"))))
+                                functionType(typeVariable("D")))
                         .build())
                 .nullable()
                 .argumentNullability(false, false, true, true, false, false, false, false)

--- a/core/trino-main/src/main/java/io/trino/type/DecimalOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalOperators.java
@@ -49,6 +49,7 @@ import static io.trino.spi.type.Int128Math.rescale;
 import static io.trino.spi.type.Int128Math.subtract;
 import static io.trino.spi.type.TypeParameter.numericVariable;
 import static io.trino.spi.type.TypeSignature.type;
+import static io.trino.type.TypeCalculation.parseNumericExpression;
 import static java.lang.Integer.max;
 import static java.lang.Long.signum;
 import static java.lang.Math.abs;
@@ -78,8 +79,8 @@ public final class DecimalOperators
         Signature.Builder signature = Signature.builder();
 
         if (legacyTypeCalculation) {
-            signature.numericVariable("r_precision", "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
-                    .numericVariable("r_scale", "max(a_scale, b_scale)");
+            signature.numericVariable("r_precision", parseNumericExpression("min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)"))
+                    .numericVariable("r_scale", parseNumericExpression("max(a_scale, b_scale)"));
         }
         else {
             // The precision and scale calculations are modeled after MSSQL (https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql),
@@ -88,8 +89,8 @@ public final class DecimalOperators
             //    raw_scale = max(a_scale, b_scale);
             //    r_precision = min(raw_scale + integral + 1, 38);
             //    r_scale = min(raw_scale, precision - integral);
-            signature.numericVariable("r_precision", "min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38)")
-                    .numericVariable("r_scale", "min(max(a_scale, b_scale), min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38) - max(a_precision - a_scale, b_precision - b_scale))");
+            signature.numericVariable("r_precision", parseNumericExpression("min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38)"))
+                    .numericVariable("r_scale", parseNumericExpression("min(max(a_scale, b_scale), min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38) - max(a_precision - a_scale, b_precision - b_scale))"));
         }
 
         return new PolymorphicScalarFunctionBuilder(ADD, DecimalOperators.class)
@@ -175,8 +176,8 @@ public final class DecimalOperators
         Signature.Builder signature = Signature.builder();
 
         if (legacyTypeCalculation) {
-            signature.numericVariable("r_precision", "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
-                    .numericVariable("r_scale", "max(a_scale, b_scale)");
+            signature.numericVariable("r_precision", parseNumericExpression("min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)"))
+                    .numericVariable("r_scale", parseNumericExpression("max(a_scale, b_scale)"));
         }
         else {
             // The precision and scale calculations are modeled after MSSQL (https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql),
@@ -185,8 +186,8 @@ public final class DecimalOperators
             //    raw_scale = max(a_scale, b_scale);
             //    r_precision = min(raw_scale + integral + 1, 38);
             //    r_scale = min(raw_scale, precision - integral);
-            signature.numericVariable("r_precision", "min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38)")
-                    .numericVariable("r_scale", "min(max(a_scale, b_scale), min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38) - max(a_precision - a_scale, b_precision - b_scale))");
+            signature.numericVariable("r_precision", parseNumericExpression("min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38)"))
+                    .numericVariable("r_scale", parseNumericExpression("min(max(a_scale, b_scale), min(max(a_scale, b_scale) + max(a_precision - a_scale, b_precision - b_scale) + 1, 38) - max(a_precision - a_scale, b_precision - b_scale))"));
         }
 
         return new PolymorphicScalarFunctionBuilder(SUBTRACT, DecimalOperators.class)
@@ -271,8 +272,8 @@ public final class DecimalOperators
 
         if (legacyTypeCalculation) {
             signature
-                    .numericVariable("r_precision", "min(38, a_precision + b_precision)")
-                    .numericVariable("r_scale", "a_scale + b_scale");
+                    .numericVariable("r_precision", parseNumericExpression("min(38, a_precision + b_precision)"))
+                    .numericVariable("r_scale", parseNumericExpression("a_scale + b_scale"));
         }
         else {
             // The precision and scale calculations are modeled after MSSQL (https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql),
@@ -286,8 +287,8 @@ public final class DecimalOperators
             //     precision = min(raw_precision, 38);
             //     scale = min(raw_scale, integral > 32 ? 6 : 38 - integral);
             signature
-                    .numericVariable("r_precision", "min(a_precision + b_precision, 38)")
-                    .numericVariable("r_scale", "min(a_scale + b_scale, if(a_precision + b_precision - (a_scale + b_scale) > 32, 6, 38 - (a_precision + b_precision - (a_scale + b_scale))))");
+                    .numericVariable("r_precision", parseNumericExpression("min(a_precision + b_precision, 38)"))
+                    .numericVariable("r_scale", parseNumericExpression("min(a_scale + b_scale, if(a_precision + b_precision - (a_scale + b_scale) > 32, 6, 38 - (a_precision + b_precision - (a_scale + b_scale))))"));
         }
 
         return new PolymorphicScalarFunctionBuilder(MULTIPLY, DecimalOperators.class)
@@ -374,8 +375,8 @@ public final class DecimalOperators
         Signature.Builder signature = Signature.builder();
 
         if (legacyTypeCalculation) {
-            signature.numericVariable("r_precision", "min(38, a_precision + b_scale + max(b_scale - a_scale, 0))")
-                    .numericVariable("r_scale", "max(a_scale, b_scale)");
+            signature.numericVariable("r_precision", parseNumericExpression("min(38, a_precision + b_scale + max(b_scale - a_scale, 0))"))
+                    .numericVariable("r_scale", parseNumericExpression("max(a_scale, b_scale)"));
         }
         else {
             // The precision and scale calculations are modeled after MSSQL (https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql),
@@ -387,8 +388,8 @@ public final class DecimalOperators
             //     integral = raw_precision - raw_scale;
             //     precision = min(raw_precision, 38);
             //     scale = min(raw_scale, integral > 32 ? 6 : 38 - integral);
-            signature.numericVariable("r_precision", "min(a_precision - a_scale + b_scale + max(6, a_scale + b_precision + 1), 38)")
-                    .numericVariable("r_scale", "min(max(6, a_scale + b_precision + 1), if(a_precision - a_scale + b_scale + max(6, a_scale + b_precision + 1) - max(6, a_scale + b_precision + 1) > 32, 6, 38 - (a_precision - a_scale + b_scale + max(6, a_scale + b_precision + 1) - max(6, a_scale + b_precision + 1))))");
+            signature.numericVariable("r_precision", parseNumericExpression("min(a_precision - a_scale + b_scale + max(6, a_scale + b_precision + 1), 38)"))
+                    .numericVariable("r_scale", parseNumericExpression("min(max(6, a_scale + b_precision + 1), if(a_precision - a_scale + b_scale + max(6, a_scale + b_precision + 1) - max(6, a_scale + b_precision + 1) > 32, 6, 38 - (a_precision - a_scale + b_scale + max(6, a_scale + b_precision + 1) - max(6, a_scale + b_precision + 1))))"));
         }
 
         return new PolymorphicScalarFunctionBuilder(DIVIDE, DecimalOperators.class)
@@ -558,8 +559,8 @@ public final class DecimalOperators
         TypeSignature decimalResultSignature = type("decimal", numericVariable("r_precision"), numericVariable("r_scale"));
 
         Signature signature = Signature.builder()
-                .numericVariable("r_precision", "min(b_precision - b_scale, a_precision - a_scale) + max(a_scale, b_scale)")
-                .numericVariable("r_scale", "max(a_scale, b_scale)")
+                .numericVariable("r_precision", parseNumericExpression("min(b_precision - b_scale, a_precision - a_scale) + max(a_scale, b_scale)"))
+                .numericVariable("r_scale", parseNumericExpression("max(a_scale, b_scale)"))
                 .argumentType(decimalLeftSignature)
                 .argumentType(decimalRightSignature)
                 .returnType(decimalResultSignature)

--- a/core/trino-main/src/main/java/io/trino/type/TypeCalculation.java
+++ b/core/trino-main/src/main/java/io/trino/type/TypeCalculation.java
@@ -13,6 +13,7 @@
  */
 package io.trino.type;
 
+import io.trino.spi.type.NumericExpression;
 import io.trino.sql.parser.ParsingException;
 import io.trino.sql.tree.NodeLocation;
 import io.trino.type.TypeCalculationParser.ArithmeticBinaryContext;
@@ -72,6 +73,108 @@ public final class TypeCalculation
         }
         catch (StackOverflowError e) {
             throw new ParsingException("Type calculation is too large (stack overflow while parsing)", new NodeLocation(1, 1));
+        }
+    }
+
+    /// Parses a calculated type-parameter expression (e.g. `min(38, x + y)`) into a structured
+    /// [NumericExpression], so it can be evaluated without re-parsing the string at every bind.
+    public static NumericExpression parseNumericExpression(String calculation)
+    {
+        try {
+            return new BuildNumericExpressionVisitor().visit(parseTypeCalculation(calculation));
+        }
+        catch (StackOverflowError e) {
+            throw new ParsingException("Type calculation is too large (stack overflow while parsing)", new NodeLocation(1, 1));
+        }
+    }
+
+    private static class BuildNumericExpressionVisitor
+            extends TypeCalculationBaseVisitor<NumericExpression>
+    {
+        @Override
+        public NumericExpression visitTypeCalculation(TypeCalculationContext context)
+        {
+            return visit(context.expression());
+        }
+
+        @Override
+        public NumericExpression visitArithmeticBinary(ArithmeticBinaryContext context)
+        {
+            NumericExpression left = visit(context.left);
+            NumericExpression right = visit(context.right);
+            return switch (context.operator.getType()) {
+                case PLUS -> new NumericExpression.Operation(NumericExpression.Operator.ADD, left, right);
+                case MINUS -> new NumericExpression.Operation(NumericExpression.Operator.SUBTRACT, left, right);
+                case ASTERISK -> new NumericExpression.Operation(NumericExpression.Operator.MULTIPLY, left, right);
+                case SLASH -> new NumericExpression.Operation(NumericExpression.Operator.DIVIDE, left, right);
+                default -> throw new IllegalArgumentException("Unsupported binary operator " + context.operator.getText());
+            };
+        }
+
+        @Override
+        public NumericExpression visitArithmeticUnary(ArithmeticUnaryContext context)
+        {
+            NumericExpression value = visit(context.expression());
+            return switch (context.operator.getType()) {
+                case PLUS -> value;
+                case MINUS -> new NumericExpression.Operation(NumericExpression.Operator.SUBTRACT, new NumericExpression.Literal(0), value);
+                default -> throw new IllegalArgumentException("Unsupported unary operator " + context.operator.getText());
+            };
+        }
+
+        @Override
+        public NumericExpression visitBinaryFunction(BinaryFunctionContext context)
+        {
+            NumericExpression left = visit(context.left);
+            NumericExpression right = visit(context.right);
+            return switch (context.binaryFunctionName().name.getType()) {
+                case MIN -> new NumericExpression.Operation(NumericExpression.Operator.MIN, left, right);
+                case MAX -> new NumericExpression.Operation(NumericExpression.Operator.MAX, left, right);
+                default -> throw new IllegalArgumentException("Unsupported binary function " + context.binaryFunctionName().getText());
+            };
+        }
+
+        @Override
+        public NumericExpression visitNumericLiteral(NumericLiteralContext context)
+        {
+            return new NumericExpression.Literal(Long.parseLong(context.INTEGER_VALUE().getText()));
+        }
+
+        @Override
+        public NumericExpression visitNullLiteral(NullLiteralContext context)
+        {
+            // Mirror the legacy calculator, which treats NULL as 0 in a type calculation.
+            return new NumericExpression.Literal(0);
+        }
+
+        @Override
+        public NumericExpression visitIdentifier(IdentifierContext context)
+        {
+            return new NumericExpression.Variable(context.getText());
+        }
+
+        @Override
+        public NumericExpression visitParenthesizedExpression(ParenthesizedExpressionContext context)
+        {
+            return visit(context.expression());
+        }
+
+        @Override
+        public NumericExpression visitIfExpression(TypeCalculationParser.IfExpressionContext context)
+        {
+            NumericExpression.ComparisonOperator operator = switch (context.operator.getText()) {
+                case ">" -> NumericExpression.ComparisonOperator.GREATER_THAN;
+                case "<" -> NumericExpression.ComparisonOperator.LESS_THAN;
+                case ">=" -> NumericExpression.ComparisonOperator.GREATER_THAN_OR_EQUAL;
+                case "<=" -> NumericExpression.ComparisonOperator.LESS_THAN_OR_EQUAL;
+                case "=" -> NumericExpression.ComparisonOperator.EQUAL;
+                case "!=" -> NumericExpression.ComparisonOperator.NOT_EQUAL;
+                default -> throw new IllegalArgumentException("Unsupported comparison operator " + context.operator.getText());
+            };
+            return new NumericExpression.Conditional(
+                    new NumericExpression.Comparison(operator, visit(context.left), visit(context.right)),
+                    visit(context.ifTrue),
+                    visit(context.ifFalse));
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestAnnotationEngineForAggregates.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestAnnotationEngineForAggregates.java
@@ -98,6 +98,7 @@ import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypeSignatures;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.type.TypeCalculation.parseNumericExpression;
 import static java.lang.invoke.MethodType.methodType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -970,7 +971,7 @@ public class TestAnnotationEngineForAggregates
     public void testLongConstraintAggregateFunctionParse()
     {
         Signature expectedSignature = Signature.builder()
-                .numericVariable("z", "x + y")
+                .numericVariable("z", parseNumericExpression("x + y"))
                 .returnType(new TypeSignature("varchar", numericVariable("z")))
                 .argumentType(new TypeSignature("varchar", numericVariable("x")))
                 .argumentType(new TypeSignature("varchar", numericVariable("y")))

--- a/core/trino-spi/src/main/java/io/trino/spi/function/NumericVariableConstraint.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/NumericVariableConstraint.java
@@ -13,10 +13,6 @@
  */
 package io.trino.spi.function;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.errorprone.annotations.DoNotCall;
-
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
@@ -32,13 +28,11 @@ public class NumericVariableConstraint
         this.expression = requireNonNull(expression, "expression is null");
     }
 
-    @JsonProperty
     public String getName()
     {
         return name;
     }
 
-    @JsonProperty
     public String getExpression()
     {
         return expression;
@@ -68,15 +62,5 @@ public class NumericVariableConstraint
     public int hashCode()
     {
         return Objects.hash(name, expression);
-    }
-
-    @JsonCreator
-    @DoNotCall // For JSON deserialization only
-    @Deprecated // Discourage usages in SPI consumers
-    public static NumericVariableConstraint fromJson(
-            @JsonProperty("name") String name,
-            @JsonProperty("expression") String expression)
-    {
-        return new NumericVariableConstraint(name, expression);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/function/NumericVariableConstraint.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/NumericVariableConstraint.java
@@ -13,6 +13,9 @@
  */
 package io.trino.spi.function;
 
+import io.trino.spi.type.NumericExpression;
+import io.trino.spi.type.NumericExpressions;
+
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
@@ -20,9 +23,9 @@ import static java.util.Objects.requireNonNull;
 public class NumericVariableConstraint
 {
     private final String name;
-    private final String expression;
+    private final NumericExpression expression;
 
-    NumericVariableConstraint(String name, String expression)
+    NumericVariableConstraint(String name, NumericExpression expression)
     {
         this.name = requireNonNull(name, "name is null");
         this.expression = requireNonNull(expression, "expression is null");
@@ -33,7 +36,7 @@ public class NumericVariableConstraint
         return name;
     }
 
-    public String getExpression()
+    public NumericExpression getExpression()
     {
         return expression;
     }
@@ -41,7 +44,7 @@ public class NumericVariableConstraint
     @Override
     public String toString()
     {
-        return name + ":" + expression;
+        return name + ":" + NumericExpressions.render(expression);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/function/Signature.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/Signature.java
@@ -18,11 +18,15 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignature;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.Set;
 
+import static java.util.Collections.unmodifiableSet;
+import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toUnmodifiableList;
@@ -43,21 +47,18 @@ public class Signature
         }
     }
 
-    private final List<TypeVariableConstraint> typeVariableConstraints;
-    private final List<NumericVariableConstraint> numericVariableConstraints;
+    private final Set<VariableDeclaration> variables;
     private final TypeSignature returnType;
     private final List<Argument> arguments;
     private final boolean variableArity;
 
     private Signature(
-            List<TypeVariableConstraint> typeVariableConstraints,
-            List<NumericVariableConstraint> numericVariableConstraints,
+            List<VariableDeclaration> variables,
             TypeSignature returnType,
             List<Argument> arguments,
             boolean variableArity)
     {
-        this.typeVariableConstraints = List.copyOf(typeVariableConstraints);
-        this.numericVariableConstraints = List.copyOf(numericVariableConstraints);
+        this.variables = unmodifiableSet(new LinkedHashSet<>(variables));
         this.returnType = requireNonNull(returnType, "returnType is null");
         this.arguments = List.copyOf(arguments);
         this.variableArity = variableArity;
@@ -90,23 +91,37 @@ public class Signature
      */
     public boolean isGeneric()
     {
-        return !typeVariableConstraints.isEmpty();
+        return variables.stream().anyMatch(VariableDeclaration.TypeVariable.class::isInstance);
     }
 
+    /// The type and numeric variables declared by this signature.
+    public List<VariableDeclaration> getVariables()
+    {
+        return List.copyOf(variables);
+    }
+
+    /// The type-variable constraints, as a view over [#getVariables()].
     public List<TypeVariableConstraint> getTypeVariableConstraints()
     {
-        return typeVariableConstraints;
+        return variables.stream()
+                .filter(VariableDeclaration.TypeVariable.class::isInstance)
+                .map(variable -> ((VariableDeclaration.TypeVariable) variable).constraint())
+                .collect(toUnmodifiableList());
     }
 
+    /// The numeric-variable constraints, as a view over [#getVariables()].
     public List<NumericVariableConstraint> getNumericVariableConstraints()
     {
-        return numericVariableConstraints;
+        return variables.stream()
+                .filter(VariableDeclaration.NumericVariable.class::isInstance)
+                .map(variable -> ((VariableDeclaration.NumericVariable) variable).constraint())
+                .collect(toUnmodifiableList());
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(typeVariableConstraints, numericVariableConstraints, returnType, arguments, variableArity);
+        return Objects.hash(variables, returnType, arguments, variableArity);
     }
 
     @Override
@@ -118,8 +133,7 @@ public class Signature
         if (!(obj instanceof Signature other)) {
             return false;
         }
-        return Objects.equals(this.typeVariableConstraints, other.typeVariableConstraints) &&
-                Objects.equals(this.numericVariableConstraints, other.numericVariableConstraints) &&
+        return Objects.equals(this.variables, other.variables) &&
                 Objects.equals(this.returnType, other.returnType) &&
                 Objects.equals(this.arguments, other.arguments) &&
                 this.variableArity == other.variableArity;
@@ -128,12 +142,14 @@ public class Signature
     @Override
     public String toString()
     {
-        List<String> allConstraints = concat(
-                typeVariableConstraints.stream().map(TypeVariableConstraint::toString),
-                numericVariableConstraints.stream().map(NumericVariableConstraint::toString))
-                .collect(Collectors.toList());
+        String constraints = variables.stream()
+                .map(variable -> switch (variable) {
+                    case VariableDeclaration.TypeVariable typeVariable -> typeVariable.constraint().toString();
+                    case VariableDeclaration.NumericVariable numericVariable -> numericVariable.constraint().toString();
+                })
+                .collect(joining(",", "<", ">"));
 
-        return (allConstraints.isEmpty() ? "" : allConstraints.stream().collect(joining(",", "<", ">"))) +
+        return (variables.isEmpty() ? "" : constraints) +
                 arguments.stream().map(Argument::type).map(Objects::toString).collect(joining(",", "(", ")")) +
                 ":" + returnType;
     }
@@ -146,8 +162,7 @@ public class Signature
     public static Builder builder(Signature base)
     {
         Builder builder = new Builder()
-                .typeVariableConstraints(base.typeVariableConstraints)
-                .numericVariableConstraints(base.numericVariableConstraints)
+                .variables(base.variables)
                 .returnType(base.returnType)
                 .arguments(base.arguments);
         if (base.variableArity) {
@@ -158,8 +173,7 @@ public class Signature
 
     public static final class Builder
     {
-        private final List<TypeVariableConstraint> typeVariableConstraints = new ArrayList<>();
-        private final List<NumericVariableConstraint> numericVariableConstraints = new ArrayList<>();
+        private final List<VariableDeclaration> variables = new ArrayList<>();
         private TypeSignature returnType;
         private final List<Argument> arguments = new ArrayList<>();
         private boolean variableArity;
@@ -168,59 +182,53 @@ public class Signature
 
         public Builder typeVariable(String name)
         {
-            typeVariableConstraints.add(TypeVariableConstraint.builder(name).build());
-            return this;
+            return typeVariableConstraint(TypeVariableConstraint.builder(name).build());
         }
 
         public Builder comparableTypeParameter(String name)
         {
-            typeVariableConstraints.add(TypeVariableConstraint.builder(name)
+            return typeVariableConstraint(TypeVariableConstraint.builder(name)
                     .comparableRequired()
                     .build());
-            return this;
         }
 
         public Builder orderableTypeParameter(String name)
         {
-            typeVariableConstraints.add(TypeVariableConstraint.builder(name)
+            return typeVariableConstraint(TypeVariableConstraint.builder(name)
                     .orderableRequired()
                     .build());
-            return this;
         }
 
         public Builder castableToTypeParameter(String name, TypeSignature toType)
         {
-            typeVariableConstraints.add(TypeVariableConstraint.builder(name)
+            return typeVariableConstraint(TypeVariableConstraint.builder(name)
                     .castableTo(toType)
                     .build());
-            return this;
         }
 
         public Builder castableFromTypeParameter(String name, TypeSignature fromType)
         {
-            typeVariableConstraints.add(TypeVariableConstraint.builder(name)
+            return typeVariableConstraint(TypeVariableConstraint.builder(name)
                     .castableFrom(fromType)
                     .build());
-            return this;
         }
 
         public Builder rowTypeParameter(String name)
         {
-            typeVariableConstraints.add(TypeVariableConstraint.builder(name)
+            return typeVariableConstraint(TypeVariableConstraint.builder(name)
                     .rowType()
                     .build());
-            return this;
         }
 
         public Builder typeVariableConstraint(TypeVariableConstraint typeVariableConstraint)
         {
-            this.typeVariableConstraints.add(requireNonNull(typeVariableConstraint, "typeVariableConstraint is null"));
+            variables.add(new VariableDeclaration.TypeVariable(typeVariableConstraint));
             return this;
         }
 
         public Builder typeVariableConstraints(List<TypeVariableConstraint> typeVariableConstraints)
         {
-            this.typeVariableConstraints.addAll(requireNonNull(typeVariableConstraints, "typeVariableConstraints is null"));
+            requireNonNull(typeVariableConstraints, "typeVariableConstraints is null").forEach(this::typeVariableConstraint);
             return this;
         }
 
@@ -237,7 +245,7 @@ public class Signature
 
         public Builder numericVariable(String name, NumericExpression expression)
         {
-            this.numericVariableConstraints.add(new NumericVariableConstraint(name, expression));
+            variables.add(new VariableDeclaration.NumericVariable(new NumericVariableConstraint(name, expression)));
             return this;
         }
 
@@ -248,7 +256,19 @@ public class Signature
 
         public Builder numericVariableConstraints(List<NumericVariableConstraint> numericVariableConstraints)
         {
-            this.numericVariableConstraints.addAll(numericVariableConstraints);
+            numericVariableConstraints.forEach(constraint -> variables.add(new VariableDeclaration.NumericVariable(constraint)));
+            return this;
+        }
+
+        public Builder variable(VariableDeclaration variable)
+        {
+            variables.add(requireNonNull(variable, "variable is null"));
+            return this;
+        }
+
+        public Builder variables(Collection<VariableDeclaration> variables)
+        {
+            this.variables.addAll(requireNonNull(variables, "variables is null"));
             return this;
         }
 
@@ -297,7 +317,16 @@ public class Signature
 
         public Signature build()
         {
-            return new Signature(typeVariableConstraints, numericVariableConstraints, returnType, arguments, variableArity);
+            // Canonicalize the declaration order: type variables before numeric variables, each kind
+            // sorted by name. Equality and hashCode are set-based, so they do not depend on the order
+            // the builder methods were called in; sorting here makes toString -- and the FunctionId
+            // derived from it -- independent of that order too, so equal signatures always render alike.
+            List<VariableDeclaration> orderedVariables = concat(
+                    variables.stream().filter(VariableDeclaration.TypeVariable.class::isInstance).sorted(comparing(VariableDeclaration::name)),
+                    variables.stream().filter(VariableDeclaration.NumericVariable.class::isInstance).sorted(comparing(VariableDeclaration::name)))
+                    .collect(toUnmodifiableList());
+
+            return new Signature(orderedVariables, returnType, arguments, variableArity);
         }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/function/Signature.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/Signature.java
@@ -302,6 +302,14 @@ public class Signature
             return this;
         }
 
+        public Builder argumentTypes(TypeSignature... argumentTypes)
+        {
+            for (TypeSignature argumentType : argumentTypes) {
+                argumentType(argumentType);
+            }
+            return this;
+        }
+
         public Builder arguments(List<Argument> arguments)
         {
             this.arguments.clear();

--- a/core/trino-spi/src/main/java/io/trino/spi/function/Signature.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/Signature.java
@@ -13,6 +13,7 @@
  */
 package io.trino.spi.function;
 
+import io.trino.spi.type.NumericExpression;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignature;
 
@@ -234,7 +235,7 @@ public class Signature
             return this;
         }
 
-        public Builder numericVariable(String name, String expression)
+        public Builder numericVariable(String name, NumericExpression expression)
         {
             this.numericVariableConstraints.add(new NumericVariableConstraint(name, expression));
             return this;
@@ -242,8 +243,7 @@ public class Signature
 
         public Builder numericVariable(String name)
         {
-            this.numericVariableConstraints.add(new NumericVariableConstraint(name, name));
-            return this;
+            return numericVariable(name, new NumericExpression.Variable(name));
         }
 
         public Builder numericVariableConstraints(List<NumericVariableConstraint> numericVariableConstraints)

--- a/core/trino-spi/src/main/java/io/trino/spi/function/VariableDeclaration.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/VariableDeclaration.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.function;
+
+import static java.util.Objects.requireNonNull;
+
+/// A variable declared by a function [Signature]: a hole bound when the signature is resolved
+/// against actual arguments. It is either a [type variable][TypeVariable] (e.g. the `E` of
+/// `array(E)`) carrying its [constraints][TypeVariableConstraint], or a
+/// [numeric variable][NumericVariable] (e.g. the `p` of `decimal(p, s)`) carrying its
+/// [definition][NumericVariableConstraint].
+public sealed interface VariableDeclaration
+        permits VariableDeclaration.TypeVariable, VariableDeclaration.NumericVariable
+{
+    String name();
+
+    record TypeVariable(TypeVariableConstraint constraint)
+            implements VariableDeclaration
+    {
+        public TypeVariable
+        {
+            requireNonNull(constraint, "constraint is null");
+        }
+
+        @Override
+        public String name()
+        {
+            return constraint.getName();
+        }
+    }
+
+    record NumericVariable(NumericVariableConstraint constraint)
+            implements VariableDeclaration
+    {
+        public NumericVariable
+        {
+            requireNonNull(constraint, "constraint is null");
+        }
+
+        @Override
+        public String name()
+        {
+            return constraint.getName();
+        }
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/type/NumericExpression.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/NumericExpression.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.type;
+
+import static java.util.Objects.requireNonNull;
+
+/// A numeric-valued expression over a function signature's numeric variables, used for a calculated type
+/// parameter such as a decimal precision/scale or varchar length (e.g. `min(38, p + 1)`).
+public sealed interface NumericExpression
+        permits NumericExpression.Conditional,
+                NumericExpression.Literal,
+                NumericExpression.Operation,
+                NumericExpression.Variable
+{
+    /// A constant, e.g. the `38` in `min(38, p + 1)`.
+    record Literal(long value)
+            implements NumericExpression {}
+
+    /// A reference to a numeric variable bound from an argument, e.g. the `p` in `decimal(p, s)`.
+    record Variable(String name)
+            implements NumericExpression
+    {
+        public Variable
+        {
+            requireNonNull(name, "name is null");
+        }
+    }
+
+    /// A binary operation over two sub-expressions.
+    record Operation(Operator operator, NumericExpression left, NumericExpression right)
+            implements NumericExpression
+    {
+        public Operation
+        {
+            requireNonNull(operator, "operator is null");
+            requireNonNull(left, "left is null");
+            requireNonNull(right, "right is null");
+        }
+    }
+
+    /// A conditional, e.g. `if(a > b, x, y)` — used by the decimal multiply/divide precision formulas.
+    record Conditional(Comparison condition, NumericExpression ifTrue, NumericExpression ifFalse)
+            implements NumericExpression
+    {
+        public Conditional
+        {
+            requireNonNull(condition, "condition is null");
+            requireNonNull(ifTrue, "ifTrue is null");
+            requireNonNull(ifFalse, "ifFalse is null");
+        }
+    }
+
+    /// A comparison between two numeric expressions, used only as the condition of a [Conditional].
+    record Comparison(ComparisonOperator operator, NumericExpression left, NumericExpression right)
+    {
+        public Comparison
+        {
+            requireNonNull(operator, "operator is null");
+            requireNonNull(left, "left is null");
+            requireNonNull(right, "right is null");
+        }
+    }
+
+    enum ComparisonOperator
+    {
+        GREATER_THAN,
+        LESS_THAN,
+        GREATER_THAN_OR_EQUAL,
+        LESS_THAN_OR_EQUAL,
+        EQUAL,
+        NOT_EQUAL,
+    }
+
+    enum Operator
+    {
+        ADD,
+        SUBTRACT,
+        MULTIPLY,
+        DIVIDE,
+        MIN,
+        MAX,
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/type/NumericExpressions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/NumericExpressions.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.type;
+
+import io.trino.spi.type.NumericExpression.Comparison;
+import io.trino.spi.type.NumericExpression.Conditional;
+import io.trino.spi.type.NumericExpression.Literal;
+import io.trino.spi.type.NumericExpression.Operation;
+import io.trino.spi.type.NumericExpression.Operator;
+import io.trino.spi.type.NumericExpression.Variable;
+
+import java.math.BigInteger;
+import java.util.Map;
+
+public final class NumericExpressions
+{
+    private NumericExpressions() {}
+
+    public static String render(NumericExpression expression)
+    {
+        return switch (expression) {
+            case Literal(long value) -> Long.toString(value);
+            case Variable(String name) -> name;
+            case Operation(Operator operator, NumericExpression left, NumericExpression right) -> switch (operator) {
+                case MIN -> "min(%s, %s)".formatted(render(left), render(right));
+                case MAX -> "max(%s, %s)".formatted(render(left), render(right));
+                case ADD -> "(%s + %s)".formatted(render(left), render(right));
+                case SUBTRACT -> "(%s - %s)".formatted(render(left), render(right));
+                case MULTIPLY -> "(%s * %s)".formatted(render(left), render(right));
+                case DIVIDE -> "(%s / %s)".formatted(render(left), render(right));
+            };
+            case Conditional(Comparison condition, NumericExpression ifTrue, NumericExpression ifFalse) -> "if(%s, %s, %s)".formatted(render(condition), render(ifTrue), render(ifFalse));
+        };
+    }
+
+    private static String render(Comparison comparison)
+    {
+        String operator = switch (comparison.operator()) {
+            case GREATER_THAN -> ">";
+            case LESS_THAN -> "<";
+            case GREATER_THAN_OR_EQUAL -> ">=";
+            case LESS_THAN_OR_EQUAL -> "<=";
+            case EQUAL -> "=";
+            case NOT_EQUAL -> "!=";
+        };
+        return render(comparison.left()) + " " + operator + " " + render(comparison.right());
+    }
+
+    /// Evaluates the expression against the given numeric-variable bindings. The result is a
+    /// [BigInteger]: a calculated parameter such as `min(2147483647, x + max(x * y / 2, y) * (x + 1))`
+    /// relies on a large intermediate being clamped back into range, so the intermediate must be computed
+    /// exactly rather than wrapping in long. Callers narrow with `longValueExact()` at the boundary.
+    public static BigInteger evaluate(NumericExpression expression, Map<String, Long> bindings)
+    {
+        return switch (expression) {
+            case Literal(long value) -> BigInteger.valueOf(value);
+            case Variable(String name) -> {
+                Long value = bindings.get(name);
+                if (value == null) {
+                    throw new IllegalArgumentException("No binding for numeric variable " + name);
+                }
+                yield BigInteger.valueOf(value);
+            }
+            case Operation(Operator operator, NumericExpression left, NumericExpression right) -> {
+                BigInteger leftValue = evaluate(left, bindings);
+                BigInteger rightValue = evaluate(right, bindings);
+                yield switch (operator) {
+                    case ADD -> leftValue.add(rightValue);
+                    case SUBTRACT -> leftValue.subtract(rightValue);
+                    case MULTIPLY -> leftValue.multiply(rightValue);
+                    case DIVIDE -> leftValue.divide(rightValue);
+                    case MIN -> leftValue.min(rightValue);
+                    case MAX -> leftValue.max(rightValue);
+                };
+            }
+            case Conditional(Comparison condition, NumericExpression ifTrue, NumericExpression ifFalse) -> evaluate(condition, bindings) ? evaluate(ifTrue, bindings) : evaluate(ifFalse, bindings);
+        };
+    }
+
+    private static boolean evaluate(Comparison comparison, Map<String, Long> bindings)
+    {
+        int order = evaluate(comparison.left(), bindings).compareTo(evaluate(comparison.right(), bindings));
+        return switch (comparison.operator()) {
+            case GREATER_THAN -> order > 0;
+            case LESS_THAN -> order < 0;
+            case GREATER_THAN_OR_EQUAL -> order >= 0;
+            case LESS_THAN_OR_EQUAL -> order <= 0;
+            case EQUAL -> order == 0;
+            case NOT_EQUAL -> order != 0;
+        };
+    }
+}


### PR DESCRIPTION
## Description

A set of preparatory cleanups to how `Signature` represents its variables and the
calculated arithmetic in type parameters. Each commit stands on its own and builds
(`trino-spi` with revapi, and `trino-main`) independently:

- **Remove dead JSON serialization from `NumericVariableConstraint`** — a `Signature` is
  never serialized to JSON at runtime (there is no `JsonCodec<Signature>`; the client/wire
  form is carried separately by `ClientTypeSignature`/`BoundSignature`), so the Jackson
  plumbing was dead weight.
- **Represent calculated type-parameter expressions as structured `NumericExpression`** —
  parse the arithmetic in signatures such as `char(x+y)` once, at registration, into a
  sealed `Literal | Variable | Operation` tree, instead of carrying raw strings and
  re-parsing them through the `TypeCalculation` grammar on every bind.
- **Consolidate a `Signature`'s type and numeric variables into one declaration list** —
  replace the two parallel constraint lists with a single `List<VariableDeclaration>`
  (sealed `TypeVariable | NumericVariable`); the kind is now structural, and the variables
  are held in an order-independent set so signature equality no longer depends on
  declaration order.
- **Add a varargs overload of `Signature.Builder.argumentTypes`** — lets a call site with a
  fixed argument list build it inline as `argumentTypes(a, b, c)` rather than wrapping the
  elements in a list; adopted by the JSON SQL functions.

There is no change to the wire/client format or to runtime behavior. The SPI changes are
recorded as accepted revapi differences.

## Additional context and related issues

Preparatory refactoring ahead of splitting the overloaded `TypeSignature` into a ground
type descriptor and an open, variable-bearing template form.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
