### PR TITLE
Fix failure when reading stats after column type changed in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -116,7 +116,6 @@ import static io.trino.plugin.iceberg.IcebergUtil.getPartitionValues;
 import static io.trino.plugin.iceberg.IcebergUtil.getPathDomain;
 import static io.trino.plugin.iceberg.IcebergUtil.primitiveFieldTypes;
 import static io.trino.plugin.iceberg.StructLikeWrapperWithFieldIdToIndex.createStructLikeWrapper;
-import static io.trino.plugin.iceberg.TypeConverter.toIcebergType;
 import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
@@ -634,6 +633,7 @@ public class IcebergSplitSource
                     column,
                     domainForStatistics(
                             column,
+                            type,
                             lowerBounds == null ? null : fromByteBuffer(type, lowerBounds.get(fieldId)),
                             upperBounds == null ? null : fromByteBuffer(type, upperBounds.get(fieldId)),
                             mayContainNulls));
@@ -643,12 +643,12 @@ public class IcebergSplitSource
 
     private static Domain domainForStatistics(
             IcebergColumnHandle columnHandle,
+            Type statisticsIcebergType,
             @Nullable Object lowerBound,
             @Nullable Object upperBound,
             boolean mayContainNulls)
     {
         io.trino.spi.type.Type type = columnHandle.getType();
-        Type icebergType = toIcebergType(type, columnHandle.getColumnIdentity());
         if (lowerBound == null && upperBound == null) {
             return Domain.create(ValueSet.all(type), mayContainNulls);
         }
@@ -657,16 +657,16 @@ public class IcebergSplitSource
         if (lowerBound != null && upperBound != null) {
             statisticsRange = Range.range(
                     type,
-                    convertIcebergValueToTrino(icebergType, lowerBound),
+                    convertIcebergValueToTrino(statisticsIcebergType, lowerBound),
                     true,
-                    convertIcebergValueToTrino(icebergType, upperBound),
+                    convertIcebergValueToTrino(statisticsIcebergType, upperBound),
                     true);
         }
         else if (upperBound != null) {
-            statisticsRange = Range.lessThanOrEqual(type, convertIcebergValueToTrino(icebergType, upperBound));
+            statisticsRange = Range.lessThanOrEqual(type, convertIcebergValueToTrino(statisticsIcebergType, upperBound));
         }
         else {
-            statisticsRange = Range.greaterThanOrEqual(type, convertIcebergValueToTrino(icebergType, lowerBound));
+            statisticsRange = Range.greaterThanOrEqual(type, convertIcebergValueToTrino(statisticsIcebergType, lowerBound));
         }
         return Domain.create(ValueSet.ofRanges(statisticsRange), mayContainNulls);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -8654,6 +8654,17 @@ public abstract class BaseIcebergConnectorTest
         }
     }
 
+    @Test // regression test for https://github.com/trinodb/trino/issues/29802
+    public void testColumnTypeEvolutionWithStatistics()
+    {
+        try (TestTable table = newTrinoTable("test_stats_type_change", "(x INT)", List.of("1", "2"))) {
+            assertUpdate("ALTER TABLE " + table.getName() + " ALTER COLUMN x SET DATA TYPE BIGINT");
+
+            assertThat(query("SELECT * FROM " + table.getName() + " WHERE x IN (SELECT DISTINCT x FROM " + table.getName() + ")"))
+                    .matches("VALUES BIGINT '1', 2");
+        }
+    }
+
     @Test
     public void testAlterTableWithUnsupportedProperties()
     {


### PR DESCRIPTION
## Description

Fix failure when reading statistics after column type changed in Iceberg connector. 
Changed IcebergSplitSource to use statistics file's original type instead of current schema type when converting bounds.

- Fixes #29802

## Release notes

```markdown
## Iceberg
* Fix failure when reading a table after column type changed. ({issue}`29802`)
```
