### PR TITLE
Fix planning of subquery operands in NEAREST predicates

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -1278,8 +1278,20 @@ class RelationPlanner
                 .add(nearest.getMatch())
                 .build();
 
-        PlanBuilder leftPlanBuilder = newPlanBuilder(leftPlanWithId, analysis, lambdaDeclarationToSymbolMap, session, plannerContext);
-        PlanBuilder rightPlanBuilder = newPlanBuilder(rightPlan, analysis, lambdaDeclarationToSymbolMap, session, plannerContext);
+        List<Symbol> candidateOutputs = ImmutableList.<Symbol>builder()
+                .addAll(leftPlanWithId.getFieldMappings())
+                .addAll(rightPlan.getFieldMappings())
+                .build();
+
+        // WHERE and MATCH were analyzed in the NEAREST scope, which exposes the FROM relation fields locally and
+        // the left join input through the parent scope. Scope both side builders to that combined scope before
+        // planning subqueries so that handleSubqueries can rewrite a subquery's operand against the correct
+        // mappings — e.g. an IN-subquery whose left-hand side is a NEAREST relation column, which planInPredicate
+        // rewrites eagerly against the side builder rather than via candidateTranslations.
+        PlanBuilder leftPlanBuilder = newPlanBuilder(leftPlanWithId, analysis, lambdaDeclarationToSymbolMap, session, plannerContext)
+                .withScope(analysis.getScope(nearest), candidateOutputs);
+        PlanBuilder rightPlanBuilder = newPlanBuilder(rightPlan, analysis, lambdaDeclarationToSymbolMap, session, plannerContext)
+                .withScope(analysis.getScope(nearest), candidateOutputs);
         Analysis.SubqueryAnalysis subqueries = analysis.getSubqueries(nearest);
         for (io.trino.sql.tree.Expression predicate : predicates) {
             Set<QualifiedName> dependencies = NamesExtractor.extractNamesNoSubqueries(predicate, analysis.getColumnReferences());
@@ -1295,13 +1307,6 @@ class RelationPlanner
             }
         }
 
-        List<Symbol> candidateOutputs = ImmutableList.<Symbol>builder()
-                .addAll(leftPlanWithId.getFieldMappings())
-                .addAll(rightPlan.getFieldMappings())
-                .build();
-        // WHERE and MATCH were analyzed in the NEAREST scope. That scope exposes the FROM relation fields locally
-        // and the left join input through the parent scope, so rewriting those expressions requires symbol mappings
-        // for both join sides even though the expression scope itself remains analysis.getScope(nearest).
         TranslationMap candidateTranslations = new TranslationMap(
                 outerContext,
                 analysis.getScope(nearest),

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestNearest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestNearest.java
@@ -555,4 +555,65 @@ public class TestNearest
                 """))
                 .matches("VALUES ('A', 10)");
     }
+
+    @Test
+    public void testNearestWithInSubqueryPredicate()
+    {
+        // A NEAREST predicate may carry an IN-subquery whose left-hand side is a column of the
+        // NEAREST relation. planInPredicate rewrites that left-hand side while planning the
+        // subquery, so it must resolve against the NEAREST scope. Here the IN filters out the
+        // price-11 quote, so every trade resolves to the price-10 quote.
+        assertThat(assertions.query(
+                """
+                WITH
+                    trades(symbol, ts) AS (
+                        VALUES
+                            ('A', TIMESTAMP '2020-01-01 00:00:02'),
+                            ('A', TIMESTAMP '2020-01-01 00:00:04')),
+                    quotes(symbol, ts, price) AS (
+                        VALUES
+                            ('A', TIMESTAMP '2020-01-01 00:00:01', 10),
+                            ('A', TIMESTAMP '2020-01-01 00:00:03', 11))
+                SELECT quotes.price
+                FROM trades
+                CROSS JOIN NEAREST (
+                    FROM quotes
+                    WHERE quotes.symbol = trades.symbol
+                        AND quotes.price IN (SELECT 10)
+                    MATCH quotes.ts <= trades.ts
+                )
+                """))
+                .matches("VALUES 10, 10");
+    }
+
+    @Test
+    public void testNearestWithQuantifiedComparisonSubqueryPredicate()
+    {
+        // A NEAREST predicate may also carry a quantified comparison whose left-hand side is a
+        // column of the NEAREST relation. planQuantifiedComparison rewrites that left-hand side
+        // eagerly while planning the subquery, so it must resolve against the NEAREST scope, just
+        // like the IN-subquery case. Here `<= ALL (SELECT 10)` excludes the price-11 quote, so
+        // every trade resolves to the price-10 quote.
+        assertThat(assertions.query(
+                """
+                WITH
+                    trades(symbol, ts) AS (
+                        VALUES
+                            ('A', TIMESTAMP '2020-01-01 00:00:02'),
+                            ('A', TIMESTAMP '2020-01-01 00:00:04')),
+                    quotes(symbol, ts, price) AS (
+                        VALUES
+                            ('A', TIMESTAMP '2020-01-01 00:00:01', 10),
+                            ('A', TIMESTAMP '2020-01-01 00:00:03', 11))
+                SELECT quotes.price
+                FROM trades
+                CROSS JOIN NEAREST (
+                    FROM quotes
+                    WHERE quotes.symbol = trades.symbol
+                        AND quotes.price <= ALL (SELECT 10)
+                    MATCH quotes.ts <= trades.ts
+                )
+                """))
+                .matches("VALUES 10, 10");
+    }
 }


### PR DESCRIPTION
## Description

Fixes an internal failure when a subquery whose left-hand side is a column of the `NEAREST` relation is used inside a `NEAREST` join's `WHERE` or `MATCH` predicate. For example:

```sql
SELECT quotes.price
FROM trades
CROSS JOIN NEAREST (
    FROM quotes
    WHERE quotes.symbol = trades.symbol
        AND quotes.price IN (SELECT 10)
    MATCH quotes.ts <= trades.ts
)
```

fails with `java.lang.IllegalStateException: No mapping for quotes.price`.

### Root cause

`NEAREST` `WHERE`/`MATCH` predicates are analyzed in the `NEAREST` scope, but `planJoinNearest` left the per-side plan builders scoped to each input relation. A scalar subquery is unaffected, because its enclosing expression is rewritten later through the combined candidate translation map. But `planInPredicate` (and the quantified-comparison planner) rewrites the subquery's operand *eagerly* against the side builder while planning the subquery, so an operand drawn from the `NEAREST` scope could not be resolved.

### Fix

Scope both side builders to the `NEAREST` scope with the combined candidate outputs before planning subqueries, mirroring what `planJoin` already does for ordinary joins. A regression test is added to `TestNearest`.

## Additional context and related issues

The failure is reproducible on `master`; no special syntax is required — any `IN`/quantified-comparison subquery in a `NEAREST` predicate whose left-hand side is a `NEAREST`-relation column triggers it.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text:

```
# General
* Fix query failure when a subquery inside a `NEAREST` join predicate references a column of the `NEAREST` relation.
```
