### PR TITLE
Add SQL UNIQUE predicate

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -615,6 +615,7 @@ primaryExpression
     | '(' query ')'                                                                       #subqueryExpression
     // This is an extension to ANSI SQL, which considers EXISTS to be a <boolean expression>
     | EXISTS '(' query ')'                                                                #exists
+    | UNIQUE '(' query ')'                                                                #unique
     | CASE operand=expression simpleWhenClause+ (ELSE elseExpression=expression)? END     #simpleCase
     | CASE searchedWhenClause+ (ELSE elseExpression=expression)? END                      #searchedCase
     | CAST '(' expression AS type ')'                                                     #cast

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -92,6 +92,7 @@ import io.trino.sql.tree.SubqueryExpression;
 import io.trino.sql.tree.SubsetDefinition;
 import io.trino.sql.tree.Table;
 import io.trino.sql.tree.TableFunctionInvocation;
+import io.trino.sql.tree.UniquePredicate;
 import io.trino.sql.tree.Unnest;
 import io.trino.sql.tree.WindowFrame;
 import io.trino.sql.tree.WindowOperation;
@@ -545,6 +546,7 @@ public class Analysis
         subqueries.addExistsSubqueries(dereference(expressionAnalysis.getExistsSubqueries()));
         subqueries.addQuantifiedComparisons(expressionAnalysis.getQuantifiedComparisons());
         subqueries.addMatchPredicates(expressionAnalysis.getMatchPredicates());
+        subqueries.addUniquePredicates(dereference(expressionAnalysis.getUniquePredicates()));
     }
 
     private <T extends Node> List<T> dereference(Collection<NodeRef<T>> nodeRefs)
@@ -1808,6 +1810,7 @@ public class Analysis
         private final List<ExistsPredicate> existsSubqueries = new ArrayList<>();
         private final List<OperandAndPredicate> quantifiedComparisons = new ArrayList<>();
         private final List<OperandAndPredicate> matchPredicates = new ArrayList<>();
+        private final List<UniquePredicate> uniquePredicates = new ArrayList<>();
 
         public void addInPredicates(List<OperandAndPredicate> predicates)
         {
@@ -1834,6 +1837,11 @@ public class Analysis
             matchPredicates.addAll(predicates);
         }
 
+        public void addUniquePredicates(List<UniquePredicate> expressions)
+        {
+            uniquePredicates.addAll(expressions);
+        }
+
         public List<OperandAndPredicate> getInPredicates()
         {
             return unmodifiableList(inPredicates);
@@ -1857,6 +1865,11 @@ public class Analysis
         public List<OperandAndPredicate> getMatchPredicates()
         {
             return unmodifiableList(matchPredicates);
+        }
+
+        public List<UniquePredicate> getUniquePredicates()
+        {
+            return unmodifiableList(uniquePredicates);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalysis.java
@@ -23,6 +23,7 @@ import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.FunctionCall;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.SubqueryExpression;
+import io.trino.sql.tree.UniquePredicate;
 
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,7 @@ public class ExpressionAnalysis
     private final Set<NodeRef<ExistsPredicate>> existsSubqueries;
     private final List<OperandAndPredicate> quantifiedComparisons;
     private final List<OperandAndPredicate> matchPredicates;
+    private final Set<NodeRef<UniquePredicate>> uniquePredicates;
     private final Set<NodeRef<FunctionCall>> windowFunctions;
 
     public ExpressionAnalysis(
@@ -51,6 +53,7 @@ public class ExpressionAnalysis
             Map<NodeRef<Expression>, ResolvedField> columnReferences,
             List<OperandAndPredicate> quantifiedComparisons,
             List<OperandAndPredicate> matchPredicates,
+            Set<NodeRef<UniquePredicate>> uniquePredicates,
             Set<NodeRef<FunctionCall>> windowFunctions)
     {
         this.expressionTypes = ImmutableMap.copyOf(requireNonNull(expressionTypes, "expressionTypes is null"));
@@ -61,6 +64,7 @@ public class ExpressionAnalysis
         this.existsSubqueries = ImmutableSet.copyOf(requireNonNull(existsSubqueries, "existsSubqueries is null"));
         this.quantifiedComparisons = ImmutableList.copyOf(requireNonNull(quantifiedComparisons, "quantifiedComparisons is null"));
         this.matchPredicates = ImmutableList.copyOf(requireNonNull(matchPredicates, "matchPredicates is null"));
+        this.uniquePredicates = ImmutableSet.copyOf(requireNonNull(uniquePredicates, "uniquePredicates is null"));
         this.windowFunctions = ImmutableSet.copyOf(requireNonNull(windowFunctions, "windowFunctions is null"));
     }
 
@@ -107,6 +111,11 @@ public class ExpressionAnalysis
     public List<OperandAndPredicate> getMatchPredicates()
     {
         return matchPredicates;
+    }
+
+    public Set<NodeRef<UniquePredicate>> getUniquePredicates()
+    {
+        return uniquePredicates;
     }
 
     public Set<NodeRef<FunctionCall>> getWindowFunctions()

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -168,6 +168,7 @@ import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.SubsetDefinition;
 import io.trino.sql.tree.Trim;
 import io.trino.sql.tree.TryExpression;
+import io.trino.sql.tree.UniquePredicate;
 import io.trino.sql.tree.ValueColumn;
 import io.trino.sql.tree.VariableDefinition;
 import io.trino.sql.tree.WhenClause;
@@ -345,6 +346,7 @@ public class ExpressionAnalyzer
     private final Map<NodeRef<Expression>, List<Integer>> argumentBindings = new LinkedHashMap<>();
     private final Set<NodeRef<SubqueryExpression>> subqueries = new LinkedHashSet<>();
     private final Set<NodeRef<ExistsPredicate>> existsSubqueries = new LinkedHashSet<>();
+    private final Set<NodeRef<UniquePredicate>> uniquePredicates = new LinkedHashSet<>();
     private final Map<NodeRef<Expression>, Type> expressionCoercions = new LinkedHashMap<>();
 
     // Coercions needed for window function frame of type RANGE.
@@ -614,6 +616,11 @@ public class ExpressionAnalyzer
     public Set<NodeRef<ExistsPredicate>> getExistsSubqueries()
     {
         return unmodifiableSet(existsSubqueries);
+    }
+
+    public Set<NodeRef<UniquePredicate>> getUniquePredicates()
+    {
+        return unmodifiableSet(uniquePredicates);
     }
 
     public List<OperandAndPredicate> getQuantifiedComparisons()
@@ -3135,6 +3142,35 @@ public class ExpressionAnalyzer
             return setExpressionType(node, BOOLEAN);
         }
 
+        @Override
+        protected Type visitUniquePredicate(UniquePredicate node, Context context)
+        {
+            StatementAnalyzer analyzer = statementAnalyzerFactory.apply(node, context.getCorrelationSupport());
+            Scope subqueryScope = Scope.builder()
+                    .withParent(context.getScope())
+                    .build();
+
+            List<RowType.Field> fields = analyzer.analyze(node.getSubquery(), subqueryScope)
+                    .getRelationType()
+                    .getAllFields().stream()
+                    .map(field -> field.getName()
+                            .map(name -> RowType.field(name, field.getType()))
+                            .orElseGet(() -> RowType.field(field.getType())))
+                    .collect(toImmutableList());
+
+            for (RowType.Field field : fields) {
+                if (!field.getType().isComparable()) {
+                    throw semanticException(TYPE_MISMATCH, node, "Type [%s] must be comparable in order to be used in UNIQUE predicate", field.getType());
+                }
+            }
+
+            setExpressionType(node.getSubquery(), RowType.from(fields));
+
+            uniquePredicates.add(NodeRef.of(node));
+
+            return setExpressionType(node, BOOLEAN);
+        }
+
         private Type analyzeQuantifiedComparison(Expression value, QuantifiedComparisonPredicate predicate, Expression anchor, Context context)
         {
             quantifiedComparisons.add(new OperandAndPredicate(value, predicate));
@@ -4265,6 +4301,7 @@ public class ExpressionAnalyzer
                 analyzer.getColumnReferences(),
                 analyzer.getQuantifiedComparisons(),
                 analyzer.getMatchPredicates(),
+                analyzer.getUniquePredicates(),
                 analyzer.getWindowFunctions());
     }
 
@@ -4297,6 +4334,7 @@ public class ExpressionAnalyzer
                 analyzer.getColumnReferences(),
                 analyzer.getQuantifiedComparisons(),
                 analyzer.getMatchPredicates(),
+                analyzer.getUniquePredicates(),
                 analyzer.getWindowFunctions());
     }
 
@@ -4326,6 +4364,7 @@ public class ExpressionAnalyzer
                 analyzer.getColumnReferences(),
                 analyzer.getQuantifiedComparisons(),
                 analyzer.getMatchPredicates(),
+                analyzer.getUniquePredicates(),
                 analyzer.getWindowFunctions());
     }
 
@@ -4354,6 +4393,7 @@ public class ExpressionAnalyzer
                         analyzer.getColumnReferences(),
                         analyzer.getQuantifiedComparisons(),
                         analyzer.getMatchPredicates(),
+                        analyzer.getUniquePredicates(),
                         analyzer.getWindowFunctions()));
     }
 
@@ -4383,6 +4423,7 @@ public class ExpressionAnalyzer
                 analyzer.getColumnReferences(),
                 analyzer.getQuantifiedComparisons(),
                 analyzer.getMatchPredicates(),
+                analyzer.getUniquePredicates(),
                 analyzer.getWindowFunctions()));
     }
 
@@ -4458,6 +4499,7 @@ public class ExpressionAnalyzer
                 analyzer.getColumnReferences(),
                 analyzer.getQuantifiedComparisons(),
                 analyzer.getMatchPredicates(),
+                analyzer.getUniquePredicates(),
                 analyzer.getWindowFunctions());
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SubqueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SubqueryPlanner.java
@@ -54,6 +54,7 @@ import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.QuantifiedComparisonPredicate;
 import io.trino.sql.tree.Query;
 import io.trino.sql.tree.SubqueryExpression;
+import io.trino.sql.tree.UniquePredicate;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -78,6 +79,7 @@ import static io.trino.sql.planner.PlanBuilder.newPlanBuilder;
 import static io.trino.sql.planner.ScopeAware.scopeAwareKey;
 import static io.trino.sql.planner.plan.AggregationNode.globalAggregation;
 import static io.trino.sql.planner.plan.AggregationNode.singleAggregation;
+import static io.trino.sql.planner.plan.AggregationNode.singleGroupingSet;
 import static java.util.Objects.requireNonNull;
 
 class SubqueryPlanner
@@ -154,6 +156,10 @@ class SubqueryPlanner
         PlanBuilder matchBuilder = builder;
         for (Cluster<OperandAndPredicate> cluster : cluster(selectSubqueryPredicates(matchBuilder, allSubExpressions, subqueries.getMatchPredicates()), entry -> subqueryPredicateKey(entry, matchBuilder.getScope()))) {
             builder = planMatchPredicate(builder, cluster, subqueries);
+        }
+        PlanBuilder uniqueBuilder = builder;
+        for (Cluster<UniquePredicate> cluster : cluster(selectSubqueries(uniqueBuilder, allSubExpressions, subqueries.getUniquePredicates()), expr -> scopeAwareKey(expr, analysis, uniqueBuilder.getScope()))) {
+            builder = planUniquePredicate(builder, cluster);
         }
 
         return builder;
@@ -358,6 +364,79 @@ class SubqueryPlanner
                         ImmutableMap.of(exists, new ApplyNode.Exists()),
                         subPlan.getRoot().getOutputSymbols(),
                         subquery));
+    }
+
+    /**
+     * Plans `UNIQUE (subquery)` per SQL:2003 §8.9. The predicate is TRUE iff no two rows of the
+     * subquery are equal under row equality, ignoring any row that contains a NULL value (those
+     * rows are not duplicates of anything, including themselves).
+     * <p>
+     * Reduces to: `NOT EXISTS (
+     *   SELECT 1 FROM subquery WHERE noneNull(R) GROUP BY R HAVING COUNT(*) > 1
+     * )`.
+     * <p>
+     * An empty subquery and a subquery containing only NULL-bearing rows both yield TRUE — the
+     * grouped + filtered relation is empty so `EXISTS` is FALSE and `NOT EXISTS` is TRUE.
+     */
+    private PlanBuilder planUniquePredicate(PlanBuilder subPlan, Cluster<UniquePredicate> cluster)
+    {
+        UniquePredicate predicate = cluster.getRepresentative();
+        io.trino.sql.tree.Expression subqueryExpression = predicate.getSubquery();
+
+        RelationPlan relationPlan = planSubquery(subqueryExpression, subPlan.getTranslations());
+        List<Symbol> subqueryFields = visibleFieldMappings(relationPlan);
+
+        // Filter out any row that contains a NULL — such rows can't form duplicates per the spec.
+        Expression noneNullFilter = combineAnd(subqueryFields.stream()
+                .map(symbol -> (Expression) not(plannerContext.getMetadata(), new IsNull(symbol.toSymbolReference())))
+                .collect(toImmutableList()));
+        PlanNode nonNullRows = new FilterNode(idAllocator.getNextId(), relationPlan.getRoot(), noneNullFilter);
+
+        // Group by the full row and count occurrences.
+        ResolvedFunction countFunction = plannerContext.getMetadata().resolveBuiltinFunction("count", ImmutableList.of());
+        Symbol countSymbol = symbolAllocator.newSymbol("count", BIGINT);
+        AggregationNode countAggregation = singleAggregation(
+                idAllocator.getNextId(),
+                nonNullRows,
+                ImmutableMap.of(countSymbol, new AggregationNode.Aggregation(
+                        countFunction,
+                        ImmutableList.of(),
+                        false,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty())),
+                singleGroupingSet(subqueryFields));
+
+        // Keep only groups that have more than one row — those are duplicates.
+        PlanNode duplicates = new FilterNode(
+                idAllocator.getNextId(),
+                countAggregation,
+                comparison(plannerContext.getMetadata(), ComparisonOperator.GREATER_THAN, countSymbol.toSymbolReference(), new Constant(BIGINT, 1L)));
+
+        // EXISTS over duplicates — TRUE iff there is at least one duplicate group.
+        Symbol existsSymbol = symbolAllocator.newSymbol("exists", BOOLEAN);
+        PlanNode apply = new ApplyNode(
+                idAllocator.getNextId(),
+                subPlan.getRoot(),
+                duplicates,
+                ImmutableMap.of(existsSymbol, new ApplyNode.Exists()),
+                subPlan.getRoot().getOutputSymbols(),
+                subqueryExpression);
+
+        // UNIQUE is the negation: no duplicate group → TRUE.
+        Symbol uniqueSymbol = symbolAllocator.newSymbol("unique", BOOLEAN);
+        PlanNode root = new ProjectNode(
+                idAllocator.getNextId(),
+                apply,
+                Assignments.builder()
+                        .putIdentities(apply.getOutputSymbols())
+                        .put(uniqueSymbol, not(plannerContext.getMetadata(), existsSymbol.toSymbolReference()))
+                        .build());
+
+        return new PlanBuilder(
+                subPlan.getTranslations()
+                        .withAdditionalMappings(mapAll(cluster, subPlan.getScope(), uniqueSymbol)),
+                root);
     }
 
     private RelationPlan planSubquery(io.trino.sql.tree.Expression subquery, TranslationMap outerContext)

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -4355,6 +4355,19 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testUniquePredicate()
+    {
+        // Comparable scalar/row types
+        analyze("SELECT UNIQUE (SELECT a FROM t1)");
+        analyze("SELECT UNIQUE (SELECT a, b FROM t1)");
+        analyze("SELECT * FROM t1 WHERE NOT UNIQUE (SELECT a FROM t1)");
+
+        // Non-comparable type rejected
+        assertFails("SELECT UNIQUE (SELECT cast(NULL AS HyperLogLog))")
+                .hasErrorCode(TYPE_MISMATCH);
+    }
+
+    @Test
     public void testJoinUnnest()
     {
         // Lateral references are only allowed in INNER and LEFT join.

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestUniquePredicate.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestUniquePredicate.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestUniquePredicate
+{
+    private final QueryAssertions assertions = new QueryAssertions();
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+    }
+
+    @Test
+    public void testDistinctRowsAreUnique()
+    {
+        assertThat(assertions.query("SELECT UNIQUE (VALUES 1, 2, 3)"))
+                .matches("VALUES true");
+        assertThat(assertions.query("SELECT UNIQUE (VALUES (1, 'a'), (2, 'b'), (3, 'c'))"))
+                .matches("VALUES true");
+    }
+
+    @Test
+    public void testDuplicateRowsAreNotUnique()
+    {
+        assertThat(assertions.query("SELECT UNIQUE (VALUES 1, 1, 2)"))
+                .matches("VALUES false");
+        assertThat(assertions.query("SELECT UNIQUE (VALUES (1, 'a'), (1, 'a'))"))
+                .matches("VALUES false");
+    }
+
+    @Test
+    public void testEmptySubqueryIsUnique()
+    {
+        // Empty table satisfies UNIQUE trivially (SQL:2003 §8.9 case a)
+        assertThat(assertions.query("SELECT UNIQUE (SELECT 1 WHERE false)"))
+                .matches("VALUES true");
+    }
+
+    @Test
+    public void testNullRowsDoNotCountAsDuplicates()
+    {
+        // Rows containing a NULL are never duplicates of anything — including each other.
+        // Two (NULL, 'a') rows are NOT duplicates.
+        assertThat(assertions.query("SELECT UNIQUE (VALUES (CAST(NULL AS INTEGER), 'a'), (CAST(NULL AS INTEGER), 'a'))"))
+                .matches("VALUES true");
+        // Mixing duplicates of non-null rows with NULL rows: the non-null duplicate kills uniqueness.
+        assertThat(assertions.query("SELECT UNIQUE (VALUES (CAST(NULL AS INTEGER), 'a'), (1, 'b'), (1, 'b'))"))
+                .matches("VALUES false");
+    }
+
+    @Test
+    public void testAllRowsContainNullsIsUnique()
+    {
+        // Every row has a NULL → no duplicate pairs possible → TRUE.
+        assertThat(assertions.query("SELECT UNIQUE (VALUES (CAST(NULL AS INTEGER), 1), (2, CAST(NULL AS INTEGER)))"))
+                .matches("VALUES true");
+    }
+
+    @Test
+    public void testNotUnique()
+    {
+        assertThat(assertions.query("SELECT NOT UNIQUE (VALUES 1, 1)"))
+                .matches("VALUES true");
+        assertThat(assertions.query("SELECT NOT UNIQUE (VALUES 1, 2)"))
+                .matches("VALUES false");
+    }
+
+    @Test
+    public void testUniqueInWhereClause()
+    {
+        assertThat(assertions.query(
+                "SELECT a FROM (VALUES 1, 2) t(a) WHERE UNIQUE (VALUES 1, 2, 3)"))
+                .matches("VALUES 1, 2");
+        assertThat(assertions.query(
+                "SELECT a FROM (VALUES 1, 2) t(a) WHERE UNIQUE (VALUES 1, 1)"))
+                .returnsEmptyResult();
+    }
+
+    @Test
+    public void testUniqueInExtendedCaseWhen()
+    {
+        // UNIQUE has no LHS, so in extended SIMPLE CASE WHEN it does not appear as a predicate
+        // fragment (the SQL:2023 F262 fragment set only includes predicates whose operand can
+        // be made implicit). It still works inside a SEARCHED CASE WHEN, which accepts any
+        // boolean expression — no extension needed.
+        assertThat(assertions.query(
+                "SELECT CASE " +
+                        "  WHEN UNIQUE (VALUES 1, 2, 3) THEN 'distinct' " +
+                        "  ELSE 'dup' " +
+                        "END"))
+                .matches("VALUES CAST('distinct' AS varchar(8))");
+        assertThat(assertions.query(
+                "SELECT CASE " +
+                        "  WHEN UNIQUE (VALUES 1, 1) THEN 'distinct' " +
+                        "  ELSE 'dup' " +
+                        "END"))
+                .matches("VALUES CAST('dup' AS varchar(8))");
+    }
+
+    // TODO: correlated UNIQUE is not yet supported — the inner shape
+    // (`EXISTS over GROUP BY HAVING COUNT(*) > 1`) is not one the existing
+    // decorrelation rules can lift. The non-correlated cases above cover
+    // the common usage; correlated UNIQUE needs new decorrelation work.
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -106,6 +106,7 @@ import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.Trim;
 import io.trino.sql.tree.TryExpression;
 import io.trino.sql.tree.TypeParameter;
+import io.trino.sql.tree.UniquePredicate;
 import io.trino.sql.tree.WhenClause;
 import io.trino.sql.tree.Window;
 import io.trino.sql.tree.WindowFrame;
@@ -438,6 +439,12 @@ public final class ExpressionFormatter
         protected String visitExists(ExistsPredicate node, Void context)
         {
             return "(EXISTS " + formatSql(node.getSubquery()) + ")";
+        }
+
+        @Override
+        protected String visitUniquePredicate(UniquePredicate node, Void context)
+        {
+            return "(UNIQUE " + formatSql(node.getSubquery()) + ")";
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -308,6 +308,7 @@ import io.trino.sql.tree.TruncateTable;
 import io.trino.sql.tree.TryExpression;
 import io.trino.sql.tree.TypeParameter;
 import io.trino.sql.tree.Union;
+import io.trino.sql.tree.UniquePredicate;
 import io.trino.sql.tree.Unnest;
 import io.trino.sql.tree.Update;
 import io.trino.sql.tree.UpdateAssignment;
@@ -2389,6 +2390,12 @@ class AstBuilder
     public Node visitExists(SqlBaseParser.ExistsContext context)
     {
         return new ExistsPredicate(getLocation(context), new SubqueryExpression(getLocation(context), (Query) visit(context.query())));
+    }
+
+    @Override
+    public Node visitUnique(SqlBaseParser.UniqueContext context)
+    {
+        return new UniquePredicate(getLocation(context), new SubqueryExpression(getLocation(context), (Query) visit(context.query())));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -577,6 +577,11 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
+    protected R visitUniquePredicate(UniquePredicate node, C context)
+    {
+        return visitExpression(node, context);
+    }
+
     protected R visitTryExpression(TryExpression node, C context)
     {
         return visitExpression(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -899,6 +899,14 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
+    protected Void visitUniquePredicate(UniquePredicate node, C context)
+    {
+        process(node.getSubquery(), context);
+
+        return null;
+    }
+
+    @Override
     protected Void visitLateral(Lateral node, C context)
     {
         process(node.getQuery(), context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
@@ -115,6 +115,11 @@ public class ExpressionRewriter<C>
         return rewriteExpression(node, context, treeRewriter);
     }
 
+    public Expression rewriteUniquePredicate(UniquePredicate node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    {
+        return rewriteExpression(node, context, treeRewriter);
+    }
+
     public Expression rewriteSubqueryExpression(SubqueryExpression node, C context, ExpressionTreeRewriter<C> treeRewriter)
     {
         return rewriteExpression(node, context, treeRewriter);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
@@ -765,6 +765,26 @@ public final class ExpressionTreeRewriter<C>
         }
 
         @Override
+        protected Expression visitUniquePredicate(UniquePredicate node, Context<C> context)
+        {
+            if (!context.isDefaultRewrite()) {
+                Expression result = rewriter.rewriteUniquePredicate(node, context.get(), ExpressionTreeRewriter.this);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            Expression subquery = node.getSubquery();
+            subquery = rewrite(subquery, context.get());
+
+            if (subquery != node.getSubquery()) {
+                return new UniquePredicate(node.getLocation().orElseThrow(), subquery);
+            }
+
+            return node;
+        }
+
+        @Override
         public Expression visitSubqueryExpression(SubqueryExpression node, Context<C> context)
         {
             if (!context.isDefaultRewrite()) {

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/UniquePredicate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/UniquePredicate.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class UniquePredicate
+        extends Expression
+{
+    private final Expression subquery;
+
+    public UniquePredicate(NodeLocation location, Expression subquery)
+    {
+        super(location);
+        this.subquery = requireNonNull(subquery, "subquery is null");
+    }
+
+    public Expression getSubquery()
+    {
+        return subquery;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitUniquePredicate(this, context);
+    }
+
+    @Override
+    public List<Node> getChildren()
+    {
+        return ImmutableList.of(subquery);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UniquePredicate that = (UniquePredicate) o;
+        return Objects.equals(subquery, that.subquery);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return subquery.hashCode();
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        return sameClass(this, other);
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -239,6 +239,7 @@ import io.trino.sql.tree.Trim;
 import io.trino.sql.tree.TruncateTable;
 import io.trino.sql.tree.TryExpression;
 import io.trino.sql.tree.Union;
+import io.trino.sql.tree.UniquePredicate;
 import io.trino.sql.tree.Unnest;
 import io.trino.sql.tree.Update;
 import io.trino.sql.tree.UpdateAssignment;
@@ -6095,6 +6096,18 @@ public class TestSqlParser
         MatchPredicate secondFragment = (MatchPredicate) ((WhenClause.Partial) secondClause.getMatch()).predicate();
         assertThat(secondFragment.isUnique()).isTrue();
         assertThat(secondFragment.getType()).isEqualTo(MatchPredicate.Type.PARTIAL);
+    }
+
+    @Test
+    public void testUniquePredicate()
+    {
+        SqlParser parser = new SqlParser();
+        UniquePredicate predicate = (UniquePredicate) parser.createExpression("UNIQUE (SELECT a FROM t)");
+        assertThat(predicate.getSubquery()).isInstanceOf(SubqueryExpression.class);
+
+        assertThat(parser.createExpression("UNIQUE (SELECT a, b FROM t)")).isInstanceOf(UniquePredicate.class);
+
+        assertThat(parser.createExpression("NOT UNIQUE (SELECT a FROM t)")).isInstanceOf(NotExpression.class);
     }
 
     @Test


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on #29810** (SQL `MATCH` predicate), which depends on #29446 (extended CASE) → #29809. This branch is stacked on `match-predicate`, so its diff includes those commits; review the final `Add SQL UNIQUE predicate` commit here. Merge order: #29809 → #29446 → #29810 → this.

## Description

Adds parser, analyzer, and planner support for the SQL:1999 `UNIQUE` predicate:

```sql
UNIQUE (subquery)
```

True iff no two rows of the subquery are equal under row equality, where rows containing any `NULL` never count as duplicates (SQL:2003 §8.9). An empty subquery, and a subquery whose rows all contain a `NULL`, both yield `TRUE`.

Unlike `MATCH`, `UNIQUE` has no left-hand operand, so it stays an `Expression` rather than becoming a `Predicate` subtype. In extended `CASE WHEN` it is reached via the searched-`WHEN` alternative (any boolean expression), not the predicate-fragment alternative — SQL:2023 F262 does not include `UNIQUE` in the fragment set since there is no operand to make implicit.

Planning reduces to:

```
NOT EXISTS (
  SELECT 1 FROM subquery
  WHERE noneNull(R)
  GROUP BY R
  HAVING COUNT(*) > 1
)
```

Correlated `UNIQUE` is not yet supported (the inner shape isn't liftable by the existing decorrelation rules) — left as a follow-up.

## Test plan

- [x] Parser shapes — `TestSqlParser`
- [x] Analyzer checks — `TestAnalyzer`
- [x] 8 end-to-end behaviors (dedup, NULL handling, empty/all-NULL → TRUE) — `TestUniquePredicate`

## Release notes

(x) Release notes are required, with the following suggested text:

```
# General
* Add support for the SQL `UNIQUE` predicate.
```
