### PR TITLE
Fix round(double/real, decimals) returning NaN on underflow

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
@@ -901,6 +901,13 @@ public final class MathFunctions
 
         double factor = Math.pow(10, decimals);
         int sign = (num < 0) ? -1 : 1;
+        if (factor == 0) {
+            // decimals so negative that 10^decimals underflows to 0; the rounding place value
+            // is larger than any finite magnitude, so any finite num rounds to 0. The sign is
+            // preserved (yielding -0.0 for negative num), consistent with the general path below.
+            return sign * 0.0;
+        }
+
         double rescaled = sign * num * factor;
         long rescaledRound = Math.round(rescaled);
         if (rescaledRound != Long.MAX_VALUE) {
@@ -928,6 +935,13 @@ public final class MathFunctions
 
         double factor = Math.pow(10, decimals);
         int sign = (numInFloat < 0) ? -1 : 1;
+        if (factor == 0) {
+            // decimals so negative that 10^decimals underflows to 0; the rounding place value
+            // is larger than any finite magnitude, so any finite num rounds to 0. The sign is
+            // preserved (yielding -0.0 for negative num), consistent with the general path below.
+            return floatToRawIntBits(sign * 0.0f);
+        }
+
         double result;
         double rescaled = sign * numInFloat * factor;
         long rescaledRound = Math.round(rescaled);

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
@@ -1868,6 +1868,39 @@ public class TestMathFunctions
         assertThat(assertions.function("round", "DOUBLE '-1.8E292'", "16"))
                 .isEqualTo(-1.8e292);
 
+        // 10^decimals underflows to 0 for decimals <= -324; rounding any finite value to such a
+        // coarse place must yield 0, not NaN (regression for the 0L / 0.0 division). The sign of
+        // zero is preserved, consistent with rounding any negative value down to zero elsewhere.
+        assertThat(assertions.function("round", "DOUBLE '123.456'", "-324"))
+                .isEqualTo(0.0);
+
+        assertThat(assertions.function("round", "DOUBLE '-123.456'", "-1000"))
+                .isEqualTo(-0.0);
+
+        assertThat(assertions.function("round", "REAL '123.456'", "-324"))
+                .isEqualTo(0.0f);
+
+        assertThat(assertions.function("round", "REAL '-123.456'", "-1000"))
+                .isEqualTo(-0.0f);
+
+        assertThat(assertions.function("round", "nan()", "-1000"))
+                .isEqualTo(Double.NaN);
+
+        assertThat(assertions.function("round", "infinity()", "-1000"))
+                .isEqualTo(Double.POSITIVE_INFINITY);
+
+        assertThat(assertions.function("round", "-infinity()", "-1000"))
+                .isEqualTo(Double.NEGATIVE_INFINITY);
+
+        assertThat(assertions.function("round", "REAL 'NaN'", "-1000"))
+                .isEqualTo(Float.NaN);
+
+        assertThat(assertions.function("round", "CAST(infinity() AS REAL)", "-1000"))
+                .isEqualTo(Float.POSITIVE_INFINITY);
+
+        assertThat(assertions.function("round", "CAST(-infinity() AS REAL)", "-1000"))
+                .isEqualTo(Float.NEGATIVE_INFINITY);
+
         assertThat(assertions.function("round", "TINYINT '3'", "TINYINT '1'"))
                 .isEqualTo((byte) 3);
 


### PR DESCRIPTION
## Description
Fix round underflow when round(num, decimals) has a very negative decimal.
- fixes https://github.com/trinodb/trino/issues/29808

**The issue**:
The factor is calculated as below, which can underflow to 0.0 and then used as a divisor:
```Java
double factor = Math.pow(10, decimals);
```
**The fix**:
A guard is added right after computing factor, in both round(double,…) and roundReal(real,…):
```Java
  if (factor == 0) {
      rreturn sign * 0.0;   // (or floatToRawIntBits(0.0f) for real)
  }
```
## Additional context and related issues
N.A

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix round underflow. ({issue}`https://github.com/trinodb/trino/issues/29808`)
```
