### PR TITLE
Fix short decimal cast to double rounding error

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
@@ -444,7 +444,7 @@ public final class DecimalCasts
     @UsedByGeneratedCode
     public static double shortDecimalToDouble(long decimal, long precision, long scale, long tenToScale)
     {
-        return ((double) decimal) / tenToScale;
+        return DecimalConversions.shortDecimalToDouble(decimal, tenToScale);
     }
 
     @UsedByGeneratedCode

--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
@@ -1100,6 +1100,24 @@ public class TestDecimalCasts
         assertThat(assertions.expression("cast(a as DOUBLE)")
                 .binding("a", "DECIMAL '99999999999999999999999999999999999999'"))
                 .isEqualTo(1.0e38);
+
+        // unscaled value does not fit in double lossless, but represented number does
+        assertThat(assertions.expression("cast(a as DOUBLE)")
+                .binding("a", "DECIMAL '912057769880088.000'"))
+                .isEqualTo(912057769880088.0);
+
+        assertThat(assertions.expression("cast(a as DOUBLE)")
+                .binding("a", "DECIMAL '-912057769880088.000'"))
+                .isEqualTo(-912057769880088.0);
+
+        // unscaled value does not fit in double lossless, but represented number does
+        assertThat(assertions.expression("cast(a as DOUBLE)")
+                .binding("a", "DECIMAL '5764607523034800.00'"))
+                .isEqualTo(5764607523034800.0);
+
+        assertThat(assertions.expression("cast(a as DOUBLE)")
+                .binding("a", "DECIMAL '-5764607523034800.00'"))
+                .isEqualTo(-5764607523034800.0);
     }
 
     @Test

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DecimalConversions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DecimalConversions.java
@@ -49,6 +49,7 @@ public final class DecimalConversions
     };
     // visible for testing
     static final Int128 MAX_EXACT_DOUBLE = Int128.valueOf(1L << 53);
+    private static final long MAX_EXACT_DOUBLE_LONG = MAX_EXACT_DOUBLE.toLongExact();
     // visible for testing
     static final Int128 MAX_EXACT_FLOAT = Int128.valueOf(1L << 24);
 
@@ -56,7 +57,10 @@ public final class DecimalConversions
 
     public static double shortDecimalToDouble(long decimal, long tenToScale)
     {
-        return ((double) decimal) / tenToScale;
+        if (-MAX_EXACT_DOUBLE_LONG <= decimal && decimal <= MAX_EXACT_DOUBLE_LONG) {
+            return ((double) decimal) / tenToScale;
+        }
+        return BigDecimal.valueOf(decimal).divide(BigDecimal.valueOf(tenToScale)).doubleValue();
     }
 
     public static double longDecimalToDouble(Int128 decimal, long scale)

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestDecimalConversions.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestDecimalConversions.java
@@ -24,6 +24,8 @@ import static io.trino.spi.type.DecimalConversions.MAX_EXACT_DOUBLE;
 import static io.trino.spi.type.DecimalConversions.MAX_EXACT_FLOAT;
 import static io.trino.spi.type.DecimalConversions.longDecimalToDouble;
 import static io.trino.spi.type.DecimalConversions.longDecimalToReal;
+import static io.trino.spi.type.DecimalConversions.shortDecimalToDouble;
+import static io.trino.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static java.lang.Math.toIntExact;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,6 +39,25 @@ class TestDecimalConversions
             for (int scale = 0; scale <= 38; scale++) {
                 assertThat(longDecimalToDouble(unscaledInt128, scale))
                         .as("longDecimalToDouble(%s, %d)", unscaledInt128, scale)
+                        .isEqualTo(new BigDecimal(unscaledValue, scale).doubleValue());
+            }
+        }
+    }
+
+    @Test
+    void testShortDecimalToDouble()
+    {
+        BigInteger shortDecimalBound = BigInteger.TEN.pow(MAX_SHORT_PRECISION);
+        for (BigInteger unscaledValue : testValues()) {
+            if (unscaledValue.abs().compareTo(shortDecimalBound) >= 0) {
+                // does not fit in a short decimal
+                continue;
+            }
+            long unscaled = unscaledValue.longValueExact();
+            for (int scale = 0; scale <= MAX_SHORT_PRECISION; scale++) {
+                long tenToScale = BigInteger.TEN.pow(scale).longValueExact();
+                assertThat(shortDecimalToDouble(unscaled, tenToScale))
+                        .as("shortDecimalToDouble(%s, scale=%d)", unscaled, scale)
                         .isEqualTo(new BigDecimal(unscaledValue, scale).doubleValue());
             }
         }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -1391,7 +1391,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
         testCheckpointWriteStatsAsStruct("smallint", "3", "32767", "0.0", "3", "32767");
         testCheckpointWriteStatsAsStruct("bigint", "1000", "9223372036854775807", "0.0", "1000", "9223372036854775807");
         testCheckpointWriteStatsAsStruct("real", "0.1", "999999.999", "0.0", "0.1", "1000000.0");
-        testCheckpointWriteStatsAsStruct("double", "1.0", "9999999999999.999", "0.0", "1.0", "'1.0E13'");
+        testCheckpointWriteStatsAsStruct("double", "1.0", "9999999999999.999", "0.0", "1.0", "'9.999999999999998E12'");
         testCheckpointWriteStatsAsStruct("decimal(3,2)", "3.14", "9.99", "0.0", "3.14", "9.99");
         testCheckpointWriteStatsAsStruct("decimal(30,1)", "12345", "99999999999999999999999999999.9", "0.0", "12345.0", "'1.0E29'");
         testCheckpointWriteStatsAsStruct("varchar", "'test'", "'ŻŻŻŻŻŻŻŻŻŻ'", "0.0", "null", "null");

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -2413,7 +2413,7 @@ public abstract class BaseHiveConnectorTest
                         .mapToObj(i -> format("MAP(ARRAY[%s, %s], ARRAY[%s, %s])", i + 567.123, i + 568.456, i + 22769, i + 22770))
                         .collect(toImmutableList()),
                 "MAP(ARRAY[567.123, 568.456], ARRAY[22769, 22770])",
-                149,
+                166,
                 1);
     }
 


### PR DESCRIPTION
## Description
**The issue**:
Casting `912057769880088.000` to DOUBLE produces `9.120577698800881E14`, which is wrong:
```SQL
trino> select CAST(DECIMAL '912057769880088.000' AS DOUBLE);
        _col0
----------------------
 9.120577698800881E14
(1 row)

Query 20260610_182807_00002_aq7au, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.11 [0 rows, 0B] [0 rows/s, 0B/s]
```
**The cause and fix**:
(Use the above case as an example) The cast does ((double) decimal) / tenToScale: take the unscaled integer (912057769880088000), make it a double, then divide by 1000. The problem is that integer is too big for double to hold it exactly - so step 1 already changes the number a little and the division rounds it again.

Two roundings in a row can give a different result than dividing first and rounding once - Everything stays in double, so the first error is not absorbed and stays in the answer. That is why 912057769880088.000 becomes 912057769880088.1 instead of the exact 912057769880088.

Fix: do not round early. If the integer is small enough, divide as before. If it is too big, divide with BigDecimal and round to double only once at the end.
## Additional context and related issues
It seems to be a similar issue of https://github.com/trinodb/trino/pull/29378 which is for DECIMAL -> DOUBLE


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix casting decimal to double in extreme cases. 
```
