### PR TITLE
Represent bound signatures as their ground return and argument types

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/BuiltinFunctionResolver.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/BuiltinFunctionResolver.java
@@ -19,10 +19,10 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.trino.cache.NonEvictableCache;
 import io.trino.connector.system.GlobalSystemConnector;
 import io.trino.metadata.FunctionBinder.CatalogFunctionBinding;
+import io.trino.metadata.SignatureBinder.GroundSignature;
 import io.trino.spi.TrinoException;
 import io.trino.spi.function.FunctionDependencyDeclaration;
 import io.trino.spi.function.OperatorType;
-import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeSignature;
@@ -134,10 +134,7 @@ class BuiltinFunctionResolver
     ResolvedFunction resolveCoercion(String functionName, Type fromType, Type toType)
     {
         CatalogFunctionBinding functionBinding = functionBinder.bindCoercion(
-                Signature.builder()
-                        .returnType(toType)
-                        .argumentType(fromType)
-                        .build(),
+                new GroundSignature(toType.getTypeSignature(), ImmutableList.of(fromType.getTypeSignature())),
                 getBuiltinFunctions(functionName));
         return resolveBuiltin(functionBinding);
     }

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
@@ -17,6 +17,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import io.trino.connector.CatalogHandle;
+import io.trino.metadata.SignatureBinder.GroundSignature;
 import io.trino.spi.TrinoException;
 import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.CatalogSchemaFunctionName;
@@ -97,7 +98,7 @@ class FunctionBinder
         return matchFunctionWithCoercion(candidates, parameterTypes);
     }
 
-    CatalogFunctionBinding bindCoercion(Signature signature, Collection<CatalogFunctionMetadata> candidates)
+    CatalogFunctionBinding bindCoercion(GroundSignature signature, Collection<CatalogFunctionMetadata> candidates)
     {
         // coercions are much more common and much simpler than function calls, so we use a custom algorithm
         List<CatalogFunctionMetadata> exactCandidates = candidates.stream()
@@ -122,21 +123,21 @@ class FunctionBinder
         throw new TrinoException(FUNCTION_IMPLEMENTATION_MISSING, format("%s not found", signature));
     }
 
-    private boolean canBindSignature(Signature declaredSignature, Signature actualSignature)
+    private boolean canBindSignature(Signature declaredSignature, GroundSignature actualSignature)
     {
         return new SignatureBinder(metadata, typeManager, declaredSignature, false)
-                .canBind(fromTypeSignatures(actualSignature.getArgumentTypes()), actualSignature.getReturnType());
+                .canBind(fromTypeSignatures(actualSignature.argumentTypes()), actualSignature.returnType());
     }
 
-    private static boolean possibleExactCastMatch(Signature signature, Signature declaredSignature)
+    private static boolean possibleExactCastMatch(GroundSignature signature, Signature declaredSignature)
     {
         if (declaredSignature.isGeneric()) {
             return false;
         }
-        if (!declaredSignature.getReturnType().getBase().equalsIgnoreCase(signature.getReturnType().getBase())) {
+        if (!declaredSignature.getReturnType().getBase().equalsIgnoreCase(signature.returnType().getBase())) {
             return false;
         }
-        return declaredSignature.getArgumentTypes().get(0).getBase().equalsIgnoreCase(signature.getArgumentTypes().get(0).getBase());
+        return declaredSignature.getArgumentTypes().get(0).getBase().equalsIgnoreCase(signature.argumentTypes().get(0).getBase());
     }
 
     private Optional<CatalogFunctionBinding> matchFunctionExact(List<CatalogFunctionMetadata> candidates, List<TypeSignatureProvider> actualParameters)
@@ -272,7 +273,7 @@ class FunctionBinder
 
     private boolean onlyCastsUnknown(ApplicableFunction applicableFunction, List<Type> actualParameters)
     {
-        List<Type> boundTypes = applicableFunction.boundSignature().getArgumentTypes().stream()
+        List<Type> boundTypes = applicableFunction.boundSignature().argumentTypes().stream()
                 .map(typeManager::getType)
                 .collect(toImmutableList());
         checkState(actualParameters.size() == boundTypes.size(), "type lists are of different lengths");
@@ -287,7 +288,7 @@ class FunctionBinder
     private boolean returnTypeIsTheSame(List<ApplicableFunction> applicableFunctions)
     {
         Set<TypeSignature> returnTypes = applicableFunctions.stream()
-                .map(function -> function.boundSignature().getReturnType())
+                .map(function -> function.boundSignature().returnType())
                 .collect(Collectors.toSet());
         return returnTypes.size() == 1;
     }
@@ -333,20 +334,20 @@ class FunctionBinder
      */
     private boolean isMoreSpecificThan(ApplicableFunction left, ApplicableFunction right)
     {
-        List<TypeSignatureProvider> resolvedTypes = fromTypeSignatures(left.boundSignature().getArgumentTypes());
+        List<TypeSignatureProvider> resolvedTypes = fromTypeSignatures(left.boundSignature().argumentTypes());
         return new SignatureBinder(metadata, typeManager, right.declaredSignature(), true)
                 .canBind(resolvedTypes);
     }
 
-    private CatalogFunctionBinding toFunctionBinding(CatalogFunctionMetadata functionMetadata, Signature signature)
+    private CatalogFunctionBinding toFunctionBinding(CatalogFunctionMetadata functionMetadata, GroundSignature signature)
     {
         BoundSignature boundSignature = new BoundSignature(
                 new CatalogSchemaFunctionName(
                         functionMetadata.catalogHandle().getCatalogName().toString(),
                         functionMetadata.schemaName(),
                         functionMetadata.functionMetadata().getCanonicalName()),
-                typeManager.getType(signature.getReturnType()),
-                signature.getArgumentTypes().stream()
+                typeManager.getType(signature.returnType()),
+                signature.argumentTypes().stream()
                         .map(typeManager::getType)
                         .collect(toImmutableList()));
         return new CatalogFunctionBinding(
@@ -423,13 +424,7 @@ class FunctionBinder
         return new TrinoException(FUNCTION_NOT_FOUND, message);
     }
 
-    /**
-     * @param boundSignature Ideally this would be a real bound signature,
-     *         but the resolver algorithm considers functions with illegal types (e.g., char(large_number))
-     *         We could just not consider these applicable functions, but there are tests that depend on
-     *         the specific error messages for these failures.
-     */
-    private record ApplicableFunction(CatalogFunctionMetadata function, Signature boundSignature)
+    private record ApplicableFunction(CatalogFunctionMetadata function, GroundSignature boundSignature)
     {
         public FunctionMetadata functionMetadata()
         {

--- a/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
@@ -64,6 +64,7 @@ import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -121,7 +122,7 @@ public class SignatureBinder
         return bindVariables(actualArgumentTypes, actualReturnType).isPresent();
     }
 
-    public Optional<Signature> bind(List<? extends TypeSignatureProvider> actualArgumentTypes)
+    Optional<GroundSignature> bind(List<? extends TypeSignatureProvider> actualArgumentTypes)
     {
         Optional<VariableBindings> boundVariables = bindVariables(actualArgumentTypes);
         if (boundVariables.isEmpty()) {
@@ -155,7 +156,7 @@ public class SignatureBinder
         return iterativeSolve(constraintSolvers.build());
     }
 
-    private static Signature applyBoundVariables(Signature signature, VariableBindings typeVariables, int arity)
+    private static GroundSignature applyBoundVariables(Signature signature, VariableBindings typeVariables, int arity)
     {
         List<TypeSignature> argumentSignatures;
         if (signature.isVariableArity()) {
@@ -165,13 +166,9 @@ public class SignatureBinder
             checkArgument(signature.getArgumentTypes().size() == arity);
             argumentSignatures = signature.getArgumentTypes();
         }
-        List<TypeSignature> boundArgumentSignatures = applyBoundVariables(argumentSignatures, typeVariables);
-        TypeSignature boundReturnTypeSignature = applyBoundVariables(signature.getReturnType(), typeVariables);
-
-        return Signature.builder()
-                .returnType(boundReturnTypeSignature)
-                .argumentTypes(boundArgumentSignatures)
-                .build();
+        return new GroundSignature(
+                applyBoundVariables(signature.getReturnType(), typeVariables),
+                applyBoundVariables(argumentSignatures, typeVariables));
     }
 
     public static List<TypeSignature> applyBoundVariables(List<TypeSignature> typeSignatures, VariableBindings typeVariables)
@@ -1038,5 +1035,30 @@ public class SignatureBinder
     public enum RelationshipType
     {
         EXACT, IMPLICIT_COERCION, EXPLICIT_COERCION_TO, EXPLICIT_COERCION_FROM
+    }
+
+    /// A function signature with all of its variables bound: the ground argument and return types of one
+    /// applicable binding. The types stay unresolved signatures rather than [Type]s because function
+    /// resolution keeps candidates whose bound types are illegal (e.g. `char(2147483647)`) so they can be
+    /// reported in error messages.
+    record GroundSignature(TypeSignature returnType, List<TypeSignature> argumentTypes)
+    {
+        public GroundSignature
+        {
+            requireNonNull(returnType, "returnType is null");
+            argumentTypes = ImmutableList.copyOf(argumentTypes);
+        }
+
+        /// The rendering participates in function resolution: ambiguous-candidate selection orders
+        /// by it, and error messages include it.
+        @Override
+        public String toString()
+        {
+            return "%s:%s".formatted(
+                    argumentTypes.stream()
+                            .map(TypeSignature::toString)
+                            .collect(joining(",", "(", ")")),
+                    returnType);
+        }
     }
 }


### PR DESCRIPTION
## Description

Binding a declared function signature to actual argument types produced another `Signature` —
a degenerate one with no variable constraints, dropped argument names, and a stale
variable-arity flag — from which the resolver only ever read the types back out (the
`ApplicableFunction` javadoc already noted it should ideally be a real bound signature).

Carry the bound result as a dedicated `GroundSignature` record of the ground return and
argument types instead: `SignatureBinder.bind()` returns it, and `FunctionBinder` /
`BuiltinFunctionResolver` consume it directly. The types stay unresolved signatures rather
than resolved `Type`s because function resolution keeps candidates whose bound types are
illegal (e.g. `char(2147483647)`) so they can be reported in error messages.

No behavior change.

## Additional context and related issues

Follow-up to #29804; preparatory refactoring ahead of splitting the overloaded
`TypeSignature` into a ground type descriptor and an open, variable-bearing template form —
with bound results already a distinct ground type, that split leaves the resolver untouched.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
