### PR TITLE
Add position_deletes system table to Iceberg

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
@@ -182,6 +182,7 @@ public class DefaultCatalogFactory
                         transactionId -> transactionManager.getConnectorTransaction(transactionId, catalogHandle),
                         accessControl,
                         catalogHandle.getCatalogName().toString(),
+                        catalogHandle,
                         catalogConnector.getPageSourceProviderFactory()));
 
         return new CatalogConnector(

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemConnector.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemConnector.java
@@ -13,6 +13,7 @@
  */
 package io.trino.connector.system;
 
+import io.trino.connector.CatalogHandle;
 import io.trino.node.InternalNode;
 import io.trino.node.InternalNodeManager;
 import io.trino.security.AccessControl;
@@ -46,6 +47,7 @@ public class SystemConnector
             Function<TransactionId, ConnectorTransactionHandle> transactionHandleFunction,
             AccessControl accessControl,
             String catalogName,
+            CatalogHandle sourceCatalogHandle,
             Optional<ConnectorPageSourceProviderFactory> pageSourceProviderFactory)
     {
         requireNonNull(currentNode, "currentNode is null");
@@ -54,10 +56,11 @@ public class SystemConnector
         requireNonNull(transactionHandleFunction, "transactionHandleFunction is null");
         requireNonNull(accessControl, "accessControl is null");
         requireNonNull(catalogName, "catalogName is null");
+        requireNonNull(sourceCatalogHandle, "sourceCatalogHandle is null");
 
         this.metadata = new SystemTablesMetadata(tables);
         this.splitManager = new SystemSplitManager(currentNode, nodeManager, tables);
-        this.pageSourceProvider = new SystemPageSourceProvider(tables, accessControl, catalogName, pageSourceProviderFactory);
+        this.pageSourceProvider = new SystemPageSourceProvider(tables, accessControl, catalogName, sourceCatalogHandle, pageSourceProviderFactory);
         this.transactionHandleFunction = transactionHandleFunction;
     }
 

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemPageSourceProvider.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemPageSourceProvider.java
@@ -14,8 +14,11 @@
 package io.trino.connector.system;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.FullConnectorSession;
+import io.trino.Session;
+import io.trino.connector.CatalogHandle;
 import io.trino.plugin.base.MappedPageSource;
 import io.trino.plugin.base.MappedRecordSet;
 import io.trino.security.AccessControl;
@@ -65,13 +68,15 @@ public class SystemPageSourceProvider
     private final SystemTablesProvider tables;
     private final AccessControl accessControl;
     private final String catalogName;
+    private final CatalogHandle sourceCatalogHandle;
     private final Optional<ConnectorPageSourceProvider> connectorPageSourceProvider;
 
-    public SystemPageSourceProvider(SystemTablesProvider tables, AccessControl accessControl, String catalogName, Optional<ConnectorPageSourceProviderFactory> pageSourceProviderFactory)
+    public SystemPageSourceProvider(SystemTablesProvider tables, AccessControl accessControl, String catalogName, CatalogHandle sourceCatalogHandle, Optional<ConnectorPageSourceProviderFactory> pageSourceProviderFactory)
     {
         this.tables = requireNonNull(tables, "tables is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.sourceCatalogHandle = requireNonNull(sourceCatalogHandle, "sourceCatalogHandle is null");
         this.connectorPageSourceProvider = requireNonNull(pageSourceProviderFactory, "pageSourceProviderFactory is null")
                 .map(ConnectorPageSourceProviderFactory::createPageSourceProvider);
     }
@@ -92,8 +97,19 @@ public class SystemPageSourceProvider
 
         // if the split is not a SystemSplit, we immediately delegate to the Connector to build a PageSource
         if (!(split instanceof SystemSplit systemSplit)) {
+            ConnectorSession sourceCatalogSession = session;
+            if (session instanceof FullConnectorSession fullSession) {
+                Session underlyingSession = fullSession.getSession();
+                sourceCatalogSession = new FullConnectorSession(
+                        underlyingSession,
+                        fullSession.getIdentity(),
+                        ImmutableMap.of(),
+                        sourceCatalogHandle,
+                        catalogName,
+                        underlyingSession.getSessionPropertyManager());
+            }
             return connectorPageSourceProvider.orElseThrow()
-                    .createPageSource(systemTransaction.getConnectorTransactionHandle(), session, split, table, tableCredentials, columns, dynamicFilter, memoryContext);
+                    .createPageSource(systemTransaction.getConnectorTransactionHandle(), sourceCatalogSession, split, table, tableCredentials, columns, dynamicFilter, memoryContext);
         }
 
         SchemaTableName tableName = ((SystemTableHandle) table).schemaTableName();

--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -1656,6 +1656,58 @@ The output of the query has the following columns:
     data files.
 :::
 
+##### `$position_deletes` table
+
+The `$position_deletes` table provides a detailed view of position delete records
+in the current snapshot of the Iceberg table. Each row represents a deleted row
+position from a data file.
+
+To retrieve position delete information for the Iceberg table `test_table`, use
+the following query:
+
+```sql
+SELECT * FROM "test_table$position_deletes";
+```
+
+```text
+ file_path                                     | pos | spec_id | delete_file_path
+-----------------------------------------------+-----+---------+----------------------------------------------
+ s3://test-bucket/test_table/data/file-001.parquet | 42  | 0       | s3://test-bucket/test_table/data/delete-001.parquet
+ s3://test-bucket/test_table/data/file-001.parquet | 108 | 0       | s3://test-bucket/test_table/data/delete-001.parquet
+```
+
+The output of the query has the following columns:
+
+:::{list-table} Position deletes columns
+:widths: 25, 30, 45
+:header-rows: 1
+
+* - Name
+  - Type
+  - Description
+* - `file_path`
+  - `VARCHAR`
+  - The path of the data file containing the deleted row.
+* - `pos`
+  - `BIGINT`
+  - The position (row number) of the deleted row within the data file.
+* - `partition`
+  - `ROW(...)`
+  - A row that contains the mapping of the partition column names to the
+    partition column values. Only present for partitioned tables.
+* - `spec_id`
+  - `INTEGER`
+  - The partition specification ID for the data file.
+* - `delete_file_path`
+  - `VARCHAR`
+  - The path of the delete file (position delete file or deletion vector) that
+    marks this row as deleted.
+:::
+
+The table includes both traditional position delete files (format v2) and deletion
+vectors (format v3). Deletion vectors are automatically expanded to show individual
+deleted row positions. Equality delete files are not included in this table.
+
 ##### `$entries` and `$all_entries` tables
 
 The `$entries` and `$all_entries` tables provide the table's manifest entries

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -68,6 +68,7 @@ import io.trino.plugin.iceberg.system.HistoryTable;
 import io.trino.plugin.iceberg.system.ManifestsTable;
 import io.trino.plugin.iceberg.system.MetadataLogEntriesTable;
 import io.trino.plugin.iceberg.system.PartitionsView;
+import io.trino.plugin.iceberg.system.PositionDeletesTable;
 import io.trino.plugin.iceberg.system.PropertiesTable;
 import io.trino.plugin.iceberg.system.RefsTable;
 import io.trino.plugin.iceberg.system.SnapshotsTable;
@@ -924,6 +925,7 @@ public class IcebergMetadata
             case FILES -> Optional.of(new FilesTable(tableName, typeManager, table, getCurrentSnapshotId(table)));
             case ALL_ENTRIES -> Optional.of(new EntriesTable(typeManager, tableName, table, ALL_ENTRIES, icebergScanExecutor));
             case ENTRIES -> Optional.of(new EntriesTable(typeManager, tableName, table, ENTRIES, icebergScanExecutor));
+            case POSITION_DELETES -> Optional.of(new PositionDeletesTable(typeManager, tableName, table));
             case PROPERTIES -> Optional.of(new PropertiesTable(tableName, table));
             case REFS -> Optional.of(new RefsTable(tableName, table, icebergScanExecutor));
             default -> Optional.empty();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -69,6 +69,9 @@ import io.trino.plugin.iceberg.fileio.ForwardingFileIoFactory;
 import io.trino.plugin.iceberg.fileio.ForwardingInputFile;
 import io.trino.plugin.iceberg.system.files.FilesTablePageSource;
 import io.trino.plugin.iceberg.system.files.FilesTableSplit;
+import io.trino.plugin.iceberg.system.positiondeletes.DeletionVectorPageSource;
+import io.trino.plugin.iceberg.system.positiondeletes.PositionDeletesTablePageSource;
+import io.trino.plugin.iceberg.system.positiondeletes.PositionDeletesTableSplit;
 import io.trino.spi.BlocksHashFactory;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
@@ -110,6 +113,7 @@ import io.trino.spi.type.TypeManager;
 import jakarta.annotation.Nullable;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericDatumReader;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
@@ -233,6 +237,8 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.apache.iceberg.FileContent.EQUALITY_DELETES;
 import static org.apache.iceberg.FileContent.POSITION_DELETES;
+import static org.apache.iceberg.MetadataColumns.DELETE_FILE_PATH;
+import static org.apache.iceberg.MetadataColumns.DELETE_FILE_POS;
 import static org.apache.iceberg.MetadataColumns.ROW_POSITION;
 import static org.apache.iceberg.TableProperties.ENCRYPTION_TABLE_KEY;
 import static org.joda.time.DateTimeZone.UTC;
@@ -311,6 +317,9 @@ public class IcebergPageSourceProvider
                     columns.stream().map(SystemColumnHandle.class::cast).map(SystemColumnHandle::columnName).collect(toImmutableList()),
                     filesTableSplit);
         }
+        if (connectorSplit instanceof PositionDeletesTableSplit positionDeletesTableSplit) {
+            return createPositionDeletesPageSource(session, columns, positionDeletesTableSplit, icebergTableCredentials);
+        }
 
         IcebergSplit split = (IcebergSplit) connectorSplit;
         List<IcebergColumnHandle> icebergColumns = columns.stream()
@@ -346,6 +355,61 @@ public class IcebergPageSourceProvider
                 tableHandle.getNameMappingJson().map(NameMappingParser::fromJson),
                 newAggregatedMemoryContext(memoryContext),
                 split.parquetFileDecryptionData());
+    }
+
+    private ConnectorPageSource createPositionDeletesPageSource(
+            ConnectorSession session,
+            List<ColumnHandle> columns,
+            PositionDeletesTableSplit split,
+            IcebergTableCredentials tableCredentials)
+    {
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity(), tableCredentials);
+        FileFormat fileFormat = split.deleteFileFormat();
+        ConnectorPageSource deleteFilePageSource;
+
+        if (fileFormat == FileFormat.PUFFIN) {
+            deleteFilePageSource = new DeletionVectorPageSource(
+                    fileSystem,
+                    split.referencedDataFile().orElseThrow(),
+                    split.deleteFilePath(),
+                    split.deleteFileLength(),
+                    split.contentOffset().orElseThrow(),
+                    split.contentSizeInBytes().orElseThrow());
+        }
+        else if (Set.of(FileFormat.PARQUET, FileFormat.ORC, FileFormat.AVRO).contains(fileFormat)) {
+            IcebergColumnHandle deleteFilePath = getColumnHandle(DELETE_FILE_PATH, typeManager);
+            IcebergColumnHandle deleteFilePos = getColumnHandle(DELETE_FILE_POS, typeManager);
+            List<IcebergColumnHandle> deleteColumns = ImmutableList.of(deleteFilePath, deleteFilePos);
+            Schema deleteFileSchema = new Schema(DELETE_FILE_PATH, DELETE_FILE_POS);
+
+            TrinoInputFile inputFile = fileSystem.newInputFile(Location.of(split.deleteFilePath()));
+            ReaderPageSourceWithRowPositions readerPageSource = createDataPageSource(
+                    session,
+                    inputFile,
+                    0,
+                    split.deleteFileLength(),
+                    split.deleteFileLength(),
+                    split.specId(),
+                    "",
+                    IcebergFileFormat.fromIceberg(fileFormat),
+                    deleteFileSchema,
+                    deleteColumns,
+                    TupleDomain.all(),
+                    Optional.empty(),
+                    "",
+                    Map.of(),
+                    OptionalLong.empty(),
+                    OptionalLong.empty());
+            deleteFilePageSource = readerPageSource.pageSource();
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported file format: " + fileFormat);
+        }
+
+        return new PositionDeletesTablePageSource(
+                deleteFilePageSource,
+                split,
+                columns.stream().map(SystemColumnHandle.class::cast).map(SystemColumnHandle::columnName).collect(toImmutableList()));
     }
 
     public ConnectorPageSource createPageSource(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -399,7 +399,9 @@ public class IcebergPageSourceProvider
                     "",
                     Map.of(),
                     OptionalLong.empty(),
-                    OptionalLong.empty());
+                    OptionalLong.empty(),
+                    newSimpleAggregatedMemoryContext(),
+                    Optional.empty());
             deleteFilePageSource = readerPageSource.pageSource();
         }
         else {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableType.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableType.java
@@ -25,6 +25,7 @@ public enum TableType
     FILES,
     ALL_ENTRIES,
     ENTRIES,
+    POSITION_DELETES,
     PROPERTIES,
     REFS,
     MATERIALIZED_VIEW_STORAGE,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/PositionDeletesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/PositionDeletesTable.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.system;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.iceberg.IcebergTableCredentials;
+import io.trino.plugin.iceberg.system.positiondeletes.PositionDeletesTableSplitSource;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.ConnectorTableCredentials;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SystemTable;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.TypeManager;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.Table;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.iceberg.util.SystemTableUtil.getAllPartitionFields;
+import static io.trino.plugin.iceberg.util.SystemTableUtil.getPartitionColumnType;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class PositionDeletesTable
+        implements SystemTable
+{
+    public static final String FILE_PATH = "file_path";
+    public static final String POS = "pos";
+    public static final String PARTITION = "partition";
+    public static final String SPEC_ID = "spec_id";
+    public static final String DELETE_FILE_PATH = "delete_file_path";
+
+    private final ConnectorTableMetadata tableMetadata;
+    private final Table icebergTable;
+    private final Optional<IcebergPartitionColumn> partitionColumnType;
+
+    public PositionDeletesTable(TypeManager typeManager, SchemaTableName tableName, Table table)
+    {
+        this.icebergTable = requireNonNull(table, "table is null");
+        List<PartitionField> partitionFields = getAllPartitionFields(table);
+        this.partitionColumnType = getPartitionColumnType(typeManager, partitionFields, table.schema());
+        this.tableMetadata = createConnectorTableMetadata(
+                requireNonNull(typeManager, "typeManager is null"),
+                requireNonNull(tableName, "tableName is null"),
+                table,
+                partitionFields);
+    }
+
+    private static ConnectorTableMetadata createConnectorTableMetadata(
+            TypeManager typeManager,
+            SchemaTableName tableName,
+            Table table,
+            List<PartitionField> partitionFields)
+    {
+        ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
+        columns.add(new ColumnMetadata(FILE_PATH, VARCHAR));
+        columns.add(new ColumnMetadata(POS, BIGINT));
+        if (!partitionFields.isEmpty()) {
+            RowType partitionType = getPartitionColumnType(typeManager, partitionFields, table.schema())
+                    .map(IcebergPartitionColumn::rowType)
+                    .orElseThrow();
+            columns.add(new ColumnMetadata(PARTITION, partitionType));
+        }
+        columns.add(new ColumnMetadata(SPEC_ID, INTEGER));
+        columns.add(new ColumnMetadata(DELETE_FILE_PATH, VARCHAR));
+        return new ConnectorTableMetadata(tableName, columns.build());
+    }
+
+    @Override
+    public Distribution getDistribution()
+    {
+        return Distribution.ALL_NODES;
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata()
+    {
+        return tableMetadata;
+    }
+
+    @Override
+    public Optional<ConnectorSplitSource> splitSource(ConnectorSession connectorSession, TupleDomain<ColumnHandle> constraint)
+    {
+        return Optional.of(new PositionDeletesTableSplitSource(
+                icebergTable,
+                SchemaParser.toJson(icebergTable.schema()),
+                icebergTable.specs().entrySet().stream().collect(toImmutableMap(
+                        Map.Entry::getKey,
+                        partitionSpec -> PartitionSpecParser.toJson(partitionSpec.getValue()))),
+                partitionColumnType));
+    }
+
+    @Override
+    public Optional<ConnectorTableCredentials> getTableCredentials(ConnectorSession session)
+    {
+        return Optional.of(IcebergTableCredentials.forFileIO(icebergTable.io()));
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/positiondeletes/DeletionVectorPageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/positiondeletes/DeletionVectorPageSource.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.system.positiondeletes;
+
+import io.airlift.slice.Slice;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.plugin.iceberg.delete.DeletionVector;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SourcePage;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalLong;
+
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_CANNOT_OPEN_SPLIT;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public final class DeletionVectorPageSource
+        implements ConnectorPageSource
+{
+    private final String dataFilePath;
+    private final long deletionVectorSize;
+    private final List<Long> deletedPositions = new ArrayList<>();
+    private final PageBuilder pageBuilder;
+
+    private int currentPosition;
+    private long completedPositions;
+    private long readTimeNanos;
+    private boolean closed;
+
+    public DeletionVectorPageSource(
+            TrinoFileSystem fileSystem,
+            String dataFilePath,
+            String deletionVectorPath,
+            long deletionVectorSize,
+            long contentOffset,
+            int contentSizeInBytes)
+    {
+        requireNonNull(fileSystem, "fileSystem is null");
+        this.dataFilePath = requireNonNull(dataFilePath, "dataFilePath is null");
+        this.deletionVectorSize = deletionVectorSize;
+
+        TrinoInputFile inputFile = fileSystem.newInputFile(Location.of(deletionVectorPath), deletionVectorSize);
+        try (TrinoInput input = inputFile.newInput()) {
+            Slice slice = input.readFully(contentOffset, toIntExact(contentSizeInBytes));
+            DeletionVector deletionVector = DeletionVector.builder().deserialize(slice).build().orElseThrow();
+            deletionVector.forEachDeletedRow(deletedPositions::add);
+        }
+        catch (IOException e) {
+            throw new TrinoException(ICEBERG_CANNOT_OPEN_SPLIT, "Failed to read deletion vector file: " + deletionVectorPath, e);
+        }
+
+        pageBuilder = new PageBuilder(List.of(VARCHAR, BIGINT));
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return deletionVectorSize;
+    }
+
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        return OptionalLong.of(completedPositions);
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return closed || currentPosition >= deletedPositions.size();
+    }
+
+    @Override
+    public SourcePage getNextSourcePage()
+    {
+        if (isFinished()) {
+            return null;
+        }
+
+        long start = System.nanoTime();
+        while (currentPosition < deletedPositions.size() && !pageBuilder.isFull()) {
+            pageBuilder.declarePosition();
+            long pos = deletedPositions.get(currentPosition++);
+            VARCHAR.writeString(pageBuilder.getBlockBuilder(0), dataFilePath);
+            BIGINT.writeLong(pageBuilder.getBlockBuilder(1), pos);
+        }
+        readTimeNanos += System.nanoTime() - start;
+
+        if (!pageBuilder.isEmpty()) {
+            Page page = pageBuilder.build();
+            completedPositions += page.getPositionCount();
+            pageBuilder.reset();
+            return SourcePage.create(page);
+        }
+
+        close();
+        return null;
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return pageBuilder.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public void close()
+    {
+        closed = true;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/positiondeletes/PositionDeletesTablePageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/positiondeletes/PositionDeletesTablePageSource.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.system.positiondeletes;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.iceberg.PartitionData;
+import io.trino.plugin.iceberg.StructLikeWrapperWithFieldIdToIndex;
+import io.trino.plugin.iceberg.delete.PositionDeleteReader;
+import io.trino.plugin.iceberg.system.IcebergPartitionColumn;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.RowBlockBuilder;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.types.Type.PrimitiveType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.iceberg.IcebergTypes.convertIcebergValueToTrino;
+import static io.trino.plugin.iceberg.IcebergUtil.primitiveFieldTypes;
+import static io.trino.plugin.iceberg.StructLikeWrapperWithFieldIdToIndex.createStructLikeWrapper;
+import static io.trino.plugin.iceberg.system.PositionDeletesTable.DELETE_FILE_PATH;
+import static io.trino.plugin.iceberg.system.PositionDeletesTable.FILE_PATH;
+import static io.trino.plugin.iceberg.system.PositionDeletesTable.PARTITION;
+import static io.trino.plugin.iceberg.system.PositionDeletesTable.POS;
+import static io.trino.plugin.iceberg.system.PositionDeletesTable.SPEC_ID;
+import static io.trino.plugin.iceberg.util.SystemTableUtil.partitionTypes;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public final class PositionDeletesTablePageSource
+        implements ConnectorPageSource
+{
+    private final PositionDeletesTableSplit split;
+    private final PageBuilder pageBuilder;
+    private final List<String> columns;
+    private final List<DeleteRow> deleteRows = new ArrayList<>();
+    private final Map<Integer, PartitionSpec> idToPartitionSpecMapping;
+    private final Map<Integer, PrimitiveType> idToTypeMapping;
+    private final Optional<IcebergPartitionColumn> partitionColumnType;
+    private int currentPosition;
+    private long completedPositions;
+    private long readTimeNanos;
+    private boolean closed;
+
+    private record DeleteRow(String filePath, long pos) {}
+
+    public PositionDeletesTablePageSource(
+            ConnectorPageSource pageSource,
+            PositionDeletesTableSplit split,
+            List<String> columns)
+    {
+        requireNonNull(pageSource, "pageSource is null");
+        this.split = requireNonNull(split, "split is null");
+        this.columns = ImmutableList.copyOf(columns);
+
+        Schema schema = SchemaParser.fromJson(split.schemaJson());
+        idToPartitionSpecMapping = split.partitionSpecsByIdJson().entrySet().stream()
+                .collect(toImmutableMap(Map.Entry::getKey, entry -> PartitionSpecParser.fromJson(schema, entry.getValue())));
+        idToTypeMapping = primitiveFieldTypes(schema);
+        partitionColumnType = split.partitionColumn();
+
+        List<Type> types = columns.stream().map(this::columnType).collect(toImmutableList());
+        pageBuilder = new PageBuilder(types);
+
+        PositionDeleteReader.readMultiFilePositionDeletes(
+                pageSource,
+                (filePath, pos) -> deleteRows.add(new DeleteRow(filePath, pos)));
+    }
+
+    private Type columnType(String columnName)
+    {
+        return switch (columnName) {
+            case FILE_PATH, DELETE_FILE_PATH -> VARCHAR;
+            case POS -> BIGINT;
+            case PARTITION -> (RowType) split.partitionColumnType().orElseThrow();
+            case SPEC_ID -> INTEGER;
+            default -> throw new IllegalArgumentException("Unknown column: " + columnName);
+        };
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return split.deleteFileLength();
+    }
+
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        return OptionalLong.of(completedPositions);
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return closed || currentPosition >= deleteRows.size();
+    }
+
+    @Override
+    public SourcePage getNextSourcePage()
+    {
+        if (isFinished()) {
+            return null;
+        }
+
+        long start = System.nanoTime();
+        while (currentPosition < deleteRows.size() && !pageBuilder.isFull()) {
+            pageBuilder.declarePosition();
+            DeleteRow deleteRow = deleteRows.get(currentPosition++);
+
+            for (int i = 0; i < columns.size(); i++) {
+                String columnName = columns.get(i);
+                BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(i);
+
+                switch (columnName) {
+                    case FILE_PATH -> VARCHAR.writeString(blockBuilder, deleteRow.filePath());
+                    case POS -> BIGINT.writeLong(blockBuilder, deleteRow.pos());
+                    case PARTITION -> writePartitionColumn(blockBuilder);
+                    case SPEC_ID -> INTEGER.writeInt(blockBuilder, split.specId());
+                    case DELETE_FILE_PATH -> VARCHAR.writeString(blockBuilder, split.deleteFilePath());
+                    default -> throw new IllegalArgumentException("Unknown column: " + columnName);
+                }
+            }
+        }
+        readTimeNanos += System.nanoTime() - start;
+
+        if (!pageBuilder.isEmpty()) {
+            Page page = pageBuilder.build();
+            completedPositions += page.getPositionCount();
+            pageBuilder.reset();
+            return SourcePage.create(page);
+        }
+
+        close();
+        return null;
+    }
+
+    private void writePartitionColumn(BlockBuilder blockBuilder)
+    {
+        if (partitionColumnType.isEmpty()) {
+            return;
+        }
+
+        PartitionSpec partitionSpec = idToPartitionSpecMapping.get(split.specId());
+        PartitionData partitionData = PartitionData.fromJson(split.partitionDataJson(), partitionSpec);
+        StructLikeWrapperWithFieldIdToIndex partitionStruct = createStructLikeWrapper(partitionSpec, partitionData);
+        List<org.apache.iceberg.types.Type> partitionTypes = partitionTypes(partitionSpec.fields(), idToTypeMapping);
+        List<? extends Class<?>> partitionColumnClass = partitionTypes.stream()
+                .map(type -> type.typeId().javaClass())
+                .collect(toImmutableList());
+        List<Type> partitionColumnTypes = partitionColumnType.orElseThrow().rowType().getFields().stream()
+                .map(RowType.Field::getType)
+                .collect(toImmutableList());
+
+        if (blockBuilder instanceof RowBlockBuilder rowBlockBuilder) {
+            rowBlockBuilder.buildEntry(fields -> {
+                for (int i = 0; i < partitionColumnTypes.size(); i++) {
+                    Type trinoType = partitionColumnTypes.get(i);
+                    Object value = null;
+                    Integer fieldId = partitionColumnType.get().fieldIds().get(i);
+                    if (partitionStruct.getFieldIdToIndex().containsKey(fieldId)) {
+                        value = convertIcebergValueToTrino(
+                                partitionTypes.get(i),
+                                partitionStruct.getStructLikeWrapper().get().get(partitionStruct.getFieldIdToIndex().get(fieldId), partitionColumnClass.get(i)));
+                    }
+                    writeNativeValue(trinoType, fields.get(i), value);
+                }
+            });
+        }
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return pageBuilder.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public void close()
+    {
+        closed = true;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/positiondeletes/PositionDeletesTableSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/positiondeletes/PositionDeletesTableSplit.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.system.positiondeletes;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.SizeOf;
+import io.trino.plugin.iceberg.system.IcebergPartitionColumn;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import org.apache.iceberg.FileFormat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static java.util.Objects.requireNonNull;
+
+public record PositionDeletesTableSplit(
+        String deleteFilePath,
+        FileFormat deleteFileFormat,
+        long deleteFileLength,
+        String partitionDataJson,
+        int specId,
+        String schemaJson,
+        Map<Integer, String> partitionSpecsByIdJson,
+        Optional<Type> partitionColumnType,
+        List<Integer> partitionFieldIds,
+        OptionalLong contentOffset,
+        Optional<Integer> contentSizeInBytes,
+        Optional<String> referencedDataFile)
+        implements ConnectorSplit
+{
+    private static final int INSTANCE_SIZE = instanceSize(PositionDeletesTableSplit.class);
+
+    public PositionDeletesTableSplit
+    {
+        requireNonNull(deleteFilePath, "deleteFilePath is null");
+        requireNonNull(deleteFileFormat, "deleteFileFormat is null");
+        requireNonNull(partitionDataJson, "partitionDataJson is null");
+        requireNonNull(schemaJson, "schemaJson is null");
+        partitionSpecsByIdJson = ImmutableMap.copyOf(partitionSpecsByIdJson);
+        requireNonNull(partitionColumnType, "partitionColumnType is null");
+        partitionFieldIds = ImmutableList.copyOf(partitionFieldIds);
+        requireNonNull(contentOffset, "contentOffset is null");
+        requireNonNull(contentSizeInBytes, "contentSizeInBytes is null");
+        requireNonNull(referencedDataFile, "referencedDataFile is null");
+    }
+
+    public Optional<IcebergPartitionColumn> partitionColumn()
+    {
+        return partitionColumnType.map(type -> new IcebergPartitionColumn((RowType) type, partitionFieldIds));
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE
+                + estimatedSizeOf(deleteFilePath)
+                + estimatedSizeOf(partitionDataJson)
+                + estimatedSizeOf(schemaJson)
+                + estimatedSizeOf(partitionSpecsByIdJson, _ -> 0, SizeOf::estimatedSizeOf);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/positiondeletes/PositionDeletesTableSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/positiondeletes/PositionDeletesTableSplitSource.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.system.positiondeletes;
+
+import io.trino.plugin.iceberg.PartitionData;
+import io.trino.plugin.iceberg.system.IcebergPartitionColumn;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitSource;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.IcebergManifestUtils.FileEntryWithMetadata;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.apache.iceberg.FileContent.POSITION_DELETES;
+import static org.apache.iceberg.IcebergManifestUtils.liveEntriesWithMetadata;
+import static org.apache.iceberg.ManifestContent.DELETES;
+import static org.apache.iceberg.ManifestFiles.readDeleteManifest;
+
+public final class PositionDeletesTableSplitSource
+        implements ConnectorSplitSource
+{
+    private final Table icebergTable;
+    private final String schemaJson;
+    private final Map<Integer, String> partitionSpecsByIdJson;
+    private final Optional<IcebergPartitionColumn> partitionColumnType;
+    private boolean finished;
+
+    public PositionDeletesTableSplitSource(
+            Table icebergTable,
+            String schemaJson,
+            Map<Integer, String> partitionSpecsByIdJson,
+            Optional<IcebergPartitionColumn> partitionColumnType)
+    {
+        this.icebergTable = requireNonNull(icebergTable, "icebergTable is null");
+        this.schemaJson = requireNonNull(schemaJson, "schemaJson is null");
+        this.partitionSpecsByIdJson = requireNonNull(partitionSpecsByIdJson, "partitionSpecsByIdJson is null");
+        this.partitionColumnType = requireNonNull(partitionColumnType, "partitionColumnType is null");
+    }
+
+    @Override
+    public CompletableFuture<ConnectorSplitBatch> getNextBatch(int maxSize)
+    {
+        TableScan scan = icebergTable.newScan();
+        List<ConnectorSplit> splits = new ArrayList<>();
+
+        try (FileIO fileIO = icebergTable.io()) {
+            for (ManifestFile manifestFile : scan.snapshot().allManifests(fileIO)) {
+                if (manifestFile.content() != DELETES) {
+                    continue;
+                }
+
+                ManifestReader<DeleteFile> manifestReader = readDeleteManifest(manifestFile, fileIO, icebergTable.specs());
+                try (CloseableIterable<FileEntryWithMetadata> entries = liveEntriesWithMetadata(manifestReader)) {
+                    for (FileEntryWithMetadata entry : entries) {
+                        DeleteFile deleteFile = (DeleteFile) entry.file();
+                        if (deleteFile.content() != POSITION_DELETES) {
+                            continue;
+                        }
+
+                        OptionalLong contentOffset = deleteFile.contentOffset() == null ? OptionalLong.empty() : OptionalLong.of(deleteFile.contentOffset());
+                        Optional<Integer> contentSizeInBytes = Optional.ofNullable(deleteFile.contentSizeInBytes()).map(Math::toIntExact);
+                        Optional<String> referencedDataFile = Optional.ofNullable(deleteFile.referencedDataFile());
+
+                        splits.add(new PositionDeletesTableSplit(
+                                deleteFile.location(),
+                                deleteFile.format(),
+                                deleteFile.fileSizeInBytes(),
+                                PartitionData.toJson(deleteFile.partition()),
+                                deleteFile.specId(),
+                                schemaJson,
+                                partitionSpecsByIdJson,
+                                partitionColumnType.map(IcebergPartitionColumn::rowType),
+                                partitionColumnType.map(IcebergPartitionColumn::fieldIds).orElseGet(List::of),
+                                contentOffset,
+                                contentSizeInBytes,
+                                referencedDataFile));
+                    }
+                }
+                catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        }
+
+        finished = true;
+        return completedFuture(new ConnectorSplitBatch(splits, true));
+    }
+
+    @Override
+    public void close()
+    {
+        // do nothing
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finished;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/positiondeletes/PositionDeletesTableSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/positiondeletes/PositionDeletesTableSplitSource.java
@@ -17,6 +17,7 @@ import io.trino.plugin.iceberg.PartitionData;
 import io.trino.plugin.iceberg.system.IcebergPartitionColumn;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.DynamicFilterSnapshot;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.IcebergManifestUtils.FileEntryWithMetadata;
 import org.apache.iceberg.ManifestFile;
@@ -64,7 +65,7 @@ public final class PositionDeletesTableSplitSource
     }
 
     @Override
-    public CompletableFuture<ConnectorSplitBatch> getNextBatch(int maxSize)
+    public CompletableFuture<List<ConnectorSplit>> getNextBatch(int maxSize, DynamicFilterSnapshot dynamicFilterSnapshot)
     {
         TableScan scan = icebergTable.newScan();
         List<ConnectorSplit> splits = new ArrayList<>();
@@ -109,7 +110,7 @@ public final class PositionDeletesTableSplitSource
         }
 
         finished = true;
-        return completedFuture(new ConnectorSplitBatch(splits, true));
+        return completedFuture(splits);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -25,12 +25,18 @@ import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.TestTable;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,6 +53,8 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
 import static io.trino.plugin.iceberg.IcebergTestUtils.getFileSystemFactory;
@@ -59,6 +67,8 @@ import static java.util.Locale.ENGLISH;
 import static java.util.Map.entry;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
+import static org.apache.iceberg.ManifestFiles.read;
+import static org.apache.iceberg.ManifestFiles.readDeleteManifest;
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_PATH;
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_POS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -1013,6 +1023,98 @@ public abstract class BaseIcebergSystemTables
 
             assertThat(query("SELECT data_file.partition FROM \"" + table.getName() + "$entries\""))
                     .matches("SELECT CAST(ROW(DATE '2014-01-01') AS ROW(dt date))");
+        }
+    }
+
+    @Test
+    public void testPositionDeletesTable()
+            throws Exception
+    {
+        try (TestTable table = newTrinoTable("test_position_deletes", "AS SELECT * FROM tpch.tiny.region")) {
+            assertQueryReturnsEmptyResult("SELECT * FROM \"" + table.getName() + "$position_deletes\"");
+
+            // Verify 1 delete file
+            assertUpdate("DELETE FROM " + table.getName() + " WHERE regionkey = 1", 1);
+            BaseTable icebergTable = loadTable(table.getName());
+
+            try (CloseableIterable<FileScanTask> iterator = icebergTable.newScan().planFiles()) {
+                FileScanTask task = getOnlyElement(iterator);
+                String filePath = task.file().location();
+                String deleteFilePath = task.deletes().stream().map(ContentFile::location).collect(onlyElement());
+                assertThat(deleteFilePath).doesNotEndWith(".puffin");
+                assertThat(query("SELECT * FROM \"" + table.getName() + "$position_deletes\""))
+                        .matches("VALUES (VARCHAR '" + filePath + "', BIGINT '1', 0, VARCHAR '" + deleteFilePath + "')");
+            }
+
+            // Verify 2 delete files (1 deleted row + 2 deleted rows)
+            assertUpdate("DELETE FROM " + table.getName() + " WHERE regionkey IN (2, 3)", 2);
+
+            icebergTable.refresh();
+            try (CloseableIterable<FileScanTask> iterator = icebergTable.newScan().planFiles()) {
+                FileScanTask task = getOnlyElement(iterator);
+                String filePath = task.file().location();
+                List<DeleteFile> deleteFiles = task.deletes();
+                assertThat(deleteFiles).hasSize(2);
+                String deleteFilePath1 = deleteFiles.getFirst().location();
+                String deleteFilePath2 = deleteFiles.getLast().location();
+                assertThat(query("SELECT * FROM \"" + table.getName() + "$position_deletes\""))
+                        .matches("VALUES " +
+                                "(VARCHAR '" + filePath + "', BIGINT '1', 0, VARCHAR '" + deleteFilePath1 + "')," +
+                                "(VARCHAR '" + filePath + "', BIGINT '2', 0, VARCHAR '" + deleteFilePath2 + "')," +
+                                "(VARCHAR '" + filePath + "', BIGINT '3', 0, VARCHAR '" + deleteFilePath2 + "')");
+            }
+        }
+    }
+
+    @Test
+    public void testPositionDeletesWithUnpartitionedTable()
+    {
+        testPositionDeletesWithUnpartitionedTable(2);
+        testPositionDeletesWithUnpartitionedTable(3);
+    }
+
+    private void testPositionDeletesWithUnpartitionedTable(int formatVersion)
+    {
+        try (TestTable table = newTrinoTable("test_position_deletes", "(id INT, part INT) WITH (format_version = " + formatVersion + ")")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (1, 10), (2, 10), (3, 20), (4, 20)", 4);
+
+            assertUpdate("DELETE FROM " + table.getName() + " WHERE id = 1", 1);
+            BaseTable icebergTable = loadTable(table.getName());
+
+            ManifestFile deleteManifest = getOnlyElement(icebergTable.currentSnapshot().deleteManifests(icebergTable.io()));
+            DeleteFile deleteFile = getOnlyElement(readDeleteManifest(deleteManifest, icebergTable.io(), icebergTable.specs()));
+
+            ManifestFile dataManifest = getOnlyElement(icebergTable.currentSnapshot().dataManifests(icebergTable.io()));
+            DataFile dataFile = getOnlyElement(read(dataManifest, icebergTable.io(), icebergTable.specs()).filterRows(Expressions.equal("part", 10)));
+
+            assertThat(query("SELECT * FROM \"" + table.getName() + "$position_deletes\""))
+                    .matches("VALUES (VARCHAR '" + dataFile.location() + "', BIGINT '0', 0, VARCHAR '" + deleteFile.location() + "')");
+        }
+    }
+
+    @Test
+    public void testPositionDeletesWithPartitionedTable()
+    {
+        testPositionDeletesTableWithPartitioning(2);
+        testPositionDeletesTableWithPartitioning(3);
+    }
+
+    private void testPositionDeletesTableWithPartitioning(int formatVersion)
+    {
+        try (TestTable table = newTrinoTable("test_position_deletes", "(id INT, part INT) WITH (partitioning = ARRAY['part'], format_version = " + formatVersion + ")")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (1, 10), (2, 10), (3, 20), (4, 20)", 4);
+
+            assertUpdate("DELETE FROM " + table.getName() + " WHERE id = 1", 1);
+            BaseTable icebergTable = loadTable(table.getName());
+
+            ManifestFile deleteManifest = getOnlyElement(icebergTable.currentSnapshot().deleteManifests(icebergTable.io()));
+            DeleteFile deleteFile = getOnlyElement(readDeleteManifest(deleteManifest, icebergTable.io(), icebergTable.specs()));
+
+            ManifestFile dataManifest = getOnlyElement(icebergTable.currentSnapshot().dataManifests(icebergTable.io()));
+            DataFile dataFile = getOnlyElement(read(dataManifest, icebergTable.io(), icebergTable.specs()).filterPartitions(Expressions.equal("part", 10)));
+
+            assertThat(query("SELECT * FROM \"" + table.getName() + "$position_deletes\""))
+                    .matches("VALUES (VARCHAR '" + dataFile.location() + "', BIGINT '0', ROW(10 AS part), 0, VARCHAR '" + deleteFile.location() + "')");
         }
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -46,6 +46,7 @@ import static io.trino.plugin.iceberg.TableType.MANIFESTS;
 import static io.trino.plugin.iceberg.TableType.MATERIALIZED_VIEW_STORAGE;
 import static io.trino.plugin.iceberg.TableType.METADATA_LOG_ENTRIES;
 import static io.trino.plugin.iceberg.TableType.PARTITIONS;
+import static io.trino.plugin.iceberg.TableType.POSITION_DELETES;
 import static io.trino.plugin.iceberg.TableType.PROPERTIES;
 import static io.trino.plugin.iceberg.TableType.REFS;
 import static io.trino.plugin.iceberg.TableType.SNAPSHOTS;
@@ -405,6 +406,12 @@ public class TestIcebergMetastoreAccessOperations
                         .addCopies(GET_TABLE, 1)
                         .build());
 
+        // select from $position_deletes
+        assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$position_deletes\"",
+                ImmutableMultiset.<MetastoreMethod>builder()
+                        .addCopies(GET_TABLE, 1)
+                        .build());
+
         // select from $properties
         assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$properties\"",
                 ImmutableMultiset.<MetastoreMethod>builder()
@@ -417,7 +424,21 @@ public class TestIcebergMetastoreAccessOperations
 
         // This test should get updated if a new system table is added.
         assertThat(TableType.values())
-                .containsExactly(DATA, HISTORY, METADATA_LOG_ENTRIES, SNAPSHOTS, ALL_MANIFESTS, MANIFESTS, PARTITIONS, FILES, ALL_ENTRIES, ENTRIES, PROPERTIES, REFS, MATERIALIZED_VIEW_STORAGE);
+                .containsExactly(
+                        DATA,
+                        HISTORY,
+                        METADATA_LOG_ENTRIES,
+                        SNAPSHOTS,
+                        ALL_MANIFESTS,
+                        MANIFESTS,
+                        PARTITIONS,
+                        FILES,
+                        ALL_ENTRIES,
+                        ENTRIES,
+                        POSITION_DELETES,
+                        PROPERTIES,
+                        REFS,
+                        MATERIALIZED_VIEW_STORAGE);
     }
 
     @Test

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
@@ -25,6 +25,7 @@ import static io.trino.plugin.iceberg.TableType.MANIFESTS;
 import static io.trino.plugin.iceberg.TableType.MATERIALIZED_VIEW_STORAGE;
 import static io.trino.plugin.iceberg.TableType.METADATA_LOG_ENTRIES;
 import static io.trino.plugin.iceberg.TableType.PARTITIONS;
+import static io.trino.plugin.iceberg.TableType.POSITION_DELETES;
 import static io.trino.plugin.iceberg.TableType.PROPERTIES;
 import static io.trino.plugin.iceberg.TableType.REFS;
 import static io.trino.plugin.iceberg.TableType.SNAPSHOTS;
@@ -70,6 +71,7 @@ public class TestLakehouseIcebergConnectorSmokeTest
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$files\"")).matches("VALUES (CAST(1 AS BIGINT))");
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$all_entries\"")).matches("VALUES (CAST(1 AS BIGINT))");
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$entries\"")).matches("VALUES (CAST(1 AS BIGINT))");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$position_deletes\"")).matches("VALUES (CAST(0 AS BIGINT))");
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$properties\"")).matches("VALUES (CAST(6 AS BIGINT))");
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$refs\"")).matches("VALUES (CAST(1 AS BIGINT))");
 
@@ -86,6 +88,7 @@ public class TestLakehouseIcebergConnectorSmokeTest
                         FILES,
                         ALL_ENTRIES,
                         ENTRIES,
+                        POSITION_DELETES,
                         PROPERTIES,
                         REFS,
                         MATERIALIZED_VIEW_STORAGE);


### PR DESCRIPTION
## Description

Add `$position_deletes` system table to Iceberg connector. 
Exposes position delete records from current snapshot—each row shows one deleted row position from data file.

- Spark https://iceberg.apache.org/docs/latest/spark-queries/#positional-delete-files

## Release notes

```markdown
## Iceberg
* Add `position_deletes` system table. ({issue}`issuenumber`)
```
