### PR TITLE
Bind a signature's variables in one structural namespace

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/BindingsBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/BindingsBuilder.java
@@ -13,6 +13,9 @@
  */
 package io.trino.metadata;
 
+import io.trino.metadata.VariableBindings.Binding;
+import io.trino.metadata.VariableBindings.NumericBinding;
+import io.trino.metadata.VariableBindings.TypeBinding;
 import io.trino.spi.type.Type;
 
 import java.util.Map;
@@ -21,79 +24,78 @@ import java.util.TreeMap;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableSortedMap.toImmutableSortedMap;
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
+import static java.util.Objects.requireNonNull;
 
 class BindingsBuilder
 {
-    private final Map<String, Type> typeVariables = new TreeMap<>(CASE_INSENSITIVE_ORDER);
-    private final Map<String, Long> longVariables = new TreeMap<>(CASE_INSENSITIVE_ORDER);
+    private final Map<String, Binding> bindings = new TreeMap<>(CASE_INSENSITIVE_ORDER);
 
     public VariableBindings build()
     {
-        return new VariableBindings(typeVariables, longVariables);
+        return new VariableBindings(bindings);
     }
 
     public Type getTypeVariable(String variableName)
     {
-        return getValue(typeVariables, variableName);
+        requireNonNull(variableName, "variableName is null");
+        checkState(bindings.get(variableName) instanceof TypeBinding, "variable '%s' is not bound to a type", variableName);
+        return ((TypeBinding) bindings.get(variableName)).type();
     }
 
     public BindingsBuilder setTypeVariable(String variableName, Type variableValue)
     {
-        setValue(typeVariables, variableName, variableValue);
+        set(variableName, new TypeBinding(requireNonNull(variableValue, "variableValue is null")));
         return this;
     }
 
     public boolean containsTypeVariable(String variableName)
     {
-        return containsValue(typeVariables, variableName);
+        requireNonNull(variableName, "variableName is null");
+        return bindings.get(variableName) instanceof TypeBinding;
     }
 
     public Map<String, Type> getTypeVariables()
     {
-        return typeVariables;
+        return bindings.entrySet().stream()
+                .filter(entry -> entry.getValue() instanceof TypeBinding)
+                .collect(toImmutableSortedMap(CASE_INSENSITIVE_ORDER, Map.Entry::getKey, entry -> ((TypeBinding) entry.getValue()).type()));
     }
 
-    public Long getLongVariable(String variableName)
+    public long getNumericVariable(String variableName)
     {
-        return getValue(longVariables, variableName);
+        requireNonNull(variableName, "variableName is null");
+        checkState(bindings.get(variableName) instanceof NumericBinding, "variable '%s' is not bound to a numeric value", variableName);
+        return ((NumericBinding) bindings.get(variableName)).value();
     }
 
-    public BindingsBuilder setLongVariable(String variableName, Long variableValue)
+    public BindingsBuilder setNumericVariable(String variableName, long variableValue)
     {
-        setValue(longVariables, variableName, variableValue);
+        set(variableName, new NumericBinding(variableValue));
         return this;
     }
 
-    public boolean containsLongVariable(String variableName)
+    public boolean containsNumericVariable(String variableName)
     {
-        return containsValue(longVariables, variableName);
+        requireNonNull(variableName, "variableName is null");
+        return bindings.get(variableName) instanceof NumericBinding;
     }
 
-    public Map<String, Long> getLongVariables()
+    public Map<String, Long> getNumericVariables()
     {
-        return longVariables;
+        return bindings.entrySet().stream()
+                .filter(entry -> entry.getValue() instanceof NumericBinding)
+                .collect(toImmutableSortedMap(CASE_INSENSITIVE_ORDER, Map.Entry::getKey, entry -> ((NumericBinding) entry.getValue()).value()));
     }
 
-    private static <T> T getValue(Map<String, T> map, String variableName)
+    private void set(String variableName, Binding binding)
     {
-        checkState(variableName != null, "variableName is null");
-        T value = map.get(variableName);
-        checkState(value != null, "value for variable '%s' is null", variableName);
-        return value;
-    }
-
-    private static boolean containsValue(Map<String, ?> map, String variableName)
-    {
-        checkState(variableName != null, "variableName is null");
-        return map.containsKey(variableName);
-    }
-
-    private static <T> void setValue(Map<String, T> map, String variableName, T value)
-    {
-        checkState(variableName != null, "variableName is null");
-        checkState(value != null, "value for variable '%s' is null", variableName);
-        map.put(variableName, value);
+        requireNonNull(variableName, "variableName is null");
+        Binding existing = bindings.get(variableName);
+        // A solver may refine a binding across iterations, but the kind of a variable never changes
+        checkState(existing == null || existing.getClass() == binding.getClass(), "variable '%s' is already bound as a %s", variableName, existing == null ? null : existing.getClass().getSimpleName());
+        bindings.put(variableName, binding);
     }
 
     @Override
@@ -106,22 +108,20 @@ class BindingsBuilder
             return false;
         }
         BindingsBuilder that = (BindingsBuilder) o;
-        return Objects.equals(typeVariables, that.typeVariables) &&
-                Objects.equals(longVariables, that.longVariables);
+        return Objects.equals(bindings, that.bindings);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(typeVariables, longVariables);
+        return Objects.hash(bindings);
     }
 
     @Override
     public String toString()
     {
         return toStringHelper(this)
-                .add("typeVariables", typeVariables)
-                .add("longVariables", longVariables)
+                .add("bindings", bindings)
                 .toString();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunctionBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunctionBuilder.java
@@ -196,7 +196,7 @@ public final class PolymorphicScalarFunctionBuilder
 
         public Long getLiteral(String name)
         {
-            return functionBinding.variables().getLongVariable(name);
+            return functionBinding.variables().getNumericVariable(name);
         }
 
         public List<Type> getParameterTypes()

--- a/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
@@ -263,19 +263,19 @@ public class SignatureBinder
         if (isTypeWithLiteralParameters(declaredTypeSignature)) {
             for (int i = 0; i < declaredTypeSignature.getParameters().size(); i++) {
                 TypeParameter parameter = declaredTypeSignature.getParameters().get(i);
-                Long actualLongBinding = ((TypeParameter.Numeric) actualType.getTypeSignature().getParameters().get(i)).value();
+                long actualNumericBinding = ((TypeParameter.Numeric) actualType.getTypeSignature().getParameters().get(i)).value();
                 switch (parameter) {
                     case TypeParameter.Variable(String variable) -> {
-                        if (bindings.containsLongVariable(variable)) {
-                            Long existingLongBinding = bindings.getLongVariable(variable);
-                            verifyBoundSignature(actualLongBinding.equals(existingLongBinding), boundSignature, declaredSignature);
+                        if (bindings.containsNumericVariable(variable)) {
+                            long existingNumericBinding = bindings.getNumericVariable(variable);
+                            verifyBoundSignature(actualNumericBinding == existingNumericBinding, boundSignature, declaredSignature);
                         }
                         else {
-                            bindings.setLongVariable(variable, actualLongBinding);
+                            bindings.setNumericVariable(variable, actualNumericBinding);
                         }
                     }
                     case TypeParameter.Numeric numeric -> {
-                        verifyBoundSignature(actualLongBinding.equals(numeric.value()), boundSignature, declaredSignature);
+                        verifyBoundSignature(actualNumericBinding == numeric.value(), boundSignature, declaredSignature);
                     }
                     default -> throw new UnsupportedOperationException("Unexpected type signature parameter: " + parameter);
                 }
@@ -539,16 +539,16 @@ public class SignatureBinder
         for (NumericVariableConstraint numericVariableConstraint : declaredSignature.getNumericVariableConstraints()) {
             NumericExpression calculation = numericVariableConstraint.getExpression();
             String variableName = numericVariableConstraint.getName();
-            Long calculatedValue = NumericExpressions.evaluate(calculation, variableBinder.getLongVariables()).longValueExact();
-            if (variableBinder.containsLongVariable(variableName)) {
-                Long currentValue = variableBinder.getLongVariable(variableName);
+            Long calculatedValue = NumericExpressions.evaluate(calculation, variableBinder.getNumericVariables()).longValueExact();
+            if (variableBinder.containsNumericVariable(variableName)) {
+                long currentValue = variableBinder.getNumericVariable(variableName);
                 checkState(Objects.equals(currentValue, calculatedValue),
                         "variable '%s' is already set to %s when trying to set %s",
                         variableName,
                         currentValue,
                         calculatedValue);
             }
-            variableBinder.setLongVariable(variableName, calculatedValue);
+            variableBinder.setNumericVariable(variableName, calculatedValue);
         }
     }
 
@@ -564,10 +564,10 @@ public class SignatureBinder
             case TypeParameter.Type type -> TypeParameter.typeParameter(type.name(), applyBoundVariables(type.type(), typeVariables));
             case TypeParameter.Variable(String variable) -> {
                 checkState(
-                        typeVariables.containsLongVariable(variable),
+                        typeVariables.containsNumericVariable(variable),
                         "Variable is not bound: %s",
                         variable);
-                Long variableValue = typeVariables.getLongVariable(variable);
+                long variableValue = typeVariables.getNumericVariable(variable);
                 yield TypeParameter.numericParameter(variableValue);
             }
             case TypeParameter.Numeric _ -> parameter;
@@ -832,8 +832,8 @@ public class SignatureBinder
 
                 switch (parameter) {
                     case TypeParameter.Variable(String variable) -> {
-                        if (bindings.containsLongVariable(variable)) {
-                            originalTypeTypeParametersBuilder.add(TypeParameter.numericParameter(bindings.getLongVariable(variable)));
+                        if (bindings.containsNumericVariable(variable)) {
+                            originalTypeTypeParametersBuilder.add(TypeParameter.numericParameter(bindings.getNumericVariable(variable)));
                         }
                         else {
                             // if an existing value doesn't exist for the given variable name, use the value that comes from the actual type.
@@ -870,8 +870,8 @@ public class SignatureBinder
 
                 switch (parameter) {
                     case TypeParameter.Variable(String name) -> {
-                        if (!bindings.containsLongVariable(name) || !bindings.getLongVariable(name).equals(commonSuperLongLiteral)) {
-                            bindings.setLongVariable(name, commonSuperLongLiteral);
+                        if (!bindings.containsNumericVariable(name) || bindings.getNumericVariable(name) != commonSuperLongLiteral) {
+                            bindings.setNumericVariable(name, commonSuperLongLiteral);
                             result = SolverReturnStatus.CHANGED;
                         }
                     }
@@ -1024,7 +1024,7 @@ public class SignatureBinder
                 }
             }
             for (String variable : longVariables) {
-                if (!bindings.containsLongVariable(variable)) {
+                if (!bindings.containsNumericVariable(variable)) {
                     return SolverReturnStatus.UNCHANGED_NOT_SATISFIED;
                 }
             }

--- a/core/trino-main/src/main/java/io/trino/metadata/VariableBindings.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/VariableBindings.java
@@ -20,49 +20,83 @@ import io.trino.spi.type.Type;
 import java.util.Map;
 import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableSortedMap.toImmutableSortedMap;
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static java.util.Objects.requireNonNull;
 
+/// The values bound to a signature's declared variables by a successful bind. A name resolves to
+/// exactly one [Binding], whose kind is structural — a variable cannot be bound as both a type and
+/// a numeric value.
 @Immutable
 public final class VariableBindings
 {
-    private final Map<String, Type> typeVariables;
-    private final Map<String, Long> longVariables;
+    /// The value bound to one signature variable: a [Type] for a type variable, a numeric value for
+    /// a numeric variable.
+    public sealed interface Binding
+            permits TypeBinding, NumericBinding {}
 
-    public VariableBindings(Map<String, Type> typeVariables, Map<String, Long> longVariables)
+    public record TypeBinding(Type type)
+            implements Binding
+    {
+        public TypeBinding
+        {
+            requireNonNull(type, "type is null");
+        }
+    }
+
+    public record NumericBinding(long value)
+            implements Binding {}
+
+    private final Map<String, Binding> bindings;
+
+    public VariableBindings(Map<String, Binding> bindings)
     {
         // Use CASE_INSENSITIVE_ORDER for consistency with other places. TODO: revisit whether this is even needed
-        this.typeVariables = ImmutableSortedMap.copyOf(typeVariables, CASE_INSENSITIVE_ORDER);
-        this.longVariables = ImmutableSortedMap.copyOf(longVariables, CASE_INSENSITIVE_ORDER);
+        this.bindings = ImmutableSortedMap.copyOf(bindings, CASE_INSENSITIVE_ORDER);
+    }
+
+    public Map<String, Type> getTypeVariables()
+    {
+        return bindings.entrySet().stream()
+                .filter(entry -> entry.getValue() instanceof TypeBinding)
+                .collect(toImmutableSortedMap(CASE_INSENSITIVE_ORDER, Map.Entry::getKey, entry -> ((TypeBinding) entry.getValue()).type()));
+    }
+
+    public Map<String, Long> getNumericVariables()
+    {
+        return bindings.entrySet().stream()
+                .filter(entry -> entry.getValue() instanceof NumericBinding)
+                .collect(toImmutableSortedMap(CASE_INSENSITIVE_ORDER, Map.Entry::getKey, entry -> ((NumericBinding) entry.getValue()).value()));
     }
 
     public Type getTypeVariable(String variableName)
     {
         requireNonNull(variableName, "variableName is null");
-        Type value = typeVariables.get(variableName);
-        checkState(value != null, "value for variable '%s' is null", variableName);
-        return value;
+        if (!(bindings.get(variableName) instanceof TypeBinding(Type type))) {
+            throw new IllegalStateException("variable '%s' is not bound to a type".formatted(variableName));
+        }
+        return type;
     }
 
     public boolean containsTypeVariable(String variableName)
     {
         requireNonNull(variableName, "variableName is null");
-        return typeVariables.containsKey(variableName);
+        return bindings.get(variableName) instanceof TypeBinding;
     }
 
-    public Long getLongVariable(String variableName)
+    public long getNumericVariable(String variableName)
     {
         requireNonNull(variableName, "variableName is null");
-        Long value = longVariables.get(variableName);
-        checkState(value != null, "value for variable '%s' is null", variableName);
+        if (!(bindings.get(variableName) instanceof NumericBinding(long value))) {
+            throw new IllegalStateException("variable '%s' is not bound to a numeric value".formatted(variableName));
+        }
         return value;
     }
 
-    public boolean containsLongVariable(String variableName)
+    public boolean containsNumericVariable(String variableName)
     {
         requireNonNull(variableName, "variableName is null");
-        return longVariables.containsKey(variableName);
+        return bindings.get(variableName) instanceof NumericBinding;
     }
 
     @Override
@@ -71,12 +105,12 @@ public final class VariableBindings
         if (!(o instanceof VariableBindings that)) {
             return false;
         }
-        return Objects.equals(typeVariables, that.typeVariables) && Objects.equals(longVariables, that.longVariables);
+        return Objects.equals(bindings, that.bindings);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(typeVariables, longVariables);
+        return Objects.hash(bindings);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/annotations/LiteralImplementationDependency.java
+++ b/core/trino-main/src/main/java/io/trino/operator/annotations/LiteralImplementationDependency.java
@@ -35,6 +35,6 @@ public final class LiteralImplementationDependency
     @Override
     public Object resolve(FunctionBinding functionBinding, FunctionDependencies functionDependencies)
     {
-        return functionBinding.variables().getLongVariable(literalName);
+        return functionBinding.variables().getNumericVariable(literalName);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/metadata/TestSignatureBinder.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestSignatureBinder.java
@@ -79,10 +79,10 @@ public class TestSignatureBinder
         assertThat(function)
                 .boundTo(createDecimalType(2, 1), createDecimalType(1, 0))
                 .produces(new BindingsBuilder()
-                        .setLongVariable("p1", 2L)
-                        .setLongVariable("s1", 1L)
-                        .setLongVariable("p2", 1L)
-                        .setLongVariable("s2", 0L)
+                        .setNumericVariable("p1", 2L)
+                        .setNumericVariable("s1", 1L)
+                        .setNumericVariable("p2", 1L)
+                        .setNumericVariable("s2", 0L)
                         .build());
     }
 
@@ -98,7 +98,7 @@ public class TestSignatureBinder
                 .boundTo(createDecimalType(2, 1))
                 .withCoercion()
                 .produces(new BindingsBuilder()
-                        .setLongVariable("s", 1L)
+                        .setNumericVariable("s", 1L)
                         .build());
 
         function = functionSignature()
@@ -110,20 +110,20 @@ public class TestSignatureBinder
                 .boundTo(createDecimalType(2, 0))
                 .withCoercion()
                 .produces(new BindingsBuilder()
-                        .setLongVariable("p", 3L)
+                        .setNumericVariable("p", 3L)
                         .build());
 
         assertThat(function)
                 .boundTo(createDecimalType(2, 1))
                 .produces(new BindingsBuilder()
-                        .setLongVariable("p", 2L)
+                        .setNumericVariable("p", 2L)
                         .build());
 
         assertThat(function)
                 .boundTo(BIGINT)
                 .withCoercion()
                 .produces(new BindingsBuilder()
-                        .setLongVariable("p", 20L)
+                        .setNumericVariable("p", 20L)
                         .build());
     }
 
@@ -142,16 +142,16 @@ public class TestSignatureBinder
         assertThat(function)
                 .boundTo(createVarcharType(42), createVarcharType(44))
                 .produces(new BindingsBuilder()
-                        .setLongVariable("x", 42L)
-                        .setLongVariable("y", 44L)
+                        .setNumericVariable("x", 42L)
+                        .setNumericVariable("y", 44L)
                         .build());
 
         assertThat(function)
                 .boundTo(UNKNOWN, createVarcharType(44))
                 .withCoercion()
                 .produces(new BindingsBuilder()
-                        .setLongVariable("x", 0L)
-                        .setLongVariable("y", 44L)
+                        .setNumericVariable("x", 0L)
+                        .setNumericVariable("y", 44L)
                         .build());
     }
 
@@ -170,25 +170,25 @@ public class TestSignatureBinder
         assertThat(function)
                 .boundTo(createVarcharType(44), createVarcharType(44))
                 .produces(new BindingsBuilder()
-                        .setLongVariable("x", 44L)
+                        .setNumericVariable("x", 44L)
                         .build());
         assertThat(function)
                 .boundTo(createVarcharType(44), createVarcharType(42))
                 .withCoercion()
                 .produces(new BindingsBuilder()
-                        .setLongVariable("x", 44L)
+                        .setNumericVariable("x", 44L)
                         .build());
         assertThat(function)
                 .boundTo(createVarcharType(42), createVarcharType(44))
                 .withCoercion()
                 .produces(new BindingsBuilder()
-                        .setLongVariable("x", 44L)
+                        .setNumericVariable("x", 44L)
                         .build());
         assertThat(function)
                 .boundTo(UNKNOWN, createVarcharType(44))
                 .withCoercion()
                 .produces(new BindingsBuilder()
-                        .setLongVariable("x", 44L)
+                        .setNumericVariable("x", 44L)
                         .build());
     }
 
@@ -207,29 +207,29 @@ public class TestSignatureBinder
         assertThat(function)
                 .boundTo(createDecimalType(10, 5), createDecimalType(10, 5))
                 .produces(new BindingsBuilder()
-                        .setLongVariable("p", 10L)
-                        .setLongVariable("s", 5L)
+                        .setNumericVariable("p", 10L)
+                        .setNumericVariable("s", 5L)
                         .build());
         assertThat(function)
                 .boundTo(createDecimalType(10, 8), createDecimalType(9, 8))
                 .withCoercion()
                 .produces(new BindingsBuilder()
-                        .setLongVariable("p", 10L)
-                        .setLongVariable("s", 8L)
+                        .setNumericVariable("p", 10L)
+                        .setNumericVariable("s", 8L)
                         .build());
         assertThat(function)
                 .boundTo(createDecimalType(10, 2), createDecimalType(10, 8))
                 .withCoercion()
                 .produces(new BindingsBuilder()
-                        .setLongVariable("p", 16L)
-                        .setLongVariable("s", 8L)
+                        .setNumericVariable("p", 16L)
+                        .setNumericVariable("s", 8L)
                         .build());
         assertThat(function)
                 .boundTo(UNKNOWN, createDecimalType(10, 5))
                 .withCoercion()
                 .produces(new BindingsBuilder()
-                        .setLongVariable("p", 10L)
-                        .setLongVariable("s", 5L)
+                        .setNumericVariable("p", 10L)
+                        .setNumericVariable("s", 5L)
                         .build());
     }
 
@@ -250,14 +250,14 @@ public class TestSignatureBinder
                 .withCoercion()
                 .boundTo(ImmutableList.of(createVarcharType(3), createVarcharType(5)), createVarcharType(5))
                 .produces(new BindingsBuilder()
-                        .setLongVariable("x", 5L)
+                        .setNumericVariable("x", 5L)
                         .build());
 
         assertThat(function)
                 .withCoercion()
                 .boundTo(ImmutableList.of(createVarcharType(3), createVarcharType(5)), createVarcharType(6))
                 .produces(new BindingsBuilder()
-                        .setLongVariable("x", 6L)
+                        .setNumericVariable("x", 6L)
                         .build());
     }
 
@@ -294,8 +294,8 @@ public class TestSignatureBinder
                 .withCoercion()
                 .produces(new BindingsBuilder()
                         .setTypeVariable("T", createDecimalType(2, 1))
-                        .setLongVariable("p", 3L)
-                        .setLongVariable("s", 1L)
+                        .setNumericVariable("p", 3L)
+                        .setNumericVariable("s", 1L)
                         .build());
     }
 
@@ -346,8 +346,8 @@ public class TestSignatureBinder
                 .boundTo(UNKNOWN)
                 .withCoercion()
                 .produces(new BindingsBuilder()
-                        .setLongVariable("p", 1L)
-                        .setLongVariable("s", 0L)
+                        .setNumericVariable("p", 1L)
+                        .setNumericVariable("s", 0L)
                         .build());
     }
 
@@ -491,7 +491,7 @@ public class TestSignatureBinder
         assertThat(function)
                 .boundTo(VARCHAR)
                 .produces(new BindingsBuilder()
-                        .setLongVariable("x", (long) Integer.MAX_VALUE)
+                        .setNumericVariable("x", (long) Integer.MAX_VALUE)
                         .build());
     }
 
@@ -1219,8 +1219,8 @@ public class TestSignatureBinder
                 .setTypeVariable("T1", DOUBLE)
                 .setTypeVariable("T2", BIGINT)
                 .setTypeVariable("T3", createDecimalType(5, 3))
-                .setLongVariable("p", 1L)
-                .setLongVariable("s", 2L)
+                .setNumericVariable("p", 1L)
+                .setNumericVariable("s", 2L)
                 .build();
 
         assertThat("bigint", boundVariables, "bigint");


### PR DESCRIPTION
## Description

A bind result held its variable bindings as two parallel string-keyed maps — one for type
variables, one for numeric variables — so a binding's kind was encoded by which map was
consulted, guarded only by lookup-time state checks, and nothing prevented one name from
silently binding as both kinds. This mirrors on the binding side the kind conflation that
the declaration side resolved with a single variable list (#29804).

Store bindings as one map to a sealed `Binding` — a `Type` for a type variable, a value
for a numeric variable — making the kind structural and a cross-kind rebind of the same
name impossible (a binding may still be refined across solver iterations, but its kind
cannot change). The numeric accessors also complete the long-to-numeric naming
(`getLongVariable` → `getNumericVariable`, etc.), matching `NumericVariableConstraint`.

No behavior change.

## Additional context and related issues

Independent of, and parallel to, #29834 — both are preparatory refactoring ahead of
splitting the overloaded `TypeSignature` into a ground type descriptor and an open,
variable-bearing template form.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
