### PR TITLE
Add function ends_with(string, suffix)

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
@@ -944,6 +944,18 @@ public final class StringFunctions
         return source.compareTo(0, prefix.length(), prefix, 0, prefix.length()) == 0;
     }
 
+    @Description("Determine whether source ends with suffix or not")
+    @ScalarFunction(neverFails = true)
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean endsWith(@SqlType("varchar(x)") Slice source, @SqlType("varchar(y)") Slice suffix)
+    {
+        if (source.length() < suffix.length()) {
+            return false;
+        }
+        return source.compareTo(source.length() - suffix.length(), suffix.length(), suffix, 0, suffix.length()) == 0;
+    }
+
     @Description("Translate characters from the source string based on original and translations strings")
     @ScalarFunction
     @LiteralParameters({"x", "y", "z"})

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
@@ -703,6 +703,36 @@ public class TestStringFunctions
         assertThat(assertions.function("starts_with", "'信念 爱 希望'", "'爱'"))
                 .isEqualTo(false);
 
+        assertThat(assertions.function("ends_with", "'foo'", "'foo'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("ends_with", "'foo'", "'bar'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.function("ends_with", "'foo'", "''"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("ends_with", "''", "'foo'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.function("ends_with", "''", "''"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("ends_with", "'foo_bar_baz'", "'baz'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("ends_with", "'foo_bar_baz'", "'bar'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.function("ends_with", "'baz'", "'foo_bar_baz'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.function("ends_with", "'信念 爱 希望'", "'希望'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("ends_with", "'信念 爱 希望'", "'爱'"))
+                .isEqualTo(false);
+
         assertThat(assertions.function("strpos", "NULL", "''"))
                 .isNull(BIGINT);
 

--- a/docs/src/main/sphinx/functions/list-by-topic.md
+++ b/docs/src/main/sphinx/functions/list-by-topic.md
@@ -477,6 +477,7 @@ For more details, see {doc}`string`
 - {func}`codepoint`
 - {func}`concat`
 - {func}`concat_ws`
+- {func}`ends_with`
 - {func}`format`
 - {func}`from_utf8`
 - {func}`hamming_distance`

--- a/docs/src/main/sphinx/functions/list.md
+++ b/docs/src/main/sphinx/functions/list.md
@@ -143,6 +143,7 @@
 - {func}`e`
 - {func}`element_at`
 - {func}`empty_approx_set`
+- {func}`ends_with`
 - `evaluate_classifier_predictions`
 - {func}`every`
 - {func}`exclude_columns`

--- a/docs/src/main/sphinx/functions/string.md
+++ b/docs/src/main/sphinx/functions/string.md
@@ -56,6 +56,10 @@ separator. If `string0` is null, then the return value is null. Any
 null values in the array are skipped.
 :::
 
+:::{function} ends_with(string, substring) -> boolean
+Tests whether `substring` is a suffix of `string`.
+:::
+
 :::{function} format(format, args...) -> varchar
 :noindex: true
 


### PR DESCRIPTION
## Description
We already have a `starts_with()`, but `ends_with()` was not implemented yet.
https://trino.io/docs/current/functions/string.html#starts_with

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
## General
* Add string function ends_with(string, suffix) 
```
