### PR TITLE
Support Iceberg table properties for write configuration

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -1142,6 +1142,16 @@ connector using a {doc}`WITH </sql/create-table-as>` clause.
     Defaults to `false`. 
 * - `data_location`
   - Optionally specifies the file system location URI for the table's data files
+* - `target_max_file_size`
+  - Target maximum [](prop-type-data-size) of written files; the actual size may
+    be larger.
+    Defaults to the value of the `iceberg.target-max-file-size` catalog
+    configuration property.
+* - `parquet_writer_row_group_size`
+  - Target maximum [](prop-type-data-size) of a Parquet row group for files
+    written by this table.
+    Defaults to the value of the `parquet.writer.row-group-size` Parquet
+    writer configuration property.
 * - `extra_properties`
   - Additional properties added to an Iceberg table. The properties are not used by Trino,
     and are available in the `$properties` metadata table.

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -34,6 +34,7 @@ import io.trino.plugin.hive.HiveCompressionCodec;
 import io.trino.plugin.hive.HiveCompressionOption;
 import io.trino.plugin.hive.RollbackAction;
 import io.trino.plugin.hive.orc.OrcWriterConfig;
+import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.plugin.iceberg.fileio.ForwardingOutputFile;
 import io.trino.spi.NodeVersion;
 import io.trino.spi.TrinoException;
@@ -82,7 +83,6 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterD
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterPageSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterPageValueCount;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterRowGroupMaxRowCount;
-import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterRowGroupSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isOrcWriterValidate;
 import static io.trino.plugin.iceberg.IcebergTableProperties.ORC_BLOOM_FILTER_FPP_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergUtil.getHiveCompressionCodec;
@@ -96,6 +96,7 @@ import static io.trino.plugin.iceberg.util.PrimitiveTypeMapBuilder.makeTypeMap;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.io.DeleteSchemaUtil.pathPosSchema;
 
 public class IcebergFileWriterFactory
@@ -109,6 +110,7 @@ public class IcebergFileWriterFactory
     private final OrcWriterStats orcWriterStats = new OrcWriterStats();
     private final HiveCompressionOption hiveCompressionOption;
     private final OrcWriterOptions orcWriterOptions;
+    private final DataSize parquetRowGroupSize;
 
     @Inject
     public IcebergFileWriterFactory(
@@ -116,7 +118,8 @@ public class IcebergFileWriterFactory
             NodeVersion nodeVersion,
             FileFormatDataSourceStats readStats,
             IcebergConfig icebergConfig,
-            OrcWriterConfig orcWriterConfig)
+            OrcWriterConfig orcWriterConfig,
+            ParquetWriterConfig parquetWriterConfig)
     {
         checkArgument(!orcWriterConfig.isUseLegacyVersion(), "the ORC writer shouldn't be configured to use a legacy version");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -124,6 +127,7 @@ public class IcebergFileWriterFactory
         this.readStats = requireNonNull(readStats, "readStats is null");
         this.hiveCompressionOption = icebergConfig.getCompressionCodec();
         this.orcWriterOptions = orcWriterConfig.toOrcWriterOptions();
+        this.parquetRowGroupSize = parquetWriterConfig.getRowGroupSize();
     }
 
     @Managed
@@ -187,7 +191,7 @@ public class IcebergFileWriterFactory
             ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                     .setMaxPageSize(getParquetWriterPageSize(session))
                     .setMaxPageValueCount(getParquetWriterPageValueCount(session))
-                    .setMaxBlockSize(getParquetWriterRowGroupSize(session))
+                    .setMaxBlockSize(getParquetWriterRowGroupSize(storageProperties, parquetRowGroupSize))
                     .setMaxRowGroupRowCount(getParquetWriterRowGroupMaxRowCount(session))
                     .setBatchSize(getParquetWriterBatchSize(session))
                     .setBloomFilterColumns(getParquetBloomFilterColumns(storageProperties))
@@ -405,5 +409,19 @@ public class IcebergFileWriterFactory
                     .collect(toImmutableList()));
         }
         return type;
+    }
+
+    static DataSize getParquetWriterRowGroupSize(Map<String, String> storageProperties, DataSize defaultRowGroupSize)
+    {
+        String tableProperty = storageProperties.get(PARQUET_ROW_GROUP_SIZE_BYTES);
+        if (tableProperty == null) {
+            return defaultRowGroupSize;
+        }
+        try {
+            return DataSize.ofBytes(Long.parseLong(tableProperty));
+        }
+        catch (NumberFormatException e) {
+            throw new TrinoException(ICEBERG_INVALID_METADATA, format("Invalid value for Iceberg table property %s: %s", PARQUET_ROW_GROUP_SIZE_BYTES, tableProperty), e);
+        }
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -330,8 +330,10 @@ import static io.trino.plugin.iceberg.IcebergTableProperties.MAX_PREVIOUS_VERSIO
 import static io.trino.plugin.iceberg.IcebergTableProperties.OBJECT_STORE_LAYOUT_ENABLED_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.ORC_BLOOM_FILTER_COLUMNS_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTableProperties.PARQUET_WRITER_ROW_GROUP_SIZE;
 import static io.trino.plugin.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.SORTED_BY_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTableProperties.TARGET_MAX_FILE_SIZE;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getFormatVersion;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getTableLocation;
@@ -448,8 +450,10 @@ import static org.apache.iceberg.TableProperties.MIN_SNAPSHOTS_TO_KEEP_DEFAULT;
 import static org.apache.iceberg.TableProperties.OBJECT_STORE_ENABLED;
 import static org.apache.iceberg.TableProperties.ORC_BLOOM_FILTER_COLUMNS;
 import static org.apache.iceberg.TableProperties.PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.WRITE_DATA_LOCATION;
 import static org.apache.iceberg.TableProperties.WRITE_LOCATION_PROVIDER_IMPL;
+import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.apache.iceberg.TableUtil.formatVersion;
 import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 import static org.apache.iceberg.types.TypeUtil.indexParents;
@@ -478,8 +482,10 @@ public class IcebergMetadata
             .add(DATA_LOCATION_PROPERTY)
             .add(ORC_BLOOM_FILTER_COLUMNS_PROPERTY)
             .add(PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY)
+            .add(PARQUET_WRITER_ROW_GROUP_SIZE)
             .add(PARTITIONING_PROPERTY)
             .add(SORTED_BY_PROPERTY)
+            .add(TARGET_MAX_FILE_SIZE)
             .build();
     private static final String SYSTEM_SCHEMA = "system";
 
@@ -2600,6 +2606,18 @@ public class IcebergMetadata
             String dataLocation = (String) properties.get(DATA_LOCATION_PROPERTY)
                     .orElseThrow(() -> new IllegalArgumentException("The data_location property cannot be empty"));
             updateProperties.set(WRITE_DATA_LOCATION, dataLocation);
+        }
+
+        if (properties.containsKey(TARGET_MAX_FILE_SIZE)) {
+            DataSize targetMaxFileSize = (DataSize) properties.get(TARGET_MAX_FILE_SIZE)
+                    .orElseThrow(() -> new IllegalArgumentException("The target_max_file_size property cannot be empty"));
+            updateProperties.set(WRITE_TARGET_FILE_SIZE_BYTES, Long.toString(targetMaxFileSize.toBytes()));
+        }
+
+        if (properties.containsKey(PARQUET_WRITER_ROW_GROUP_SIZE)) {
+            DataSize rowGroupSize = (DataSize) properties.get(PARQUET_WRITER_ROW_GROUP_SIZE)
+                    .orElseThrow(() -> new IllegalArgumentException("The parquet_writer_row_group_size property cannot be empty"));
+            updateProperties.set(PARQUET_ROW_GROUP_SIZE_BYTES, Long.toString(rowGroupSize.toBytes()));
         }
 
         try {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -113,6 +113,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.apache.iceberg.FileContent.DATA;
+import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 
 public class IcebergPageSink
         implements ConnectorPageSink
@@ -130,7 +131,7 @@ public class IcebergPageSink
     private final IcebergFileFormat fileFormat;
     private final MetricsConfig metricsConfig;
     private final PagePartitioner pagePartitioner;
-    private final long targetMaxFileSize;
+    private final long targetMaxFileSizeBytes;
     private final long idleWriterMinFileSize;
     private final Map<String, String> storageProperties;
     private final List<TrinoSortField> sortFields;
@@ -172,6 +173,7 @@ public class IcebergPageSink
             int maxOpenWriters,
             List<TrinoSortField> sortFields,
             int sortOrderId,
+            DataSize targetMaxFileSize,
             DataSize sortingFileWriterBufferSize,
             int sortingFileWriterMaxOpenFiles,
             Optional<String> sortedWritingLocalStagingPath,
@@ -190,7 +192,7 @@ public class IcebergPageSink
         this.metricsConfig = MetricsConfig.from(requireNonNull(storageProperties, "storageProperties is null"), null, null);
         this.maxOpenWriters = maxOpenWriters;
         this.pagePartitioner = new PagePartitioner(pageIndexerFactory, toPartitionColumns(partitionColumns, partitionSpec, outputSchema));
-        this.targetMaxFileSize = IcebergSessionProperties.getTargetMaxFileSize(session);
+        this.targetMaxFileSizeBytes = getTargetMaxFileSizeBytes(storageProperties, targetMaxFileSize);
         this.idleWriterMinFileSize = IcebergSessionProperties.getIdleWriterMinFileSize(session);
         this.storageProperties = requireNonNull(storageProperties, "storageProperties is null");
         this.sortFields = requireNonNull(sortFields, "sortFields is null");
@@ -508,7 +510,7 @@ public class IcebergPageSink
             int writerIndex = writerIndexes[position];
             WriteContext writer = writers.get(writerIndex);
             if (writer != null) {
-                if (writer.getWrittenBytes() <= targetMaxFileSize) {
+                if (writer.getWrittenBytes() <= targetMaxFileSizeBytes) {
                     continue;
                 }
                 closeWriter(writerIndex);
@@ -774,6 +776,20 @@ public class IcebergPageSink
             return location;
         }
         return Location.of("local:///" + location.path());
+    }
+
+    static long getTargetMaxFileSizeBytes(Map<String, String> storageProperties, DataSize targetMaxFileSize)
+    {
+        String tableProperty = storageProperties.get(WRITE_TARGET_FILE_SIZE_BYTES);
+        if (tableProperty == null) {
+            return targetMaxFileSize.toBytes();
+        }
+        try {
+            return Long.parseLong(tableProperty);
+        }
+        catch (NumberFormatException e) {
+            throw new TrinoException(ICEBERG_INVALID_METADATA, format("Invalid value for Iceberg table property %s: %s", WRITE_TARGET_FILE_SIZE_BYTES, tableProperty), e);
+        }
     }
 
     private static class WriteContext

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -62,6 +62,7 @@ public class IcebergPageSinkProvider
     private final DataSize sortingFileWriterBufferSize;
     private final int sortingFileWriterMaxOpenFiles;
     private final Optional<String> sortingFileWriterLocalStagingPath;
+    private final DataSize targetMaxFileSize;
     private final TypeManager typeManager;
     private final PageSorter pageSorter;
 
@@ -83,6 +84,7 @@ public class IcebergPageSinkProvider
         this.sortingFileWriterBufferSize = sortingFileWriterConfig.getWriterSortBufferSize();
         this.sortingFileWriterMaxOpenFiles = sortingFileWriterConfig.getMaxOpenSortFiles();
         this.sortingFileWriterLocalStagingPath = icebergConfig.getSortedWritingLocalStagingPath();
+        this.targetMaxFileSize = icebergConfig.getTargetMaxFileSize();
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.pageSorter = requireNonNull(pageSorter, "pageSorter is null");
     }
@@ -129,6 +131,7 @@ public class IcebergPageSinkProvider
                 maxPartitionsPerWriter(session),
                 tableHandle.sortFields(),
                 tableHandle.sortOrderId(),
+                targetMaxFileSize,
                 sortingFileWriterBufferSize,
                 sortingFileWriterMaxOpenFiles,
                 sortingFileWriterLocalStagingPath,
@@ -165,6 +168,7 @@ public class IcebergPageSinkProvider
                         maxPartitionsPerWriter(session),
                         optimizeHandle.sortFields(),
                         optimizeHandle.sortOrderId(),
+                        targetMaxFileSize,
                         sortingFileWriterBufferSize,
                         sortingFileWriterMaxOpenFiles,
                         sortingFileWriterLocalStagingPath,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -44,7 +44,6 @@ import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMinDataS
 import static io.trino.plugin.hive.parquet.ParquetReaderConfig.PARQUET_READER_MAX_SMALL_FILE_THRESHOLD;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_VALUE_COUNT;
-import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_ROW_GROUP_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_VALUE_COUNT;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_ROW_GROUP_ROW_COUNT;
@@ -87,8 +86,6 @@ public final class IcebergSessionProperties
     private static final String PARQUET_SMALL_FILE_THRESHOLD = "parquet_small_file_threshold";
     private static final String PARQUET_IGNORE_STATISTICS = "parquet_ignore_statistics";
     private static final String PARQUET_VECTORIZED_DECODING_ENABLED = "parquet_vectorized_decoding_enabled";
-    private static final String PARQUET_WRITER_ROW_GROUP_SIZE = "parquet_writer_row_group_size";
-    private static final String LEGACY_PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT = "parquet_writer_row_group_max_row_count";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_PAGE_VALUE_COUNT = "parquet_writer_page_value_count";
@@ -97,7 +94,6 @@ public final class IcebergSessionProperties
     public static final String DYNAMIC_FILTERING_WAIT_TIMEOUT = "dynamic_filtering_wait_timeout";
     private static final String STATISTICS_ENABLED = "statistics_enabled";
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
-    private static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
     private static final String IDLE_WRITER_MIN_FILE_SIZE = "idle_writer_min_file_size";
     public static final String COLLECT_EXTENDED_STATISTICS_ON_WRITE = "collect_extended_statistics_on_write";
     private static final String HIVE_CATALOG_NAME = "hive_catalog_name";
@@ -260,12 +256,6 @@ public final class IcebergSessionProperties
                         "Enable using Java Vector API for faster decoding of parquet files",
                         parquetReaderConfig.isVectorizedDecodingEnabled(),
                         false))
-                .add(dataSizeProperty(
-                        PARQUET_WRITER_ROW_GROUP_SIZE,
-                        "Parquet: Writer row group size",
-                        parquetWriterConfig.getRowGroupSize(),
-                        value -> validateMaxDataSize(PARQUET_WRITER_ROW_GROUP_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_ROW_GROUP_SIZE)),
-                        false))
                 .add(integerProperty(
                         PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT,
                         "Parquet: The maximum row count of row groups created by the Parquet writer",
@@ -278,12 +268,6 @@ public final class IcebergSessionProperties
                             }
                         },
                         false))
-                .add(dataSizeProperty(
-                        LEGACY_PARQUET_WRITER_BLOCK_SIZE,
-                        "Deprecated. Use parquet_writer_row_group_size instead.",
-                        null,
-                        value -> validateMaxDataSize(LEGACY_PARQUET_WRITER_BLOCK_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_ROW_GROUP_SIZE)),
-                        true))
                 .add(dataSizeProperty(
                         PARQUET_WRITER_PAGE_SIZE,
                         "Parquet: Writer page size",
@@ -329,11 +313,6 @@ public final class IcebergSessionProperties
                         PROJECTION_PUSHDOWN_ENABLED,
                         "Read only required fields from a row type",
                         icebergConfig.isProjectionPushdownEnabled(),
-                        false))
-                .add(dataSizeProperty(
-                        TARGET_MAX_FILE_SIZE,
-                        "Target maximum size of written files; the actual size may be larger",
-                        icebergConfig.getTargetMaxFileSize(),
                         false))
                 .add(dataSizeProperty(
                         IDLE_WRITER_MIN_FILE_SIZE,
@@ -562,15 +541,6 @@ public final class IcebergSessionProperties
         return session.getProperty(PARQUET_WRITER_PAGE_VALUE_COUNT, Integer.class);
     }
 
-    public static DataSize getParquetWriterRowGroupSize(ConnectorSession session)
-    {
-        DataSize legacyValue = session.getProperty(LEGACY_PARQUET_WRITER_BLOCK_SIZE, DataSize.class);
-        if (legacyValue != null) {
-            return legacyValue;
-        }
-        return session.getProperty(PARQUET_WRITER_ROW_GROUP_SIZE, DataSize.class);
-    }
-
     public static int getParquetWriterRowGroupMaxRowCount(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_ROW_GROUP_MAX_ROW_COUNT, Integer.class);
@@ -609,11 +579,6 @@ public final class IcebergSessionProperties
     public static boolean isProjectionPushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(PROJECTION_PUSHDOWN_ENABLED, Boolean.class);
-    }
-
-    public static long getTargetMaxFileSize(ConnectorSession session)
-    {
-        return session.getProperty(TARGET_MAX_FILE_SIZE, DataSize.class).toBytes();
     }
 
     public static long getIdleWriterMinFileSize(ConnectorSession session)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
@@ -17,6 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
+import io.airlift.units.DataSize;
 import io.trino.plugin.hive.HiveCompressionCodec;
 import io.trino.plugin.hive.HiveCompressionCodecs;
 import io.trino.plugin.hive.HiveCompressionOption;
@@ -35,6 +36,8 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.base.session.PropertyMetadataUtil.dataSizeProperty;
+import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_ROW_GROUP_SIZE;
 import static io.trino.plugin.iceberg.IcebergConfig.FORMAT_VERSION_SUPPORT_MAX;
 import static io.trino.plugin.iceberg.IcebergConfig.FORMAT_VERSION_SUPPORT_MIN;
 import static io.trino.plugin.iceberg.IcebergFileFormat.AVRO;
@@ -53,7 +56,9 @@ import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 import static org.apache.iceberg.TableProperties.ORC_BLOOM_FILTER_COLUMNS;
 import static org.apache.iceberg.TableProperties.ORC_BLOOM_FILTER_FPP;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.RESERVED_PROPERTIES;
+import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 
 public class IcebergTableProperties
 {
@@ -69,6 +74,8 @@ public class IcebergTableProperties
     public static final String ORC_BLOOM_FILTER_COLUMNS_PROPERTY = "orc_bloom_filter_columns";
     public static final String ORC_BLOOM_FILTER_FPP_PROPERTY = "orc_bloom_filter_fpp";
     public static final String PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY = "parquet_bloom_filter_columns";
+    public static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
+    public static final String PARQUET_WRITER_ROW_GROUP_SIZE = "parquet_writer_row_group_size";
     public static final String OBJECT_STORE_LAYOUT_ENABLED_PROPERTY = "object_store_layout_enabled";
     public static final String DATA_LOCATION_PROPERTY = "data_location";
     public static final String EXTRA_PROPERTIES_PROPERTY = "extra_properties";
@@ -89,6 +96,8 @@ public class IcebergTableProperties
             .add(DATA_LOCATION_PROPERTY)
             .add(EXTRA_PROPERTIES_PROPERTY)
             .add(PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY)
+            .add(TARGET_MAX_FILE_SIZE)
+            .add(PARQUET_WRITER_ROW_GROUP_SIZE)
             .build();
 
     // These properties are used by Trino or Iceberg internally and cannot be set directly by users through extra_properties
@@ -98,6 +107,8 @@ public class IcebergTableProperties
             .add(ORC_BLOOM_FILTER_FPP)
             .add(DEFAULT_FILE_FORMAT)
             .add(FORMAT_VERSION)
+            .add(WRITE_TARGET_FILE_SIZE_BYTES)
+            .add(PARQUET_ROW_GROUP_SIZE_BYTES)
             .build();
 
     private final List<PropertyMetadata<?>> tableProperties;
@@ -205,6 +216,18 @@ public class IcebergTableProperties
                                 .map(name -> name.toLowerCase(ENGLISH))
                                 .collect(toImmutableList()),
                         value -> value))
+                .add(dataSizeProperty(
+                        TARGET_MAX_FILE_SIZE,
+                        "Target maximum size of written files; the actual size may be larger",
+                        null,
+                        value -> validateMaxDataSize(TARGET_MAX_FILE_SIZE, value, DataSize.ofBytes(Long.MAX_VALUE)),
+                        false))
+                .add(dataSizeProperty(
+                        PARQUET_WRITER_ROW_GROUP_SIZE,
+                        "Parquet writer row group size",
+                        null,
+                        value -> validateMaxDataSize(PARQUET_WRITER_ROW_GROUP_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_ROW_GROUP_SIZE)),
+                        false))
                 .add(new PropertyMetadata<>(
                         EXTRA_PROPERTIES_PROPERTY,
                         "Extra table properties",
@@ -344,6 +367,13 @@ public class IcebergTableProperties
         }
     }
 
+    private static void validateMaxDataSize(String name, DataSize value, DataSize max)
+    {
+        if (value.compareTo(max) > 0) {
+            throw new TrinoException(INVALID_TABLE_PROPERTY, "%s must be at most %s: %s".formatted(name, max, value));
+        }
+    }
+
     public static List<String> getParquetBloomFilterColumns(Map<String, Object> tableProperties)
     {
         List<String> parquetBloomFilterColumns = (List<String>) tableProperties.get(PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY);
@@ -353,6 +383,16 @@ public class IcebergTableProperties
     public static boolean getObjectStoreLayoutEnabled(Map<String, Object> tableProperties)
     {
         return (boolean) tableProperties.getOrDefault(OBJECT_STORE_LAYOUT_ENABLED_PROPERTY, false);
+    }
+
+    public static Optional<DataSize> getTargetMaxFileSize(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((DataSize) tableProperties.get(TARGET_MAX_FILE_SIZE));
+    }
+
+    public static Optional<DataSize> getParquetWriterRowGroupSize(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((DataSize) tableProperties.get(PARQUET_WRITER_ROW_GROUP_SIZE));
     }
 
     public static Optional<String> getDataLocation(Map<String, Object> tableProperties)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Sets;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceUtf8;
 import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
 import io.trino.filesystem.FileEntry;
 import io.trino.filesystem.FileIterator;
 import io.trino.filesystem.Location;
@@ -151,10 +152,12 @@ import static io.trino.plugin.iceberg.IcebergTableProperties.OBJECT_STORE_LAYOUT
 import static io.trino.plugin.iceberg.IcebergTableProperties.ORC_BLOOM_FILTER_COLUMNS_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.ORC_BLOOM_FILTER_FPP_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTableProperties.PARQUET_WRITER_ROW_GROUP_SIZE;
 import static io.trino.plugin.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.PROTECTED_ICEBERG_NATIVE_PROPERTIES;
 import static io.trino.plugin.iceberg.IcebergTableProperties.SORTED_BY_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.SUPPORTED_PROPERTIES;
+import static io.trino.plugin.iceberg.IcebergTableProperties.TARGET_MAX_FILE_SIZE;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getMaxPreviousVersions;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getSortOrder;
@@ -217,8 +220,10 @@ import static org.apache.iceberg.TableProperties.ORC_BLOOM_FILTER_FPP;
 import static org.apache.iceberg.TableProperties.ORC_COMPRESSION;
 import static org.apache.iceberg.TableProperties.PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.WRITE_DATA_LOCATION;
 import static org.apache.iceberg.TableProperties.WRITE_LOCATION_PROVIDER_IMPL;
+import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.apache.iceberg.TableUtil.formatVersion;
 import static org.apache.iceberg.expressions.Expressions.lit;
 import static org.apache.iceberg.types.Type.TypeID.BINARY;
@@ -377,6 +382,14 @@ public final class IcebergUtil
         if (icebergTable.properties().containsKey(METADATA_PREVIOUS_VERSIONS_MAX)) {
             int maxPreviousVersions = parseInt(icebergTable.properties().get(METADATA_PREVIOUS_VERSIONS_MAX));
             properties.put(MAX_PREVIOUS_VERSIONS, maxPreviousVersions);
+        }
+
+        if (icebergTable.properties().containsKey(WRITE_TARGET_FILE_SIZE_BYTES)) {
+            properties.put(TARGET_MAX_FILE_SIZE, DataSize.succinctBytes(Long.parseLong(icebergTable.properties().get(WRITE_TARGET_FILE_SIZE_BYTES))));
+        }
+
+        if (icebergTable.properties().containsKey(PARQUET_ROW_GROUP_SIZE_BYTES)) {
+            properties.put(PARQUET_WRITER_ROW_GROUP_SIZE, DataSize.succinctBytes(Long.parseLong(icebergTable.properties().get(PARQUET_ROW_GROUP_SIZE_BYTES))));
         }
 
         // iceberg ORC format bloom filter properties
@@ -1020,6 +1033,11 @@ public final class IcebergUtil
                 propertiesBuilder.put(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + column, "true");
             }
         }
+
+        IcebergTableProperties.getTargetMaxFileSize(tableMetadata.getProperties())
+                .ifPresent(value -> propertiesBuilder.put(WRITE_TARGET_FILE_SIZE_BYTES, Long.toString(value.toBytes())));
+        IcebergTableProperties.getParquetWriterRowGroupSize(tableMetadata.getProperties())
+                .ifPresent(value -> propertiesBuilder.put(PARQUET_ROW_GROUP_SIZE_BYTES, Long.toString(value.toBytes())));
 
         if (tableMetadata.getComment().isPresent()) {
             propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -190,6 +190,8 @@ import static org.apache.iceberg.TableMetadata.newTableMetadata;
 import static org.apache.iceberg.TableProperties.AVRO_COMPRESSION;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
+import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.offset;
@@ -5477,7 +5479,7 @@ public abstract class BaseIcebergConnectorTest
             try (TestTable table = newTrinoTable(
                     "test_split_pruning_data_file_statistics",
                     // Random double is needed to make sure rows are different. Otherwise compression may deduplicate rows, resulting in only one row group
-                    "(col " + testSetup.getTrinoTypeName() + ", r double)")) {
+                    "(col " + testSetup.getTrinoTypeName() + ", r double) WITH (parquet_writer_row_group_size = '256B')")) {
                 String tableName = table.getName();
                 String values =
                         Stream.concat(
@@ -5485,7 +5487,7 @@ public abstract class BaseIcebergConnectorTest
                                         nCopies(100, testSetup.getHighValueLiteral()).stream())
                                 .map(value -> "(" + value + ", rand())")
                                 .collect(joining(", "));
-                assertUpdate(withSplitPruningRowGroups(getSession()), "INSERT INTO " + tableName + " VALUES " + values, 200);
+                assertUpdate(withSmallRowGroups(getSession()), "INSERT INTO " + tableName + " VALUES " + values, 200);
 
                 String query = "SELECT * FROM " + tableName + " WHERE col = " + testSetup.getSampleValueLiteral();
                 verifyPredicatePushdownDataRead(query, supportsRowGroupStatistics(testSetup.getTrinoTypeName()));
@@ -5494,13 +5496,6 @@ public abstract class BaseIcebergConnectorTest
     }
 
     protected abstract boolean supportsRowGroupStatistics(String typeName);
-
-    private static Session withSplitPruningRowGroups(Session session)
-    {
-        return Session.builder(withSmallRowGroups(session))
-                .setCatalogSessionProperty("iceberg", "parquet_writer_row_group_size", "256B")
-                .build();
-    }
 
     private void verifySplitCount(String query, int expectedSplitCount)
     {
@@ -6229,14 +6224,12 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate(format("DROP TABLE %s", tableName));
 
         DataSize maxSize = DataSize.of(80, DataSize.Unit.KILOBYTE);
-        session = Session.builder(getSession())
-                .setSystemProperty("task_min_writer_count", "1")
-                // task scale writers should be disabled since we want to write with a single task writer
-                .setSystemProperty("task_scale_writers_enabled", "false")
-                .setCatalogSessionProperty("iceberg", "target_max_file_size", maxSize.toString())
-                .build();
+        String createTableWithMaxFileSizeSql = format(
+                "CREATE TABLE %s WITH (target_max_file_size = '%s') AS SELECT * FROM tpch.sf1.lineitem LIMIT 200000",
+                tableName,
+                maxSize);
 
-        assertUpdate(session, createTableSql, 200000);
+        assertUpdate(session, createTableWithMaxFileSizeSql, 200000);
         assertThat(query(format("SELECT count(*) FROM %s", tableName))).matches("VALUES BIGINT '200000'");
         List<String> updatedFiles = getActiveFiles(tableName);
         assertThat(updatedFiles.size()).isGreaterThan(10);
@@ -6246,6 +6239,7 @@ public abstract class BaseIcebergConnectorTest
                 // as target_max_file_size is set to quite low value it can happen that created files are bigger,
                 // so just to be safe we check if it is not much bigger
                 .forEach(row -> assertThat((Long) row.getField(0)).isBetween(1L, maxSize.toBytes() * 6));
+        assertUpdate(format("DROP TABLE %s", tableName));
     }
 
     @Test
@@ -6265,14 +6259,12 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate(format("DROP TABLE %s", tableName));
 
         DataSize maxSize = DataSize.of(50, DataSize.Unit.KILOBYTE);
-        session = Session.builder(getSession())
-                .setSystemProperty("task_min_writer_count", "1")
-                // task scale writers should be disabled since we want to write with a single task writer
-                .setSystemProperty("task_scale_writers_enabled", "false")
-                .setCatalogSessionProperty("iceberg", "target_max_file_size", maxSize.toString())
-                .build();
+        String createTableWithMaxFileSizeSql = format(
+                "CREATE TABLE %s WITH (sorted_by = ARRAY['shipdate'], target_max_file_size = '%s') AS SELECT * FROM tpch.sf1.lineitem LIMIT 200000",
+                tableName,
+                maxSize);
 
-        assertUpdate(session, createTableSql, 200000);
+        assertUpdate(session, createTableWithMaxFileSizeSql, 200000);
         assertThat(query(format("SELECT count(*) FROM %s", tableName))).matches("VALUES BIGINT '200000'");
         List<String> updatedFiles = getActiveFiles(tableName);
         assertThat(updatedFiles.size()).isGreaterThan(5);
@@ -6282,6 +6274,40 @@ public abstract class BaseIcebergConnectorTest
                 // as target_max_file_size is set to quite low value it can happen that created files are bigger,
                 // so just to be safe we check if it is not much bigger
                 .forEach(row -> assertThat((Long) row.getField(0)).isBetween(1L, maxSize.toBytes() * 20));
+        assertUpdate(format("DROP TABLE %s", tableName));
+    }
+
+    @Test
+    public void testWriteTablePropertiesRoundTrip()
+    {
+        assertQueryFails(
+                "CREATE TABLE test_invalid_parquet_writer_row_group_size_" + randomNameSuffix() + " (a int) WITH (parquet_writer_row_group_size = '3GB')",
+                ".*\\Qparquet_writer_row_group_size must be at most 2GB\\E.*");
+
+        try (TestTable table = newTrinoTable(
+                "test_write_table_properties_round_trip",
+                "(a int) WITH (target_max_file_size = '100MB', parquet_writer_row_group_size = '4MB')")) {
+            String tableName = table.getName();
+
+            // Properties surface in SHOW CREATE TABLE
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))
+                    .contains("target_max_file_size = '100MB'")
+                    .contains("parquet_writer_row_group_size = '4MB'");
+
+            // Properties are persisted as Iceberg native properties
+            assertThat(getTableProperties(tableName))
+                    .containsEntry(WRITE_TARGET_FILE_SIZE_BYTES, Long.toString(100L * 1024 * 1024))
+                    .containsEntry(PARQUET_ROW_GROUP_SIZE_BYTES, Long.toString(4L * 1024 * 1024));
+
+            // ALTER TABLE SET PROPERTIES updates both
+            assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES target_max_file_size = '200MB', parquet_writer_row_group_size = '8MB'");
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))
+                    .contains("target_max_file_size = '200MB'")
+                    .contains("parquet_writer_row_group_size = '8MB'");
+            assertThat(getTableProperties(tableName))
+                    .containsEntry(WRITE_TARGET_FILE_SIZE_BYTES, Long.toString(200L * 1024 * 1024))
+                    .containsEntry(PARQUET_ROW_GROUP_SIZE_BYTES, Long.toString(8L * 1024 * 1024));
+        }
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -71,7 +71,6 @@ import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.iceberg.IcebergTestUtils.FILE_IO_FACTORY;
 import static io.trino.plugin.iceberg.IcebergTestUtils.getFileSystemFactory;
-import static io.trino.plugin.iceberg.IcebergTestUtils.withSmallRowGroups;
 import static io.trino.server.testing.TestingTrinoServer.SESSION_START_TIME_PROPERTY;
 import static io.trino.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
 import static io.trino.spi.function.table.TableFunctionProcessorState.Finished.FINISHED;
@@ -1474,8 +1473,8 @@ public abstract class BaseIcebergMaterializedViewTest
     public void testSplitOffsetsOnStorageTable()
     {
         String materializedViewName = "test_split_offsets_" + randomNameSuffix();
-        computeActual(format("CREATE MATERIALIZED VIEW %s AS SELECT * FROM tpch.tiny.nation", materializedViewName));
-        assertUpdate(withSmallRowGroups(getSession()), "REFRESH MATERIALIZED VIEW " + materializedViewName, 25);
+        computeActual(format("CREATE MATERIALIZED VIEW %s WITH (parquet_writer_row_group_size = '1kB') AS SELECT * FROM tpch.tiny.nation", materializedViewName));
+        assertUpdate("REFRESH MATERIALIZED VIEW " + materializedViewName, 25);
 
         assertQueryStats(
                 getSession(),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergParquetConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergParquetConnectorTest.java
@@ -68,7 +68,7 @@ public abstract class BaseIcebergParquetConnectorTest
     {
         try (TestTable table = newTrinoTable(
                 "test_row_group_reset_dictionary",
-                "(plain_col varchar, dict_col int)")) {
+                "(plain_col varchar, dict_col int) WITH (parquet_writer_row_group_size = '1kB')")) {
             String tableName = table.getName();
             String values = IntStream.range(0, 100)
                     .mapToObj(i -> "('ABCDEFGHIJ" + i + "' , " + (i < 20 ? "1" : "null") + ")")
@@ -110,7 +110,7 @@ public abstract class BaseIcebergParquetConnectorTest
     {
         try (TestTable table = newTrinoTable(
                 "test_ignore_parquet_statistics",
-                "WITH (sorted_by = ARRAY['custkey']) AS TABLE tpch.tiny.customer WITH NO DATA")) {
+                "WITH (sorted_by = ARRAY['custkey'], parquet_writer_row_group_size = '1kB') AS TABLE tpch.tiny.customer WITH NO DATA")) {
             assertUpdate(
                     withSmallRowGroups(getSession()),
                     "INSERT INTO " + table.getName() + " TABLE tpch.tiny.customer",
@@ -142,7 +142,7 @@ public abstract class BaseIcebergParquetConnectorTest
     {
         try (TestTable table = newTrinoTable(
                 "test_pushdown_predicate_statistics",
-                "WITH (sorted_by = ARRAY['custkey']) AS TABLE tpch.tiny.customer WITH NO DATA")) {
+                "WITH (sorted_by = ARRAY['custkey'], parquet_writer_row_group_size = '1kB') AS TABLE tpch.tiny.customer WITH NO DATA")) {
             assertUpdate(
                     withSmallRowGroups(getSession()),
                     "INSERT INTO " + table.getName() + " TABLE tpch.tiny.customer",
@@ -172,12 +172,9 @@ public abstract class BaseIcebergParquetConnectorTest
     {
         try (TestTable table = newTrinoTable(
                 "test_table_changes_function_multi_row_groups_",
-                "AS SELECT orderkey, partkey, suppkey FROM tpch.tiny.lineitem WITH NO DATA")) {
+                "WITH (parquet_writer_row_group_size = '" + getTableChangesParquetRowGroupSize() + "') AS SELECT orderkey, partkey, suppkey FROM tpch.tiny.lineitem WITH NO DATA")) {
             long initialSnapshot = getMostRecentSnapshotId(table.getName());
-            assertUpdate(
-                    withTableChangesRowGroups(getSession()),
-                    "INSERT INTO %s SELECT orderkey, partkey, suppkey FROM tpch.tiny.lineitem".formatted(table.getName()),
-                    60175L);
+            assertUpdate("INSERT INTO %s SELECT orderkey, partkey, suppkey FROM tpch.tiny.lineitem".formatted(table.getName()), 60175L);
             long snapshotAfterInsert = getMostRecentSnapshotId(table.getName());
             DateTimeFormatter instantMillisFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss.SSSVV").withZone(UTC);
             String snapshotAfterInsertTime = getSnapshotTime(table.getName(), snapshotAfterInsert).format(instantMillisFormatter);
@@ -199,16 +196,14 @@ public abstract class BaseIcebergParquetConnectorTest
         }
     }
 
-    protected Session withTableChangesRowGroups(Session session)
-    {
-        return Session.builder(withSmallRowGroups(session))
-                .setCatalogSessionProperty("iceberg", "parquet_writer_row_group_size", "256B")
-                .build();
-    }
-
     protected int getTableChangesSplitBatchSize()
     {
         return new QueryManagerConfig().getScheduleSplitBatchSize();
+    }
+
+    protected String getTableChangesParquetRowGroupSize()
+    {
+        return "256B";
     }
 
     private String getOnlyTableFilePath(String tableName)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergTestUtils.java
@@ -108,7 +108,6 @@ public final class IcebergTestUtils
     {
         return Session.builder(session)
                 .setCatalogSessionProperty("iceberg", "orc_writer_max_stripe_rows", "20")
-                .setCatalogSessionProperty("iceberg", "parquet_writer_row_group_size", "1kB")
                 .setCatalogSessionProperty("iceberg", "parquet_writer_batch_size", "20")
                 .build();
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
@@ -384,7 +384,7 @@ public class TestIcebergFileOperations
         String catalog = getSession().getCatalog().orElseThrow();
 
         assertUpdate("DROP TABLE IF EXISTS test_read_whole_splittable_file");
-        assertUpdate("CREATE TABLE test_read_whole_splittable_file(key varchar, data varchar) WITH (partitioning=ARRAY['key'])");
+        assertUpdate("CREATE TABLE test_read_whole_splittable_file(key varchar, data varchar) WITH (partitioning=ARRAY['key'], parquet_writer_row_group_size = '1kB')");
 
         assertUpdate(
                 withSmallRowGroups(Session.builder(getSession())

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergLocalConcurrentWrites.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergLocalConcurrentWrites.java
@@ -15,7 +15,6 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.concurrent.MoreFutures;
-import io.trino.Session;
 import io.trino.plugin.blackhole.BlackHolePlugin;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
@@ -417,13 +416,11 @@ final class TestIcebergLocalConcurrentWrites
         CyclicBarrier barrier = new CyclicBarrier(threads);
         ExecutorService executor = newFixedThreadPool(threads);
         String tableName = "test_concurrent_non_overlapping_updates_table_" + randomNameSuffix();
-        // Force creating more parquet files
-        Session session = Session.builder(getSession())
-                .setCatalogSessionProperty("iceberg", "target_max_file_size", "1kB")
-                .build();
-
-        assertUpdate("CREATE TABLE " + tableName + " (a BIGINT, part BIGINT) WITH (partitioning = ARRAY['part'])");
-        assertUpdate(session, " INSERT INTO " + tableName + " SELECT * FROM " +
+        // Force creating more parquet files via the target_max_file_size table property
+        assertUpdate("CREATE TABLE " + tableName + " (a BIGINT, part BIGINT) WITH (partitioning = ARRAY['part'], target_max_file_size = '1kB')");
+        assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))
+                .contains("target_max_file_size = '1kB'");
+        assertUpdate("INSERT INTO " + tableName + " SELECT * FROM " +
                 "(select * from UNNEST(SEQUENCE(1, 10000)) AS t(a)) CROSS JOIN (select * from UNNEST(SEQUENCE(1, 3)) AS t(part))", 30000);
 
         // UPDATE will increase every value by 1
@@ -434,17 +431,17 @@ final class TestIcebergLocalConcurrentWrites
             executor.invokeAll(ImmutableList.<Callable<Void>>builder()
                             .add(() -> {
                                 barrier.await(10, SECONDS);
-                                getQueryRunner().execute(session, "UPDATE " + tableName + " SET a = a + 1 WHERE part = 1");
+                                getQueryRunner().execute("UPDATE " + tableName + " SET a = a + 1 WHERE part = 1");
                                 return null;
                             })
                             .add(() -> {
                                 barrier.await(10, SECONDS);
-                                getQueryRunner().execute(session, "UPDATE " + tableName + " SET a = a + 1  WHERE part = 2");
+                                getQueryRunner().execute("UPDATE " + tableName + " SET a = a + 1  WHERE part = 2");
                                 return null;
                             })
                             .add(() -> {
                                 barrier.await(10, SECONDS);
-                                getQueryRunner().execute(session, "UPDATE " + tableName + " SET a = a + 1  WHERE part = 3");
+                                getQueryRunner().execute("UPDATE " + tableName + " SET a = a + 1  WHERE part = 3");
                                 return null;
                             })
                             .build())

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetComplexTypesPredicatePushDown.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetComplexTypesPredicatePushDown.java
@@ -61,7 +61,7 @@ public class TestIcebergParquetComplexTypesPredicatePushDown
             throws IOException
     {
         String tableName = "test_nested_column_pruning_" + randomNameSuffix();
-        assertUpdate("CREATE TABLE " + tableName + " (col1Row ROW(a BIGINT, b BIGINT), col2 BIGINT) WITH (sorted_by=ARRAY['col2'])");
+        assertUpdate("CREATE TABLE " + tableName + " (col1Row ROW(a BIGINT, b BIGINT), col2 BIGINT) WITH (sorted_by=ARRAY['col2'], parquet_writer_row_group_size = '1kB')");
         assertUpdate("INSERT INTO " + tableName + " SELECT * FROM unnest(transform(SEQUENCE(1, 10000), x -> ROW(ROW(x*2, 100), x)))", 10000);
 
         long valueBetweenRowGroups = getValueBetweenRowGroups(tableName, "col1row.a");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -250,7 +250,7 @@ public class TestIcebergSplitSource
     {
         assertUpdate(
                 withSmallRowGroups(getSession()),
-                "CREATE TABLE test_row_group_merging WITH (format = 'PARQUET') AS SELECT * FROM tpch.tiny.nation",
+                "CREATE TABLE test_row_group_merging WITH (format = 'PARQUET', parquet_writer_row_group_size = '1kB') AS SELECT * FROM tpch.tiny.nation",
                 25);
         try {
             SchemaTableName schemaTableName = new SchemaTableName("tpch", "test_row_group_merging");

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergParquetFaultTolerantExecutionConnectorTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/iceberg/TestIcebergParquetFaultTolerantExecutionConnectorTest.java
@@ -13,7 +13,6 @@
  */
 package io.trino.faulttolerant.iceberg;
 
-import io.trino.Session;
 import io.trino.filesystem.Location;
 import io.trino.plugin.exchange.filesystem.containers.MinioStorage;
 import io.trino.plugin.iceberg.BaseIcebergParquetConnectorTest;
@@ -25,7 +24,6 @@ import org.junit.jupiter.api.parallel.Isolated;
 
 import static io.trino.plugin.exchange.filesystem.containers.MinioStorage.getExchangeManagerProperties;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
-import static io.trino.plugin.iceberg.IcebergTestUtils.withSmallRowGroups;
 import static io.trino.testing.FaultTolerantExecutionConnectorTestHelper.getExtraProperties;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -95,11 +93,9 @@ public class TestIcebergParquetFaultTolerantExecutionConnectorTest
     }
 
     @Override
-    protected Session withTableChangesRowGroups(Session session)
+    protected String getTableChangesParquetRowGroupSize()
     {
-        return Session.builder(withSmallRowGroups(session))
-                .setCatalogSessionProperty("iceberg", "parquet_writer_row_group_size", "16kB")
-                .build();
+        return "16kB";
     }
 
     @Override

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergAlluxioCaching.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergAlluxioCaching.java
@@ -91,8 +91,7 @@ public class TestIcebergAlluxioCaching
     {
         onTrino().executeQuery("DROP TABLE IF EXISTS " + tableName);
         onTrino().executeQuery("DROP SCHEMA IF EXISTS iceberg.test_caching");
-        onTrino().executeQuery("SET SESSION iceberg.target_max_file_size = '2MB'");
         onTrino().executeQuery("CREATE SCHEMA iceberg.test_caching with (location = 's3://" + bucketName + "/test_iceberg_caching')");
-        onTrino().executeQuery("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.sf1.customer");
+        onTrino().executeQuery("CREATE TABLE " + tableName + " WITH (target_max_file_size = '2MB') AS SELECT * FROM tpch.sf1.customer");
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -219,6 +219,35 @@ public class TestIcebergSparkCompatibility
         onSpark().executeQuery("DROP TABLE " + sparkTableName);
     }
 
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS, ICEBERG_REST, ICEBERG_JDBC, ICEBERG_NESSIE})
+    public void testTrinoReadingSparkWriteTableProperties()
+    {
+        String baseTableName = toLowerCase("test_trino_reading_spark_write_table_properties_" + randomNameSuffix());
+        String trinoTableName = trinoTableName(baseTableName);
+        String sparkTableName = sparkTableName(baseTableName);
+
+        onSpark().executeQuery("DROP TABLE IF EXISTS " + sparkTableName);
+
+        onSpark().executeQuery(format(
+                "CREATE TABLE %s (a INT) USING ICEBERG " +
+                        "TBLPROPERTIES (" +
+                        "  'write.target-file-size-bytes' = '%s'," +
+                        "  'write.parquet.row-group-size-bytes' = '%s'" +
+                        ")",
+                sparkTableName,
+                100L * 1024 * 1024,
+                4L * 1024 * 1024));
+
+        try {
+            assertThat((String) onTrino().executeQuery("SHOW CREATE TABLE " + trinoTableName).getOnlyValue())
+                    .contains("target_max_file_size = '100MB'")
+                    .contains("parquet_writer_row_group_size = '4MB'");
+        }
+        finally {
+            onSpark().executeQuery("DROP TABLE " + sparkTableName);
+        }
+    }
+
     @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS, ICEBERG_REST, ICEBERG_JDBC, ICEBERG_NESSIE}, dataProvider = "testSparkReadingTrinoDataDataProvider")
     public void testSparkReadingTrinoData(StorageFormat storageFormat, CreateMode createMode)
     {


### PR DESCRIPTION
Allows per-table configuration of the target maximum file size that persists in the Iceberg table metadata as write.target-file-size-bytes. The session property is removed; the connector config default still applies when the table property is not set.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Attempt 2 for #28057

This PR converts two Iceberg write configuration settings from session properties to table properties, allowing per-table configuration that persists in the Iceberg table metadata.

### Converted Properties

1. **`target_max_file_size`** → `write.target-file-size-bytes` (Iceberg table property)
   - Controls the target maximum size of data files written by Trino
   - Default: 1GB

2. **`parquet_writer_block_size`** → `write.parquet.row-group-size-bytes` (Iceberg table property)
   - Controls the Parquet row group size
   - Default: 128MB


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes #28250
#28057


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Add support for the `target_max_file_size` and `parquet_writer_row_group_size` table properties, persisted as the iceberg-native `write.target-file-size-bytes` and `write.parquet.row-group-size-bytes` properties for cross-engine consistency.
* {{breaking}} Remove the `target_max_file_size` and `parquet_writer_row_group_size` session properties (and the deprecated `parquet_writer_block_size` alias). Use the equivalent table properties instead.
```
