### PR TITLE
Fix SHOW CREATE SCHEMA failure for Iceberg JDBC catalog with invalid namespace properties

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -85,6 +85,7 @@ import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_CATALOG_ERROR;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_UNSUPPORTED_VIEW_DIALECT;
 import static io.trino.plugin.iceberg.IcebergSchemaProperties.LOCATION_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergSchemaProperties.SUPPORTED_SCHEMA_PROPERTIES;
 import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableWithMetadata;
 import static io.trino.plugin.iceberg.IcebergUtil.loadIcebergTable;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -148,6 +149,7 @@ public class TrinoJdbcCatalog
     public Map<String, Object> loadNamespaceMetadata(ConnectorSession session, String namespace)
     {
         return jdbcCatalog.loadNamespaceMetadata(Namespace.of(namespace)).entrySet().stream()
+                .filter(entry -> SUPPORTED_SCHEMA_PROPERTIES.contains(entry.getKey()))
                 .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestTrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestTrinoJdbcCatalog.java
@@ -158,12 +158,4 @@ final class TestTrinoJdbcCatalog
             catalog.dropNamespace(SESSION, namespace);
         }
     }
-
-    @Test
-    @Override
-    public void testSchemaWithInvalidProperties()
-    {
-        // JDBC catalog preserves arbitrary namespace properties
-        // https://github.com/trinodb/trino/issues/29769
-    }
 }


### PR DESCRIPTION
## Description

Fixes #29769

`TrinoJdbcCatalog.loadNamespaceMetadata` returned all namespace properties
stored by the underlying JDBC catalog, including arbitrary ones not recognised
by Trino. When `SHOW CREATE SCHEMA` attempted to reconstruct the DDL it failed
on those unknown properties.

Fix by filtering the returned map to only include keys present in
`SUPPORTED_SCHEMA_PROPERTIES` (currently just `location`), consistent with how
`TrinoRestCatalog` already handles this.

## Additional context and related issues

This bug was surfaced in #29738, where `testSchemaWithInvalidProperties` in
`TestTrinoJdbcCatalog` was suppressed with a TODO pointing to this issue.
That PR adds `TestTrinoJdbcCatalog` (not yet on master); once it merges the
suppressed override can be removed and `BaseTrinoCatalogTest.testSchemaWithInvalidProperties`
will run as a full integration test against this fix.

Unit tests are included in `TestTrinoJdbcCatalogLoadNamespaceMetadata` covering
the filtering behaviour in the meantime.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Fix `SHOW CREATE SCHEMA` failure for Iceberg JDBC catalog when the schema
  was created with arbitrary namespace properties. ({issue}`29769`)
```