### PR TITLE
Add OAuth2 client credentials flow to JDBC and CLI

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -31,6 +31,7 @@ import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
 import picocli.CommandLine;
 
+import java.io.Console;
 import java.lang.annotation.Retention;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -67,6 +68,8 @@ import static io.trino.client.uri.PropertyName.KERBEROS_PRINCIPAL;
 import static io.trino.client.uri.PropertyName.KERBEROS_REMOTE_SERVICE_NAME;
 import static io.trino.client.uri.PropertyName.KERBEROS_SERVICE_PRINCIPAL_PATTERN;
 import static io.trino.client.uri.PropertyName.KERBEROS_USE_CANONICAL_HOSTNAME;
+import static io.trino.client.uri.PropertyName.OAUTH2_CLIENT_ID;
+import static io.trino.client.uri.PropertyName.OAUTH2_CLIENT_SECRET;
 import static io.trino.client.uri.PropertyName.PASSWORD;
 import static io.trino.client.uri.PropertyName.RESOURCE_ESTIMATES;
 import static io.trino.client.uri.PropertyName.SCHEMA;
@@ -193,6 +196,14 @@ public class ClientOptions
     @PropertyMapping(EXTERNAL_AUTHENTICATION_REDIRECT_HANDLERS)
     @Option(names = "--external-authentication-redirect-handler", paramLabel = "<externalAuthenticationRedirectHandler>", description = "External authentication redirect handlers: ${COMPLETION-CANDIDATES} " + DEFAULT_VALUE, defaultValue = "ALL")
     public List<ExternalRedirectStrategy> externalAuthenticationRedirectHandler = new ArrayList<>();
+
+    @PropertyMapping(OAUTH2_CLIENT_ID)
+    @Option(names = "--oauth2-client-id", paramLabel = "<clientId>", description = "OAuth2 client ID for client credentials authentication")
+    public Optional<String> oauth2ClientId;
+
+    @PropertyMapping(OAUTH2_CLIENT_SECRET)
+    @Option(names = "--oauth2-client-secret", description = "Prompt for OAuth2 client secret for client credentials authentication")
+    public boolean oauth2ClientSecret;
 
     @PropertyMapping(SOURCE)
     @Option(names = "--source", paramLabel = "<source>", description = "Name of the client to use as source that submits the query (default: " + SOURCE_DEFAULT + ")")
@@ -381,6 +392,7 @@ public class ClientOptions
         List<PropertyName> bannedProperties = ImmutableList.<PropertyName>builder()
                 .addAll(restrictedProperties.keySet())
                 .add(PASSWORD)
+                .add(OAUTH2_CLIENT_SECRET)
                 .build();
         TrinoUri.Builder builder = TrinoUri.builder()
                 .setUri(uri)
@@ -438,6 +450,10 @@ public class ClientOptions
         if (!externalAuthenticationRedirectHandler.isEmpty()) {
             builder.setExternalAuthenticationRedirectHandlers(externalAuthenticationRedirectHandler);
         }
+        oauth2ClientId.ifPresent(builder::setOauth2ClientId);
+        if (oauth2ClientSecret) {
+            builder.setOauth2ClientSecret(getClientSecret());
+        }
         source.ifPresent(builder::setSource);
         clientInfo.ifPresent(builder::setClientInfo);
         clientTags.ifPresent(builder::setClientTags);
@@ -468,6 +484,27 @@ public class ClientOptions
         }
     }
 
+    private String getClientSecret()
+    {
+        checkState(oauth2ClientId.isPresent() && !oauth2ClientId.get().isEmpty(), "Both client ID and client secret must be specified");
+        String defaultSecret = System.getenv("TRINO_OAUTH2_CLIENT_SECRET");
+        if (defaultSecret != null) {
+            return defaultSecret;
+        }
+
+        Console console = System.console();
+        if (console != null) {
+            char[] secret = console.readPassword("OAuth2 client secret: ");
+            if (secret == null) {
+                throw new IllegalArgumentException("OAuth2 client secret not provided");
+            }
+            return new String(secret);
+        }
+
+        LineReader reader = LineReaderBuilder.builder().terminal(getTerminal()).build();
+        return reader.readLine("OAuth2 client secret: ", (char) 0);
+    }
+
     private String getPassword()
     {
         checkState(user.isPresent() && !user.get().isEmpty(), "Both username and password must be specified");
@@ -476,7 +513,7 @@ public class ClientOptions
             return defaultPassword;
         }
 
-        java.io.Console console = System.console();
+        Console console = System.console();
         if (console != null) {
             char[] password = console.readPassword("Password: ");
             if (password != null) {

--- a/client/trino-client/src/main/java/io/trino/client/auth/external/ClientCredentialsAuthenticator.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/ClientCredentialsAuthenticator.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.external;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nullable;
+import okhttp3.Authenticator;
+import okhttp3.Challenge;
+import okhttp3.FormBody;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Predicate.not;
+
+/**
+ * OkHttp Interceptor and Authenticator that implements OAuth2 client credentials flow.
+ * <p>
+ * On the first request the authenticator:
+ * 1. Receives a 401 from Trino with a {@code WWW-Authenticate: Bearer x_token_endpoint="...", scope="..."} challenge.
+ * 2. POSTs to the token endpoint with {@code grant_type=client_credentials}.
+ * 3. Caches the resulting access token, its expiry time, the token endpoint URL, and the scope.
+ * 4. Subsequent requests proactively inject the cached token (via the interceptor).
+ * 5. Re-fetches transparently when the token expires (proactively via interceptor,
+ *    reactively via authenticator on 401).
+ * <p>
+ * The client secret is only ever sent to the IdP token endpoint — never to Trino.
+ */
+public class ClientCredentialsAuthenticator
+        implements Interceptor, Authenticator
+{
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String TOKEN_ENDPOINT_FIELD = "x_token_endpoint";
+    private static final String SCOPE_FIELD = "scope";
+    private static final int EXPIRY_BUFFER_SECONDS = 30;
+
+    private final OkHttpClient httpClient;
+    private final String clientId;
+    private final String clientSecret;
+
+    private final Lock lock = new ReentrantLock();
+    private volatile String cachedToken;
+    private volatile Instant tokenExpiry = Instant.EPOCH;
+    private volatile String tokenEndpoint;
+    private volatile String cachedScope;
+
+    public ClientCredentialsAuthenticator(
+            OkHttpClient httpClient,
+            String clientId,
+            String clientSecret)
+    {
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.clientId = requireNonNull(clientId, "clientId is null");
+        this.clientSecret = requireNonNull(clientSecret, "clientSecret is null");
+    }
+
+    @Override
+    public Response intercept(Chain chain)
+            throws IOException
+    {
+        if (tokenEndpoint == null) {
+            return chain.proceed(chain.request());
+        }
+        String token = getValidToken(new ChallengeHints(Optional.empty(), Optional.empty()));
+        return chain.proceed(withBearerToken(chain.request(), token));
+    }
+
+    @Nullable
+    @Override
+    public Request authenticate(Route route, Response response)
+            throws IOException
+    {
+        if (response.priorResponse() != null && response.priorResponse().code() == 401) {
+            return null;
+        }
+
+        tokenExpiry = Instant.EPOCH;
+
+        ChallengeHints hints = extractFromChallenge(response);
+        try {
+            String token = getValidToken(hints);
+            return withBearerToken(response.request(), token);
+        }
+        catch (IOException e) {
+            throw new IOException("Failed to obtain OAuth2 client credentials token", e);
+        }
+    }
+
+    private static final class ChallengeHints
+    {
+        private final Optional<String> tokenEndpoint;
+        private final Optional<String> scope;
+
+        ChallengeHints(Optional<String> tokenEndpoint, Optional<String> scope)
+        {
+            this.tokenEndpoint = tokenEndpoint;
+            this.scope = scope;
+        }
+
+        Optional<String> tokenEndpoint()
+        {
+            return tokenEndpoint;
+        }
+
+        Optional<String> scope()
+        {
+            return scope;
+        }
+    }
+
+    private static ChallengeHints extractFromChallenge(Response response)
+    {
+        for (Challenge challenge : response.challenges()) {
+            if (challenge.scheme().equalsIgnoreCase("Bearer")) {
+                Map<String, String> params = challenge.authParams();
+                String tokenEndpoint = params.get(TOKEN_ENDPOINT_FIELD);
+                String scope = params.get(SCOPE_FIELD);
+                return new ChallengeHints(
+                        Optional.ofNullable(tokenEndpoint).filter(not(String::isEmpty)),
+                        Optional.ofNullable(scope).filter(not(String::isEmpty)));
+            }
+        }
+        return new ChallengeHints(Optional.empty(), Optional.empty());
+    }
+
+    private String getValidToken(ChallengeHints hints)
+            throws IOException
+    {
+        if (cachedToken != null && Instant.now().isBefore(tokenExpiry)) {
+            return cachedToken;
+        }
+        lock.lock();
+        try {
+            if (cachedToken != null && Instant.now().isBefore(tokenExpiry)) {
+                return cachedToken;
+            }
+            if (tokenEndpoint == null) {
+                tokenEndpoint = hints.tokenEndpoint()
+                        .orElseThrow(() -> new IOException("OAuth2 token endpoint is not available; the server did not return x_token_endpoint in the WWW-Authenticate challenge"));
+            }
+            hints.scope().ifPresent(scope -> cachedScope = scope);
+
+            FormBody.Builder formBuilder = new FormBody.Builder()
+                    .add("grant_type", "client_credentials")
+                    .add("client_id", clientId)
+                    .add("client_secret", clientSecret);
+            if (cachedScope != null) {
+                formBuilder.add("scope", cachedScope);
+            }
+
+            Request request = new Request.Builder()
+                    .url(tokenEndpoint)
+                    .post(formBuilder.build())
+                    .build();
+
+            try (Response response = httpClient.newCall(request).execute()) {
+                if (!response.isSuccessful()) {
+                    throw new IOException("OAuth2 Client Credentials authentication failed, HTTP " + response.code());
+                }
+                TokenResponse tokenResponse = OBJECT_MAPPER.readValue(response.body().string(), TokenResponse.class);
+                if (tokenResponse.accessToken() == null) {
+                    throw new IOException("Token response missing 'access_token' field");
+                }
+                cachedToken = tokenResponse.accessToken();
+                tokenExpiry = Instant.now().plusSeconds(Math.max(0, tokenResponse.expiresIn() - EXPIRY_BUFFER_SECONDS));
+            }
+            catch (IOException e) {
+                tokenEndpoint = null;
+                throw e;
+            }
+            return cachedToken;
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    private static Request withBearerToken(Request request, String token)
+    {
+        return request.newBuilder()
+                .header(AUTHORIZATION, "Bearer " + token)
+                .build();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static final class TokenResponse
+    {
+        private final String accessToken;
+        private final long expiresIn;
+
+        @JsonCreator
+        TokenResponse(
+                @JsonProperty("access_token") String accessToken,
+                @JsonProperty("expires_in") Long expiresIn)
+        {
+            this.accessToken = accessToken;
+            this.expiresIn = expiresIn != null ? expiresIn : 300;
+        }
+
+        String accessToken()
+        {
+            return accessToken;
+        }
+
+        long expiresIn()
+        {
+            return expiresIn;
+        }
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
@@ -96,6 +96,8 @@ final class ConnectionProperties
     public static final ConnectionProperty<String, String> ACCESS_TOKEN = new AccessToken();
     public static final ConnectionProperty<String, Boolean> EXTERNAL_AUTHENTICATION = new ExternalAuthentication();
     public static final ConnectionProperty<String, Duration> EXTERNAL_AUTHENTICATION_TIMEOUT = new ExternalAuthenticationTimeout();
+    public static final ConnectionProperty<String, String> OAUTH2_CLIENT_ID = new Oauth2ClientId();
+    public static final ConnectionProperty<String, String> OAUTH2_CLIENT_SECRET = new Oauth2ClientSecret();
     public static final ConnectionProperty<String, List<ExternalRedirectStrategy>> EXTERNAL_AUTHENTICATION_REDIRECT_HANDLERS = new ExternalAuthenticationRedirectHandlers();
     public static final ConnectionProperty<String, KnownTokenCache> EXTERNAL_AUTHENTICATION_TOKEN_CACHE = new ExternalAuthenticationTokenCache();
     public static final ConnectionProperty<String, Map<String, String>> EXTRA_CREDENTIALS = new ExtraCredentials();
@@ -156,6 +158,8 @@ final class ConnectionProperties
             .add(KERBEROS_SERVICE_PRINCIPAL_PATTERN)
             .add(KERBEROS_USE_CANONICAL_HOSTNAME)
             .add(LOCALE)
+            .add(OAUTH2_CLIENT_ID)
+            .add(OAUTH2_CLIENT_SECRET)
             .add(PASSWORD)
             .add(RESOURCE_ESTIMATES)
             .add(ROLES)
@@ -712,6 +716,36 @@ final class ConnectionProperties
         public ExternalAuthentication()
         {
             super(PropertyName.EXTERNAL_AUTHENTICATION, Optional.of(false), NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
+        }
+    }
+
+    private static class Oauth2ClientId
+            extends AbstractConnectionProperty<String, String>
+    {
+        private static final Validator<Properties> VALIDATE_NO_EXTERNAL_AUTHENTICATION = validator(
+                properties -> !EXTERNAL_AUTHENTICATION.getValueOrDefault(properties, false),
+                format("Connection property %s cannot be set when %s is enabled", PropertyName.OAUTH2_CLIENT_ID, PropertyName.EXTERNAL_AUTHENTICATION));
+
+        private static final Validator<Properties> VALIDATE_CLIENT_SECRET_SET = validator(
+                properties -> OAUTH2_CLIENT_SECRET.getValue(properties).isPresent(),
+                format("Connection property %s requires %s to be set", PropertyName.OAUTH2_CLIENT_ID, PropertyName.OAUTH2_CLIENT_SECRET));
+
+        public Oauth2ClientId()
+        {
+            super(PropertyName.OAUTH2_CLIENT_ID, NOT_REQUIRED, VALIDATE_NO_EXTERNAL_AUTHENTICATION.and(VALIDATE_CLIENT_SECRET_SET), STRING_CONVERTER);
+        }
+    }
+
+    private static class Oauth2ClientSecret
+            extends AbstractConnectionProperty<String, String>
+    {
+        private static final Validator<Properties> VALIDATE_CLIENT_ID_SET = validator(
+                properties -> OAUTH2_CLIENT_ID.getValue(properties).isPresent(),
+                format("Connection property %s requires %s to be set", PropertyName.OAUTH2_CLIENT_SECRET, PropertyName.OAUTH2_CLIENT_ID));
+
+        public Oauth2ClientSecret()
+        {
+            super(PropertyName.OAUTH2_CLIENT_SECRET, NOT_REQUIRED, VALIDATE_CLIENT_ID_SET, STRING_CONVERTER);
         }
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/uri/HttpClientFactory.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/HttpClientFactory.java
@@ -16,6 +16,7 @@ package io.trino.client.uri;
 import io.trino.client.ClientException;
 import io.trino.client.DisallowLocalRedirectInterceptor;
 import io.trino.client.DnsResolver;
+import io.trino.client.auth.external.ClientCredentialsAuthenticator;
 import io.trino.client.auth.external.CompositeRedirectHandler;
 import io.trino.client.auth.external.ExternalAuthenticator;
 import io.trino.client.auth.external.HttpTokenPoller;
@@ -107,6 +108,18 @@ public class HttpClientFactory
                 }
                 return externalAuthenticator.authenticate(route, response);
             });
+        }
+
+        if (uri.isClientCredentialsAuthenticationEnabled()) {
+            if (!uri.isUseSecureConnection()) {
+                throw new RuntimeException("TLS/SSL is required for authentication with client credentials");
+            }
+            ClientCredentialsAuthenticator clientCredentialsAuthenticator = new ClientCredentialsAuthenticator(
+                    builder.build(),
+                    uri.getOauth2ClientId().get(),
+                    uri.getOauth2ClientSecret().get());
+            builder.addNetworkInterceptor(clientCredentialsAuthenticator);
+            builder.authenticator(clientCredentialsAuthenticator);
         }
 
         if (!uri.getExtraHeaders().isEmpty()) {

--- a/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
@@ -54,6 +54,8 @@ public enum PropertyName
     KERBEROS_SERVICE_PRINCIPAL_PATTERN("KerberosServicePrincipalPattern"),
     KERBEROS_USE_CANONICAL_HOSTNAME("KerberosUseCanonicalHostname"),
     LOCALE("locale"),
+    OAUTH2_CLIENT_ID("oauth2ClientId"),
+    OAUTH2_CLIENT_SECRET("oauth2ClientSecret"),
     PASSWORD("password"),
     SQL_PATH("path"),
     RESOURCE_ESTIMATES("resourceEstimates"),

--- a/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
@@ -74,6 +74,8 @@ import static io.trino.client.uri.ConnectionProperties.KERBEROS_REMOTE_SERVICE_N
 import static io.trino.client.uri.ConnectionProperties.KERBEROS_SERVICE_PRINCIPAL_PATTERN;
 import static io.trino.client.uri.ConnectionProperties.KERBEROS_USE_CANONICAL_HOSTNAME;
 import static io.trino.client.uri.ConnectionProperties.LOCALE;
+import static io.trino.client.uri.ConnectionProperties.OAUTH2_CLIENT_ID;
+import static io.trino.client.uri.ConnectionProperties.OAUTH2_CLIENT_SECRET;
 import static io.trino.client.uri.ConnectionProperties.PASSWORD;
 import static io.trino.client.uri.ConnectionProperties.RESOURCE_ESTIMATES;
 import static io.trino.client.uri.ConnectionProperties.ROLES;
@@ -388,6 +390,22 @@ public class TrinoUri
     public boolean isExternalAuthenticationEnabled()
     {
         return resolveWithDefault(EXTERNAL_AUTHENTICATION, false);
+    }
+
+    public Optional<String> getOauth2ClientId()
+    {
+        return resolveOptional(OAUTH2_CLIENT_ID);
+    }
+
+    public Optional<String> getOauth2ClientSecret()
+    {
+        return resolveOptional(OAUTH2_CLIENT_SECRET);
+    }
+
+    public boolean isClientCredentialsAuthenticationEnabled()
+    {
+        return resolveOptional(OAUTH2_CLIENT_ID).isPresent()
+                && resolveOptional(OAUTH2_CLIENT_SECRET).isPresent();
     }
 
     public Optional<Duration> getExternalAuthenticationTimeout()
@@ -949,6 +967,16 @@ public class TrinoUri
         public Builder setExternalAuthentication(Boolean externalAuthentication)
         {
             return setProperty(EXTERNAL_AUTHENTICATION, requireNonNull(externalAuthentication, "externalAuthentication is null"));
+        }
+
+        public Builder setOauth2ClientId(String clientId)
+        {
+            return setProperty(OAUTH2_CLIENT_ID, requireNonNull(clientId, "clientId is null"));
+        }
+
+        public Builder setOauth2ClientSecret(String clientSecret)
+        {
+            return setProperty(OAUTH2_CLIENT_SECRET, requireNonNull(clientSecret, "clientSecret is null"));
         }
 
         public Builder setExternalAuthenticationTimeout(Duration externalAuthenticationTimeout)

--- a/client/trino-client/src/test/java/io/trino/client/auth/external/TestClientCredentialsAuthenticator.java
+++ b/client/trino-client/src/test/java/io/trino/client/auth/external/TestClientCredentialsAuthenticator.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.external;
+
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
+import mockwebserver3.junit5.StartStop;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
+
+@TestInstance(PER_METHOD)
+public class TestClientCredentialsAuthenticator
+{
+    private static final String TOKEN_PATH = "/token";
+    private static final String TRINO_PATH = "/v1/statement";
+
+    @StartStop
+    private final MockWebServer idpServer = new MockWebServer();
+
+    @StartStop
+    private final MockWebServer trinoServer = new MockWebServer();
+
+    @Test
+    public void testSuccessfulTokenFetchAndInjection()
+            throws Exception
+    {
+        // Enqueue responses
+        trinoServer.enqueue(new MockResponse.Builder()
+                .code(HTTP_UNAUTHORIZED)
+                .addHeader("WWW-Authenticate", fullChallenge())
+                .build());
+        enqueueToken("initial-token", 3600);
+        trinoServer.enqueue(ok());
+
+        // Execute
+        OkHttpClient client = buildTrinoClient();
+        Response response = client.newCall(trinoRequest()).execute();
+        response.close();
+        assertThat(response.code()).isEqualTo(HTTP_OK);
+
+        // Verify IdP server
+        assertThat(idpServer.getRequestCount()).isEqualTo(1);
+        RecordedRequest tokenRequest = idpServer.takeRequest();
+        assertThat(tokenRequest.getTarget()).isEqualTo(TOKEN_PATH);
+        assertThat(tokenRequest.getMethod()).isEqualTo("POST");
+
+        // Verify Trino server
+        assertThat(trinoServer.getRequestCount()).isEqualTo(2);
+        trinoServer.takeRequest();
+        RecordedRequest authenticatedRequest = trinoServer.takeRequest();
+        assertThat(authenticatedRequest.getHeaders().get(AUTHORIZATION)).isEqualTo("Bearer initial-token");
+    }
+
+    @Test
+    public void testTokenIsCachedAcrossRequests()
+            throws Exception
+    {
+        // First call: 401 exchange to learn token endpoint
+        trinoServer.enqueue(new MockResponse.Builder()
+                .code(HTTP_UNAUTHORIZED)
+                .addHeader("WWW-Authenticate", fullChallenge())
+                .build());
+        enqueueToken("cached-token", 3600);
+        trinoServer.enqueue(ok());
+        // Second call: interceptor proactively injects cached token
+        trinoServer.enqueue(ok());
+
+        OkHttpClient client = buildTrinoClient();
+        client.newCall(trinoRequest()).execute().close();
+        client.newCall(trinoRequest()).execute().close();
+
+        // Only one token fetch for two Trino calls
+        assertThat(idpServer.getRequestCount()).isEqualTo(1);
+
+        // Third Trino request (second call) has the cached token
+        trinoServer.takeRequest(); // discard initial 401
+        trinoServer.takeRequest(); // discard retry
+        RecordedRequest secondCallRequest = trinoServer.takeRequest();
+        assertThat(secondCallRequest.getHeaders().get(AUTHORIZATION)).isEqualTo("Bearer cached-token");
+    }
+
+    @Test
+    public void testReactiveFetchOn401()
+            throws Exception
+    {
+        // First call: establish token endpoint via 401 exchange
+        trinoServer.enqueue(new MockResponse.Builder()
+                .code(HTTP_UNAUTHORIZED)
+                .addHeader("WWW-Authenticate", fullChallenge())
+                .build());
+        enqueueToken("first-token", 3600);
+        trinoServer.enqueue(ok());
+
+        OkHttpClient client = buildTrinoClient();
+        client.newCall(trinoRequest()).execute().close();
+
+        // Second call: interceptor injects cached token, but Trino rejects it
+        trinoServer.enqueue(new MockResponse.Builder().code(HTTP_UNAUTHORIZED).build());
+        enqueueToken("refreshed-token", 3600);
+        trinoServer.enqueue(ok());
+
+        Response response = client.newCall(trinoRequest()).execute();
+        response.close();
+
+        assertThat(response.code()).isEqualTo(HTTP_OK);
+        assertThat(idpServer.getRequestCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void testExpiredTokenIsRefreshedProactively()
+            throws Exception
+    {
+        trinoServer.enqueue(new MockResponse.Builder()
+                .code(HTTP_UNAUTHORIZED)
+                .addHeader("WWW-Authenticate", fullChallenge())
+                .build());
+        enqueueToken("expired-token", 0);
+        // The network interceptor also fires on the authenticated retry; with expiresIn=0 the
+        // token is already stale by then, so it fetches again before the retry reaches Trino.
+        enqueueToken("interim-token", 0);
+        trinoServer.enqueue(ok());
+
+        OkHttpClient client = buildTrinoClient();
+        client.newCall(trinoRequest()).execute().close();
+
+        enqueueToken("fresh-token", 3600);
+        trinoServer.enqueue(ok());
+
+        Response response = client.newCall(trinoRequest()).execute();
+        response.close();
+
+        assertThat(response.code()).isEqualTo(HTTP_OK);
+        assertThat(idpServer.getRequestCount()).isEqualTo(3);
+
+        trinoServer.takeRequest();
+        trinoServer.takeRequest();
+        RecordedRequest secondCallRequest = trinoServer.takeRequest();
+        assertThat(secondCallRequest.getHeaders().get(AUTHORIZATION)).isEqualTo("Bearer fresh-token");
+    }
+
+    @Test
+    public void testMissingTokenEndpoint()
+    {
+        trinoServer.enqueue(new MockResponse.Builder()
+                .code(HTTP_UNAUTHORIZED)
+                .addHeader("WWW-Authenticate", "Bearer x_redirect_server=\"https://localhost:443/oauth2/token/initiate/550e8400-e29b-41d4-a716-446655440000\", x_token_server=\"https://localhost:443/oauth2/token/550e8400-e29b-41d4-a716-446655440000\", scope=\"openid\"")
+                .build());
+
+        OkHttpClient client = buildTrinoClient();
+        assertThatThrownBy(() -> client.newCall(trinoRequest()).execute())
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to obtain OAuth2 client credentials token")
+                .cause()
+                .hasMessageContaining("OAuth2 token endpoint is not available");
+    }
+
+    @Test
+    public void testMissingAccessTokenInResponse()
+    {
+        trinoServer.enqueue(new MockResponse.Builder()
+                .code(HTTP_UNAUTHORIZED)
+                .addHeader("WWW-Authenticate", fullChallenge())
+                .build());
+        idpServer.enqueue(new MockResponse.Builder()
+                .code(HTTP_OK)
+                .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                .body("{\"token_type\":\"Bearer\"}")
+                .build());
+
+        OkHttpClient client = buildTrinoClient();
+        assertThatThrownBy(() -> client.newCall(trinoRequest()).execute())
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to obtain OAuth2 client credentials token")
+                .cause()
+                .hasMessageContaining("Token response missing 'access_token'");
+    }
+
+    @Test
+    public void testIdpErrorResponse()
+    {
+        trinoServer.enqueue(new MockResponse.Builder()
+                .code(HTTP_UNAUTHORIZED)
+                .addHeader("WWW-Authenticate", fullChallenge())
+                .build());
+        idpServer.enqueue(new MockResponse.Builder().code(HTTP_UNAUTHORIZED).build());
+
+        OkHttpClient client = buildTrinoClient();
+        assertThatThrownBy(() -> client.newCall(trinoRequest()).execute())
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Failed to obtain OAuth2 client credentials token")
+                .cause()
+                .hasMessageContaining("OAuth2 Client Credentials authentication failed, HTTP 401");
+    }
+
+    private OkHttpClient buildTrinoClient()
+    {
+        OkHttpClient baseClient = new OkHttpClient();
+        ClientCredentialsAuthenticator authenticator = new ClientCredentialsAuthenticator(
+                baseClient,
+                "test-client",
+                "test-secret");
+        return baseClient.newBuilder()
+                .addNetworkInterceptor(authenticator)
+                .authenticator(authenticator)
+                .build();
+    }
+
+    private String fullChallenge()
+    {
+        return "Bearer x_redirect_server=\"https://localhost:443/oauth2/token/initiate/550e8400-e29b-41d4-a716-446655440000\""
+                + ", x_token_server=\"https://localhost:443/oauth2/token/550e8400-e29b-41d4-a716-446655440000\""
+                + ", x_token_endpoint=\"" + idpTokenUrl() + "\""
+                + ", scope=\"openid\"";
+    }
+
+    private String idpTokenUrl()
+    {
+        return "http://" + idpServer.getHostName() + ":" + idpServer.getPort() + TOKEN_PATH;
+    }
+
+    private Request trinoRequest()
+    {
+        return new Request.Builder()
+                .url("http://" + trinoServer.getHostName() + ":" + trinoServer.getPort() + TRINO_PATH)
+                .get()
+                .build();
+    }
+
+    private void enqueueToken(String accessToken, long expiresIn)
+    {
+        idpServer.enqueue(new MockResponse.Builder()
+                .code(HTTP_OK)
+                .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                .body("{\"access_token\":\"" + accessToken + "\",\"token_type\":\"Bearer\",\"expires_in\":" + expiresIn + "}")
+                .build());
+    }
+
+    private static MockResponse ok()
+    {
+        return new MockResponse.Builder().code(HTTP_OK).build();
+    }
+}

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcClientCredentialsAuthentication.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcClientCredentialsAuthentication.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jdbc;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.log.Logging;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.server.security.AuthenticationException;
+import io.trino.server.security.Authenticator;
+import io.trino.server.security.SecurityConfig;
+import io.trino.server.testing.TestingTrinoServer;
+import io.trino.spi.security.Identity;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import static com.google.common.io.Resources.getResource;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static io.airlift.testing.Closeables.closeAll;
+import static io.trino.server.security.ServerSecurityModule.authenticatorModule;
+import static java.lang.String.format;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+@TestInstance(PER_CLASS)
+@Execution(SAME_THREAD)
+public class TestJdbcClientCredentialsAuthentication
+{
+    private static final String TEST_CATALOG = "test_catalog";
+    private static final String TOKEN_PATH = "/token";
+    private static final String VALID_CLIENT_ID = "test-client";
+    private static final String VALID_CLIENT_SECRET = "test-secret";
+    private static final String ACCESS_TOKEN = "my-access-token";
+
+    private MockWebServer idpServer;
+
+    private TestingTrinoServer trinoServer;
+    private TokenStore tokenStore;
+
+    @BeforeAll
+    public void setup()
+            throws Exception
+    {
+        Logging.initialize();
+
+        tokenStore = new TokenStore();
+        tokenStore.issue(ACCESS_TOKEN);
+
+        trinoServer = TestingTrinoServer.builder()
+                .setAdditionalModule(new BearerTokenAuthModule(tokenStore, () -> idpServerBaseUrl()))
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .put("http-server.authentication.type", "bearer-token")
+                        .put("http-server.https.enabled", "true")
+                        .put("http-server.https.keystore.path", new File(getResource("localhost.keystore").toURI()).getPath())
+                        .put("http-server.https.keystore.key", "changeit")
+                        .put("web-ui.enabled", "false")
+                        .buildOrThrow())
+                .build();
+        trinoServer.installPlugin(new TpchPlugin());
+        trinoServer.createCatalog(TEST_CATALOG, "tpch");
+    }
+
+    @BeforeEach
+    public void beforeEach()
+            throws Exception
+    {
+        idpServer = new MockWebServer();
+        idpServer.start();
+
+        tokenStore.invalidateAll();
+        tokenStore.issue(ACCESS_TOKEN);
+    }
+
+    @AfterEach
+    public void afterEach()
+            throws Exception
+    {
+        idpServer.close();
+        idpServer = null;
+    }
+
+    @AfterAll
+    public void teardown()
+            throws Exception
+    {
+        closeAll(trinoServer);
+        trinoServer = null;
+    }
+
+    @Test
+    public void testSuccessfulQuery()
+            throws Exception
+    {
+        enqueueToken(ACCESS_TOKEN, 3600);
+
+        try (Connection connection = createConnection();
+                Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery("SELECT 1")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getInt(1)).isEqualTo(1);
+        }
+
+        assertThat(idpServer.getRequestCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testTokenIsCachedAcrossStatements()
+            throws Exception
+    {
+        enqueueToken(ACCESS_TOKEN, 3600);
+
+        try (Connection connection = createConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("SELECT 1");
+            statement.execute("SELECT 2");
+        }
+
+        assertThat(idpServer.getRequestCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testTokenRefreshedAfterServerRejects()
+            throws Exception
+    {
+        enqueueToken(ACCESS_TOKEN, 3600);
+
+        try (Connection connection = createConnection();
+                Statement statement = connection.createStatement()) {
+            assertThat(statement.execute("SELECT 1")).isTrue();
+
+            tokenStore.invalidate(ACCESS_TOKEN);
+            String rotatedToken = "rotated-token";
+            tokenStore.issue(rotatedToken);
+            enqueueToken(rotatedToken, 3600);
+
+            assertThat(statement.execute("SELECT 2")).isTrue();
+        }
+
+        assertThat(idpServer.getRequestCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void testQueryFailsWhenAllTokensRevoked()
+            throws Exception
+    {
+        enqueueToken(ACCESS_TOKEN, 3600);
+
+        try (Connection connection = createConnection();
+                Statement statement = connection.createStatement()) {
+            try (ResultSet rs = statement.executeQuery("SELECT 1")) {
+                assertThat(rs.next()).isTrue();
+            }
+
+            tokenStore.invalidateAll();
+            enqueueToken(ACCESS_TOKEN, 3600);
+
+            assertThatThrownBy(() -> statement.execute("SELECT 1"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("Authentication failed");
+        }
+    }
+
+    @Test
+    public void testMissingClientIdThrowsSqlException()
+    {
+        assertThatThrownBy(() -> {
+            Properties props = baseProperties();
+            props.setProperty("oauth2ClientSecret", VALID_CLIENT_SECRET);
+            DriverManager.getConnection(trinoUrl(), props);
+        }).isInstanceOf(SQLException.class);
+    }
+
+    @Test
+    public void testMissingClientSecretThrowsSqlException()
+    {
+        assertThatThrownBy(() -> {
+            Properties props = baseProperties();
+            props.setProperty("oauth2ClientId", VALID_CLIENT_ID);
+            DriverManager.getConnection(trinoUrl(), props);
+        }).isInstanceOf(SQLException.class);
+    }
+
+    private String trinoUrl()
+    {
+        return format("jdbc:trino://localhost:%s", trinoServer.getHttpsAddress().getPort());
+    }
+
+    private String idpServerBaseUrl()
+    {
+        return "http://" + idpServer.getHostName() + ":" + idpServer.getPort();
+    }
+
+    private Properties baseProperties()
+            throws Exception
+    {
+        Properties props = new Properties();
+        props.setProperty("SSL", "true");
+        props.setProperty("SSLTrustStorePath", new File(getResource("localhost.truststore").toURI()).getPath());
+        props.setProperty("SSLTrustStorePassword", "changeit");
+        return props;
+    }
+
+    private Connection createConnection()
+            throws Exception
+    {
+        Properties props = baseProperties();
+        props.setProperty("oauth2ClientId", VALID_CLIENT_ID);
+        props.setProperty("oauth2ClientSecret", VALID_CLIENT_SECRET);
+        return DriverManager.getConnection(trinoUrl(), props);
+    }
+
+    private void enqueueToken(String accessToken, long expiresIn)
+    {
+        idpServer.enqueue(new MockResponse.Builder()
+                .code(HTTP_OK)
+                .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                .body(format("{\"access_token\":\"%s\",\"token_type\":\"Bearer\",\"expires_in\":%d}", accessToken, expiresIn))
+                .build());
+    }
+
+    static class TokenStore
+    {
+        private final Set<String> validTokens = ConcurrentHashMap.newKeySet();
+
+        public void issue(String token)
+        {
+            validTokens.add(token);
+        }
+
+        public boolean isValid(String token)
+        {
+            return validTokens.contains(token);
+        }
+
+        public void invalidate(String token)
+        {
+            validTokens.remove(token);
+        }
+
+        public void invalidateAll()
+        {
+            validTokens.clear();
+        }
+    }
+
+    private static final class BearerTokenAuthModule
+            extends AbstractConfigurationAwareModule
+    {
+        private final TokenStore tokenStore;
+        private final Supplier<String> idpBaseUrl;
+
+        BearerTokenAuthModule(TokenStore tokenStore, Supplier<String> idpBaseUrl)
+        {
+            this.tokenStore = requireNonNull(tokenStore, "tokenStore is null");
+            this.idpBaseUrl = requireNonNull(idpBaseUrl, "idpBaseUrl is null");
+        }
+
+        @Override
+        protected void setup(Binder binder)
+        {
+            install(authenticatorModule(
+                    buildConfigObject(SecurityConfig.class),
+                    "bearer-token",
+                    BearerTokenAuthenticator.class,
+                    b -> {
+                        b.bind(TokenStore.class).toInstance(tokenStore);
+                        b.bind(IdpBaseUrl.class).toInstance(new IdpBaseUrl(idpBaseUrl));
+                    }));
+        }
+    }
+
+    static final class IdpBaseUrl
+    {
+        private final Supplier<String> supplier;
+
+        IdpBaseUrl(Supplier<String> supplier)
+        {
+            this.supplier = requireNonNull(supplier, "supplier is null");
+        }
+
+        String get()
+        {
+            return supplier.get();
+        }
+    }
+
+    public static class BearerTokenAuthenticator
+            implements Authenticator
+    {
+        private final TokenStore tokenStore;
+        private final IdpBaseUrl idpBaseUrl;
+
+        @Inject
+        public BearerTokenAuthenticator(TokenStore tokenStore, IdpBaseUrl idpBaseUrl)
+        {
+            this.tokenStore = requireNonNull(tokenStore, "tokenStore is null");
+            this.idpBaseUrl = requireNonNull(idpBaseUrl, "idpBaseUrl is null");
+        }
+
+        @Override
+        public Identity authenticate(ContainerRequestContext request)
+                throws AuthenticationException
+        {
+            List<String> headers = request.getHeaders().getOrDefault("Authorization", ImmutableList.of());
+            for (String header : headers) {
+                if (header.startsWith("Bearer ")) {
+                    String token = header.substring("Bearer ".length());
+                    if (tokenStore.isValid(token)) {
+                        return Identity.ofUser("test-user");
+                    }
+                }
+            }
+            throw new AuthenticationException(
+                    "Authentication required",
+                    format("Bearer x_token_endpoint=\"%s\", scope=\"openid\"", idpBaseUrl.get() + TOKEN_PATH));
+        }
+    }
+}

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverUri.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverUri.java
@@ -184,6 +184,17 @@ public class TestTrinoDriverUri
         // legacy url
         assertInvalid("jdbc:presto://localhost:8080", "Invalid JDBC URL: jdbc:presto://localhost:8080");
 
+        // client credentials: clientSecret without clientId
+        assertInvalid("jdbc:trino://localhost:8080?oauth2ClientSecret=secret", "Connection property oauth2ClientSecret requires oauth2ClientId to be set");
+
+        // client credentials: clientId without clientSecret
+        assertInvalid("jdbc:trino://localhost:8080?oauth2ClientId=id", "Connection property oauth2ClientId requires oauth2ClientSecret to be set");
+
+        // client credentials: clientId cannot be combined with externalAuthentication
+        assertInvalid(
+                "jdbc:trino://localhost:8080?oauth2ClientId=id&externalAuthentication=true",
+                "Connection property oauth2ClientId cannot be set when externalAuthentication is enabled");
+
         // cannot set mutually exclusive properties for non-conforming clients to true
         assertInvalid(
                 "jdbc:trino://localhost:8080?assumeLiteralNamesInMetadataCallsForNonConformingClients=true&assumeLiteralUnderscoreInMetadataCallsForNonConformingClients=true",
@@ -467,6 +478,18 @@ public class TestTrinoDriverUri
                 .hasMessage("Connection property timezone value is invalid: Asia/NOT_FOUND")
                 .hasRootCauseInstanceOf(ZoneRulesException.class)
                 .hasRootCauseMessage("Unknown time-zone ID: Asia/NOT_FOUND");
+    }
+
+    @Test
+    public void testClientCredentials()
+            throws SQLException
+    {
+        TrinoDriverUri uri = createDriverUri(
+                "jdbc:trino://localhost:8080?oauth2ClientId=my-client" +
+                        "&oauth2ClientSecret=my-secret");
+        assertThat(uri.getOauth2ClientId()).hasValue("my-client");
+        assertThat(uri.getOauth2ClientSecret()).hasValue("my-secret");
+        assertThat(uri.isClientCredentialsAuthenticationEnabled()).isTrue();
     }
 
     @Test

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
@@ -43,17 +43,21 @@ public class OAuth2Authenticator
     private static final Logger log = Logger.get(OAuth2Authenticator.class);
     private final OAuth2Client client;
     private final String principalField;
+    private final String scopes;
     private final UserMapping userMapping;
     private final TokenPairSerializer tokenPairSerializer;
     private final TokenRefresher tokenRefresher;
+    private final OAuth2ServerConfigProvider serverConfigProvider;
 
     @Inject
-    public OAuth2Authenticator(OAuth2Client client, OAuth2Config config, TokenRefresher tokenRefresher, TokenPairSerializer tokenPairSerializer)
+    public OAuth2Authenticator(OAuth2Client client, OAuth2Config config, TokenRefresher tokenRefresher, TokenPairSerializer tokenPairSerializer, OAuth2ServerConfigProvider serverConfigProvider)
     {
         this.client = requireNonNull(client, "service is null");
         this.principalField = config.getPrincipalField();
+        this.scopes = String.join(" ", config.getScopes());
         this.tokenRefresher = requireNonNull(tokenRefresher, "tokenRefresher is null");
         this.tokenPairSerializer = requireNonNull(tokenPairSerializer, "tokenPairSerializer is null");
+        this.serverConfigProvider = requireNonNull(serverConfigProvider, "serverConfigProvider is null");
         userMapping = createUserMapping(config.getUserMappingPattern(), config.getUserMappingFile());
     }
 
@@ -110,6 +114,6 @@ public class OAuth2Authenticator
         UUID authId = UUID.randomUUID();
         URI initiateUri = request.getUriInfo().getBaseUri().resolve(getInitiateUri(authId));
         URI tokenUri = request.getUriInfo().getBaseUri().resolve(getTokenUri(authId));
-        return new AuthenticationException(message, format("Bearer x_redirect_server=\"%s\", x_token_server=\"%s\"", initiateUri, tokenUri));
+        return new AuthenticationException(message, format("Bearer x_redirect_server=\"%s\", x_token_server=\"%s\", x_token_endpoint=\"%s\", scope=\"%s\"", initiateUri, tokenUri, serverConfigProvider.get().tokenUrl(), scopes));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscovery.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscovery.java
@@ -16,6 +16,8 @@ package io.trino.server.security.oauth2;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.inject.Inject;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
@@ -58,6 +60,7 @@ public class OidcDiscovery
     private final Optional<String> jwksUrl;
     private final Optional<String> userinfoUrl;
     private final NimbusHttpClient httpClient;
+    private final Supplier<OAuth2ServerConfig> configCache;
 
     @Inject
     public OidcDiscovery(OAuth2Config oauthConfig, OidcDiscoveryConfig oidcConfig, NimbusHttpClient httpClient)
@@ -71,10 +74,16 @@ public class OidcDiscovery
         jwksUrl = requireNonNull(oidcConfig.getJwksUrl(), "jwksUrl is null");
         userinfoUrl = requireNonNull(oidcConfig.getUserinfoUrl(), "userinfoUrl is null");
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.configCache = Suppliers.memoize(this::discover);
     }
 
     @Override
     public OAuth2ServerConfig get()
+    {
+        return configCache.get();
+    }
+
+    private OAuth2ServerConfig discover()
     {
         return Failsafe.with(RetryPolicy.builder()
                         .withMaxAttempts(-1)

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -75,6 +75,7 @@ import java.nio.file.Path;
 import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
@@ -753,7 +754,7 @@ public class TestResourceSecurity
                     .isEqualTo(SC_UNAUTHORIZED);
             String authenticateHeader = response.header(WWW_AUTHENTICATE);
             assertThat(authenticateHeader).isNotNull();
-            Pattern oauth2BearerPattern = Pattern.compile("Bearer x_redirect_server=\"(https://127.0.0.1:[0-9]+/oauth2/token/initiate/.+)\", x_token_server=\"(https://127.0.0.1:[0-9]+/oauth2/token/.+)\"");
+            Pattern oauth2BearerPattern = Pattern.compile("Bearer x_redirect_server=\"(https://127.0.0.1:[0-9]+/oauth2/token/initiate/[^\"]+)\", x_token_server=\"(https://127.0.0.1:[0-9]+/oauth2/token/[^\"]+)\", x_token_endpoint=\"[^\"]+\", scope=\"[^\"]+\"");
             Matcher matcher = oauth2BearerPattern.matcher(authenticateHeader);
             assertThat(matcher.matches())
                     .describedAs(format("Invalid authentication header.\nExpected: %s\nPattern: %s", authenticateHeader, oauth2BearerPattern))
@@ -853,6 +854,149 @@ public class TestResourceSecurity
                 assertThat(response.code()).isEqualTo(SC_OK);
                 assertThat(response.header("user")).isEqualTo(TEST_USER);
                 assertThat(response.header("principal")).isEqualTo(TEST_USER);
+            }
+        }
+    }
+
+    @Test
+    public void testOAuth2AuthenticatorChallengeWithMultipleScopes()
+            throws Exception
+    {
+        try (TokenServer tokenServer = new TokenServer(Optional.empty());
+                TestingTrinoServer server = TestingTrinoServer.builder()
+                        .setProperties(ImmutableMap.<String, String>builder()
+                                .putAll(SECURE_PROPERTIES)
+                                .put("http-server.authentication.type", "oauth2")
+                                .putAll(getOAuth2Properties(tokenServer))
+                                .put("http-server.authentication.oauth2.scopes", "openid,profile,email")
+                                .buildOrThrow())
+                        .setAdditionalModule(oauth2Module(tokenServer))
+                        .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
+                        .build()) {
+            URI baseUri = server.getInstance(Key.get(HttpServerInfo.class)).getHttpsUri();
+            try (Response response = client.newCall(new Request.Builder()
+                            .url(getAuthorizedUserLocation(baseUri))
+                            .build())
+                    .execute()) {
+                assertThat(response.code()).isEqualTo(SC_UNAUTHORIZED);
+                // RFC 6750: scopes are space-separated within a single scope parameter
+                String challenge = response.header(WWW_AUTHENTICATE);
+                assertThat(challenge).containsPattern("scope=\"[^\"]*openid[^\"]*\"");
+                assertThat(challenge).containsPattern("scope=\"[^\"]*profile[^\"]*\"");
+                assertThat(challenge).containsPattern("scope=\"[^\"]*email[^\"]*\"");
+            }
+        }
+    }
+
+    @Test
+    public void testOAuth2AuthenticatorExpiredTokenReturns401()
+            throws Exception
+    {
+        try (TokenServer tokenServer = new TokenServer(Optional.empty());
+                TestingTrinoServer server = TestingTrinoServer.builder()
+                        .setProperties(ImmutableMap.<String, String>builder()
+                                .putAll(SECURE_PROPERTIES)
+                                .put("http-server.authentication.type", "oauth2")
+                                .putAll(getOAuth2Properties(tokenServer))
+                                .put("http-server.authentication.oauth2.refresh-tokens", "true")
+                                .buildOrThrow())
+                        .setAdditionalModule(oauth2Module(tokenServer))
+                        .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
+                        .build()) {
+            URI baseUri = server.getInstance(Key.get(HttpServerInfo.class)).getHttpsUri();
+            TokenPairSerializer serializer = server.getInstance(Key.get(TokenPairSerializer.class));
+
+            String expiredToken = serializer.serialize(
+                    TokenPair.withAccessAndRefreshTokens(tokenServer.getAccessToken(), Date.from(Instant.EPOCH), null));
+
+            assertResponseCode(
+                    client,
+                    getAuthorizedUserLocation(baseUri),
+                    SC_UNAUTHORIZED,
+                    Headers.of(AUTHORIZATION, "Bearer " + expiredToken));
+        }
+    }
+
+    @Test
+    public void testOAuth2AuthenticatorUnrecognizedTokenReturns401()
+            throws Exception
+    {
+        try (TokenServer tokenServer = new TokenServer(Optional.empty());
+                TestingTrinoServer server = TestingTrinoServer.builder()
+                        .setProperties(ImmutableMap.<String, String>builder()
+                                .putAll(SECURE_PROPERTIES)
+                                .put("http-server.authentication.type", "oauth2")
+                                .putAll(getOAuth2Properties(tokenServer))
+                                .buildOrThrow())
+                        .setAdditionalModule(oauth2Module(tokenServer))
+                        .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
+                        .build()) {
+            URI baseUri = server.getInstance(Key.get(HttpServerInfo.class)).getHttpsUri();
+
+            assertResponseCode(
+                    client,
+                    getAuthorizedUserLocation(baseUri),
+                    SC_UNAUTHORIZED,
+                    Headers.of(AUTHORIZATION, "Bearer not-a-valid-jwt-token"));
+        }
+    }
+
+    @Test
+    public void testOAuth2AuthenticatorMissingPrincipalFieldReturns401()
+            throws Exception
+    {
+        try (TokenServer tokenServer = new TokenServer(Optional.empty());
+                TestingTrinoServer server = TestingTrinoServer.builder()
+                        .setProperties(ImmutableMap.<String, String>builder()
+                                .putAll(SECURE_PROPERTIES)
+                                .put("http-server.authentication.type", "oauth2")
+                                .putAll(getOAuth2Properties(tokenServer))
+                                .buildOrThrow())
+                        .setAdditionalModule(oauth2Module(tokenServer))
+                        .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
+                        .build()) {
+            URI baseUri = server.getInstance(Key.get(HttpServerInfo.class)).getHttpsUri();
+
+            assertResponseCode(
+                    client,
+                    getAuthorizedUserLocation(baseUri),
+                    SC_UNAUTHORIZED,
+                    Headers.of(AUTHORIZATION, "Bearer " + tokenServer.issueTokenWithoutSubject()));
+        }
+    }
+
+    @Test
+    public void testOAuth2AuthenticatorWithRefreshableTokenChallengeContainsOnlyTokenServer()
+            throws Exception
+    {
+        try (TokenServer tokenServer = new TokenServer(Optional.empty(), true);
+                TestingTrinoServer server = TestingTrinoServer.builder()
+                        .setProperties(ImmutableMap.<String, String>builder()
+                                .putAll(SECURE_PROPERTIES)
+                                .put("http-server.authentication.type", "oauth2")
+                                .putAll(getOAuth2Properties(tokenServer))
+                                .put("http-server.authentication.oauth2.refresh-tokens", "true")
+                                .buildOrThrow())
+                        .setAdditionalModule(oauth2Module(tokenServer))
+                        .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
+                        .build()) {
+            URI baseUri = server.getInstance(Key.get(HttpServerInfo.class)).getHttpsUri();
+            TokenPairSerializer serializer = server.getInstance(Key.get(TokenPairSerializer.class));
+
+            // Expired access token with a refresh token — server refreshes it and responds with x_token_server only
+            String tokenWithRefresh = serializer.serialize(
+                    TokenPair.withAccessAndRefreshTokens(tokenServer.getAccessToken(), Date.from(Instant.EPOCH), tokenServer.getRefreshToken()));
+
+            try (Response response = client.newCall(new Request.Builder()
+                            .url(getAuthorizedUserLocation(baseUri))
+                            .header(AUTHORIZATION, "Bearer " + tokenWithRefresh)
+                            .build())
+                    .execute()) {
+                assertThat(response.code()).isEqualTo(SC_UNAUTHORIZED);
+                String challenge = response.header(WWW_AUTHENTICATE);
+                assertThat(challenge).contains("x_token_server=");
+                assertThat(challenge).doesNotContain("x_redirect_server");
+                assertThat(challenge).doesNotContain("x_token_endpoint");
             }
         }
     }
@@ -1032,13 +1176,21 @@ public class TestResourceSecurity
         private final Date tokenExpiration = Date.from(ZonedDateTime.now().plusMinutes(5).toInstant());
         private final JwtParser jwtParser = newJwtParserBuilder().verifyWith(JWK_PUBLIC_KEY).build();
         private final Optional<String> principalField;
+        private final boolean supportsRefresh;
         private final TestingHttpServer jwkServer;
         private final String accessToken;
 
         public TokenServer(Optional<String> principalField)
                 throws Exception
         {
+            this(principalField, false);
+        }
+
+        public TokenServer(Optional<String> principalField, boolean supportsRefresh)
+                throws Exception
+        {
             this.principalField = requireNonNull(principalField, "principalField is null");
+            this.supportsRefresh = supportsRefresh;
             jwkServer = createTestingJwkServer();
             jwkServer.start();
             accessToken = issueAccessToken();
@@ -1083,6 +1235,9 @@ public class TestResourceSecurity
                 public Response refreshTokens(String refreshToken)
                         throws ChallengeFailedException
                 {
+                    if (supportsRefresh) {
+                        return new Response(issueAccessToken(), now().plus(5, ChronoUnit.MINUTES), Optional.empty(), Optional.empty());
+                    }
                     throw new UnsupportedOperationException("refresh tokens not supported");
                 }
 
@@ -1139,6 +1294,17 @@ public class TestResourceSecurity
                 accessToken.subject(TEST_USER);
             }
             return accessToken.compact();
+        }
+
+        public String issueTokenWithoutSubject()
+        {
+            return newJwtBuilder()
+                    .signWith(JWK_PRIVATE_KEY)
+                    .header().keyId(JWK_KEY_ID).and()
+                    .issuer(issuer)
+                    .audience().add(clientId).and()
+                    .expiration(tokenExpiration)
+                    .compact();
         }
 
         private String issueIdToken(Optional<String> nonceHash)

--- a/docs/src/main/sphinx/client/cli.md
+++ b/docs/src/main/sphinx/client/cli.md
@@ -166,6 +166,13 @@ mode:
 * - `--extra-header`
   - HTTP header to add to the authenticated HTTP requests
     (property can be used multiple times; format is key=value).
+* - `--oauth2-client-id`
+  - OAuth2 client ID for client credentials authentication.
+* - `--oauth2-client-secret`
+  - Prompt for OAuth2 client secret for client credentials authentication. You 
+    can set the `TRINO_OAUTH2_CLIENT_SECRET` environment variable with the 
+    OAuth2 client secret value to avoid the prompt. For more information, see
+    [](cli-oauth2-client-credentials-auth)
 * - `--http-proxy`
   - Configures the URL of the HTTP proxy to connect to Trino.
 * - `--history-file`
@@ -321,10 +328,6 @@ export TRINO_PASSWORD='LongSecurePassword123!@#'
 If the `TRINO_PASSWORD` environment variable is set, you are not prompted
 to provide a password to connect with the CLI.
 
-```text
-./trino https://trino.example.com --user=exampleusername --password
-```
-
 (cli-external-sso-auth)=
 ### External authentication - SSO
 
@@ -347,6 +350,32 @@ The detailed behavior is as follows:
   authentication token remains valid. Token expiration depends on the external
   authentication type configuration.
 - Expired tokens force you to log in again.
+
+(cli-oauth2-client-credentials-auth)=
+### OAuth2 client credentials authentication
+
+OAuth2 client credentials authentication is used for non-interactive
+(machine-to-machine) authentication using the OAuth2 client credentials flow,
+as detailed in {doc}`/security/oauth2`. Unlike browser-based SSO, the client
+authenticates directly with a client ID and secret without user involvement.
+
+The following example connects to the server and prompts the CLI for your
+client secret:
+
+```text
+./trino https://trino.example.com --oauth2-client-id=myclientid --oauth2-client-secret
+```
+
+Alternatively, set the client secret as the value of the
+`TRINO_OAUTH2_CLIENT_SECRET` environment variable. Typically use single quotes
+to avoid problems with special characters such as `$`:
+
+```text
+export TRINO_OAUTH2_CLIENT_SECRET='MyClientSecret123!@#'
+```
+
+If the `TRINO_OAUTH2_CLIENT_SECRET` environment variable is set, you are not
+prompted to provide a client secret to connect with the CLI.
 
 (cli-certificate-auth)=
 ### Certificate authentication

--- a/docs/src/main/sphinx/client/jdbc.md
+++ b/docs/src/main/sphinx/client/jdbc.md
@@ -255,6 +255,12 @@ may not be specified using both methods.
     allowing it to be reused across separate CLI or JDBC processes. If the JDBC
     driver is used in a shared mode by different users, the first registered
     token is stored and authenticates all users.
+* - `oauth2ClientId`
+  - OAuth2 client ID for non-interactive (machine-to-machine) authentication using the client
+    credentials flow. Unlike browser-based authentication, the client authenticates directly
+    using a client ID and secret without user involvement.
+* - `oauth2ClientSecret`
+  - OAuth2 client secret for client credentials authentication.
 * - `disableCompression`
   -  Whether HTTP compression should be disabled. Defaults to `false`.
 * - `disallowLocalRedirect`

--- a/docs/src/main/sphinx/security/oauth2.md
+++ b/docs/src/main/sphinx/security/oauth2.md
@@ -1,26 +1,52 @@
 # OAuth 2.0 authentication
 
 Trino can be configured to enable OAuth 2.0 authentication over HTTPS for the
-Web UI and the JDBC driver. Trino uses the [Authorization Code](https://tools.ietf.org/html/rfc6749#section-1.3.1) flow which exchanges an
-Authorization Code for a token. At a high level, the flow includes the following
-steps:
+Web UI and the JDBC driver. Two flows are supported:
 
-1. the Trino coordinator redirects a user's browser to the Authorization Server
-2. the user authenticates with the Authorization Server, and it approves the Trino's permissions request
-3. the user's browser is redirected back to the Trino coordinator with an authorization code
-4. the Trino coordinator exchanges the authorization code for a token
+- **Authorization code flow** — browser-based, interactive authentication for end users.
+- **Client credentials flow** — non-interactive, machine-to-machine authentication.
+
+(trino-oauth2-authorization-code)=
+## Authorization code flow
+
+Trino uses the [Authorization Code](https://tools.ietf.org/html/rfc6749#section-1.3.1)
+flow which exchanges an Authorization Code for a token. At a high level, the flow
+includes the following steps:
+
+1. The Trino coordinator redirects a user's browser to the Authorization Server
+2. The user authenticates with the Authorization Server, and it approves the Trino's permissions request
+3. The user's browser is redirected back to the Trino coordinator with an authorization code
+4. The Trino coordinator exchanges the authorization code for a token
+
+(trino-oauth2-client-credentials)=
+## Client credentials flow
+
+The OAuth 2.0 [client credentials](https://tools.ietf.org/html/rfc6749#section-1.3.4)
+flow enables non-interactive (machine-to-machine) authentication. Unlike the
+authorization code flow, no browser or user interaction is required. At a high 
+level, the flow includes the following steps:
+
+1. The client sends a request to Trino without a valid access token.
+2. Trino responds with an HTTP 401 challenge containing the token endpoint URL
+   and required scopes in the `WWW-Authenticate` header.
+3. The client POSTs a `grant_type=client_credentials` request to the token
+   endpoint using its client ID and secret.
+4. The client re-sends the original request to Trino with the resulting access
+   token.
+
+## Authorization server setup
 
 To enable OAuth 2.0 authentication for Trino, configuration changes are made on
 the Trino coordinator. No changes are required to the worker configuration;
 only the communication from the clients to the coordinator is authenticated.
 
-Set the callback/redirect URL to `https://<trino-coordinator-domain-name>/oauth2/callback`,
-when configuring an OAuth 2.0 authorization server like an OpenID Connect (OIDC)
-provider.
+For the authorization code flow, configure the following URLs in the
+authorization server:
 
-If Web UI is enabled, set the post-logout callback URL to
-`https://<trino-coordinator-domain-name>/ui/logout/logout.html` when configuring
-an OAuth 2.0 authentication server like an OpenID Connect (OIDC) provider.
+- Set the callback/redirect URL to
+  `https://<trino-coordinator-domain-name>/oauth2/callback`.
+- If Web UI is enabled, set the post-logout callback URL to
+  `https://<trino-coordinator-domain-name>/ui/logout/logout.html`.
 
 Using {doc}`TLS <tls>` and {doc}`a configured shared secret
 </security/internal-communication>` is required for OAuth 2.0 authentication.


### PR DESCRIPTION
## Description

Adds OAuth2 client credentials flow to the Trino JDBC driver and CLI. This enables non-interactive, machine-to-machine authentication against a Trino cluster configured with OAuth2.

**How it works:**

1. The client sends an unauthenticated request; Trino returns a 401 with a `WWW-Authenticate: Bearer x_token_endpoint="...", scope="..."` challenge.
2. The client POSTs `grant_type=client_credentials` directly to the token endpoint — no OIDC discovery round-trip.
3. The resulting token is cached and injected into subsequent requests. Tokens are refreshed proactively using the `expires_in` field (with a 30-second buffer) and reactively on 401 responses. The scope from the challenge is cached and included in token renewal requests.

**New JDBC connection properties:**

| Property | Description |
|---|---|
| `oauth2ClientId` | OAuth2 client ID |
| `oauth2ClientSecret` | OAuth2 client secret |

**New CLI options:** `--oauth2-client-id`, `--oauth2-client-secret` (prompts for masked input, or reads `TRINO_OAUTH2_CLIENT_SECRET` env var)

## Additional context and related issues

The existing `--external-authentication` browser-redirect flow is unchanged. This adds a parallel path for headless/service clients that hold client credentials.

The server-side change (in `OAuth2Authenticator`) embeds `x_token_endpoint` and `scope` in the Bearer challenge so the client can authenticate without any pre-configuration beyond the client ID and secret.

Closes #15836

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## JDBC driver
* Add support for OAuth2 client credentials flow via `oauth2ClientId` and `oauth2ClientSecret` connection properties.

## CLI
* Add support for OAuth2 client credentials flow via `--oauth2-client-id` and `--oauth2-client-secret` options.
```