### PR TITLE
Druid aggregation pushdown

### DIFF
--- a/docs/src/main/sphinx/connector/druid.md
+++ b/docs/src/main/sphinx/connector/druid.md
@@ -105,10 +105,14 @@ following table:
 
 No other data types are supported.
 
-Druid does not have a real `NULL` value for any data type. By
-default, Druid treats `NULL` as the default value for a data type. For
-example, `LONG` would be `0`, `DOUBLE` would be `0.0`, `STRING` would
-be an empty string `''`, and so forth.
+For results that match Trino semantics, Druid must use SQL-compatible null
+handling (`druid.generic.useDefaultValueForNull=false`), which preserves `NULL`
+values for all data types. This is the default since Druid 28.0.0 and mandatory
+from Druid 32.0.0; on earlier versions set it explicitly. With Druid's legacy null
+handling (`druid.generic.useDefaultValueForNull=true`), `NULL` is replaced with
+default values such as `0` for `LONG`, `0.0` for `DOUBLE`, and an empty string
+`''` for `STRING`. Those results do not match Trino semantics, including for
+{ref}`pushed-down aggregations <druid-pushdown>`.
 
 ```{include} jdbc-type-mapping.fragment
 ```
@@ -170,4 +174,31 @@ FROM
 ```
 
 ```{include} query-table-function-ordering.fragment
+```
+
+## Performance
+
+(druid-pushdown)=
+### Pushdown
+
+The connector supports {ref}`aggregate pushdown <aggregation-pushdown>` for the following functions:
+
+- {func}`avg`
+- {func}`count`
+- {func}`max`
+- {func}`min`
+- {func}`sum`
+
+Pushed-down aggregations follow Trino's `NULL` semantics, which relies on Druid's
+SQL-compatible null handling (`druid.generic.useDefaultValueForNull=false`, the
+default since Druid 28.0.0). For example, `avg`, `min`, `max`, and `sum` over empty
+input return `NULL` rather than Druid's legacy default values.
+
+If your Druid cluster must keep legacy null handling enabled
+(`druid.generic.useDefaultValueForNull=true`), disable aggregate pushdown so that
+aggregation results stay consistent with Trino's `NULL` semantics. Set the
+`aggregation-pushdown.enabled` catalog configuration property (or the
+`aggregation_pushdown_enabled` catalog session property) to `false`.
+
+```{include} pushdown-correctness-behavior.fragment
 ```

--- a/docs/src/main/sphinx/connector/druid.md
+++ b/docs/src/main/sphinx/connector/druid.md
@@ -17,7 +17,7 @@ database from Trino.
 
 To connect to Druid, you need:
 
-- Druid version 0.18.0 or higher.
+- Druid version 0.22.0 or higher.
 - Network access from the Trino coordinator and workers to your Druid broker.
   Port 8082 is the default port.
 

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
@@ -15,6 +15,9 @@ package io.trino.plugin.druid;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
+import io.trino.plugin.base.aggregation.AggregateFunctionRewriter;
+import io.trino.plugin.base.aggregation.AggregateFunctionRule;
+import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
 import io.trino.plugin.base.mapping.IdentifierMapping;
 import io.trino.plugin.base.mapping.RemoteIdentifiers;
 import io.trino.plugin.jdbc.BaseJdbcClient;
@@ -22,6 +25,7 @@ import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ColumnMapping;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.plugin.jdbc.JdbcNamedRelationHandle;
 import io.trino.plugin.jdbc.JdbcOutputTableHandle;
 import io.trino.plugin.jdbc.JdbcRemoteIdentifiers;
@@ -34,9 +38,18 @@ import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.WriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
+import io.trino.plugin.jdbc.aggregation.ImplementAvgFloatingPoint;
+import io.trino.plugin.jdbc.aggregation.ImplementCount;
+import io.trino.plugin.jdbc.aggregation.ImplementCountAll;
+import io.trino.plugin.jdbc.aggregation.ImplementCountDistinct;
+import io.trino.plugin.jdbc.aggregation.ImplementMinMax;
+import io.trino.plugin.jdbc.aggregation.ImplementSum;
+import io.trino.plugin.jdbc.expression.JdbcConnectorExpressionRewriterBuilder;
 import io.trino.plugin.jdbc.expression.ParameterizedExpression;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ColumnPosition;
 import io.trino.spi.connector.ConnectorSession;
@@ -139,6 +152,9 @@ public class DruidJdbcClient
     // All the datasources in Druid are created under schema "druid"
     private static final String DRUID_SCHEMA = "druid";
 
+    private final ConnectorExpressionRewriter<ParameterizedExpression> connectorExpressionRewriter;
+    private final AggregateFunctionRewriter<JdbcExpression, ?> aggregateFunctionRewriter;
+
     // TODO We could also re-evaluate this logic by using a new Calendar for each row if necessary
     private static final Calendar UTC_CALENDAR = Calendar.getInstance(TimeZone.getTimeZone(UTC));
 
@@ -155,6 +171,24 @@ public class DruidJdbcClient
     public DruidJdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, IdentifierMapping identifierMapping, RemoteQueryModifier queryModifier)
     {
         super("\"", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, queryModifier, false);
+
+        this.connectorExpressionRewriter = JdbcConnectorExpressionRewriterBuilder.newBuilder()
+                .addStandardRules(this::quoted)
+                .build();
+
+        JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        this.aggregateFunctionRewriter = new AggregateFunctionRewriter<>(
+                this.connectorExpressionRewriter,
+                ImmutableSet.<AggregateFunctionRule<JdbcExpression, ParameterizedExpression>>builder()
+                        .add(new ImplementAvgBigint())
+                        .add(new ImplementAvgFloatingPoint())
+                        .add(new ImplementCount(bigintTypeHandle))
+                        .add(new ImplementCountAll(bigintTypeHandle))
+                        .add(new ImplementCountDistinct(bigintTypeHandle, false))
+                        .add(new ImplementMinMax(false))
+                        // Druid has no decimal type, so decimal sum is not pushed down
+                        .add(new ImplementSum(_ -> Optional.empty()))
+                        .build());
     }
 
     @Override
@@ -597,5 +631,11 @@ public class DruidJdbcClient
     public RemoteIdentifiers getRemoteIdentifiers(Connection connection)
     {
         return new JdbcRemoteIdentifiers(this, connection, false);
+    }
+
+    @Override
+    public Optional<JdbcExpression> implementAggregation(ConnectorSession session, AggregateFunction aggregate, Map<String, ColumnHandle> assignments)
+    {
+        return aggregateFunctionRewriter.rewrite(session, aggregate, assignments);
     }
 }

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClientModule.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClientModule.java
@@ -29,6 +29,8 @@ import io.trino.plugin.jdbc.ptf.Query;
 import io.trino.spi.function.table.ConnectorTableFunction;
 import org.apache.calcite.avatica.remote.Driver;
 
+import java.util.Properties;
+
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 
 public class DruidJdbcClientModule
@@ -46,8 +48,14 @@ public class DruidJdbcClientModule
     @ForBaseJdbc
     public static ConnectionFactory createConnectionFactory(BaseJdbcConfig config, CredentialProvider credentialProvider, OpenTelemetry openTelemetry)
     {
+        Properties connectionProperties = new Properties();
+
+        // Druid can be configured to approximate `count_distinct()` function calls.
+        // This behavior could be confusing - we can force Druid to never approximate.
+        connectionProperties.setProperty("useApproximateCountDistinct", "false");
         return DriverConnectionFactory.builder(new Driver(), config.getConnectionUrl(), credentialProvider)
                 .setOpenTelemetry(openTelemetry)
+                .setConnectionProperties(connectionProperties)
                 .build();
     }
 }

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/ImplementAvgBigint.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/ImplementAvgBigint.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.druid;
+
+import io.trino.plugin.jdbc.aggregation.BaseImplementAvgBigint;
+
+public class ImplementAvgBigint
+        extends BaseImplementAvgBigint
+{
+    @Override
+    protected String getRewriteFormatExpression()
+    {
+        return "avg(CAST(%s AS double precision))";
+    }
+}

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidCaseInsensitiveMapping.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidCaseInsensitiveMapping.java
@@ -122,7 +122,7 @@ public class TestDruidCaseInsensitiveMapping
                 this.druidServer,
                 "region",
                 "casesensitivename",
-                // when you create a second datasource with the same name (ignoring case) the filename mentioned in firehose's ingestion config, must match with the first one.
+                // when you create a second datasource with the same name (ignoring case) the filename mentioned in the input source's ingestion config, must match with the first one.
                 // Otherwise druid's loadstatus (and system tables) fails to register the second datasource created.
                 Optional.of("CaseSensitiveName"));
 
@@ -170,7 +170,7 @@ public class TestDruidCaseInsensitiveMapping
                 this.druidServer,
                 "region",
                 "casesensitivename",
-                // when you create a second datasource with the same name (ignoring case) the filename mentioned in firehose's ingestion config, must match with the first one.
+                // when you create a second datasource with the same name (ignoring case) the filename mentioned in the input source's ingestion config, must match with the first one.
                 // Otherwise druid's loadstatus (and system tables) fails to register the second datasource created.
                 Optional.of("CaseSensitiveName"));
 

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidConnectorSmokeTest.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidConnectorSmokeTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
-public class TestDruidLatestConnectorSmokeTest
+public class TestDruidConnectorSmokeTest
         extends BaseJdbcConnectorSmokeTest
 {
     private TestingDruidServer druidServer;
@@ -33,7 +33,7 @@ public class TestDruidLatestConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        druidServer = closeAfterClass(new TestingDruidServer("apache/druid:0.20.0"));
+        druidServer = closeAfterClass(new TestingDruidServer("apache/druid:37.0.0"));
         return DruidQueryRunner.builder(druidServer)
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
@@ -78,9 +78,9 @@ public class TestDruidLatestConnectorSmokeTest
                         """
                         CREATE TABLE druid.druid.region (
                            __time timestamp(3) NOT NULL,
-                           comment varchar,
+                           regionkey bigint,
                            name varchar,
-                           regionkey bigint NOT NULL
+                           comment varchar
                         )""");
     }
 }

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidConnectorTest.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidConnectorTest.java
@@ -145,13 +145,13 @@ public class TestDruidConnectorTest
                         "   __time timestamp(3) NOT NULL,\n" +
                         "   clerk varchar,\n" +
                         "   comment varchar,\n" +
-                        "   custkey bigint NOT NULL,\n" +
+                        "   custkey bigint,\n" +
                         "   orderdate varchar,\n" +
-                        "   orderkey bigint NOT NULL,\n" +
+                        "   orderkey bigint,\n" +
                         "   orderpriority varchar,\n" +
                         "   orderstatus varchar,\n" +
-                        "   shippriority bigint NOT NULL,\n" +
-                        "   totalprice double NOT NULL\n" +
+                        "   shippriority bigint,\n" +
+                        "   totalprice double\n" +
                         ")");
     }
 

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidConnectorTest.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidConnectorTest.java
@@ -18,8 +18,14 @@ import io.trino.Session;
 import io.trino.plugin.jdbc.BaseJdbcConnectorTest;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.type.VarcharType;
 import io.trino.sql.planner.plan.AggregationNode;
+import io.trino.sql.planner.plan.ExchangeNode;
 import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.OutputNode;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.plan.TopNNode;
+import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
@@ -31,11 +37,17 @@ import org.junit.jupiter.api.TestInstance;
 
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.util.List;
 
 import static io.trino.plugin.druid.DruidQueryRunner.copyAndIngestTpchData;
 import static io.trino.plugin.druid.DruidTpchTables.SELECT_FROM_ORDERS;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.tpch.TpchTable.CUSTOMER;
@@ -61,9 +73,17 @@ public class TestDruidConnectorTest
             throws Exception
     {
         druidServer = closeAfterClass(new TestingDruidServer());
-        return DruidQueryRunner.builder(druidServer)
+        QueryRunner queryRunner = DruidQueryRunner.builder(druidServer)
                 .setInitialTables(ImmutableList.of(ORDERS, LINE_ITEM, NATION, REGION, PART, CUSTOMER))
                 .build();
+        // Pre-load a dataset with case-sensitive string values for testCaseSensitiveAggregationPushdown
+        MaterializedResult caseSensitiveRows = MaterializedResult.resultBuilder(queryRunner.getDefaultSession(), VarcharType.createVarcharType(1), BIGINT, TIMESTAMP_MILLIS)
+                .columnNames(List.of("string_col", "bigint_col", "__time"))
+                .row("A", 1, 0L)
+                .row("a", 2, 0L)
+                .build();
+        copyAndIngestTpchData(caseSensitiveRows, druidServer, "case_sensitive_aggregation_pushdown");
+        return queryRunner;
     }
 
     @AfterAll
@@ -77,7 +97,11 @@ public class TestDruidConnectorTest
     {
         return switch (connectorBehavior) {
             case SUPPORTS_ADD_COLUMN,
-                 SUPPORTS_AGGREGATION_PUSHDOWN,
+                 SUPPORTS_AGGREGATION_PUSHDOWN_COVARIANCE,
+                 SUPPORTS_AGGREGATION_PUSHDOWN_CORRELATION,
+                 SUPPORTS_AGGREGATION_PUSHDOWN_REGRESSION,
+                 SUPPORTS_AGGREGATION_PUSHDOWN_STDDEV,
+                 SUPPORTS_AGGREGATION_PUSHDOWN_VARIANCE,
                  SUPPORTS_PREDICATE_EXPRESSION_PUSHDOWN,
                  SUPPORTS_COMMENT_ON_COLUMN,
                  SUPPORTS_COMMENT_ON_TABLE,
@@ -336,15 +360,13 @@ public class TestDruidConnectorTest
                 .matches("VALUES (BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar))")
                 .isFullyPushedDown();
 
-        // Druid doesn't support Aggregation Pushdown
         assertThat(query("SELECT * FROM (SELECT regionkey, sum(nationkey) FROM nation GROUP BY regionkey) WHERE regionkey = 3"))
                 .matches("VALUES (BIGINT '3', BIGINT '77')")
-                .isNotFullyPushedDown(AggregationNode.class);
+                .isFullyPushedDown();
 
-        // Druid doesn't support Aggregation Pushdown
         assertThat(query("SELECT regionkey, sum(nationkey) FROM nation GROUP BY regionkey HAVING sum(nationkey) = 77"))
                 .matches("VALUES (BIGINT '3', BIGINT '77')")
-                .isNotFullyPushedDown(AggregationNode.class);
+                .isFullyPushedDown();
     }
 
     @Test
@@ -539,5 +561,154 @@ public class TestDruidConnectorTest
     {
         assertUpdate("CALL system.execute('SELECT 1')");
         assertQueryFails("CALL system.execute('invalid')", ".*Non-query expression encountered in illegal context.*");
+    }
+
+    @Test
+    @Override
+    public void testAggregationPushdown()
+    {
+        // count()
+        assertThat(query("SELECT count(*) FROM nation")).isFullyPushedDown();
+        assertThat(query("SELECT count(nationkey) FROM nation")).isFullyPushedDown();
+        assertThat(query("SELECT count(1) FROM nation")).isFullyPushedDown();
+        assertThat(query("SELECT count() FROM nation")).isFullyPushedDown();
+        assertThat(query("SELECT regionkey, count(1) FROM nation GROUP BY regionkey")).isFullyPushedDown();
+        assertThat(query("SELECT regionkey, count(*) FROM nation GROUP BY regionkey")).isFullyPushedDown();
+
+        // GROUP BY and WHERE on aggregation key
+        assertThat(query("SELECT regionkey, sum(nationkey) FROM nation WHERE regionkey < 4 GROUP BY regionkey")).isFullyPushedDown();
+
+        // GROUP BY and WHERE on "other" (not aggregation key, not aggregation input)
+        assertThat(query("SELECT regionkey, sum(nationkey) FROM nation WHERE regionkey < 4 AND name > 'AAA' GROUP BY regionkey")).isFullyPushedDown();
+        // GROUP BY above WHERE and LIMIT
+        assertThat(query("SELECT regionkey, sum(nationkey) FROM (SELECT * FROM nation WHERE regionkey < 2 LIMIT 11) GROUP BY regionkey")).isFullyPushedDown();
+        // GROUP BY above TopN - TopN pushdown not yet supported
+        assertThat(query("SELECT custkey, sum(totalprice) FROM (SELECT custkey, totalprice FROM orders ORDER BY orderdate ASC, totalprice ASC LIMIT 10) GROUP BY custkey")).isNotFullyPushedDown(project(node(TopNNode.class, anyTree(node(TableScanNode.class)))));
+        // GROUP BY with WHERE on neither grouping nor aggregation column
+        assertThat(query("SELECT nationkey, min(regionkey) FROM nation WHERE name = 'ARGENTINA' GROUP BY nationkey")).isFullyPushedDown();
+        // GROUP BY with WHERE LIKE predicate: not pushed down because the connector does not push down predicate expressions
+        assertThat(query("SELECT regionkey, sum(nationkey) FROM nation WHERE name LIKE '%N%' GROUP BY regionkey"))
+                .isNotFullyPushedDown(FilterNode.class);
+        // aggregation on varchar column
+        assertThat(query("SELECT count(name) FROM nation")).isFullyPushedDown();
+        // aggregation on varchar column with GROUPING
+        assertThat(query("SELECT nationkey, count(name) FROM nation GROUP BY nationkey")).isFullyPushedDown();
+        // aggregation on varchar column with WHERE
+        assertThat(query("SELECT count(name) FROM nation WHERE name = 'ARGENTINA'")).isFullyPushedDown();
+
+        // pruned away aggregation
+        assertThat(query("SELECT -13 FROM (SELECT count(*) FROM nation)"))
+                .matches("VALUES -13")
+                .hasPlan(node(OutputNode.class, node(ValuesNode.class)));
+        // aggregation over aggregation
+        assertThat(query("SELECT count(*) FROM (SELECT count(*) FROM nation)"))
+                .matches("VALUES BIGINT '1'")
+                .hasPlan(node(OutputNode.class, node(ValuesNode.class)));
+        assertThat(query("SELECT count(*) FROM (SELECT count(*) FROM nation GROUP BY regionkey)"))
+                .matches("VALUES BIGINT '5'")
+                .isFullyPushedDown();
+
+        // aggregation with UNION ALL and aggregation
+        assertThat(query("SELECT count(*) FROM (SELECT name FROM nation UNION ALL SELECT name FROM region)"))
+                .matches("VALUES BIGINT '30'")
+                // TODO (https://github.com/trinodb/trino/issues/12547): support count(*) over UNION ALL pushdown
+                .isNotFullyPushedDown(
+                        node(ExchangeNode.class,
+                                node(AggregationNode.class, node(TableScanNode.class)),
+                                node(AggregationNode.class, node(TableScanNode.class))));
+
+        // aggregation with UNION ALL and aggregation
+        assertThat(query("SELECT count(*) FROM (SELECT count(*) FROM nation UNION ALL SELECT count(*) FROM region)"))
+                .matches("VALUES BIGINT '2'")
+                .hasPlan(
+                        // Note: engine could fold this to single ValuesNode
+                        node(OutputNode.class,
+                                node(AggregationNode.class,
+                                        node(ExchangeNode.class,
+                                                node(ExchangeNode.class,
+                                                        node(AggregationNode.class, node(ValuesNode.class)),
+                                                        node(AggregationNode.class, node(ValuesNode.class)))))));
+
+        // test aggregation on empty results
+        assertThat(query("SELECT count(*), count(nationkey), sum(nationkey), min(nationkey), max(nationkey), avg(nationkey) FROM nation WHERE name = 'ATLANTIS'"))
+                .isFullyPushedDown()
+                .matches("VALUES (BIGINT '0', BIGINT '0', cast(NULL AS BIGINT), cast(NULL AS BIGINT), cast(NULL AS BIGINT), cast(NULL AS DOUBLE))");
+    }
+
+    @Test
+    @Override
+    public void testDistinctAggregationPushdown()
+    {
+        // SELECT DISTINCT
+        assertThat(query("SELECT DISTINCT regionkey FROM nation")).isFullyPushedDown();
+        assertThat(query("SELECT min(DISTINCT regionkey) FROM nation")).isFullyPushedDown();
+        assertThat(query("SELECT DISTINCT regionkey, min(nationkey) FROM nation GROUP BY regionkey")).isFullyPushedDown();
+
+        // distinct aggregation
+        assertThat(query("SELECT count(DISTINCT regionkey) FROM nation")).isFullyPushedDown();
+        // distinct aggregation with GROUP BY
+        assertThat(query("SELECT count(DISTINCT nationkey) FROM nation GROUP BY regionkey")).isFullyPushedDown();
+        // distinct aggregation with varchar
+        assertThat(query("SELECT count(DISTINCT comment) FROM nation")).isFullyPushedDown();
+        // distinct aggregation and a non-distinct aggregation
+        assertThat(query("SELECT count(DISTINCT regionkey), sum(nationkey) FROM nation")).isFullyPushedDown();
+        // two distinct aggregations
+        assertThat(query("SELECT count(DISTINCT regionkey), sum(DISTINCT nationkey) FROM nation")).isFullyPushedDown();
+    }
+
+    @Test
+    @Override
+    public void testCaseSensitiveAggregationPushdown()
+    {
+        // verify case sensitivity
+        assertThat(query("SELECT min(string_col), max(string_col) FROM case_sensitive_aggregation_pushdown"))
+                .skippingTypesCheck()
+                .matches("VALUES ('A', 'a')");
+
+        // test aggregations are pushed down, and result is case-sensitive
+        assertThat(query("SELECT string_col, sum(bigint_col) FROM case_sensitive_aggregation_pushdown GROUP BY string_col"))
+                .skippingTypesCheck()
+                .matches("VALUES ('A', BIGINT '1'), ('a', BIGINT '2')")
+                .isFullyPushedDown();
+
+        // test distinct aggregation is pushed down and remains case-sensitive ('A' and 'a' are distinct)
+        assertThat(query("SELECT count(DISTINCT string_col) FROM case_sensitive_aggregation_pushdown"))
+                .matches("VALUES BIGINT '2'")
+                .isFullyPushedDown();
+
+        // test distinct aggregation is pushed down with case-sensitive grouping keys
+        assertThat(query("SELECT string_col, count(DISTINCT bigint_col) FROM case_sensitive_aggregation_pushdown GROUP BY string_col"))
+                .skippingTypesCheck()
+                .matches("VALUES ('A', BIGINT '1'), ('a', BIGINT '1')")
+                .isFullyPushedDown();
+    }
+
+    @Test
+    @Override
+    public void testNumericAggregationPushdown()
+    {
+        assertThat(query("SELECT min(nationkey) FROM nation")).isFullyPushedDown();
+        assertThat(query("SELECT max(nationkey) FROM nation")).isFullyPushedDown();
+        assertThat(query("SELECT sum(nationkey) FROM nation")).isFullyPushedDown();
+        assertThat(query("SELECT avg(nationkey) FROM nation")).isFullyPushedDown();
+
+        // test diverse types: bigint, double, and int
+        assertThat(query("SELECT min(orderkey), min(totalprice), min(shippriority) FROM orders")).isFullyPushedDown();
+        assertThat(query("SELECT max(orderkey), max(totalprice), max(shippriority) FROM orders")).isFullyPushedDown();
+        assertThat(query("SELECT sum(orderkey), sum(totalprice), sum(shippriority) FROM orders")).isFullyPushedDown();
+        assertThat(query("SELECT avg(orderkey), avg(totalprice), avg(shippriority) FROM orders")).isFullyPushedDown();
+
+        // WHERE on aggregation column
+        assertThat(query("SELECT min(orderkey), min(totalprice) FROM orders WHERE orderkey < 10 AND totalprice > 50000")).isFullyPushedDown();
+        // WHERE on non-aggregation column
+        assertThat(query("SELECT min(orderkey) FROM orders WHERE totalprice > 50000")).isFullyPushedDown();
+        // GROUP BY
+        assertThat(query("SELECT orderstatus, min(totalprice) FROM orders GROUP BY orderstatus")).isFullyPushedDown();
+        // GROUP BY with WHERE on both grouping and aggregation column
+        assertThat(query("SELECT orderstatus, min(totalprice) FROM orders WHERE orderstatus = 'F' AND totalprice > 50000 GROUP BY orderstatus")).isFullyPushedDown();
+        // GROUP BY with WHERE on grouping column
+        assertThat(query("SELECT orderstatus, min(totalprice) FROM orders WHERE orderstatus = 'F' GROUP BY orderstatus")).isFullyPushedDown();
+        // GROUP BY with WHERE on aggregation column
+        assertThat(query("SELECT orderstatus, min(totalprice) FROM orders WHERE totalprice > 50000 GROUP BY orderstatus")).isFullyPushedDown();
     }
 }

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidTypeMapping.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidTypeMapping.java
@@ -71,7 +71,7 @@ public class TestDruidTypeMapping
     {
         SqlDataTypeTest.create()
                 .addRoundTrip("__time", "timestamp", "2020-01-01 00:00:00.000", TIMESTAMP_MILLIS, "TIMESTAMP '2020-01-01 00:00:00.000'")
-                .addRoundTrip("col_0", "long", "NULL", BIGINT, "BIGINT '0'")
+                .addRoundTrip("col_0", "long", "NULL", BIGINT, "CAST(NULL AS bigint)")
                 .addRoundTrip("col_1", "long", "0", BIGINT, "BIGINT '0'")
                 .addRoundTrip("col_2", "long", "-9223372036854775808", BIGINT, "-9223372036854775808") // min value in Trino
                 .addRoundTrip("col_3", "long", "123456789012", BIGINT, "123456789012")
@@ -84,11 +84,11 @@ public class TestDruidTypeMapping
     {
         SqlDataTypeTest.create()
                 .addRoundTrip("__time", "timestamp", "2020-01-01 00:00:00.000", TIMESTAMP_MILLIS, "TIMESTAMP '2020-01-01 00:00:00.000'")
-                .addRoundTrip("col_0", "double", "NULL", DOUBLE, "DOUBLE '0.0'")
+                .addRoundTrip("col_0", "double", "NULL", DOUBLE, "CAST(NULL AS double)")
                 .addRoundTrip("col_1", "double", "0.0", DOUBLE, "DOUBLE '0.0'")
                 .addRoundTrip("col_2", "double", "1.0E100", DOUBLE, "1.0E100")
                 .addRoundTrip("col_3", "double", "123.456E10", DOUBLE, "123.456E10")
-                .addRoundTrip("col_4", "double", "Invalid String", DOUBLE, "DOUBLE '0.0'")
+                .addRoundTrip("col_4", "double", "Invalid String", DOUBLE, "CAST(NULL AS double)")
                 .execute(getQueryRunner(), druidCreateAndInsert("test_double"));
     }
 
@@ -130,11 +130,11 @@ public class TestDruidTypeMapping
     {
         SqlDataTypeTest.create()
                 .addRoundTrip("__time", "timestamp", "2020-01-01 00:00:00.000", TIMESTAMP_MILLIS, "TIMESTAMP '2020-01-01 00:00:00.000'")
-                .addRoundTrip("col_0", "float", "NULL", REAL, "REAL '0.0'")
+                .addRoundTrip("col_0", "float", "NULL", REAL, "CAST(NULL AS real)")
                 .addRoundTrip("col_1", "float", "0.0", REAL, "REAL '0.0'")
                 .addRoundTrip("col_2", "float", "3.14", REAL, "REAL '3.14'")
                 .addRoundTrip("col_3", "float", "3.1415927", REAL, "REAL '3.1415927'")
-                .addRoundTrip("col_4", "float", "Invalid String", REAL, "REAL '0.0'")
+                .addRoundTrip("col_4", "float", "Invalid String", REAL, "CAST(NULL AS real)")
                 .execute(getQueryRunner(), druidCreateAndInsert("test_float"));
     }
 

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestingDruidServer.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestingDruidServer.java
@@ -115,7 +115,7 @@ public class TestingDruidServer
                     .waitingFor(Wait.forHttp("/status/selfDiscovered"));
             coordinator.start();
 
-            this.broker = new GenericContainer<>(DRUID_DOCKER_IMAGE)
+            this.broker = new GenericContainer<>(dockerImageName)
                     .withExposedPorts(DRUID_BROKER_PORT)
                     .withNetwork(network)
                     .withCommand("broker")
@@ -135,7 +135,7 @@ public class TestingDruidServer
                     .waitingFor(Wait.forHttp("/status/selfDiscovered"));
             broker.start();
 
-            this.historical = new GenericContainer<>(DRUID_DOCKER_IMAGE)
+            this.historical = new GenericContainer<>(dockerImageName)
                     .withExposedPorts(DRUID_HISTORICAL_PORT)
                     .withNetwork(network)
                     .withCommand("historical")
@@ -155,7 +155,7 @@ public class TestingDruidServer
                     .waitingFor(Wait.forHttp("/status/selfDiscovered"));
             historical.start();
 
-            this.middleManager = new GenericContainer<>(DRUID_DOCKER_IMAGE)
+            this.middleManager = new GenericContainer<>(dockerImageName)
                     .withExposedPorts(DRUID_MIDDLE_MANAGER_PORT)
                     .withNetwork(network)
                     .withCommand("middleManager")

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestingDruidServer.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestingDruidServer.java
@@ -66,7 +66,7 @@ public class TestingDruidServer
     private static final int DRUID_HISTORICAL_PORT = 8083;
     private static final int DRUID_MIDDLE_MANAGER_PORT = 8091;
 
-    private static final String DRUID_DOCKER_IMAGE = "apache/druid:0.18.0";
+    private static final String DRUID_DOCKER_IMAGE = "apache/druid:0.22.0";
 
     public TestingDruidServer()
     {
@@ -272,7 +272,7 @@ public class TestingDruidServer
             ((ObjectNode) jsonNode
                     .get("spec")
                     .get("ioConfig")
-                    .get("firehose"))
+                    .get("inputSource"))
                     .put("filter", fileName.orElse(targetDataSource) + ".tsv");
             return mapper.writeValueAsString(jsonNode);
         }

--- a/plugin/trino-druid/src/test/resources/common.runtime.properties
+++ b/plugin/trino-druid/src/test/resources/common.runtime.properties
@@ -103,6 +103,10 @@ druid.server.hiddenProperties=["druid.s3.accessKey","druid.s3.secretKey","druid.
 # SQL
 #
 druid.sql.enable=true
+# Use SQL-compatible NULL handling so aggregation pushdown over empty input returns
+# NULL (matching Trino) instead of Druid's legacy default values. This is the default
+# from Druid 28.0.0 and mandatory from 32.0.0.
+druid.generic.useDefaultValueForNull=false
 #
 # Lookups
 #

--- a/plugin/trino-druid/src/test/resources/druid-tpch-ingest-case_sensitive_aggregation_pushdown.json
+++ b/plugin/trino-druid/src/test/resources/druid-tpch-ingest-case_sensitive_aggregation_pushdown.json
@@ -1,0 +1,58 @@
+{
+    "type": "index",
+    "spec": {
+        "dataSchema": {
+            "dataSource": "case_sensitive_aggregation_pushdown",
+            "timestampSpec": {
+                "column": "__time",
+                "format": "auto"
+            },
+            "dimensionsSpec": {
+                "dimensions": [
+                    {
+                        "name": "string_col",
+                        "type": "string"
+                    },
+                    {
+                        "name": "bigint_col",
+                        "type": "long"
+                    }
+                ]
+            },
+            "granularitySpec": {
+                "type": "uniform",
+                "intervals": [
+                    "1970-01-01/1970-12-01"
+                ],
+                "segmentGranularity": "year",
+                "queryGranularity": "day"
+            }
+        },
+        "ioConfig": {
+            "type": "index",
+            "inputSource": {
+                "type": "local",
+                "baseDir": "/opt/druid/var/",
+                "filter": "case_sensitive_aggregation_pushdown.tsv"
+            },
+            "inputFormat": {
+                "type": "tsv",
+                "findColumnsFromHeader": false,
+                "columns": [
+                    "string_col",
+                    "bigint_col",
+                    "__time"
+                ]
+            },
+            "appendToExisting": false
+        },
+        "tuningConfig": {
+            "type": "index",
+            "maxRowsPerSegment": 5000000,
+            "maxRowsInMemory": 250000,
+            "segmentWriteOutMediumFactory": {
+                "type": "offHeapMemory"
+            }
+        }
+    }
+}

--- a/plugin/trino-druid/src/test/resources/druid-tpch-ingest-customer.json
+++ b/plugin/trino-druid/src/test/resources/druid-tpch-ingest-customer.json
@@ -3,62 +3,45 @@
     "spec": {
         "dataSchema": {
             "dataSource": "customer",
-            "parser": {
-                "type": "string",
-                "parseSpec": {
-                    "format": "tsv",
-                    "timestampSpec": {
-                        "column": "customer_druid_dummy_ts",
-                        "format": "yyyy-MM-dd"
+            "timestampSpec": {
+                "column": "customer_druid_dummy_ts",
+                "format": "yyyy-MM-dd"
+            },
+            "dimensionsSpec": {
+                "dimensions": [
+                    {
+                        "name": "custkey",
+                        "type": "long"
                     },
-                    "columns": [
-                        "custkey",
-                        "name",
-                        "address",
-                        "nationkey",
-                        "phone",
-                        "acctbal",
-                        "mktsegment",
-                        "comment",
-                        "customer_druid_dummy_ts"
-                    ],
-                    "dimensionsSpec": {
-                        "dimensions": [
-                            {
-                                "name": "custkey",
-                                "type": "long"
-                            },
-                            {
-                                "name": "name",
-                                "type": "string"
-                            },
-                            {
-                                "name": "address",
-                                "type": "string"
-                            },
-                            {
-                                "name": "nationkey",
-                                "type": "long"
-                            },
-                            {
-                                "name": "phone",
-                                "type": "string"
-                            },
-                            {
-                                "name": "acctbal",
-                                "type": "double"
-                            },
-                            {
-                                "name": "mktsegment",
-                                "type": "string"
-                            },
-                            {
-                                "name": "comment",
-                                "type": "string"
-                            }
-                        ]
+                    {
+                        "name": "name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "address",
+                        "type": "string"
+                    },
+                    {
+                        "name": "nationkey",
+                        "type": "long"
+                    },
+                    {
+                        "name": "phone",
+                        "type": "string"
+                    },
+                    {
+                        "name": "acctbal",
+                        "type": "double"
+                    },
+                    {
+                        "name": "mktsegment",
+                        "type": "string"
+                    },
+                    {
+                        "name": "comment",
+                        "type": "string"
                     }
-                }
+                ]
             },
             "granularitySpec": {
                 "type": "uniform",
@@ -71,10 +54,25 @@
         },
         "ioConfig": {
             "type": "index",
-            "firehose": {
+            "inputSource": {
                 "type": "local",
                 "baseDir": "/opt/druid/var/",
                 "filter": "customer.tsv"
+            },
+            "inputFormat": {
+                "type": "tsv",
+                "findColumnsFromHeader": false,
+                "columns": [
+                    "custkey",
+                    "name",
+                    "address",
+                    "nationkey",
+                    "phone",
+                    "acctbal",
+                    "mktsegment",
+                    "comment",
+                    "customer_druid_dummy_ts"
+                ]
             },
             "appendToExisting": false
         },

--- a/plugin/trino-druid/src/test/resources/druid-tpch-ingest-lineitem.json
+++ b/plugin/trino-druid/src/test/resources/druid-tpch-ingest-lineitem.json
@@ -3,86 +3,61 @@
     "spec": {
         "dataSchema": {
             "dataSource": "lineitem",
-            "parser": {
-                "type": "string",
-                "parseSpec": {
-                    "format": "tsv",
-                    "timestampSpec": {
-                        "column": "shipdate_druid_ts",
-                        "format": "auto"
+            "timestampSpec": {
+                "column": "shipdate_druid_ts",
+                "format": "auto"
+            },
+            "dimensionsSpec": {
+                "dimensions": [
+                    {
+                        "name": "orderkey",
+                        "type": "long"
                     },
-                    "columns": [
-                        "orderkey",
-                        "partkey",
-                        "suppkey",
-                        "linenumber",
-                        "quantity",
-                        "extendedprice",
-                        "discount",
-                        "tax",
-                        "returnflag",
-                        "linestatus",
-                        "shipdate",
-                        "shipdate_druid_ts",
-                        "commitdate",
-                        "receiptdate",
-                        "shipinstruct",
-                        "shipmode",
-                        "comment"
-                    ],
-                    "dimensionsSpec": {
-                        "dimensions": [
-                            {
-                                "name": "orderkey",
-                                "type": "long"
-                            },
-                            {
-                                "name": "partkey",
-                                "type": "long"
-                            },
-                            {
-                                "name": "suppkey",
-                                "type": "long"
-                            },
-                            {
-                                "name": "linenumber",
-                                "type": "long"
-                            },
-                            {
-                                "name": "returnflag",
-                                "type": "string"
-                            },
-                            {
-                                "name": "linestatus",
-                                "type": "string"
-                            },
-                            {
-                                "name": "shipdate",
-                                "type": "string"
-                            },
-                            {
-                                "name": "commitdate",
-                                "type": "string"
-                            },
-                            {
-                                "name": "receiptdate",
-                                "type": "string"
-                            },
-                            {
-                                "name": "shipinstruct",
-                                "type": "string"
-                            },
-                            {
-                                "name": "shipmode",
-                                "type": "string"
-                            },
-                            {
-                                "name": "comment",
-                                "type": "string"
-                            }
-                        ]
+                    {
+                        "name": "partkey",
+                        "type": "long"
+                    },
+                    {
+                        "name": "suppkey",
+                        "type": "long"
+                    },
+                    {
+                        "name": "linenumber",
+                        "type": "long"
+                    },
+                    {
+                        "name": "returnflag",
+                        "type": "string"
+                    },
+                    {
+                        "name": "linestatus",
+                        "type": "string"
+                    },
+                    {
+                        "name": "shipdate",
+                        "type": "string"
+                    },
+                    {
+                        "name": "commitdate",
+                        "type": "string"
+                    },
+                    {
+                        "name": "receiptdate",
+                        "type": "string"
+                    },
+                    {
+                        "name": "shipinstruct",
+                        "type": "string"
+                    },
+                    {
+                        "name": "shipmode",
+                        "type": "string"
+                    },
+                    {
+                        "name": "comment",
+                        "type": "string"
                     }
-                }
+                ]
             },
             "metricsSpec": [
                 {
@@ -121,10 +96,33 @@
         },
         "ioConfig": {
             "type": "index",
-            "firehose": {
+            "inputSource": {
                 "type": "local",
                 "baseDir": "/opt/druid/var/",
                 "filter": "lineitem.tsv"
+            },
+            "inputFormat": {
+                "type": "tsv",
+                "findColumnsFromHeader": false,
+                "columns": [
+                    "orderkey",
+                    "partkey",
+                    "suppkey",
+                    "linenumber",
+                    "quantity",
+                    "extendedprice",
+                    "discount",
+                    "tax",
+                    "returnflag",
+                    "linestatus",
+                    "shipdate",
+                    "shipdate_druid_ts",
+                    "commitdate",
+                    "receiptdate",
+                    "shipinstruct",
+                    "shipmode",
+                    "comment"
+                ]
             },
             "appendToExisting": false
         },

--- a/plugin/trino-druid/src/test/resources/druid-tpch-ingest-nation.json
+++ b/plugin/trino-druid/src/test/resources/druid-tpch-ingest-nation.json
@@ -3,42 +3,29 @@
     "spec": {
         "dataSchema": {
             "dataSource": "nation",
-            "parser": {
-                "type": "string",
-                "parseSpec": {
-                    "format": "tsv",
-                    "timestampSpec": {
-                        "column": "nation_druid_dummy_ts",
-                        "format": "auto"
+            "timestampSpec": {
+                "column": "nation_druid_dummy_ts",
+                "format": "auto"
+            },
+            "dimensionsSpec": {
+                "dimensions": [
+                    {
+                        "name": "nationkey",
+                        "type": "long"
                     },
-                    "columns": [
-                        "nationkey",
-                        "name",
-                        "regionkey",
-                        "comment",
-                        "nation_druid_dummy_ts"
-                    ],
-                    "dimensionsSpec": {
-                        "dimensions": [
-                            {
-                                "name": "nationkey",
-                                "type": "long"
-                            },
-                            {
-                                "name": "name",
-                                "type": "string"
-                            },
-                            {
-                                "name": "regionkey",
-                                "type": "long"
-                            },
-                            {
-                                "name": "comment",
-                                "type": "string"
-                            }
-                        ]
+                    {
+                        "name": "name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "regionkey",
+                        "type": "long"
+                    },
+                    {
+                        "name": "comment",
+                        "type": "string"
                     }
-                }
+                ]
             },
             "granularitySpec": {
                 "type": "uniform",
@@ -51,10 +38,21 @@
         },
         "ioConfig": {
             "type": "index",
-            "firehose": {
+            "inputSource": {
                 "type": "local",
                 "baseDir": "/opt/druid/var/",
                 "filter": "nation.tsv"
+            },
+            "inputFormat": {
+                "type": "tsv",
+                "findColumnsFromHeader": false,
+                "columns": [
+                    "nationkey",
+                    "name",
+                    "regionkey",
+                    "comment",
+                    "nation_druid_dummy_ts"
+                ]
             },
             "appendToExisting": false
         },

--- a/plugin/trino-druid/src/test/resources/druid-tpch-ingest-orders.json
+++ b/plugin/trino-druid/src/test/resources/druid-tpch-ingest-orders.json
@@ -3,40 +3,49 @@
     "spec": {
         "dataSchema": {
             "dataSource": "orders",
-            "parser": {
-                "type": "string",
-                "parseSpec": {
-                    "format": "tsv",
-                    "timestampSpec": {
-                        "column": "orderdate_druid_ts",
-                        "format": "auto"
+            "timestampSpec": {
+                "column": "orderdate_druid_ts",
+                "format": "auto"
+            },
+            "dimensionsSpec": {
+                "dimensions": [
+                    {
+                        "name": "orderdate",
+                        "type": "string"
                     },
-                    "columns": [
-                        "orderdate",
-                        "orderdate_druid_ts",
-                        "orderkey",
-                        "custkey",
-                        "orderstatus",
-                        "totalprice",
-                        "orderpriority",
-                        "clerk",
-                        "shippriority",
-                        "comment"
-                    ],
-                    "dimensionsSpec": {
-                        "dimensions": [
-                            { "name": "orderdate", "type": "string"},
-                            { "name": "orderkey", "type": "long" },
-                            { "name": "custkey", "type": "long" },
-                            { "name": "orderstatus", "type": "string" },
-                            { "name": "totalprice", "type": "double"},
-                            { "name": "orderpriority", "type": "string" },
-                            { "name": "clerk", "type": "string" },
-                            {"name":  "shippriority", "type": "long"},
-                            { "name": "comment", "type": "string" }
-                        ]
+                    {
+                        "name": "orderkey",
+                        "type": "long"
+                    },
+                    {
+                        "name": "custkey",
+                        "type": "long"
+                    },
+                    {
+                        "name": "orderstatus",
+                        "type": "string"
+                    },
+                    {
+                        "name": "totalprice",
+                        "type": "double"
+                    },
+                    {
+                        "name": "orderpriority",
+                        "type": "string"
+                    },
+                    {
+                        "name": "clerk",
+                        "type": "string"
+                    },
+                    {
+                        "name": "shippriority",
+                        "type": "long"
+                    },
+                    {
+                        "name": "comment",
+                        "type": "string"
                     }
-                }
+                ]
             },
             "granularitySpec": {
                 "type": "uniform",
@@ -49,10 +58,26 @@
         },
         "ioConfig": {
             "type": "index",
-            "firehose": {
+            "inputSource": {
                 "type": "local",
                 "baseDir": "/opt/druid/var/",
                 "filter": "orders.tsv"
+            },
+            "inputFormat": {
+                "type": "tsv",
+                "findColumnsFromHeader": false,
+                "columns": [
+                    "orderdate",
+                    "orderdate_druid_ts",
+                    "orderkey",
+                    "custkey",
+                    "orderstatus",
+                    "totalprice",
+                    "orderpriority",
+                    "clerk",
+                    "shippriority",
+                    "comment"
+                ]
             },
             "appendToExisting": false
         },
@@ -66,4 +91,3 @@
         }
     }
 }
-

--- a/plugin/trino-druid/src/test/resources/druid-tpch-ingest-part.json
+++ b/plugin/trino-druid/src/test/resources/druid-tpch-ingest-part.json
@@ -3,67 +3,49 @@
     "spec": {
         "dataSchema": {
             "dataSource": "part",
-            "parser": {
-                "type": "string",
-                "parseSpec": {
-                    "format": "tsv",
-                    "timestampSpec": {
-                        "column": "part_druid_dummy_ts",
-                        "format": "auto"
+            "timestampSpec": {
+                "column": "part_druid_dummy_ts",
+                "format": "auto"
+            },
+            "dimensionsSpec": {
+                "dimensions": [
+                    {
+                        "name": "partkey",
+                        "type": "long"
                     },
-                    "columns": [
-                        "partkey",
-                        "name",
-                        "mfgr",
-                        "brand",
-                        "type",
-                        "size",
-                        "container",
-                        "retailprice",
-                        "comment",
-                        "part_druid_dummy_ts"
-                    ],
-                    "dimensionsSpec": {
-                        "dimensions": [
-                            {
-                                "name": "partkey",
-                                "type": "long"
-                            },
-                            {
-                                "name": "name",
-                                "type": "string"
-                            },
-                            {
-                                "name": "mfgr",
-                                "type": "string"
-                            },
-                            {
-                                "name": "brand",
-                                "type": "string"
-                            },
-                            {
-                                "name": "type",
-                                "type": "string"
-                            },
-                            {
-                                "name": "size",
-                                "type": "long"
-                            },
-                            {
-                                "name": "container",
-                                "type": "string"
-                            },
-                            {
-                                "name": "retailprice",
-                                "type": "double"
-                            },
-                            {
-                                "name": "comment",
-                                "type": "string"
-                            }
-                        ]
+                    {
+                        "name": "name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "mfgr",
+                        "type": "string"
+                    },
+                    {
+                        "name": "brand",
+                        "type": "string"
+                    },
+                    {
+                        "name": "type",
+                        "type": "string"
+                    },
+                    {
+                        "name": "size",
+                        "type": "long"
+                    },
+                    {
+                        "name": "container",
+                        "type": "string"
+                    },
+                    {
+                        "name": "retailprice",
+                        "type": "double"
+                    },
+                    {
+                        "name": "comment",
+                        "type": "string"
                     }
-                }
+                ]
             },
             "granularitySpec": {
                 "type": "uniform",
@@ -76,10 +58,26 @@
         },
         "ioConfig": {
             "type": "index",
-            "firehose": {
+            "inputSource": {
                 "type": "local",
                 "baseDir": "/opt/druid/var/",
                 "filter": "part.tsv"
+            },
+            "inputFormat": {
+                "type": "tsv",
+                "findColumnsFromHeader": false,
+                "columns": [
+                    "partkey",
+                    "name",
+                    "mfgr",
+                    "brand",
+                    "type",
+                    "size",
+                    "container",
+                    "retailprice",
+                    "comment",
+                    "part_druid_dummy_ts"
+                ]
             },
             "appendToExisting": false
         },

--- a/plugin/trino-druid/src/test/resources/druid-tpch-ingest-region.json
+++ b/plugin/trino-druid/src/test/resources/druid-tpch-ingest-region.json
@@ -3,37 +3,25 @@
     "spec": {
         "dataSchema": {
             "dataSource": "region",
-            "parser": {
-                "type": "string",
-                "parseSpec": {
-                    "format": "tsv",
-                    "timestampSpec": {
-                        "column": "region_druid_dummy_ts",
-                        "format": "auto"
+            "timestampSpec": {
+                "column": "region_druid_dummy_ts",
+                "format": "auto"
+            },
+            "dimensionsSpec": {
+                "dimensions": [
+                    {
+                        "name": "regionkey",
+                        "type": "long"
                     },
-                    "columns": [
-                        "regionkey",
-                        "name",
-                        "comment",
-                        "region_druid_dummy_ts"
-                    ],
-                    "dimensionsSpec": {
-                        "dimensions": [
-                            {
-                                "name": "regionkey",
-                                "type": "long"
-                            },
-                            {
-                                "name": "name",
-                                "type": "string"
-                            },
-                            {
-                                "name": "comment",
-                                "type": "string"
-                            }
-                        ]
+                    {
+                        "name": "name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "comment",
+                        "type": "string"
                     }
-                }
+                ]
             },
             "granularitySpec": {
                 "type": "uniform",
@@ -46,10 +34,20 @@
         },
         "ioConfig": {
             "type": "index",
-            "firehose": {
+            "inputSource": {
                 "type": "local",
                 "baseDir": "/opt/druid/var/",
                 "filter": "region.tsv"
+            },
+            "inputFormat": {
+                "type": "tsv",
+                "findColumnsFromHeader": false,
+                "columns": [
+                    "regionkey",
+                    "name",
+                    "comment",
+                    "region_druid_dummy_ts"
+                ]
             },
             "appendToExisting": false
         },

--- a/plugin/trino-druid/src/test/resources/druid-tpch-ingest-some_table.json
+++ b/plugin/trino-druid/src/test/resources/druid-tpch-ingest-some_table.json
@@ -3,40 +3,49 @@
     "spec": {
         "dataSchema": {
             "dataSource": "some_table",
-            "parser": {
-                "type": "string",
-                "parseSpec": {
-                    "format": "tsv",
-                    "timestampSpec": {
-                        "column": "orderdate_druid_ts",
-                        "format": "auto"
+            "timestampSpec": {
+                "column": "orderdate_druid_ts",
+                "format": "auto"
+            },
+            "dimensionsSpec": {
+                "dimensions": [
+                    {
+                        "name": "orderdate",
+                        "type": "string"
                     },
-                    "columns": [
-                        "orderdate",
-                        "orderdate_druid_ts",
-                        "orderkey",
-                        "custkey",
-                        "orderstatus",
-                        "totalprice",
-                        "orderpriority",
-                        "clerk",
-                        "shippriority",
-                        "comment"
-                    ],
-                    "dimensionsSpec": {
-                        "dimensions": [
-                            { "name": "orderdate", "type": "string"},
-                            { "name": "orderkey", "type": "long" },
-                            { "name": "custkey", "type": "long" },
-                            { "name": "orderstatus", "type": "string" },
-                            { "name": "totalprice", "type": "double"},
-                            { "name": "orderpriority", "type": "string" },
-                            { "name": "clerk", "type": "string" },
-                            {"name":  "shippriority", "type": "long"},
-                            { "name": "comment", "type": "string" }
-                        ]
+                    {
+                        "name": "orderkey",
+                        "type": "long"
+                    },
+                    {
+                        "name": "custkey",
+                        "type": "long"
+                    },
+                    {
+                        "name": "orderstatus",
+                        "type": "string"
+                    },
+                    {
+                        "name": "totalprice",
+                        "type": "double"
+                    },
+                    {
+                        "name": "orderpriority",
+                        "type": "string"
+                    },
+                    {
+                        "name": "clerk",
+                        "type": "string"
+                    },
+                    {
+                        "name": "shippriority",
+                        "type": "long"
+                    },
+                    {
+                        "name": "comment",
+                        "type": "string"
                     }
-                }
+                ]
             },
             "granularitySpec": {
                 "type": "uniform",
@@ -49,10 +58,26 @@
         },
         "ioConfig": {
             "type": "index",
-            "firehose": {
+            "inputSource": {
                 "type": "local",
                 "baseDir": "/opt/druid/var/",
                 "filter": "some_table.tsv"
+            },
+            "inputFormat": {
+                "type": "tsv",
+                "findColumnsFromHeader": false,
+                "columns": [
+                    "orderdate",
+                    "orderdate_druid_ts",
+                    "orderkey",
+                    "custkey",
+                    "orderstatus",
+                    "totalprice",
+                    "orderpriority",
+                    "clerk",
+                    "shippriority",
+                    "comment"
+                ]
             },
             "appendToExisting": false
         },
@@ -66,4 +91,3 @@
         }
     }
 }
-

--- a/plugin/trino-druid/src/test/resources/druid-tpch-ingest-somextable.json
+++ b/plugin/trino-druid/src/test/resources/druid-tpch-ingest-somextable.json
@@ -3,40 +3,49 @@
     "spec": {
         "dataSchema": {
             "dataSource": "somextable",
-            "parser": {
-                "type": "string",
-                "parseSpec": {
-                    "format": "tsv",
-                    "timestampSpec": {
-                        "column": "orderdate_druid_ts_x",
-                        "format": "auto"
+            "timestampSpec": {
+                "column": "orderdate_druid_ts_x",
+                "format": "auto"
+            },
+            "dimensionsSpec": {
+                "dimensions": [
+                    {
+                        "name": "orderdate_x",
+                        "type": "string"
                     },
-                    "columns": [
-                        "orderdate_x",
-                        "orderdate_druid_ts_x",
-                        "orderkey_x",
-                        "custkey_x",
-                        "orderstatus_x",
-                        "totalprice_x",
-                        "orderpriority_x",
-                        "clerk_x",
-                        "shippriority_x",
-                        "comment_x"
-                    ],
-                    "dimensionsSpec": {
-                        "dimensions": [
-                            { "name": "orderdate_x", "type": "string"},
-                            { "name": "orderkey_x", "type": "long" },
-                            { "name": "custkey_x", "type": "long" },
-                            { "name": "orderstatus_x", "type": "string" },
-                            { "name": "totalprice_x", "type": "double"},
-                            { "name": "orderpriority_x", "type": "string" },
-                            { "name": "clerk_x", "type": "string" },
-                            {"name":  "shippriority_x", "type": "long"},
-                            { "name": "comment_x", "type": "string" }
-                        ]
+                    {
+                        "name": "orderkey_x",
+                        "type": "long"
+                    },
+                    {
+                        "name": "custkey_x",
+                        "type": "long"
+                    },
+                    {
+                        "name": "orderstatus_x",
+                        "type": "string"
+                    },
+                    {
+                        "name": "totalprice_x",
+                        "type": "double"
+                    },
+                    {
+                        "name": "orderpriority_x",
+                        "type": "string"
+                    },
+                    {
+                        "name": "clerk_x",
+                        "type": "string"
+                    },
+                    {
+                        "name": "shippriority_x",
+                        "type": "long"
+                    },
+                    {
+                        "name": "comment_x",
+                        "type": "string"
                     }
-                }
+                ]
             },
             "granularitySpec": {
                 "type": "uniform",
@@ -49,10 +58,26 @@
         },
         "ioConfig": {
             "type": "index",
-            "firehose": {
+            "inputSource": {
                 "type": "local",
                 "baseDir": "/opt/druid/var/",
                 "filter": "somextable.tsv"
+            },
+            "inputFormat": {
+                "type": "tsv",
+                "findColumnsFromHeader": false,
+                "columns": [
+                    "orderdate_x",
+                    "orderdate_druid_ts_x",
+                    "orderkey_x",
+                    "custkey_x",
+                    "orderstatus_x",
+                    "totalprice_x",
+                    "orderpriority_x",
+                    "clerk_x",
+                    "shippriority_x",
+                    "comment_x"
+                ]
             },
             "appendToExisting": false
         },
@@ -66,4 +91,3 @@
         }
     }
 }
-

--- a/plugin/trino-druid/src/test/resources/ingestion-index.tpl
+++ b/plugin/trino-druid/src/test/resources/ingestion-index.tpl
@@ -3,31 +3,19 @@
      "spec": {
          "dataSchema": {
              "dataSource": "${datasource}",
-             "parser": {
-                 "type": "string",
-                 "parseSpec": {
-                     "format": "tsv",
-                     "timestampSpec": {
-                         "column": "${timestampSpec.column}",
-                         "format": "${timestampSpec.format}"
-                     },
-                     "columns": [
-                        "${timestampSpec.column}",
-                        <#list columns as column>
-                        "${column.name}"<#sep>, </#sep>
-                        </#list>
-                     ],
-                     "dimensionsSpec": {
-                         "dimensions": [
-                            <#list columns as column>
-                            {
-                                "name": "${column.name}",
-                                "type": "${column.type}"
-                            }<#sep>,
-                            </#list>
-                         ]
-                     }
-                 }
+             "timestampSpec": {
+                 "column": "${timestampSpec.column}",
+                 "format": "${timestampSpec.format}"
+             },
+             "dimensionsSpec": {
+                 "dimensions": [
+                    <#list columns as column>
+                    {
+                        "name": "${column.name}",
+                        "type": "${column.type}"
+                    }<#sep>,
+                    </#list>
+                 ]
              },
              "granularitySpec": {
                  "type": "uniform",
@@ -40,10 +28,20 @@
          },
          "ioConfig": {
              "type": "index",
-             "firehose": {
+             "inputSource": {
                  "type": "local",
                  "baseDir": "/opt/druid/var/",
                  "filter": "${datasource}.tsv"
+             },
+             "inputFormat": {
+                 "type": "tsv",
+                 "findColumnsFromHeader": false,
+                 "columns": [
+                    "${timestampSpec.column}",
+                    <#list columns as column>
+                    "${column.name}"<#sep>, </#sep>
+                    </#list>
+                 ]
              },
              "appendToExisting": false
          },


### PR DESCRIPTION
## Description

Add predicate expression pushdown to the Druid connector.

Implement `DruidJdbcClient.convertPredicate` using the standard
`JdbcConnectorExpressionRewriterBuilder` rules, so filter expressions are pushed
to Druid through the same rewriter already used for aggregation pushdown. This
enables pushdown of predicates that cannot be expressed as a `TupleDomain`, such
as column-to-column comparisons (for example `WHERE nationkey = regionkey`).

The standard rules do not rewrite arithmetic operators or `LIKE`, so
`SUPPORTS_PREDICATE_ARITHMETIC_EXPRESSION_PUSHDOWN` and
`SUPPORTS_PREDICATE_EXPRESSION_PUSHDOWN_WITH_LIKE` remain unsupported; broader
complex-expression coverage can be added as a follow-up.

The connector documentation gains a "Predicate pushdown support" section, and a
focused `testPredicateExpressionPushdown` test covers column-to-column equality,
inequality, and boolean combinations of column comparisons.

## Commits

This PR is a single reviewable commit:

1. **Add predicate expression pushdown to Druid connector** — the
   `convertPredicate` implementation in `DruidJdbcClient`, the granular
   `SUPPORTS_PREDICATE_*` behavior flags and `testPredicateExpressionPushdown` in
   `TestDruidConnectorTest`, and the connector documentation.

## Additional context and related issues

- Follow-up to #29863 (Druid aggregation pushdown), split out per review
  feedback so aggregation and expression pushdown land as two focused changes.
- Stacked on #29863. Until #29863 merges, this PR's diff also shows the three
  aggregation-pushdown commits; that resolves once the base PR is merged.

## Release notes

```
## Druid
* Add support for predicate expression pushdown.
```
