### PR TITLE
Validate and fix incorrect `neverFails` declarations

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
@@ -42,6 +42,7 @@ import io.trino.spi.type.TypeOperators;
 import io.trino.type.BlockTypeOperators;
 
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.List;
 
@@ -59,6 +60,21 @@ import static java.util.Objects.requireNonNull;
 
 public class FunctionManager
 {
+    private static final boolean ASSERTIONS_ENABLED = FunctionManager.class.desiredAssertionStatus();
+    private static final MethodHandle NEVER_FAILS_VIOLATED;
+
+    static {
+        try {
+            NEVER_FAILS_VIOLATED = MethodHandles.lookup().findStatic(
+                    FunctionManager.class,
+                    "neverFailsViolated",
+                    MethodType.methodType(RuntimeException.class, String.class, Throwable.class));
+        }
+        catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
     private final NonEvictableCache<FunctionKey, ScalarFunctionImplementation> specializedScalarCache;
     private final NonEvictableCache<ResolvedFunction, AggregationImplementation> specializedAggregationCache;
     private final NonEvictableCache<ResolvedFunction, WindowFunctionSupplier> specializedWindowCache;
@@ -114,7 +130,33 @@ public class FunctionManager
         }
 
         verifyMethodHandleSignature(resolvedFunction.signature(), scalarFunctionImplementation, invocationConvention);
+        if (ASSERTIONS_ENABLED && resolvedFunction.neverFails()) {
+            scalarFunctionImplementation = reportIfNeverFailsViolated(resolvedFunction, scalarFunctionImplementation);
+        }
         return scalarFunctionImplementation;
+    }
+
+    private static ScalarFunctionImplementation reportIfNeverFailsViolated(ResolvedFunction resolvedFunction, ScalarFunctionImplementation scalarFunctionImplementation)
+    {
+        MethodHandle target = scalarFunctionImplementation.getMethodHandle();
+        MethodHandle thrower = MethodHandles.throwException(target.type().returnType(), RuntimeException.class);
+        MethodHandle constructViolation = MethodHandles.insertArguments(NEVER_FAILS_VIOLATED, 0, resolvedFunction.signature().toString());
+        MethodHandle throwViolation = MethodHandles.filterArguments(thrower, 0, constructViolation);
+        MethodHandle wrapped = MethodHandles.catchException(target, Throwable.class, throwViolation);
+
+        return ScalarFunctionImplementation.builder()
+                .methodHandle(wrapped)
+                .instanceFactory(scalarFunctionImplementation.getInstanceFactory())
+                .lambdaInterfaces(scalarFunctionImplementation.getLambdaInterfaces())
+                .build();
+    }
+
+    private static RuntimeException neverFailsViolated(String signature, Throwable callException)
+    {
+        RuntimeException failure = new IllegalStateException("Function %s declared as never failing threw %s".formatted(signature, callException));
+        // Preserve failure, but not as a cause, to make sure violation is not overlooked in tests
+        failure.addSuppressed(callException);
+        return failure;
     }
 
     public AggregationImplementation getAggregationImplementation(ResolvedFunction resolvedFunction)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayDistinctFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayDistinctFunction.java
@@ -35,7 +35,7 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.IDENTICAL;
 import static io.trino.spi.type.BigintType.BIGINT;
 
-@ScalarFunction(value = "array_distinct", neverFails = true)
+@ScalarFunction(value = "array_distinct")
 @Description("Remove duplicate values from the given array")
 public final class ArrayDistinctFunction
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ChoicesSpecializedSqlScalarFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ChoicesSpecializedSqlScalarFunction.java
@@ -117,11 +117,11 @@ public final class ChoicesSpecializedSqlScalarFunction
                 boundSignature.getArgumentTypes(),
                 bestChoice.getInvocationConvention(),
                 invocationConvention);
-        ScalarFunctionImplementation.Builder builder = ScalarFunctionImplementation.builder()
-                .methodHandle(methodHandle);
-        bestChoice.getInstanceFactory().ifPresent(builder::instanceFactory);
-        builder.lambdaInterfaces(bestChoice.getLambdaInterfaces());
-        return builder.build();
+        return ScalarFunctionImplementation.builder()
+                .methodHandle(methodHandle)
+                .instanceFactory(bestChoice.getInstanceFactory())
+                .lambdaInterfaces(bestChoice.getLambdaInterfaces())
+                .build();
     }
 
     public static class ScalarImplementationChoice

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOperator.java
@@ -42,7 +42,6 @@ public class GenericLessThanOperator
                         .argumentType(typeVariable("T"))
                         .argumentType(typeVariable("T"))
                         .build())
-                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
@@ -96,9 +96,9 @@ public final class DecimalCasts
     public static final SqlScalarFunction TINYINT_TO_DECIMAL_CAST = castFunctionToDecimalFrom(TINYINT.getTypeSignature(), false, "tinyintToShortDecimal", "tinyintToLongDecimal");
     public static final SqlScalarFunction DECIMAL_TO_TINYINT_CAST = castFunctionFromDecimalTo(TINYINT.getTypeSignature(), false, "shortDecimalToTinyint", "longDecimalToTinyint");
     public static final SqlScalarFunction DECIMAL_TO_DOUBLE_CAST = castFunctionFromDecimalTo(DOUBLE.getTypeSignature(), true, "shortDecimalToDouble", "longDecimalToDouble");
-    public static final SqlScalarFunction DOUBLE_TO_DECIMAL_CAST = castFunctionToDecimalFrom(DOUBLE.getTypeSignature(), true, "doubleToShortDecimal", "doubleToLongDecimal");
+    public static final SqlScalarFunction DOUBLE_TO_DECIMAL_CAST = castFunctionToDecimalFrom(DOUBLE.getTypeSignature(), false, "doubleToShortDecimal", "doubleToLongDecimal");
     public static final SqlScalarFunction DECIMAL_TO_REAL_CAST = castFunctionFromDecimalTo(REAL.getTypeSignature(), true, "shortDecimalToReal", "longDecimalToReal");
-    public static final SqlScalarFunction REAL_TO_DECIMAL_CAST = castFunctionToDecimalFrom(REAL.getTypeSignature(), true, "realToShortDecimal", "realToLongDecimal");
+    public static final SqlScalarFunction REAL_TO_DECIMAL_CAST = castFunctionToDecimalFrom(REAL.getTypeSignature(), false, "realToShortDecimal", "realToLongDecimal");
     public static final SqlScalarFunction DECIMAL_TO_NUMBER_CAST = castFunctionFromDecimalTo(NUMBER.getTypeSignature(), true, "shortDecimalToNumber", "longDecimalToNumber");
     public static final SqlScalarFunction NUMBER_TO_DECIMAL_CAST = castFunctionToDecimalFrom(NUMBER.getTypeSignature(), false, "numberToShortDecimal", "numberToLongDecimal");
     public static final SqlScalarFunction VARCHAR_TO_DECIMAL_CAST = castFunctionToDecimalFrom(type("varchar", numericVariable("x")), false, "varcharToShortDecimal", "varcharToLongDecimal");

--- a/core/trino-main/src/test/java/io/trino/metadata/TestReportNeverFailsViolated.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestReportNeverFailsViolated.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestReportNeverFailsViolated
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+        assertions.addFunctions(InternalFunctionBundle.builder()
+                .scalars(getClass())
+                .build());
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @ScalarFunction(neverFails = true)
+    @SqlType(StandardTypes.BIGINT)
+    public static long lyingNeverFails(@SqlType(StandardTypes.BOOLEAN) boolean fail)
+    {
+        if (fail) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "lying_never_fails: caller asked to fail");
+        }
+        return 0;
+    }
+
+    @ScalarFunction(deterministic = false, neverFails = true)
+    @SqlType(StandardTypes.BIGINT)
+    public static long lyingNonDeterministicNeverFails(@SqlType(StandardTypes.BOOLEAN) boolean fail)
+    {
+        if (fail) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "lying_non_deterministic_never_fails: caller asked to fail");
+        }
+        return 0;
+    }
+
+    @Test
+    void testIncorrectNeverFails()
+    {
+        assertThat(assertions.expression("lying_never_fails(false)"))
+                .matches("BIGINT '0'");
+
+        assertThatThrownBy(assertions.expression("lying_never_fails(true)")::evaluate)
+                .hasMessage("Function system.builtin.lying_never_fails(boolean):bigint declared as never failing threw io.trino.spi.TrinoException: lying_never_fails: caller asked to fail")
+                .hasStackTraceContaining("lying_never_fails: caller asked to fail");
+    }
+
+    @Test
+    void testIncorrectNonDeterministicNeverFails()
+    {
+        assertThat(assertions.expression("lying_non_deterministic_never_fails(false)"))
+                .matches("BIGINT '0'");
+
+        assertThatThrownBy(assertions.expression("lying_non_deterministic_never_fails(true)")::evaluate)
+                .hasMessage("Function system.builtin.lying_non_deterministic_never_fails(boolean):bigint declared as never failing threw io.trino.spi.TrinoException: lying_non_deterministic_never_fails: caller asked to fail")
+                .hasStackTraceContaining("lying_non_deterministic_never_fails: caller asked to fail");
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
@@ -1822,6 +1822,10 @@ public class TestStringFunctions
         assertThat(assertions.function("ltrim", "CAST('\u017a\u00f3\u0142\u0107' AS CHAR(4))", "'\u00f3\u017a'"))
                 .hasType(createVarcharType(4))
                 .isEqualTo("\u0142\u0107");
+
+        // invalid utf-8 characters
+        assertTrinoExceptionThrownBy(assertions.function("ltrim", "'hello world'", "CAST(utf8(from_hex('81')) AS CHAR(1))")::evaluate)
+                .hasMessage("Invalid UTF-8 encoding in characters: \ufffd ");
     }
 
     private static SqlVarbinary varbinary(int... bytesAsInts)

--- a/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionImplementation.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionImplementation.java
@@ -13,6 +13,8 @@
  */
 package io.trino.spi.function;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
 import java.lang.invoke.MethodHandle;
 import java.util.List;
 import java.util.Optional;
@@ -60,18 +62,21 @@ public class ScalarFunctionImplementation
 
         private Builder() {}
 
+        @CanIgnoreReturnValue
         public Builder methodHandle(MethodHandle methodHandle)
         {
             this.methodHandle = requireNonNull(methodHandle, "methodHandle is null");
             return this;
         }
 
+        @CanIgnoreReturnValue
         public Builder instanceFactory(MethodHandle instanceFactory)
         {
             this.instanceFactory = requireNonNull(instanceFactory, "instanceFactory is null");
             return this;
         }
 
+        @CanIgnoreReturnValue
         public Builder lambdaInterfaces(List<Class<?>> lambdaInterfaces)
         {
             this.lambdaInterfaces = List.copyOf(requireNonNull(lambdaInterfaces, "lambdaInterfaces is null"));

--- a/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionImplementation.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionImplementation.java
@@ -57,7 +57,7 @@ public class ScalarFunctionImplementation
     public static class Builder
     {
         private MethodHandle methodHandle;
-        private MethodHandle instanceFactory;
+        private Optional<MethodHandle> instanceFactory = Optional.empty();
         private List<Class<?>> lambdaInterfaces = List.of();
 
         private Builder() {}
@@ -72,6 +72,13 @@ public class ScalarFunctionImplementation
         @CanIgnoreReturnValue
         public Builder instanceFactory(MethodHandle instanceFactory)
         {
+            this.instanceFactory = Optional.of(requireNonNull(instanceFactory, "instanceFactory is null"));
+            return this;
+        }
+
+        @CanIgnoreReturnValue
+        public Builder instanceFactory(Optional<MethodHandle> instanceFactory)
+        {
             this.instanceFactory = requireNonNull(instanceFactory, "instanceFactory is null");
             return this;
         }
@@ -85,7 +92,7 @@ public class ScalarFunctionImplementation
 
         public ScalarFunctionImplementation build()
         {
-            return new ScalarFunctionImplementation(methodHandle, Optional.ofNullable(instanceFactory), lambdaInterfaces);
+            return new ScalarFunctionImplementation(methodHandle, instanceFactory, lambdaInterfaces);
         }
     }
 }


### PR DESCRIPTION
- Fail tests when neverFails=true function fails
- ~overlaps with https://github.com/trinodb/trino/pull/29861 so that the new test covers infallible `@ScalaOperator`s too~