### PR TITLE
Fix hudi split inflation and add max split size config

### DIFF
--- a/docs/src/main/sphinx/connector/hudi.md
+++ b/docs/src/main/sphinx/connector/hudi.md
@@ -101,6 +101,9 @@ Additionally, following configuration properties can be set depending on the use
     failing the query. This skips data that may be expected to be part of the
     table.
   - `false`
+* - `hudi.max-split-size`
+  - Maximum size of a single split.
+  - `120MB`
 
 :::
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConfig.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConfig.java
@@ -48,6 +48,7 @@ public class HudiConfig
     private long perTransactionMetastoreCacheMaximumSize = 2000;
     private boolean queryPartitionFilterRequired;
     private boolean ignoreAbsentPartitions;
+    private DataSize maxSplitSize = DataSize.of(120, MEGABYTE);
 
     public List<String> getColumnsToHide()
     {
@@ -215,5 +216,19 @@ public class HudiConfig
     public boolean isIgnoreAbsentPartitions()
     {
         return ignoreAbsentPartitions;
+    }
+
+    @Config("hudi.max-split-size")
+    @ConfigDescription("Maximum size for a single split. Defaults to 120MB.")
+    public HudiConfig setMaxSplitSize(DataSize maxSplitSize)
+    {
+        this.maxSplitSize = maxSplitSize;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getMaxSplitSize()
+    {
+        return maxSplitSize;
     }
 }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitManager.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitManager.java
@@ -57,6 +57,7 @@ public class HudiSplitManager
     private final ExecutorService executor;
     private final ScheduledExecutorService splitLoaderExecutorService;
     private final SplitAffinityProvider splitAffinityProvider;
+    private final long maxSplitSize;
 
     @Inject
     public HudiSplitManager(
@@ -65,7 +66,8 @@ public class HudiSplitManager
             @ForHudiSplitManager ExecutorService executor,
             TrinoFileSystemFactory fileSystemFactory,
             @ForHudiSplitSource ScheduledExecutorService splitLoaderExecutorService,
-            SplitAffinityProvider splitAffinityProvider)
+            SplitAffinityProvider splitAffinityProvider,
+            HudiConfig hudiConfig)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
@@ -73,6 +75,7 @@ public class HudiSplitManager
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.splitLoaderExecutorService = requireNonNull(splitLoaderExecutorService, "splitLoaderExecutorService is null");
         this.splitAffinityProvider = requireNonNull(splitAffinityProvider, "splitAffinityProvider is null");
+        this.maxSplitSize = requireNonNull(hudiConfig, "hudiConfig is null").getMaxSplitSize().toBytes();
     }
 
     @Override
@@ -105,6 +108,7 @@ public class HudiSplitManager
                 getMaxSplitsPerSecond(session),
                 getMaxOutstandingSplits(session),
                 splitAffinityProvider,
+                maxSplitSize,
                 partitions);
         return new ClassLoaderSafeConnectorSplitSource(splitSource, HudiSplitManager.class.getClassLoader());
     }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
@@ -72,6 +72,7 @@ public class HudiSplitSource
             int maxSplitsPerSecond,
             int maxOutstandingSplits,
             SplitAffinityProvider splitAffinityProvider,
+            long maxSplitSize,
             List<String> partitions)
     {
         HoodieTableMetaClient metaClient = buildTableMetaClient(fileSystemFactory.create(session), tableHandle.getBasePath());
@@ -85,7 +86,8 @@ public class HudiSplitSource
                 table,
                 partitionColumnHandles,
                 partitions,
-                !tableHandle.getPartitionColumns().isEmpty() && isIgnoreAbsentPartitions(session));
+                !tableHandle.getPartitionColumns().isEmpty() && isIgnoreAbsentPartitions(session),
+                maxSplitSize);
 
         this.queue = new ThrottledAsyncQueue<>(maxSplitsPerSecond, maxOutstandingSplits, executor);
         HudiBackgroundSplitLoader splitLoader = new HudiBackgroundSplitLoader(

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiReadOptimizedDirectoryLister.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiReadOptimizedDirectoryLister.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.hudi.query;
 
 import io.airlift.log.Logger;
-import io.airlift.units.DataSize;
 import io.trino.filesystem.Location;
 import io.trino.metastore.Column;
 import io.trino.metastore.HiveMetastore;
@@ -37,8 +36,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.airlift.units.DataSize.Unit.MEGABYTE;
-import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static org.apache.hudi.common.table.view.HoodieTableFileSystemView.fileListingBasedFileSystemView;
 
@@ -46,11 +43,11 @@ public class HudiReadOptimizedDirectoryLister
         implements HudiDirectoryLister
 {
     private static final Logger LOG = Logger.get(HudiReadOptimizedDirectoryLister.class);
-    private static final long MIN_BLOCK_SIZE = DataSize.of(32, MEGABYTE).toBytes();
 
     private final HoodieTableFileSystemView fileSystemView;
     private final List<Column> partitionColumns;
     private final Map<String, HudiPartitionInfo> allPartitionInfoMap;
+    private final long maxSplitSize;
 
     public HudiReadOptimizedDirectoryLister(
             HudiTableHandle tableHandle,
@@ -59,13 +56,15 @@ public class HudiReadOptimizedDirectoryLister
             Table hiveTable,
             List<HiveColumnHandle> partitionColumnHandles,
             List<String> hivePartitionNames,
-            boolean ignoreAbsentPartitions)
+            boolean ignoreAbsentPartitions,
+            long maxSplitSize)
     {
         this.fileSystemView = fileListingBasedFileSystemView(
                 new HoodieLocalEngineContext(metaClient.getStorageConf()),
                 metaClient,
                 metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants());
         this.partitionColumns = hiveTable.getPartitionColumns();
+        this.maxSplitSize = maxSplitSize;
         this.allPartitionInfoMap = hivePartitionNames.stream()
                 .collect(Collectors.toMap(
                         Function.identity(),
@@ -89,7 +88,7 @@ public class HudiReadOptimizedDirectoryLister
                         false,
                         fileEntry.getLength(),
                         fileEntry.getModificationTime(),
-                        max(fileEntry.getBlockSize(), min(fileEntry.getLength(), MIN_BLOCK_SIZE))))
+                        min(fileEntry.getLength(), maxSplitSize)))
                 .collect(toImmutableList());
     }
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/storage/TrinoHudiStorage.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/storage/TrinoHudiStorage.java
@@ -73,7 +73,7 @@ public class TrinoHudiStorage
                 fileEntry.length(),
                 false,
                 (short) 0,
-                0,
+                fileEntry.length(),
                 fileEntry.lastModified().toEpochMilli());
     }
 

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConfig.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConfig.java
@@ -42,7 +42,8 @@ public class TestHudiConfig
                 .setSplitGeneratorParallelism(4)
                 .setPerTransactionMetastoreCacheMaximumSize(2000)
                 .setQueryPartitionFilterRequired(false)
-                .setIgnoreAbsentPartitions(false));
+                .setIgnoreAbsentPartitions(false)
+                .setMaxSplitSize(DataSize.of(120, MEGABYTE)));
     }
 
     @Test
@@ -61,6 +62,7 @@ public class TestHudiConfig
                 .put("hudi.per-transaction-metastore-cache-maximum-size", "1000")
                 .put("hudi.query-partition-filter-required", "true")
                 .put("hudi.ignore-absent-partitions", "true")
+                .put("hudi.max-split-size", "128MB")
                 .buildOrThrow();
 
         HudiConfig expected = new HudiConfig()
@@ -75,7 +77,8 @@ public class TestHudiConfig
                 .setSplitGeneratorParallelism(32)
                 .setPerTransactionMetastoreCacheMaximumSize(1000)
                 .setQueryPartitionFilterRequired(true)
-                .setIgnoreAbsentPartitions(true);
+                .setIgnoreAbsentPartitions(true)
+                .setMaxSplitSize(DataSize.of(128, MEGABYTE));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description

Fix split inflation in the Hudi connector on S3-backed tables. `TrinoHudiStorage.convertToPathInfo` hardcoded `blockSize=0`, which caused `HudiReadOptimizedDirectoryLister.listStatus` to fall back to a 32MB minimum block size for every file. A typical 120MB Parquet file on S3 was being split into 4 pieces instead of 1, producing ~4x more splits than necessary.

Fix: pass `fileEntry.length()` as the block size in `convertToPathInfo` so each S3 file produces a single split.

Additionally, expose the fallback minimum block size as a configurable catalog property `hudi.max-split-size` (default: 120MB) for operators who want finer control where block boundaries are meaningful.

## Additional context and related issues

Fixes #29842

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Hudi connector
* Improve performance of scans on Hudi tables. ({issue}`29842`)
* Add `hudi.max-split-size` config property to control split size. ({issue}`29842`)
```
