### PR TITLE
Skip redundant copy in IPADDRESS/UUID cast to VARBINARY

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ObjectCasts.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ObjectCasts.java
@@ -119,7 +119,7 @@ final class ObjectCasts
         throw invalidConversion(x, targetSqlType);
     }
 
-    public static long castToLong(Object x, int targetSqlType)
+    public static long castToBigint(Object x, int targetSqlType)
             throws SQLException
     {
         if (x instanceof Boolean) {

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoPreparedStatement.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoPreparedStatement.java
@@ -70,13 +70,13 @@ import static io.trino.jdbc.AbstractTrinoResultSet.TIMESTAMP_FORMATTER;
 import static io.trino.jdbc.AbstractTrinoResultSet.TIME_FORMATTER;
 import static io.trino.jdbc.ColumnInfo.setTypeInfo;
 import static io.trino.jdbc.ObjectCasts.castToBigDecimal;
+import static io.trino.jdbc.ObjectCasts.castToBigint;
 import static io.trino.jdbc.ObjectCasts.castToBinary;
 import static io.trino.jdbc.ObjectCasts.castToBoolean;
 import static io.trino.jdbc.ObjectCasts.castToByte;
 import static io.trino.jdbc.ObjectCasts.castToDouble;
 import static io.trino.jdbc.ObjectCasts.castToFloat;
 import static io.trino.jdbc.ObjectCasts.castToInt;
-import static io.trino.jdbc.ObjectCasts.castToLong;
 import static io.trino.jdbc.ObjectCasts.castToShort;
 import static io.trino.jdbc.ObjectCasts.invalidConversion;
 import static java.lang.Long.parseLong;
@@ -515,7 +515,7 @@ public class TrinoPreparedStatement
                 setInt(parameterIndex, castToInt(x, targetSqlType));
                 return;
             case Types.BIGINT:
-                setLong(parameterIndex, castToLong(x, targetSqlType));
+                setLong(parameterIndex, castToBigint(x, targetSqlType));
                 return;
             case Types.FLOAT:
             case Types.REAL:

--- a/core/trino-main/src/main/java/io/trino/json/PathEvaluationVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/json/PathEvaluationVisitor.java
@@ -536,7 +536,7 @@ class PathEvaluationVisitor
         }
         if (type.equals(DOUBLE)) {
             try {
-                return DoubleOperators.castToLong(value.getDoubleValue());
+                return DoubleOperators.castToBigint(value.getDoubleValue());
             }
             catch (Exception e) {
                 throw new PathEvaluationException(e);
@@ -544,7 +544,7 @@ class PathEvaluationVisitor
         }
         if (type.equals(REAL)) {
             try {
-                return RealOperators.castToLong(value.getLongValue());
+                return RealOperators.castToBigint(value.getLongValue());
             }
             catch (Exception e) {
                 throw new PathEvaluationException(e);

--- a/core/trino-main/src/main/java/io/trino/type/CharOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/CharOperators.java
@@ -56,7 +56,7 @@ public final class CharOperators
     @LiteralParameters("x")
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.REAL)
-    public static long castToFloat(@SqlType("char(x)") Slice slice)
+    public static long castToReal(@SqlType("char(x)") Slice slice)
     {
         try {
             return toReal(Float.parseFloat(slice.toStringUtf8().trim()));

--- a/core/trino-main/src/main/java/io/trino/type/DoubleOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DoubleOperators.java
@@ -156,7 +156,7 @@ public final class DoubleOperators
 
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.BIGINT)
-    public static long castToLong(@SqlType(StandardTypes.DOUBLE) double value)
+    public static long castToBigint(@SqlType(StandardTypes.DOUBLE) double value)
     {
         if (Double.isNaN(value)) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, "Cannot cast double NaN to bigint");

--- a/core/trino-main/src/main/java/io/trino/type/DoubleOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DoubleOperators.java
@@ -227,7 +227,7 @@ public final class DoubleOperators
 
     @ScalarOperator(SATURATED_FLOOR_CAST)
     @SqlType(StandardTypes.REAL)
-    public static long saturatedFloorCastToFloat(@SqlType(StandardTypes.DOUBLE) double value)
+    public static long saturatedFloorCastToReal(@SqlType(StandardTypes.DOUBLE) double value)
     {
         if (Double.isNaN(value)) {
             return toReal(Float.NaN);

--- a/core/trino-main/src/main/java/io/trino/type/IpAddressOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/IpAddressOperators.java
@@ -99,6 +99,6 @@ public final class IpAddressOperators
     @SqlType(StandardTypes.VARBINARY)
     public static Slice castFromIpAddressToVarbinary(@SqlType(StandardTypes.IPADDRESS) Slice slice)
     {
-        return wrappedBuffer(slice.getBytes());
+        return slice;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/type/RealOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/RealOperators.java
@@ -141,7 +141,7 @@ public final class RealOperators
 
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.BIGINT)
-    public static long castToLong(@SqlType(StandardTypes.REAL) long value)
+    public static long castToBigint(@SqlType(StandardTypes.REAL) long value)
     {
         float floatValue = intBitsToFloat((int) value);
         if (Float.isNaN(floatValue)) {

--- a/core/trino-main/src/main/java/io/trino/type/UuidOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/UuidOperators.java
@@ -26,7 +26,6 @@ import io.trino.spi.type.StandardTypes;
 import java.util.UUID;
 
 import static io.airlift.slice.Slices.utf8Slice;
-import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.UuidType.javaUuidToTrinoUuid;
@@ -91,6 +90,6 @@ public final class UuidOperators
     @SqlType(StandardTypes.VARBINARY)
     public static Slice castFromUuidToVarbinary(@SqlType(StandardTypes.UUID) Slice slice)
     {
-        return wrappedBuffer(slice.getBytes());
+        return slice;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/type/VarcharOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/VarcharOperators.java
@@ -90,7 +90,7 @@ public final class VarcharOperators
     @LiteralParameters("x")
     @ScalarOperator(CAST)
     @SqlType(StandardTypes.REAL)
-    public static long castToFloat(@SqlType("varchar(x)") Slice slice)
+    public static long castToReal(@SqlType("varchar(x)") Slice slice)
     {
         try {
             return toReal(Float.parseFloat(slice.toStringUtf8().trim()));

--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -815,7 +815,7 @@ public final class JsonUtil
     {
         return switch (parser.currentToken()) {
             case VALUE_NULL -> null;
-            case VALUE_STRING, FIELD_NAME -> VarcharOperators.castToFloat(utf8Slice(parser.getText()));
+            case VALUE_STRING, FIELD_NAME -> VarcharOperators.castToReal(utf8Slice(parser.getText()));
             case VALUE_NUMBER_FLOAT -> (long) floatToRawIntBits(parser.getFloatValue());
             // An alternative is calling getLongValue and then BigintOperators.castToReal.
             // It doesn't work as well because it can result in overflow and underflow exceptions for large integral numbers.

--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -744,7 +744,7 @@ public final class JsonUtil
         return switch (parser.currentToken()) {
             case VALUE_NULL -> null;
             case VALUE_STRING, FIELD_NAME -> VarcharOperators.castToBigint(utf8Slice(parser.getText()));
-            case VALUE_NUMBER_FLOAT -> DoubleOperators.castToLong(parser.getDoubleValue());
+            case VALUE_NUMBER_FLOAT -> DoubleOperators.castToBigint(parser.getDoubleValue());
             case VALUE_NUMBER_INT -> parser.getLongValue();
             case VALUE_TRUE -> BooleanOperators.castToBigint(true);
             case VALUE_FALSE -> BooleanOperators.castToBigint(false);

--- a/core/trino-main/src/main/java/io/trino/util/variant/VariantUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/variant/VariantUtil.java
@@ -395,7 +395,7 @@ public final class VariantUtil
                 case NULL -> null;
                 case BOOLEAN_TRUE -> BooleanOperators.castToReal(true);
                 case BOOLEAN_FALSE -> BooleanOperators.castToReal(false);
-                case STRING -> VarcharOperators.castToFloat(variant.getString());
+                case STRING -> VarcharOperators.castToReal(variant.getString());
                 case INT8 -> TinyintOperators.castToReal(variant.getByte());
                 case INT16 -> SmallintOperators.castToReal(variant.getShort());
                 case INT32 -> IntegerOperators.castToReal(variant.getInt());
@@ -405,7 +405,7 @@ public final class VariantUtil
                 case DOUBLE -> DoubleOperators.castToReal(variant.getDouble());
                 default -> throw new VariantCastException("Unsupported VARIANT primitive type for cast to REAL: " + variant.primitiveType());
             };
-            case SHORT_STRING -> VarcharOperators.castToFloat(variant.getString());
+            case SHORT_STRING -> VarcharOperators.castToReal(variant.getString());
             default -> throw new VariantCastException("Unsupported VARIANT type for cast to REAL: " + variant.basicType());
         };
     }

--- a/core/trino-main/src/main/java/io/trino/util/variant/VariantUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/variant/VariantUtil.java
@@ -379,8 +379,8 @@ public final class VariantUtil
                         throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Out of range for bigint: " + decimalValue, e);
                     }
                 }
-                case FLOAT -> DoubleOperators.castToLong(variant.getFloat());
-                case DOUBLE -> DoubleOperators.castToLong(variant.getDouble());
+                case FLOAT -> DoubleOperators.castToBigint(variant.getFloat());
+                case DOUBLE -> DoubleOperators.castToBigint(variant.getDouble());
                 default -> throw new VariantCastException("Unsupported VARIANT primitive type for cast to BIGINT: " + variant.primitiveType());
             };
             case SHORT_STRING -> VarcharOperators.castToBigint(variant.getString());


### PR DESCRIPTION
- Skip redundant copy in IPADDRESS/UUID cast to VARBINARY
- Fix name of functions casting to BIGINT/REAL