### PR TITLE
Allow parametric functions to declare fallibility per call site 

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
@@ -375,9 +375,7 @@ class FunctionBinder
         if (!functionMetadata.isDeterministic()) {
             newMetadata.nondeterministic();
         }
-        if (functionMetadata.isNeverFails()) {
-            newMetadata.neverFails();
-        }
+        newMetadata.neverFails(functionMetadata.getNeverFails());
         if (functionMetadata.isDeprecated()) {
             newMetadata.deprecated();
         }

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
@@ -210,7 +210,7 @@ public class FunctionResolver
                     resolvedFunctionId,
                     functionBinding.boundFunctionMetadata().getKind(),
                     functionBinding.boundFunctionMetadata().isDeterministic(),
-                    functionBinding.boundFunctionMetadata().isNeverFails(),
+                    functionBinding.boundFunctionMetadata().getNeverFails().test(functionBinding.functionBinding().getBoundSignature()),
                     functionBinding.boundFunctionMetadata().getFunctionNullability(),
                     ImmutableMap.of(),
                     ImmutableSet.of());
@@ -327,7 +327,7 @@ public class FunctionResolver
                 functionBinding.getFunctionId(),
                 functionMetadata.getKind(),
                 functionMetadata.isDeterministic(),
-                functionMetadata.isNeverFails(),
+                functionMetadata.getNeverFails().test(functionBinding.getBoundSignature()),
                 functionMetadata.getFunctionNullability(),
                 dependentTypes,
                 functions.build());

--- a/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunctionBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunctionBuilder.java
@@ -16,6 +16,7 @@ package io.trino.metadata;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Booleans;
 import io.trino.metadata.PolymorphicScalarFunction.PolymorphicScalarFunctionChoice;
+import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.InvocationConvention.InvocationArgumentConvention;
 import io.trino.spi.function.InvocationConvention.InvocationReturnConvention;
@@ -30,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -54,7 +56,7 @@ public final class PolymorphicScalarFunctionBuilder
     private String description;
     private boolean hidden;
     private Boolean deterministic;
-    private boolean neverFails;
+    private Predicate<BoundSignature> neverFails = _ -> false;
 
     private final List<PolymorphicScalarFunctionChoice> choices = new ArrayList<>();
 
@@ -112,7 +114,12 @@ public final class PolymorphicScalarFunctionBuilder
 
     public PolymorphicScalarFunctionBuilder neverFails(boolean neverFails)
     {
-        this.neverFails = neverFails;
+        return neverFails(neverFails ? _ -> true : _ -> false);
+    }
+
+    public PolymorphicScalarFunctionBuilder neverFails(Predicate<BoundSignature> neverFails)
+    {
+        this.neverFails = requireNonNull(neverFails, "neverFails is null");
         return this;
     }
 
@@ -144,9 +151,7 @@ public final class PolymorphicScalarFunctionBuilder
         if (!deterministic) {
             functionMetadata.nondeterministic();
         }
-        if (neverFails) {
-            functionMetadata.neverFails();
-        }
+        functionMetadata.neverFails(neverFails);
         if (nullableResult) {
             functionMetadata.nullable();
         }

--- a/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
@@ -26,6 +26,7 @@ import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.metadata.PolymorphicScalarFunctionBuilder;
 import io.trino.metadata.SqlScalarFunction;
 import io.trino.spi.TrinoException;
+import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.DecimalConversions;
 import io.trino.spi.type.DecimalType;
@@ -42,7 +43,9 @@ import io.trino.util.variant.VariantUtil;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.function.Predicate;
 
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
@@ -87,33 +90,52 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class DecimalCasts
 {
-    public static final SqlScalarFunction DECIMAL_TO_BOOLEAN_CAST = castFunctionFromDecimalTo(BOOLEAN.getTypeDescriptor(), true, "shortDecimalToBoolean", "longDecimalToBoolean");
-    public static final SqlScalarFunction BOOLEAN_TO_DECIMAL_CAST = castFunctionToDecimalFrom(BOOLEAN.getTypeDescriptor(), false, "booleanToShortDecimal", "booleanToLongDecimal");
-    public static final SqlScalarFunction DECIMAL_TO_BIGINT_CAST = castFunctionFromDecimalTo(BIGINT.getTypeDescriptor(), false, "shortDecimalToBigint", "longDecimalToBigint");
-    public static final SqlScalarFunction BIGINT_TO_DECIMAL_CAST = castFunctionToDecimalFrom(BIGINT.getTypeDescriptor(), false, "bigintToShortDecimal", "bigintToLongDecimal");
-    public static final SqlScalarFunction INTEGER_TO_DECIMAL_CAST = castFunctionToDecimalFrom(INTEGER.getTypeDescriptor(), false, "integerToShortDecimal", "integerToLongDecimal");
-    public static final SqlScalarFunction DECIMAL_TO_INTEGER_CAST = castFunctionFromDecimalTo(INTEGER.getTypeDescriptor(), false, "shortDecimalToInteger", "longDecimalToInteger");
-    public static final SqlScalarFunction SMALLINT_TO_DECIMAL_CAST = castFunctionToDecimalFrom(SMALLINT.getTypeDescriptor(), false, "smallintToShortDecimal", "smallintToLongDecimal");
-    public static final SqlScalarFunction DECIMAL_TO_SMALLINT_CAST = castFunctionFromDecimalTo(SMALLINT.getTypeDescriptor(), false, "shortDecimalToSmallint", "longDecimalToSmallint");
-    public static final SqlScalarFunction TINYINT_TO_DECIMAL_CAST = castFunctionToDecimalFrom(TINYINT.getTypeDescriptor(), false, "tinyintToShortDecimal", "tinyintToLongDecimal");
-    public static final SqlScalarFunction DECIMAL_TO_TINYINT_CAST = castFunctionFromDecimalTo(TINYINT.getTypeDescriptor(), false, "shortDecimalToTinyint", "longDecimalToTinyint");
-    public static final SqlScalarFunction DECIMAL_TO_DOUBLE_CAST = castFunctionFromDecimalTo(DOUBLE.getTypeDescriptor(), true, "shortDecimalToDouble", "longDecimalToDouble");
-    public static final SqlScalarFunction DOUBLE_TO_DECIMAL_CAST = castFunctionToDecimalFrom(DOUBLE.getTypeDescriptor(), false, "doubleToShortDecimal", "doubleToLongDecimal");
-    public static final SqlScalarFunction DECIMAL_TO_REAL_CAST = castFunctionFromDecimalTo(REAL.getTypeDescriptor(), true, "shortDecimalToReal", "longDecimalToReal");
-    public static final SqlScalarFunction REAL_TO_DECIMAL_CAST = castFunctionToDecimalFrom(REAL.getTypeDescriptor(), false, "realToShortDecimal", "realToLongDecimal");
-    public static final SqlScalarFunction DECIMAL_TO_NUMBER_CAST = castFunctionFromDecimalTo(NUMBER.getTypeDescriptor(), true, "shortDecimalToNumber", "longDecimalToNumber");
-    public static final SqlScalarFunction NUMBER_TO_DECIMAL_CAST = castFunctionToDecimalFrom(NUMBER.getTypeDescriptor(), false, "numberToShortDecimal", "numberToLongDecimal");
-    public static final SqlScalarFunction VARCHAR_TO_DECIMAL_CAST = castFunctionToDecimalFrom(type("varchar", numericVariable("x")), false, "varcharToShortDecimal", "varcharToLongDecimal");
+    private static final Predicate<BoundSignature> NEVER_FAILS = _ -> true;
+    private static final Predicate<BoundSignature> MAY_FAIL = _ -> false;
+
+    private static Predicate<BoundSignature> whenTargetCoversIntegerDigits(int requiredIntegerDigits)
+    {
+        return boundSignature -> {
+            DecimalType target = (DecimalType) boundSignature.getReturnType();
+            return target.getPrecision() - target.getScale() >= requiredIntegerDigits;
+        };
+    }
+
+    private static Predicate<BoundSignature> whenSourceIntegerDigitsAtMost(int maxIntegerDigits)
+    {
+        return boundSignature -> {
+            DecimalType source = (DecimalType) getOnlyElement(boundSignature.getArgumentTypes());
+            return source.getPrecision() - source.getScale() <= maxIntegerDigits;
+        };
+    }
+
+    public static final SqlScalarFunction DECIMAL_TO_BOOLEAN_CAST = castFunctionFromDecimalTo(BOOLEAN.getTypeDescriptor(), NEVER_FAILS, "shortDecimalToBoolean", "longDecimalToBoolean");
+    public static final SqlScalarFunction BOOLEAN_TO_DECIMAL_CAST = castFunctionToDecimalFrom(BOOLEAN.getTypeDescriptor(), whenTargetCoversIntegerDigits(1), "booleanToShortDecimal", "booleanToLongDecimal");
+    public static final SqlScalarFunction DECIMAL_TO_BIGINT_CAST = castFunctionFromDecimalTo(BIGINT.getTypeDescriptor(), whenSourceIntegerDigitsAtMost(18), "shortDecimalToBigint", "longDecimalToBigint");
+    public static final SqlScalarFunction BIGINT_TO_DECIMAL_CAST = castFunctionToDecimalFrom(BIGINT.getTypeDescriptor(), whenTargetCoversIntegerDigits(19), "bigintToShortDecimal", "bigintToLongDecimal");
+    public static final SqlScalarFunction INTEGER_TO_DECIMAL_CAST = castFunctionToDecimalFrom(INTEGER.getTypeDescriptor(), whenTargetCoversIntegerDigits(10), "integerToShortDecimal", "integerToLongDecimal");
+    public static final SqlScalarFunction DECIMAL_TO_INTEGER_CAST = castFunctionFromDecimalTo(INTEGER.getTypeDescriptor(), whenSourceIntegerDigitsAtMost(9), "shortDecimalToInteger", "longDecimalToInteger");
+    public static final SqlScalarFunction SMALLINT_TO_DECIMAL_CAST = castFunctionToDecimalFrom(SMALLINT.getTypeDescriptor(), whenTargetCoversIntegerDigits(5), "smallintToShortDecimal", "smallintToLongDecimal");
+    public static final SqlScalarFunction DECIMAL_TO_SMALLINT_CAST = castFunctionFromDecimalTo(SMALLINT.getTypeDescriptor(), whenSourceIntegerDigitsAtMost(4), "shortDecimalToSmallint", "longDecimalToSmallint");
+    public static final SqlScalarFunction TINYINT_TO_DECIMAL_CAST = castFunctionToDecimalFrom(TINYINT.getTypeDescriptor(), whenTargetCoversIntegerDigits(3), "tinyintToShortDecimal", "tinyintToLongDecimal");
+    public static final SqlScalarFunction DECIMAL_TO_TINYINT_CAST = castFunctionFromDecimalTo(TINYINT.getTypeDescriptor(), whenSourceIntegerDigitsAtMost(2), "shortDecimalToTinyint", "longDecimalToTinyint");
+    public static final SqlScalarFunction DECIMAL_TO_DOUBLE_CAST = castFunctionFromDecimalTo(DOUBLE.getTypeDescriptor(), NEVER_FAILS, "shortDecimalToDouble", "longDecimalToDouble");
+    public static final SqlScalarFunction DOUBLE_TO_DECIMAL_CAST = castFunctionToDecimalFrom(DOUBLE.getTypeDescriptor(), MAY_FAIL, "doubleToShortDecimal", "doubleToLongDecimal");
+    public static final SqlScalarFunction DECIMAL_TO_REAL_CAST = castFunctionFromDecimalTo(REAL.getTypeDescriptor(), NEVER_FAILS, "shortDecimalToReal", "longDecimalToReal");
+    public static final SqlScalarFunction REAL_TO_DECIMAL_CAST = castFunctionToDecimalFrom(REAL.getTypeDescriptor(), MAY_FAIL, "realToShortDecimal", "realToLongDecimal");
+    public static final SqlScalarFunction DECIMAL_TO_NUMBER_CAST = castFunctionFromDecimalTo(NUMBER.getTypeDescriptor(), NEVER_FAILS, "shortDecimalToNumber", "longDecimalToNumber");
+    public static final SqlScalarFunction NUMBER_TO_DECIMAL_CAST = castFunctionToDecimalFrom(NUMBER.getTypeDescriptor(), MAY_FAIL, "numberToShortDecimal", "numberToLongDecimal");
+    public static final SqlScalarFunction VARCHAR_TO_DECIMAL_CAST = castFunctionToDecimalFrom(type("varchar", numericVariable("x")), MAY_FAIL, "varcharToShortDecimal", "varcharToLongDecimal");
     // Despite decimalToJson having a catch inside that suggests that function can fail, IOException comes from the Jackson writing to an OutputStream
     // that never happens for SliceOutput.
-    public static final SqlScalarFunction DECIMAL_TO_JSON_CAST = castFunctionFromDecimalTo(JSON.getTypeDescriptor(), true, "shortDecimalToJson", "longDecimalToJson");
-    public static final SqlScalarFunction JSON_TO_DECIMAL_CAST = castFunctionToDecimalFromBuilder(fromTypeDescriptor(JSON.getTypeDescriptor()), true, false, "jsonToShortDecimal", "jsonToLongDecimal");
-    public static final SqlScalarFunction DECIMAL_TO_VARIANT_CAST = castFunctionFromDecimalTo(VARIANT.getTypeDescriptor(), true, "shortDecimalToVariant", "longDecimalToVariant");
-    public static final SqlScalarFunction VARIANT_TO_DECIMAL_CAST = castFunctionToDecimalFromBuilder(fromTypeDescriptor(VARIANT.getTypeDescriptor()), true, false, "variantToShortDecimal", "variantToLongDecimal");
+    public static final SqlScalarFunction DECIMAL_TO_JSON_CAST = castFunctionFromDecimalTo(JSON.getTypeDescriptor(), NEVER_FAILS, "shortDecimalToJson", "longDecimalToJson");
+    public static final SqlScalarFunction JSON_TO_DECIMAL_CAST = castFunctionToDecimalFromBuilder(fromTypeDescriptor(JSON.getTypeDescriptor()), true, MAY_FAIL, "jsonToShortDecimal", "jsonToLongDecimal");
+    public static final SqlScalarFunction DECIMAL_TO_VARIANT_CAST = castFunctionFromDecimalTo(VARIANT.getTypeDescriptor(), NEVER_FAILS, "shortDecimalToVariant", "longDecimalToVariant");
+    public static final SqlScalarFunction VARIANT_TO_DECIMAL_CAST = castFunctionToDecimalFromBuilder(fromTypeDescriptor(VARIANT.getTypeDescriptor()), true, MAY_FAIL, "variantToShortDecimal", "variantToLongDecimal");
 
     private static final JsonMapper JSON_MAPPER = new JsonMapper(createJsonFactory());
 
-    private static SqlScalarFunction castFunctionFromDecimalTo(TypeDescriptor to, boolean neverFails, String... methodNames)
+    private static SqlScalarFunction castFunctionFromDecimalTo(TypeDescriptor to, Predicate<BoundSignature> neverFails, String... methodNames)
     {
         Signature signature = Signature.builder()
                 .argumentType(type("decimal", numericVariable("precision"), numericVariable("scale")))
@@ -141,17 +163,17 @@ public final class DecimalCasts
                 .build();
     }
 
-    private static SqlScalarFunction castFunctionToDecimalFrom(TypeDescriptor from, boolean neverFails, String... methodNames)
+    private static SqlScalarFunction castFunctionToDecimalFrom(TypeDescriptor from, Predicate<BoundSignature> neverFails, String... methodNames)
     {
         return castFunctionToDecimalFromBuilder(fromTypeDescriptor(from), false, neverFails, methodNames);
     }
 
-    private static SqlScalarFunction castFunctionToDecimalFrom(TypeTemplate from, boolean neverFails, String... methodNames)
+    private static SqlScalarFunction castFunctionToDecimalFrom(TypeTemplate from, Predicate<BoundSignature> neverFails, String... methodNames)
     {
         return castFunctionToDecimalFromBuilder(from, false, neverFails, methodNames);
     }
 
-    private static SqlScalarFunction castFunctionToDecimalFromBuilder(TypeTemplate from, boolean nullableResult, boolean neverFails, String... methodNames)
+    private static SqlScalarFunction castFunctionToDecimalFromBuilder(TypeTemplate from, boolean nullableResult, Predicate<BoundSignature> neverFails, String... methodNames)
     {
         Signature signature = Signature.builder()
                 .argumentType(from)

--- a/core/trino-main/src/main/java/io/trino/type/DecimalSaturatedFloorCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalSaturatedFloorCasts.java
@@ -115,7 +115,6 @@ public final class DecimalSaturatedFloorCasts
                         .returnType(type.getTypeDescriptor())
                         .build())
                 .deterministic(true)
-                .neverFails(true) // saturated casts never overflow
                 .choice(choice -> choice
                         .implementation(methodsGroup -> methodsGroup
                                 .methods("shortDecimalToGenericIntegerType", "longDecimalToGenericIntegerType")

--- a/core/trino-main/src/main/java/io/trino/type/DecimalToDecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalToDecimalCasts.java
@@ -22,6 +22,7 @@ import io.trino.spi.type.DecimalType;
 
 import java.util.Set;
 
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.Decimals.longTenToNth;
 import static io.trino.sql.analyzer.TypeDescriptorTranslator.parseTypeTemplate;
@@ -37,6 +38,14 @@ public final class DecimalToDecimalCasts
     public static final SqlScalarFunction DECIMAL_TO_DECIMAL_CAST = new PolymorphicScalarFunctionBuilder(CAST, DecimalConversions.class)
             .signature(SIGNATURE)
             .deterministic(true)
+            .neverFails(boundSignature -> {
+                DecimalType source = (DecimalType) getOnlyElement(boundSignature.getArgumentTypes());
+                DecimalType target = (DecimalType) boundSignature.getReturnType();
+                // When target scale shrinks, rounding can push the result up by one integer digit (e.g. 99.9 → 100).
+                int requiredIntegerDigits = source.getPrecision() - source.getScale()
+                        + (target.getScale() < source.getScale() ? 1 : 0);
+                return target.getPrecision() - target.getScale() >= requiredIntegerDigits;
+            })
             .choice(choice -> choice
                     .implementation(methodsGroup -> methodsGroup
                             .methods("shortToShortCast")

--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
@@ -117,6 +117,80 @@ public class TestDecimalCasts
     }
 
     @Test
+    public void testCastToDecimalNeverFailsBoundaries()
+    {
+        assertThat(assertions.expression("cast(a as DECIMAL(2, 1))").binding("a", "true"))
+                .neverFails()
+                .isEqualTo(decimal("1.0", createDecimalType(2, 1)));
+        assertTrinoExceptionThrownBy(assertions.expression("cast(a as DECIMAL(2, 2))")
+                .binding("a", "true")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+        assertThat(assertions.expression("cast(a as DECIMAL(2, 2))").binding("a", "false"))
+                .couldFail()
+                .isEqualTo(decimal(".00", createDecimalType(2, 2)));
+
+        assertThat(assertions.expression("cast(a as DECIMAL(4, 1))").binding("a", "TINYINT '12'"))
+                .neverFails()
+                .isEqualTo(decimal("012.0", createDecimalType(4, 1)));
+        assertThat(assertions.expression("cast(a as DECIMAL(3, 1))").binding("a", "TINYINT '12'"))
+                .couldFail()
+                .isEqualTo(decimal("12.0", createDecimalType(3, 1)));
+
+        assertThat(assertions.expression("cast(a as DECIMAL(6, 1))").binding("a", "SMALLINT '12'"))
+                .neverFails()
+                .isEqualTo(decimal("00012.0", createDecimalType(6, 1)));
+        assertThat(assertions.expression("cast(a as DECIMAL(5, 1))").binding("a", "SMALLINT '12'"))
+                .couldFail()
+                .isEqualTo(decimal("0012.0", createDecimalType(5, 1)));
+
+        assertThat(assertions.expression("cast(a as DECIMAL(11, 1))").binding("a", "INTEGER '12'"))
+                .neverFails()
+                .isEqualTo(decimal("0000000012.0", createDecimalType(11, 1)));
+        assertThat(assertions.expression("cast(a as DECIMAL(10, 1))").binding("a", "INTEGER '12'"))
+                .couldFail()
+                .isEqualTo(decimal("000000012.0", createDecimalType(10, 1)));
+
+        assertThat(assertions.expression("cast(a as DECIMAL(22, 1))").binding("a", "BIGINT '234'"))
+                .neverFails()
+                .isEqualTo(decimal("000000000000000000234.0", createDecimalType(22, 1)));
+        assertThat(assertions.expression("cast(a as DECIMAL(4, 1))").binding("a", "BIGINT '234'"))
+                .couldFail()
+                .isEqualTo(decimal("234.0", createDecimalType(4, 1)));
+    }
+
+    @Test
+    public void testCastFromDecimalNeverFailsBoundaries()
+    {
+        assertThat(assertions.expression("cast(a as TINYINT)").binding("a", "DECIMAL '99'"))
+                .neverFails()
+                .isEqualTo((byte) 99);
+        assertThat(assertions.expression("cast(a as TINYINT)").binding("a", "DECIMAL '100'"))
+                .couldFail()
+                .isEqualTo((byte) 100);
+
+        assertThat(assertions.expression("cast(a as SMALLINT)").binding("a", "DECIMAL '1234'"))
+                .neverFails()
+                .isEqualTo((short) 1234);
+        assertThat(assertions.expression("cast(a as SMALLINT)").binding("a", "DECIMAL '12345'"))
+                .couldFail()
+                .isEqualTo((short) 12345);
+
+        assertThat(assertions.expression("cast(a as INTEGER)").binding("a", "DECIMAL '123456789'"))
+                .neverFails()
+                .isEqualTo(123456789);
+        assertThat(assertions.expression("cast(a as INTEGER)").binding("a", "DECIMAL '1234567890'"))
+                .couldFail()
+                .isEqualTo(1234567890);
+
+        assertThat(assertions.expression("cast(a as BIGINT)").binding("a", "DECIMAL '123456789012345678'"))
+                .neverFails()
+                .isEqualTo(123456789012345678L);
+        assertThat(assertions.expression("cast(a as BIGINT)").binding("a", "DECIMAL '1234567890123456789'"))
+                .couldFail()
+                .isEqualTo(1234567890123456789L);
+    }
+
+    @Test
     public void testDecimalToBooleanCasts()
     {
         assertThat(assertions.expression("cast(a as BOOLEAN)")

--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalToDecimalCasts.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalToDecimalCasts.java
@@ -156,6 +156,31 @@ public class TestDecimalToDecimalCasts
     }
 
     @Test
+    public void testDecimalToDecimalNeverFailsBoundaries()
+    {
+        assertThat(assertions.expression("cast(a as DECIMAL(4, 1))").binding("a", "DECIMAL '12.3'"))
+                .neverFails()
+                .isEqualTo(decimal("12.3", createDecimalType(4, 1)));
+        assertThat(assertions.expression("cast(a as DECIMAL(2, 1))").binding("a", "CAST(DECIMAL '1.2' AS DECIMAL(3, 1))"))
+                .couldFail()
+                .isEqualTo(decimal("1.2", createDecimalType(2, 1)));
+
+        assertThat(assertions.expression("cast(a as DECIMAL(5, 3))").binding("a", "DECIMAL '12.3'"))
+                .neverFails()
+                .isEqualTo(decimal("12.300", createDecimalType(5, 3)));
+        assertThat(assertions.expression("cast(a as DECIMAL(3, 2))").binding("a", "CAST(DECIMAL '1.2' AS DECIMAL(3, 1))"))
+                .couldFail()
+                .isEqualTo(decimal("1.20", createDecimalType(3, 2)));
+
+        assertThat(assertions.expression("cast(a as DECIMAL(3, 0))").binding("a", "DECIMAL '12.3'"))
+                .neverFails()
+                .isEqualTo(decimal("012", createDecimalType(3, 0)));
+        assertThat(assertions.expression("cast(a as DECIMAL(2, 0))").binding("a", "DECIMAL '12.3'"))
+                .couldFail()
+                .isEqualTo(decimal("12", createDecimalType(2, 0)));
+    }
+
+    @Test
     public void testLongDecimalToLongDecimalCasts()
     {
         assertThat(assertions.expression("cast(a as DECIMAL(21, 20))")

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -436,6 +436,11 @@
                                     <old>method long io.trino.spi.type.Timestamps::truncateEpochMicrosToMillis(long)</old>
                                 </item>
                                 <item>
+                                    <code>java.method.removed</code>
+                                    <old>method boolean io.trino.spi.function.FunctionMetadata::isNeverFails()</old>
+                                    <justification>Replaced with getNeverFails() returning Predicate&lt;BoundSignature&gt; so per-binding (e.g., decimal precision/scale) infallibility can be expressed and is type-enforced at the read side.</justification>
+                                </item>
+                                <item>
                                     <code>java.method.addedToInterface</code>
                                     <new>method boolean io.trino.spi.type.TypeManager::isTypeRegistered(java.lang.String)</new>
                                     <justification>Required for resolving static method calls on parametric type bases (array, row, map). Cannot be a default that calls getType because parametric bases require parameters and would force exception-driven control flow.</justification>

--- a/core/trino-spi/src/main/java/io/trino/spi/function/FunctionMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/FunctionMetadata.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static io.trino.spi.function.FunctionKind.AGGREGATE;
 import static io.trino.spi.function.FunctionKind.SCALAR;
@@ -40,7 +41,7 @@ public class FunctionMetadata
     private final FunctionNullability functionNullability;
     private final boolean hidden;
     private final boolean deterministic;
-    private final boolean neverFails;
+    private final Predicate<BoundSignature> neverFails;
     private final String description;
     private final FunctionKind kind;
     private final boolean deprecated;
@@ -55,7 +56,7 @@ public class FunctionMetadata
             FunctionNullability functionNullability,
             boolean hidden,
             boolean deterministic,
-            boolean neverFails,
+            Predicate<BoundSignature> neverFails,
             String description,
             FunctionKind kind,
             boolean deprecated,
@@ -76,7 +77,7 @@ public class FunctionMetadata
 
         this.hidden = hidden;
         this.deterministic = deterministic;
-        this.neverFails = neverFails;
+        this.neverFails = requireNonNull(neverFails, "neverFails is null");
         this.description = requireNonNull(description, "description is null");
         this.kind = requireNonNull(kind, "kind is null");
         this.deprecated = deprecated;
@@ -135,9 +136,10 @@ public class FunctionMetadata
     }
 
     /**
-     * Whether function never fails for any possible combination of input parameters.
+     * Predicate that returns whether this function never fails for the
+     * given bound signature (call site).
      */
-    public boolean isNeverFails()
+    public Predicate<BoundSignature> getNeverFails()
     {
         return neverFails;
     }
@@ -226,7 +228,7 @@ public class FunctionMetadata
         private List<Boolean> argumentNullability;
         private boolean hidden;
         private boolean deterministic = true;
-        private boolean neverFails;
+        private Predicate<BoundSignature> neverFails = _ -> false;
         private String description;
         private FunctionId functionId;
         private boolean deprecated;
@@ -298,7 +300,12 @@ public class FunctionMetadata
 
         public Builder neverFails()
         {
-            this.neverFails = true;
+            return neverFails(_ -> true);
+        }
+
+        public Builder neverFails(Predicate<BoundSignature> neverFails)
+        {
+            this.neverFails = requireNonNull(neverFails, "neverFails is null");
             return this;
         }
 


### PR DESCRIPTION
- allow `FunctionMetadata` to declare `neverFails` taking into account the call site (`BoundedSignature`)
- declare fallibility in `DecimalCast` taking into account bound decimal precision and scale
- ~extend `ExpressionAssert` to allow testing effective `neverFails` declaration of an expression~ (extracted to https://github.com/trinodb/trino/pull/29889)