### PR TITLE
Fix equality delete filtering for iceberg metadata column queries

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/FlatEqualityDeleteFilter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/FlatEqualityDeleteFilter.java
@@ -28,7 +28,6 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.types.Types.StructType;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -40,12 +39,10 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.google.common.base.Verify.verify;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_CANNOT_OPEN_SPLIT;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.isMetadataColumnId;
-import static io.trino.plugin.iceberg.IcebergUtil.structTypeFromHandles;
 import static java.util.Objects.requireNonNull;
 
 public final class FlatEqualityDeleteFilter
@@ -63,28 +60,23 @@ public final class FlatEqualityDeleteFilter
     @Override
     public PageFilter createPageFilter(List<IcebergColumnHandle> columns, long splitDataSequenceNumber)
     {
-        StructType fileStructType = structTypeFromHandles(columns.stream()
-                .filter(column -> !isMetadataColumnId(column.getId())) // equality deletes don't apply to metadata columns
-                .collect(toImmutableList()));
-        if (deleteSchema.columns().stream().anyMatch(column -> fileStructType.field(column.fieldId()) == null)) {
-            throw new TrinoException(ICEBERG_CANNOT_OPEN_SPLIT, "columns list doesn't contain all equality delete columns");
-        }
-
-        Map<Integer, Integer> dataChannelsByFieldId = new HashMap<>();
-        for (int channel = 0; channel < fileStructType.fields().size(); channel++) {
-            int fieldId = fileStructType.fields().get(channel).fieldId();
-            verify(dataChannelsByFieldId.put(fieldId, channel) == null,
-                    "duplicate column for field ID %s",
-                    fieldId);
+        // Deduplicate by base column ID to handle nested field projections where multiple
+        // nested fields from the same base struct appear (e.g., root.a, root.b both reference base column "root")
+        Map<Integer, Integer> dataChannelsByBaseId = new HashMap<>();
+        for (int channel = 0; channel < columns.size(); channel++) {
+            IcebergColumnHandle column = columns.get(channel);
+            if (!isMetadataColumnId(column.getId())) {
+                dataChannelsByBaseId.putIfAbsent(column.getBaseColumnIdentity().getId(), channel);
+            }
         }
         // map from delete schema channel to data page channel
         int[] channels = new int[deleteSchema.columns().size()];
         for (int deleteChannel = 0; deleteChannel < deleteSchema.columns().size(); deleteChannel++) {
             int fieldId = deleteSchema.columns().get(deleteChannel).fieldId();
-            Integer channel = dataChannelsByFieldId.get(fieldId);
-            verify(channel != null,
-                    "columns list doesn't contain equality delete field ID %s",
-                    fieldId);
+            Integer channel = dataChannelsByBaseId.get(fieldId);
+            if (channel == null) {
+                throw new TrinoException(ICEBERG_CANNOT_OPEN_SPLIT, "columns list doesn't contain equality delete field ID %s".formatted(fieldId));
+            }
             channels[deleteChannel] = channel;
         }
         return new EqualityDeletePageFilter(channels, index, splitDataSequenceNumber);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -647,10 +647,20 @@ public class TestIcebergV2
             // verify equality deletes work with nested field in projection and WHERE clause
             assertThat(query("SELECT root.nested FROM " + tableName))
                     .matches("VALUES BIGINT '10'");
+            assertThat(query("SELECT root.nested, root.nested_other FROM " + tableName))
+                    .matches("VALUES (BIGINT '10', BIGINT '100')");
             assertThat(query("SELECT id FROM " + tableName + " WHERE root.nested = 10"))
                     .matches("VALUES BIGINT '1'");
             assertThat(query("SELECT id FROM " + tableName + " WHERE root.nested = 20"))
                     .returnsEmptyResult();
+
+            // verify equality deletes work with nested field and querying metadata columns
+            assertThat(query("SELECT \"$partition\" FROM " + tableName))
+                    .matches("VALUES VARCHAR ''");
+            assertThat(query("SELECT root.nested, \"$partition\" FROM " + tableName))
+                    .matches("VALUES (BIGINT '10', VARCHAR '')");
+            assertThat(query("SELECT \"$partition\", root.nested FROM " + tableName))
+                    .matches("VALUES (VARCHAR '', BIGINT '10')");
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
e086473fff1762e069fd038c0c8ca641f598c53d introduced a regression. The channel map could be incorrectly aligned when queries used a mix of iceberg metadata columns and non-metadata columns.

Cause: I rebased off of master to include these [correct] fixes: https://github.com/trinodb/trino/pull/29763
But I applied the change incorrectly to EqualityDeleteFilter, need to preserve the source columns to produce the correct channel mapping. 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

I think no release notes are required since there has not been a trino release containing the above broken commit. 

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
