### PR TITLE
Detect out-of-range unscaled values in DecimalType.getObjectValue

### DIFF
--- a/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
@@ -62,6 +62,8 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.Decimals.MAX_SHORT_PRECISION;
+import static io.trino.spi.type.Decimals.bigIntegerTenToNth;
+import static io.trino.spi.type.Decimals.longTenToNth;
 import static io.trino.spi.type.Decimals.writeBigDecimal;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -157,9 +159,9 @@ public final class BlockAssertions
         }
         if (type instanceof DecimalType decimalType) {
             if (decimalType.isShort()) {
-                return createRandomLongsBlock(positionCount, nullRate);
+                return createRandomShortDecimalsBlock(decimalType, positionCount, nullRate);
             }
-            return createRandomLongDecimalsBlock(positionCount, nullRate);
+            return createRandomLongDecimalsBlock(decimalType, positionCount, nullRate);
         }
         if (type == VARCHAR) {
             return createRandomStringBlock(positionCount, nullRate, MAX_STRING_SIZE);
@@ -236,7 +238,24 @@ public final class BlockAssertions
             Block[] fieldBlocks = new Block[rowType.getFields().size()];
 
             for (int i = 0; i < fieldBlocks.length; i++) {
-                fieldBlocks[i] = createRandomBlockForType(rowType.getFields().get(i).getType(), positionCount, nullRate);
+                Type fieldType = rowType.getFields().get(i).getType();
+                ValueBlock fieldBlock = createRandomBlockForType(fieldType, positionCount, nullRate);
+                if (isNull == null) {
+                    fieldBlocks[i] = fieldBlock;
+                }
+                else {
+                    // Mask ROW nulls in the field block
+                    BlockBuilder builder = fieldType.createBlockBuilder(null, positionCount);
+                    for (int position = 0; position < positionCount; position++) {
+                        if (isNull[position] || fieldBlock.isNull(position)) {
+                            builder.appendNull();
+                        }
+                        else {
+                            builder.append(fieldBlock, position);
+                        }
+                    }
+                    fieldBlocks[i] = builder.build();
+                }
             }
 
             return RowBlock.fromNotNullSuppressedFieldBlocks(positionCount, Optional.ofNullable(isNull), fieldBlocks);
@@ -257,13 +276,37 @@ public final class BlockAssertions
         return createIntsBlock(generateListWithNulls(positionCount, nullRate, random::nextInt));
     }
 
-    public static ValueBlock createRandomLongDecimalsBlock(int positionCount, float nullRate)
+    public static ValueBlock createRandomShortDecimalsBlock(DecimalType type, int positionCount, float nullRate)
     {
+        long bound = longTenToNth(type.getPrecision());
         Random random = random();
-        return createLongDecimalsBlock(generateListWithNulls(
-                positionCount,
-                nullRate,
-                () -> String.valueOf(random.nextLong())));
+        BlockBuilder blockBuilder = type.createFixedSizeBlockBuilder(positionCount);
+        for (int i = 0; i < positionCount; i++) {
+            if (nullRate > 0 && random.nextFloat() < nullRate) {
+                blockBuilder.appendNull();
+            }
+            else {
+                type.writeLong(blockBuilder, random.nextLong() % bound);
+            }
+        }
+        return blockBuilder.buildValueBlock();
+    }
+
+    public static ValueBlock createRandomLongDecimalsBlock(DecimalType type, int positionCount, float nullRate)
+    {
+        BigInteger bound = bigIntegerTenToNth(type.getPrecision());
+        Random random = random();
+        BlockBuilder blockBuilder = type.createFixedSizeBlockBuilder(positionCount);
+        for (int i = 0; i < positionCount; i++) {
+            if (nullRate > 0 && random.nextFloat() < nullRate) {
+                blockBuilder.appendNull();
+            }
+            else {
+                BigInteger magnitude = new BigInteger(128, random).mod(bound);
+                type.writeObject(blockBuilder, Int128.valueOf(random.nextBoolean() ? magnitude : magnitude.negate()));
+            }
+        }
+        return blockBuilder.buildValueBlock();
     }
 
     public static ValueBlock createRandomShortTimestampBlock(TimestampType type, int positionCount, float nullRate)

--- a/core/trino-main/src/test/java/io/trino/type/TestLongDecimalType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestLongDecimalType.java
@@ -22,9 +22,14 @@ import io.trino.spi.type.SqlDecimal;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.Decimals.MAX_PRECISION;
+import static io.trino.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static io.trino.spi.type.Decimals.writeBigDecimal;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestLongDecimalType
         extends AbstractTestType
@@ -91,5 +96,36 @@ public class TestLongDecimalType
     {
         assertThat(type.getNextValue(getSampleValue()))
                 .isEmpty();
+    }
+
+    @Test
+    public void testGetObjectValueRejectsOutOfRange()
+    {
+        for (int precision = MAX_SHORT_PRECISION + 1; precision <= MAX_PRECISION; precision++) {
+            for (int scale : new int[] {0, precision / 2, precision}) {
+                DecimalType type = createDecimalType(precision, scale);
+
+                BigInteger tenToPrecision = BigInteger.TEN.pow(precision);
+                BigInteger maxUnscaled = tenToPrecision.subtract(BigInteger.ONE);
+                assertThat(type.getObjectValue(blockOf(type, Int128.valueOf(maxUnscaled)), 0))
+                        .isEqualTo(new SqlDecimal(maxUnscaled, precision, scale));
+                assertThat(type.getObjectValue(blockOf(type, Int128.valueOf(maxUnscaled.negate())), 0))
+                        .isEqualTo(new SqlDecimal(maxUnscaled.negate(), precision, scale));
+
+                assertThatThrownBy(() -> type.getObjectValue(blockOf(type, Int128.valueOf(tenToPrecision)), 0))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessage("Value out of range for DECIMAL(%s, %s): %s", precision, scale, tenToPrecision);
+                assertThatThrownBy(() -> type.getObjectValue(blockOf(type, Int128.valueOf(tenToPrecision.negate())), 0))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessage("Value out of range for DECIMAL(%s, %s): %s", precision, scale, tenToPrecision.negate());
+            }
+        }
+    }
+
+    private static ValueBlock blockOf(DecimalType type, Int128 unscaledValue)
+    {
+        BlockBuilder blockBuilder = type.createFixedSizeBlockBuilder(1);
+        type.writeObject(blockBuilder, unscaledValue);
+        return blockBuilder.buildValueBlock();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestShortDecimalType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestShortDecimalType.java
@@ -20,12 +20,15 @@ import io.trino.spi.type.SqlDecimal;
 import io.trino.spi.type.Type;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigInteger;
 import java.util.Optional;
 
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.Decimals.MAX_SHORT_PRECISION;
+import static io.trino.spi.type.Decimals.longTenToNth;
 import static java.lang.Math.pow;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestShortDecimalType
         extends AbstractTestType
@@ -90,6 +93,37 @@ public class TestShortDecimalType
                 .isEqualTo(Optional.of(maxValue - 2));
         assertThat(type.getPreviousValue(maxValue))
                 .isEqualTo(Optional.of(maxValue - 1));
+    }
+
+    @Test
+    public void testGetObjectValueRejectsOutOfRange()
+    {
+        for (int precision = 1; precision <= MAX_SHORT_PRECISION; precision++) {
+            for (int scale : new int[] {0, precision / 2, precision}) {
+                DecimalType type = createDecimalType(precision, scale);
+
+                long tenToPrecision = longTenToNth(precision);
+                long maxUnscaled = tenToPrecision - 1;
+                assertThat(type.getObjectValue(blockOf(type, maxUnscaled), 0))
+                        .isEqualTo(new SqlDecimal(BigInteger.valueOf(maxUnscaled), precision, scale));
+                assertThat(type.getObjectValue(blockOf(type, -maxUnscaled), 0))
+                        .isEqualTo(new SqlDecimal(BigInteger.valueOf(-maxUnscaled), precision, scale));
+
+                assertThatThrownBy(() -> type.getObjectValue(blockOf(type, tenToPrecision), 0))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessage("Value out of range for DECIMAL(%s, %s): %s", precision, scale, tenToPrecision);
+                assertThatThrownBy(() -> type.getObjectValue(blockOf(type, -tenToPrecision), 0))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessage("Value out of range for DECIMAL(%s, %s): %s", precision, scale, -tenToPrecision);
+            }
+        }
+    }
+
+    private static ValueBlock blockOf(DecimalType type, long unscaledValue)
+    {
+        BlockBuilder blockBuilder = type.createFixedSizeBlockBuilder(1);
+        type.writeLong(blockBuilder, unscaledValue);
+        return blockBuilder.buildValueBlock();
     }
 
     @Test

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongDecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongDecimalType.java
@@ -30,7 +30,6 @@ import io.trino.spi.function.ScalarOperator;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
-import java.math.BigInteger;
 import java.nio.ByteOrder;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
@@ -39,7 +38,9 @@ import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
+import static io.trino.spi.type.Decimals.overflows;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
+import static java.lang.String.format;
 import static java.lang.invoke.MethodHandles.lookup;
 
 final class LongDecimalType
@@ -95,8 +96,10 @@ final class LongDecimalType
             return null;
         }
         Int128 value = getObject(block, position);
-        BigInteger unscaledValue = value.toBigInteger();
-        return new SqlDecimal(unscaledValue, getPrecision(), getScale());
+        if (overflows(value, getPrecision())) {
+            throw new IllegalArgumentException(format("Value out of range for DECIMAL(%s, %s): %s", getPrecision(), getScale(), value.toBigInteger()));
+        }
+        return new SqlDecimal(value.toBigInteger(), getPrecision(), getScale());
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortDecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortDecimalType.java
@@ -46,7 +46,9 @@ import static io.trino.spi.function.OperatorType.READ_VALUE;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static io.trino.spi.type.Decimals.longTenToNth;
+import static io.trino.spi.type.Decimals.overflows;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
+import static java.lang.String.format;
 import static java.lang.invoke.MethodHandles.lookup;
 
 final class ShortDecimalType
@@ -123,7 +125,11 @@ final class ShortDecimalType
         if (block.isNull(position)) {
             return null;
         }
-        return new SqlDecimal(BigInteger.valueOf(getLong(block, position)), getPrecision(), getScale());
+        long value = getLong(block, position);
+        if (overflows(value, getPrecision())) {
+            throw new IllegalArgumentException(format("Value out of range for DECIMAL(%s, %s): %s", getPrecision(), getScale(), value));
+        }
+        return new SqlDecimal(BigInteger.valueOf(value), getPrecision(), getScale());
     }
 
     @Override

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestInt128ArrayBlockEncoding.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestInt128ArrayBlockEncoding.java
@@ -14,9 +14,11 @@
 package io.trino.spi.block;
 
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.Type;
 
+import java.math.BigInteger;
 import java.util.Random;
 
 final class TestInt128ArrayBlockEncoding
@@ -39,6 +41,8 @@ final class TestInt128ArrayBlockEncoding
     @Override
     protected Int128 randomValue(Random random)
     {
-        return Int128.valueOf(random.nextLong(), random.nextLong());
+        BigInteger bound = Decimals.bigIntegerTenToNth(TYPE.getPrecision());
+        BigInteger magnitude = new BigInteger(128, random).mod(bound);
+        return Int128.valueOf(random.nextBoolean() ? magnitude : magnitude.negate());
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ValueDecoders.java
@@ -1118,7 +1118,7 @@ public final class ValueDecoders
                 int[] buffer = new int[length];
                 delegate.read(buffer, 0, length);
                 for (int i = 0; i < length; i++) {
-                    if (overflows(buffer[i], decimalType.getPrecision())) {
+                    if (overflows(buffer[i], decimalType.getPrecision() - decimalType.getScale())) {
                         throw new TrinoException(
                                 INVALID_CAST_ARGUMENT,
                                 format("Cannot read parquet INT32 value '%s' as DECIMAL(%s, %s)", buffer[i], decimalType.getPrecision(), decimalType.getScale()));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -1236,10 +1236,11 @@ public abstract class AbstractTestParquetReader
                 parquetSchema);
 
         // Read INT32 as a short decimal of precision >= 10 with non-zero scale
+        // Maximum value fitting in DECIMAL(10, 1): unscaled = 999999999 * 10^1 = 9999999999 <= 10^10 - 1
         tester.testRoundTrip(
                 javaIntObjectInspector,
-                ImmutableList.of(Integer.MAX_VALUE),
-                ImmutableList.of(new SqlDecimal(BigInteger.valueOf(Integer.MAX_VALUE * 10L), 10, 1)),
+                ImmutableList.of(999_999_999),
+                ImmutableList.of(new SqlDecimal(BigInteger.valueOf(999_999_999L * 10), 10, 1)),
                 createDecimalType(10, 1),
                 parquetSchema);
 
@@ -1251,7 +1252,7 @@ public abstract class AbstractTestParquetReader
                 createDecimalType(4, 0),
                 parquetSchema);
 
-        // Cannot read INT32 as a short decimal if value exceeds supported precision
+        // Cannot read INT32 as a short decimal if value exceeds supported precision (no scale)
         assertThatThrownBy(() -> tester.assertRoundTripWithHiveWriter(
                 List.of(javaIntObjectInspector),
                 new Iterable[] {ImmutableList.of(Integer.MAX_VALUE)},
@@ -1261,6 +1262,18 @@ public abstract class AbstractTestParquetReader
                 parquetSchema,
                 ParquetSchemaOptions.defaultOptions()))
                 .hasMessage("Cannot read parquet INT32 value '2147483647' as DECIMAL(9, 0)")
+                .isInstanceOf(TrinoException.class);
+
+        // Cannot read INT32 as a short decimal when rescaling causes overflow: 10^9 * 10^1 = 10^10 > DECIMAL(10, 1) max
+        assertThatThrownBy(() -> tester.assertRoundTripWithHiveWriter(
+                List.of(javaIntObjectInspector),
+                new Iterable[] {ImmutableList.of(Integer.MAX_VALUE)},
+                new Iterable[] {ImmutableList.of(new SqlDecimal(BigInteger.valueOf(Integer.MAX_VALUE * 10L), 10, 1))},
+                List.of("test"),
+                List.of(createDecimalType(10, 1)),
+                parquetSchema,
+                ParquetSchemaOptions.defaultOptions()))
+                .hasMessage("Cannot read parquet INT32 value '2147483647' as DECIMAL(10, 1)")
                 .isInstanceOf(TrinoException.class);
     }
 


### PR DESCRIPTION
Type.getObjectValue is the contract by which Trino validates that an in-memory value is well-formed for its type (see e.g. CharType, TimestampType). DecimalType lacked such a check: a block holding an unscaled value that does not fit the type's precision was silently returned as a SqlDecimal that does not represent a valid DECIMAL(p, s).
