### PR TITLE
Fix incorrect neverFails=true on <= operator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOrEqualOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOrEqualOperator.java
@@ -42,7 +42,6 @@ public class GenericLessThanOrEqualOperator
                         .argumentType(typeVariable("T"))
                         .argumentType(typeVariable("T"))
                         .build())
-                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
@@ -744,6 +744,12 @@ public class TestRowOperators
         assertTrinoExceptionThrownBy(assertions.expression("row(1, CAST(NULL AS INTEGER)) < row(1, 2)")::evaluate)
                 .hasErrorCode(StandardErrorCode.NOT_SUPPORTED);
 
+        assertTrinoExceptionThrownBy(assertions.expression("row(1, CAST(NULL AS INTEGER)) <= row(1, 2)")::evaluate)
+                .hasErrorCode(StandardErrorCode.NOT_SUPPORTED);
+
+        assertTrinoExceptionThrownBy(assertions.expression("row(1, CAST(NULL AS INTEGER)) >= row(1, 2)")::evaluate)
+                .hasErrorCode(StandardErrorCode.NOT_SUPPORTED);
+
         assertComparisonCombination("row(1.0E0, ARRAY [1,2,3], row(2, 2.0E0))", "row(1.0E0, ARRAY [1,3,3], row(2, 2.0E0))");
         assertComparisonCombination("row(TRUE, ARRAY [1])", "row(TRUE, ARRAY [1, 2])");
         assertComparisonCombination("ROW(1, 2)", "ROW(2, 1)");


### PR DESCRIPTION
## Description
https://github.com/trinodb/trino/pull/29864 fixes `neverFails` (declared neverFails but may throw NOT_SUPPORTED) for the operator `<`. The `<=` seems to have the same issue too.


## Additional context and related issues
Related to https://github.com/trinodb/trino/pull/29864

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
