### PR TITLE
ci: fix expression injection in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,13 +164,16 @@ jobs:
           action-fixup: none
       - name: Set matrix (dispatch commit checks)
         id: set-matrix
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Make sure the PR branch contains the compile-commit composite job
-          if git merge-base --is-ancestor $( git rev-list HEAD -- .github/actions/compile-commit/action.yml | tail -n 1 ) ${{ github.event.pull_request.head.sha }}
+          if git merge-base --is-ancestor $( git rev-list HEAD -- .github/actions/compile-commit/action.yml | tail -n 1 ) "${PR_HEAD_SHA}"
           then
             # The HEAD commit of the PR can be safely ignored since it's already compiled in other jobs
             # This is achieved by adding a tilde (~) after the HEAD sha
-            git log --reverse --pretty=format:'%H,%T,"%s"' refs/remotes/origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }}~ | ./.github/bin/prepare-check-commits-matrix.py > commit-matrix.json
+            git log --reverse --pretty=format:'%H,%T,"%s"' "refs/remotes/origin/${PR_BASE_REF}".."${PR_HEAD_SHA}"~ | ./.github/bin/prepare-check-commits-matrix.py > commit-matrix.json
           else
             echo -n '' > commit-matrix.json
           fi


### PR DESCRIPTION
The set-matrix step in ci.yml interpolated
github.event.pull_request.base.ref directly inside a git log shell
command without passing it through an env: variable first:

  git log ... refs/remotes/origin/${{ github.event.pull_request.base.ref }}..

A pull request whose base branch name contains shell metacharacters
(semicolon, backtick, dollar-parenthesis, etc.) would cause arbitrary
command execution in the GitHub Actions runner.

Fix: move github.event.pull_request.base.ref (and head.sha for
consistency) into PR_BASE_REF and PR_HEAD_SHA env: variables at the
step level, then reference them with double-quoted expansion
"${PR_BASE_REF}" and "${PR_HEAD_SHA}" in the shell body.

This follows the safe interpolation pattern described in GitHub's
security hardening for GitHub Actions guide and enforced by tools
such as zizmor and StepSecurity Harden-Runner.

No behaviour change is intended.
