### PR TITLE
Make QuerySessionSupplier customizable in TestingTrinoServer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -257,6 +257,7 @@ public class TestingTrinoServer
             Map<String, String> properties,
             Optional<String> environment,
             Module additionalModule,
+            Module sessionSupplierModule,
             Optional<Path> baseDataDir,
             Optional<SpanProcessor> spanProcessor,
             Optional<FactoryConfiguration> systemAccessControlConfiguration,
@@ -359,11 +360,13 @@ public class TestingTrinoServer
                                     millis -> Instant.parse((String) millis),
                                     Instant::toString)));
                     if (coordinator) {
-                        binder.bind(QuerySessionSupplier.class).in(Scopes.SINGLETON);
                         newOptionalBinder(binder, SessionSupplier.class).setBinding().to(TestingSessionSupplier.class).in(Scopes.SINGLETON);
                     }
                 });
 
+        if (coordinator) {
+            modules.add(sessionSupplierModule);
+        }
         modules.add(additionalModule);
 
         Bootstrap app = new Bootstrap("io.trino.bootstrap.engine", modules.build());
@@ -748,6 +751,7 @@ public class TestingTrinoServer
         private Map<String, String> properties = ImmutableMap.of();
         private Optional<String> environment = Optional.empty();
         private Module additionalModule = EMPTY_MODULE;
+        private Module sessionSupplierModule = binder -> binder.bind(QuerySessionSupplier.class).in(Scopes.SINGLETON);
         private Optional<Path> baseDataDir = Optional.empty();
         private Optional<SpanProcessor> spanProcessor = Optional.empty();
         private Optional<FactoryConfiguration> systemAccessControlConfiguration = Optional.empty();
@@ -800,6 +804,12 @@ public class TestingTrinoServer
         public Builder setAdditionalModule(Module additionalModule)
         {
             this.additionalModule = requireNonNull(additionalModule, "additionalModule is null");
+            return this;
+        }
+
+        public Builder setSessionSupplierModule(Module sessionSupplierModule)
+        {
+            this.sessionSupplierModule = requireNonNull(sessionSupplierModule, "sessionSupplierModule is null");
             return this;
         }
 
@@ -857,6 +867,7 @@ public class TestingTrinoServer
                     properties,
                     environment,
                     additionalModule,
+                    sessionSupplierModule,
                     baseDataDir,
                     spanProcessor,
                     systemAccessControlConfiguration,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Since https://github.com/trinodb/trino/commit/a2ffc214e2d4efabe0066387ff02293670565dba, `SessionSupplier` is hard-bound to `TestingSessionSupplier` with `QuerySessionSupplier` inside `TestingTrinoServer`, which denies using a custom session supplier with `TestingTrinoServer`. 

With this change, we can use a custom `QuerySessionSupplier` by setting a custom `sessionSupplierModule` to `TestingTrinoServer`.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- https://github.com/trinodb/trino/pull/20048


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
