### PR TITLE
Recognize infallible non-coercion casts

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
@@ -184,6 +184,10 @@ public final class IrExpressions
         if (mayFail(plannerContext, cast.expression())) {
             return true;
         }
+        ResolvedFunction castFunction = plannerContext.getMetadata().getCoercion(cast.expression().type(), cast.type());
+        if (castFunction.neverFails()) {
+            return false;
+        }
 
         TypeCoercion coercions = new TypeCoercion(plannerContext.getTypeManager()::getType);
         if (coercions.canCoerce(cast.expression().type(), cast.type())) {

--- a/core/trino-main/src/test/java/io/trino/type/TestBigintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestBigintOperators.java
@@ -497,6 +497,7 @@ public class TestBigintOperators
     {
         assertThat(assertions.expression("cast(a as boolean)")
                 .binding("a", "BIGINT '37'"))
+                .couldFail()
                 .isEqualTo(true);
 
         assertThat(assertions.expression("cast(a as boolean)")
@@ -506,10 +507,6 @@ public class TestBigintOperators
         assertThat(assertions.expression("cast(a as boolean)")
                 .binding("a", "BIGINT '0'"))
                 .isEqualTo(false);
-
-        assertThat(assertions.expression("cast(a as boolean)")
-                .binding("a", "BIGINT '0'"))
-                .couldFail();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestCharacterStringCasts.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestCharacterStringCasts.java
@@ -54,9 +54,11 @@ public class TestCharacterStringCasts
     @Test
     public void testVarcharToVarcharCast()
     {
+        // widening
         assertThat(assertions.expression("cast(a as varchar(20))")
                 .binding("a", "'bar'"))
                 .hasType(createVarcharType(20))
+                .neverFails()
                 .isEqualTo("bar");
 
         assertThat(assertions.expression("cast(cast(a as varchar(20)) as varchar(30))")
@@ -69,9 +71,11 @@ public class TestCharacterStringCasts
                 .hasType(VARCHAR)
                 .isEqualTo("bar");
 
+        // narrowing (truncation)
         assertThat(assertions.expression("cast(a as varchar(3))")
                 .binding("a", "'banana'"))
                 .hasType(createVarcharType(3))
+                .couldFail()
                 .isEqualTo("ban");
 
         assertThat(assertions.expression("cast(cast(a as varchar(20)) as varchar(3))")
@@ -83,14 +87,18 @@ public class TestCharacterStringCasts
     @Test
     public void testVarcharToCharCast()
     {
+        // widening
         assertThat(assertions.expression("cast(a as char(10))")
                 .binding("a", "'bar  '"))
                 .hasType(createCharType(10))
+                .neverFails()
                 .isEqualTo("bar       ");
 
+        // narrowing (truncation)
         assertThat(assertions.expression("cast(a as char)")
                 .binding("a", "'bar'"))
                 .hasType(createCharType(1))
+                .couldFail()
                 .isEqualTo("b");
 
         assertThat(assertions.expression("cast(a as char)")
@@ -102,6 +110,13 @@ public class TestCharacterStringCasts
     @Test
     public void testCharToVarcharCast()
     {
+        // widening
+        assertThat(assertions.expression("cast(a as varchar(10))")
+                .binding("a", "CAST('bar' AS char(5))"))
+                .hasType(createVarcharType(10))
+                .couldFail()
+                .isEqualTo("bar  ");
+
         assertThat(assertions.expression("cast(cast(a as char(5)) as varchar(10))")
                 .binding("a", "'bar'"))
                 .hasType(createVarcharType(10))
@@ -131,6 +146,43 @@ public class TestCharacterStringCasts
                 .binding("a", "'b'"))
                 .hasType(createVarcharType(3))
                 .isEqualTo("b  ");
+
+        // narrowing (truncation)
+        assertThat(assertions.expression("cast(a as varchar(4))")
+                .binding("a", "CAST('bar' AS char(5))"))
+                .hasType(createVarcharType(4))
+                .couldFail()
+                .isEqualTo("bar ");
+
+        assertThat(assertions.expression("cast(a as varchar(2))")
+                .binding("a", "CAST('bar' AS char(5))"))
+                .hasType(createVarcharType(2))
+                .couldFail()
+                .isEqualTo("ba");
+    }
+
+    @Test
+    public void testCharToCharCast()
+    {
+        // widening
+        assertThat(assertions.expression("cast(a as char(10))")
+                .binding("a", "CAST('bar' AS char(5))"))
+                .hasType(createCharType(10))
+                .neverFails()
+                .isEqualTo("bar       ");
+
+        // narrowing (truncation)
+        assertThat(assertions.expression("cast(a as char(4))")
+                .binding("a", "CAST('bar' AS char(5))"))
+                .hasType(createCharType(4))
+                .couldFail()
+                .isEqualTo("bar ");
+
+        assertThat(assertions.expression("cast(a as char(2))")
+                .binding("a", "CAST('bar' AS char(5))"))
+                .hasType(createCharType(2))
+                .couldFail()
+                .isEqualTo("ba");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
@@ -121,7 +121,7 @@ public class TestDecimalCasts
     {
         assertThat(assertions.expression("cast(a as BOOLEAN)")
                 .binding("a", "DECIMAL '1.1'"))
-                .couldFail()
+                .neverFails()
                 .isEqualTo(true);
 
         assertThat(assertions.expression("cast(a as BOOLEAN)")

--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
@@ -121,6 +121,7 @@ public class TestDecimalCasts
     {
         assertThat(assertions.expression("cast(a as BOOLEAN)")
                 .binding("a", "DECIMAL '1.1'"))
+                .couldFail()
                 .isEqualTo(true);
 
         assertThat(assertions.expression("cast(a as BOOLEAN)")

--- a/core/trino-main/src/test/java/io/trino/type/TestDoubleOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDoubleOperators.java
@@ -728,6 +728,7 @@ public class TestDoubleOperators
     {
         assertThat(assertions.expression("cast(a as boolean)")
                 .binding("a", "37.7E0"))
+                .couldFail()
                 .isEqualTo(true);
 
         assertThat(assertions.expression("cast(a as boolean)")

--- a/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
@@ -501,6 +501,7 @@ public class TestIntegerOperators
     {
         assertThat(assertions.expression("cast(a as boolean)")
                 .binding("a", "INTEGER '37'"))
+                .couldFail()
                 .isEqualTo(true);
 
         assertThat(assertions.expression("cast(a as boolean)")

--- a/core/trino-main/src/test/java/io/trino/type/TestRealOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRealOperators.java
@@ -851,6 +851,7 @@ public class TestRealOperators
     {
         assertThat(assertions.expression("cast(a as BOOLEAN)")
                 .binding("a", "REAL '754.1985'"))
+                .couldFail()
                 .isEqualTo(true);
 
         assertThat(assertions.expression("cast(a as BOOLEAN)")

--- a/core/trino-main/src/test/java/io/trino/type/TestSmallintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestSmallintOperators.java
@@ -503,6 +503,7 @@ public class TestSmallintOperators
     {
         assertThat(assertions.expression("cast(a as boolean)")
                 .binding("a", "SMALLINT '37'"))
+                .couldFail()
                 .isEqualTo(true);
 
         assertThat(assertions.expression("cast(a as boolean)")

--- a/core/trino-main/src/test/java/io/trino/type/TestTinyintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTinyintOperators.java
@@ -500,6 +500,7 @@ public class TestTinyintOperators
     {
         assertThat(assertions.expression("cast(a as boolean)")
                 .binding("a", "TINYINT '37'"))
+                .couldFail()
                 .isEqualTo(true);
 
         assertThat(assertions.expression("cast(a as boolean)")


### PR DESCRIPTION
For example casting numbers to BOOLEAN cannot fail. This is not a
coercion, so it was previously not recognized as infallible by
`IrExpressions.mayFail`.