### PR TITLE
Implement complex expression pushdown for Druid

### DIFF
--- a/docs/src/main/sphinx/connector/druid.md
+++ b/docs/src/main/sphinx/connector/druid.md
@@ -202,3 +202,11 @@ aggregation results stay consistent with Trino's `NULL` semantics. Set the
 
 ```{include} pushdown-correctness-behavior.fragment
 ```
+
+### Predicate pushdown support
+
+The connector supports {ref}`predicate expression pushdown <predicate-pushdown>`.
+Comparisons between numeric columns (`=`, `<>`, `<`, `<=`, `>`, `>=`) are pushed down
+to Druid rather than evaluated by Trino, including predicates that cannot be expressed
+as a range, such as comparisons between two columns. Arithmetic operators and `LIKE`
+expressions are not pushed down.

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
@@ -26,6 +26,7 @@ import io.trino.plugin.jdbc.ColumnMapping;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
+import io.trino.plugin.jdbc.JdbcJoinCondition;
 import io.trino.plugin.jdbc.JdbcNamedRelationHandle;
 import io.trino.plugin.jdbc.JdbcOutputTableHandle;
 import io.trino.plugin.jdbc.JdbcRemoteIdentifiers;
@@ -54,7 +55,10 @@ import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ColumnPosition;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.JoinStatistics;
+import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.spi.type.CharType;
@@ -174,6 +178,13 @@ public class DruidJdbcClient
 
         this.connectorExpressionRewriter = JdbcConnectorExpressionRewriterBuilder.newBuilder()
                 .addStandardRules(this::quoted)
+                .withTypeClass("numeric_type", ImmutableSet.of("tinyint", "smallint", "integer", "bigint", "real", "double"))
+                .map("$equal(left: numeric_type, right: numeric_type)").to("left = right")
+                .map("$not_equal(left: numeric_type, right: numeric_type)").to("left <> right")
+                .map("$less_than(left: numeric_type, right: numeric_type)").to("left < right")
+                .map("$less_than_or_equal(left: numeric_type, right: numeric_type)").to("left <= right")
+                .map("$greater_than(left: numeric_type, right: numeric_type)").to("left > right")
+                .map("$greater_than_or_equal(left: numeric_type, right: numeric_type)").to("left >= right")
                 .build();
 
         JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
@@ -637,5 +648,44 @@ public class DruidJdbcClient
     public Optional<JdbcExpression> implementAggregation(ConnectorSession session, AggregateFunction aggregate, Map<String, ColumnHandle> assignments)
     {
         return aggregateFunctionRewriter.rewrite(session, aggregate, assignments);
+    }
+
+    @Override
+    public Optional<ParameterizedExpression> convertPredicate(ConnectorSession session, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    {
+        return connectorExpressionRewriter.rewrite(session, expression, assignments);
+    }
+
+    @Override
+    public Optional<PreparedQuery> implementJoin(
+            ConnectorSession session,
+            JoinType joinType,
+            PreparedQuery leftSource,
+            Map<JdbcColumnHandle, String> leftProjections,
+            PreparedQuery rightSource,
+            Map<JdbcColumnHandle, String> rightProjections,
+            List<ParameterizedExpression> joinConditions,
+            JoinStatistics statistics)
+    {
+        // Join pushdown is not supported. The shared connector expression rewriter is used for predicate
+        // expression pushdown, which would otherwise let the engine translate equi-join conditions and push
+        // joins down to Druid; opt out so only predicate expressions are pushed.
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<PreparedQuery> legacyImplementJoin(
+            ConnectorSession session,
+            JoinType joinType,
+            PreparedQuery leftSource,
+            PreparedQuery rightSource,
+            List<JdbcJoinCondition> joinConditions,
+            Map<JdbcColumnHandle, String> rightAssignments,
+            Map<JdbcColumnHandle, String> leftAssignments,
+            JoinStatistics statistics)
+    {
+        // Join pushdown is not supported; opt out of the legacy join pushdown path as well so join pushdown
+        // stays disabled regardless of the complex_join_pushdown session toggle.
+        return Optional.empty();
     }
 }

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidConnectorTest.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidConnectorTest.java
@@ -102,7 +102,6 @@ public class TestDruidConnectorTest
                  SUPPORTS_AGGREGATION_PUSHDOWN_REGRESSION,
                  SUPPORTS_AGGREGATION_PUSHDOWN_STDDEV,
                  SUPPORTS_AGGREGATION_PUSHDOWN_VARIANCE,
-                 SUPPORTS_PREDICATE_EXPRESSION_PUSHDOWN,
                  SUPPORTS_COMMENT_ON_COLUMN,
                  SUPPORTS_COMMENT_ON_TABLE,
                  SUPPORTS_CREATE_SCHEMA,
@@ -110,6 +109,9 @@ public class TestDruidConnectorTest
                  SUPPORTS_DELETE,
                  SUPPORTS_DROP_NOT_NULL_CONSTRAINT,
                  SUPPORTS_INSERT,
+                 // Connector expression pushdown rewrites numeric comparisons only; it rewrites neither arithmetic operators nor LIKE
+                 SUPPORTS_PREDICATE_ARITHMETIC_EXPRESSION_PUSHDOWN,
+                 SUPPORTS_PREDICATE_EXPRESSION_PUSHDOWN_WITH_LIKE,
                  SUPPORTS_RENAME_COLUMN,
                  SUPPORTS_RENAME_TABLE,
                  SUPPORTS_ROW_TYPE,
@@ -370,6 +372,29 @@ public class TestDruidConnectorTest
     }
 
     @Test
+    public void testPredicateExpressionPushdown()
+    {
+        // Numeric column-to-column comparisons cannot be expressed as a TupleDomain, so they are
+        // pushed down only through connector expression pushdown (convertPredicate). Exercise every mapped
+        // comparison operator (=, <>, <, <=, >, >=).
+        assertThat(query("SELECT nationkey, regionkey FROM nation WHERE nationkey = regionkey"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT nationkey, regionkey FROM nation WHERE nationkey <> regionkey"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT nationkey, regionkey FROM nation WHERE nationkey < regionkey"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT nationkey, regionkey FROM nation WHERE nationkey <= regionkey"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT nationkey, regionkey FROM nation WHERE nationkey > regionkey"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT nationkey, regionkey FROM nation WHERE nationkey >= regionkey"))
+                .isFullyPushedDown();
+        // A column-to-column expression combines with a TupleDomain predicate into a single pushed-down filter.
+        assertThat(query("SELECT nationkey, regionkey FROM nation WHERE nationkey > regionkey AND regionkey > 1"))
+                .isFullyPushedDown();
+    }
+
+    @Test
     public void testPredicatePushdownForTimestampWithSecondsPrecision()
     {
         // timestamp equality
@@ -586,7 +611,7 @@ public class TestDruidConnectorTest
         assertThat(query("SELECT custkey, sum(totalprice) FROM (SELECT custkey, totalprice FROM orders ORDER BY orderdate ASC, totalprice ASC LIMIT 10) GROUP BY custkey")).isNotFullyPushedDown(project(node(TopNNode.class, anyTree(node(TableScanNode.class)))));
         // GROUP BY with WHERE on neither grouping nor aggregation column
         assertThat(query("SELECT nationkey, min(regionkey) FROM nation WHERE name = 'ARGENTINA' GROUP BY nationkey")).isFullyPushedDown();
-        // GROUP BY with WHERE LIKE predicate: not pushed down because the connector does not push down predicate expressions
+        // GROUP BY with WHERE LIKE predicate: not pushed down because the standard expression rules do not include a LIKE rewrite
         assertThat(query("SELECT regionkey, sum(nationkey) FROM nation WHERE name LIKE '%N%' GROUP BY regionkey"))
                 .isNotFullyPushedDown(FilterNode.class);
         // aggregation on varchar column


### PR DESCRIPTION
## Description

Add aggregation pushdown to the Druid connector.

Push down the common aggregate functions `avg`, `count` (including
`count(DISTINCT ...)`), `min`, `max`, and `sum` by reusing the shared
`io.trino.plugin.base.aggregation` JDBC aggregation rules, so the change is
largely wiring rather than new rewrite logic. `count(DISTINCT ...)` is computed
exactly by setting `useApproximateCountDistinct=false` on the JDBC connection,
instead of using Druid's approximate cardinality algorithm, so pushed-down
results stay consistent with Trino's semantics. Druid has no decimal type, so
decimal aggregation rules are not registered.

Statistical aggregations (`stddev`, `variance`, `covariance`, `correlation`, and
`regression`) are not pushed down: Druid has no native equivalents, and its
standard-deviation / variance functions require a separate extension.

For pushed-down aggregations to match Trino semantics, the Druid cluster must
return SQL-standard `NULL` for aggregations over empty input and preserve `NULL`
for nullable columns. Druid does this only with
`druid.generic.useDefaultValueForNull=false`, the default since Druid `28.0.0`
and mandatory from `32.0.0`. Clusters that must keep legacy null handling can
disable aggregation pushdown with the standard `aggregation-pushdown.enabled`
config property (or the `aggregation_pushdown_enabled` session property), so
results stay consistent with Trino. The SQL-compatible mode also flips numeric
columns to nullable in `SHOW CREATE TABLE` and maps Druid `NULL`s to Trino
`NULL` instead of legacy defaults (`0`, `0.0`, `''`).

The shared test Druid image is raised from `0.18.0` to `0.22.0`. `0.18.0` has a
planner bug ([apache/druid#9949](https://github.com/apache/druid/issues/9949),
fixed in `0.19.0`) that fails `SELECT agg(*) FROM (SELECT ... LIMIT N)` — exactly
the query shape aggregation-pushdown tests exercise. The test server is also
fixed to run a single, consistent Druid version across the coordinator, broker,
historical, and middle-manager containers (previously the non-coordinator
containers were pinned to a hardcoded version, producing a mixed-version cluster
that failed segment loading when a non-default version was requested).
`TestDruidTypeMapping` continues to run on `0.18.0`, where its low-level type
round-trip expectations are pinned.

## Commits

This PR is organized as three reviewable commits:

1. **Run all Druid test containers on a consistent version** — build the broker,
   historical, and middle-manager containers from the same image as the
   coordinator (the constructor argument) instead of a hardcoded version, so a
   non-default image produces a single-version cluster rather than a mixed-version
   one that fails segment loading.
2. **Use SQL-compatible null handling in Druid tests** — raise the shared test
   image to `0.22.0` (past the `0.19.0` planner-bug fix), bump
   `TestDruidLatestConnectorSmokeTest` to `0.23.0` (the most recent release that
   still supports the firehose-based batch ingestion used by the test harness),
   enable `druid.generic.useDefaultValueForNull=false` in the test cluster, and
   update the type-mapping and `SHOW CREATE TABLE` expectations to SQL `NULL`
   semantics. This is a prerequisite for correct aggregation pushdown.
3. **Add aggregation pushdown to Druid connector** — the aggregation pushdown
   wiring (`DruidJdbcClient`, `ImplementAvgBigint`, `DruidJdbcClientModule`),
   connector documentation, and Druid-specific aggregation tests (including a
   dedicated ingest spec for the case-sensitive aggregation test and a
   count-anchored empty-input `NULL` assertion).

## Additional context and related issues

- Fixes #4109.
- Supersedes the earlier attempts #4313 and #25706. The latter was reviewed by
  maintainers and closed only for inactivity; this PR carries that feedback
  forward, in particular forcing `count(DISTINCT ...)` to exact computation
  rather than exposing a configurable strategy, prioritizing correctness.
- Predicate expression pushdown is split into a dedicated follow-up PR so this
  change can land as a focused, well-validated aggregation contribution.

Because Druid does not support `CREATE TABLE`, the aggregation-pushdown tests in
`BaseJdbcConnectorTest` cannot be inherited directly; Druid-specific equivalents
that use pre-ingested TPC-H tables (and a dedicated ingest spec for the
case-sensitive aggregation test) are added in `TestDruidConnectorTest`. Coverage
includes `count` variants, distinct aggregations, numeric `min`/`max`/`sum`/`avg`
over multiple types, case-sensitive aggregation, and a count-anchored empty-input
assertion verifying SQL `NULL` results.

## Release notes

```
## Druid
* Add support for aggregation pushdown. ({issue}`4109`)
```
