### PR TITLE
Fix duplicate "the" in LabelEvaluator comment

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/window/pattern/LabelEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/pattern/LabelEvaluator.java
@@ -40,7 +40,7 @@ public class LabelEvaluator
     // by the common base frame in case of pattern recognition in WINDOW clause.
     private final int searchStart;
 
-    // exclusive - the first row after the the partition area available for pattern search.
+    // exclusive - the first row after the partition area available for pattern search.
     // this area is the whole partition in case of MATCH_RECOGNIZE, and the area enclosed
     // by the common base frame in case of pattern recognition in WINDOW clause.
     private final int searchEnd;


### PR DESCRIPTION
Removes a duplicated "the" in a comment in `LabelEvaluator.java`.

```
- // exclusive - the first row after the the partition area available for pattern search.
+ // exclusive - the first row after the partition area available for pattern search.
```

Comment-only change; no code or behavior is affected.

## Release notes

`(x) This is not user-visible or docs-only and no release notes are required.`
