### PR TITLE
Support named arguments in method-call syntax

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -606,8 +606,8 @@ primaryExpression
         filter? over?                                                                     #functionCall
     | processingMode? qualifiedName '(' (setQuantifier? argument (',' argument)*)?
         orderBy? ')' filter? (nullTreatment? over)?                                       #functionCall
-    | qualifiedName '::' identifier '(' (expression (',' expression)*)? ')'               #staticMethodCall
-    | primaryExpression '.' identifier '(' (expression (',' expression)*)? ')'            #methodCall
+    | qualifiedName '::' identifier '(' (argument (',' argument)*)? ')'                   #staticMethodCall
+    | primaryExpression '.' identifier '(' (argument (',' argument)*)? ')'                #methodCall
     | identifier over                                                                     #measure
     | identifier '->' expression                                                          #lambda
     | '(' (identifier (',' identifier)*)? ')' '->' expression                             #lambda

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -227,7 +227,7 @@ public class Analysis
     private final Map<NodeRef<Node>, RoutineEntry> resolvedFunctions = new LinkedHashMap<>();
     private final Map<NodeRef<FunctionCall>, Identifier> methodCallReceivers = new LinkedHashMap<>();
 
-    private final Map<NodeRef<FunctionCall>, List<Integer>> argumentBindings = new LinkedHashMap<>();
+    private final Map<NodeRef<Expression>, List<Integer>> argumentBindings = new LinkedHashMap<>();
     private final Map<NodeRef<Identifier>, LambdaArgumentDeclaration> lambdaArgumentReferences = new LinkedHashMap<>();
 
     private final Map<Field, ColumnHandle> columns = new LinkedHashMap<>();
@@ -739,12 +739,12 @@ public class Analysis
     /// positionally this is the identity binding `[0, 1, ..., N-1]`; for a call
     /// with named arguments it reorders so the named values land at their declared
     /// positions.
-    public void setArgumentBinding(FunctionCall node, List<Integer> binding)
+    public void setArgumentBinding(Expression node, List<Integer> binding)
     {
         argumentBindings.put(NodeRef.of(node), List.copyOf(binding));
     }
 
-    public List<Integer> getArgumentBinding(FunctionCall node)
+    public List<Integer> getArgumentBinding(Expression node)
     {
         List<Integer> binding = argumentBindings.get(NodeRef.of(node));
         if (binding == null) {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -58,6 +58,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeDescriptor;
 import io.trino.spi.type.TypeNotFoundException;
 import io.trino.spi.type.TypeParameter;
+import io.trino.spi.type.TypeTemplate;
 import io.trino.spi.type.VarcharType;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.analyzer.Analysis.PredicateCoercions;
@@ -187,6 +188,7 @@ import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -336,7 +338,7 @@ public class ExpressionAnalyzer
 
     private final Map<NodeRef<Node>, ResolvedFunction> resolvedFunctions = new LinkedHashMap<>();
     private final Map<NodeRef<FunctionCall>, Identifier> methodCallReceivers = new LinkedHashMap<>();
-    private final Map<NodeRef<FunctionCall>, List<Integer>> argumentBindings = new LinkedHashMap<>();
+    private final Map<NodeRef<Expression>, List<Integer>> argumentBindings = new LinkedHashMap<>();
     private final Set<NodeRef<SubqueryExpression>> subqueries = new LinkedHashSet<>();
     private final Set<NodeRef<ExistsPredicate>> existsSubqueries = new LinkedHashSet<>();
     private final Map<NodeRef<Expression>, Type> expressionCoercions = new LinkedHashMap<>();
@@ -450,7 +452,7 @@ public class ExpressionAnalyzer
         return unmodifiableMap(methodCallReceivers);
     }
 
-    public Map<NodeRef<FunctionCall>, List<Integer>> getArgumentBindings()
+    public Map<NodeRef<Expression>, List<Integer>> getArgumentBindings()
     {
         return unmodifiableMap(argumentBindings);
     }
@@ -1490,7 +1492,7 @@ public class ExpressionAnalyzer
                 }
             }
             resolvedFunctions.put(NodeRef.of(node), function);
-            argumentBindings.put(NodeRef.of(node), argumentBinding);
+            argumentBindings.put(NodeRef.<Expression>of(node), argumentBinding);
 
             // must run after arguments are processed and labels are recorded
             if (context.isPatternRecognition() && isAggregation) {
@@ -1512,24 +1514,32 @@ public class ExpressionAnalyzer
         //  binder is a much bigger change.
         private List<Integer> computeArgumentBinding(FunctionCall node)
         {
-            List<CallArgument> arguments = node.getArguments();
-            int arity = arguments.size();
-            int firstNamedArgument = findFirstNamedArgument(arguments);
-            verifyNoDuplicateNames(arguments);
-
             // SQL name resolution picks the first path entry that has any candidate;
             // we stop iterating the path after that. Registration enforces that
             // overloads of the same name at the same arity place each named parameter
             // at the same position (see InternalFunctionBundle), so the first
             // arity-matching overload that fits is enough to build the binding.
-            List<FunctionMetadata> candidates = findCandidates(node.getName());
+            return computeArgumentBinding(node.getArguments(), findCandidates(node.getName()), 0, node, "function " + node.getName());
+        }
+
+        /// Computes the binding from declared-argument position to AST argument index for
+        /// a call with named arguments. `candidates` are the overloads in scope for the
+        /// callee; `receiverSlots` is the number of leading signature slots not visible to
+        /// the caller (1 for an instance method's `self`, 0 otherwise). `subject` names the
+        /// callee for diagnostics (for example `function foo` or `method bar`).
+        private List<Integer> computeArgumentBinding(List<CallArgument> arguments, List<FunctionMetadata> candidates, int receiverSlots, Node errorNode, String subject)
+        {
+            int arity = arguments.size();
+            int firstNamedArgument = findFirstNamedArgument(arguments);
+            verifyNoDuplicateNames(arguments);
+
             Optional<FunctionMetadata> chosen = Optional.empty();
             for (FunctionMetadata candidate : candidates) {
                 if (candidate.getSignature().isVariableArity()) {
                     // Variadic + named args is intentionally unsupported.
                     continue;
                 }
-                List<Signature.Argument> declared = candidate.getSignature().getArguments();
+                List<Signature.Argument> declared = callerVisibleArguments(candidate, receiverSlots);
                 if (declared.size() == arity && satisfiesNamedArguments(arguments, firstNamedArgument, declared)) {
                     chosen = Optional.of(candidate);
                     break;
@@ -1542,12 +1552,12 @@ public class ExpressionAnalyzer
                     if (candidate.getSignature().isVariableArity()) {
                         continue;
                     }
-                    candidate.getSignature().getArguments().forEach(argument -> argument.name().ifPresent(knownNames::add));
+                    callerVisibleArguments(candidate, receiverSlots).forEach(argument -> argument.name().ifPresent(knownNames::add));
                 }
                 for (int i = firstNamedArgument; i < arity; i++) {
                     Identifier name = arguments.get(i).getName().orElseThrow();
                     if (!knownNames.contains(name.getValue())) {
-                        throw semanticException(INVALID_FUNCTION_ARGUMENT, name, "No argument named %s for function %s", name.getValue(), node.getName());
+                        throw semanticException(INVALID_FUNCTION_ARGUMENT, name, "No argument named %s for %s", name.getValue(), subject);
                     }
                 }
                 // Names are known but no overload accepts them — typically because a
@@ -1556,22 +1566,22 @@ public class ExpressionAnalyzer
                 for (FunctionMetadata candidate : candidates) {
                     for (int i = firstNamedArgument; i < arity; i++) {
                         Identifier name = arguments.get(i).getName().orElseThrow();
-                        OptionalInt declaredPosition = findArgumentPosition(candidate.getSignature().getArguments(), name.getValue());
+                        OptionalInt declaredPosition = findArgumentPosition(callerVisibleArguments(candidate, receiverSlots), name.getValue());
                         if (declaredPosition.isPresent() && declaredPosition.getAsInt() < firstNamedArgument) {
                             throw semanticException(
                                     INVALID_FUNCTION_ARGUMENT,
                                     name,
-                                    "Named argument %s for function %s refers to parameter position %s, which is already supplied positionally",
+                                    "Named argument %s for %s refers to parameter position %s, which is already supplied positionally",
                                     name.getValue(),
-                                    node.getName(),
+                                    subject,
                                     declaredPosition.getAsInt());
                         }
                     }
                 }
-                throw semanticException(INVALID_FUNCTION_ARGUMENT, node, "No overload of function %s accepts the given named arguments", node.getName());
+                throw semanticException(INVALID_FUNCTION_ARGUMENT, errorNode, "No overload of %s accepts the given named arguments", subject);
             }
 
-            List<Signature.Argument> chosenArguments = chosen.get().getSignature().getArguments();
+            List<Signature.Argument> chosenArguments = callerVisibleArguments(chosen.get(), receiverSlots);
             List<Integer> binding = new ArrayList<>(identityBinding(arity));
             for (int i = firstNamedArgument; i < arity; i++) {
                 Identifier name = arguments.get(i).getName().orElseThrow();
@@ -1579,6 +1589,49 @@ public class ExpressionAnalyzer
                 binding.set(signaturePosition, i);
             }
             return List.copyOf(binding);
+        }
+
+        /// Returns the declared arguments visible to the caller, dropping the leading
+        /// `receiverSlots` entries that the call syntax supplies implicitly (an instance
+        /// method's `self`).
+        private static List<Signature.Argument> callerVisibleArguments(FunctionMetadata candidate, int receiverSlots)
+        {
+            List<Signature.Argument> arguments = candidate.getSignature().getArguments();
+            return arguments.subList(receiverSlots, arguments.size());
+        }
+
+        private List<FunctionMetadata> findInstanceMethodCandidates(String methodName, Type receiverType)
+        {
+            String receiverBase = receiverType.getTypeDescriptor().getBase();
+            return findMethodCandidates(methodName, candidate -> candidate.isInstanceMethod()
+                    && candidate.getReceiverType().map(TypeTemplate::baseName).equals(Optional.of(receiverBase)));
+        }
+
+        private List<FunctionMetadata> findStaticMethodCandidates(String methodName, String receiverBase)
+        {
+            return findMethodCandidates(methodName, candidate -> !candidate.isInstanceMethod()
+                    && candidate.getReceiverType().map(TypeTemplate::baseName).equals(Optional.of(receiverBase)));
+        }
+
+        /// Returns the method overloads named `methodName` from the first function-path
+        /// entry that declares one matching `filter` (instance vs static and receiver
+        /// type). This follows the same first-path-entry strategy as [#findCandidates]
+        /// — and inherits the same approximation of [FunctionResolver]'s binding, which
+        /// aggregates across the path: name binding only reads parameter names, and
+        /// registration keeps each name at a stable position per name+arity, so the
+        /// first matching entry's overloads are enough to build the binding.
+        private List<FunctionMetadata> findMethodCandidates(String methodName, Predicate<FunctionMetadata> filter)
+        {
+            for (CatalogSchemaFunctionName candidateName : FunctionResolver.toPath(session, QualifiedName.of(methodName), accessControl)) {
+                List<FunctionMetadata> matching = plannerContext.getMetadata().getFunctions(session, candidateName).stream()
+                        .map(CatalogFunctionMetadata::functionMetadata)
+                        .filter(filter)
+                        .collect(toImmutableList());
+                if (!matching.isEmpty()) {
+                    return matching;
+                }
+            }
+            return List.of();
         }
 
         /// Returns the index of the first named argument (or `arguments.size()` for
@@ -1656,15 +1709,20 @@ public class ExpressionAnalyzer
             return result.build();
         }
 
+        /// Returns the argument values reordered into declared-signature order, as given
+        /// by `binding` (the identity for a purely positional call).
+        private static List<Expression> orderedArgumentValues(List<CallArgument> arguments, List<Integer> binding)
+        {
+            return binding.stream()
+                    .map(arguments::get)
+                    .map(CallArgument::getValue)
+                    .collect(toImmutableList());
+        }
+
         private Optional<Type> tryResolveAsInstanceMethod(FunctionCall node, Context context)
         {
             QualifiedName name = node.getName();
             if (name.getParts().size() != 2) {
-                return Optional.empty();
-            }
-            if (node.hasNamedArguments()) {
-                // Method-call syntax (receiver.method(...)) does not support named arguments;
-                // fall through to ordinary function resolution so the caller sees a clear error.
                 return Optional.empty();
             }
             if (node.isDistinct()
@@ -1692,7 +1750,22 @@ public class ExpressionAnalyzer
             }
             Type receiverType = resolvedReceiver.get().getField().getType();
 
-            List<Expression> argumentValues = node.argumentValues();
+            List<CallArgument> arguments = node.getArguments();
+            List<Integer> binding;
+            if (node.hasNamedArguments()) {
+                List<FunctionMetadata> candidates = findInstanceMethodCandidates(method.getValue(), receiverType);
+                if (candidates.isEmpty()) {
+                    // No instance method of this name on the receiver type; let ordinary
+                    // function resolution handle (and reject) the call.
+                    return Optional.empty();
+                }
+                binding = computeArgumentBinding(arguments, candidates, 1, node, "method " + method.getValue());
+            }
+            else {
+                binding = identityBinding(arguments.size());
+            }
+            List<Expression> argumentValues = orderedArgumentValues(arguments, binding);
+
             MethodResolution resolution;
             try {
                 resolution = resolveInstanceMethodCall(receiverType, method.getValue(), argumentValues, context);
@@ -1706,7 +1779,7 @@ public class ExpressionAnalyzer
 
             Type result = analyzeInstanceMethodInvocation(node, receiver, receiverType, method.getValue(), argumentValues, resolution, context);
             methodCallReceivers.put(NodeRef.of(node), receiver);
-            argumentBindings.put(NodeRef.of(node), identityBinding(node.getArguments().size()));
+            argumentBindings.put(NodeRef.<Expression>of(node), binding);
             return Optional.of(result);
         }
 
@@ -1716,9 +1789,24 @@ public class ExpressionAnalyzer
             Type receiverType = process(node.getReceiver(), context);
             String methodName = node.getMethod().getValue();
 
+            List<CallArgument> arguments = node.getArguments();
+            List<Integer> binding;
+            if (node.hasNamedArguments()) {
+                List<FunctionMetadata> candidates = findInstanceMethodCandidates(methodName, receiverType);
+                // With no instance method of this name on the receiver type, bind positionally so
+                // resolution reports method-not-found rather than a misleading "No argument named ...".
+                binding = candidates.isEmpty()
+                        ? identityBinding(arguments.size())
+                        : computeArgumentBinding(arguments, candidates, 1, node, "method " + methodName);
+            }
+            else {
+                binding = identityBinding(arguments.size());
+            }
+            List<Expression> argumentValues = orderedArgumentValues(arguments, binding);
+
             MethodResolution resolution;
             try {
-                resolution = resolveInstanceMethodCall(receiverType, methodName, node.getArguments(), context);
+                resolution = resolveInstanceMethodCall(receiverType, methodName, argumentValues, context);
             }
             catch (TrinoException e) {
                 if (e.getLocation().isPresent()) {
@@ -1727,7 +1815,8 @@ public class ExpressionAnalyzer
                 throw new TrinoException(e::getErrorCode, extractLocation(node), e.getMessage(), e);
             }
 
-            return analyzeInstanceMethodInvocation(node, node.getReceiver(), receiverType, methodName, node.getArguments(), resolution, context);
+            argumentBindings.put(NodeRef.<Expression>of(node), binding);
+            return analyzeInstanceMethodInvocation(node, node.getReceiver(), receiverType, methodName, argumentValues, resolution, context);
         }
 
         private MethodResolution resolveInstanceMethodCall(Type receiverType, String methodName, List<Expression> arguments, Context context)
@@ -1788,15 +1877,31 @@ public class ExpressionAnalyzer
                 throw semanticException(TYPE_NOT_FOUND, node, "Unknown type: %s", receiver);
             }
             TypeDescriptor receiverSignature = new TypeDescriptor(receiver.getSuffix());
+            String methodName = node.getMethod().getValue();
 
-            List<TypeDescriptorProvider> argumentTypes = getCallArgumentTypes(node.getArguments(), context);
+            List<CallArgument> arguments = node.getArguments();
+            List<Integer> binding;
+            if (node.hasNamedArguments()) {
+                List<FunctionMetadata> candidates = findStaticMethodCandidates(methodName, receiverSignature.getBase());
+                // With no static method of this name on the receiver type, bind positionally so
+                // resolution reports method-not-found rather than a misleading "No argument named ...".
+                binding = candidates.isEmpty()
+                        ? identityBinding(arguments.size())
+                        : computeArgumentBinding(arguments, candidates, 0, node, "static method " + receiver + "::" + methodName);
+            }
+            else {
+                binding = identityBinding(arguments.size());
+            }
+            List<Expression> argumentValues = orderedArgumentValues(arguments, binding);
+
+            List<TypeDescriptorProvider> argumentTypes = getCallArgumentTypes(argumentValues, context);
 
             ResolvedFunction function;
             try {
                 function = functionResolver.resolveStaticMethod(
                         session,
                         receiverSignature,
-                        QualifiedName.of(node.getMethod().getValue()),
+                        QualifiedName.of(methodName),
                         argumentTypes,
                         accessControl);
             }
@@ -1807,13 +1912,13 @@ public class ExpressionAnalyzer
                 throw new TrinoException(e::getErrorCode, extractLocation(node), e.getMessage(), e);
             }
 
-            if (node.getArguments().size() > 127) {
-                throw semanticException(TOO_MANY_ARGUMENTS, node, "Too many arguments for static method call %s::%s()", receiver, node.getMethod().getValue());
+            if (argumentValues.size() > 127) {
+                throw semanticException(TOO_MANY_ARGUMENTS, node, "Too many arguments for static method call %s::%s()", receiver, methodName);
             }
 
             BoundSignature signature = function.signature();
             for (int i = 0; i < argumentTypes.size(); i++) {
-                Expression expression = node.getArguments().get(i);
+                Expression expression = argumentValues.get(i);
                 Type expectedType = signature.getArgumentTypes().get(i);
                 if (argumentTypes.get(i).hasDependency()) {
                     FunctionType expectedFunctionType = (FunctionType) expectedType;
@@ -1821,10 +1926,11 @@ public class ExpressionAnalyzer
                 }
                 else {
                     Type actualType = plannerContext.getTypeManager().getType(argumentTypes.get(i).getTypeDescriptor());
-                    coerceType(expression, actualType, expectedType, format("Static method %s::%s argument %d", receiver, node.getMethod().getValue(), i));
+                    coerceType(expression, actualType, expectedType, format("Static method %s::%s argument %d", receiver, methodName, i));
                 }
             }
             resolvedFunctions.put(NodeRef.of(node), function);
+            argumentBindings.put(NodeRef.<Expression>of(node), binding);
             return setExpressionType(node, signature.getReturnType());
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -711,11 +711,7 @@ public class TranslationMap
         Optional<ResolvedFunction> resolvedFunction = analysis.getResolvedFunction(expression);
         checkArgument(resolvedFunction.isPresent(), "Static method has not been analyzed: %s", expression);
 
-        return new Call(
-                resolvedFunction.get(),
-                expression.getArguments().stream()
-                        .map(this::translateExpression)
-                        .collect(toImmutableList()));
+        return new Call(resolvedFunction.get(), translateMethodArguments(expression, expression.getArguments()));
     }
 
     private io.trino.sql.ir.Expression translate(MethodCall expression)
@@ -727,10 +723,20 @@ public class TranslationMap
                 resolvedFunction.get(),
                 ImmutableList.<io.trino.sql.ir.Expression>builder()
                         .add(translateExpression(expression.getReceiver()))
-                        .addAll(expression.getArguments().stream()
-                                .map(this::translateExpression)
-                                .collect(toImmutableList()))
+                        .addAll(translateMethodArguments(expression, expression.getArguments()))
                         .build());
+    }
+
+    // Emit arguments in resolved signature order: for positional calls the binding
+    // is the identity; for named calls it reorders so values land at their
+    // declared positions.
+    private List<io.trino.sql.ir.Expression> translateMethodArguments(Expression methodCall, List<CallArgument> arguments)
+    {
+        return analysis.getArgumentBinding(methodCall).stream()
+                .map(arguments::get)
+                .map(CallArgument::getValue)
+                .map(this::translateExpression)
+                .collect(toImmutableList());
     }
 
     private io.trino.sql.ir.Expression translate(DereferenceExpression expression)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestMethodCall.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestMethodCall.java
@@ -17,6 +17,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.metadata.InternalFunctionBundle;
 import io.trino.spi.function.InstanceMethod;
+import io.trino.spi.function.Name;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.StaticMethod;
@@ -69,9 +70,24 @@ public class TestMethodCall
     @ScalarFunction("repeat")
     @InstanceMethod
     @SqlType(StandardTypes.VARCHAR)
-    public static Slice varcharRepeat(@SqlType(StandardTypes.VARCHAR) Slice self, @SqlType(StandardTypes.BIGINT) long count)
+    public static Slice varcharRepeat(@SqlType(StandardTypes.VARCHAR) Slice self, @Name("count") @SqlType(StandardTypes.BIGINT) long count)
     {
         return Slices.utf8Slice(self.toStringUtf8().repeat((int) count));
+    }
+
+    @ScalarFunction("pad")
+    @InstanceMethod
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice varcharPad(
+            @SqlType(StandardTypes.VARCHAR) Slice self,
+            @Name("length") @SqlType(StandardTypes.BIGINT) long length,
+            @Name("pad") @SqlType(StandardTypes.VARCHAR) Slice pad)
+    {
+        StringBuilder builder = new StringBuilder(self.toStringUtf8());
+        while (builder.length() < length) {
+            builder.append(pad.toStringUtf8());
+        }
+        return Slices.utf8Slice(builder.substring(0, (int) Math.max(length, self.toStringUtf8().length())));
     }
 
     @ScalarFunction("from_string")
@@ -99,7 +115,7 @@ public class TestMethodCall
     @Test
     public void testWithArguments()
     {
-        assertThat(assertions.expression("('ab').repeat(3)"))
+        assertThat(assertions.expression("'ab'.repeat(3)"))
                 .matches("VARCHAR 'ababab'");
     }
 
@@ -116,7 +132,7 @@ public class TestMethodCall
     @Test
     public void testUnknownMethod()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.expression("('hello').nope()").evaluate())
+        assertTrinoExceptionThrownBy(() -> assertions.expression("'hello'.nope()").evaluate())
                 .hasErrorCode(FUNCTION_NOT_FOUND);
     }
 
@@ -140,7 +156,7 @@ public class TestMethodCall
     public void testStaticMethodNotResolvableAsInstanceMethod()
     {
         // `from_string` is a @StaticMethod on bigint, so the instance-method form must not find it.
-        assertTrinoExceptionThrownBy(() -> assertions.expression("('42').from_string()").evaluate())
+        assertTrinoExceptionThrownBy(() -> assertions.expression("'42'.from_string()").evaluate())
                 .hasErrorCode(FUNCTION_NOT_FOUND);
     }
 
@@ -164,7 +180,7 @@ public class TestMethodCall
     public void testArgumentCoercion()
     {
         // TINYINT coerces to BIGINT, matching the declared argument type.
-        assertThat(assertions.expression("('ab').repeat(TINYINT '3')"))
+        assertThat(assertions.expression("'ab'.repeat(TINYINT '3')"))
                 .matches("VARCHAR 'ababab'");
     }
 
@@ -172,28 +188,89 @@ public class TestMethodCall
     public void testArgumentNotCoercible()
     {
         // VARCHAR has no implicit coercion to BIGINT, so the call fails to resolve.
-        assertTrinoExceptionThrownBy(() -> assertions.expression("('ab').repeat('three')").evaluate())
+        assertTrinoExceptionThrownBy(() -> assertions.expression("'ab'.repeat('three')").evaluate())
                 .hasErrorCode(FUNCTION_NOT_FOUND);
     }
 
     @Test
     public void testCaseInsensitiveMethodName()
     {
-        assertThat(assertions.expression("('hello').CHAR_LENGTH()"))
+        assertThat(assertions.expression("'hello'.CHAR_LENGTH()"))
                 .matches("BIGINT '5'");
-        assertThat(assertions.expression("('hello').Char_Length()"))
+        assertThat(assertions.expression("'hello'.Char_Length()"))
                 .matches("BIGINT '5'");
     }
 
     @Test
-    public void testNamedArgumentsRejectedOnMethodCall()
+    public void testNamedArgument()
     {
-        // Method-call syntax (receiver.method(...)) does not support named arguments.
-        // The call must not silently bind by position; instance-method resolution declines
-        // it, and ordinary function resolution then rejects the unknown argument name.
-        assertTrinoExceptionThrownBy(() -> assertions.getQueryRunner().execute("SELECT s.repeat(count => 3) FROM (VALUES VARCHAR 'ab') t(s)"))
+        assertThat(assertions.expression("'ab'.repeat(count => 3)"))
+                .matches("VARCHAR 'ababab'");
+    }
+
+    @Test
+    public void testNamedArgumentsReordered()
+    {
+        // Named arguments may appear in any order; they bind by declared name.
+        assertThat(assertions.expression("'xy'.pad(pad => '-', length => 5)"))
+                .matches("VARCHAR 'xy---'");
+    }
+
+    @Test
+    public void testPositionalThenNamedArguments()
+    {
+        assertThat(assertions.expression("'xy'.pad(5, pad => '-')"))
+                .matches("VARCHAR 'xy---'");
+    }
+
+    @Test
+    public void testNamedArgumentOnBareReceiver()
+    {
+        // The receiver resolves as a column, so s.repeat(count => 3) is an instance-method
+        // call with a named argument rather than a function named "s.repeat".
+        assertThat(assertions.query("SELECT s.repeat(count => 3) FROM (VALUES VARCHAR 'ab') t(s)"))
+                .matches("VALUES VARCHAR 'ababab'");
+    }
+
+    @Test
+    public void testUnknownNamedArgument()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression("'ab'.repeat(bogus => 3)").evaluate())
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
-                .hasMessageContaining("No argument named count");
+                .hasMessageContaining("No argument named bogus for method repeat");
+    }
+
+    @Test
+    public void testNamedArgumentOnUnknownMethod()
+    {
+        // A named argument on a method that does not exist reports method-not-found, rather
+        // than a misleading "No argument named ..." that would imply the method exists.
+        assertTrinoExceptionThrownBy(() -> assertions.expression("'hello'.nope(count => 1)").evaluate())
+                .hasErrorCode(FUNCTION_NOT_FOUND);
+    }
+
+    @Test
+    public void testPositionalArgumentAfterNamed()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression("'xy'.pad(length => 5, '-')").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("Positional arguments cannot follow named arguments");
+    }
+
+    @Test
+    public void testNamedArgumentForPositionallySuppliedSlot()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression("'xy'.pad(5, length => 3)").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("Named argument length for method pad refers to parameter position 0, which is already supplied positionally");
+    }
+
+    @Test
+    public void testDuplicateNamedArgument()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression("'xy'.pad(length => 5, length => 6)").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("Duplicate named argument: length");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStaticMethodCall.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStaticMethodCall.java
@@ -16,6 +16,7 @@ package io.trino.operator.scalar;
 import io.airlift.slice.Slice;
 import io.trino.metadata.InternalFunctionBundle;
 import io.trino.spi.TrinoException;
+import io.trino.spi.function.Name;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.StaticMethod;
@@ -61,7 +62,7 @@ public class TestStaticMethodCall
     @ScalarFunction("parse")
     @StaticMethod(StandardTypes.BIGINT)
     @SqlType(StandardTypes.BIGINT)
-    public static long bigintParse(@SqlType(StandardTypes.VARCHAR) Slice value)
+    public static long bigintParse(@Name("value") @SqlType(StandardTypes.VARCHAR) Slice value)
     {
         try {
             return Long.parseLong(value.toStringUtf8());
@@ -69,6 +70,17 @@ public class TestStaticMethodCall
         catch (NumberFormatException e) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Cannot parse '%s' as bigint".formatted(value.toStringUtf8()));
         }
+    }
+
+    @ScalarFunction("clamp")
+    @StaticMethod(StandardTypes.BIGINT)
+    @SqlType(StandardTypes.BIGINT)
+    public static long bigintClamp(
+            @Name("value") @SqlType(StandardTypes.BIGINT) long value,
+            @Name("low") @SqlType(StandardTypes.BIGINT) long low,
+            @Name("high") @SqlType(StandardTypes.BIGINT) long high)
+    {
+        return Math.max(low, Math.min(high, value));
     }
 
     @ScalarFunction("array_method")
@@ -127,6 +139,77 @@ public class TestStaticMethodCall
 
         assertThat(assertions.expression("bigint::parse('-1234567890')"))
                 .matches("BIGINT '-1234567890'");
+    }
+
+    @Test
+    public void testNamedArgument()
+    {
+        assertThat(assertions.expression("bigint::parse(value => '42')"))
+                .matches("BIGINT '42'");
+    }
+
+    @Test
+    public void testNamedArgumentsReordered()
+    {
+        // Named arguments may appear in any order; they bind by declared name.
+        assertThat(assertions.expression("bigint::clamp(high => 10, value => 20, low => 0)"))
+                .matches("BIGINT '10'");
+    }
+
+    @Test
+    public void testPositionalThenNamedArguments()
+    {
+        assertThat(assertions.expression("bigint::clamp(20, high => 10, low => 0)"))
+                .matches("BIGINT '10'");
+    }
+
+    @Test
+    public void testUnknownNamedArgument()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression("bigint::parse(bogus => '42')").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("No argument named bogus for static method bigint::parse");
+    }
+
+    @Test
+    public void testTooManyArguments()
+    {
+        // No overload of parse accepts a second argument, so the call fails to resolve.
+        assertTrinoExceptionThrownBy(() -> assertions.expression("bigint::parse('42', '43')").evaluate())
+                .hasErrorCode(FUNCTION_NOT_FOUND);
+    }
+
+    @Test
+    public void testPositionalArgumentAfterNamed()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression("bigint::clamp(value => 20, 0, 10)").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("Positional arguments cannot follow named arguments");
+    }
+
+    @Test
+    public void testNamedArgumentForPositionallySuppliedSlot()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression("bigint::clamp(5, value => 3)").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("Named argument value for static method bigint::clamp refers to parameter position 0, which is already supplied positionally");
+    }
+
+    @Test
+    public void testDuplicateNamedArgument()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression("bigint::clamp(value => 1, value => 2)").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("Duplicate named argument: value");
+    }
+
+    @Test
+    public void testNamedArgumentOnUnknownMethod()
+    {
+        // A named argument on a method that does not exist reports method-not-found, rather
+        // than a misleading "No argument named ..." that would imply the method exists.
+        assertTrinoExceptionThrownBy(() -> assertions.expression("bigint::nope(value => '42')").evaluate())
+                .hasErrorCode(FUNCTION_NOT_FOUND);
     }
 
     @Test

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -529,13 +529,13 @@ public final class ExpressionFormatter
         @Override
         protected String visitStaticMethodCall(StaticMethodCall node, Void context)
         {
-            return formatName(node.getType()) + "::" + formatExpression(node.getMethod()) + "(" + joinExpressions(node.getArguments()) + ")";
+            return formatName(node.getType()) + "::" + formatExpression(node.getMethod()) + "(" + joinCallArguments(node.getArguments()) + ")";
         }
 
         @Override
         protected String visitMethodCall(MethodCall node, Void context)
         {
-            return "(" + formatExpression(node.getReceiver()) + ")." + formatExpression(node.getMethod()) + "(" + joinExpressions(node.getArguments()) + ")";
+            return "(" + formatExpression(node.getReceiver()) + ")." + formatExpression(node.getMethod()) + "(" + joinCallArguments(node.getArguments()) + ")";
         }
 
         @Override
@@ -986,6 +986,13 @@ public final class ExpressionFormatter
         {
             return expressions.stream()
                     .map(e -> process(e, null))
+                    .collect(joining(", "));
+        }
+
+        private String joinCallArguments(List<CallArgument> arguments)
+        {
+            return arguments.stream()
+                    .map(argument -> process(argument, null))
                     .collect(joining(", "));
         }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -3188,7 +3188,7 @@ class AstBuilder
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
                 (Identifier) visit(context.identifier()),
-                visit(context.expression(), Expression.class));
+                visit(context.argument(), CallArgument.class));
     }
 
     @Override
@@ -3198,7 +3198,7 @@ class AstBuilder
                 getLocation(context),
                 (Expression) visit(context.primaryExpression()),
                 (Identifier) visit(context.identifier()),
-                visit(context.expression(), Expression.class));
+                visit(context.argument(), CallArgument.class));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -234,8 +234,8 @@ public abstract class DefaultTraversalVisitor<C>
     @Override
     protected Void visitStaticMethodCall(StaticMethodCall node, C context)
     {
-        for (Expression argument : node.getArguments()) {
-            process(argument, context);
+        for (CallArgument argument : node.getArguments()) {
+            process(argument.getValue(), context);
         }
         return null;
     }
@@ -244,8 +244,8 @@ public abstract class DefaultTraversalVisitor<C>
     protected Void visitMethodCall(MethodCall node, C context)
     {
         process(node.getReceiver(), context);
-        for (Expression argument : node.getArguments()) {
-            process(argument, context);
+        for (CallArgument argument : node.getArguments()) {
+            process(argument.getValue(), context);
         }
         return null;
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
@@ -514,13 +514,7 @@ public final class ExpressionTreeRewriter<C>
                 }
             }
 
-            List<CallArgument> arguments = new ArrayList<>(node.getArguments().size());
-            for (CallArgument argument : node.getArguments()) {
-                Expression rewrittenValue = rewrite(argument.getValue(), context.get());
-                arguments.add(rewrittenValue == argument.getValue()
-                        ? argument
-                        : new CallArgument(argument.getLocation().orElse(null), argument.getName(), rewrittenValue));
-            }
+            List<CallArgument> arguments = rewriteCallArguments(node.getArguments(), context);
 
             Optional<OrderBy> orderBy = node.getOrderBy();
             if (orderBy.isPresent()) {
@@ -556,7 +550,7 @@ public final class ExpressionTreeRewriter<C>
                 }
             }
 
-            List<Expression> arguments = rewrite(node.getArguments(), context);
+            List<CallArgument> arguments = rewriteCallArguments(node.getArguments(), context);
             if (!sameElements(node.getArguments(), arguments)) {
                 return new StaticMethodCall(node.getLocation().orElseThrow(), node.getType(), node.getMethod(), arguments);
             }
@@ -574,11 +568,23 @@ public final class ExpressionTreeRewriter<C>
             }
 
             Expression receiver = rewrite(node.getReceiver(), context.get());
-            List<Expression> arguments = rewrite(node.getArguments(), context);
+            List<CallArgument> arguments = rewriteCallArguments(node.getArguments(), context);
             if (receiver != node.getReceiver() || !sameElements(node.getArguments(), arguments)) {
                 return new MethodCall(node.getLocation().orElseThrow(), receiver, node.getMethod(), arguments);
             }
             return node;
+        }
+
+        private List<CallArgument> rewriteCallArguments(List<CallArgument> callArguments, Context<C> context)
+        {
+            List<CallArgument> arguments = new ArrayList<>(callArguments.size());
+            for (CallArgument argument : callArguments) {
+                Expression rewrittenValue = rewrite(argument.getValue(), context.get());
+                arguments.add(rewrittenValue == argument.getValue()
+                        ? argument
+                        : new CallArgument(argument.getLocation().orElse(null), argument.getName(), rewrittenValue));
+            }
+            return arguments;
         }
 
         // Since OrderBy contains list of SortItems, we want to process each SortItem's key, which is an expression

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/MethodCall.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/MethodCall.java
@@ -25,9 +25,9 @@ public class MethodCall
 {
     private final Expression receiver;
     private final Identifier method;
-    private final List<Expression> arguments;
+    private final List<CallArgument> arguments;
 
-    public MethodCall(NodeLocation location, Expression receiver, Identifier method, List<Expression> arguments)
+    public MethodCall(NodeLocation location, Expression receiver, Identifier method, List<CallArgument> arguments)
     {
         super(location);
         this.receiver = requireNonNull(receiver, "receiver is null");
@@ -45,9 +45,14 @@ public class MethodCall
         return method;
     }
 
-    public List<Expression> getArguments()
+    public List<CallArgument> getArguments()
     {
         return arguments;
+    }
+
+    public boolean hasNamedArguments()
+    {
+        return arguments.stream().anyMatch(argument -> argument.getName().isPresent());
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/StaticMethodCall.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/StaticMethodCall.java
@@ -25,9 +25,9 @@ public class StaticMethodCall
 {
     private final QualifiedName type;
     private final Identifier method;
-    private final List<Expression> arguments;
+    private final List<CallArgument> arguments;
 
-    public StaticMethodCall(NodeLocation location, QualifiedName type, Identifier method, List<Expression> arguments)
+    public StaticMethodCall(NodeLocation location, QualifiedName type, Identifier method, List<CallArgument> arguments)
     {
         super(location);
         this.type = requireNonNull(type, "type is null");
@@ -45,9 +45,14 @@ public class StaticMethodCall
         return method;
     }
 
-    public List<Expression> getArguments()
+    public List<CallArgument> getArguments()
     {
         return arguments;
+    }
+
+    public boolean hasNamedArguments()
+    {
+        return arguments.stream().anyMatch(argument -> argument.getName().isPresent());
     }
 
     @Override

--- a/core/trino-parser/src/test/java/io/trino/sql/TestExpressionFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestExpressionFormatter.java
@@ -14,15 +14,20 @@
 package io.trino.sql;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.sql.tree.CallArgument;
 import io.trino.sql.tree.CompositeIntervalQualifier;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.IntervalField;
 import io.trino.sql.tree.IntervalLiteral;
+import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.MethodCall;
 import io.trino.sql.tree.NodeLocation;
+import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Row;
 import io.trino.sql.tree.SimpleIntervalQualifier;
+import io.trino.sql.tree.StaticMethodCall;
 import io.trino.sql.tree.StringLiteral;
 import org.junit.jupiter.api.Test;
 
@@ -207,6 +212,46 @@ public class TestExpressionFormatter
         assertFormattedExpression(
                 new Row(ImmutableList.of(createRowField(null, new Row(ImmutableList.of(createRowField(null, createRow("a", null, "b"))))))),
                 "ROW(ROW(ROW('v0' AS a, 'v1', 'v2' AS b)))");
+    }
+
+    @Test
+    public void testMethodCall()
+    {
+        NodeLocation location = new NodeLocation(1, 1);
+
+        // static method, positional and named, round-trip through format and re-parse
+        assertFormattedExpression(
+                new StaticMethodCall(
+                        location,
+                        QualifiedName.of("bigint"),
+                        new Identifier("parse"),
+                        ImmutableList.of(new CallArgument(location, Optional.empty(), new StringLiteral("42")))),
+                "bigint::parse('42')");
+        assertFormattedExpression(
+                new StaticMethodCall(
+                        location,
+                        QualifiedName.of("bigint"),
+                        new Identifier("parse"),
+                        ImmutableList.of(new CallArgument(location, Optional.of(new Identifier("value")), new StringLiteral("42")))),
+                "bigint::parse(value => '42')");
+
+        // instance method, named and mixed positional-then-named
+        assertFormattedExpression(
+                new MethodCall(
+                        location,
+                        new Identifier("x"),
+                        new Identifier("repeat"),
+                        ImmutableList.of(new CallArgument(location, Optional.of(new Identifier("count")), new LongLiteral(location, "3")))),
+                "(x).repeat(count => 3)");
+        assertFormattedExpression(
+                new MethodCall(
+                        location,
+                        new Identifier("x"),
+                        new Identifier("pad"),
+                        ImmutableList.of(
+                                new CallArgument(location, Optional.empty(), new LongLiteral(location, "5")),
+                                new CallArgument(location, Optional.of(new Identifier("pad")), new StringLiteral("-")))),
+                "(x).pad(5, pad => '-')");
     }
 
     private static Row createRow(String... fieldNames)

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -349,7 +349,7 @@ public class TestSqlParser
                         location(1, 1),
                         QualifiedName.of(ImmutableList.of(new Identifier(location(1, 1), "bigint", false))),
                         new Identifier(location(1, 9), "parse", false),
-                        ImmutableList.of(new StringLiteral(location(1, 15), "42"))));
+                        ImmutableList.of(new CallArgument(location(1, 15), Optional.empty(), new StringLiteral(location(1, 15), "42")))));
 
         assertThat(expression("cat.sch.t::method()"))
                 .isEqualTo(new StaticMethodCall(
@@ -367,8 +367,16 @@ public class TestSqlParser
                         QualifiedName.of(ImmutableList.of(new Identifier(location(1, 1), "array", false))),
                         new Identifier(location(1, 8), "contains", false),
                         ImmutableList.of(
-                                new Identifier(location(1, 17), "x", false),
-                                new LongLiteral(location(1, 20), "1"))));
+                                new CallArgument(location(1, 17), Optional.empty(), new Identifier(location(1, 17), "x", false)),
+                                new CallArgument(location(1, 20), Optional.empty(), new LongLiteral(location(1, 20), "1")))));
+
+        // Named arguments are accepted, mirroring ordinary function-call syntax.
+        assertThat(expression("bigint::parse(value => '42')"))
+                .isEqualTo(new StaticMethodCall(
+                        location(1, 1),
+                        QualifiedName.of(ImmutableList.of(new Identifier(location(1, 1), "bigint", false))),
+                        new Identifier(location(1, 9), "parse", false),
+                        ImmutableList.of(new CallArgument(location(1, 15), Optional.of(new Identifier(location(1, 15), "value", false)), new StringLiteral(location(1, 24), "42")))));
 
         // Parametric receiver types are not allowed in the grammar.
         assertInvalidExpression("varchar(5)::parse('42')", "mismatched input '::'.*");
@@ -451,8 +459,17 @@ public class TestSqlParser
                         new Identifier(location(1, 2), "x", false),
                         new Identifier(location(1, 5), "contains", false),
                         ImmutableList.of(
-                                new LongLiteral(location(1, 14), "1"),
-                                new LongLiteral(location(1, 17), "2"))));
+                                new CallArgument(location(1, 14), Optional.empty(), new LongLiteral(location(1, 14), "1")),
+                                new CallArgument(location(1, 17), Optional.empty(), new LongLiteral(location(1, 17), "2")))));
+
+        // Named arguments are accepted, mirroring ordinary function-call syntax.
+        assertThat(expression("(x).contains(element => 1)"))
+                .isEqualTo(new MethodCall(
+                        location(1, 1),
+                        new Identifier(location(1, 2), "x", false),
+                        new Identifier(location(1, 5), "contains", false),
+                        ImmutableList.of(
+                                new CallArgument(location(1, 14), Optional.of(new Identifier(location(1, 14), "element", false)), new LongLiteral(location(1, 25), "1")))));
 
         // Bare two-part name still parses as a function call; method-call
         // interpretation happens at semantic time per SQL:2023 6.3 SR 2.


### PR DESCRIPTION
## Description

Instance- and static-method invocation syntax (`receiver.method(...)` and `Type::method(...)`) previously accepted only positional arguments. Named arguments were rejected: an instance-method call fell through to ordinary function resolution to produce an error, and the static-method grammar didn't admit them at all. Ordinary function calls already support the `name => value` form, and there is no reason method syntax should not, so this extends the same argument binding to both method forms.

```sql
SELECT (s).repeat(count => 3);          -- instance method, named
SELECT bigint::clamp(high => 10, value => 20, low => 0);  -- static method, reordered
SELECT (s).pad(5, pad => '-');          -- mixed positional then named
```

The change spans the parse → analyze → plan pipeline as a single commit:

- **Grammar** (`SqlBase.g4`): the `staticMethodCall` / `methodCall` rules accept `argument` (which includes `name => value`) instead of plain `expression` — the same rule ordinary function calls use.
- **AST**: `MethodCall` / `StaticMethodCall` hold `List<CallArgument>` instead of `List<Expression>`, threaded through `AstBuilder`, `DefaultTraversalVisitor`, `ExpressionTreeRewriter` (factored a shared `rewriteCallArguments` helper, removing pre-existing duplication), and `ExpressionFormatter`.
- **Analyzer** (`ExpressionAnalyzer`): generalized `computeArgumentBinding` to take the candidate overloads, a `receiverSlots` offset (1 for an instance method's implicit `self`, 0 otherwise), and a diagnostic subject. The bare-receiver `FunctionCall` reinterpretation, `visitMethodCall`, and `visitStaticMethodCall` compute a binding, reorder arguments into declared order, and record it. Candidate gathering uses the same first-path-entry strategy as the function path's `findCandidates`, filtered by instance/static and exact receiver type base.
- **Planning** (`Analysis` / `TranslationMap`): the argument-binding map is keyed by `Expression` so method nodes carry bindings, and method translation reorders arguments by the recorded binding before emitting the `Call`.

The same validation as functions applies, with method-appropriate diagnostics: unknown argument name, positional-after-named, naming an already-positional slot, and duplicate names. A named call on a method that does not exist on the receiver reports method-not-found, not a misleading "no argument named …". Existing function-path error messages are preserved verbatim.

## Additional context and related issues

Builds directly on the existing named-argument support for ordinary function calls (`name => value`) and the instance/static method-call syntax, reusing the same binding machinery.

Tests: parser round-trips in `TestSqlParser` and `TestExpressionFormatter`, and end-to-end coverage (named, reordered, mixed, and all error cases) in `TestMethodCall` / `TestStaticMethodCall`.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add support for named arguments in instance and static method invocations, for example `value.repeat(count => 3)`.
```
