### PR TITLE
Compact values in InOut aggregation state and account single-state memory

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/StateCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/StateCompiler.java
@@ -46,6 +46,7 @@ import io.trino.spi.block.RowBlockBuilder;
 import io.trino.spi.block.RowValueBuilder;
 import io.trino.spi.block.SqlMap;
 import io.trino.spi.block.SqlRow;
+import io.trino.spi.block.ValueBlock;
 import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.function.AccumulatorStateFactory;
 import io.trino.spi.function.AccumulatorStateMetadata;
@@ -445,8 +446,6 @@ public final class StateCompiler
                 type(InOut.class),
                 type(InternalDataAccessor.class));
 
-        estimatedSize(definition);
-
         // Generate constructor
         MethodDefinition constructor = definition.declareConstructor(a(PUBLIC));
 
@@ -472,6 +471,15 @@ public final class StateCompiler
 
         constructor.getBody()
                 .ret();
+
+        if (type.getJavaType().isPrimitive()) {
+            estimatedSize(definition);
+        }
+        else {
+            // The stored object value (row, array, map, varchar, ...) is not part of the instance size,
+            // so account for its retained size explicitly.
+            inOutSingleEstimatedSize(definition, type, valueGetter, nullGetter);
+        }
 
         inOutSingleCopy(definition, valueField, nullField);
 
@@ -577,7 +585,7 @@ public final class StateCompiler
         generateInOutGetType(definition, sqlType);
         generateInOutIsNull(definition, nullGetter);
         generateInOutGetBlockBuilder(definition, sqlType, valueGetter);
-        generateInOutSetBlockPosition(definition, sqlType, setNullGenerator, setValueGenerator);
+        generateInOutSetBlockPosition(definition, type, sqlType, setNullGenerator, setValueGenerator);
         generateInOutSetInOut(definition, type, setNullGenerator, setValueGenerator);
         generateInOutGetValue(definition, type, valueGetter);
     }
@@ -698,6 +706,7 @@ public final class StateCompiler
 
     private static void generateInOutSetBlockPosition(
             ClassDefinition definition,
+            Type type,
             SqlTypeBytecodeExpression sqlType,
             Function<Scope, BytecodeNode> setNullGenerator,
             BiFunction<Scope, BytecodeExpression, BytecodeNode> setValueGenerator)
@@ -705,13 +714,68 @@ public final class StateCompiler
         Parameter blockArg = arg("block", Block.class);
         Parameter positionArg = arg("position", int.class);
         MethodDefinition setBlockBuilderMethod = definition.declareMethod(a(PUBLIC), "set", type(void.class), blockArg, positionArg);
+        Scope scope = setBlockBuilderMethod.getScope();
         BytecodeBlock body = setBlockBuilderMethod.getBody();
+
+        BytecodeNode setValue;
+        if (inOutValueRetainsSourcePage(type)) {
+            // Compact-copy the selected value into a single-position owned block so the state does not
+            // retain the entire source page the value was read from.
+            Variable single = scope.declareVariable(Block.class, "single");
+            BytecodeBlock objectSet = new BytecodeBlock();
+            objectSet.append(single.set(blockArg.invoke("getSingleValueBlock", ValueBlock.class, positionArg)));
+            objectSet.append(setValueGenerator.apply(scope, sqlType.getValue(single, constantInt(0))));
+            setValue = objectSet;
+        }
+        else {
+            setValue = setValueGenerator.apply(scope, sqlType.getValue(blockArg, positionArg));
+        }
 
         body.append(new IfStatement()
                 .condition(blockArg.invoke("isNull", boolean.class, positionArg))
-                .ifTrue(setNullGenerator.apply(setBlockBuilderMethod.getScope()))
-                .ifFalse(setValueGenerator.apply(setBlockBuilderMethod.getScope(), sqlType.getValue(blockArg, positionArg))));
+                .ifTrue(setNullGenerator.apply(scope))
+                .ifFalse(setValue));
         body.ret();
+    }
+
+    /**
+     * Whether the value object returned by {@code Type.getObject}/{@code getSlice} keeps a reference into the
+     * source page. Rows, arrays, maps and varchars/varbinaries view their backing block, so the InOut state
+     * must compact-copy them to avoid retaining the whole source page; other object-native types (e.g.
+     * {@code Int128}, long timestamps) are self-contained value objects that retain nothing else.
+     */
+    private static boolean inOutValueRetainsSourcePage(Type type)
+    {
+        Class<?> javaType = type.getJavaType();
+        return javaType == Slice.class || javaType == Block.class || javaType == SqlRow.class || javaType == SqlMap.class;
+    }
+
+    private static BytecodeExpression inOutValueRetainedSize(Type type, BytecodeExpression value)
+    {
+        Class<?> javaType = type.getJavaType();
+        if (javaType == Slice.class) {
+            return value.cast(Slice.class).invoke("getRetainedSize", long.class);
+        }
+        if (inOutValueRetainsSourcePage(type)) {
+            // Block, SqlRow and SqlMap all expose getRetainedSizeInBytes()
+            return value.cast(javaType).invoke("getRetainedSizeInBytes", long.class);
+        }
+        // Self-contained value objects (e.g. Int128, long timestamps) retain only themselves.
+        return constantLong(SizeOf.instanceSize(javaType));
+    }
+
+    private static void inOutSingleEstimatedSize(ClassDefinition definition, Type type, Function<Scope, BytecodeExpression> valueGetter, Function<Scope, BytecodeExpression> nullGetter)
+    {
+        FieldDefinition instanceSize = generateInstanceSize(definition);
+        MethodDefinition method = definition.declareMethod(a(PUBLIC), "getEstimatedSize", type(long.class));
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        Variable size = scope.declareVariable("size", body, getStatic(instanceSize));
+        body.append(new IfStatement()
+                .condition(nullGetter.apply(scope))
+                .ifFalse(size.set(add(size, inOutValueRetainedSize(type, valueGetter.apply(scope))))));
+        body.append(size.ret());
     }
 
     private static void generateInOutSetInOut(

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/state/TestStateCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/state/TestStateCompiler.java
@@ -28,8 +28,11 @@ import io.trino.spi.block.SqlRow;
 import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.function.AccumulatorStateFactory;
 import io.trino.spi.function.AccumulatorStateSerializer;
+import io.trino.spi.function.GroupedAccumulatorState;
 import io.trino.spi.function.InOut;
 import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Int128;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import org.junit.jupiter.api.Test;
@@ -41,6 +44,7 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.block.BlockAssertions.createLongsBlock;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -258,6 +262,87 @@ public class TestStateCompiler
         assertThat(singleState.getEstimatedSize())
                 .isEqualTo(instanceSize(singleState.getClass()))
                 .isEqualTo(24);
+    }
+
+    @Test
+    public void testInOutSingleStateAccountsForRetainedObjectValueMemory()
+    {
+        // VARCHAR (Slice) and a nested row (Block/SqlRow) keep a reference into the source block; the single
+        // state must account for the retained size of the stored value, which is not part of the instance size.
+        BlockBuilder varcharBuilder = VARCHAR.createBlockBuilder(null, 1);
+        VARCHAR.writeSlice(varcharBuilder, utf8Slice("x".repeat(1024)));
+        assertThat(assertInOutSingleStateAccountsForValue(VARCHAR, varcharBuilder.build())).isGreaterThan(1024);
+
+        RowType rowType = RowType.anonymousRow(VARCHAR, BIGINT, VARCHAR);
+        BlockBuilder rowBuilder = rowType.createBlockBuilder(null, 1);
+        rowType.writeObject(rowBuilder, sqlRowOf(rowType, "x".repeat(1024), 777, "y".repeat(1024)));
+        assertThat(assertInOutSingleStateAccountsForValue(rowType, rowBuilder.build())).isGreaterThan(2048);
+
+        // DECIMAL(38) is backed by the self-contained Int128 value object: it retains nothing beyond itself,
+        // so the state charges its flat instance size rather than an inflated single-value block size.
+        DecimalType decimalType = createDecimalType(38);
+        BlockBuilder decimalBuilder = decimalType.createBlockBuilder(null, 1);
+        decimalType.writeObject(decimalBuilder, Int128.valueOf(1234567890123456789L, 987654321L));
+        assertThat(assertInOutSingleStateAccountsForValue(decimalType, decimalBuilder.build())).isEqualTo(Int128.INSTANCE_SIZE);
+    }
+
+    private static long assertInOutSingleStateAccountsForValue(Type type, Block valueBlock)
+    {
+        AccumulatorStateFactory<InOut> factory = StateCompiler.generateInOutStateFactory(type);
+        InOut single = factory.createSingleState();
+        long emptySingle = single.getEstimatedSize();
+        single.set(valueBlock, 0);
+        long perValue = single.getEstimatedSize() - emptySingle;
+        assertThat(perValue).isPositive();
+
+        // The stored value round-trips through the output path.
+        BlockBuilder out = type.createBlockBuilder(null, 1);
+        single.get(out);
+        Block outBlock = out.build();
+        assertThat(outBlock.isNull(0)).isFalse();
+        assertThat(type.getObjectValue(outBlock, 0)).isEqualTo(type.getObjectValue(valueBlock, 0));
+
+        // Setting back to null releases the accounted bytes.
+        BlockBuilder nullBuilder = type.createBlockBuilder(null, 1);
+        nullBuilder.appendNull();
+        single.set(nullBuilder.build(), 0);
+        assertThat(single.getEstimatedSize()).isEqualTo(emptySingle);
+        return perValue;
+    }
+
+    @Test
+    public void testInOutStateCompactsSelectedValueInsteadOfRetainingSourcePage()
+    {
+        // A wide source page: many positions sharing backing arrays. Storing one position must not pin the whole page.
+        int positions = 1000;
+        BlockBuilder builder = VARCHAR.createBlockBuilder(null, positions);
+        for (int i = 0; i < positions; i++) {
+            VARCHAR.writeSlice(builder, utf8Slice("x".repeat(1024)));
+        }
+        Block sourcePage = builder.build();
+        long sourceRetained = sourcePage.getRetainedSizeInBytes();
+        // The state charges the retained size of the compacted stored value, far smaller than the whole source page.
+        long perValue = VARCHAR.getSlice(sourcePage.getSingleValueBlock(7), 0).getRetainedSize();
+        assertThat(perValue).isLessThan(sourceRetained / 100);
+
+        AccumulatorStateFactory<InOut> factory = StateCompiler.generateInOutStateFactory(VARCHAR);
+
+        // Single state: accounts for one compacted value, not the source page it was selected from.
+        InOut single = factory.createSingleState();
+        long emptySingle = single.getEstimatedSize();
+        single.set(sourcePage, 7);
+        assertThat(single.getEstimatedSize() - emptySingle)
+                .isEqualTo(perValue)
+                .isLessThan(sourceRetained / 100);
+
+        // Grouped state (specialized BigArray) likewise charges only the compacted value, not the source page.
+        InOut groupedInOut = factory.createGroupedState();
+        GroupedAccumulatorState grouped = (GroupedAccumulatorState) groupedInOut;
+        grouped.ensureCapacity(1);
+        long emptyGrouped = groupedInOut.getEstimatedSize();
+        grouped.setGroupId(0);
+        groupedInOut.set(sourcePage, 7);
+        assertThat(groupedInOut.getEstimatedSize() - emptyGrouped).isLessThan(sourceRetained / 100);
     }
 
     @Test


### PR DESCRIPTION
## Description

The generated `InOut` aggregation state (used by `any_value`/`arbitrary`, `min`/`max`, `min_by`/`max_by`) stored the object returned by `Type.getObject`/`getSlice` directly. For `ROW`, `ARRAY`, `MAP` and `VARCHAR`/`VARBINARY`, that object is a region/sub-block of the input page, so a single stored value pins the **entire upstream page**. Across a high-cardinality `GROUP BY` this retains far more memory than the stored values warrant (issue #15285).

This change:

1. **Compact-copies** the selected value into a single-position owned block via `Block.getSingleValueBlock` before storing it, so the state retains only the value and releases the source page. Self-contained value objects (e.g. `Int128`, long timestamps) are left untouched since they reference nothing else.
2. **Accounts single-state retained memory.** The single `InOut` state previously returned only the instance size from `getEstimatedSize()`, ignoring the stored object value entirely. Its retained size is now included, so a non-grouped `any_value`/`arbitrary` over a large value is reflected in the operator's memory reservation. (Grouped state already accounts correctly via the per-type `BigArray`s since `c0e4e667`.)

Net effect: `arbitrary(<wide nested column>) ... GROUP BY <high-cardinality key>` retains memory proportional to the selected values instead of to whole retained input pages, and a global `arbitrary`/`any_value` over a large value is now memory-accounted.

## Additional context and related issues

Addresses the retention/accounting gaps behind #15285. The grouped-aggregation memory-tracking part of that issue was already fixed in `c0e4e667`; this completes it for the source-page retention and the single-state path.

Trade-off: compacting copies each selected value out of its source page. When many groups read values from the same page this reduces memory (the page is released); in the rare case where many groups reference an identical large value backed by the same position, copying can duplicate data that reference-counting previously shared. In practice distinct groups read distinct positions, so this is a net reduction.

## Release notes

(x) Release notes are required, with the following suggested text:

```
# General
* Reduce the memory footprint of `arbitrary`, `any_value`, `min`, `max`, `min_by` and `max_by` aggregations over `ROW`, `ARRAY`, `MAP` and `VARCHAR` values by compacting the retained value instead of pinning the source page. ({issue}`15285`)
```
