### PR TITLE
Recognize type-level `neverFails` in `Generic*Operator` metadata

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedFirstOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedFirstOperator.java
@@ -23,6 +23,9 @@ import io.trino.spi.type.TypeOperators;
 
 import java.lang.invoke.MethodHandle;
 
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_FIRST;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TypeTemplates.typeVariable;
@@ -42,7 +45,7 @@ public class GenericComparisonUnorderedFirstOperator
                         .argumentType(typeVariable("T"))
                         .argumentType(typeVariable("T"))
                         .build())
-                .neverFails()
+                .neverFails(boundSignature -> typeOperators.getComparisonUnorderedFirstOperatorHandle(boundSignature.getArgumentType(0), simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL)).isNeverFails())
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedLastOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedLastOperator.java
@@ -23,6 +23,9 @@ import io.trino.spi.type.TypeOperators;
 
 import java.lang.invoke.MethodHandle;
 
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TypeTemplates.typeVariable;
@@ -42,7 +45,7 @@ public class GenericComparisonUnorderedLastOperator
                         .argumentType(typeVariable("T"))
                         .argumentType(typeVariable("T"))
                         .build())
-                .neverFails()
+                .neverFails(boundSignature -> typeOperators.getComparisonUnorderedLastOperatorHandle(boundSignature.getArgumentType(0), simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL)).isNeverFails())
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOperator.java
@@ -23,6 +23,9 @@ import io.trino.spi.type.TypeOperators;
 
 import java.lang.invoke.MethodHandle;
 
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.TypeTemplates.typeVariable;
@@ -42,6 +45,7 @@ public class GenericLessThanOperator
                         .argumentType(typeVariable("T"))
                         .argumentType(typeVariable("T"))
                         .build())
+                .neverFails(boundSignature -> typeOperators.getLessThanOperatorHandle(boundSignature.getArgumentType(0), simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL)).isNeverFails())
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOrEqualOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOrEqualOperator.java
@@ -23,6 +23,9 @@ import io.trino.spi.type.TypeOperators;
 
 import java.lang.invoke.MethodHandle;
 
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.TypeTemplates.typeVariable;
@@ -42,6 +45,7 @@ public class GenericLessThanOrEqualOperator
                         .argumentType(typeVariable("T"))
                         .argumentType(typeVariable("T"))
                         .build())
+                .neverFails(boundSignature -> typeOperators.getLessThanOrEqualOperatorHandle(boundSignature.getArgumentType(0), simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL)).isNeverFails())
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
@@ -16,6 +16,7 @@ package io.trino.sql.ir;
 import com.google.common.collect.ImmutableList;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.ResolvedFunction;
+import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.DoubleType;
@@ -28,6 +29,7 @@ import io.trino.spi.type.SmallintType;
 import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.TrinoNumber;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
 import io.trino.sql.PlannerContext;
 import io.trino.type.TypeCoercion;
 
@@ -37,6 +39,9 @@ import java.util.List;
 
 import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
 import static io.trino.spi.block.RowValueBuilder.buildRowValue;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.function.OperatorType.DIVIDE;
 import static io.trino.spi.function.OperatorType.MODULO;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -167,7 +172,7 @@ public final class IrExpressions
                     mayFail(plannerContext, e.defaultValue());
             case Cast e -> mayFail(plannerContext, e);
             case Coalesce e -> e.operands().stream().anyMatch(argument -> mayFail(plannerContext, argument));
-            case Comparison e -> mayFail(plannerContext, e.left()) || mayFail(plannerContext, e.right());
+            case Comparison e -> mayFail(plannerContext, e) || mayFail(plannerContext, e.left()) || mayFail(plannerContext, e.right());
             case In e -> mayFail(plannerContext, e.value()) || e.valueList().stream().anyMatch(argument -> mayFail(plannerContext, argument));
             case IsNull e -> mayFail(plannerContext, e.value());
             case Logical e -> e.terms().stream().anyMatch(argument -> mayFail(plannerContext, argument));
@@ -175,6 +180,19 @@ public final class IrExpressions
             case Row e -> e.items().stream().anyMatch(argument -> mayFail(plannerContext, argument));
             case Switch e -> mayFail(plannerContext, e.operand()) || e.whenClauses().stream().anyMatch(clause -> mayFail(plannerContext, clause.getOperand()) || mayFail(plannerContext, clause.getResult())) ||
                     mayFail(plannerContext, e.defaultValue());
+        };
+    }
+
+    private static boolean mayFail(PlannerContext plannerContext, Comparison comparison)
+    {
+        TypeOperators typeOperators = plannerContext.getTypeOperators();
+        Type operandType = comparison.left().type();
+        InvocationConvention convention = simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL);
+        return switch (comparison.operator()) {
+            // Required to be infallible
+            case EQUAL, NOT_EQUAL, IDENTICAL -> false;
+            case LESS_THAN, GREATER_THAN -> !typeOperators.getLessThanOperatorHandle(operandType, convention).isNeverFails();
+            case LESS_THAN_OR_EQUAL, GREATER_THAN_OR_EQUAL -> !typeOperators.getLessThanOrEqualOperatorHandle(operandType, convention).isNeverFails();
         };
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
@@ -166,7 +166,7 @@ public final class IrExpressions
 
             // These expressions need to verify their operands
             case Array e -> e.elements().stream().anyMatch(element -> mayFail(plannerContext, element));
-            case Between e -> mayFail(plannerContext, e.value()) || mayFail(plannerContext, e.min()) || mayFail(plannerContext, e.max());
+            case Between e -> mayFail(plannerContext, e) || mayFail(plannerContext, e.value()) || mayFail(plannerContext, e.min()) || mayFail(plannerContext, e.max());
             case Call e -> mayFail(e) || e.arguments().stream().anyMatch(argument -> mayFail(plannerContext, argument));
             case Case e -> e.whenClauses().stream().anyMatch(clause -> mayFail(plannerContext, clause.getOperand()) || mayFail(plannerContext, clause.getResult())) ||
                     mayFail(plannerContext, e.defaultValue());
@@ -194,6 +194,14 @@ public final class IrExpressions
             case LESS_THAN, GREATER_THAN -> !typeOperators.getLessThanOperatorHandle(operandType, convention).isNeverFails();
             case LESS_THAN_OR_EQUAL, GREATER_THAN_OR_EQUAL -> !typeOperators.getLessThanOrEqualOperatorHandle(operandType, convention).isNeverFails();
         };
+    }
+
+    private static boolean mayFail(PlannerContext plannerContext, Between between)
+    {
+        TypeOperators typeOperators = plannerContext.getTypeOperators();
+        Type operandType = between.value().type();
+        InvocationConvention convention = simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL);
+        return !typeOperators.getLessThanOrEqualOperatorHandle(operandType, convention).isNeverFails();
     }
 
     // TODO: record "safety" (can the cast fail at runtime) in Cast node

--- a/core/trino-main/src/main/java/io/trino/type/BlockTypeOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/BlockTypeOperators.java
@@ -37,7 +37,6 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.DEFAULT_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
-import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_FIRST;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
 import static io.trino.type.TypeUtils.NULL_HASH_CODE;
 import static io.trino.util.SingleAccessMethodCompiler.compileSingleAccessMethod;
@@ -52,7 +51,6 @@ public final class BlockTypeOperators
     private static final InvocationConvention IDENTICAL_CONVENTION = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION);
     private static final InvocationConvention COMPARISON_CONVENTION = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION);
     private static final InvocationConvention ORDERING_CONVENTION = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION);
-    private static final InvocationConvention LESS_THAN_CONVENTION = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION);
 
     private final NonKeyEvictableCache<GeneratedBlockOperatorKey<?>, GeneratedBlockOperator<?>> generatedBlockOperatorCache;
     private final TypeOperators typeOperators;
@@ -135,11 +133,6 @@ public final class BlockTypeOperators
         return getBlockOperator(type, BlockPositionComparison.class, () -> typeOperators.getComparisonUnorderedLastOperator(type, COMPARISON_CONVENTION), Optional.of(COMPARISON_UNORDERED_LAST));
     }
 
-    public BlockPositionComparison getComparisonUnorderedFirstOperator(Type type)
-    {
-        return getBlockOperator(type, BlockPositionComparison.class, () -> typeOperators.getComparisonUnorderedFirstOperator(type, COMPARISON_CONVENTION), Optional.of(COMPARISON_UNORDERED_FIRST));
-    }
-
     public interface BlockPositionComparison
     {
         long compare(Block left, int leftPosition, Block right, int rightPosition);
@@ -153,16 +146,6 @@ public final class BlockTypeOperators
     public interface BlockPositionOrdering
     {
         int order(Block left, int leftPosition, Block right, int rightPosition);
-    }
-
-    public BlockPositionLessThan generateBlockPositionLessThan(Type type)
-    {
-        return getBlockOperator(type, BlockPositionLessThan.class, () -> typeOperators.getLessThanOperator(type, LESS_THAN_CONVENTION));
-    }
-
-    public interface BlockPositionLessThan
-    {
-        boolean lessThan(Block left, int leftPosition, Block right, int rightPosition);
     }
 
     private <T> T getBlockOperator(Type type, Class<T> operatorInterface, Supplier<MethodHandle> methodHandleSupplier)
@@ -197,16 +180,6 @@ public final class BlockTypeOperators
             this.type = requireNonNull(type, "type is null");
             this.operatorInterface = requireNonNull(operatorInterface, "operatorInterface is null");
             this.additionalKey = requireNonNull(additionalKey, "additionalKey is null");
-        }
-
-        public Type getType()
-        {
-            return type;
-        }
-
-        public Class<T> getOperatorInterface()
-        {
-            return operatorInterface;
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/time/TestTime.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/time/TestTime.java
@@ -2094,8 +2094,7 @@ public class TestTime
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "TIME '12:34:56'", "TIME '12:34:56'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
 
         assertThat(assertions.expression("a <= b")
                 .binding("a", "TIME '12:34:56'")
@@ -2103,8 +2102,7 @@ public class TestTime
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "TIME '12:34:56'", "TIME '12:34:56'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     private static BiFunction<Session, QueryRunner, Object> time(int precision, int hour, int minute, int second, long picoOfSecond)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
@@ -3408,8 +3408,7 @@ public class TestTimestamp
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "TIMESTAMP '2001-1-22 03:04:05.321'", "TIMESTAMP '2001-1-22 03:04:05.321'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
 
         // long timestamp (precision > 6 → LongTimestampType)
         assertThat(assertions.expression("a < b")
@@ -3418,8 +3417,7 @@ public class TestTimestamp
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "TIMESTAMP '2020-05-01 12:34:56.123456789'", "TIMESTAMP '2020-05-01 12:34:56.123456789'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test
@@ -3450,8 +3448,7 @@ public class TestTimestamp
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "TIMESTAMP '2001-1-22 03:04:05.321'", "TIMESTAMP '2001-1-22 03:04:05.321'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
 
         // long timestamp (precision > 6 → LongTimestampType)
         assertThat(assertions.expression("a <= b")
@@ -3460,8 +3457,7 @@ public class TestTimestamp
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "TIMESTAMP '2020-05-01 12:34:56.123456789'", "TIMESTAMP '2020-05-01 12:34:56.123456789'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
@@ -2977,8 +2977,7 @@ public class TestTimestampWithTimeZone
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "TIMESTAMP '2020-05-01 12:34:56 UTC'", "TIMESTAMP '2020-05-01 12:34:56 UTC'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
 
         assertThat(assertions.expression("a <= b")
                 .binding("a", "TIMESTAMP '2020-05-01 12:34:56 UTC'")
@@ -2986,8 +2985,7 @@ public class TestTimestampWithTimeZone
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "TIMESTAMP '2020-05-01 12:34:56 UTC'", "TIMESTAMP '2020-05-01 12:34:56 UTC'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
 
         // long (precision > 3 → LongTimestampWithTimeZoneType)
         assertThat(assertions.expression("a = b")
@@ -3004,8 +3002,7 @@ public class TestTimestampWithTimeZone
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "TIMESTAMP '2020-05-01 12:34:56.123456789 UTC'", "TIMESTAMP '2020-05-01 12:34:56.123456789 UTC'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
 
         assertThat(assertions.expression("a <= b")
                 .binding("a", "TIMESTAMP '2020-05-01 12:34:56.123456789 UTC'")
@@ -3013,8 +3010,7 @@ public class TestTimestampWithTimeZone
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "TIMESTAMP '2020-05-01 12:34:56.123456789 UTC'", "TIMESTAMP '2020-05-01 12:34:56.123456789 UTC'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     private BiFunction<Session, QueryRunner, Object> timestampWithTimeZone(int precision, int year, int month, int day, int hour, int minute, int second, long picoOfSecond, TimeZoneKey timeZoneKey)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timetz/TestTimeWithTimeZone.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timetz/TestTimeWithTimeZone.java
@@ -2420,8 +2420,7 @@ public class TestTimeWithTimeZone
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "TIME '12:34:56+08:35'", "TIME '12:34:56+08:35'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
 
         assertThat(assertions.expression("a <= b")
                 .binding("a", "TIME '12:34:56+08:35'")
@@ -2429,8 +2428,7 @@ public class TestTimeWithTimeZone
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "TIME '12:34:56+08:35'", "TIME '12:34:56+08:35'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
 
         // long (precision > 9 → LongTimeWithTimeZoneType)
         assertThat(assertions.expression("a = b")
@@ -2447,8 +2445,7 @@ public class TestTimeWithTimeZone
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "TIME '12:34:56.1234567891+08:35'", "TIME '12:34:56.1234567891+08:35'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
 
         assertThat(assertions.expression("a <= b")
                 .binding("a", "TIME '12:34:56.1234567891+08:35'")
@@ -2456,8 +2453,7 @@ public class TestTimeWithTimeZone
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "TIME '12:34:56.1234567891+08:35'", "TIME '12:34:56.1234567891+08:35'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     private static BiFunction<Session, QueryRunner, Object> timeWithTimeZone(int precision, int hour, int minute, int second, long picoOfSecond, int offsetMinutes)

--- a/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
@@ -48,8 +48,15 @@ import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.OPERATOR_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
+import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
+import static io.trino.spi.function.OperatorType.EQUAL;
+import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.IDENTICAL;
 import static io.trino.spi.function.OperatorType.INDETERMINATE;
+import static io.trino.spi.function.OperatorType.LESS_THAN;
+import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DecimalType.createDecimalType;
@@ -82,6 +89,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
@@ -5889,5 +5897,91 @@ public class TestArrayOperators
         assertThat(assertions.function("flatten", "ARRAY[NULL, ARRAY[MAP(ARRAY[3, 4], ARRAY[3, 4])]]"))
                 .hasType(new ArrayType(mapType(INTEGER, INTEGER)))
                 .isEqualTo(ImmutableList.of(ImmutableMap.of(3, 3, 4, 4)));
+    }
+
+    /**
+     * Probe every {@code Generic*Operator} class on an ARRAY with a NULL element, in both SQL form
+     * (when one exists) and the mangled {@code "$operator$x"(...)} form. The assertions document
+     * which {@code Generic*Operator.neverFails} declarations match the operator's actual runtime
+     * behavior. A mismatch (planner-belief {@code .neverFails()} passing while the runtime
+     * assertion proves the operator can throw) indicates the declaration is incorrect — see
+     * https://github.com/trinodb/trino/issues/29891.
+     *
+     * Planner-belief assertions use NULL-free input of the same type, since the planner reasons
+     * type-wise, not value-wise.
+     */
+    @Test
+    public void testOperatorsOnArrayWithNullElement()
+    {
+        String arrayWithNull = "ARRAY[1, CAST(NULL AS INTEGER)]";
+        String arrayConcrete = "ARRAY[1, 2]";
+        String arrayConcreteOther = "ARRAY[3, 4]";
+
+        // EQUAL — returns NULL when comparison hits a NULL element; GenericEqualOperator declares neverFails=true.
+        // Runtime — SQL form
+        assertThat(assertions.expression("a = b").binding("a", arrayWithNull).binding("b", arrayConcrete))
+                .isNull(BOOLEAN);
+        // Runtime — mangled form
+        assertThat(assertions.operator(EQUAL, arrayWithNull, arrayConcrete))
+                .isNull(BOOLEAN);
+        // Planner belief
+        assertThat(assertions.operator(EQUAL, arrayConcrete, arrayConcreteOther))
+                .neverFails();
+
+        // IDENTICAL — NULL-aware; GenericIdenticalOperator declares neverFails=true.
+        assertThat(assertions.expression("a IS NOT DISTINCT FROM b").binding("a", arrayWithNull).binding("b", arrayWithNull))
+                .isEqualTo(true);
+        assertThat(assertions.operator(IDENTICAL, arrayWithNull, arrayWithNull))
+                .isEqualTo(true);
+        assertThat(assertions.operator(IDENTICAL, arrayConcrete, arrayConcreteOther))
+                .neverFails();
+
+        // INDETERMINATE — detects NULL; GenericIndeterminateOperator declares neverFails=true.
+        assertThat(assertions.operator(INDETERMINATE, arrayWithNull))
+                .isEqualTo(true);
+        assertThat(assertions.operator(INDETERMINATE, arrayConcrete))
+                .neverFails();
+
+        // LESS_THAN — array ordering must skip past NULL elements; GenericLessThanOperator does NOT declare neverFails (correct).
+        // ARRAY ordering currently throws NOT_SUPPORTED when a NULL element forces comparison.
+        assertTrinoExceptionThrownBy(assertions.expression("a < b").binding("a", arrayWithNull).binding("b", arrayConcrete)::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
+        assertTrinoExceptionThrownBy(assertions.operator(LESS_THAN, arrayWithNull, arrayConcrete)::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
+        assertThat(assertions.operator(LESS_THAN, arrayConcrete, arrayConcreteOther))
+                .couldFail();
+
+        // LESS_THAN_OR_EQUAL — same as LESS_THAN. Declaration was fixed in 72cdd389025.
+        assertTrinoExceptionThrownBy(assertions.expression("a <= b").binding("a", arrayWithNull).binding("b", arrayConcrete)::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
+        assertTrinoExceptionThrownBy(assertions.operator(LESS_THAN_OR_EQUAL, arrayWithNull, arrayConcrete)::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, arrayConcrete, arrayConcreteOther))
+                .couldFail();
+
+        // COMPARISON_UNORDERED_FIRST — throws at runtime when NULL ordering is reached, but
+        // GenericComparisonUnorderedFirstOperator declares neverFails=true (incorrect).
+        // The runtime sanity check wraps the TrinoException with IllegalStateException
+        // ("... declared as never failing threw ..."), which is itself evidence the declaration is wrong.
+        // TODO (https://github.com/trinodb/trino/issues/29891) GenericComparisonUnorderedFirstOperator.neverFails should not be hardcoded.
+        assertThatThrownBy(assertions.operator(COMPARISON_UNORDERED_FIRST, arrayWithNull, arrayConcrete)::evaluate)
+                .hasMessageContaining("ARRAY comparison not supported for arrays with null elements");
+        assertThat(assertions.operator(COMPARISON_UNORDERED_FIRST, arrayConcrete, arrayConcreteOther))
+                .neverFails();
+
+        // COMPARISON_UNORDERED_LAST — same suspicion.
+        // TODO (https://github.com/trinodb/trino/issues/29891) GenericComparisonUnorderedLastOperator.neverFails should not be hardcoded.
+        assertThatThrownBy(assertions.operator(COMPARISON_UNORDERED_LAST, arrayWithNull, arrayConcrete)::evaluate)
+                .hasMessageContaining("ARRAY comparison not supported for arrays with null elements");
+        assertThat(assertions.operator(COMPARISON_UNORDERED_LAST, arrayConcrete, arrayConcreteOther))
+                .neverFails();
+
+        // HASH_CODE — hashing tolerates NULL elements. GenericHashCodeOperator declares neverFails=true.
+        assertThat(assertions.operator(HASH_CODE, arrayWithNull))
+                .neverFails();
+
+        // XX_HASH_64 — same as HASH_CODE.
+        assertThat(assertions.operator(XX_HASH_64, arrayWithNull))
+                .neverFails();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
@@ -89,7 +89,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
@@ -5959,22 +5958,19 @@ public class TestArrayOperators
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, arrayConcrete, arrayConcreteOther))
                 .couldFail();
 
-        // COMPARISON_UNORDERED_FIRST — throws at runtime when NULL ordering is reached, but
-        // GenericComparisonUnorderedFirstOperator declares neverFails=true (incorrect).
-        // The runtime sanity check wraps the TrinoException with IllegalStateException
-        // ("... declared as never failing threw ..."), which is itself evidence the declaration is wrong.
-        // TODO (https://github.com/trinodb/trino/issues/29891) GenericComparisonUnorderedFirstOperator.neverFails should not be hardcoded.
-        assertThatThrownBy(assertions.operator(COMPARISON_UNORDERED_FIRST, arrayWithNull, arrayConcrete)::evaluate)
-                .hasMessageContaining("ARRAY comparison not supported for arrays with null elements");
+        // COMPARISON_UNORDERED_FIRST — throws NOT_SUPPORTED at runtime. GenericComparisonUnorderedFirstOperator
+        // routes its neverFails declaration through TypeOperators per binding, so for ARRAY (whose comparison
+        // implementation is not declared neverFails) the planner correctly believes the operator may fail.
+        assertTrinoExceptionThrownBy(assertions.operator(COMPARISON_UNORDERED_FIRST, arrayWithNull, arrayConcrete)::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
         assertThat(assertions.operator(COMPARISON_UNORDERED_FIRST, arrayConcrete, arrayConcreteOther))
-                .neverFails();
+                .couldFail();
 
-        // COMPARISON_UNORDERED_LAST — same suspicion.
-        // TODO (https://github.com/trinodb/trino/issues/29891) GenericComparisonUnorderedLastOperator.neverFails should not be hardcoded.
-        assertThatThrownBy(assertions.operator(COMPARISON_UNORDERED_LAST, arrayWithNull, arrayConcrete)::evaluate)
-                .hasMessageContaining("ARRAY comparison not supported for arrays with null elements");
+        // COMPARISON_UNORDERED_LAST — same as above.
+        assertTrinoExceptionThrownBy(assertions.operator(COMPARISON_UNORDERED_LAST, arrayWithNull, arrayConcrete)::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
         assertThat(assertions.operator(COMPARISON_UNORDERED_LAST, arrayConcrete, arrayConcreteOther))
-                .neverFails();
+                .couldFail();
 
         // HASH_CODE — hashing tolerates NULL elements. GenericHashCodeOperator declares neverFails=true.
         assertThat(assertions.operator(HASH_CODE, arrayWithNull))

--- a/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
@@ -5972,6 +5972,14 @@ public class TestArrayOperators
         assertThat(assertions.operator(COMPARISON_UNORDERED_LAST, arrayConcrete, arrayConcreteOther))
                 .couldFail();
 
+        // BETWEEN
+        assertTrinoExceptionThrownBy(assertions.expression("a BETWEEN b AND c")
+                .binding("a", arrayWithNull).binding("b", arrayConcrete).binding("c", arrayConcreteOther)::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
+        assertThat(assertions.expression("a BETWEEN b AND c")
+                .binding("a", arrayConcrete).binding("b", arrayConcrete).binding("c", arrayConcreteOther))
+                .couldFail();
+
         // HASH_CODE — hashing tolerates NULL elements. GenericHashCodeOperator declares neverFails=true.
         assertThat(assertions.operator(HASH_CODE, arrayWithNull))
                 .neverFails();

--- a/core/trino-main/src/test/java/io/trino/type/TestBigintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestBigintOperators.java
@@ -258,8 +258,7 @@ public class TestBigintOperators
                 .isEqualTo(false);
 
         assertThat(assertions.operator(LESS_THAN, "100000000017", "100000000017"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
 
         assertThat(assertions.expression("a < b")
                 .binding("a", "100000000017")
@@ -283,8 +282,7 @@ public class TestBigintOperators
                 .isEqualTo(true);
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "100000000017", "100000000017"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
 
         assertThat(assertions.expression("a <= b")
                 .binding("a", "100000000017")

--- a/core/trino-main/src/test/java/io/trino/type/TestBooleanOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestBooleanOperators.java
@@ -142,8 +142,7 @@ public class TestBooleanOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "false", "false"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test
@@ -167,8 +166,7 @@ public class TestBooleanOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "false", "false"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalOperators.java
@@ -1393,8 +1393,7 @@ public class TestDecimalOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "DECIMAL '37'", "DECIMAL '37'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test
@@ -1735,8 +1734,7 @@ public class TestDecimalOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "DECIMAL '37'", "DECIMAL '37'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestDoubleOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDoubleOperators.java
@@ -382,8 +382,7 @@ public class TestDoubleOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "37.7E0", "37.7E0"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test
@@ -416,8 +415,7 @@ public class TestDoubleOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "37.7E0", "37.7E0"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
@@ -283,8 +283,7 @@ public class TestIntegerOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "INTEGER '17'", "INTEGER '17'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test
@@ -308,8 +307,7 @@ public class TestIntegerOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "INTEGER '17'", "INTEGER '17'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestNumberOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestNumberOperators.java
@@ -2097,8 +2097,7 @@ public class TestNumberOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "NUMBER '37'", "NUMBER '37'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test
@@ -2574,8 +2573,7 @@ public class TestNumberOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "NUMBER '37'", "NUMBER '37'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestRealOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRealOperators.java
@@ -379,8 +379,7 @@ public class TestRealOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "REAL '12.34'", "REAL '12.34'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test
@@ -413,8 +412,7 @@ public class TestRealOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "REAL '12.34'", "REAL '12.34'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
@@ -45,14 +45,19 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
+import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.IDENTICAL;
 import static io.trino.spi.function.OperatorType.INDETERMINATE;
+import static io.trino.spi.function.OperatorType.LESS_THAN;
+import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -76,6 +81,7 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
@@ -1024,6 +1030,98 @@ public class TestRowOperators
             }
         }
         return types;
+    }
+
+    /**
+     * Probe every {@code Generic*Operator} class on a ROW with a NULL field, in both SQL form
+     * (when one exists) and the mangled {@code "$operator$x"(...)} form. The assertions document
+     * which {@code Generic*Operator.neverFails} declarations match the operator's actual runtime
+     * behavior. A mismatch (planner-belief {@code .neverFails()} passing while the runtime
+     * assertion proves the operator can throw) indicates the declaration is incorrect — see
+     * https://github.com/trinodb/trino/issues/29891.
+     *
+     * Note: the planner's fallibility belief is type-driven, not value-driven, so the planner-belief
+     * assertions use a NULL-free row of the same type — they would be unreachable on a value that
+     * actually throws.
+     */
+    @Test
+    public void testOperatorsOnRowWithNullField()
+    {
+        String rowWithNull = "row(1, CAST(NULL AS INTEGER))";
+        String rowConcrete = "row(1, 2)";
+        String rowConcreteOther = "row(3, 4)";
+
+        // EQUAL — returns NULL per SQL standard; GenericEqualOperator declares neverFails=true (correct).
+        // Runtime — SQL form
+        assertThat(assertions.expression("a = b").binding("a", rowWithNull).binding("b", rowConcrete))
+                .isNull(BOOLEAN);
+        // Runtime — mangled form
+        assertThat(assertions.operator(EQUAL, rowWithNull, rowConcrete))
+                .isNull(BOOLEAN);
+        // Planner belief (uses NULL-free input; planner reasons type-wise)
+        assertThat(assertions.operator(EQUAL, rowConcrete, rowConcreteOther))
+                .neverFails();
+
+        // IDENTICAL — NULL-aware (NULL ≡ NULL is TRUE); GenericIdenticalOperator declares neverFails=true (correct).
+        assertThat(assertions.expression("a IS NOT DISTINCT FROM b").binding("a", rowWithNull).binding("b", rowWithNull))
+                .isEqualTo(true);
+        assertThat(assertions.operator(IDENTICAL, rowWithNull, rowWithNull))
+                .isEqualTo(true);
+        assertThat(assertions.operator(IDENTICAL, rowConcrete, rowConcreteOther))
+                .neverFails();
+
+        // INDETERMINATE — exists to detect NULL; GenericIndeterminateOperator declares neverFails=true (correct).
+        // No SQL form.
+        assertThat(assertions.operator(INDETERMINATE, rowWithNull))
+                .isEqualTo(true);
+        assertThat(assertions.operator(INDETERMINATE, rowConcrete))
+                .neverFails();
+
+        // LESS_THAN — throws NOT_SUPPORTED when NULL ordering is reached; GenericLessThanOperator does NOT declare neverFails (correct).
+        // Runtime — SQL form
+        assertTrinoExceptionThrownBy(assertions.expression("a < b").binding("a", rowWithNull).binding("b", rowConcrete)::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
+        // Runtime — mangled form
+        assertTrinoExceptionThrownBy(assertions.operator(LESS_THAN, rowWithNull, rowConcrete)::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
+        // Planner belief (uses NULL-free input; planner is type-driven and conservative for this op)
+        assertThat(assertions.operator(LESS_THAN, rowConcrete, rowConcreteOther))
+                .couldFail();
+
+        // LESS_THAN_OR_EQUAL — same as LESS_THAN; declaration fixed in 72cdd389025 to omit neverFails (correct).
+        assertTrinoExceptionThrownBy(assertions.expression("a <= b").binding("a", rowWithNull).binding("b", rowConcrete)::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
+        assertTrinoExceptionThrownBy(assertions.operator(LESS_THAN_OR_EQUAL, rowWithNull, rowConcrete)::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, rowConcrete, rowConcreteOther))
+                .couldFail();
+
+        // COMPARISON_UNORDERED_FIRST — throws at runtime, but GenericComparisonUnorderedFirstOperator
+        // declares neverFails=true. The runtime sanity check wraps the TrinoException with
+        // IllegalStateException("... declared as never failing threw ..."), which is itself
+        // evidence the declaration is wrong. No SQL form.
+        // TODO (https://github.com/trinodb/trino/issues/29891) GenericComparisonUnorderedFirstOperator.neverFails should not be hardcoded;
+        //   once fixed, replace assertThatThrownBy with assertTrinoExceptionThrownBy(...).hasErrorCode(NOT_SUPPORTED)
+        //   and replace .neverFails() with .couldFail().
+        assertThatThrownBy(assertions.operator(COMPARISON_UNORDERED_FIRST, rowWithNull, rowConcrete)::evaluate)
+                .hasMessageContaining("ROW comparison not supported for fields with null elements");
+        assertThat(assertions.operator(COMPARISON_UNORDERED_FIRST, rowConcrete, rowConcreteOther))
+                .neverFails();
+
+        // COMPARISON_UNORDERED_LAST — same suspicion. No SQL form.
+        // TODO (https://github.com/trinodb/trino/issues/29891) GenericComparisonUnorderedLastOperator.neverFails should not be hardcoded.
+        assertThatThrownBy(assertions.operator(COMPARISON_UNORDERED_LAST, rowWithNull, rowConcrete)::evaluate)
+                .hasMessageContaining("ROW comparison not supported for fields with null elements");
+        assertThat(assertions.operator(COMPARISON_UNORDERED_LAST, rowConcrete, rowConcreteOther))
+                .neverFails();
+
+        // HASH_CODE — hashing tolerates NULL fields; GenericHashCodeOperator declares neverFails=true. No SQL form.
+        assertThat(assertions.operator(HASH_CODE, rowWithNull))
+                .neverFails();
+
+        // XX_HASH_64 — same as HASH_CODE. No SQL form.
+        assertThat(assertions.operator(XX_HASH_64, rowWithNull))
+                .neverFails();
     }
 
     private void assertComparisonCombination(String base, String greater)

--- a/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
@@ -81,7 +81,6 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
@@ -1096,24 +1095,20 @@ public class TestRowOperators
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, rowConcrete, rowConcreteOther))
                 .couldFail();
 
-        // COMPARISON_UNORDERED_FIRST — throws at runtime, but GenericComparisonUnorderedFirstOperator
-        // declares neverFails=true. The runtime sanity check wraps the TrinoException with
-        // IllegalStateException("... declared as never failing threw ..."), which is itself
-        // evidence the declaration is wrong. No SQL form.
-        // TODO (https://github.com/trinodb/trino/issues/29891) GenericComparisonUnorderedFirstOperator.neverFails should not be hardcoded;
-        //   once fixed, replace assertThatThrownBy with assertTrinoExceptionThrownBy(...).hasErrorCode(NOT_SUPPORTED)
-        //   and replace .neverFails() with .couldFail().
-        assertThatThrownBy(assertions.operator(COMPARISON_UNORDERED_FIRST, rowWithNull, rowConcrete)::evaluate)
-                .hasMessageContaining("ROW comparison not supported for fields with null elements");
+        // COMPARISON_UNORDERED_FIRST — throws NOT_SUPPORTED at runtime. GenericComparisonUnorderedFirstOperator
+        // routes its neverFails declaration through TypeOperators per binding, so for ROW (whose comparison
+        // implementation is not declared neverFails) the planner correctly believes the operator may fail.
+        // No SQL form.
+        assertTrinoExceptionThrownBy(assertions.operator(COMPARISON_UNORDERED_FIRST, rowWithNull, rowConcrete)::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
         assertThat(assertions.operator(COMPARISON_UNORDERED_FIRST, rowConcrete, rowConcreteOther))
-                .neverFails();
+                .couldFail();
 
-        // COMPARISON_UNORDERED_LAST — same suspicion. No SQL form.
-        // TODO (https://github.com/trinodb/trino/issues/29891) GenericComparisonUnorderedLastOperator.neverFails should not be hardcoded.
-        assertThatThrownBy(assertions.operator(COMPARISON_UNORDERED_LAST, rowWithNull, rowConcrete)::evaluate)
-                .hasMessageContaining("ROW comparison not supported for fields with null elements");
+        // COMPARISON_UNORDERED_LAST — same as above. No SQL form.
+        assertTrinoExceptionThrownBy(assertions.operator(COMPARISON_UNORDERED_LAST, rowWithNull, rowConcrete)::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
         assertThat(assertions.operator(COMPARISON_UNORDERED_LAST, rowConcrete, rowConcreteOther))
-                .neverFails();
+                .couldFail();
 
         // HASH_CODE — hashing tolerates NULL fields; GenericHashCodeOperator declares neverFails=true. No SQL form.
         assertThat(assertions.operator(HASH_CODE, rowWithNull))

--- a/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
@@ -1110,6 +1110,14 @@ public class TestRowOperators
         assertThat(assertions.operator(COMPARISON_UNORDERED_LAST, rowConcrete, rowConcreteOther))
                 .couldFail();
 
+        // BETWEEN
+        assertTrinoExceptionThrownBy(assertions.expression("a BETWEEN b AND c")
+                .binding("a", rowWithNull).binding("b", rowConcrete).binding("c", rowConcreteOther)::evaluate)
+                .hasErrorCode(NOT_SUPPORTED);
+        assertThat(assertions.expression("a BETWEEN b AND c")
+                .binding("a", rowConcrete).binding("b", rowConcrete).binding("c", rowConcreteOther))
+                .couldFail();
+
         // HASH_CODE — hashing tolerates NULL fields; GenericHashCodeOperator declares neverFails=true. No SQL form.
         assertThat(assertions.operator(HASH_CODE, rowWithNull))
                 .neverFails();

--- a/core/trino-main/src/test/java/io/trino/type/TestSmallintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestSmallintOperators.java
@@ -284,8 +284,7 @@ public class TestSmallintOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "SMALLINT '17'", "SMALLINT '17'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test
@@ -309,8 +308,7 @@ public class TestSmallintOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "SMALLINT '17'", "SMALLINT '17'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestTinyintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTinyintOperators.java
@@ -282,8 +282,7 @@ public class TestTinyintOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN, "TINYINT '17'", "TINYINT '17'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test
@@ -307,8 +306,7 @@ public class TestTinyintOperators
                 .neverFails();
 
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, "TINYINT '17'", "TINYINT '17'"))
-                // TODO (https://github.com/trinodb/trino/issues/29891) this should be recognized infallible
-                .couldFail();
+                .neverFails();
     }
 
     @Test

--- a/core/trino-spi/src/main/java/io/trino/spi/function/OperatorMethodHandle.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/OperatorMethodHandle.java
@@ -21,11 +21,19 @@ public class OperatorMethodHandle
 {
     private final InvocationConvention callingConvention;
     private final MethodHandle methodHandle;
+    private final boolean neverFails;
 
+    @Deprecated
     public OperatorMethodHandle(InvocationConvention callingConvention, MethodHandle methodHandle)
+    {
+        this(callingConvention, methodHandle, false);
+    }
+
+    public OperatorMethodHandle(InvocationConvention callingConvention, MethodHandle methodHandle, boolean neverFails)
     {
         this.callingConvention = requireNonNull(callingConvention, "callingConvention is null");
         this.methodHandle = requireNonNull(methodHandle, "methodHandle is null");
+        this.neverFails = neverFails;
     }
 
     public InvocationConvention getCallingConvention()
@@ -36,5 +44,14 @@ public class OperatorMethodHandle
     public MethodHandle getMethodHandle()
     {
         return methodHandle;
+    }
+
+    /**
+     * Whether the underlying method handle guarantees it does not throw for any input
+     * of the declared signature. Used by the planner to reason about expression fallibility.
+     */
+    public boolean isNeverFails()
+    {
+        return neverFails;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
@@ -385,37 +385,48 @@ public final class TypeOperatorDeclaration
                     throw new RuntimeException(e);
                 }
 
+                boolean neverFails = scalarOperator.neverFails();
                 switch (operatorType) {
                     case READ_VALUE -> addReadValueOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, typeJavaType),
-                            methodHandle));
+                            methodHandle,
+                            neverFails));
                     case EQUAL -> addEqualOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle));
+                            methodHandle,
+                            neverFails));
                     case HASH_CODE -> addHashCodeOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, long.class),
-                            methodHandle));
+                            methodHandle,
+                            neverFails));
                     case XX_HASH_64 -> addXxHash64Operator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, long.class),
-                            methodHandle));
+                            methodHandle,
+                            neverFails));
                     case IDENTICAL -> addIdenticalOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle));
+                            methodHandle,
+                            neverFails));
                     case INDETERMINATE -> addIndeterminateOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle));
+                            methodHandle,
+                            neverFails));
                     case COMPARISON_UNORDERED_LAST -> addComparisonUnorderedLastOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, long.class),
-                            methodHandle));
+                            methodHandle,
+                            neverFails));
                     case COMPARISON_UNORDERED_FIRST -> addComparisonUnorderedFirstOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, long.class),
-                            methodHandle));
+                            methodHandle,
+                            neverFails));
                     case LESS_THAN -> addLessThanOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle));
+                            methodHandle,
+                            neverFails));
                     case LESS_THAN_OR_EQUAL -> addLessThanOrEqualOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle));
+                            methodHandle,
+                            neverFails));
                     default -> throw new IllegalArgumentException(operatorType + " operator is not supported: " + method);
                 }
                 addedOperator = true;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
@@ -95,7 +95,7 @@ public class TypeOperators
 
     public MethodHandle getReadValueOperator(Type type, InvocationConvention callingConvention)
     {
-        return getOperatorAdaptor(type, callingConvention, READ_VALUE).get();
+        return getOperatorAdaptor(type, callingConvention, READ_VALUE).get().getMethodHandle();
     }
 
     public MethodHandle getEqualOperator(Type type, InvocationConvention callingConvention)
@@ -103,7 +103,7 @@ public class TypeOperators
         if (!type.isComparable()) {
             throw new UnsupportedOperationException(type + " is not comparable");
         }
-        return getOperatorAdaptor(type, callingConvention, EQUAL).get();
+        return getOperatorAdaptor(type, callingConvention, EQUAL).get().getMethodHandle();
     }
 
     public MethodHandle getHashCodeOperator(Type type, InvocationConvention callingConvention)
@@ -111,7 +111,7 @@ public class TypeOperators
         if (!type.isComparable()) {
             throw new UnsupportedOperationException(type + " is not comparable");
         }
-        return getOperatorAdaptor(type, callingConvention, OperatorType.HASH_CODE).get();
+        return getOperatorAdaptor(type, callingConvention, OperatorType.HASH_CODE).get().getMethodHandle();
     }
 
     public MethodHandle getXxHash64Operator(Type type, InvocationConvention callingConvention)
@@ -119,7 +119,7 @@ public class TypeOperators
         if (!type.isComparable()) {
             throw new UnsupportedOperationException(type + " is not comparable");
         }
-        return getOperatorAdaptor(type, callingConvention, OperatorType.XX_HASH_64).get();
+        return getOperatorAdaptor(type, callingConvention, OperatorType.XX_HASH_64).get().getMethodHandle();
     }
 
     public MethodHandle getIdenticalOperator(Type type, InvocationConvention callingConvention)
@@ -127,7 +127,7 @@ public class TypeOperators
         if (!type.isComparable()) {
             throw new UnsupportedOperationException(type + " is not comparable");
         }
-        return getOperatorAdaptor(type, callingConvention, OperatorType.IDENTICAL).get();
+        return getOperatorAdaptor(type, callingConvention, OperatorType.IDENTICAL).get().getMethodHandle();
     }
 
     public MethodHandle getIndeterminateOperator(Type type, InvocationConvention callingConvention)
@@ -135,10 +135,15 @@ public class TypeOperators
         if (!type.isComparable()) {
             throw new UnsupportedOperationException(type + " is not comparable");
         }
-        return getOperatorAdaptor(type, callingConvention, OperatorType.INDETERMINATE).get();
+        return getOperatorAdaptor(type, callingConvention, OperatorType.INDETERMINATE).get().getMethodHandle();
     }
 
     public MethodHandle getComparisonUnorderedLastOperator(Type type, InvocationConvention callingConvention)
+    {
+        return getComparisonUnorderedLastOperatorHandle(type, callingConvention).getMethodHandle();
+    }
+
+    public OperatorMethodHandle getComparisonUnorderedLastOperatorHandle(Type type, InvocationConvention callingConvention)
     {
         if (!type.isOrderable()) {
             throw new UnsupportedOperationException(type + " is not orderable");
@@ -147,6 +152,11 @@ public class TypeOperators
     }
 
     public MethodHandle getComparisonUnorderedFirstOperator(Type type, InvocationConvention callingConvention)
+    {
+        return getComparisonUnorderedFirstOperatorHandle(type, callingConvention).getMethodHandle();
+    }
+
+    public OperatorMethodHandle getComparisonUnorderedFirstOperatorHandle(Type type, InvocationConvention callingConvention)
     {
         if (!type.isOrderable()) {
             throw new UnsupportedOperationException(type + " is not orderable");
@@ -160,10 +170,15 @@ public class TypeOperators
             throw new UnsupportedOperationException(type + " is not orderable");
         }
         OperatorType comparisonType = sortOrder.isNullsFirst() ? COMPARISON_UNORDERED_FIRST : COMPARISON_UNORDERED_LAST;
-        return getOperatorAdaptor(type, Optional.of(sortOrder), callingConvention, comparisonType).get();
+        return getOperatorAdaptor(type, Optional.of(sortOrder), callingConvention, comparisonType).get().getMethodHandle();
     }
 
     public MethodHandle getLessThanOperator(Type type, InvocationConvention callingConvention)
+    {
+        return getLessThanOperatorHandle(type, callingConvention).getMethodHandle();
+    }
+
+    public OperatorMethodHandle getLessThanOperatorHandle(Type type, InvocationConvention callingConvention)
     {
         if (!type.isOrderable()) {
             throw new UnsupportedOperationException(type + " is not orderable");
@@ -172,6 +187,11 @@ public class TypeOperators
     }
 
     public MethodHandle getLessThanOrEqualOperator(Type type, InvocationConvention callingConvention)
+    {
+        return getLessThanOrEqualOperatorHandle(type, callingConvention).getMethodHandle();
+    }
+
+    public OperatorMethodHandle getLessThanOrEqualOperatorHandle(Type type, InvocationConvention callingConvention)
     {
         if (!type.isOrderable()) {
             throw new UnsupportedOperationException(type + " is not orderable");
@@ -193,14 +213,14 @@ public class TypeOperators
     private class OperatorAdaptor
     {
         private final OperatorConvention operatorConvention;
-        private volatile MethodHandle adapted;
+        private volatile OperatorMethodHandle adapted;
 
         public OperatorAdaptor(OperatorConvention operatorConvention)
         {
             this.operatorConvention = operatorConvention;
         }
 
-        public MethodHandle get()
+        public OperatorMethodHandle get()
         {
             if (adapted == null) {
                 synchronized (this) {
@@ -212,11 +232,11 @@ public class TypeOperators
             return adapted;
         }
 
-        private MethodHandle adaptOperator(OperatorConvention operatorConvention)
+        private OperatorMethodHandle adaptOperator(OperatorConvention operatorConvention)
         {
             OperatorMethodHandle operatorMethodHandle = selectOperatorMethodHandleToAdapt(operatorConvention);
             MethodHandle methodHandle = adaptOperator(operatorConvention, operatorMethodHandle);
-            return methodHandle;
+            return new OperatorMethodHandle(operatorConvention.callingConvention(), methodHandle, operatorMethodHandle.isNeverFails());
         }
 
         private static MethodHandle adaptOperator(OperatorConvention operatorConvention, OperatorMethodHandle operatorMethodHandle)
@@ -384,8 +404,7 @@ public class TypeOperators
             // if none of the arguments are nullable, return "equal"
             if (argumentConventions.stream().noneMatch(InvocationArgumentConvention::isNullable)) {
                 InvocationConvention convention = new InvocationConvention(argumentConventions, FAIL_ON_NULL, false, false);
-                MethodHandle equalMethodHandle = adaptOperator(new OperatorConvention(operatorConvention.type(), EQUAL, Optional.empty(), convention));
-                return new OperatorMethodHandle(convention, equalMethodHandle);
+                return adaptOperator(new OperatorConvention(operatorConvention.type(), EQUAL, Optional.empty(), convention));
             }
 
             // one or both of the arguments are nullable
@@ -415,7 +434,7 @@ public class TypeOperators
                     operatorConvention.type(),
                     EQUAL,
                     Optional.empty(),
-                    new InvocationConvention(equalArgumentConventions, FAIL_ON_NULL, false, false)));
+                    new InvocationConvention(equalArgumentConventions, FAIL_ON_NULL, false, false))).getMethodHandle();
             // add the unused null flag if necessary
             if (rightDistinctConvention == NULL_FLAG) {
                 equalMethodHandle = dropArguments(equalMethodHandle, equalMethodHandle.type().parameterCount(), boolean.class);
@@ -485,11 +504,11 @@ public class TypeOperators
             }
 
             OperatorConvention comparisonOperator = new OperatorConvention(operatorConvention.type(), COMPARISON_UNORDERED_LAST, Optional.empty(), comparisonCallingConvention);
-            MethodHandle comparisonMethod = adaptOperator(comparisonOperator);
+            OperatorMethodHandle comparison = adaptOperator(comparisonOperator);
             if (orEqual) {
-                return adaptComparisonToLessThanOrEqual(new OperatorMethodHandle(comparisonCallingConvention, comparisonMethod));
+                return adaptComparisonToLessThanOrEqual(comparison);
             }
-            return adaptComparisonToLessThan(new OperatorMethodHandle(comparisonCallingConvention, comparisonMethod));
+            return adaptComparisonToLessThan(comparison);
         }
 
         private OperatorMethodHandle generateOrderingOperator(OperatorConvention operatorConvention)
@@ -503,13 +522,11 @@ public class TypeOperators
                         Optional.empty(),
                         // null positions are handled separately in adaptBlockPositionComparisonToOrdering and not used in the comparison
                         simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL));
-                MethodHandle comparisonInvoker = adaptOperator(comparisonOperator);
-                return adaptBlockPositionComparisonToOrdering(sortOrder, comparisonInvoker);
+                return adaptBlockPositionComparisonToOrdering(sortOrder, adaptOperator(comparisonOperator));
             }
 
             OperatorConvention comparisonOperator = new OperatorConvention(operatorConvention.type(), comparisonType, Optional.empty(), simpleConvention(FAIL_ON_NULL, NULL_FLAG, NULL_FLAG));
-            MethodHandle comparisonInvoker = adaptOperator(comparisonOperator);
-            return adaptNeverNullComparisonToOrdering(sortOrder, comparisonInvoker);
+            return adaptNeverNullComparisonToOrdering(sortOrder, adaptOperator(comparisonOperator));
         }
 
         private static Type getOperatorReturnType(OperatorConvention operatorConvention)
@@ -646,23 +663,24 @@ public class TypeOperators
     // Adapt comparison to ordering
     //
 
-    private static OperatorMethodHandle adaptNeverNullComparisonToOrdering(SortOrder sortOrder, MethodHandle neverNullComparison)
+    private static OperatorMethodHandle adaptNeverNullComparisonToOrdering(SortOrder sortOrder, OperatorMethodHandle neverNullComparison)
     {
+        MethodHandle comparisonHandle = neverNullComparison.getMethodHandle();
         MethodType finalSignature = MethodType.methodType(
                 int.class,
                 boolean.class,
-                neverNullComparison.type().parameterType(0),
+                comparisonHandle.type().parameterType(0),
                 boolean.class,
-                neverNullComparison.type().parameterType(1));
+                comparisonHandle.type().parameterType(1));
 
         // (leftIsNull, rightIsNull, leftValue, rightValue)::int
-        MethodHandle order = adaptComparisonToOrdering(sortOrder, neverNullComparison);
+        MethodHandle order = adaptComparisonToOrdering(sortOrder, comparisonHandle);
         // (leftIsNull, leftValue, rightIsNull, rightValue)::int
         order = permuteArguments(order, finalSignature, 0, 2, 1, 3);
-        return new OperatorMethodHandle(simpleConvention(FAIL_ON_NULL, NULL_FLAG, NULL_FLAG), order);
+        return new OperatorMethodHandle(simpleConvention(FAIL_ON_NULL, NULL_FLAG, NULL_FLAG), order, neverNullComparison.isNeverFails());
     }
 
-    private static OperatorMethodHandle adaptBlockPositionComparisonToOrdering(SortOrder sortOrder, MethodHandle blockPositionComparison)
+    private static OperatorMethodHandle adaptBlockPositionComparisonToOrdering(SortOrder sortOrder, OperatorMethodHandle blockPositionComparison)
     {
         MethodType finalSignature = MethodType.methodType(
                 int.class,
@@ -672,14 +690,14 @@ public class TypeOperators
                 int.class);
 
         // (leftIsNull, rightIsNull, leftBlock, leftPosition, rightBlock, rightPosition)::int
-        MethodHandle order = adaptComparisonToOrdering(sortOrder, blockPositionComparison);
+        MethodHandle order = adaptComparisonToOrdering(sortOrder, blockPositionComparison.getMethodHandle());
         // (leftBlock, leftPosition, rightBlock, rightPosition, leftBlock, leftPosition, rightBlock, rightPosition)::int
         order = collectArguments(order, 1, BLOCK_IS_NULL);
         order = collectArguments(order, 0, BLOCK_IS_NULL);
         // (leftBlock, leftPosition, rightBlock, rightPosition)::int
         order = permuteArguments(order, finalSignature, 0, 1, 2, 3, 0, 1, 2, 3);
 
-        return new OperatorMethodHandle(simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION), order);
+        return new OperatorMethodHandle(simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION), order, blockPositionComparison.isNeverFails());
     }
 
     // input: (args)::int
@@ -737,7 +755,7 @@ public class TypeOperators
         if (returnConvention != FAIL_ON_NULL) {
             throw new IllegalArgumentException("Return convention must be " + FAIL_ON_NULL + ", but is " + returnConvention);
         }
-        return new OperatorMethodHandle(invoker.getCallingConvention(), filterReturnValue(invoker.getMethodHandle(), IS_COMPARISON_LESS_THAN));
+        return new OperatorMethodHandle(invoker.getCallingConvention(), filterReturnValue(invoker.getMethodHandle(), IS_COMPARISON_LESS_THAN), invoker.isNeverFails());
     }
 
     private static boolean isComparisonLessThan(long comparisonResult)
@@ -751,7 +769,7 @@ public class TypeOperators
         if (returnConvention != FAIL_ON_NULL) {
             throw new IllegalArgumentException("Return convention must be " + FAIL_ON_NULL + ", but is " + returnConvention);
         }
-        return new OperatorMethodHandle(invoker.getCallingConvention(), filterReturnValue(invoker.getMethodHandle(), IS_COMPARISON_LESS_THAN_OR_EQUAL));
+        return new OperatorMethodHandle(invoker.getCallingConvention(), filterReturnValue(invoker.getMethodHandle(), IS_COMPARISON_LESS_THAN_OR_EQUAL), invoker.isNeverFails());
     }
 
     private static boolean isComparisonLessThanOrEqual(long comparisonResult)


### PR DESCRIPTION
- fixes https://github.com/trinodb/trino/issues/29891
- fixes https://github.com/trinodb/trino/issues/29898