### PR TITLE
Respect source schema for unqualified RENAME VIEW target

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/RenameMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameMaterializedViewTask.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.trino.metadata.MetadataUtil.createTargetQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_ALREADY_EXISTS;
@@ -87,7 +88,7 @@ public class RenameMaterializedViewTask
             throw semanticException(TABLE_NOT_FOUND, statement, "Materialized View '%s' does not exist", materializedViewName);
         }
 
-        QualifiedObjectName target = createQualifiedObjectName(session, statement, statement.getTarget());
+        QualifiedObjectName target = createTargetQualifiedObjectName(materializedViewName, statement.getTarget());
         if (metadata.getCatalogHandle(session, target.catalogName()).isEmpty()) {
             throw semanticException(CATALOG_NOT_FOUND, statement, "Target catalog '%s' not found", target.catalogName());
         }

--- a/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
@@ -22,23 +22,20 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.RedirectionAwareTableHandle;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
-import io.trino.spi.TrinoException;
 import io.trino.sql.tree.Expression;
-import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.RenameTable;
 
 import java.util.List;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.trino.metadata.MetadataUtil.createTargetQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
-import static io.trino.spi.StandardErrorCode.SYNTAX_ERROR;
 import static io.trino.spi.StandardErrorCode.TABLE_ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class RenameTableTask
@@ -119,20 +116,5 @@ public class RenameTableTask
         metadata.renameTable(session, tableHandle, source.asCatalogSchemaTableName(), target);
 
         return immediateVoidFuture();
-    }
-
-    private static QualifiedObjectName createTargetQualifiedObjectName(QualifiedObjectName source, QualifiedName target)
-    {
-        requireNonNull(target, "target is null");
-        if (target.getParts().size() > 3) {
-            throw new TrinoException(SYNTAX_ERROR, format("Too many dots in table name: %s", target));
-        }
-
-        List<String> parts = target.getParts().reversed();
-        String objectName = parts.get(0);
-        String schemaName = (parts.size() > 1) ? parts.get(1) : source.schemaName();
-        String catalogName = (parts.size() > 2) ? parts.get(2) : source.catalogName();
-
-        return new QualifiedObjectName(catalogName, schemaName, objectName);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.trino.metadata.MetadataUtil.createTargetQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -85,7 +86,7 @@ public class RenameViewTask
             throw semanticException(TABLE_NOT_FOUND, statement, "View '%s' does not exist", viewName);
         }
 
-        QualifiedObjectName target = createQualifiedObjectName(session, statement, statement.getTarget());
+        QualifiedObjectName target = createTargetQualifiedObjectName(viewName, statement.getTarget());
         if (metadata.getCatalogHandle(session, target.catalogName()).isEmpty()) {
             throw semanticException(CATALOG_NOT_FOUND, statement, "Target catalog '%s' not found", target.catalogName());
         }

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataUtil.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataUtil.java
@@ -208,7 +208,7 @@ public final class MetadataUtil
     {
         requireNonNull(target, "target is null");
         if (target.getParts().size() > 3) {
-            throw new TrinoException(SYNTAX_ERROR, format("Too many dots in table name: %s", target));
+            throw new TrinoException(SYNTAX_ERROR, format("Too many dots in name: %s", target));
         }
 
         List<String> parts = target.getParts().reversed();

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataUtil.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataUtil.java
@@ -204,6 +204,21 @@ public final class MetadataUtil
         return new QualifiedObjectName(catalogName, schemaName, objectName);
     }
 
+    public static QualifiedObjectName createTargetQualifiedObjectName(QualifiedObjectName source, QualifiedName target)
+    {
+        requireNonNull(target, "target is null");
+        if (target.getParts().size() > 3) {
+            throw new TrinoException(SYNTAX_ERROR, format("Too many dots in table name: %s", target));
+        }
+
+        List<String> parts = target.getParts().reversed();
+        String objectName = parts.get(0);
+        String schemaName = (parts.size() > 1) ? parts.get(1) : source.schemaName();
+        String catalogName = (parts.size() > 2) ? parts.get(2) : source.catalogName();
+
+        return new QualifiedObjectName(catalogName, schemaName, objectName);
+    }
+
     public static EntityKindAndName createEntityKindAndName(String entityKind, QualifiedName name)
     {
         return new EntityKindAndName(entityKind, name.getParts());

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameMaterializedViewTask.java
@@ -48,6 +48,19 @@ public class TestRenameMaterializedViewTask
     }
 
     @Test
+    public void testRenameToUnqualifiedTargetKeepsSourceSchema()
+    {
+        String sourceSchema = "other_schema";
+        QualifiedObjectName materializedViewName = new QualifiedObjectName(TEST_CATALOG_NAME, sourceSchema, "existing_materialized_view");
+        QualifiedObjectName newMaterializedViewName = new QualifiedObjectName(TEST_CATALOG_NAME, sourceSchema, "existing_materialized_view_new");
+        metadata.createMaterializedView(testSession, materializedViewName, someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
+
+        getFutureValue(executeRenameMaterializedView(asQualifiedName(materializedViewName), QualifiedName.of("existing_materialized_view_new")));
+        assertThat(metadata.isMaterializedView(testSession, materializedViewName)).isFalse();
+        assertThat(metadata.isMaterializedView(testSession, newMaterializedViewName)).isTrue();
+    }
+
+    @Test
     public void testRenameNotExistingMaterializedView()
     {
         QualifiedName materializedViewName = qualifiedName("not_existing_materialized_view");

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameViewTask.java
@@ -49,6 +49,19 @@ public class TestRenameViewTask
     }
 
     @Test
+    public void testRenameToUnqualifiedTargetKeepsSourceSchema()
+    {
+        String sourceSchema = "other_schema";
+        QualifiedObjectName viewName = new QualifiedObjectName(TEST_CATALOG_NAME, sourceSchema, "existing_view");
+        QualifiedObjectName newViewName = new QualifiedObjectName(TEST_CATALOG_NAME, sourceSchema, "existing_view_new");
+        metadata.createView(testSession, viewName, someView(), ImmutableMap.of(), false);
+
+        getFutureValue(executeRenameView(asQualifiedName(viewName), QualifiedName.of("existing_view_new")));
+        assertThat(metadata.isView(testSession, viewName)).isFalse();
+        assertThat(metadata.isView(testSession, newViewName)).isTrue();
+    }
+
+    @Test
     public void testRenameNotExistingView()
     {
         QualifiedName viewName = qualifiedName("not_existing_view");


### PR DESCRIPTION
## Description

RenameViewTask and RenameMaterializedViewTask filled an unqualified rename target's catalog/schema from the session rather than the source object, unlike RenameTableTask. Share RenameTableTask's createTargetQualifiedObjectName via MetadataUtil so all three tasks resolve the target from the source.

## Additional context and related issues

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
