### PR TITLE
Use azure blob client's deleteIfExists

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
@@ -71,7 +71,6 @@ import static io.trino.filesystem.TrinoFileSystem.checkStartingFrom;
 import static io.trino.filesystem.azure.AzureUtils.blobCustomerProvidedKey;
 import static io.trino.filesystem.azure.AzureUtils.encodedKey;
 import static io.trino.filesystem.azure.AzureUtils.handleAzureException;
-import static io.trino.filesystem.azure.AzureUtils.isFileNotFoundException;
 import static io.trino.filesystem.azure.AzureUtils.keySha256Checksum;
 import static io.trino.filesystem.azure.AzureUtils.lakeCustomerProvidedKey;
 import static java.lang.Math.toIntExact;
@@ -194,12 +193,9 @@ public class AzureFileSystem
         AzureLocation azureLocation = new AzureLocation(location);
         BlobClient client = createBlobClient(azureLocation, Optional.empty());
         try {
-            client.delete();
+            client.deleteIfExists();
         }
         catch (RuntimeException e) {
-            if (isFileNotFoundException(e)) {
-                return;
-            }
             throw handleAzureException(e, "deleting file", azureLocation);
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

I was looking at making improvements to the azure file system. This was a low hanging fruit. `deleteIfExists` is already used in [AbstractTestAzureFileSystem](https://github.com/trinodb/trino/blob/2977b267719c22627e632a4ea8758409a86c7da2/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java#L176).

EDIT: And [deleteBlobDirectory](https://github.com/trinodb/trino/blob/2977b267719c22627e632a4ea8758409a86c7da2/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java#L256).

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Method largely unchanged from ...
 * [Initial azure implementation](https://github.com/trinodb/trino/pull/17237)
 * Followed up only by [these changes to ignore already deleted files globally](https://github.com/trinodb/trino/pull/19937/changes/2d551782c6b7eb866c2c7b97eff1ece9bdcb7e82).

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* N.A
```
