### PR TITLE
fix(glue): surface PERMISSION_DENIED when Lake Formation returns AccessDeniedException at metastore layer

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -282,8 +282,36 @@ public class GlueHiveMetastore
         catch (EntityNotFoundException e) {
             return Optional.empty();
         }
+        catch (AccessDeniedException e) {
+            // Lake Formation returns AccessDeniedException (HTTP 400) for databases that do not exist
+            // in Glue, indistinguishable from a genuine permission denial. Perform a secondary
+            // GetDatabases probe (requires only catalog-level LF permission) to distinguish the two cases.
+            if (e.getMessage() != null && e.getMessage().contains("Lake Formation")) {
+                if (!glueDatabaseExists(databaseName)) {
+                    throw new SchemaNotFoundException(databaseName, e);
+                }
+            }
+            throw new TrinoException(HIVE_METASTORE_ERROR, e);
+        }
         catch (SdkException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    private boolean glueDatabaseExists(String databaseName)
+    {
+        try {
+            return stats.getGetDatabases().call(() -> glueClient
+                            .getDatabasesPaginator(builder -> builder
+                                    .expression(databaseName)).stream()
+                            .map(GetDatabasesResponse::databaseList)
+                            .flatMap(List::stream))
+                    .anyMatch(db -> db.name().equalsIgnoreCase(databaseName));
+        }
+        catch (SdkException ignored) {
+            // If GetDatabases also fails (e.g. no catalog-level LF permission), we cannot determine
+            // whether the database exists. Return true to avoid masking genuine permission errors.
+            return true;
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -145,6 +145,7 @@ import static java.util.Map.entry;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.function.Predicate.not;
+import static java.lang.String.format;
 import static java.util.function.UnaryOperator.identity;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toMap;
@@ -506,8 +507,40 @@ public class GlueHiveMetastore
         catch (EntityNotFoundException e) {
             return Optional.empty();
         }
+        catch (AccessDeniedException e) {
+            // Lake Formation returns AccessDeniedException (HTTP 400) for tables that do not exist
+            // in Glue, indistinguishable from a genuine permission denial. Perform a secondary
+            // GetTables probe (requires only database-level LF permission) to distinguish the two cases.
+            if (e.getMessage() != null && e.getMessage().contains("Lake Formation")) {
+                if (!glueTableExists(databaseName, tableName)) {
+                    throw new TableNotFoundException(
+                            new SchemaTableName(databaseName, tableName),
+                            format("Table '%s.%s' does not exist in Glue catalog.", databaseName, tableName),
+                            e);
+                }
+            }
+            throw new TrinoException(HIVE_METASTORE_ERROR, e);
+        }
         catch (SdkException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    private boolean glueTableExists(String databaseName, String tableName)
+    {
+        try {
+            return stats.getGetTables().call(() -> glueClient
+                            .getTablesPaginator(builder -> builder
+                                    .databaseName(databaseName)
+                                    .expression(tableName)).stream()
+                            .map(GetTablesResponse::tableList)
+                            .flatMap(List::stream))
+                    .anyMatch(t -> t.name().equalsIgnoreCase(tableName));
+        }
+        catch (SdkException ignored) {
+            // If GetTables also fails (e.g. no database-level LF permission), we cannot determine
+            // whether the table exists. Return true to avoid masking genuine permission errors.
+            return true;
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -137,6 +137,7 @@ import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.StandardErrorCode.PERMISSION_DENIED;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.UNSUPPORTED_TABLE_TYPE;
 import static io.trino.spi.connector.SchemaTableName.schemaTableName;
@@ -283,35 +284,12 @@ public class GlueHiveMetastore
             return Optional.empty();
         }
         catch (AccessDeniedException e) {
-            // Lake Formation returns AccessDeniedException (HTTP 400) for databases that do not exist
-            // in Glue, indistinguishable from a genuine permission denial. Perform a secondary
-            // GetDatabases probe (requires only catalog-level LF permission) to distinguish the two cases.
-            if (e.getMessage() != null && e.getMessage().contains("Lake Formation")) {
-                if (!glueDatabaseExists(databaseName)) {
-                    throw new SchemaNotFoundException(databaseName, e);
-                }
-            }
-            throw new TrinoException(HIVE_METASTORE_ERROR, e);
+            // Glue/Lake Formation returns AccessDenied when the caller lacks permission (e.g. LF Describe).
+            // Surface it as a permission error instead of converting it to SchemaNotFoundException.
+            throw new TrinoException(PERMISSION_DENIED, format("Cannot access schema '%s' in Glue catalog: insufficient Lake Formation permissions", databaseName), e);
         }
         catch (SdkException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
-        }
-    }
-
-    private boolean glueDatabaseExists(String databaseName)
-    {
-        try {
-            return stats.getGetDatabases().call(() -> glueClient
-                            .getDatabasesPaginator(builder -> builder
-                                    .expression(databaseName)).stream()
-                            .map(GetDatabasesResponse::databaseList)
-                            .flatMap(List::stream))
-                    .anyMatch(db -> db.name().equalsIgnoreCase(databaseName));
-        }
-        catch (SdkException ignored) {
-            // If GetDatabases also fails (e.g. no catalog-level LF permission), we cannot determine
-            // whether the database exists. Return true to avoid masking genuine permission errors.
-            return true;
         }
     }
 
@@ -536,39 +514,14 @@ public class GlueHiveMetastore
             return Optional.empty();
         }
         catch (AccessDeniedException e) {
-            // Lake Formation returns AccessDeniedException (HTTP 400) for tables that do not exist
-            // in Glue, indistinguishable from a genuine permission denial. Perform a secondary
-            // GetTables probe (requires only database-level LF permission) to distinguish the two cases.
-            if (e.getMessage() != null && e.getMessage().contains("Lake Formation")) {
-                if (!glueTableExists(databaseName, tableName)) {
-                    throw new TableNotFoundException(
-                            new SchemaTableName(databaseName, tableName),
-                            format("Table '%s.%s' does not exist in Glue catalog.", databaseName, tableName),
-                            e);
-                }
-            }
-            throw new TrinoException(HIVE_METASTORE_ERROR, e);
+            // Glue/Lake Formation returns AccessDenied when the caller lacks permission (e.g. LF Describe).
+            // Surface it as a permission error instead of converting it to TableNotFoundException: the
+            // latter is misleading (especially for CREATE TABLE, where the table not yet existing is
+            // expected) and masks the real cause, which is the missing Lake Formation permission.
+            throw new TrinoException(PERMISSION_DENIED, format("Cannot access table '%s.%s' in Glue catalog: insufficient Lake Formation permissions", databaseName, tableName), e);
         }
         catch (SdkException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
-        }
-    }
-
-    private boolean glueTableExists(String databaseName, String tableName)
-    {
-        try {
-            return stats.getGetTables().call(() -> glueClient
-                            .getTablesPaginator(builder -> builder
-                                    .databaseName(databaseName)
-                                    .expression(tableName)).stream()
-                            .map(GetTablesResponse::tableList)
-                            .flatMap(List::stream))
-                    .anyMatch(t -> t.name().equalsIgnoreCase(tableName));
-        }
-        catch (SdkException ignored) {
-            // If GetTables also fails (e.g. no database-level LF permission), we cannot determine
-            // whether the table exists. Return true to avoid masking genuine permission errors.
-            return true;
         }
     }
 


### PR DESCRIPTION
## Problem

When a table or schema does not exist in AWS Glue but Lake Formation (LF) is enabled,
`GetTable`/`GetDatabase` returns an `AccessDeniedException` (HTTP 400) with a message like:

```
Insufficient Lake Formation permission(s): Required Describe on table ...
```

This is indistinguishable from a genuine IAM permission denial. The previous approach performed
a secondary `GetTables`/`GetDatabases` probe to determine whether the object actually existed
and raised `TableNotFoundException`/`SchemaNotFoundException` if it did not.

## Problem with the probe approach

The metastore `getTableInternal` / `getDatabaseInternal` methods are called for **every**
operation — `SELECT`, `CREATE`, `DROP`, `ALTER`, `INSERT`. For `CREATE TABLE` the table
does not yet exist, which is expected; raising `TableNotFoundException` in that case is
misleading and masks the real error: missing Lake Formation permissions.

The secondary probe also requires a separate LF permission on the caller, adds extra Glue
API calls on every permission-denied path, and still cannot reliably distinguish the two
cases when the probe itself is denied.

## Fix

Catch `AccessDeniedException` at the metastore layer and surface it directly as
`PERMISSION_DENIED` with a clear message naming the missing object:

```
Cannot access table 'myschema.mytable' in Glue catalog: insufficient Lake Formation permissions
```

This applies consistently across all operations and gives users an actionable error
instead of a confusing `Table does not exist`.

## Changes

- `getTableInternal`: catch `AccessDeniedException` → throw `PERMISSION_DENIED`
- `getDatabaseInternal`: same pattern for schema-level access
- Remove `glueTableExists()` and `glueDatabaseExists()` probe helpers

## Testing

Tested manually against a Glue catalog with Lake Formation enabled and a role that has
`GetTable` / `GetDatabase` denied at the LF layer. Operations that previously returned
`Table 'x' does not exist` now return the correct permission-denied error.
