### PR TITLE
Strip empty-valued table properties before REST catalog createTable call

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -432,7 +432,7 @@ public class TrinoRestCatalog
             Catalog.TableBuilder tableBuilder = restSessionCatalog.buildTable(convert(session), toRemoteTable(session, schemaTableName, true), schema)
                     .withPartitionSpec(partitionSpec)
                     .withSortOrder(sortOrder)
-                    .withProperties(properties);
+                    .withProperties(stripEmptyValues(properties));
             if (location.isEmpty()) {
                 // TODO Replace with createTransaction once S3 Tables supports stage-create option
                 return tableBuilder.create().newTransaction();
@@ -459,12 +459,19 @@ public class TrinoRestCatalog
                     .withPartitionSpec(partitionSpec)
                     .withSortOrder(sortOrder)
                     .withLocation(location)
-                    .withProperties(properties)
+                    .withProperties(stripEmptyValues(properties))
                     .createOrReplaceTransaction();
         }
         catch (RESTException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to create transaction", e);
         }
+    }
+
+    private static Map<String, String> stripEmptyValues(Map<String, String> properties)
+    {
+        return properties.entrySet().stream()
+                .filter(entry -> !entry.getValue().isEmpty())
+                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @Override


### PR DESCRIPTION
## Problem

`CREATE TABLE` against a REST catalog fails when the table properties map contains entries with empty string values. Some REST catalog implementations reject empty-valued properties as prohibited keys, causing the entire `CREATE TABLE` to fail with an error like:

```
TrinoException: Failed to create transaction for table ...
```

## Root Cause

Since #25755, `IcebergUtil.createTableProperties()` injects `write.parquet.compression-codec=""` (empty string) as a sentinel to suppress Iceberg's ZSTD default. The intent is to remove this sentinel after the transaction opens, via a post-transaction `updateProperties().remove()` call.

However, for REST catalogs, the `createTable` REST API call happens *before* that cleanup step. The empty-valued property reaches the REST endpoint directly, where it may be rejected.

## Fix

Add a `stripEmptyValues()` helper in `TrinoRestCatalog` that filters out properties with empty string values before passing them to `.withProperties()`. Applied in both `newCreateTableTransaction()` and `newCreateOrReplaceTableTransaction()`.

The empty-value sentinel for `write.parquet.compression-codec` is never meaningful for a REST catalog — either the property has a real value (user-specified codec) or it should be absent (letting Iceberg or the catalog apply its default). Stripping empty values before the REST call is safe and has no effect on non-empty properties.

```java
private static Map<String, String> stripEmptyValues(Map<String, String> properties)
{
    return properties.entrySet().stream()
            .filter(entry -> !entry.getValue().isEmpty())
            .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
}
```

## Testing

- [ ] Unit test: verify `newCreateTableTransaction` strips empty-valued properties before the REST call
- [ ] Unit test: verify `newCreateOrReplaceTableTransaction` strips empty-valued properties before the REST call
- [ ] Non-empty properties pass through unchanged
- [ ] Manual validation against a REST catalog that rejects empty property values confirms `CREATE TABLE` succeeds after this fix

## Related

- #25755 — introduced the `write.parquet.compression-codec=""` sentinel in `IcebergUtil.createTableProperties()`