### PR TITLE
feat(security): support {user} substitution in schema/table/catalog fields of file-based ACL

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AnyCatalogPermissionsRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AnyCatalogPermissionsRule.java
@@ -23,14 +23,14 @@ public class AnyCatalogPermissionsRule
     private final Optional<Pattern> userRegex;
     private final Optional<Pattern> roleRegex;
     private final Optional<Pattern> groupRegex;
-    private final Optional<Pattern> catalogRegex;
+    private final Optional<UserSubstitutingPattern> catalogPattern;
 
-    public AnyCatalogPermissionsRule(Optional<Pattern> userRegex, Optional<Pattern> roleRegex, Optional<Pattern> groupRegex, Optional<Pattern> catalogRegex)
+    public AnyCatalogPermissionsRule(Optional<Pattern> userRegex, Optional<Pattern> roleRegex, Optional<Pattern> groupRegex, Optional<UserSubstitutingPattern> catalogPattern)
     {
         this.userRegex = userRegex;
         this.roleRegex = roleRegex;
         this.groupRegex = groupRegex;
-        this.catalogRegex = catalogRegex;
+        this.catalogPattern = catalogPattern;
     }
 
     public boolean match(String user, Set<String> roles, Set<String> groups, String catalog)
@@ -38,7 +38,8 @@ public class AnyCatalogPermissionsRule
         return userRegex.map(regex -> regex.matcher(user).matches()).orElse(true) &&
                 roleRegex.map(regex -> roles.stream().anyMatch(role -> regex.matcher(role).matches())).orElse(true) &&
                 groupRegex.map(regex -> groups.stream().anyMatch(group -> regex.matcher(group).matches())).orElse(true) &&
-                catalogRegex.map(regex -> regex.matcher(catalog).matches()).orElse(true);
+                // A {user}-bearing catalog pattern may match after substitution — treat as potentially matching
+                catalogPattern.map(p -> p.hasUserPlaceholder() || p.matches(user, catalog)).orElse(true);
     }
 
     @Override
@@ -54,7 +55,9 @@ public class AnyCatalogPermissionsRule
         return patternEquals(userRegex, that.userRegex) &&
                 patternEquals(roleRegex, that.roleRegex) &&
                 patternEquals(groupRegex, that.groupRegex) &&
-                patternEquals(catalogRegex, that.catalogRegex);
+                Objects.equals(
+                        catalogPattern.map(UserSubstitutingPattern::raw),
+                        that.catalogPattern.map(UserSubstitutingPattern::raw));
     }
 
     private static boolean patternEquals(Optional<Pattern> left, Optional<Pattern> right)
@@ -70,6 +73,6 @@ public class AnyCatalogPermissionsRule
     @Override
     public int hashCode()
     {
-        return Objects.hash(userRegex, roleRegex, groupRegex, catalogRegex);
+        return Objects.hash(userRegex, roleRegex, groupRegex, catalogPattern.map(UserSubstitutingPattern::raw));
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AnyCatalogSchemaPermissionsRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AnyCatalogSchemaPermissionsRule.java
@@ -23,16 +23,16 @@ public class AnyCatalogSchemaPermissionsRule
     private final Optional<Pattern> userRegex;
     private final Optional<Pattern> groupRegex;
     private final Optional<Pattern> roleRegex;
-    private final Optional<Pattern> catalogRegex;
-    private final Optional<Pattern> schemaRegex;
+    private final Optional<UserSubstitutingPattern> catalogPattern;
+    private final Optional<UserSubstitutingPattern> schemaPattern;
 
-    public AnyCatalogSchemaPermissionsRule(Optional<Pattern> userRegex, Optional<Pattern> roleRegex, Optional<Pattern> groupRegex, Optional<Pattern> catalogRegex, Optional<Pattern> schemaRegex)
+    public AnyCatalogSchemaPermissionsRule(Optional<Pattern> userRegex, Optional<Pattern> roleRegex, Optional<Pattern> groupRegex, Optional<UserSubstitutingPattern> catalogPattern, Optional<UserSubstitutingPattern> schemaPattern)
     {
         this.userRegex = userRegex;
         this.roleRegex = roleRegex;
         this.groupRegex = groupRegex;
-        this.catalogRegex = catalogRegex;
-        this.schemaRegex = schemaRegex;
+        this.catalogPattern = catalogPattern;
+        this.schemaPattern = schemaPattern;
     }
 
     public boolean match(String user, Set<String> roles, Set<String> groups, String catalogName, String schemaName)
@@ -40,8 +40,9 @@ public class AnyCatalogSchemaPermissionsRule
         return userRegex.map(regex -> regex.matcher(user).matches()).orElse(true) &&
                 roleRegex.map(regex -> roles.stream().anyMatch(role -> regex.matcher(role).matches())).orElse(true) &&
                 groupRegex.map(regex -> groups.stream().anyMatch(group -> regex.matcher(group).matches())).orElse(true) &&
-                catalogRegex.map(regex -> regex.matcher(catalogName).matches()).orElse(true) &&
-                schemaRegex.map(regex -> regex.matcher(schemaName).matches()).orElse(true);
+                // A {user}-bearing pattern may match after substitution — treat as potentially matching
+                catalogPattern.map(p -> p.hasUserPlaceholder() || p.matches(user, catalogName)).orElse(true) &&
+                schemaPattern.map(p -> p.hasUserPlaceholder() || p.matches(user, schemaName)).orElse(true);
     }
 
     @Override
@@ -57,8 +58,12 @@ public class AnyCatalogSchemaPermissionsRule
         return patternEquals(userRegex, that.userRegex) &&
                 patternEquals(roleRegex, that.roleRegex) &&
                 patternEquals(groupRegex, that.groupRegex) &&
-                patternEquals(catalogRegex, that.catalogRegex) &&
-                patternEquals(schemaRegex, that.schemaRegex);
+                Objects.equals(
+                        catalogPattern.map(UserSubstitutingPattern::raw),
+                        that.catalogPattern.map(UserSubstitutingPattern::raw)) &&
+                Objects.equals(
+                        schemaPattern.map(UserSubstitutingPattern::raw),
+                        that.schemaPattern.map(UserSubstitutingPattern::raw));
     }
 
     private static boolean patternEquals(Optional<Pattern> left, Optional<Pattern> right)
@@ -74,6 +79,8 @@ public class AnyCatalogSchemaPermissionsRule
     @Override
     public int hashCode()
     {
-        return Objects.hash(userRegex, roleRegex, groupRegex, catalogRegex, schemaRegex);
+        return Objects.hash(userRegex, roleRegex, groupRegex,
+                catalogPattern.map(UserSubstitutingPattern::raw),
+                schemaPattern.map(UserSubstitutingPattern::raw));
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AnySchemaPermissionsRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AnySchemaPermissionsRule.java
@@ -23,14 +23,14 @@ public class AnySchemaPermissionsRule
     private final Optional<Pattern> userRegex;
     private final Optional<Pattern> roleRegex;
     private final Optional<Pattern> groupRegex;
-    private final Optional<Pattern> schemaRegex;
+    private final Optional<UserSubstitutingPattern> schemaPattern;
 
-    public AnySchemaPermissionsRule(Optional<Pattern> userRegex, Optional<Pattern> roleRegex, Optional<Pattern> groupRegex, Optional<Pattern> schemaRegex)
+    public AnySchemaPermissionsRule(Optional<Pattern> userRegex, Optional<Pattern> roleRegex, Optional<Pattern> groupRegex, Optional<UserSubstitutingPattern> schemaPattern)
     {
         this.userRegex = userRegex;
         this.roleRegex = roleRegex;
         this.groupRegex = groupRegex;
-        this.schemaRegex = schemaRegex;
+        this.schemaPattern = schemaPattern;
     }
 
     public boolean match(String user, Set<String> roles, Set<String> groups, String schemaName)
@@ -38,7 +38,8 @@ public class AnySchemaPermissionsRule
         return userRegex.map(regex -> regex.matcher(user).matches()).orElse(true) &&
                 roleRegex.map(regex -> roles.stream().anyMatch(role -> regex.matcher(role).matches())).orElse(true) &&
                 groupRegex.map(regex -> groups.stream().anyMatch(group -> regex.matcher(group).matches())).orElse(true) &&
-                schemaRegex.map(regex -> regex.matcher(schemaName).matches()).orElse(true);
+                // A {user}-bearing schema pattern may match after substitution — treat as potentially matching
+                schemaPattern.map(p -> p.hasUserPlaceholder() || p.matches(user, schemaName)).orElse(true);
     }
 
     @Override
@@ -54,7 +55,9 @@ public class AnySchemaPermissionsRule
         return patternEquals(userRegex, that.userRegex) &&
                 patternEquals(roleRegex, that.roleRegex) &&
                 patternEquals(groupRegex, that.groupRegex) &&
-                patternEquals(schemaRegex, that.schemaRegex);
+                Objects.equals(
+                        schemaPattern.map(UserSubstitutingPattern::raw),
+                        that.schemaPattern.map(UserSubstitutingPattern::raw));
     }
 
     private static boolean patternEquals(Optional<Pattern> left, Optional<Pattern> right)
@@ -70,6 +73,6 @@ public class AnySchemaPermissionsRule
     @Override
     public int hashCode()
     {
-        return Objects.hash(userRegex, roleRegex, groupRegex, schemaRegex);
+        return Objects.hash(userRegex, roleRegex, groupRegex, schemaPattern.map(UserSubstitutingPattern::raw));
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/CatalogTableAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/CatalogTableAccessControlRule.java
@@ -15,6 +15,7 @@ package io.trino.plugin.base.security;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege;
 import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.security.ViewExpression;
@@ -31,7 +32,7 @@ public class CatalogTableAccessControlRule
     public static final CatalogTableAccessControlRule ALLOW_ALL = new CatalogTableAccessControlRule(TableAccessControlRule.ALLOW_ALL, Optional.empty());
 
     private final TableAccessControlRule tableAccessControlRule;
-    private final Optional<Pattern> catalogRegex;
+    private final Optional<UserSubstitutingPattern> catalogPattern;
 
     @JsonCreator
     public CatalogTableAccessControlRule(
@@ -42,23 +43,23 @@ public class CatalogTableAccessControlRule
             @JsonProperty("user") Optional<Pattern> userRegex,
             @JsonProperty("role") Optional<Pattern> roleRegex,
             @JsonProperty("group") Optional<Pattern> groupRegex,
-            @JsonProperty("schema") Optional<Pattern> schemaRegex,
-            @JsonProperty("table") Optional<Pattern> tableRegex,
-            @JsonProperty("catalog") Optional<Pattern> catalogRegex)
+            @JsonProperty("schema") @JsonDeserialize(contentUsing = UserSubstitutingPattern.Deserializer.class) Optional<UserSubstitutingPattern> schemaPattern,
+            @JsonProperty("table") @JsonDeserialize(contentUsing = UserSubstitutingPattern.Deserializer.class) Optional<UserSubstitutingPattern> tablePattern,
+            @JsonProperty("catalog") @JsonDeserialize(contentUsing = UserSubstitutingPattern.Deserializer.class) Optional<UserSubstitutingPattern> catalogPattern)
     {
-        this.tableAccessControlRule = new TableAccessControlRule(privileges, columns, filter, filterEnvironment, userRegex, roleRegex, groupRegex, schemaRegex, tableRegex);
-        this.catalogRegex = requireNonNull(catalogRegex, "catalogRegex is null");
+        this.tableAccessControlRule = new TableAccessControlRule(privileges, columns, filter, filterEnvironment, userRegex, roleRegex, groupRegex, schemaPattern, tablePattern);
+        this.catalogPattern = requireNonNull(catalogPattern, "catalogPattern is null");
     }
 
-    public CatalogTableAccessControlRule(TableAccessControlRule tableAccessControlRule, Optional<Pattern> catalogRegex)
+    public CatalogTableAccessControlRule(TableAccessControlRule tableAccessControlRule, Optional<UserSubstitutingPattern> catalogPattern)
     {
         this.tableAccessControlRule = tableAccessControlRule;
-        this.catalogRegex = catalogRegex;
+        this.catalogPattern = catalogPattern;
     }
 
     public boolean matches(String user, Set<String> roles, Set<String> groups, CatalogSchemaTableName table)
     {
-        if (!catalogRegex.map(regex -> regex.matcher(table.getCatalogName()).matches()).orElse(true)) {
+        if (!catalogPattern.map(p -> p.matches(user, table.getCatalogName())).orElse(true)) {
             return false;
         }
         return tableAccessControlRule.matches(user, roles, groups, table.getSchemaTableName());
@@ -98,7 +99,7 @@ public class CatalogTableAccessControlRule
                 tableAccessControlRule.getUserRegex(),
                 tableAccessControlRule.getRoleRegex(),
                 tableAccessControlRule.getGroupRegex(),
-                catalogRegex));
+                catalogPattern));
     }
 
     Optional<AnyCatalogSchemaPermissionsRule> toAnyCatalogSchemaPermissionsRule()
@@ -110,7 +111,7 @@ public class CatalogTableAccessControlRule
                 tableAccessControlRule.getUserRegex(),
                 tableAccessControlRule.getRoleRegex(),
                 tableAccessControlRule.getGroupRegex(),
-                catalogRegex,
-                tableAccessControlRule.getSchemaRegex()));
+                catalogPattern,
+                tableAccessControlRule.getSchemaPattern()));
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/TableAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/TableAccessControlRule.java
@@ -15,6 +15,7 @@ package io.trino.plugin.base.security;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -53,8 +54,8 @@ public class TableAccessControlRule
     private final Optional<Pattern> userRegex;
     private final Optional<Pattern> roleRegex;
     private final Optional<Pattern> groupRegex;
-    private final Optional<Pattern> schemaRegex;
-    private final Optional<Pattern> tableRegex;
+    private final Optional<UserSubstitutingPattern> schemaPattern;
+    private final Optional<UserSubstitutingPattern> tablePattern;
 
     @JsonCreator
     public TableAccessControlRule(
@@ -65,8 +66,8 @@ public class TableAccessControlRule
             @JsonProperty("user") Optional<Pattern> userRegex,
             @JsonProperty("role") Optional<Pattern> roleRegex,
             @JsonProperty("group") Optional<Pattern> groupRegex,
-            @JsonProperty("schema") Optional<Pattern> schemaRegex,
-            @JsonProperty("table") Optional<Pattern> tableRegex)
+            @JsonProperty("schema") @JsonDeserialize(contentUsing = UserSubstitutingPattern.Deserializer.class) Optional<UserSubstitutingPattern> schemaPattern,
+            @JsonProperty("table") @JsonDeserialize(contentUsing = UserSubstitutingPattern.Deserializer.class) Optional<UserSubstitutingPattern> tablePattern)
     {
         this.privileges = ImmutableSet.copyOf(requireNonNull(privileges, "privileges is null"));
         this.columnConstraints = Maps.uniqueIndex(columns.orElse(ImmutableList.of()), ColumnConstraint::getName);
@@ -79,8 +80,8 @@ public class TableAccessControlRule
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
         this.roleRegex = requireNonNull(roleRegex, "roleRegex is null");
         this.groupRegex = requireNonNull(groupRegex, "groupRegex is null");
-        this.schemaRegex = requireNonNull(schemaRegex, "schemaRegex is null");
-        this.tableRegex = requireNonNull(tableRegex, "tableRegex is null");
+        this.schemaPattern = requireNonNull(schemaPattern, "schemaPattern is null");
+        this.tablePattern = requireNonNull(tablePattern, "tablePattern is null");
     }
 
     public boolean matches(String user, Set<String> roles, Set<String> groups, SchemaTableName table)
@@ -88,8 +89,8 @@ public class TableAccessControlRule
         return userRegex.map(regex -> regex.matcher(user).matches()).orElse(true) &&
                 roleRegex.map(regex -> roles.stream().anyMatch(role -> regex.matcher(role).matches())).orElse(true) &&
                 groupRegex.map(regex -> groups.stream().anyMatch(group -> regex.matcher(group).matches())).orElse(true) &&
-                schemaRegex.map(regex -> regex.matcher(table.getSchemaName()).matches()).orElse(true) &&
-                tableRegex.map(regex -> regex.matcher(table.getTableName()).matches()).orElse(true);
+                schemaPattern.map(p -> p.matches(user, table.getSchemaName())).orElse(true) &&
+                tablePattern.map(p -> p.matches(user, table.getTableName())).orElse(true);
     }
 
     public Set<String> getRestrictedColumns()
@@ -127,7 +128,7 @@ public class TableAccessControlRule
         if (privileges.isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(new AnySchemaPermissionsRule(userRegex, roleRegex, groupRegex, schemaRegex));
+        return Optional.of(new AnySchemaPermissionsRule(userRegex, roleRegex, groupRegex, schemaPattern));
     }
 
     Set<TablePrivilege> getPrivileges()
@@ -150,9 +151,9 @@ public class TableAccessControlRule
         return groupRegex;
     }
 
-    Optional<Pattern> getSchemaRegex()
+    Optional<UserSubstitutingPattern> getSchemaPattern()
     {
-        return schemaRegex;
+        return schemaPattern;
     }
 
     public enum TablePrivilege

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/UserSubstitutingPattern.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/UserSubstitutingPattern.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A pattern that may contain the literal placeholder {@code {user}}.
+ * <p>
+ * If the raw string contains {@code {user}}, compilation is deferred to match
+ * time and the placeholder is replaced with {@link Pattern#quote(String)} of
+ * the authenticated username before compiling.  If the raw string does not
+ * contain {@code {user}} it is compiled once at deserialise time, preserving
+ * the existing behaviour exactly.
+ */
+public final class UserSubstitutingPattern
+{
+    private static final String USER_PLACEHOLDER = "{user}";
+
+    /** Non-null when the raw string contained no {@code {user}} placeholder. */
+    private final Pattern compiled;
+    /** Non-null when the raw string contained a {@code {user}} placeholder. */
+    private final String template;
+
+    private UserSubstitutingPattern(Pattern compiled, String template)
+    {
+        this.compiled = compiled;
+        this.template = template;
+    }
+
+    public static UserSubstitutingPattern of(String raw)
+    {
+        requireNonNull(raw, "raw is null");
+        if (raw.contains(USER_PLACEHOLDER)) {
+            return new UserSubstitutingPattern(null, raw);
+        }
+        return new UserSubstitutingPattern(Pattern.compile(raw), null);
+    }
+
+    /**
+     * Returns {@code true} if {@code value} matches this pattern after
+     * substituting {@code {user}} with the authenticated {@code user}.
+     */
+    public boolean matches(String user, String value)
+    {
+        Pattern p = (template != null)
+                ? Pattern.compile(template.replace(USER_PLACEHOLDER, Pattern.quote(user)))
+                : compiled;
+        return p.matcher(value).matches();
+    }
+
+    /**
+     * Returns {@code true} if this pattern contains a {@code {user}}
+     * placeholder and therefore cannot be evaluated without a specific user.
+     */
+    public boolean hasUserPlaceholder()
+    {
+        return template != null;
+    }
+
+    /** Returns the raw pattern string as written in rules.json. */
+    public String raw()
+    {
+        return template != null ? template : compiled.pattern();
+    }
+
+    @Override
+    public String toString()
+    {
+        return raw();
+    }
+
+    // -------------------------------------------------------------------------
+    // Jackson deserializer
+    // -------------------------------------------------------------------------
+
+    public static final class Deserializer
+            extends StdDeserializer<UserSubstitutingPattern>
+    {
+        public Deserializer()
+        {
+            super(UserSubstitutingPattern.class);
+        }
+
+        @Override
+        public UserSubstitutingPattern deserialize(JsonParser p, DeserializationContext ctx)
+                throws IOException
+        {
+            String raw = p.getText();
+            if (!raw.contains(USER_PLACEHOLDER)) {
+                // Validate that it is a legal regex right now (fail-fast, same as before).
+                try {
+                    Pattern.compile(raw);
+                }
+                catch (PatternSyntaxException e) {
+                    throw new IOException("Invalid regex pattern '" + raw + "': " + e.getMessage(), e);
+                }
+            }
+            return UserSubstitutingPattern.of(raw);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Using `{user}` in the `schema`, `table`, or `catalog` fields of `rules.json` causes a startup failure:

```
Cannot deserialize value of type `java.util.regex.Pattern` from String "^{user}$": Illegal repetition
```

Jackson deserialises those fields directly into `java.util.regex.Pattern` at startup, before any substitution. Java regex treats `{user}` as an illegal quantifier (`{` expects digits like `{3}` or `{1,5}`).

`{user}` already works in the `user` and `principal` fields — this PR extends the same capability to `schema`, `table`, and `catalog` fields in table rules.

## Solution

Introduce `UserSubstitutingPattern`: a thin wrapper around a pattern string that:

- **Without `{user}`**: compiles to `java.util.regex.Pattern` immediately at deserialise time (identical to existing behaviour, zero regression risk)
- **With `{user}`**: stores the raw template string and defers `Pattern` compilation to match time, substituting `Pattern.quote(user)` for `{user}` so special characters in usernames are treated as literals

A custom Jackson `StdDeserializer` reads the raw string, validates it as a legal regex when `{user}` is absent (same fail-fast behaviour as before), and wraps it in `UserSubstitutingPattern`.

### Files changed

| File | Change |
|------|--------|
| `UserSubstitutingPattern.java` | **New** — wrapper + Jackson deserializer |
| `TableAccessControlRule.java` | `schemaRegex`/`tableRegex` → `UserSubstitutingPattern`; `matches()` passes `user` |
| `CatalogTableAccessControlRule.java` | `catalogRegex` → `UserSubstitutingPattern`; `matches()` passes `user` |
| `AnyCatalogPermissionsRule.java` | Accepts `UserSubstitutingPattern`; `{user}` patterns treated as potentially-matching in show-catalog checks |
| `AnyCatalogSchemaPermissionsRule.java` | Same treatment for catalog + schema |
| `AnySchemaPermissionsRule.java` | Same treatment for schema |

### `{user}` in `AnyXxxPermissionsRule` (SHOW SCHEMAS / SHOW TABLES)

The `AnyXxx` rules are used to decide whether a user has *any* access to a catalog/schema (i.e. whether it should appear in `SHOW SCHEMAS`). When a pattern contains `{user}`, it is impossible to evaluate without knowing the specific schema name — so we treat it as **potentially matching** (`true`). This means a user may see a schema listed even if the per-table rule ultimately denies access to tables inside it, which is the safe and user-friendly behaviour.

## Usage

```json
{
  "tables": [
    {
      "catalog": "^(hive|iceberg)$",
      "schema": "^{user}$",
      "privileges": ["SELECT", "INSERT", "DELETE", "UPDATE", "OWNERSHIP", "GRANT_SELECT"]
    }
  ]
}
```

User `alice` → `schema` pattern becomes `^alice$` at match time.
User `alice-smith` → `schema` pattern becomes `^alice\-smith$` (via `Pattern.quote`).

## Testing

- [ ] Unit tests for `UserSubstitutingPattern` (matches own schema, blocks other user's schema, no-placeholder compiles once at deserialise time)
- [ ] Integration test in `TestFileBasedSystemAccessControl` for `{user}` in `schema` field
- [ ] Verify startup no longer throws `Illegal repetition` when `{user}` appears in schema/table/catalog fields
- [ ] Non-`{user}` patterns behave identically to before (zero regression)