### PR TITLE
Add missing IDENTICAL operator to NUMBER to handle NaN correctly

### DIFF
--- a/core/trino-main/src/test/java/io/trino/type/TestNumberOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestNumberOperators.java
@@ -3393,6 +3393,22 @@ public class TestNumberOperators
 
         assertThat(assertions.operator(IDENTICAL, "ARRAY [1234567890.123456789, NULL]", "ARRAY [NULL, 9876543210.987654321]"))
                 .isEqualTo(false);
+
+        assertThat(assertions.operator(IDENTICAL, "NUMBER 'NaN'", "NUMBER 'NaN'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.operator(IDENTICAL, "NUMBER 'NaN'", "NUMBER '37'"))
+                .isEqualTo(false);
+    }
+
+    @Test
+    void testNaNGroupedByDistinctAndGroupBy()
+    {
+        assertThat(assertions.query("SELECT count(*) FROM (SELECT DISTINCT n FROM (VALUES NUMBER 'NaN', NUMBER 'NaN', NUMBER 'NaN') t(n))"))
+                .matches("VALUES BIGINT '1'");
+
+        assertThat(assertions.query("SELECT count(*) FROM (VALUES NUMBER 'NaN', NUMBER 'NaN', NUMBER 'NaN') t(n) GROUP BY n"))
+                .matches("VALUES BIGINT '3'");
     }
 
     @Test

--- a/core/trino-spi/src/main/java/io/trino/spi/type/NumberType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/NumberType.java
@@ -26,10 +26,12 @@ import io.trino.spi.function.FlatFixedOffset;
 import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.ScalarOperator;
+import io.trino.spi.function.SqlNullable;
 
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.EQUAL;
+import static io.trino.spi.function.OperatorType.IDENTICAL;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
@@ -156,6 +158,15 @@ public class NumberType
         if (left.isNaN() || right.isNaN()) {
             // NaN is not equal to any value, including itself
             return false;
+        }
+        return left.bytes().equals(right.bytes());
+    }
+
+    @ScalarOperator(value = IDENTICAL, neverFails = true)
+    private static boolean identicalOperator(@SqlNullable TrinoNumber left, @SqlNullable TrinoNumber right)
+    {
+        if (left == null || right == null) {
+            return left == right;
         }
         return left.bytes().equals(right.bytes());
     }


### PR DESCRIPTION
## Description
`NUMBER` doesn't offer `IDENTICAL` for the time being so `TypeOperators.generateIdenticalOperators` make it to `EQUAL`, while `NumberType.equalOperator` returns false for NaN. - this could cause `DISTINCT`, `GROUP BY`, etc returning wrong results. For example:
```SQL
 SELECT count(*) FROM (SELECT DISTINCT n FROM (VALUES NUMBER 'NaN', NUMBER 'NaN') t(n));
 -- returns 2, should be 1
```
The same query returns 1 for `REAL` and `DOUBLE`:
```SQL
trino> SELECT count(*) FROM (SELECT DISTINCT n FROM (VALUES NUMBER 'NaN', NUMBER 'NaN') t(n));
 _col0
-------
     2
(1 row)

Query 20260617_005849_00000_irgbm, FINISHED, 1 node
Splits: 10 total, 10 done (100.00%)
0.76 [0 rows, 0B] [0 rows/s, 0B/s]

trino> SELECT count(*) FROM (SELECT DISTINCT n FROM (VALUES DOUBLE 'NaN', DOUBLE 'NaN') t(n));
 _col0
-------
     1
(1 row)

Query 20260617_010236_00001_irgbm, FINISHED, 1 node
Splits: 10 total, 10 done (100.00%)
0.13 [0 rows, 0B] [0 rows/s, 0B/s]

trino> SELECT count(*) FROM (SELECT DISTINCT n FROM (VALUES REAL 'NaN', REAL 'NaN') t(n));
 _col0
-------
     1
(1 row)

Query 20260617_010246_00002_irgbm, FINISHED, 1 node
Splits: 10 total, 10 done (100.00%)
0.17 [0 rows, 0B] [0 rows/s, 0B/s]
```
 
This PR adds the IDENTICAL operator, mirroring DOUBLE/REAL

## Additional context and related issues


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix incorrect NUMBER type IDENTICAL handling for NaN
```
