### PR TITLE
Add JMX gauges for query admission state monitoring

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
@@ -62,6 +62,7 @@ import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.execution.QueryState.FINISHING;
 import static io.trino.execution.QueryState.QUEUED;
 import static io.trino.execution.QueryState.RUNNING;
+import static io.trino.execution.QueryState.WAITING_FOR_RESOURCES;
 import static io.trino.spi.StandardErrorCode.QUERY_TEXT_TOO_LARGE;
 import static io.trino.tracing.ScopedSpan.scopedSpan;
 import static io.trino.util.Failures.toFailure;
@@ -357,6 +358,26 @@ public class DispatchManager
         return queryTracker.getAllQueries().stream()
                 .filter(query -> query.getState() == RUNNING && query.getBasicQueryInfo().getQueryStats().isFullyBlocked())
                 .count();
+    }
+
+    @Managed
+    public long getWaitingForResourcesQueries()
+    {
+        return queryTracker.getAllQueries().stream()
+                .filter(query -> query.getState() == WAITING_FOR_RESOURCES)
+                .count();
+    }
+
+    @Managed
+    public double getWaitingForResourcesMaxAgeInSeconds()
+    {
+        // Only materialize BasicQueryInfo for queries currently waiting for resources,
+        // then report the longest resource-waiting time among them (0 when none wait).
+        return queryTracker.getAllQueries().stream()
+                .filter(query -> query.getState() == WAITING_FOR_RESOURCES)
+                .mapToDouble(query -> query.getBasicQueryInfo().getQueryStats().getResourceWaitingTime().getValue(SECONDS))
+                .max()
+                .orElse(0.0);
     }
 
     public boolean isQueryRegistered(QueryId queryId)

--- a/docs/src/main/sphinx/admin/jmx.md
+++ b/docs/src/main/sphinx/admin/jmx.md
@@ -58,6 +58,8 @@ A small subset of the available metrics are described below.
 - Failed queries (user): `trino.execution:name=QueryManager:UserErrorFailures.FiveMinute.Count`
 - Execution latency (P50): `trino.execution:name=QueryManager:ExecutionTime.FiveMinutes.P50`
 - Input data rate (P90): `trino.execution:name=QueryManager:WallInputBytesRate.FiveMinutes.P90`
+- Queries waiting for resources: `trino.execution:name=QueryManager:WaitingForResourcesQueries`
+- Longest wait for resources (seconds): `trino.execution:name=QueryManager:WaitingForResourcesMaxAgeInSeconds`
 
 ## Trino tasks
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMinWorkerRequirement.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMinWorkerRequirement.java
@@ -18,6 +18,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.trino.Session;
+import io.trino.dispatcher.DispatchManager;
 import io.trino.execution.QueryInfo;
 import io.trino.execution.QueryManager;
 import io.trino.testing.DistributedQueryRunner;
@@ -195,6 +196,11 @@ public class TestMinWorkerRequirement
     {
         ListeningExecutorService service = MoreExecutors.listeningDecorator(newFixedThreadPool(3));
         try (DistributedQueryRunner queryRunner = TpchQueryRunner.builder().setWorkerCount(0).build()) {
+            DispatchManager dispatchManager = queryRunner.getCoordinator().getDispatchManager();
+            // With no queries submitted, the gauges report the empty-set defaults.
+            assertThat(dispatchManager.getWaitingForResourcesQueries()).isEqualTo(0);
+            assertThat(dispatchManager.getWaitingForResourcesMaxAgeInSeconds()).isEqualTo(0.0);
+
             Session session1 = Session.builder(queryRunner.getDefaultSession())
                     .setSystemProperty(REQUIRED_WORKERS_COUNT, "2")
                     .build();
@@ -215,6 +221,11 @@ public class TestMinWorkerRequirement
             assertThat(queryFuture1.isDone()).isFalse();
             assertThat(queryFuture2.isDone()).isFalse();
             assertThat(queryFuture3.isDone()).isFalse();
+
+            // All three queries are gated in WAITING_FOR_RESOURCES; the DispatchManager
+            // JMX gauges should reflect the in-state set.
+            assertThat(dispatchManager.getWaitingForResourcesQueries()).isEqualTo(3);
+            assertThat(dispatchManager.getWaitingForResourcesMaxAgeInSeconds()).isGreaterThan(0.0);
 
             queryRunner.addServers(1);
             assertThat(queryRunner.getCoordinator().getWorkerCount()).isEqualTo(1);


### PR DESCRIPTION
## Description

Add two policy-agnostic JMX gauges that give operators visibility into how many
queries are waiting for cluster resources and how long the longest waiter has
been stuck.

The gauges are exposed as `@Managed` methods on `DispatchManager`, alongside the
existing per-state query counters (`QueuedQueries`, `RunningQueries`,
`FinishingQueries`, etc.), under the existing
`trino.execution:name=QueryManager` MBean:

- `WaitingForResourcesQueries` — number of queries currently in
  `WAITING_FOR_RESOURCES`. Counted directly via `DispatchQuery.getState()`
  without materializing `BasicQueryInfo` for every query.
- `WaitingForResourcesMaxAgeInSeconds` — the longest resource waiting time among
  those queries. `BasicQueryInfo` is only built for queries already filtered to
  the waiting state.

Both gauges compute their values on demand from existing per-query state on each
JMX read. No background threads, timers, or scheduled tasks are introduced.

## Additional context and related issues

The gauges are policy-agnostic: they describe the pre-existing
`WAITING_FOR_RESOURCES` engine state and are independent of any admission
strategy. This complements the pluggable admission policy work (see #29598) but
has no dependency on it.

## Release notes

(x) Release notes are required, with the following suggested text:

```
### General
* Add JMX gauges for monitoring queries waiting for resources:
  `WaitingForResourcesQueries` and `WaitingForResourcesMaxAgeInSeconds` under
  the `"trino.execution:name=QueryManager"` table. ({issue}`29940`)
```