### PR TITLE
Resource-aware query admission control (memory/vCPU based)

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java
@@ -27,6 +27,7 @@ import io.trino.execution.QueryInfo;
 import io.trino.execution.QueryState;
 import io.trino.execution.QueryStateMachine;
 import io.trino.execution.StateMachine.StateChangeListener;
+import io.trino.execution.admission.ResourceAwareAdmissionController;
 import io.trino.server.BasicQueryInfo;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.QueryId;
@@ -39,6 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
+import static com.google.common.util.concurrent.Futures.transformAsync;
 import static io.airlift.concurrent.MoreFutures.addExceptionCallback;
 import static io.airlift.concurrent.MoreFutures.addSuccessCallback;
 import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
@@ -59,6 +61,7 @@ public class LocalDispatchQuery
 
     private final QueryMonitor queryMonitor;
     private final ClusterSizeMonitor clusterSizeMonitor;
+    private final ResourceAwareAdmissionController admissionController;
 
     private final Executor queryExecutor;
 
@@ -72,6 +75,7 @@ public class LocalDispatchQuery
             ListenableFuture<QueryExecution> queryExecutionFuture,
             QueryMonitor queryMonitor,
             ClusterSizeMonitor clusterSizeMonitor,
+            ResourceAwareAdmissionController admissionController,
             Executor queryExecutor,
             Consumer<QueryExecution> querySubmitter)
     {
@@ -79,6 +83,7 @@ public class LocalDispatchQuery
         this.queryExecutionFuture = requireNonNull(queryExecutionFuture, "queryExecutionFuture is null");
         this.queryMonitor = requireNonNull(queryMonitor, "queryMonitor is null");
         this.clusterSizeMonitor = requireNonNull(clusterSizeMonitor, "clusterSizeMonitor is null");
+        this.admissionController = requireNonNull(admissionController, "admissionController is null");
         this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
         this.querySubmitter = requireNonNull(querySubmitter, "querySubmitter is null");
 
@@ -130,9 +135,14 @@ public class LocalDispatchQuery
             if (queryExecution.shouldWaitForMinWorkers()) {
                 executionMinCount = getRequiredWorkers(session);
             }
-            ListenableFuture<Void> minimumWorkerFuture = clusterSizeMonitor.waitForMinimumWorkers(executionMinCount, getRequiredWorkersMaxWait(session));
+            int requiredWorkers = executionMinCount;
+            // gate on resource-aware admission first (a no-op future when disabled), then wait for minimum workers
+            ListenableFuture<Void> minimumWorkerFuture = transformAsync(admissionController.awaitAdmission(session), _ -> clusterSizeMonitor.waitForMinimumWorkers(requiredWorkers, getRequiredWorkersMaxWait(session)), queryExecutor);
             // when worker requirement is met, start the execution
-            addSuccessCallback(minimumWorkerFuture, () -> startExecution(queryExecution), queryExecutor);
+            addSuccessCallback(minimumWorkerFuture, () -> {
+                admissionController.recordOnCompletion(queryExecution);
+                startExecution(queryExecution);
+            }, queryExecutor);
             addExceptionCallback(minimumWorkerFuture, stateMachine::transitionToFailed, queryExecutor);
 
             // cancel minimumWorkerFuture if query fails for some reason or is cancelled by user

--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQueryFactory.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQueryFactory.java
@@ -30,6 +30,7 @@ import io.trino.execution.QueryManager;
 import io.trino.execution.QueryManagerConfig;
 import io.trino.execution.QueryPreparer.PreparedQuery;
 import io.trino.execution.QueryStateMachine;
+import io.trino.execution.admission.ResourceAwareAdmissionController;
 import io.trino.execution.querystats.PlanOptimizersStatsCollector;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.execution.warnings.WarningCollectorFactory;
@@ -66,6 +67,7 @@ public class LocalDispatchQueryFactory
     private final LocationFactory locationFactory;
 
     private final ClusterSizeMonitor clusterSizeMonitor;
+    private final ResourceAwareAdmissionController admissionController;
 
     private final Map<Class<? extends Statement>, QueryExecutionFactory<?>> executionFactories;
     private final WarningCollectorFactory warningCollectorFactory;
@@ -90,6 +92,7 @@ public class LocalDispatchQueryFactory
             WarningCollectorFactory warningCollectorFactory,
             ExchangeMetricsCollector exchangeMetricsCollector,
             ClusterSizeMonitor clusterSizeMonitor,
+            ResourceAwareAdmissionController admissionController,
             DispatchExecutor dispatchExecutor,
             FeaturesConfig featuresConfig,
             NodeVersion version)
@@ -105,6 +108,7 @@ public class LocalDispatchQueryFactory
         this.warningCollectorFactory = requireNonNull(warningCollectorFactory, "warningCollectorFactory is null");
         this.exchangeMetricsCollector = requireNonNull(exchangeMetricsCollector, "exchangeMetricsCollector is null");
         this.clusterSizeMonitor = requireNonNull(clusterSizeMonitor, "clusterSizeMonitor is null");
+        this.admissionController = requireNonNull(admissionController, "admissionController is null");
         this.executor = dispatchExecutor.getExecutor();
         this.maxStateMachineThreadsPerQuery = queryManagerConfig.getMaxStateMachineCallbackThreads();
         this.queryReportedRuleStatsLimit = queryManagerConfig.getQueryReportedRuleStatsLimit();
@@ -186,6 +190,7 @@ public class LocalDispatchQueryFactory
                 queryExecutionFuture,
                 queryMonitor,
                 clusterSizeMonitor,
+                admissionController,
                 executor,
                 queryManager::createQuery);
     }

--- a/core/trino-main/src/main/java/io/trino/execution/admission/AdmissionModule.java
+++ b/core/trino-main/src/main/java/io/trino/execution/admission/AdmissionModule.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.SystemSessionPropertiesProvider;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+/**
+ * Wires the resource-aware query admission feature, installed from {@code CoordinatorModule}.
+ * The feature is self-contained in this package; the dispatch path consults the controller
+ * through {@link ResourceAwareAdmissionController}.
+ */
+public class AdmissionModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(ResourceAwareAdmissionConfig.class);
+        binder.bind(ResourceAwareAdmissionController.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, SystemSessionPropertiesProvider.class).addBinding().to(ResourceAwareAdmissionSessionProperties.class).in(Scopes.SINGLETON);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/admission/ClusterCapacity.java
+++ b/core/trino-main/src/main/java/io/trino/execution/admission/ClusterCapacity.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import io.trino.memory.MemoryInfo;
+
+import java.util.Collection;
+import java.util.Optional;
+
+import static java.lang.Math.max;
+import static java.lang.Math.round;
+
+/**
+ * A point-in-time snapshot of observed cluster capacity, derived from the per-worker
+ * {@link MemoryInfo} reported to {@code ClusterMemoryManager}.
+ *
+ * @param freeMemoryBytes summed free bytes of the general memory pool across observed workers
+ * @param availableVcpu approximate free vCPU across observed workers, derived from
+ *         {@code availableProcessors * (1 - systemCpuLoad)}
+ */
+public record ClusterCapacity(long freeMemoryBytes, int availableVcpu)
+{
+    public ClusterCapacity
+    {
+        if (freeMemoryBytes < 0) {
+            throw new IllegalArgumentException("freeMemoryBytes must not be negative");
+        }
+        if (availableVcpu < 0) {
+            throw new IllegalArgumentException("availableVcpu must not be negative");
+        }
+    }
+
+    /**
+     * Folds a collection of per-worker memory info (as returned by
+     * {@code ClusterMemoryManager.getWorkersMemoryInfo()}) into a single capacity snapshot.
+     * Workers that have not yet reported memory info are skipped.
+     */
+    public static ClusterCapacity from(Collection<Optional<MemoryInfo>> workerMemoryInfo)
+    {
+        long freeMemoryBytes = 0;
+        long availableVcpu = 0;
+        for (Optional<MemoryInfo> maybeInfo : workerMemoryInfo) {
+            if (maybeInfo.isEmpty()) {
+                continue;
+            }
+            MemoryInfo info = maybeInfo.get();
+            freeMemoryBytes += info.getPool().getFreeBytes();
+            double idleFraction = max(0.0, 1.0 - info.getSystemCpuLoad());
+            availableVcpu += round(info.getAvailableProcessors() * idleFraction);
+        }
+        return new ClusterCapacity(max(0, freeMemoryBytes), (int) max(0, availableVcpu));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/admission/QueryAdmissionContext.java
+++ b/core/trino-main/src/main/java/io/trino/execution/admission/QueryAdmissionContext.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.trino.spi.QueryId;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Per-query context handed to the {@link ResourceAwareAdmissionController}. The engine resolves the
+ * effective thresholds (session override falling back to the cluster-wide config default)
+ * before invoking the policy, keeping the policy a pure function of context and observed capacity.
+ *
+ * @param queryId the query being admitted
+ * @param requiredFreeMemory minimum cluster-wide free memory required before admitting
+ * @param requiredFreeVcpu minimum cluster-wide free vCPU required before admitting
+ * @param maxWait how long the query may be held before failing with insufficient resources
+ */
+public record QueryAdmissionContext(
+        QueryId queryId,
+        DataSize requiredFreeMemory,
+        int requiredFreeVcpu,
+        Duration maxWait)
+{
+    public QueryAdmissionContext
+    {
+        requireNonNull(queryId, "queryId is null");
+        requireNonNull(requiredFreeMemory, "requiredFreeMemory is null");
+        requireNonNull(maxWait, "maxWait is null");
+        if (requiredFreeVcpu < 0) {
+            throw new IllegalArgumentException("requiredFreeVcpu must not be negative");
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/admission/QueryMemoryHistory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/admission/QueryMemoryHistory.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.units.DataSize;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A thread-safe, fixed-window rolling average of recently completed queries' peak memory.
+ * <p>
+ * The {@link ResourceAwareAdmissionController} uses this average as the per-query "required free memory"
+ * estimate for the next admission decision. Samples are the peak <em>user</em> memory
+ * reservation of completed queries, matching the general-pool free bytes the gate observes
+ * through {@link ClusterCapacity}.
+ * <p>
+ * Backed by a count-based circular buffer of the last {@code windowSize} samples with an
+ * O(1) running sum, so {@link #averageOrDefault} is cheap to call on every poll cycle. Until
+ * at least one sample has been recorded, {@link #averageOrDefault} returns the supplied
+ * fallback (the configured {@code required-free-memory} default), giving sane cold-start
+ * behavior without special-casing the gate.
+ */
+final class QueryMemoryHistory
+{
+    private final long[] samplesBytes;
+
+    private int nextIndex;      // ring write cursor
+    private int count;          // number of valid samples (<= windowSize)
+    private long sumBytes;      // running sum of valid samples, for O(1) average
+
+    QueryMemoryHistory(int windowSize)
+    {
+        checkArgument(windowSize > 0, "windowSize must be positive");
+        this.samplesBytes = new long[windowSize];
+    }
+
+    /**
+     * Record one completed query's peak memory. Negative values are clamped to zero so a
+     * misbehaving metric can never corrupt the running sum.
+     */
+    synchronized void record(long peakMemoryBytes)
+    {
+        long sample = max(0, peakMemoryBytes);
+        if (count == samplesBytes.length) {
+            // window full: evict the oldest sample (the one at the cursor) before overwriting it
+            sumBytes -= samplesBytes[nextIndex];
+        }
+        else {
+            count++;
+        }
+        samplesBytes[nextIndex] = sample;
+        sumBytes += sample;
+        nextIndex = (nextIndex + 1) % samplesBytes.length;
+    }
+
+    /**
+     * Average peak memory over the current window, or {@code fallback} when no samples have
+     * been recorded yet (cold start).
+     */
+    synchronized DataSize averageOrDefault(DataSize fallback)
+    {
+        requireNonNull(fallback, "fallback is null");
+        if (count == 0) {
+            return fallback;
+        }
+        return DataSize.ofBytes(sumBytes / count);
+    }
+
+    @VisibleForTesting
+    synchronized int sampleCount()
+    {
+        return count;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/admission/ResourceAwareAdmissionConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/admission/ResourceAwareAdmissionConfig.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Cluster-wide configuration for resource-aware query admission.
+ * <p>
+ * When enabled, a query is held in {@code WAITING_FOR_RESOURCES} until the cluster has enough
+ * observed free memory and vCPU to run it. This admission gate is independent of, and additional
+ * to, the existing minimum-worker-count requirement ({@code query-manager.required-workers}); the
+ * worker-count gate is unchanged.
+ * <p>
+ * The feature is off by default ({@code enabled=false}). When disabled, admission behaves exactly
+ * as it does without this gate.
+ */
+public class ResourceAwareAdmissionConfig
+{
+    private boolean enabled;
+    private DataSize requiredFreeMemory = DataSize.of(0, BYTE);
+    private int requiredFreeVcpu;
+    private Duration maxWait = new Duration(5, MINUTES);
+    private Duration pollInterval = new Duration(1, SECONDS);
+    private int memoryWindowSize = 50;
+    private double requiredMemoryMultiplier = 1.0;
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    @Config("query-admission.enabled")
+    @ConfigDescription("Hold queries in WAITING_FOR_RESOURCES until the cluster has enough free capacity")
+    public ResourceAwareAdmissionConfig setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getRequiredFreeMemory()
+    {
+        return requiredFreeMemory;
+    }
+
+    @Config("query-admission.required-free-memory")
+    @ConfigDescription("Minimum cluster-wide free memory required before a query is admitted (cold-start default before history accumulates)")
+    public ResourceAwareAdmissionConfig setRequiredFreeMemory(DataSize requiredFreeMemory)
+    {
+        this.requiredFreeMemory = requiredFreeMemory;
+        return this;
+    }
+
+    @Min(0)
+    public int getRequiredFreeVcpu()
+    {
+        return requiredFreeVcpu;
+    }
+
+    @Config("query-admission.required-free-vcpu")
+    @ConfigDescription("Minimum cluster-wide free vCPU required before a query is admitted")
+    public ResourceAwareAdmissionConfig setRequiredFreeVcpu(int requiredFreeVcpu)
+    {
+        this.requiredFreeVcpu = requiredFreeVcpu;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("0s")
+    public Duration getMaxWait()
+    {
+        return maxWait;
+    }
+
+    @Config("query-admission.max-wait")
+    @ConfigDescription("Maximum time a query is held waiting for capacity before failing")
+    public ResourceAwareAdmissionConfig setMaxWait(Duration maxWait)
+    {
+        this.maxWait = maxWait;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("1ms")
+    public Duration getPollInterval()
+    {
+        return pollInterval;
+    }
+
+    @Config("query-admission.poll-interval")
+    @ConfigDescription("How often held queries are re-evaluated against observed cluster capacity")
+    public ResourceAwareAdmissionConfig setPollInterval(Duration pollInterval)
+    {
+        this.pollInterval = pollInterval;
+        return this;
+    }
+
+    @Min(1)
+    public int getMemoryWindowSize()
+    {
+        return memoryWindowSize;
+    }
+
+    @Config("query-admission.memory-window-size")
+    @ConfigDescription("Number of most-recent completed queries averaged to estimate a query's required memory")
+    public ResourceAwareAdmissionConfig setMemoryWindowSize(int memoryWindowSize)
+    {
+        this.memoryWindowSize = memoryWindowSize;
+        return this;
+    }
+
+    @DecimalMin("0")
+    public double getRequiredMemoryMultiplier()
+    {
+        return requiredMemoryMultiplier;
+    }
+
+    @Config("query-admission.required-memory-multiplier")
+    @ConfigDescription("Headroom multiplier applied to the rolling-average required memory before admitting a query")
+    public ResourceAwareAdmissionConfig setRequiredMemoryMultiplier(double requiredMemoryMultiplier)
+    {
+        this.requiredMemoryMultiplier = requiredMemoryMultiplier;
+        return this;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/admission/ResourceAwareAdmissionController.java
+++ b/core/trino-main/src/main/java/io/trino/execution/admission/ResourceAwareAdmissionController.java
@@ -1,0 +1,353 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ticker;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.airlift.units.DataSize;
+import io.trino.Session;
+import io.trino.execution.QueryExecution;
+import io.trino.memory.ClusterMemoryManager;
+import io.trino.memory.MemoryInfo;
+import io.trino.spi.TrinoException;
+import jakarta.annotation.PreDestroy;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.PriorityQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.execution.admission.ResourceAwareAdmissionSessionProperties.getQueryAdmissionMaxWait;
+import static io.trino.execution.admission.ResourceAwareAdmissionSessionProperties.getRequiredFreeClusterMemory;
+import static io.trino.execution.admission.ResourceAwareAdmissionSessionProperties.getRequiredFreeClusterVcpu;
+import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * Resource-aware query admission controller.
+ * <p>
+ * This is an admission gate the dispatch path waits on in addition to the existing
+ * minimum-worker-count requirement. It does not replace or wrap that requirement:
+ * {@code LocalDispatchQuery} keeps its {@code ClusterSizeMonitor.waitForMinimumWorkers(...)} call
+ * and simply gates on admission first, so the two concerns stay independent.
+ * <p>
+ * {@link #awaitAdmission(Session)} returns a future that completes once the cluster has enough
+ * observed free memory and vCPU for the query (per {@link ResourceAwareAdmissionConfig} / session
+ * overrides), or fails with {@link io.trino.spi.StandardErrorCode#GENERIC_INSUFFICIENT_RESOURCES}
+ * if the wait budget is exhausted. When the feature is disabled (the default) it returns an
+ * already-completed future, so admission behaves exactly as it does without this gate.
+ * <p>
+ * Held queries sit in {@code WAITING_FOR_RESOURCES} and are re-evaluated on a fixed poll interval
+ * against a fresh capacity snapshot read through the public
+ * {@link ClusterMemoryManager#getWorkersMemoryInfo()}, releasing the oldest waiting query first
+ * (FIFO, one release per cycle). This class is thread-safe.
+ */
+public class ResourceAwareAdmissionController
+{
+    private static final Logger log = Logger.get(ResourceAwareAdmissionController.class);
+
+    private final Supplier<Map<String, Optional<MemoryInfo>>> workersMemoryInfoSupplier;
+    private final ResourceAwareAdmissionConfig config;
+    private final Ticker ticker;
+    private final ScheduledExecutorService executor;
+    private final QueryMemoryHistory memoryHistory;
+
+    private final AtomicLong sequence = new AtomicLong();
+
+    @GuardedBy("this")
+    private final PriorityQueue<PendingQuery> pending = new PriorityQueue<>(Comparator.comparingLong(PendingQuery::sequence));
+
+    @GuardedBy("this")
+    private boolean scheduled;
+
+    @Inject
+    public ResourceAwareAdmissionController(ClusterMemoryManager clusterMemoryManager, ResourceAwareAdmissionConfig config)
+    {
+        this(clusterMemoryManager::getWorkersMemoryInfo,
+                config,
+                Ticker.systemTicker(),
+                newSingleThreadScheduledExecutor(daemonThreadsNamed("query-admission-%s")));
+    }
+
+    @VisibleForTesting
+    public ResourceAwareAdmissionController(
+            ClusterMemoryManager clusterMemoryManager,
+            ResourceAwareAdmissionConfig config,
+            Ticker ticker,
+            ScheduledExecutorService executor)
+    {
+        this(clusterMemoryManager::getWorkersMemoryInfo, config, ticker, executor);
+    }
+
+    @VisibleForTesting
+    public ResourceAwareAdmissionController(
+            Supplier<Map<String, Optional<MemoryInfo>>> workersMemoryInfoSupplier,
+            ResourceAwareAdmissionConfig config,
+            Ticker ticker,
+            ScheduledExecutorService executor)
+    {
+        this.workersMemoryInfoSupplier = requireNonNull(workersMemoryInfoSupplier, "workersMemoryInfoSupplier is null");
+        this.config = requireNonNull(config, "config is null");
+        this.ticker = requireNonNull(ticker, "ticker is null");
+        this.executor = requireNonNull(executor, "executor is null");
+        this.memoryHistory = new QueryMemoryHistory(config.getMemoryWindowSize());
+    }
+
+    /**
+     * Package-private constructor for the no-op testing factory. When disabled, the controller
+     * never calls {@code workersMemoryInfoSupplier} so it can safely return empty.
+     */
+    private ResourceAwareAdmissionController(ResourceAwareAdmissionConfig config)
+    {
+        this.workersMemoryInfoSupplier = Map::of;
+        this.config = requireNonNull(config, "config is null");
+        this.ticker = Ticker.systemTicker();
+        this.executor = newSingleThreadScheduledExecutor(daemonThreadsNamed("query-admission-noop-%s"));
+        this.memoryHistory = new QueryMemoryHistory(config.getMemoryWindowSize());
+    }
+
+    /**
+     * Returns a future that completes when the cluster has enough free capacity to admit the query,
+     * or fails with {@code GENERIC_INSUFFICIENT_RESOURCES} after the query's wait budget elapses.
+     * Returns an already-completed future when the feature is disabled.
+     */
+    public ListenableFuture<Void> awaitAdmission(Session session)
+    {
+        requireNonNull(session, "session is null");
+        if (!config.isEnabled()) {
+            return immediateVoidFuture();
+        }
+        return enqueue(buildContext(session));
+    }
+
+    @VisibleForTesting
+    ListenableFuture<Void> enqueue(QueryAdmissionContext context)
+    {
+        long deadlineNanos = ticker.read() + context.maxWait().roundTo(NANOSECONDS);
+        PendingQuery query = new PendingQuery(sequence.getAndIncrement(), context, deadlineNanos, SettableFuture.create());
+
+        synchronized (this) {
+            pending.add(query);
+            scheduleIfNeeded();
+        }
+        // Drop the entry from the queue whenever its future settles (admitted, failed, or cancelled).
+        query.future().addListener(() -> remove(query), directExecutor());
+        return query.future();
+    }
+
+    private QueryAdmissionContext buildContext(Session session)
+    {
+        return new QueryAdmissionContext(
+                session.getQueryId(),
+                effectiveRequiredMemory(getRequiredFreeClusterMemory(session)),
+                getRequiredFreeClusterVcpu(session),
+                getQueryAdmissionMaxWait(session));
+    }
+
+    /**
+     * Register a hook that feeds a completed query's peak user memory into the rolling history,
+     * so subsequent admission decisions size their memory requirement from observed demand. The
+     * {@code fallback} (configured {@code required-free-memory}) is used until the window fills.
+     * No-op when the feature is disabled, so no listener is attached and there is zero overhead.
+     */
+    public void recordOnCompletion(QueryExecution queryExecution)
+    {
+        requireNonNull(queryExecution, "queryExecution is null");
+        if (!config.isEnabled()) {
+            return;
+        }
+        queryExecution.addFinalQueryInfoListener(queryInfo ->
+                recordPeakMemory(queryInfo.getQueryStats().getPeakUserMemoryReservation().toBytes()));
+    }
+
+    /**
+     * The memory a query must find free before admission: the rolling average of recent query
+     * peaks (or {@code fallback} during cold start) scaled by the configured headroom multiplier.
+     */
+    @VisibleForTesting
+    DataSize effectiveRequiredMemory(DataSize fallback)
+    {
+        DataSize average = memoryHistory.averageOrDefault(fallback);
+        double multiplier = config.getRequiredMemoryMultiplier();
+        if (multiplier == 1.0) {
+            return average;
+        }
+        return DataSize.ofBytes(Math.round(average.toBytes() * multiplier));
+    }
+
+    @VisibleForTesting
+    void recordPeakMemory(long peakMemoryBytes)
+    {
+        memoryHistory.record(peakMemoryBytes);
+    }
+
+    /**
+     * Decide whether the query may proceed against the supplied capacity snapshot. Exposed for
+     * testing; the engine drives admission through {@link #awaitAdmission(Session)}.
+     */
+    @VisibleForTesting
+    WaitDecision shouldQueryWait(QueryAdmissionContext context, ClusterCapacity capacity)
+    {
+        long requiredMemoryBytes = context.requiredFreeMemory().toBytes();
+        boolean enoughMemory = capacity.freeMemoryBytes() >= requiredMemoryBytes;
+        boolean enoughVcpu = capacity.availableVcpu() >= context.requiredFreeVcpu();
+
+        if (enoughMemory && enoughVcpu) {
+            return new WaitDecision.ProceedNow(format(
+                    "capacity available (free memory %s bytes >= %s, free vCPU %s >= %s)",
+                    capacity.freeMemoryBytes(),
+                    requiredMemoryBytes,
+                    capacity.availableVcpu(),
+                    context.requiredFreeVcpu()));
+        }
+
+        return new WaitDecision.Wait(context.maxWait(), format(
+                "waiting for cluster capacity (free memory %s bytes / required %s, free vCPU %s / required %s)",
+                capacity.freeMemoryBytes(),
+                requiredMemoryBytes,
+                capacity.availableVcpu(),
+                context.requiredFreeVcpu()));
+    }
+
+    @GuardedBy("this")
+    private void scheduleIfNeeded()
+    {
+        if (!scheduled && !pending.isEmpty()) {
+            scheduled = true;
+            executor.schedule(this::process, config.getPollInterval().toMillis(), MILLISECONDS);
+        }
+    }
+
+    @VisibleForTesting
+    void process()
+    {
+        List<PendingQuery> toAdmit = new ArrayList<>();
+        List<PendingQuery> toExpire = new ArrayList<>();
+        synchronized (this) {
+            scheduled = false;
+            if (pending.isEmpty()) {
+                return;
+            }
+
+            long now = ticker.read();
+            ClusterCapacity capacity = snapshotCapacity();
+
+            // Fail any query that has exhausted its wait budget, regardless of position.
+            Iterator<PendingQuery> iterator = pending.iterator();
+            while (iterator.hasNext()) {
+                PendingQuery query = iterator.next();
+                if (now >= query.deadlineNanos()) {
+                    toExpire.add(query);
+                    iterator.remove();
+                }
+            }
+
+            // FIFO release: only the oldest waiting query is considered each cycle, so that a query
+            // admitted this cycle starts consuming memory before the next snapshot is taken. This
+            // throttles admission and pairs with demand-driven scaling.
+            PendingQuery head = pending.peek();
+            if (head != null && shouldQueryWait(head.context(), capacity) instanceof WaitDecision.ProceedNow) {
+                pending.poll();
+                toAdmit.add(head);
+            }
+
+            scheduleIfNeeded();
+        }
+
+        // Complete futures outside the lock to avoid running listener callbacks while holding it.
+        for (PendingQuery query : toAdmit) {
+            query.future().set(null);
+        }
+        for (PendingQuery query : toExpire) {
+            query.future().setException(insufficientResources(query.context()));
+        }
+    }
+
+    private synchronized void remove(PendingQuery query)
+    {
+        pending.remove(query);
+    }
+
+    private ClusterCapacity snapshotCapacity()
+    {
+        try {
+            return ClusterCapacity.from(workersMemoryInfoSupplier.get().values());
+        }
+        catch (RuntimeException e) {
+            // Never let an observation hiccup wedge the gate; treat as no capacity this cycle.
+            log.warn(e, "Failed to read cluster capacity; treating as zero capacity for this cycle");
+            return new ClusterCapacity(0, 0);
+        }
+    }
+
+    private static TrinoException insufficientResources(QueryAdmissionContext context)
+    {
+        return new TrinoException(
+                GENERIC_INSUFFICIENT_RESOURCES,
+                format("Insufficient cluster capacity. Waited %s for query %s but required free memory %s / vCPU %s was not available",
+                        context.maxWait(),
+                        context.queryId(),
+                        context.requiredFreeMemory(),
+                        context.requiredFreeVcpu()));
+    }
+
+    @VisibleForTesting
+    synchronized int waitingQueryCount()
+    {
+        return pending.size();
+    }
+
+    /**
+     * Creates a disabled admission controller that always admits immediately.
+     * For use in tests where a real {@link ClusterMemoryManager} is not available.
+     */
+    @VisibleForTesting
+    public static ResourceAwareAdmissionController createNoOpForTesting()
+    {
+        return new ResourceAwareAdmissionController(new ResourceAwareAdmissionConfig());
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        executor.shutdownNow();
+    }
+
+    private record PendingQuery(long sequence, QueryAdmissionContext context, long deadlineNanos, SettableFuture<Void> future)
+    {
+        private PendingQuery
+        {
+            requireNonNull(context, "context is null");
+            requireNonNull(future, "future is null");
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/admission/ResourceAwareAdmissionSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/execution/admission/ResourceAwareAdmissionSessionProperties.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.trino.Session;
+import io.trino.SystemSessionPropertiesProvider;
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.List;
+
+import static io.trino.plugin.base.session.PropertyMetadataUtil.dataSizeProperty;
+import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty;
+import static io.trino.spi.session.PropertyMetadata.integerProperty;
+
+/**
+ * Session-level overrides for resource-aware query admission thresholds, registered as a
+ * {@link SystemSessionPropertiesProvider}. Defaults are sourced from
+ * {@link ResourceAwareAdmissionConfig}, so an operator who sets only the cluster-wide config gets
+ * consistent behavior without anyone setting a session property.
+ */
+public class ResourceAwareAdmissionSessionProperties
+        implements SystemSessionPropertiesProvider
+{
+    public static final String REQUIRED_FREE_CLUSTER_MEMORY = "required_free_cluster_memory";
+    public static final String REQUIRED_FREE_CLUSTER_VCPU = "required_free_cluster_vcpu";
+    public static final String QUERY_ADMISSION_MAX_WAIT = "query_admission_max_wait";
+
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    @Inject
+    public ResourceAwareAdmissionSessionProperties(ResourceAwareAdmissionConfig config)
+    {
+        sessionProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .add(dataSizeProperty(
+                        REQUIRED_FREE_CLUSTER_MEMORY,
+                        "Minimum cluster-wide free memory required before this query is admitted",
+                        config.getRequiredFreeMemory(),
+                        false))
+                .add(integerProperty(
+                        REQUIRED_FREE_CLUSTER_VCPU,
+                        "Minimum cluster-wide free vCPU required before this query is admitted",
+                        config.getRequiredFreeVcpu(),
+                        false))
+                .add(durationProperty(
+                        QUERY_ADMISSION_MAX_WAIT,
+                        "Maximum time this query is held waiting for capacity before failing",
+                        config.getMaxWait(),
+                        false))
+                .build();
+    }
+
+    public static DataSize getRequiredFreeClusterMemory(Session session)
+    {
+        return session.getSystemProperty(REQUIRED_FREE_CLUSTER_MEMORY, DataSize.class);
+    }
+
+    public static int getRequiredFreeClusterVcpu(Session session)
+    {
+        return session.getSystemProperty(REQUIRED_FREE_CLUSTER_VCPU, Integer.class);
+    }
+
+    public static Duration getQueryAdmissionMaxWait(Session session)
+    {
+        return session.getSystemProperty(QUERY_ADMISSION_MAX_WAIT, Duration.class);
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/admission/WaitDecision.java
+++ b/core/trino-main/src/main/java/io/trino/execution/admission/WaitDecision.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import io.airlift.units.Duration;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The decision a {@link ResourceAwareAdmissionController} hands back to the engine for a single
+ * query entering the {@code WAITING_FOR_RESOURCES} state.
+ * <p>
+ * Two terminal cases:
+ * <ul>
+ *     <li>{@link ProceedNow} — the cluster currently has enough capacity; admit the query now.</li>
+ *     <li>{@link Wait} — hold the query until capacity frees up or {@code maxWait} elapses.</li>
+ * </ul>
+ * The shape intentionally mirrors a pluggable admission-policy SPI, so the decision logic can be
+ * factored into a separate policy interface later without reshaping callers.
+ */
+public sealed interface WaitDecision
+        permits WaitDecision.ProceedNow, WaitDecision.Wait
+{
+    /**
+     * Human-readable reason for observability (logs, events, UI). Must be 1..256 chars, non-null.
+     */
+    String reason();
+
+    record ProceedNow(String reason)
+            implements WaitDecision
+    {
+        public ProceedNow
+        {
+            validateReason(reason);
+        }
+    }
+
+    record Wait(Duration maxWait, String reason)
+            implements WaitDecision
+    {
+        public Wait
+        {
+            requireNonNull(maxWait, "maxWait is null");
+            if (maxWait.toMillis() < 0) {
+                throw new IllegalArgumentException("maxWait must not be negative");
+            }
+            validateReason(reason);
+        }
+    }
+
+    private static void validateReason(String reason)
+    {
+        requireNonNull(reason, "reason is null");
+        if (reason.isEmpty() || reason.length() > 256) {
+            throw new IllegalArgumentException("reason must be between 1 and 256 characters");
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -66,6 +66,7 @@ import io.trino.execution.StagesInfo;
 import io.trino.execution.TaskInfo;
 import io.trino.execution.TaskManagerConfig;
 import io.trino.execution.TaskStatus;
+import io.trino.execution.admission.AdmissionModule;
 import io.trino.execution.resourcegroups.InternalResourceGroupManager;
 import io.trino.execution.resourcegroups.LegacyResourceGroupConfigurationManager;
 import io.trino.execution.resourcegroups.ResourceGroupInfoProvider;
@@ -222,6 +223,9 @@ public class CoordinatorModule
 
         // local dispatcher
         binder.bind(DispatchQueryFactory.class).to(LocalDispatchQueryFactory.class);
+
+        // Resource-aware query admission gate (off by default; see ResourceAwareAdmissionConfig)
+        install(new AdmissionModule());
 
         // cluster memory manager
         binder.bind(ClusterMemoryManager.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/test/java/io/trino/dispatcher/TestLocalDispatchQuery.java
+++ b/core/trino-main/src/test/java/io/trino/dispatcher/TestLocalDispatchQuery.java
@@ -38,6 +38,7 @@ import io.trino.execution.QueryPreparer;
 import io.trino.execution.QueryState;
 import io.trino.execution.QueryStateMachine;
 import io.trino.execution.StagesInfo;
+import io.trino.execution.admission.ResourceAwareAdmissionController;
 import io.trino.execution.scheduler.NodeSchedulerConfig;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.FunctionManager;
@@ -159,6 +160,7 @@ public class TestLocalDispatchQuery
                 Futures.immediateFuture(dataDefinitionExecution),
                 queryMonitor,
                 new TestClusterSizeMonitor(TestingInternalNodeManager.createDefault(), new NodeSchedulerConfig()),
+                ResourceAwareAdmissionController.createNoOpForTesting(),
                 executor,
                 _ -> dataDefinitionExecution.start());
         queryStateMachine.addStateChangeListener(state -> {

--- a/core/trino-main/src/test/java/io/trino/execution/admission/TestQueryMemoryHistory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/admission/TestQueryMemoryHistory.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import io.airlift.units.DataSize;
+import org.junit.jupiter.api.Test;
+
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestQueryMemoryHistory
+{
+    private static final DataSize FALLBACK = DataSize.of(7, MEGABYTE);
+
+    @Test
+    public void testColdStartReturnsFallback()
+    {
+        QueryMemoryHistory history = new QueryMemoryHistory(4);
+        assertThat(history.sampleCount()).isZero();
+        assertThat(history.averageOrDefault(FALLBACK)).isEqualTo(FALLBACK);
+    }
+
+    @Test
+    public void testAveragesRecordedSamples()
+    {
+        QueryMemoryHistory history = new QueryMemoryHistory(4);
+        history.record(DataSize.of(100, MEGABYTE).toBytes());
+        history.record(DataSize.of(200, MEGABYTE).toBytes());
+
+        assertThat(history.sampleCount()).isEqualTo(2);
+        assertThat(history.averageOrDefault(FALLBACK).toBytes())
+                .isEqualTo(DataSize.of(150, MEGABYTE).toBytes());
+    }
+
+    @Test
+    public void testWindowEvictsOldestSample()
+    {
+        QueryMemoryHistory history = new QueryMemoryHistory(3);
+        history.record(DataSize.of(30, MEGABYTE).toBytes());
+        history.record(DataSize.of(60, MEGABYTE).toBytes());
+        history.record(DataSize.of(90, MEGABYTE).toBytes());
+        // average of 30, 60, 90 = 60
+        assertThat(history.averageOrDefault(FALLBACK).toBytes())
+                .isEqualTo(DataSize.of(60, MEGABYTE).toBytes());
+
+        // overflow the window: 30 is evicted, leaving 60, 90, 120 -> 90
+        history.record(DataSize.of(120, MEGABYTE).toBytes());
+        assertThat(history.sampleCount()).isEqualTo(3);
+        assertThat(history.averageOrDefault(FALLBACK).toBytes())
+                .isEqualTo(DataSize.of(90, MEGABYTE).toBytes());
+    }
+
+    @Test
+    public void testNegativeSampleClampedToZero()
+    {
+        QueryMemoryHistory history = new QueryMemoryHistory(2);
+        history.record(-1);
+        history.record(DataSize.of(100, MEGABYTE).toBytes());
+        // (0 + 100MB) / 2 = 50MB
+        assertThat(history.averageOrDefault(FALLBACK).toBytes())
+                .isEqualTo(DataSize.of(50, MEGABYTE).toBytes());
+    }
+
+    @Test
+    public void testRejectsNonPositiveWindow()
+    {
+        assertThatThrownBy(() -> new QueryMemoryHistory(0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/admission/TestResourceAwareAdmissionConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/admission/TestResourceAwareAdmissionConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+class TestResourceAwareAdmissionConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(ResourceAwareAdmissionConfig.class)
+                .setEnabled(false)
+                .setRequiredFreeMemory(DataSize.of(0, BYTE))
+                .setRequiredFreeVcpu(0)
+                .setMaxWait(new Duration(5, MINUTES))
+                .setPollInterval(new Duration(1, SECONDS))
+                .setMemoryWindowSize(50)
+                .setRequiredMemoryMultiplier(1.0));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("query-admission.enabled", "true")
+                .put("query-admission.required-free-memory", "10GB")
+                .put("query-admission.required-free-vcpu", "16")
+                .put("query-admission.max-wait", "10m")
+                .put("query-admission.poll-interval", "2s")
+                .put("query-admission.memory-window-size", "100")
+                .put("query-admission.required-memory-multiplier", "1.5")
+                .buildOrThrow();
+
+        ResourceAwareAdmissionConfig expected = new ResourceAwareAdmissionConfig()
+                .setEnabled(true)
+                .setRequiredFreeMemory(DataSize.of(10, GIGABYTE))
+                .setRequiredFreeVcpu(16)
+                .setMaxWait(new Duration(10, MINUTES))
+                .setPollInterval(new Duration(2, SECONDS))
+                .setMemoryWindowSize(100)
+                .setRequiredMemoryMultiplier(1.5);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/admission/TestResourceAwareAdmissionController.java
+++ b/core/trino-main/src/test/java/io/trino/execution/admission/TestResourceAwareAdmissionController.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import com.google.common.base.Ticker;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.trino.memory.MemoryInfo;
+import io.trino.spi.QueryId;
+import io.trino.spi.TrinoException;
+import io.trino.spi.memory.MemoryPoolInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestResourceAwareAdmissionController
+{
+    private static final QueryId QUERY_ID = new QueryId("test_query");
+
+    private final AtomicLong now = new AtomicLong();
+    private final Ticker ticker = new Ticker()
+    {
+        @Override
+        public long read()
+        {
+            return now.get();
+        }
+    };
+
+    private final AtomicReference<Map<String, Optional<MemoryInfo>>> workers = new AtomicReference<>(Map.of());
+
+    private ScheduledExecutorService executor;
+
+    @BeforeEach
+    public void setUp()
+    {
+        executor = newSingleThreadScheduledExecutor();
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        executor.shutdownNow();
+    }
+
+    // --- pure decision logic ---
+
+    @Test
+    public void testProceedsWhenMemoryAndVcpuAvailable()
+    {
+        ResourceAwareAdmissionController policy = policy(new ResourceAwareAdmissionConfig());
+        WaitDecision decision = policy.shouldQueryWait(
+                context(DataSize.of(100, MEGABYTE), 4),
+                new ClusterCapacity(DataSize.of(200, MEGABYTE).toBytes(), 8));
+        assertThat(decision).isInstanceOf(WaitDecision.ProceedNow.class);
+    }
+
+    @Test
+    public void testWaitsWhenMemoryInsufficient()
+    {
+        ResourceAwareAdmissionController policy = policy(new ResourceAwareAdmissionConfig());
+        QueryAdmissionContext context = context(DataSize.of(100, MEGABYTE), 0);
+        WaitDecision decision = policy.shouldQueryWait(context, new ClusterCapacity(DataSize.of(50, MEGABYTE).toBytes(), 8));
+        assertThat(decision).isInstanceOf(WaitDecision.Wait.class);
+        assertThat(((WaitDecision.Wait) decision).maxWait()).isEqualTo(context.maxWait());
+    }
+
+    @Test
+    public void testWaitsWhenVcpuInsufficient()
+    {
+        ResourceAwareAdmissionController policy = policy(new ResourceAwareAdmissionConfig());
+        WaitDecision decision = policy.shouldQueryWait(
+                context(DataSize.of(0, MEGABYTE), 8),
+                new ClusterCapacity(DataSize.of(200, MEGABYTE).toBytes(), 2));
+        assertThat(decision).isInstanceOf(WaitDecision.Wait.class);
+    }
+
+    @Test
+    public void testProceedsAtExactThreshold()
+    {
+        ResourceAwareAdmissionController policy = policy(new ResourceAwareAdmissionConfig());
+        WaitDecision decision = policy.shouldQueryWait(
+                context(DataSize.of(100, MEGABYTE), 4),
+                new ClusterCapacity(DataSize.of(100, MEGABYTE).toBytes(), 4));
+        assertThat(decision).isInstanceOf(WaitDecision.ProceedNow.class);
+    }
+
+    // --- rolling-average required memory ---
+
+    @Test
+    public void testEffectiveRequiredMemoryColdStartUsesFallback()
+    {
+        ResourceAwareAdmissionController policy = policy(new ResourceAwareAdmissionConfig());
+        DataSize fallback = DataSize.of(42, MEGABYTE);
+        assertThat(policy.effectiveRequiredMemory(fallback)).isEqualTo(fallback);
+    }
+
+    @Test
+    public void testEffectiveRequiredMemoryUsesRollingAverage()
+    {
+        ResourceAwareAdmissionController policy = policy(new ResourceAwareAdmissionConfig());
+        policy.recordPeakMemory(DataSize.of(100, MEGABYTE).toBytes());
+        policy.recordPeakMemory(DataSize.of(300, MEGABYTE).toBytes());
+        // average 200MB; ignores the fallback once samples exist
+        assertThat(policy.effectiveRequiredMemory(DataSize.of(42, MEGABYTE)).toBytes())
+                .isEqualTo(DataSize.of(200, MEGABYTE).toBytes());
+    }
+
+    @Test
+    public void testEffectiveRequiredMemoryAppliesHeadroomMultiplier()
+    {
+        ResourceAwareAdmissionController policy = policy(new ResourceAwareAdmissionConfig().setRequiredMemoryMultiplier(1.5));
+        policy.recordPeakMemory(DataSize.of(200, MEGABYTE).toBytes());
+        // 200MB * 1.5 = 300MB
+        assertThat(policy.effectiveRequiredMemory(DataSize.of(42, MEGABYTE)).toBytes())
+                .isEqualTo(DataSize.of(300, MEGABYTE).toBytes());
+    }
+
+    @Test
+    public void testHeadroomMultiplierAppliesToColdStartFallback()
+    {
+        ResourceAwareAdmissionController policy = policy(new ResourceAwareAdmissionConfig().setRequiredMemoryMultiplier(2.0));
+        // no samples recorded: fallback is scaled too
+        assertThat(policy.effectiveRequiredMemory(DataSize.of(50, MEGABYTE)).toBytes())
+                .isEqualTo(DataSize.of(100, MEGABYTE).toBytes());
+    }
+
+    // --- gating behavior ---
+
+    @Test
+    public void testAdmitsWhenCapacityAvailable()
+            throws Exception
+    {
+        setCapacity(DataSize.of(200, MEGABYTE).toBytes(), 8);
+        ResourceAwareAdmissionController policy = enabledPolicy();
+
+        ListenableFuture<Void> future = policy.enqueue(context(DataSize.of(100, MEGABYTE), 0));
+        assertThat(future).isNotDone();
+
+        policy.process();
+        assertThat(future).isDone();
+        future.get();
+        assertThat(policy.waitingQueryCount()).isZero();
+    }
+
+    @Test
+    public void testHoldsUntilCapacityAppears()
+            throws Exception
+    {
+        setCapacity(DataSize.of(50, MEGABYTE).toBytes(), 0);
+        ResourceAwareAdmissionController policy = enabledPolicy();
+
+        ListenableFuture<Void> future = policy.enqueue(context(DataSize.of(100, MEGABYTE), 0));
+
+        policy.process();
+        assertThat(future).isNotDone();
+        assertThat(policy.waitingQueryCount()).isEqualTo(1);
+
+        setCapacity(DataSize.of(150, MEGABYTE).toBytes(), 0);
+        policy.process();
+        assertThat(future).isDone();
+        future.get();
+    }
+
+    @Test
+    public void testFailsAfterMaxWait()
+    {
+        setCapacity(0, 0);
+        ResourceAwareAdmissionController policy = enabledPolicy();
+
+        ListenableFuture<Void> future = policy.enqueue(context(DataSize.of(100, MEGABYTE), 0, new Duration(1, MINUTES)));
+
+        policy.process();
+        assertThat(future).isNotDone();
+
+        now.addAndGet(new Duration(2, MINUTES).roundTo(NANOSECONDS));
+        policy.process();
+
+        assertThat(future).isDone();
+        assertThatThrownBy(future::get)
+                .cause()
+                .isInstanceOf(TrinoException.class)
+                .satisfies(t -> assertThat(((TrinoException) t).getErrorCode()).isEqualTo(GENERIC_INSUFFICIENT_RESOURCES.toErrorCode()));
+    }
+
+    @Test
+    public void testReleasesOldestFirst()
+            throws Exception
+    {
+        setCapacity(DataSize.of(150, MEGABYTE).toBytes(), 0);
+        ResourceAwareAdmissionController policy = enabledPolicy();
+
+        ListenableFuture<Void> first = policy.enqueue(context(DataSize.of(100, MEGABYTE), 0));
+        ListenableFuture<Void> second = policy.enqueue(context(DataSize.of(100, MEGABYTE), 0));
+
+        // one release per cycle, oldest first
+        policy.process();
+        assertThat(first).isDone();
+        assertThat(second).isNotDone();
+
+        policy.process();
+        assertThat(second).isDone();
+        first.get();
+        second.get();
+    }
+
+    private ResourceAwareAdmissionController enabledPolicy()
+    {
+        // Poll interval is set very large so the executor never auto-fires; tests drive process() directly.
+        return policy(new ResourceAwareAdmissionConfig()
+                .setEnabled(true)
+                .setPollInterval(new Duration(1, HOURS)));
+    }
+
+    private ResourceAwareAdmissionController policy(ResourceAwareAdmissionConfig config)
+    {
+        return new ResourceAwareAdmissionController(workers::get, config, ticker, executor);
+    }
+
+    private void setCapacity(long freeBytes, int processors)
+    {
+        // getFreeBytes() == maxBytes - reservedBytes - reservedRevocableBytes
+        MemoryPoolInfo pool = new MemoryPoolInfo(freeBytes, 0, 0, Map.of(), Map.of(), Map.of(), Map.of());
+        MemoryInfo info = new MemoryInfo(processors, 0.0, pool);
+        workers.set(Map.of("worker1", Optional.of(info)));
+    }
+
+    private static QueryAdmissionContext context(DataSize requiredMemory, int requiredVcpu)
+    {
+        return context(requiredMemory, requiredVcpu, new Duration(5, MINUTES));
+    }
+
+    private static QueryAdmissionContext context(DataSize requiredMemory, int requiredVcpu, Duration maxWait)
+    {
+        return new QueryAdmissionContext(QUERY_ID, requiredMemory, requiredVcpu, maxWait);
+    }
+}


### PR DESCRIPTION
## Description

Add an optional resource-aware query admission gate that holds a query in
`WAITING_FOR_RESOURCES` until the cluster has enough observed free memory and vCPU to run it.

Without resource-aware admission, queries are admitted based only on worker count and can pile
onto a memory-constrained cluster. This gate throttles admission to observed free capacity,
releasing the oldest waiting query first (FIFO, one per poll cycle) so admitted queries begin
consuming memory before the next capacity snapshot.

A query's required free memory is estimated as a rolling average of recent completed queries'
peak user memory, scaled by a configurable headroom multiplier, with the configured
`query-admission.required-free-memory` value as the cold-start fallback until history accumulates.

**Key design points:**

- New self-contained package `io.trino.execution.admission`.
- Single dispatch-path change in `LocalDispatchQuery` — the admission gate is chained before the
  existing minimum-worker wait via `Futures.transformAsync`.
- Independent of, and additional to, the existing minimum-worker requirement
  (`query-manager.required-workers`). That gate is unchanged.
- **Off by default** (`query-admission.enabled=false`): when disabled, `awaitAdmission` returns an
  already-completed future, so admission behaves exactly as it does today.

**Configuration (`query-admission.*`):**

| Key | Default | Meaning |
|---|---|---|
| `enabled` | `false` | Enable the gate |
| `required-free-memory` | `0B` | Cold-start required free memory (fallback before history fills) |
| `required-free-vcpu` | `0` | Minimum cluster-wide free vCPU |
| `max-wait` | `5m` | Max hold time before failing with `GENERIC_INSUFFICIENT_RESOURCES` |
| `poll-interval` | `1s` | Re-evaluation cadence for held queries |
| `memory-window-size` | `50` | Number of recent queries averaged for required memory |
| `required-memory-multiplier` | `1.0` | Headroom multiplier on the rolling average |

Session overrides: `required_free_cluster_memory`, `required_free_cluster_vcpu`,
`query_admission_max_wait`.

## Additional context and related issues

This enables managed-scaling integrations (e.g. EMR, Kubernetes autoscalers) to keep queries
waiting while capacity is being provisioned, rather than admitting them into a
memory-constrained cluster where they would be killed by the low-memory killer.

## Release notes

(x) Release notes are required, with the following suggested text:

## General

* Add optional resource-aware query admission control that holds queries in
  `WAITING_FOR_RESOURCES` until the cluster has sufficient free memory and vCPU.
  Configured under `query-admission.*` and disabled by default. ({issue}`issuenumber`)

