### PR TITLE
Use `getAccessControl` to detect Azure HNS

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
@@ -26,7 +26,6 @@ import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.models.UserDelegationKey;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
-import com.azure.storage.blob.specialized.BlockBlobClient;
 import com.azure.storage.common.sas.SasProtocol;
 import com.azure.storage.file.datalake.DataLakeDirectoryClient;
 import com.azure.storage.file.datalake.DataLakeFileClient;
@@ -38,6 +37,7 @@ import com.azure.storage.file.datalake.models.DataLakeStorageException;
 import com.azure.storage.file.datalake.models.ListPathsOptions;
 import com.azure.storage.file.datalake.models.PathItem;
 import com.azure.storage.file.datalake.options.DataLakePathDeleteOptions;
+import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
@@ -650,10 +650,24 @@ public class AzureFileSystem
             throws IOException
     {
         try {
-            BlockBlobClient blockBlobClient = createBlobContainerClient(location, Optional.empty())
-                    .getBlobClient("/")
-                    .getBlockBlobClient();
-            return blockBlobClient.exists();
+            // Normalize consecutive slashes: the Azure DataLake getAccessControl API returns HTTP 400
+            // for paths containing "//", while other APIs like listPaths silently canonicalize them
+            String canonicalPath = CharMatcher.is('/').collapseFrom(
+                    CharMatcher.is('/').trimTrailingFrom(location.path()), '/');
+            DataLakeFileSystemClient fileSystemClient = createFileSystemClient(location, Optional.empty());
+            fileSystemClient.getDirectoryClient(canonicalPath).getAccessControl();
+            return true;
+        }
+        catch (DataLakeStorageException e) {
+            // getAccessControl() is only supported on HNS-enabled accounts; flat namespace returns HierarchicalNamespaceNotEnabled
+            if ("HierarchicalNamespaceNotEnabled".equals(e.getErrorCode())) {
+                return false;
+            }
+            // Path does not exist yet (e.g. creating a new nested directory), but the account supports HNS
+            if (e.getStatusCode() == 404) {
+                return true;
+            }
+            throw new IOException("Checking whether hierarchical namespace is enabled for the location %s failed".formatted(location), e);
         }
         catch (RuntimeException e) {
             throw new IOException("Checking whether hierarchical namespace is enabled for the location %s failed".formatted(location), e);
@@ -703,8 +717,11 @@ public class AzureFileSystem
         azureAuth.setAuth(location.account(), builder);
         DataLakeServiceClient client = builder.buildClient();
         DataLakeFileSystemClient fileSystemClient = client.getFileSystemClient(location.container().orElseThrow());
-        if (!fileSystemClient.exists()) {
-            throw new IllegalArgumentException();
+        // SAS tokens are scoped to an existing container; directory-scoped tokens cannot perform container-level operations
+        if (!(azureAuth instanceof AzureAuthSasToken)) {
+            if (!fileSystemClient.exists()) {
+                throw new IllegalArgumentException();
+            }
         }
         return fileSystemClient;
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description


The previous approach checked universally for the existence of a
"/" blob via the Blob Storage API, which fails with vended credentials
scoped to a subtree.

Directory-scoped SAS tokens cannot access the container-root blob via
the Blob API. 

Make use of `getAccessControl()` call on the DataLake API,
which returns `HierarchicalNamespaceNotEnabled` error code on
flat namespace accounts and either succeeds or returns 404 on HNS-enabled accounts.

### Warning

While the current implementation works - it is rather fragile with regards to eventual changes.
If the error code `HierarchicalNamespaceNotEnabled` returned by the call `getAccessControl()` changes, the functionality may not work anymore in the future.
I'm hopeful that we'll eventually receive a functionality that requires only "Storage Blob Data Reader" for figuring out whether the storage account has HNS enabled via https://github.com/Azure/azure-sdk-for-java/issues/49567


## Permissions needed to check for HNS with the new method

The role "Storage Blob Data Reader" should be sufficient:

https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-reader

Storage Blob Data Reader explicitly grants the `Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read`  action. This action gives the identity full clearance to look up the properties and ACLs of any path it has access to.

Tested the changes locally with an service principal having "Storage Blob Data Reader" role on a flat storage account and it worked.


## Test coverage

- [TestIcebergAbfsVendingRestCatalogConnectorSmokeTest.java](https://github.com/trinodb/trino/blob/4947e8e82e8e6bb9b8220de8af9a0e8c2473be72/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergAbfsVendingRestCatalogConnectorSmokeTest.java)

- [TestAzureFileSystemGen2Flat.java](https://github.com/trinodb/trino/blob/2f267acfd48b6b6d262347d59f9a011b2c224ca5/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Flat.java)

- [TestAzureFileSystemGen2Hierarchical.java](https://github.com/trinodb/trino/blob/2f267acfd48b6b6d262347d59f9a011b2c224ca5/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Hierarchical.java)


## hadooop-azure check for HNS (root object based) 

https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/AzureBlobFileSystemStore.java#L406-L461


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Previous attempt for checking Azure HNS https://github.com/trinodb/trino/pull/26354 reverted by https://github.com/trinodb/trino/pull/27278

Getting account information is not used universally because it
requires the "Storage Account Contributor" Azure role, which may not
be provided to service principals with data-plane-only permissions.



https://github.com/trinodb/trino/pull/25457 has suggested the parent directory existence to check for HNS
Doing a HEAD request to the DFS endpoint `(/{filesystem}/{path}?resource=filesystem)`
and verifying it resolves (even with 403), the account is HNS-capable. But that's fragile (e.g. : when creating a nested directory structure, this approach will fail because the parent directory of the leaf directory does not yet exist).

Fixes https://github.com/trinodb/trino/issues/29293

Initial azure-sdk-java feature request https://github.com/Azure/azure-sdk-for-java/issues/38912
Current azure-sdk-java feature request spawned by the efforts in coming up with the currrent PR https://github.com/Azure/azure-sdk-for-java/issues/49567



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## File System
* Support performing hierarchical namespace checks in Azure with vended credentials. ({issue}`issuenumber`)
```
