### PR TITLE
Remove gcs-analytics-core from Iceberg

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -424,13 +424,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.cloud.gcs.analytics</groupId>
-            <artifactId>gcs-analytics-core</artifactId>
-            <version>1.3.0</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>http-client</artifactId>
             <scope>runtime</scope>


### PR DESCRIPTION
## Description

This dependency is probably unnecessary thanks to:
- https://github.com/apache/iceberg/pull/16258

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
