### PR TITLE
Model FileWriter rollback action with dedicated interface

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
@@ -28,6 +28,7 @@ import io.trino.parquet.writer.ParquetWriterOptions;
 import io.trino.plugin.deltalake.DataFileInfo.DataFileType;
 import io.trino.plugin.deltalake.metastore.VendedCredentialsHandle;
 import io.trino.plugin.deltalake.util.DeltaLakeWriteUtils;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.plugin.hive.parquet.ParquetFileWriter;
 import io.trino.spi.Page;
 import io.trino.spi.PageIndexer;
@@ -40,7 +41,6 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
 import org.apache.parquet.format.CompressionCodec;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -105,7 +105,7 @@ public abstract class AbstractDeltaLakePageSink
     private long memoryUsage;
     private long validationCpuNanos;
 
-    private final List<Closeable> closedWriterRollbackActions = new ArrayList<>();
+    private final List<RollbackAction> closedWriterRollbackActions = new ArrayList<>();
     private final List<Boolean> activeWriters = new ArrayList<>();
     protected final ImmutableList.Builder<DataFileInfo> dataFileInfos = ImmutableList.builder();
     private final DeltaLakeParquetSchemaMapping parquetSchemaMapping;
@@ -239,7 +239,7 @@ public abstract class AbstractDeltaLakePageSink
     @Override
     public void abort()
     {
-        List<Closeable> rollbackActions = Streams.concat(
+        List<RollbackAction> rollbackActions = Streams.concat(
                         writers.stream()
                                 // writers can contain nulls if an exception is thrown when doAppend expands the writer list
                                 .filter(Objects::nonNull)
@@ -247,9 +247,9 @@ public abstract class AbstractDeltaLakePageSink
                         closedWriterRollbackActions.stream())
                 .collect(toImmutableList());
         RuntimeException rollbackException = null;
-        for (Closeable rollbackAction : rollbackActions) {
+        for (RollbackAction rollbackAction : rollbackActions) {
             try {
-                rollbackAction.close();
+                rollbackAction.run();
             }
             catch (Throwable t) {
                 if (rollbackException == null) {
@@ -477,7 +477,7 @@ public abstract class AbstractDeltaLakePageSink
                 .orElseThrow(); // validated on the session property level
 
         try {
-            Closeable rollbackAction = () -> fileSystem.deleteFile(path);
+            RollbackAction rollbackAction = () -> fileSystem.deleteFile(path);
 
             List<Type> parquetTypes = dataColumnTypes.stream()
                     .map(type -> toParquetType(typeOperators, type))

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -32,6 +32,7 @@ import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
 import io.trino.plugin.deltalake.delete.RoaringBitmapArray;
 import io.trino.plugin.deltalake.metastore.VendedCredentialsHandle;
 import io.trino.plugin.deltalake.transactionlog.DeletionVectorEntry;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.plugin.hive.parquet.ParquetFileWriter;
 import io.trino.plugin.hive.parquet.ParquetPageSourceFactory;
 import io.trino.plugin.hive.parquet.TrinoParquetDataSource;
@@ -51,7 +52,6 @@ import jakarta.annotation.Nullable;
 import org.apache.parquet.format.CompressionCodec;
 import org.joda.time.DateTimeZone;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -528,7 +528,7 @@ public class DeltaLakeMergeSink
                 .orElseThrow(); // validated on the session property level
 
         try {
-            Closeable rollbackAction = () -> fileSystem.deleteFile(path);
+            RollbackAction rollbackAction = () -> fileSystem.deleteFile(path);
             dataColumns.forEach(column -> verify(column.isBaseColumn(), "Unexpected dereference: %s", column));
 
             List<Type> parquetTypes = dataColumns.stream()

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
@@ -25,6 +25,7 @@ import io.trino.parquet.metadata.ParquetMetadata;
 import io.trino.plugin.deltalake.DataFileInfo.DataFileType;
 import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeJsonFileStatistics;
 import io.trino.plugin.hive.FileWriter;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.plugin.hive.parquet.ParquetFileWriter;
 import io.trino.spi.Page;
 import io.trino.spi.block.ArrayBlock;
@@ -43,7 +44,6 @@ import io.trino.spi.type.Type;
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.format.FileMetaData;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collection;
@@ -152,7 +152,7 @@ public final class DeltaLakeWriter
     }
 
     @Override
-    public Closeable commit()
+    public RollbackAction commit()
     {
         return fileWriter.commit();
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSink.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSink.java
@@ -37,7 +37,6 @@ import io.trino.spi.type.Type;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
-import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -85,7 +84,7 @@ public class HivePageSink
 
     private final long targetMaxFileSize;
     private final long idleWriterMinFileSize;
-    private final List<Closeable> closedWriterRollbackActions = new ArrayList<>();
+    private final List<RollbackAction> closedWriterRollbackActions = new ArrayList<>();
     private final List<Slice> partitionUpdates = new ArrayList<>();
     private final List<Boolean> activeWriters = new ArrayList<>();
 
@@ -219,7 +218,7 @@ public class HivePageSink
     @Override
     public void abort()
     {
-        List<Closeable> rollbackActions = Streams.concat(
+        List<RollbackAction> rollbackActions = Streams.concat(
                         writers.stream()
                                 // writers can contain nulls if an exception is thrown when doAppend expands the writer list
                                 .filter(Objects::nonNull)
@@ -227,9 +226,9 @@ public class HivePageSink
                         closedWriterRollbackActions.stream())
                 .collect(toImmutableList());
         RuntimeException rollbackException = null;
-        for (Closeable rollbackAction : rollbackActions) {
+        for (RollbackAction rollbackAction : rollbackActions) {
             try {
-                rollbackAction.close();
+                rollbackAction.run();
             }
             catch (Throwable t) {
                 if (rollbackException == null) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriter.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import io.trino.plugin.hive.PartitionUpdate.UpdateMode;
 import io.trino.spi.Page;
 
-import java.io.Closeable;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -78,7 +77,7 @@ public class HiveWriter
         inputSizeInBytes += dataPage.getSizeInBytes();
     }
 
-    public Closeable commit()
+    public RollbackAction commit()
     {
         return fileWriter.commit();
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/MergeFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/MergeFileWriter.java
@@ -29,7 +29,6 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.MergePage;
 import io.trino.spi.type.TypeManager;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -183,14 +182,14 @@ public final class MergeFileWriter
     }
 
     @Override
-    public Closeable commit()
+    public RollbackAction commit()
     {
-        Optional<Closeable> deleteRollbackAction = deleteFileWriter.map(FileWriter::commit);
-        Optional<Closeable> insertRollbackAction = insertFileWriter.map(FileWriter::commit);
+        Optional<RollbackAction> deleteRollbackAction = deleteFileWriter.map(FileWriter::commit);
+        Optional<RollbackAction> insertRollbackAction = insertFileWriter.map(FileWriter::commit);
         return () -> {
             try (Closer closer = Closer.create()) {
-                insertRollbackAction.ifPresent(closer::register);
-                deleteRollbackAction.ifPresent(closer::register);
+                insertRollbackAction.ifPresent(rollbackAction -> closer.register(rollbackAction::run));
+                deleteRollbackAction.ifPresent(rollbackAction -> closer.register(rollbackAction::run));
             }
         };
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriter.java
@@ -53,7 +53,7 @@ public final class RcFileFileWriter
     private final CountingOutputStream outputStream;
     private final AggregatedMemoryContext outputStreamMemoryContext;
     private final RcFileWriter rcFileWriter;
-    private final Closeable rollbackAction;
+    private final RollbackAction rollbackAction;
     private final int[] fileInputColumnIndexes;
     private final List<Block> nullBlocks;
     private final Optional<Supplier<TrinoInputFile>> validationInputFactory;
@@ -63,7 +63,7 @@ public final class RcFileFileWriter
     public RcFileFileWriter(
             OutputStream outputStream,
             AggregatedMemoryContext outputStreamMemoryContext,
-            Closeable rollbackAction,
+            RollbackAction rollbackAction,
             ColumnEncodingFactory columnEncodingFactory,
             List<Type> fileColumnTypes,
             Optional<CompressionKind> compressionKind,
@@ -128,14 +128,14 @@ public final class RcFileFileWriter
     }
 
     @Override
-    public Closeable commit()
+    public RollbackAction commit()
     {
         try {
             rcFileWriter.close();
         }
         catch (IOException | UncheckedIOException e) {
             try {
-                rollbackAction.close();
+                rollbackAction.run();
             }
             catch (Exception _) {
                 // ignore
@@ -161,7 +161,7 @@ public final class RcFileFileWriter
     @Override
     public void rollback()
     {
-        try (rollbackAction) {
+        try (Closeable _ = rollbackAction::run) {
             rcFileWriter.close();
         }
         catch (Exception e) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriterFactory.java
@@ -33,7 +33,6 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import org.joda.time.DateTimeZone;
 
-import java.io.Closeable;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
@@ -135,7 +134,7 @@ public class RcFileFileWriterFactory
                 validationInputFactory = Optional.of(() -> fileSystem.newInputFile(location));
             }
 
-            Closeable rollbackAction = () -> fileSystem.deleteFile(location);
+            RollbackAction rollbackAction = () -> fileSystem.deleteFile(location);
 
             return Optional.of(new RcFileFileWriter(
                     outputStream,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RollbackAction.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RollbackAction.java
@@ -13,22 +13,10 @@
  */
 package io.trino.plugin.hive;
 
-import io.trino.spi.Page;
+import java.io.IOException;
 
-public interface FileWriter
+public interface RollbackAction
 {
-    long getWrittenBytes();
-
-    long getMemoryUsage();
-
-    void appendRows(Page dataPage);
-
-    /**
-     * Commits written data. Returns rollback action which can be used to clean up on failure.
-     */
-    RollbackAction commit();
-
-    void rollback();
-
-    long getValidationCpuNanos();
+    void run()
+            throws IOException;
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SortingFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SortingFileWriter.java
@@ -30,7 +30,6 @@ import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
@@ -128,11 +127,11 @@ public final class SortingFileWriter
     }
 
     @Override
-    public Closeable commit()
+    public RollbackAction commit()
     {
         flushed = true;
 
-        Closeable rollbackAction = createRollbackAction(fileSystem, tempFiles);
+        RollbackAction rollbackAction = createRollbackAction(fileSystem, tempFiles);
         if (!sortBuffer.isEmpty()) {
             // skip temporary files entirely if the total output size is small
             if (tempFiles.isEmpty()) {
@@ -158,17 +157,17 @@ public final class SortingFileWriter
     @Override
     public void rollback()
     {
-        Closeable rollbackAction = createRollbackAction(fileSystem, tempFiles);
+        RollbackAction rollbackAction = createRollbackAction(fileSystem, tempFiles);
         try (Closer closer = Closer.create()) {
             closer.register(outputWriter::rollback);
-            closer.register(rollbackAction);
+            closer.register(rollbackAction::run);
         }
         catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private static Closeable createRollbackAction(TrinoFileSystem fileSystem, Queue<TempFile> tempFiles)
+    private static RollbackAction createRollbackAction(TrinoFileSystem fileSystem, Queue<TempFile> tempFiles)
     {
         return () -> {
             for (TempFile file : tempFiles) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroFileWriterFactory.java
@@ -29,6 +29,7 @@ import io.trino.plugin.hive.FileWriter;
 import io.trino.plugin.hive.HiveCompressionCodec;
 import io.trino.plugin.hive.HiveFileWriterFactory;
 import io.trino.plugin.hive.HiveTimestampPrecision;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.plugin.hive.WriterKind;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.spi.NodeVersion;
@@ -38,7 +39,6 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import org.apache.avro.Schema;
 
-import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -118,7 +118,7 @@ public class AvroFileWriterFactory
             TrinoOutputFile outputFile = fileSystem.newOutputFile(location);
             AggregatedMemoryContext outputStreamMemoryContext = newSimpleAggregatedMemoryContext();
 
-            Closeable rollbackAction = () -> fileSystem.deleteFile(location);
+            RollbackAction rollbackAction = () -> fileSystem.deleteFile(location);
 
             return Optional.of(new AvroHiveFileWriter(
                     outputFile.create(outputStreamMemoryContext),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroHiveFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroHiveFileWriter.java
@@ -22,6 +22,7 @@ import io.trino.hive.formats.avro.AvroTypeException;
 import io.trino.hive.formats.avro.AvroTypeManager;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.plugin.hive.FileWriter;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
@@ -57,7 +58,7 @@ public final class AvroHiveFileWriter
     private final CountingOutputStream countingOutputStream;
     private final AggregatedMemoryContext outputStreamMemoryContext;
 
-    private final Closeable rollbackAction;
+    private final RollbackAction rollbackAction;
 
     public AvroHiveFileWriter(
             OutputStream outputStream,
@@ -65,7 +66,7 @@ public final class AvroHiveFileWriter
             Schema fileSchema,
             AvroTypeManager typeManager,
             AvroTypeBlockHandler avroTypeBlockHandler,
-            Closeable rollbackAction,
+            RollbackAction rollbackAction,
             List<String> inputColumnNames,
             List<Type> inputColumnTypes,
             AvroCompressionKind compressionKind,
@@ -131,7 +132,7 @@ public final class AvroHiveFileWriter
     }
 
     @Override
-    public Closeable commit()
+    public RollbackAction commit()
     {
         try {
             fileWriter.close();
@@ -145,7 +146,7 @@ public final class AvroHiveFileWriter
     @Override
     public void rollback()
     {
-        try (rollbackAction) {
+        try (Closeable _ = rollbackAction::run) {
             fileWriter.close();
         }
         catch (Exception e) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LineFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LineFileWriter.java
@@ -18,6 +18,7 @@ import io.airlift.slice.DynamicSliceOutput;
 import io.trino.hive.formats.line.LineSerializer;
 import io.trino.hive.formats.line.LineWriter;
 import io.trino.plugin.hive.FileWriter;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
@@ -40,13 +41,13 @@ public final class LineFileWriter
 
     private final LineWriter lineWriter;
     private final LineSerializer serializer;
-    private final Closeable rollbackAction;
+    private final RollbackAction rollbackAction;
     private final int[] fileInputColumnIndexes;
     private final List<Block> nullBlocks;
 
     private final DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1024);
 
-    public LineFileWriter(LineWriter lineWriter, LineSerializer serializer, Closeable rollbackAction, int[] fileInputColumnIndexes)
+    public LineFileWriter(LineWriter lineWriter, LineSerializer serializer, RollbackAction rollbackAction, int[] fileInputColumnIndexes)
     {
         this.lineWriter = requireNonNull(lineWriter, "lineWriter is null");
         this.serializer = requireNonNull(serializer, "serializer is null");
@@ -103,14 +104,14 @@ public final class LineFileWriter
     }
 
     @Override
-    public Closeable commit()
+    public RollbackAction commit()
     {
         try {
             lineWriter.close();
         }
         catch (Exception e) {
             try {
-                rollbackAction.close();
+                rollbackAction.run();
             }
             catch (Exception _) {
                 // ignore
@@ -123,7 +124,7 @@ public final class LineFileWriter
     @Override
     public void rollback()
     {
-        try (rollbackAction) {
+        try (Closeable _ = rollbackAction::run) {
             lineWriter.close();
         }
         catch (Exception e) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
@@ -26,6 +26,7 @@ import io.trino.orc.metadata.ColumnMetadata;
 import io.trino.orc.metadata.CompressionKind;
 import io.trino.orc.metadata.OrcType;
 import io.trino.plugin.hive.FileWriter;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.plugin.hive.WriterKind;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.spi.Page;
@@ -73,7 +74,7 @@ public final class OrcFileWriter
     private final AcidTransaction transaction;
     private final boolean useAcidSchema;
     private final OptionalInt bucketNumber;
-    private final Closeable rollbackAction;
+    private final RollbackAction rollbackAction;
     private final int[] fileInputColumnIndexes;
     private final List<Block> nullBlocks;
     private final Optional<Supplier<OrcDataSource>> validationInputFactory;
@@ -88,7 +89,7 @@ public final class OrcFileWriter
             AcidTransaction transaction,
             boolean useAcidSchema,
             OptionalInt bucketNumber,
-            Closeable rollbackAction,
+            RollbackAction rollbackAction,
             List<String> columnNames,
             List<Type> fileColumnTypes,
             ColumnMetadata<OrcType> fileColumnOrcTypes,
@@ -175,7 +176,7 @@ public final class OrcFileWriter
     }
 
     @Override
-    public Closeable commit()
+    public RollbackAction commit()
     {
         try {
             if (transaction.isAcidTransactionRunning() && useAcidSchema) {
@@ -185,7 +186,7 @@ public final class OrcFileWriter
         }
         catch (IOException | UncheckedIOException e) {
             try {
-                rollbackAction.close();
+                rollbackAction.run();
             }
             catch (Exception ex) {
                 // ignore
@@ -236,7 +237,7 @@ public final class OrcFileWriter
     @Override
     public void rollback()
     {
-        try (rollbackAction) {
+        try (Closeable _ = rollbackAction::run) {
             orcWriter.close();
         }
         catch (Exception e) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriterFactory.java
@@ -31,6 +31,7 @@ import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
 import io.trino.plugin.hive.FileWriter;
 import io.trino.plugin.hive.HiveCompressionCodec;
 import io.trino.plugin.hive.HiveFileWriterFactory;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.plugin.hive.WriterKind;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.spi.NodeVersion;
@@ -41,7 +42,6 @@ import io.trino.spi.type.TypeManager;
 import org.weakref.jmx.Flatten;
 import org.weakref.jmx.Managed;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -168,7 +168,7 @@ public class OrcFileWriterFactory
                 });
             }
 
-            Closeable rollbackAction = () -> fileSystem.deleteFile(location);
+            RollbackAction rollbackAction = () -> fileSystem.deleteFile(location);
 
             if (transaction.isInsert() && useAcidSchema) {
                 // Only add the ACID columns if the request is for insert-type operations - - for delete operations,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
@@ -20,6 +20,7 @@ import io.trino.parquet.ParquetDataSource;
 import io.trino.parquet.writer.ParquetWriter;
 import io.trino.parquet.writer.ParquetWriterOptions;
 import io.trino.plugin.hive.FileWriter;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
@@ -58,7 +59,7 @@ public final class ParquetFileWriter
     private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
 
     private final ParquetWriter parquetWriter;
-    private final Closeable rollbackAction;
+    private final RollbackAction rollbackAction;
     private final int[] fileInputColumnIndexes;
     private final List<Block> nullBlocks;
     private final Optional<Supplier<ParquetDataSource>> validationInputFactory;
@@ -67,7 +68,7 @@ public final class ParquetFileWriter
 
     public ParquetFileWriter(
             TrinoOutputFile outputFile,
-            Closeable rollbackAction,
+            RollbackAction rollbackAction,
             List<Type> fileColumnTypes,
             List<String> fileColumnNames,
             MessageType messageType,
@@ -100,7 +101,7 @@ public final class ParquetFileWriter
                             : Optional.empty());
         }
         catch (Exception e) {
-            closeAllSuppress(e, outputStream, rollbackAction);
+            closeAllSuppress(e, outputStream, rollbackAction::run);
             throw e;
         }
 
@@ -149,7 +150,7 @@ public final class ParquetFileWriter
     }
 
     @Override
-    public Closeable commit()
+    public RollbackAction commit()
     {
         try {
             parquetWriter.close();
@@ -157,7 +158,7 @@ public final class ParquetFileWriter
         catch (IOException | UncheckedIOException e) {
             TrinoException trinoException = new TrinoException(HIVE_WRITER_CLOSE_ERROR, "Error committing write to Parquet file", e);
             try {
-                rollbackAction.close();
+                rollbackAction.run();
             }
             catch (Exception rollbackException) {
                 trinoException.addSuppressed(rollbackException);
@@ -184,7 +185,7 @@ public final class ParquetFileWriter
     @Override
     public void rollback()
     {
-        try (rollbackAction) {
+        try (Closeable _ = rollbackAction::run) {
             parquetWriter.close();
         }
         catch (Exception e) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -29,6 +29,7 @@ import io.trino.plugin.hive.HiveCompressionCodec;
 import io.trino.plugin.hive.HiveConfig;
 import io.trino.plugin.hive.HiveFileWriterFactory;
 import io.trino.plugin.hive.HiveSessionProperties;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.plugin.hive.WriterKind;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.spi.NodeVersion;
@@ -40,7 +41,6 @@ import org.joda.time.DateTimeZone;
 import org.weakref.jmx.Flatten;
 import org.weakref.jmx.Managed;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -128,7 +128,7 @@ public class ParquetFileWriterFactory
         try {
             TrinoFileSystem fileSystem = fileSystemFactory.create(session);
 
-            Closeable rollbackAction = () -> fileSystem.deleteFile(location);
+            RollbackAction rollbackAction = () -> fileSystem.deleteFile(location);
 
             ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(
                     fileColumnTypes,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroFileWriter.java
@@ -15,6 +15,7 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.hive.HiveCompressionCodec;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.Type;
@@ -52,11 +53,11 @@ public final class IcebergAvroFileWriter
     private final Schema icebergSchema;
     private final List<Type> types;
     private final FileAppender<Record> avroWriter;
-    private final Closeable rollbackAction;
+    private final RollbackAction rollbackAction;
 
     public IcebergAvroFileWriter(
             OutputFile file,
-            Closeable rollbackAction,
+            RollbackAction rollbackAction,
             Schema icebergSchema,
             List<Type> types,
             HiveCompressionCodec hiveCompressionCodec)
@@ -101,14 +102,14 @@ public final class IcebergAvroFileWriter
     }
 
     @Override
-    public Closeable commit()
+    public RollbackAction commit()
     {
         try {
             avroWriter.close();
         }
         catch (IOException e) {
             try {
-                rollbackAction.close();
+                rollbackAction.run();
             }
             catch (Exception ex) {
                 if (!e.equals(ex)) {
@@ -124,7 +125,7 @@ public final class IcebergAvroFileWriter
     @Override
     public void rollback()
     {
-        try (rollbackAction) {
+        try (Closeable _ = rollbackAction::run) {
             avroWriter.close();
         }
         catch (Exception e) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -32,6 +32,7 @@ import io.trino.parquet.writer.ParquetWriterOptions;
 import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
 import io.trino.plugin.hive.HiveCompressionCodec;
 import io.trino.plugin.hive.HiveCompressionOption;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.iceberg.fileio.ForwardingOutputFile;
 import io.trino.spi.NodeVersion;
@@ -49,7 +50,6 @@ import org.apache.iceberg.types.Type.TypeID;
 import org.apache.iceberg.types.Types;
 import org.weakref.jmx.Managed;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
@@ -182,7 +182,7 @@ public class IcebergFileWriterFactory
         try {
             TrinoOutputFile outputFile = fileSystem.newOutputFile(outputPath);
 
-            Closeable rollbackAction = () -> fileSystem.deleteFile(outputPath);
+            RollbackAction rollbackAction = () -> fileSystem.deleteFile(outputPath);
 
             ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                     .setMaxPageSize(getParquetWriterPageSize(session))
@@ -228,7 +228,7 @@ public class IcebergFileWriterFactory
         try {
             OrcDataSink orcDataSink = OutputStreamOrcDataSink.create(fileSystem.newOutputFile(outputPath));
 
-            Closeable rollbackAction = () -> fileSystem.deleteFile(outputPath);
+            RollbackAction rollbackAction = () -> fileSystem.deleteFile(outputPath);
 
             List<Types.NestedField> columnFields = icebergSchema.columns();
             List<String> fileColumnNames = columnFields.stream()
@@ -311,7 +311,7 @@ public class IcebergFileWriterFactory
             Schema icebergSchema,
             Map<String, String> storageProperties)
     {
-        Closeable rollbackAction = () -> fileSystem.deleteFile(outputPath);
+        RollbackAction rollbackAction = () -> fileSystem.deleteFile(outputPath);
 
         List<Type> columnTypes = icebergSchema.columns().stream()
                 .map(column -> toTrinoType(column.type(), typeManager))

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergOrcFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergOrcFileWriter.java
@@ -23,6 +23,7 @@ import io.trino.orc.OrcWriterStats;
 import io.trino.orc.metadata.ColumnMetadata;
 import io.trino.orc.metadata.CompressionKind;
 import io.trino.orc.metadata.OrcType;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
@@ -61,7 +62,7 @@ public final class IcebergOrcFileWriter
     private final Schema icebergSchema;
     private final ColumnMetadata<OrcType> orcColumns;
     private final MetricsConfig metricsConfig;
-    private final Closeable rollbackAction;
+    private final RollbackAction rollbackAction;
     private final int[] fileInputColumnIndexes;
     private final List<Block> nullBlocks;
     private final Optional<Supplier<OrcDataSource>> validationInputFactory;
@@ -71,7 +72,7 @@ public final class IcebergOrcFileWriter
             MetricsConfig metricsConfig,
             Schema icebergSchema,
             OrcDataSink orcDataSink,
-            Closeable rollbackAction,
+            RollbackAction rollbackAction,
             List<String> columnNames,
             List<Type> fileColumnTypes,
             ColumnMetadata<OrcType> fileColumnOrcTypes,
@@ -152,14 +153,14 @@ public final class IcebergOrcFileWriter
     }
 
     @Override
-    public Closeable commit()
+    public RollbackAction commit()
     {
         try {
             orcWriter.close();
         }
         catch (IOException | UncheckedIOException e) {
             try {
-                rollbackAction.close();
+                rollbackAction.run();
             }
             catch (IOException | RuntimeException ex) {
                 if (!e.equals(ex)) {
@@ -189,7 +190,7 @@ public final class IcebergOrcFileWriter
     @Override
     public void rollback()
     {
-        try (rollbackAction) {
+        try (Closeable _ = rollbackAction::run) {
             orcWriter.close();
         }
         catch (Exception e) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -23,6 +23,7 @@ import io.airlift.units.DataSize;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.geospatial.serde.JtsGeometrySerde;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.plugin.iceberg.PartitionTransforms.ColumnTransform;
 import io.trino.spi.Page;
 import io.trino.spi.PageIndexer;
@@ -59,7 +60,6 @@ import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 
-import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -148,7 +148,7 @@ public class IcebergPageSink
     private final Map<Integer, org.apache.iceberg.types.Type> columnsWithGeometry;
 
     private final List<WriteContext> writers = new ArrayList<>();
-    private final List<Closeable> closedWriterRollbackActions = new ArrayList<>();
+    private final List<RollbackAction> closedWriterRollbackActions = new ArrayList<>();
     private final Collection<Slice> commitTasks = new ArrayList<>();
     private final List<Boolean> activeWriters = new ArrayList<>();
 
@@ -280,16 +280,16 @@ public class IcebergPageSink
     @Override
     public void abort()
     {
-        List<Closeable> rollbackActions = Streams.concat(
+        List<RollbackAction> rollbackActions = Streams.concat(
                         writers.stream()
                                 .filter(Objects::nonNull)
                                 .map(writer -> writer::rollback),
                         closedWriterRollbackActions.stream())
                 .collect(toImmutableList());
         RuntimeException error = null;
-        for (Closeable rollbackAction : rollbackActions) {
+        for (RollbackAction rollbackAction : rollbackActions) {
             try {
-                rollbackAction.close();
+                rollbackAction.run();
             }
             catch (Throwable t) {
                 if (error == null) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
@@ -20,6 +20,7 @@ import io.trino.parquet.ParquetDataSourceId;
 import io.trino.parquet.metadata.BlockMetadata;
 import io.trino.parquet.metadata.ParquetMetadata;
 import io.trino.parquet.writer.ParquetWriterOptions;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.plugin.hive.parquet.ParquetFileWriter;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
@@ -28,7 +29,6 @@ import org.apache.iceberg.MetricsConfig;
 import org.apache.parquet.format.CompressionCodec;
 import org.apache.parquet.schema.MessageType;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
@@ -53,7 +53,7 @@ public final class IcebergParquetFileWriter
     public IcebergParquetFileWriter(
             MetricsConfig metricsConfig,
             TrinoOutputFile outputFile,
-            Closeable rollbackAction,
+            RollbackAction rollbackAction,
             List<Type> fileColumnTypes,
             List<String> fileColumnNames,
             MessageType messageType,
@@ -113,7 +113,7 @@ public final class IcebergParquetFileWriter
     }
 
     @Override
-    public Closeable commit()
+    public RollbackAction commit()
     {
         return parquetFileWriter.commit();
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSortingFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSortingFileWriter.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg;
 import io.airlift.units.DataSize;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
+import io.trino.plugin.hive.RollbackAction;
 import io.trino.plugin.hive.SortingFileWriter;
 import io.trino.spi.Page;
 import io.trino.spi.PageSorter;
@@ -23,7 +24,6 @@ import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
 
-import java.io.Closeable;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
@@ -85,7 +85,7 @@ public final class IcebergSortingFileWriter
     }
 
     @Override
-    public Closeable commit()
+    public RollbackAction commit()
     {
         return sortingFileWriter.commit();
     }


### PR DESCRIPTION
Modelling it as `Closeable` felt sub-ideal. `Closeable` is something that should be closed, while rollback action is only invoked conditionally. In fact, use of `Closeable` triggered IDE warnings about unclosed `Closeable`.
