### PR TITLE
Add pluggable AdmissionPolicy SPI for query admission decisions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java
@@ -31,9 +31,13 @@ import io.trino.server.BasicQueryInfo;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.QueryId;
 import io.trino.spi.TrinoException;
+import io.trino.spi.admission.AdmissionPolicy;
+import io.trino.spi.admission.QueryAdmissionContext;
+import io.trino.spi.admission.WaitDecision;
 
 import java.time.Instant;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -41,10 +45,12 @@ import java.util.function.Consumer;
 import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
 import static io.airlift.concurrent.MoreFutures.addExceptionCallback;
 import static io.airlift.concurrent.MoreFutures.addSuccessCallback;
+import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
 import static io.airlift.units.Duration.succinctDuration;
 import static io.trino.SystemSessionProperties.getRequiredWorkers;
 import static io.trino.SystemSessionProperties.getRequiredWorkersMaxWait;
+import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.util.Failures.toFailure;
 import static java.util.Objects.requireNonNull;
@@ -59,6 +65,7 @@ public class LocalDispatchQuery
 
     private final QueryMonitor queryMonitor;
     private final ClusterSizeMonitor clusterSizeMonitor;
+    private final AdmissionPolicy admissionPolicy;
 
     private final Executor queryExecutor;
 
@@ -72,6 +79,7 @@ public class LocalDispatchQuery
             ListenableFuture<QueryExecution> queryExecutionFuture,
             QueryMonitor queryMonitor,
             ClusterSizeMonitor clusterSizeMonitor,
+            AdmissionPolicy admissionPolicy,
             Executor queryExecutor,
             Consumer<QueryExecution> querySubmitter)
     {
@@ -79,6 +87,7 @@ public class LocalDispatchQuery
         this.queryExecutionFuture = requireNonNull(queryExecutionFuture, "queryExecutionFuture is null");
         this.queryMonitor = requireNonNull(queryMonitor, "queryMonitor is null");
         this.clusterSizeMonitor = requireNonNull(clusterSizeMonitor, "clusterSizeMonitor is null");
+        this.admissionPolicy = requireNonNull(admissionPolicy, "admissionPolicy is null");
         this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
         this.querySubmitter = requireNonNull(querySubmitter, "querySubmitter is null");
 
@@ -130,18 +139,78 @@ public class LocalDispatchQuery
             if (queryExecution.shouldWaitForMinWorkers()) {
                 executionMinCount = getRequiredWorkers(session);
             }
-            ListenableFuture<Void> minimumWorkerFuture = clusterSizeMonitor.waitForMinimumWorkers(executionMinCount, getRequiredWorkersMaxWait(session));
-            // when worker requirement is met, start the execution
-            addSuccessCallback(minimumWorkerFuture, () -> startExecution(queryExecution), queryExecutor);
-            addExceptionCallback(minimumWorkerFuture, stateMachine::transitionToFailed, queryExecutor);
 
-            // cancel minimumWorkerFuture if query fails for some reason or is cancelled by user
-            stateMachine.addStateChangeListener(state -> {
-                if (state.isDone()) {
-                    minimumWorkerFuture.cancel(true);
+            QueryAdmissionContext context;
+            WaitDecision decision;
+            try {
+                context = buildAdmissionContext(session);
+                decision = admissionPolicy.shouldQueryWait(context);
+            }
+            catch (Throwable t) {
+                // Any unchecked exception from the policy fails the query with the cause preserved.
+                stateMachine.transitionToFailed(insufficientResources("Admission policy threw", t));
+                return;
+            }
+            if (decision == null) {
+                // A null decision is treated as a policy failure.
+                stateMachine.transitionToFailed(insufficientResources("Admission policy returned null decision", null));
+                return;
+            }
+
+            int minCount = executionMinCount;
+            switch (decision) {
+                case WaitDecision.ProceedNow _ -> startExecution(queryExecution);
+                case WaitDecision.Wait wait when wait.releaseCondition().isEmpty() -> {
+                    // Built-in cluster-capacity gate: wait for the minimum required workers using
+                    // the configured timeout, preserving today's behavior byte-for-byte.
+                    ListenableFuture<Void> minimumWorkerFuture = clusterSizeMonitor.waitForMinimumWorkers(minCount, getRequiredWorkersMaxWait(session));
+                    // when worker requirement is met, start the execution
+                    addSuccessCallback(minimumWorkerFuture, () -> startExecution(queryExecution), queryExecutor);
+                    addExceptionCallback(minimumWorkerFuture, stateMachine::transitionToFailed, queryExecutor);
+
+                    // cancel minimumWorkerFuture if query fails for some reason or is cancelled by user
+                    stateMachine.addStateChangeListener(state -> {
+                        if (state.isDone()) {
+                            minimumWorkerFuture.cancel(true);
+                        }
+                    });
                 }
-            });
+                case WaitDecision.Wait wait -> {
+                    // Policy-supplied release condition, bounded by the policy's maxWait. The query is
+                    // admitted when the condition completes normally; a timeout or exceptional completion
+                    // fails the query with GENERIC_INSUFFICIENT_RESOURCES.
+                    CompletableFuture<Void> releaseCondition = wait.releaseCondition().orElseThrow();
+                    releaseCondition.orTimeout(wait.maxWait().toMillis(), MILLISECONDS);
+                    ListenableFuture<Void> gate = toListenableFuture(releaseCondition);
+                    addSuccessCallback(gate, () -> startExecution(queryExecution), queryExecutor);
+                    addExceptionCallback(gate,
+                            throwable -> stateMachine.transitionToFailed(
+                                    insufficientResources("Admission policy release condition not satisfied within " + wait.maxWait() + " (" + wait.reason() + ")", throwable)),
+                            queryExecutor);
+
+                    // cancel the policy's release condition if the query fails for some reason or is cancelled by user
+                    stateMachine.addStateChangeListener(state -> {
+                        if (state.isDone()) {
+                            releaseCondition.cancel(true);
+                        }
+                    });
+                }
+            }
         });
+    }
+
+    private QueryAdmissionContext buildAdmissionContext(Session session)
+    {
+        return new QueryAdmissionContext(
+                session.getQueryId(),
+                session.getUser(),
+                stateMachine.getBasicQueryInfo(Optional.empty()).getResourceGroupId().map(Object::toString),
+                session.getSystemProperties());
+    }
+
+    private static TrinoException insufficientResources(String message, Throwable cause)
+    {
+        return new TrinoException(GENERIC_INSUFFICIENT_RESOURCES, message, cause);
     }
 
     private void startExecution(QueryExecution queryExecution)

--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQueryFactory.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQueryFactory.java
@@ -38,6 +38,7 @@ import io.trino.security.AccessControl;
 import io.trino.server.protocol.Slug;
 import io.trino.spi.NodeVersion;
 import io.trino.spi.TrinoException;
+import io.trino.spi.admission.AdmissionPolicy;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.sql.SessionPropertyResolver;
 import io.trino.sql.tree.Statement;
@@ -66,6 +67,7 @@ public class LocalDispatchQueryFactory
     private final LocationFactory locationFactory;
 
     private final ClusterSizeMonitor clusterSizeMonitor;
+    private final AdmissionPolicy admissionPolicy;
 
     private final Map<Class<? extends Statement>, QueryExecutionFactory<?>> executionFactories;
     private final WarningCollectorFactory warningCollectorFactory;
@@ -90,6 +92,7 @@ public class LocalDispatchQueryFactory
             WarningCollectorFactory warningCollectorFactory,
             ExchangeMetricsCollector exchangeMetricsCollector,
             ClusterSizeMonitor clusterSizeMonitor,
+            AdmissionPolicy admissionPolicy,
             DispatchExecutor dispatchExecutor,
             FeaturesConfig featuresConfig,
             NodeVersion version)
@@ -105,6 +108,7 @@ public class LocalDispatchQueryFactory
         this.warningCollectorFactory = requireNonNull(warningCollectorFactory, "warningCollectorFactory is null");
         this.exchangeMetricsCollector = requireNonNull(exchangeMetricsCollector, "exchangeMetricsCollector is null");
         this.clusterSizeMonitor = requireNonNull(clusterSizeMonitor, "clusterSizeMonitor is null");
+        this.admissionPolicy = requireNonNull(admissionPolicy, "admissionPolicy is null");
         this.executor = dispatchExecutor.getExecutor();
         this.maxStateMachineThreadsPerQuery = queryManagerConfig.getMaxStateMachineCallbackThreads();
         this.queryReportedRuleStatsLimit = queryManagerConfig.getQueryReportedRuleStatsLimit();
@@ -186,6 +190,7 @@ public class LocalDispatchQueryFactory
                 queryExecutionFuture,
                 queryMonitor,
                 clusterSizeMonitor,
+                admissionPolicy,
                 executor,
                 queryManager::createQuery);
     }

--- a/core/trino-main/src/main/java/io/trino/execution/admission/AdmissionPolicyConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/admission/AdmissionPolicyConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.NotNull;
+
+public class AdmissionPolicyConfig
+{
+    public static final String DEFAULT_NAME = "min-workers";
+
+    private String name = DEFAULT_NAME;
+
+    @NotNull
+    public String getName()
+    {
+        return name;
+    }
+
+    @Config("query-manager.admission-policy.name")
+    @ConfigDescription("Stable factory name of the bound AdmissionPolicy")
+    public AdmissionPolicyConfig setName(String name)
+    {
+        this.name = name;
+        return this;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/admission/AdmissionPolicyManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/admission/AdmissionPolicyManager.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.ThreadSafe;
+import com.google.inject.Inject;
+import io.trino.spi.admission.AdmissionPolicyFactory;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Runtime registry for plugin-supplied {@link AdmissionPolicyFactory} instances.
+ *
+ * <p>{@code PluginManager} populates this registry as plugins are loaded by
+ * iterating {@code Plugin.getAdmissionPolicyFactories()} and calling
+ * {@link #addAdmissionPolicyFactory(AdmissionPolicyFactory)}. The registry
+ * itself does not enforce name uniqueness; per the design, duplicate-name
+ * validation lives in {@link AdmissionPolicyModule}'s
+ * {@code @Provides AdmissionPolicy} provider, which merges the multibinder
+ * set (containing the bundled default factory) with the factories registered
+ * here and validates uniqueness across both sources at provision time.
+ *
+ * <p>The bundled default factory ({@link MinWorkersAdmissionPolicy.Factory})
+ * is bound directly via the {@code Multibinder<AdmissionPolicyFactory>} in
+ * {@link AdmissionPolicyModule} and is therefore never registered through this
+ * manager.
+ */
+@ThreadSafe
+public class AdmissionPolicyManager
+{
+    private final List<AdmissionPolicyFactory> factories = new CopyOnWriteArrayList<>();
+
+    @Inject
+    public AdmissionPolicyManager() {}
+
+    public void addAdmissionPolicyFactory(AdmissionPolicyFactory factory)
+    {
+        requireNonNull(factory, "factory is null");
+        factories.add(factory);
+    }
+
+    public Collection<AdmissionPolicyFactory> getAdmissionPolicyFactories()
+    {
+        return ImmutableList.copyOf(factories);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/admission/AdmissionPolicyModule.java
+++ b/core/trino-main/src/main/java/io/trino/execution/admission/AdmissionPolicyModule.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.AbstractModule;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import io.airlift.log.Logger;
+import io.trino.spi.admission.AdmissionPolicy;
+import io.trino.spi.admission.AdmissionPolicyFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Guice wiring for the {@link AdmissionPolicy} SPI.
+ *
+ * <p>Owns the {@code Multibinder<AdmissionPolicyFactory>} that holds the bundled
+ * default factory ({@link MinWorkersAdmissionPolicy.Factory}) and any
+ * plugin-supplied factories registered by {@code PluginManager}. Provides the
+ * single bound {@link AdmissionPolicy} as a Guice singleton, resolved at
+ * provision time from {@link AdmissionPolicyConfig}.
+ *
+ * <p>All resolution failures (unknown name, duplicate factory names, factory
+ * returning {@code null}, factory throwing) are surfaced as runtime exceptions
+ * during Guice provision so the coordinator fails before the HTTP server
+ * accepts traffic.
+ */
+public class AdmissionPolicyModule
+        extends AbstractModule
+{
+    private static final Logger log = Logger.get(AdmissionPolicyModule.class);
+
+    private static final File CONFIG_FILE = new File("etc/admission-policy.properties");
+
+    @Override
+    protected void configure()
+    {
+        Binder binder = binder();
+        configBinder(binder).bindConfig(AdmissionPolicyConfig.class);
+
+        // The bundled default factory is registered directly via the multibinder.
+        // Plugin-supplied factories are registered at plugin-load time through
+        // AdmissionPolicyManager (populated by PluginManager). The @Provides
+        // method below merges both sources and validates uniqueness across them.
+        newSetBinder(binder, AdmissionPolicyFactory.class)
+                .addBinding()
+                .to(MinWorkersAdmissionPolicy.Factory.class)
+                .in(Scopes.SINGLETON);
+        // AdmissionPolicyManager (the plugin factory registry) is bound server-wide in
+        // ServerMainModule because PluginManager populates it on every node. This module,
+        // installed only on the coordinator, consumes that binding via the @Provides method.
+    }
+
+    @Provides
+    @Singleton
+    public AdmissionPolicy createAdmissionPolicy(
+            Set<AdmissionPolicyFactory> defaultFactories,
+            AdmissionPolicyManager pluginFactories,
+            AdmissionPolicyConfig config)
+    {
+        requireNonNull(defaultFactories, "defaultFactories is null");
+        requireNonNull(pluginFactories, "pluginFactories is null");
+        requireNonNull(config, "config is null");
+
+        ImmutableList.Builder<AdmissionPolicyFactory> merged = ImmutableList.builder();
+        merged.addAll(defaultFactories);
+        merged.addAll(pluginFactories.getAdmissionPolicyFactories());
+        Map<String, AdmissionPolicyFactory> byName = indexUnique(merged.build());
+
+        String requestedName = config.getName();
+        AdmissionPolicyFactory factory = byName.get(requestedName);
+        if (factory == null) {
+            throw new RuntimeException(format(
+                    "No admission policy factory registered for name '%s'; registered: %s",
+                    requestedName,
+                    byName.keySet()));
+        }
+
+        Map<String, String> properties = loadProperties();
+
+        log.info("-- Loading admission policy '%s' from %s --", requestedName, factory.getClass().getName());
+
+        AdmissionPolicy policy;
+        try {
+            policy = factory.create(ImmutableMap.copyOf(properties));
+        }
+        catch (Throwable t) {
+            throw new RuntimeException(format(
+                    "Admission policy factory '%s' (%s) threw while creating policy",
+                    requestedName,
+                    factory.getClass().getName()), t);
+        }
+        if (policy == null) {
+            throw new RuntimeException(format(
+                    "Admission policy factory '%s' (%s) returned null",
+                    requestedName,
+                    factory.getClass().getName()));
+        }
+
+        log.info("-- Loaded admission policy '%s' --", requestedName);
+        return policy;
+    }
+
+    /**
+     * Validates that no two registered factories share a name (case-sensitive)
+     * and returns a map keyed by {@code getName()}.
+     */
+    private static Map<String, AdmissionPolicyFactory> indexUnique(List<AdmissionPolicyFactory> factories)
+    {
+        Map<String, AdmissionPolicyFactory> byName = new LinkedHashMap<>();
+        for (AdmissionPolicyFactory factory : factories) {
+            String name = factory.getName();
+            if (name == null || name.isEmpty()) {
+                throw new RuntimeException(format(
+                        "Admission policy factory %s returned a null or empty name",
+                        factory.getClass().getName()));
+            }
+            AdmissionPolicyFactory existing = byName.putIfAbsent(name, factory);
+            if (existing != null) {
+                throw new RuntimeException(format(
+                        "Duplicate admission policy factory name '%s' from %s and %s",
+                        name,
+                        existing.getClass().getName(),
+                        factory.getClass().getName()));
+            }
+        }
+        return byName;
+    }
+
+    /**
+     * Loads {@code etc/admission-policy.properties} into a mutable map. Returns
+     * an empty map when the file is absent so vanilla operators are not required
+     * to create it.
+     */
+    private static Map<String, String> loadProperties()
+    {
+        File configFile = CONFIG_FILE.getAbsoluteFile();
+        if (!configFile.exists()) {
+            return new HashMap<>();
+        }
+        try {
+            return new HashMap<>(loadPropertiesFrom(configFile.getPath()));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to read admission policy configuration file: " + configFile, e);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/admission/MinWorkersAdmissionPolicy.java
+++ b/core/trino-main/src/main/java/io/trino/execution/admission/MinWorkersAdmissionPolicy.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import io.trino.spi.admission.AdmissionPolicy;
+import io.trino.spi.admission.AdmissionPolicyFactory;
+import io.trino.spi.admission.QueryAdmissionContext;
+import io.trino.spi.admission.WaitDecision;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Default OSS {@link AdmissionPolicy} implementation. Emits a fixed
+ * {@link WaitDecision.Wait} for every query so the engine routes admission
+ * through {@code ClusterSizeMonitor.waitForMinimumWorkers(...)}, preserving
+ * today's behavior byte-for-byte.
+ *
+ * <p>The policy itself does not call {@code ClusterSizeMonitor}; that call is
+ * made by the engine in {@code LocalDispatchQuery} based on the returned
+ * decision. Keeping the call out of the SPI lets the SPI live in
+ * {@code trino-spi} without reaching into {@code io.trino.execution}.
+ */
+public class MinWorkersAdmissionPolicy
+        implements AdmissionPolicy
+{
+    static final String NAME = AdmissionPolicyConfig.DEFAULT_NAME;
+
+    @Override
+    public WaitDecision shouldQueryWait(QueryAdmissionContext query)
+    {
+        // Gate on the engine's built-in cluster-capacity condition (an empty
+        // releaseCondition). The engine (LocalDispatchQuery) waits via
+        // ClusterSizeMonitor.waitForMinimumWorkers(...) using the configured
+        // getRequiredWorkersMaxWait(session) timeout, preserving today's behavior
+        // byte-for-byte. The maxWait carried here is unused for
+        // the built-in gate — the engine applies its own configured timeout — so a
+        // zero sentinel is fine. Custom policies instead return
+        // WaitDecision.Wait.forCondition(future, maxWait, reason) with their own
+        // release condition.
+        return WaitDecision.Wait.forClusterCapacity(Duration.ZERO, "wait for required workers");
+    }
+
+    public static class Factory
+            implements AdmissionPolicyFactory
+    {
+        @Override
+        public String getName()
+        {
+            return NAME;
+        }
+
+        @Override
+        public AdmissionPolicy create(Map<String, String> config)
+        {
+            // Default factory ignores the properties map; vanilla operators do not
+            // need an etc/admission-policy.properties file.
+            return new MinWorkersAdmissionPolicy();
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -67,6 +67,7 @@ import io.trino.execution.StagesInfo;
 import io.trino.execution.TaskInfo;
 import io.trino.execution.TaskManagerConfig;
 import io.trino.execution.TaskStatus;
+import io.trino.execution.admission.AdmissionPolicyModule;
 import io.trino.execution.resourcegroups.InternalResourceGroupManager;
 import io.trino.execution.resourcegroups.LegacyResourceGroupConfigurationManager;
 import io.trino.execution.resourcegroups.ResourceGroupInfoProvider;
@@ -428,6 +429,7 @@ public class CoordinatorModule
         executionPolicyBinder.addBinding("phased").to(PhasedExecutionPolicy.class);
 
         install(new QueryExecutionFactoryModule());
+        install(new AdmissionPolicyModule());
 
         // cleanup
         closingBinder(binder).registerExecutor(Key.get(ExecutorService.class, ForStatementResource.class));

--- a/core/trino-main/src/main/java/io/trino/server/PluginManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/PluginManager.java
@@ -22,6 +22,7 @@ import io.trino.connector.CatalogFactory;
 import io.trino.connector.CatalogStoreManager;
 import io.trino.eventlistener.EventListenerManager;
 import io.trino.exchange.ExchangeManagerRegistry;
+import io.trino.execution.admission.AdmissionPolicyManager;
 import io.trino.execution.resourcegroups.ResourceGroupManager;
 import io.trino.metadata.BlockEncodingManager;
 import io.trino.metadata.GlobalFunctionCatalog;
@@ -37,6 +38,7 @@ import io.trino.server.security.CertificateAuthenticatorManager;
 import io.trino.server.security.HeaderAuthenticatorManager;
 import io.trino.server.security.PasswordAuthenticatorManager;
 import io.trino.spi.Plugin;
+import io.trino.spi.admission.AdmissionPolicyFactory;
 import io.trino.spi.block.BlockEncoding;
 import io.trino.spi.cache.BlobCacheManagerFactory;
 import io.trino.spi.catalog.CatalogStoreFactory;
@@ -119,6 +121,7 @@ public class PluginManager
     private final TypeRegistry typeRegistry;
     private final BlockEncodingManager blockEncodingManager;
     private final HandleResolver handleResolver;
+    private final AdmissionPolicyManager admissionPolicyManager;
     private final AtomicBoolean pluginsLoading = new AtomicBoolean();
 
     @Inject
@@ -141,7 +144,8 @@ public class PluginManager
             HandleResolver handleResolver,
             ExchangeManagerRegistry exchangeManagerRegistry,
             SpoolingManagerRegistry spoolingManagerRegistry,
-            CacheManagerRegistry cacheManagerRegistry)
+            CacheManagerRegistry cacheManagerRegistry,
+            AdmissionPolicyManager admissionPolicyManager)
     {
         this.pluginsProvider = requireNonNull(pluginsProvider, "pluginsProvider is null");
         this.catalogStoreManager = requireNonNull(catalogStoreManager, "catalogStoreManager is null");
@@ -162,6 +166,7 @@ public class PluginManager
         this.exchangeManagerRegistry = requireNonNull(exchangeManagerRegistry, "exchangeManagerRegistry is null");
         this.spoolingManagerRegistry = requireNonNull(spoolingManagerRegistry, "spoolingManagerRegistry is null");
         this.cacheManagerRegistry = requireNonNull(cacheManagerRegistry, "cacheManagerRegistry is null");
+        this.admissionPolicyManager = requireNonNull(admissionPolicyManager, "admissionPolicyManager is null");
     }
 
     @Override
@@ -313,6 +318,11 @@ public class PluginManager
         for (BlobCacheManagerFactory factory : plugin.getBlobCacheManagerFactories()) {
             log.info("Registering blob cache manager %s", factory.getName());
             cacheManagerRegistry.addBlobCacheManagerFactory(factory);
+        }
+
+        for (AdmissionPolicyFactory admissionPolicyFactory : plugin.getAdmissionPolicyFactories()) {
+            log.info("Registering admission policy %s", admissionPolicyFactory.getName());
+            admissionPolicyManager.addAdmissionPolicyFactory(admissionPolicyFactory);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -51,6 +51,7 @@ import io.trino.execution.SqlTaskManager;
 import io.trino.execution.TableExecuteContextManager;
 import io.trino.execution.TaskManagementExecutor;
 import io.trino.execution.TaskManagerConfig;
+import io.trino.execution.admission.AdmissionPolicyManager;
 import io.trino.execution.executor.TaskExecutor;
 import io.trino.execution.executor.dedicated.ThreadPerDriverTaskExecutor;
 import io.trino.execution.executor.timesharing.MultilevelSplitQueue;
@@ -440,6 +441,10 @@ public class ServerMainModule
         // plugin manager
         newOptionalBinder(binder, PluginInstaller.class).setDefault()
                 .to(PluginManager.class).in(Scopes.SINGLETON);
+        // admission policy factory registry — populated by PluginManager on every node,
+        // so it must be bound server-wide (coordinator and workers), independent of the
+        // coordinator-only AdmissionPolicyModule that wires policy selection and dispatch
+        binder.bind(AdmissionPolicyManager.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, PluginsProvider.class).setDefault()
                 .to(ServerPluginsProvider.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(ServerPluginsProviderConfig.class);

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -81,6 +81,7 @@ import io.trino.execution.SessionPropertyEvaluator;
 import io.trino.execution.SplitAssignment;
 import io.trino.execution.TableExecuteContextManager;
 import io.trino.execution.TaskManagerConfig;
+import io.trino.execution.admission.AdmissionPolicyManager;
 import io.trino.execution.querystats.PlanOptimizersStatsCollector;
 import io.trino.execution.resourcegroups.NoOpResourceGroupManager;
 import io.trino.execution.scheduler.NodeScheduler;
@@ -551,7 +552,8 @@ public class PlanTester
                 new HandleResolver(),
                 exchangeManagerRegistry,
                 spoolingManagerRegistry,
-                cacheManagerRegistry);
+                cacheManagerRegistry,
+                new AdmissionPolicyManager());
 
         catalogManager.registerGlobalSystemConnector(globalSystemConnector);
         languageFunctionManager.setPlannerContext(plannerContext);

--- a/core/trino-main/src/test/java/io/trino/execution/admission/TestAdmissionPolicyConfigStartup.java
+++ b/core/trino-main/src/test/java/io/trino/execution/admission/TestAdmissionPolicyConfigStartup.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.airlift.bootstrap.Bootstrap;
+import io.trino.spi.admission.AdmissionPolicy;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * End-to-end coverage for the
+ * {@code query-manager.admission-policy.name=does-not-exist} startup scenario.
+ *
+ * <p>Boots an {@link AdmissionPolicyModule} the same way {@code CoordinatorModule}
+ * does and asserts startup fails with a clear error naming the unknown policy
+ * name and the registered set, which always includes the bundled
+ * {@code min-workers} default factory.
+ *
+ * <p>A full {@code DistributedQueryRunner} or coordinator boot is unnecessary
+ * here: the SPI resolution lives entirely inside {@link AdmissionPolicyModule}'s
+ * provider, and the surrounding coordinator infrastructure adds no behaviour
+ * relevant to this acceptance criterion. Booting only the module keeps the test
+ * fast while exercising the same code path the coordinator would.
+ */
+public class TestAdmissionPolicyConfigStartup
+{
+    private static final String UNKNOWN_NAME = "does-not-exist";
+
+    // ServerMainModule binds AdmissionPolicyManager server-wide in production; supply the
+    // same binding here so the coordinator-only AdmissionPolicyModule can be booted in isolation.
+    private static final Module ADMISSION_POLICY_MANAGER_BINDING =
+            binder -> binder.bind(AdmissionPolicyManager.class).in(Scopes.SINGLETON);
+
+    @Test
+    public void startupFailsWithUnknownPolicyNameAndRegisteredSet()
+    {
+        assertThatThrownBy(() -> bootCoordinator(UNKNOWN_NAME))
+                .hasMessageContaining(UNKNOWN_NAME)
+                .hasMessageContaining(MinWorkersAdmissionPolicy.NAME);
+    }
+
+    @Test
+    public void startupSucceedsWithDefaultPolicyName()
+    {
+        AdmissionPolicy policy = bootCoordinator(MinWorkersAdmissionPolicy.NAME);
+        assertThat(policy).isInstanceOf(MinWorkersAdmissionPolicy.class);
+    }
+
+    @Test
+    public void startupSucceedsWithoutExplicitPolicyName()
+    {
+        // No configuration override — the AdmissionPolicyConfig default must
+        // resolve to the bundled min-workers factory.
+        Bootstrap app = new Bootstrap(new AdmissionPolicyModule(), ADMISSION_POLICY_MANAGER_BINDING);
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .quiet()
+                .initialize();
+
+        AdmissionPolicy policy = injector.getInstance(AdmissionPolicy.class);
+        assertThat(policy).isInstanceOf(MinWorkersAdmissionPolicy.class);
+    }
+
+    private static AdmissionPolicy bootCoordinator(String policyName)
+    {
+        Bootstrap app = new Bootstrap(new AdmissionPolicyModule(), ADMISSION_POLICY_MANAGER_BINDING);
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .quiet()
+                .setRequiredConfigurationProperties(ImmutableMap.of("query-manager.admission-policy.name", policyName))
+                .initialize();
+
+        return injector.getInstance(AdmissionPolicy.class);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/admission/TestAdmissionPolicyFactoryFailures.java
+++ b/core/trino-main/src/test/java/io/trino/execution/admission/TestAdmissionPolicyFactoryFailures.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Injector;
+import io.trino.spi.admission.AdmissionPolicy;
+import io.trino.spi.admission.AdmissionPolicyFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Coverage for factory failure modes: a factory that throws and a factory that
+ * returns null, plus duplicate-name detection.
+ */
+public class TestAdmissionPolicyFactoryFailures
+{
+    private static final String FAILING_FACTORY_NAME = "failing-factory";
+
+    @Test
+    public void throwingFactoryFailsStartupWithCausePreserved()
+    {
+        IllegalStateException root = new IllegalStateException("boom from the stub factory");
+        ThrowingFactory factory = new ThrowingFactory(root);
+
+        Throwable assertionTarget = catchInjectorError(FAILING_FACTORY_NAME, ImmutableList.of(factory));
+
+        assertThat(assertionTarget).isNotNull();
+        assertThat(messageChain(assertionTarget)).contains(FAILING_FACTORY_NAME);
+        assertThat(messageChain(assertionTarget)).contains(ThrowingFactory.class.getName());
+        assertThat(rootCauseChain(assertionTarget)).contains(root);
+    }
+
+    @Test
+    public void factoryReturningNullFailsStartupWithFactoryNameInMessage()
+    {
+        NullReturningFactory factory = new NullReturningFactory();
+
+        Throwable assertionTarget = catchInjectorError(FAILING_FACTORY_NAME, ImmutableList.of(factory));
+
+        assertThat(assertionTarget).isNotNull();
+        assertThat(messageChain(assertionTarget))
+                .contains(FAILING_FACTORY_NAME)
+                .contains(NullReturningFactory.class.getName())
+                .contains("returned null");
+    }
+
+    @Test
+    public void duplicateFactoryNameFailsStartup()
+    {
+        DuplicateFactoryA first = new DuplicateFactoryA();
+        DuplicateFactoryB second = new DuplicateFactoryB();
+        assertThat(first.getName()).isEqualTo(second.getName());
+
+        Throwable assertionTarget = catchInjectorError(first.getName(), ImmutableList.of(first, second));
+
+        assertThat(assertionTarget).isNotNull();
+        String chain = messageChain(assertionTarget);
+        assertThat(chain).contains(first.getName());
+        assertThat(chain).contains(DuplicateFactoryA.class.getName());
+        assertThat(chain).contains(DuplicateFactoryB.class.getName());
+    }
+
+    private static Throwable catchInjectorError(String configuredName, ImmutableList<AdmissionPolicyFactory> factories)
+    {
+        try {
+            Injector injector = TestAdmissionPolicyFactoryLoading.boot(configuredName, factories);
+            // If initialization completed without failure, force an instantiation
+            // to surface the provider error (defensive — initialize() should
+            // already have failed).
+            injector.getInstance(AdmissionPolicy.class);
+            return null;
+        }
+        catch (Throwable t) {
+            return t;
+        }
+    }
+
+    /**
+     * Walks {@code throwable.getCause()} and concatenates each level's message
+     * so callers can assert against the full failure chain in one go. Guice
+     * wraps user-thrown failures inside a {@code CreationException}, and the
+     * Trino factory wrapper adds another layer; both levels carry information
+     * the tests need to validate.
+     */
+    private static String messageChain(Throwable throwable)
+    {
+        StringBuilder builder = new StringBuilder();
+        for (Throwable t = throwable; t != null; t = t.getCause()) {
+            if (builder.length() > 0) {
+                builder.append('\n');
+            }
+            builder.append(t.getClass().getName());
+            String message = t.getMessage();
+            if (message != null) {
+                builder.append(": ").append(message);
+            }
+        }
+        return builder.toString();
+    }
+
+    private static List<Throwable> rootCauseChain(Throwable throwable)
+    {
+        List<Throwable> result = new ArrayList<>();
+        for (Throwable t = throwable; t != null; t = t.getCause()) {
+            result.add(t);
+        }
+        return result;
+    }
+
+    private static final class ThrowingFactory
+            implements AdmissionPolicyFactory
+    {
+        private final RuntimeException toThrow;
+
+        private ThrowingFactory(RuntimeException toThrow)
+        {
+            this.toThrow = toThrow;
+        }
+
+        @Override
+        public String getName()
+        {
+            return FAILING_FACTORY_NAME;
+        }
+
+        @Override
+        public AdmissionPolicy create(Map<String, String> config)
+        {
+            throw toThrow;
+        }
+    }
+
+    private static final class NullReturningFactory
+            implements AdmissionPolicyFactory
+    {
+        @Override
+        public String getName()
+        {
+            return FAILING_FACTORY_NAME;
+        }
+
+        @Override
+        public AdmissionPolicy create(Map<String, String> config)
+        {
+            return null;
+        }
+    }
+
+    private static final class DuplicateFactoryA
+            implements AdmissionPolicyFactory
+    {
+        @Override
+        public String getName()
+        {
+            return "duplicate-name";
+        }
+
+        @Override
+        public AdmissionPolicy create(Map<String, String> config)
+        {
+            throw new UnsupportedOperationException("uniqueness check should fail before this is invoked");
+        }
+    }
+
+    private static final class DuplicateFactoryB
+            implements AdmissionPolicyFactory
+    {
+        @Override
+        public String getName()
+        {
+            return "duplicate-name";
+        }
+
+        @Override
+        public AdmissionPolicy create(Map<String, String> config)
+        {
+            throw new UnsupportedOperationException("uniqueness check should fail before this is invoked");
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/admission/TestAdmissionPolicyFactoryLoading.java
+++ b/core/trino-main/src/test/java/io/trino/execution/admission/TestAdmissionPolicyFactoryLoading.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+import io.airlift.bootstrap.Bootstrap;
+import io.trino.spi.QueryId;
+import io.trino.spi.admission.AdmissionPolicy;
+import io.trino.spi.admission.AdmissionPolicyFactory;
+import io.trino.spi.admission.QueryAdmissionContext;
+import io.trino.spi.admission.WaitDecision;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Property-style coverage for plugin discovery and factory selection.
+ *
+ * <p>For a registered set of factories with random names, asserts:
+ * (a) for every {@code name ∈ registered}, setting
+ * {@code query-manager.admission-policy.name=name} resolves to that factory's policy;
+ * (b) for any {@code name ∉ registered}, startup fails with both the requested name and
+ * the registered set in the error message.
+ *
+ * <p>Test factories are contributed through a test module that adds them to the same
+ * {@code Multibinder<AdmissionPolicyFactory>} that {@link AdmissionPolicyModule} owns.
+ * That keeps factory registration synchronous with module installation, which is the
+ * shape Guice requires when the {@code AdmissionPolicy} provider is an eager
+ * {@code @Singleton} resolved during {@link Bootstrap#initialize()}.
+ */
+public class TestAdmissionPolicyFactoryLoading
+{
+    /**
+     * Number of factory generations exercised. Each iteration here boots one
+     * {@link AdmissionPolicyModule} per registered factory plus one for the
+     * unregistered-name case, so the effective Guice bootstrap count per
+     * iteration is up to {@code n + 1}. 30 iterations keeps wall-clock cost
+     * bounded while still covering 100+ distinct boot scenarios.
+     */
+    private static final int ITERATIONS = 30;
+
+    private static final long SEED = 0xA17_F1A6L;
+
+    private static Stream<List<String>> randomFactoryNameSets()
+    {
+        Random random = new Random(SEED);
+        List<List<String>> generated = new ArrayList<>();
+        for (int i = 0; i < ITERATIONS; i++) {
+            int n = 1 + random.nextInt(5); // 1..5 factories
+            ImmutableList.Builder<String> names = ImmutableList.builder();
+            int produced = 0;
+            int attempts = 0;
+            // De-duplicate within a single set to avoid exercising the duplicate-name
+            // failure path in the success cases.
+            List<String> seen = new ArrayList<>();
+            while (produced < n && attempts < 50) {
+                attempts++;
+                String candidate = randomName(random);
+                if (candidate.equals(MinWorkersAdmissionPolicy.NAME)) {
+                    continue;
+                }
+                if (seen.contains(candidate)) {
+                    continue;
+                }
+                seen.add(candidate);
+                names.add(candidate);
+                produced++;
+            }
+            generated.add(names.build());
+        }
+        return generated.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("randomFactoryNameSets")
+    public void registeredNameResolvesToCorrectFactory(List<String> names)
+    {
+        List<StubAdmissionPolicyFactory> factories = makeStubFactories(names);
+
+        for (StubAdmissionPolicyFactory factory : factories) {
+            Injector injector = boot(factory.getName(), factories);
+            AdmissionPolicy resolved = injector.getInstance(AdmissionPolicy.class);
+            WaitDecision decision = resolved.shouldQueryWait(sampleContext());
+            assertThat(decision).isInstanceOf(WaitDecision.Wait.class);
+            assertThat(decision.reason())
+                    .as("policy resolved for %s should be the matching stub", factory.getName())
+                    .isEqualTo(factory.expectedReason());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("randomFactoryNameSets")
+    public void unregisteredNameFailsStartup(List<String> names)
+    {
+        List<StubAdmissionPolicyFactory> factories = makeStubFactories(names);
+        String unregistered = unregisteredName(names);
+
+        assertThatThrownBy(() -> boot(unregistered, factories))
+                .hasMessageContaining(unregistered)
+                .hasMessageContaining(MinWorkersAdmissionPolicy.NAME);
+    }
+
+    @Test
+    public void defaultFactoryIsAlwaysAvailable()
+    {
+        Injector injector = boot(MinWorkersAdmissionPolicy.NAME, ImmutableList.of());
+        AdmissionPolicy policy = injector.getInstance(AdmissionPolicy.class);
+        assertThat(policy).isInstanceOf(MinWorkersAdmissionPolicy.class);
+    }
+
+    private static String randomName(Random random)
+    {
+        int length = 1 + random.nextInt(32);
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            int kind = random.nextInt(3);
+            char c;
+            if (kind == 0) {
+                c = (char) ('a' + random.nextInt(26));
+            }
+            else if (kind == 1) {
+                c = (char) ('A' + random.nextInt(26));
+            }
+            else {
+                c = (char) ('0' + random.nextInt(10));
+            }
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    private static String unregisteredName(List<String> names)
+    {
+        Random random = new Random(SEED ^ 0x77L);
+        for (int i = 0; i < 100; i++) {
+            String candidate = "missing-" + randomName(random);
+            if (!names.contains(candidate) && !candidate.equals(MinWorkersAdmissionPolicy.NAME)) {
+                return candidate;
+            }
+        }
+        // Falls through only on pathological random sequences; the loop bound is
+        // deliberately generous, so this is unreachable in practice.
+        throw new IllegalStateException("could not generate an unregistered name");
+    }
+
+    private static List<StubAdmissionPolicyFactory> makeStubFactories(List<String> names)
+    {
+        ImmutableList.Builder<StubAdmissionPolicyFactory> builder = ImmutableList.builder();
+        for (String name : names) {
+            builder.add(new StubAdmissionPolicyFactory(name));
+        }
+        return builder.build();
+    }
+
+    private static QueryAdmissionContext sampleContext()
+    {
+        return new QueryAdmissionContext(
+                new QueryId("test_query"),
+                "test_user",
+                Optional.empty(),
+                ImmutableMap.of());
+    }
+
+    /**
+     * Builds and initializes a Bootstrap injector wiring the production
+     * {@link AdmissionPolicyModule} plus a test module that contributes the
+     * supplied stub factories through the same multibinder.
+     */
+    static Injector boot(String configuredName, List<? extends AdmissionPolicyFactory> factories)
+    {
+        Module testModule = binder -> {
+            // ServerMainModule binds AdmissionPolicyManager server-wide in production;
+            // supply it here so AdmissionPolicyModule can be booted in isolation.
+            binder.bind(AdmissionPolicyManager.class).in(Scopes.SINGLETON);
+            Multibinder<AdmissionPolicyFactory> multibinder = Multibinder.newSetBinder(binder, AdmissionPolicyFactory.class);
+            for (AdmissionPolicyFactory factory : factories) {
+                multibinder.addBinding().toInstance(factory);
+            }
+        };
+
+        Bootstrap app = new Bootstrap(new AdmissionPolicyModule(), testModule);
+
+        return app
+                .doNotInitializeLogging()
+                .quiet()
+                .setRequiredConfigurationProperties(ImmutableMap.of("query-manager.admission-policy.name", configuredName))
+                .initialize();
+    }
+
+    /**
+     * Stub factory whose policy returns a {@link WaitDecision.Wait} carrying a
+     * reason string derived from the factory name. The reason is what the
+     * tests inspect to confirm the right factory was bound.
+     */
+    static final class StubAdmissionPolicyFactory
+            implements AdmissionPolicyFactory
+    {
+        private final String name;
+
+        StubAdmissionPolicyFactory(String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public String getName()
+        {
+            return name;
+        }
+
+        @Override
+        public AdmissionPolicy create(Map<String, String> config)
+        {
+            String reason = expectedReason();
+            return _ -> WaitDecision.Wait.forClusterCapacity(Duration.ZERO, reason);
+        }
+
+        String expectedReason()
+        {
+            return "stub:" + name;
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/admission/TestLocalDispatchQueryAdmissionPolicy.java
+++ b/core/trino-main/src/test/java/io/trino/execution/admission/TestLocalDispatchQueryAdmissionPolicy.java
@@ -1,0 +1,517 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.configuration.secrets.SecretsResolver;
+import io.airlift.node.NodeInfo;
+import io.airlift.units.Duration;
+import io.trino.connector.CatalogHandle;
+import io.trino.connector.ConnectorCatalogServiceProvider;
+import io.trino.connector.ConnectorServices;
+import io.trino.connector.ConnectorServicesProvider;
+import io.trino.cost.StatsAndCosts;
+import io.trino.dispatcher.LocalDispatchQuery;
+import io.trino.event.QueryMonitor;
+import io.trino.event.QueryMonitorConfig;
+import io.trino.eventlistener.EventListenerConfig;
+import io.trino.eventlistener.EventListenerManager;
+import io.trino.exchange.ExchangeMetricsCollector;
+import io.trino.execution.ClusterSizeMonitor;
+import io.trino.execution.DataDefinitionExecution;
+import io.trino.execution.DataDefinitionTask;
+import io.trino.execution.ExecutionFailureInfo;
+import io.trino.execution.QueryPreparer;
+import io.trino.execution.QueryState;
+import io.trino.execution.QueryStateMachine;
+import io.trino.execution.StagesInfo;
+import io.trino.execution.scheduler.NodeSchedulerConfig;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.FunctionManager;
+import io.trino.metadata.GlobalFunctionCatalog;
+import io.trino.metadata.LanguageFunctionProvider;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.SessionPropertyManager;
+import io.trino.node.InternalNodeManager;
+import io.trino.node.TestingInternalNodeManager;
+import io.trino.operator.OperatorStats;
+import io.trino.plugin.base.security.AllowAllSystemAccessControl;
+import io.trino.plugin.base.security.DefaultSystemAccessControl;
+import io.trino.security.AccessControlConfig;
+import io.trino.security.AccessControlManager;
+import io.trino.server.protocol.Slug;
+import io.trino.spi.NodeVersion;
+import io.trino.spi.admission.AdmissionPolicy;
+import io.trino.spi.admission.WaitDecision;
+import io.trino.spi.catalog.CatalogProperties;
+import io.trino.spi.resourcegroups.QueryType;
+import io.trino.spi.resourcegroups.ResourceGroupId;
+import io.trino.sql.tree.CreateTable;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.NodeLocation;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.Statement;
+import io.trino.transaction.TransactionManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.airlift.tracing.Tracing.noopTracer;
+import static io.opentelemetry.api.OpenTelemetry.noop;
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
+import static io.trino.metadata.TestingMetadataManager.createTestingMetadataManager;
+import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
+import static io.trino.sql.tree.SaveMode.FAIL;
+import static io.trino.testing.TestingEventListenerManager.emptyEventListenerManager;
+import static io.trino.transaction.InMemoryTransactionManager.createTestTransactionManager;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Variant-dispatch and failure-handling tests for the
+ * {@link LocalDispatchQuery} ↔ {@link AdmissionPolicy} integration.
+ *
+ * <p>Test framework choice: this file uses JUnit 5 {@code @ParameterizedTest}
+ * with {@code @MethodSource} rather than jqwik's {@code @Property}. jqwik is
+ * not currently a dependency of {@code core/trino-main}. The deterministic
+ * generators below cover the four variant cases ({@code ProceedNow},
+ * {@code Wait}, {@code throw}, {@code null}) across at least 100 cases
+ * combined, with reproducible seeded inputs.
+ */
+public class TestLocalDispatchQueryAdmissionPolicy
+{
+    private static final int CASES_PER_VARIANT = 25;
+
+    /**
+     * For {@code ProceedNow}: engine transitions to {@code DISPATCHING} and
+     * does NOT call {@code clusterSizeMonitor.waitForMinimumWorkers}.
+     */
+    @ParameterizedTest(name = "[{index}] ProceedNow reason={0}")
+    @MethodSource("proceedNowCases")
+    @DisplayName("ProceedNow → engine starts execution without invoking ClusterSizeMonitor")
+    public void testProceedNowSkipsClusterSizeMonitor(String reason)
+            throws InterruptedException
+    {
+        WaitDecision decision = new WaitDecision.ProceedNow(reason);
+        AdmissionPolicy policy = _ -> decision;
+
+        Fixture fixture = Fixture.create();
+        fixture.run(policy);
+
+        assertThat(fixture.clusterSizeMonitor.waitCallCount.get())
+                .as("ClusterSizeMonitor.waitForMinimumWorkers must not be called for ProceedNow")
+                .isZero();
+        assertThat(fixture.observedDispatching.get())
+                .as("query state machine must reach DISPATCHING for ProceedNow")
+                .isTrue();
+        assertThat(fixture.observedFailed.get())
+                .as("ProceedNow must not lead to FAILED")
+                .isFalse();
+    }
+
+    /**
+     * For {@code Wait.forClusterCapacity} (empty release condition): engine uses its built-in
+     * gate — {@code clusterSizeMonitor.waitForMinimumWorkers(...)} — and admits when workers
+     * become available.
+     */
+    @Test
+    @DisplayName("Wait.forClusterCapacity → engine waits via ClusterSizeMonitor and admits")
+    public void testForClusterCapacityUsesBuiltInGate()
+            throws InterruptedException
+    {
+        AdmissionPolicy policy = _ -> WaitDecision.Wait.forClusterCapacity(java.time.Duration.ofSeconds(30), "stub-cluster-capacity");
+
+        Fixture fixture = Fixture.create();
+        fixture.run(policy);
+
+        assertThat(fixture.clusterSizeMonitor.waitCallCount.get())
+                .as("built-in cluster-capacity gate must call waitForMinimumWorkers exactly once")
+                .isEqualTo(1);
+        assertThat(fixture.observedDispatching.get())
+                .as("query must be admitted once the built-in gate is satisfied")
+                .isTrue();
+    }
+
+    /**
+     * For {@code Wait.forCondition} whose future completes: engine awaits the policy-supplied
+     * future, admits the query, and never touches the built-in ClusterSizeMonitor gate.
+     */
+    @Test
+    @DisplayName("Wait.forCondition → engine awaits the policy future and admits on completion, without ClusterSizeMonitor")
+    public void testForConditionAdmitsWhenFutureCompletes()
+            throws InterruptedException
+    {
+        CompletableFuture<Void> condition = CompletableFuture.completedFuture(null);
+        AdmissionPolicy policy = _ -> WaitDecision.Wait.forCondition(condition, java.time.Duration.ofSeconds(30), "stub-condition");
+
+        Fixture fixture = Fixture.create();
+        fixture.run(policy);
+
+        assertThat(fixture.clusterSizeMonitor.waitCallCount.get())
+                .as("a policy-supplied release condition must not invoke the built-in ClusterSizeMonitor gate")
+                .isZero();
+        assertThat(fixture.observedDispatching.get())
+                .as("query must be admitted once the policy-supplied condition completes")
+                .isTrue();
+    }
+
+    /**
+     * For {@code Wait.forCondition} whose future never completes: engine fails the query with
+     * {@code GENERIC_INSUFFICIENT_RESOURCES} once {@code maxWait} elapses, without touching
+     * the built-in ClusterSizeMonitor gate.
+     */
+    @Test
+    @DisplayName("Wait.forCondition → engine fails with GENERIC_INSUFFICIENT_RESOURCES when maxWait elapses")
+    public void testForConditionFailsQueryOnTimeout()
+            throws InterruptedException
+    {
+        CompletableFuture<Void> neverCompletes = new CompletableFuture<>();
+        AdmissionPolicy policy = _ -> WaitDecision.Wait.forCondition(neverCompletes, java.time.Duration.ofMillis(100), "stub-condition-timeout");
+
+        Fixture fixture = Fixture.create();
+        fixture.run(policy);
+
+        assertThat(fixture.clusterSizeMonitor.waitCallCount.get()).isZero();
+        assertThat(fixture.queryStateMachine.getQueryState()).isEqualTo(QueryState.FAILED);
+        Optional<ExecutionFailureInfo> failureInfo = fixture.queryStateMachine.getFailureInfo();
+        assertThat(failureInfo).isPresent();
+        assertThat(failureInfo.get().errorCode())
+                .isEqualTo(GENERIC_INSUFFICIENT_RESOURCES.toErrorCode());
+    }
+
+    /**
+     * For an unchecked exception thrown by the policy: engine fails the query
+     * with {@code GENERIC_INSUFFICIENT_RESOURCES} and preserves the cause.
+     */
+    @ParameterizedTest(name = "[{index}] throw {0}")
+    @MethodSource("throwCases")
+    @DisplayName("throw → engine fails with GENERIC_INSUFFICIENT_RESOURCES and preserves cause")
+    public void testThrowFailsQueryWithCausePreserved(String marker)
+            throws InterruptedException
+    {
+        RuntimeException thrown = new RuntimeException("policy bug: " + marker);
+        AdmissionPolicy policy = _ -> {
+            throw thrown;
+        };
+
+        Fixture fixture = Fixture.create();
+        fixture.run(policy);
+
+        assertThat(fixture.clusterSizeMonitor.waitCallCount.get()).isZero();
+        assertThat(fixture.queryStateMachine.getQueryState()).isEqualTo(QueryState.FAILED);
+        Optional<ExecutionFailureInfo> failureInfo = fixture.queryStateMachine.getFailureInfo();
+        assertThat(failureInfo).isPresent();
+        assertThat(failureInfo.get().errorCode())
+                .isEqualTo(GENERIC_INSUFFICIENT_RESOURCES.toErrorCode());
+        // The TrinoException wraps the original; the original's message is preserved
+        // on the inner cause node of ExecutionFailureInfo.
+        ExecutionFailureInfo cause = failureInfo.get().cause();
+        assertThat(cause)
+                .as("the thrown RuntimeException must be preserved as the failure cause")
+                .isNotNull();
+        assertThat(cause.message()).contains("policy bug: " + marker);
+    }
+
+    /**
+     * For a {@code null} return: engine fails the query with
+     * {@code GENERIC_INSUFFICIENT_RESOURCES} and the message names "null decision".
+     */
+    @ParameterizedTest(name = "[{index}]")
+    @MethodSource("nullCases")
+    @DisplayName("null → engine fails with GENERIC_INSUFFICIENT_RESOURCES naming 'null decision'")
+    public void testNullDecisionFailsQuery(int seed)
+            throws InterruptedException
+    {
+        AdmissionPolicy policy = _ -> null;
+
+        Fixture fixture = Fixture.create();
+        fixture.run(policy);
+
+        assertThat(fixture.clusterSizeMonitor.waitCallCount.get()).isZero();
+        assertThat(fixture.queryStateMachine.getQueryState()).isEqualTo(QueryState.FAILED);
+        Optional<ExecutionFailureInfo> failureInfo = fixture.queryStateMachine.getFailureInfo();
+        assertThat(failureInfo).isPresent();
+        assertThat(failureInfo.get().errorCode())
+                .isEqualTo(GENERIC_INSUFFICIENT_RESOURCES.toErrorCode());
+        assertThat(failureInfo.get().message())
+                .as("null-decision failure message must name 'null decision'")
+                .contains("null decision");
+    }
+
+    static Stream<String> proceedNowCases()
+    {
+        Random random = new Random(0xC011BACEL);
+        ImmutableList.Builder<String> reasons = ImmutableList.builder();
+        reasons.add("admission-policy-spi-test/proceed");
+        for (int i = 0; i < CASES_PER_VARIANT - 1; i++) {
+            reasons.add("proceed/" + Integer.toHexString(random.nextInt()));
+        }
+        return reasons.build().stream();
+    }
+
+    static Stream<String> throwCases()
+    {
+        Random random = new Random(0xC011BACEL ^ 0x2L);
+        ImmutableList.Builder<String> markers = ImmutableList.builder();
+        for (int i = 0; i < CASES_PER_VARIANT; i++) {
+            markers.add(Integer.toHexString(random.nextInt()));
+        }
+        return markers.build().stream();
+    }
+
+    static Stream<Integer> nullCases()
+    {
+        ImmutableList.Builder<Integer> seeds = ImmutableList.builder();
+        for (int i = 0; i < CASES_PER_VARIANT; i++) {
+            seeds.add(i);
+        }
+        return seeds.build().stream();
+    }
+
+    /**
+     * Test fixture wiring a {@link LocalDispatchQuery} with a stub
+     * {@link ClusterSizeMonitor} that records invocations and an injected
+     * {@link AdmissionPolicy}. Mirrors the construction pattern in
+     * {@code TestLocalDispatchQuery}.
+     */
+    private static final class Fixture
+    {
+        final QueryStateMachine queryStateMachine;
+        final RecordingClusterSizeMonitor clusterSizeMonitor;
+        final AtomicBoolean observedDispatching = new AtomicBoolean();
+        final AtomicBoolean observedFailed = new AtomicBoolean();
+        final CountDownLatch terminalLatch = new CountDownLatch(1);
+        final QueryMonitor queryMonitor;
+        final DataDefinitionExecution<?> dataDefinitionExecution;
+        final Executor executor;
+
+        private Fixture(
+                QueryStateMachine queryStateMachine,
+                RecordingClusterSizeMonitor clusterSizeMonitor,
+                QueryMonitor queryMonitor,
+                DataDefinitionExecution<?> dataDefinitionExecution,
+                Executor executor)
+        {
+            this.queryStateMachine = queryStateMachine;
+            this.clusterSizeMonitor = clusterSizeMonitor;
+            this.queryMonitor = queryMonitor;
+            this.dataDefinitionExecution = dataDefinitionExecution;
+            this.executor = executor;
+
+            queryStateMachine.addStateChangeListener(state -> {
+                if (state == QueryState.DISPATCHING || state.ordinal() >= QueryState.PLANNING.ordinal()) {
+                    if (state != QueryState.FAILED) {
+                        observedDispatching.set(true);
+                    }
+                }
+                if (state == QueryState.FAILED) {
+                    observedFailed.set(true);
+                }
+                if (state.isDone() || state == QueryState.DISPATCHING || state.ordinal() >= QueryState.PLANNING.ordinal()) {
+                    terminalLatch.countDown();
+                }
+            });
+        }
+
+        static Fixture create()
+        {
+            Executor executor = newCachedThreadPool(daemonThreadsNamed("admission-policy-test-%s"));
+            Metadata metadata = createTestingMetadataManager();
+            TransactionManager transactionManager = createTestTransactionManager();
+            AccessControlManager accessControl = new AccessControlManager(
+                    NodeVersion.UNKNOWN,
+                    transactionManager,
+                    emptyEventListenerManager(),
+                    new AccessControlConfig(),
+                    noop(),
+                    new SecretsResolver(ImmutableMap.of()),
+                    DefaultSystemAccessControl.NAME);
+            accessControl.setSystemAccessControls(List.of(AllowAllSystemAccessControl.INSTANCE));
+
+            QueryStateMachine queryStateMachine = QueryStateMachine.begin(
+                    Optional.empty(),
+                    "sql",
+                    Optional.empty(),
+                    TEST_SESSION,
+                    URI.create("fake://fake-query"),
+                    new ResourceGroupId("test"),
+                    false,
+                    transactionManager,
+                    accessControl,
+                    executor,
+                    metadata,
+                    WarningCollector.NOOP,
+                    createPlanOptimizersStatsCollector(),
+                    new ExchangeMetricsCollector(ImmutableList::of, java.time.Duration.ofMillis(1)),
+                    Optional.of(QueryType.DATA_DEFINITION),
+                    true,
+                    Optional.empty(),
+                    new NodeVersion("test"));
+
+            QueryMonitor queryMonitor = new QueryMonitor(
+                    jsonCodec(StagesInfo.class),
+                    jsonCodec(OperatorStats.class),
+                    jsonCodec(ExecutionFailureInfo.class),
+                    jsonCodec(StatsAndCosts.class),
+                    new EventListenerManager(new EventListenerConfig(), new SecretsResolver(ImmutableMap.of()), noop(), noopTracer(), new NodeVersion("test")),
+                    new NodeInfo("node"),
+                    new NodeVersion("version"),
+                    new SessionPropertyManager(),
+                    metadata,
+                    new FunctionManager(
+                            new ConnectorCatalogServiceProvider<>("function provider", new NoConnectorServicesProvider(), ConnectorServices::getFunctionProvider),
+                            new GlobalFunctionCatalog(
+                                    () -> { throw new UnsupportedOperationException(); },
+                                    () -> { throw new UnsupportedOperationException(); },
+                                    () -> { throw new UnsupportedOperationException(); }),
+                            LanguageFunctionProvider.DISABLED),
+                    new QueryMonitorConfig());
+
+            CreateTable createTable = new CreateTable(new NodeLocation(1, 1), QualifiedName.of("table"), ImmutableList.of(), FAIL, ImmutableList.of(), Optional.empty());
+            QueryPreparer.PreparedQuery preparedQuery = new QueryPreparer.PreparedQuery(createTable, ImmutableList.of(), Optional.empty());
+            DataDefinitionExecution.DataDefinitionExecutionFactory dataDefinitionExecutionFactory =
+                    new DataDefinitionExecution.DataDefinitionExecutionFactory(
+                            ImmutableMap.<Class<? extends Statement>, DataDefinitionTask<?>>of(CreateTable.class, new SleepingCreateTableTask()));
+            DataDefinitionExecution<?> dataDefinitionExecution = dataDefinitionExecutionFactory.createQueryExecution(
+                    preparedQuery,
+                    queryStateMachine,
+                    Slug.createNew(),
+                    WarningCollector.NOOP,
+                    null);
+
+            RecordingClusterSizeMonitor clusterSizeMonitor = new RecordingClusterSizeMonitor(
+                    TestingInternalNodeManager.createDefault(),
+                    new NodeSchedulerConfig());
+
+            return new Fixture(queryStateMachine, clusterSizeMonitor, queryMonitor, dataDefinitionExecution, executor);
+        }
+
+        void run(AdmissionPolicy policy)
+                throws InterruptedException
+        {
+            LocalDispatchQuery localDispatchQuery = new LocalDispatchQuery(
+                    queryStateMachine,
+                    Futures.immediateFuture(dataDefinitionExecution),
+                    queryMonitor,
+                    clusterSizeMonitor,
+                    policy,
+                    executor,
+                    _ -> dataDefinitionExecution.start());
+            localDispatchQuery.startWaitingForResources();
+            // Wait for the dispatcher thread to observe the decision and either
+            // start execution, fail the query, or invoke the cluster-size monitor.
+            terminalLatch.await(30, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Stub {@link ClusterSizeMonitor} that records invocations of
+     * {@link #waitForMinimumWorkers(int, Duration)} and immediately satisfies
+     * the wait so the rest of the dispatcher pipeline runs to completion.
+     */
+    private static final class RecordingClusterSizeMonitor
+            extends ClusterSizeMonitor
+    {
+        final AtomicInteger waitCallCount = new AtomicInteger();
+
+        RecordingClusterSizeMonitor(InternalNodeManager nodeManager, NodeSchedulerConfig nodeSchedulerConfig)
+        {
+            super(nodeManager, nodeSchedulerConfig);
+        }
+
+        @Override
+        public synchronized ListenableFuture<Void> waitForMinimumWorkers(int executionMinCount, Duration executionMaxWait)
+        {
+            waitCallCount.incrementAndGet();
+            return immediateVoidFuture();
+        }
+    }
+
+    private static final class NoConnectorServicesProvider
+            implements ConnectorServicesProvider
+    {
+        @Override
+        public void loadInitialCatalogs() {}
+
+        @Override
+        public void ensureCatalogsLoaded(List<CatalogProperties> catalogs) {}
+
+        @Override
+        public PrunableState getPrunableState()
+        {
+            return PrunableState.empty();
+        }
+
+        @Override
+        public void pruneCatalogs(PrunableState prunableState, Set<CatalogHandle> catalogsInUse)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ConnectorServices getConnectorServices(CatalogHandle catalogHandle)
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class SleepingCreateTableTask
+            implements DataDefinitionTask<CreateTable>
+    {
+        @Override
+        public String getName()
+        {
+            return "test";
+        }
+
+        @Override
+        public ListenableFuture<Void> execute(
+                CreateTable statement,
+                QueryStateMachine stateMachine,
+                List<Expression> parameters,
+                WarningCollector warningCollector)
+        {
+            // Block briefly so the test can observe DISPATCHING / PLANNING before the
+            // query advances further. Short enough not to delay the suite materially.
+            try {
+                Thread.sleep(50L);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return immediateVoidFuture();
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/admission/TestMinWorkersAdmissionPolicy.java
+++ b/core/trino-main/src/test/java/io/trino/execution/admission/TestMinWorkersAdmissionPolicy.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.QueryId;
+import io.trino.spi.admission.AdmissionPolicy;
+import io.trino.spi.admission.AdmissionPolicyFactory;
+import io.trino.spi.admission.QueryAdmissionContext;
+import io.trino.spi.admission.WaitDecision;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the default OSS {@link MinWorkersAdmissionPolicy} returns a
+ * {@link WaitDecision.Wait} for any input context and ignores all
+ * {@link QueryAdmissionContext} fields.
+ */
+public class TestMinWorkersAdmissionPolicy
+{
+    private static final int RANDOMIZED_CASES = 100;
+
+    @Test
+    @DisplayName("Default policy returns Wait('wait for required workers') for any context")
+    public void testReturnsWaitDecisionWithExpectedReason()
+    {
+        MinWorkersAdmissionPolicy policy = new MinWorkersAdmissionPolicy();
+        QueryAdmissionContext context = new QueryAdmissionContext(
+                new QueryId("query_under_test"),
+                "alice",
+                Optional.of("global.user"),
+                ImmutableMap.of("required_workers_count", "4"));
+
+        WaitDecision decision = policy.shouldQueryWait(context);
+
+        assertThat(decision).isInstanceOf(WaitDecision.Wait.class);
+        WaitDecision.Wait wait = (WaitDecision.Wait) decision;
+        assertThat(wait.reason()).isEqualTo("wait for required workers");
+        // Built-in cluster-capacity gate: empty releaseCondition, and the engine applies its
+        // own configured timeout (the carried maxWait is an unused zero sentinel).
+        assertThat(wait.releaseCondition()).isEmpty();
+        assertThat(wait.maxWait().toMillis()).isEqualTo(0L);
+    }
+
+    /**
+     * Generates {@value #RANDOMIZED_CASES} pseudo-random {@link QueryAdmissionContext}
+     * values covering the field space (random user names, random session property
+     * maps, random resource group strings, randomly empty/non-empty resource group).
+     *
+     * <p>We use deterministic generators (seed-fixed) instead of adding
+     * {@code net.jqwik:jqwik} as a new dependency — jqwik is not currently used
+     * in {@code core/trino-main}. The 100-case generator below covers the input
+     * space intelligently (see {@code generateContext}).
+     */
+    @ParameterizedTest(name = "[{index}] context={0}")
+    @MethodSource("randomContexts")
+    @DisplayName("Default policy ignores QueryAdmissionContext fields")
+    public void testIgnoresAllContextFields(QueryAdmissionContext context)
+    {
+        MinWorkersAdmissionPolicy policy = new MinWorkersAdmissionPolicy();
+
+        WaitDecision decision = policy.shouldQueryWait(context);
+
+        assertThat(decision).isInstanceOf(WaitDecision.Wait.class);
+        WaitDecision.Wait wait = (WaitDecision.Wait) decision;
+        assertThat(wait.reason()).isEqualTo("wait for required workers");
+        assertThat(wait.maxWait().toMillis()).isGreaterThanOrEqualTo(0L);
+    }
+
+    static Stream<QueryAdmissionContext> randomContexts()
+    {
+        // Deterministic seed so failures are reproducible.
+        Random random = new Random(0xA110_1C_5EEDL);
+        List<QueryAdmissionContext> contexts = new ArrayList<>(RANDOMIZED_CASES);
+        for (int i = 0; i < RANDOMIZED_CASES; i++) {
+            contexts.add(generateContext(random, i));
+        }
+        return contexts.stream();
+    }
+
+    private static QueryAdmissionContext generateContext(Random random, int index)
+    {
+        QueryId queryId = new QueryId("query_" + Integer.toHexString(random.nextInt()).replace('-', '_'));
+        String userName = "user_" + Integer.toHexString(random.nextInt()).replace('-', '_');
+        Optional<String> resourceGroupId = (index % 5 == 0)
+                ? Optional.empty()
+                : Optional.of("rg_" + random.nextInt(1024) + "." + random.nextInt(64));
+
+        int propertyCount = random.nextInt(8);
+        ImmutableMap.Builder<String, String> sessionProperties = ImmutableMap.builder();
+        for (int i = 0; i < propertyCount; i++) {
+            sessionProperties.put(
+                    "prop_" + random.nextInt(64),
+                    "val_" + random.nextInt(1024));
+        }
+        return new QueryAdmissionContext(queryId, userName, resourceGroupId, sessionProperties.buildKeepingLast());
+    }
+
+    @Test
+    public void testReturnedWaitIsWellFormed()
+    {
+        MinWorkersAdmissionPolicy policy = new MinWorkersAdmissionPolicy();
+        QueryAdmissionContext context = new QueryAdmissionContext(
+                new QueryId("q"),
+                "u",
+                Optional.empty(),
+                Map.of());
+
+        WaitDecision decision = policy.shouldQueryWait(context);
+
+        assertThat(decision).isInstanceOf(WaitDecision.Wait.class);
+        WaitDecision.Wait wait = (WaitDecision.Wait) decision;
+        assertThat(wait.reason()).isNotNull();
+        assertThat(wait.reason().length()).isBetween(1, 256);
+        assertThat(wait.maxWait()).isNotNull();
+        assertThat(wait.maxWait().toMillis()).isGreaterThanOrEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("Feature: admission-policy-spi, MinWorkersAdmissionPolicy.NAME equals AdmissionPolicyConfig.DEFAULT_NAME ('min-workers')")
+    public void testNameConstantMatchesConfigDefault()
+    {
+        assertThat(MinWorkersAdmissionPolicy.NAME)
+                .as("MinWorkersAdmissionPolicy.NAME must equal AdmissionPolicyConfig.DEFAULT_NAME")
+                .isEqualTo(AdmissionPolicyConfig.DEFAULT_NAME)
+                .isEqualTo("min-workers");
+    }
+
+    @Test
+    @DisplayName("Feature: admission-policy-spi, MinWorkersAdmissionPolicy.Factory.getName() equals AdmissionPolicyConfig.DEFAULT_NAME")
+    public void testFactoryNameMatchesConfigDefault()
+    {
+        AdmissionPolicyFactory factory = new MinWorkersAdmissionPolicy.Factory();
+        assertThat(factory.getName())
+                .as("Factory.getName() must equal the configured default name")
+                .isEqualTo(AdmissionPolicyConfig.DEFAULT_NAME)
+                .isEqualTo("min-workers");
+    }
+
+    @ParameterizedTest(name = "[{index}] config={0}")
+    @MethodSource("factoryConfigs")
+    @DisplayName("Feature: admission-policy-spi, MinWorkersAdmissionPolicy.Factory.create(...) returns non-null and ignores the config map")
+    public void testFactoryCreateReturnsNonNullAndIgnoresConfig(Map<String, String> factoryConfig)
+    {
+        AdmissionPolicyFactory factory = new MinWorkersAdmissionPolicy.Factory();
+
+        AdmissionPolicy policy = factory.create(factoryConfig);
+
+        assertThat(policy)
+                .as("Factory.create(...) must return a non-null AdmissionPolicy regardless of the config map")
+                .isNotNull()
+                .isInstanceOf(MinWorkersAdmissionPolicy.class);
+
+        // Ignoring the config means the produced policy still emits the same Wait
+        // decision shape regardless of which properties were passed in.
+        QueryAdmissionContext context = new QueryAdmissionContext(
+                new QueryId("q"),
+                "u",
+                Optional.empty(),
+                Map.of());
+        WaitDecision decision = policy.shouldQueryWait(context);
+        assertThat(decision).isInstanceOf(WaitDecision.Wait.class);
+        assertThat(((WaitDecision.Wait) decision).reason()).isEqualTo("wait for required workers");
+    }
+
+    static Stream<Map<String, String>> factoryConfigs()
+    {
+        return Stream.of(
+                Map.of(),
+                Map.of("foo", "bar"),
+                Map.of("query-manager.admission-policy.name", "should-be-ignored"),
+                ImmutableMap.<String, String>builder()
+                        .put("a", "1")
+                        .put("b", "2")
+                        .put("c", "3")
+                        .buildOrThrow());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/admission/TestPickFriendlyDiff.java
+++ b/core/trino-main/src/test/java/io/trino/execution/admission/TestPickFriendlyDiff.java
@@ -1,0 +1,384 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.admission;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Static-check test that keeps the change to existing engine files small and reviewable.
+ *
+ * <p>Runs {@code git diff} against the merge base on {@code origin/master} and
+ * asserts:
+ * <ul>
+ *   <li>Four protected engine files have zero-line diffs.</li>
+ *   <li>{@code LocalDispatchQuery.java} diff matches the admission-integration
+ *       regex allowlist.</li>
+ *   <li>{@code CoordinatorModule.java} diff is exactly one
+ *       {@code install(new AdmissionPolicyModule())} line plus its import.</li>
+ *   <li>{@code Plugin.java} diff is exactly one default method matching
+ *       {@code default Iterable<AdmissionPolicyFactory> getAdmissionPolicyFactories()}.</li>
+ *   <li>Every newly added {@code .java} file under {@code src/main/} lives
+ *       under one of two allowed directory roots.</li>
+ * </ul>
+ *
+ * <p>Skipped via {@code assumeTrue} when {@code .git} is unavailable in CI.
+ */
+public class TestPickFriendlyDiff
+{
+    private static final List<String> PROTECTED_FILES = List.of(
+            "core/trino-main/src/main/java/io/trino/execution/ClusterSizeMonitor.java",
+            "core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java",
+            "core/trino-main/src/main/java/io/trino/SystemSessionProperties.java",
+            "core/trino-main/src/main/java/io/trino/memory/ClusterMemoryManager.java");
+
+    private static final String ALLOWED_SPI_PATH_PREFIX =
+            "core/trino-spi/src/main/java/io/trino/spi/admission/";
+    private static final String ALLOWED_MAIN_PATH_PREFIX =
+            "core/trino-main/src/main/java/io/trino/execution/admission/";
+
+    /**
+     * Regex matching the expected single-line addition in CoordinatorModule.java:
+     * whitespace followed by {@code binder.install(new AdmissionPolicyModule());}.
+     */
+    private static final Pattern COORDINATOR_MODULE_LINE_PATTERN =
+            Pattern.compile("\\s*(?:binder\\.)?install\\(new AdmissionPolicyModule\\(\\)\\);");
+
+    /**
+     * Regex matching the expected default method addition in Plugin.java.
+     */
+    private static final Pattern PLUGIN_DEFAULT_METHOD_PATTERN =
+            Pattern.compile("default Iterable<AdmissionPolicyFactory> getAdmissionPolicyFactories\\(\\)");
+
+    /**
+     * Regex allowlist for the LocalDispatchQuery.java diff — the call-site-swap
+     * replacing the unconditional {@code clusterSizeMonitor.waitForMinimumWorkers}
+     * with the admission policy invocation and switch dispatch.
+     */
+    private static final List<Pattern> LOCAL_DISPATCH_QUERY_ALLOWLIST = List.of(
+            // Import additions for admission types
+            Pattern.compile(".*import io\\.trino\\.spi\\.admission\\..*"),
+            // The admission policy field / injection
+            Pattern.compile(".*admissionPolicy.*"),
+            Pattern.compile(".*AdmissionPolicy.*"),
+            // The buildAdmissionContext helper method
+            Pattern.compile(".*buildAdmissionContext.*"),
+            Pattern.compile(".*QueryAdmissionContext.*"),
+            // The shouldQueryWait invocation
+            Pattern.compile(".*shouldQueryWait.*"),
+            // The WaitDecision switch and branches
+            Pattern.compile(".*WaitDecision.*"),
+            Pattern.compile(".*ProceedNow.*"),
+            Pattern.compile(".*Wait\\s+wait.*"),
+            // The insufficientResources helper
+            Pattern.compile(".*insufficientResources.*"),
+            // The instanceof check for default policy
+            Pattern.compile(".*instanceof MinWorkersAdmissionPolicy.*"),
+            // Decision variable
+            Pattern.compile(".*decision.*"),
+            // Blank/brace-only lines and comments
+            Pattern.compile("\\s*"),
+            Pattern.compile("\\s*[{}]\\s*"),
+            Pattern.compile("\\s*//.*"),
+            // The switch/case/arrow syntax lines
+            Pattern.compile(".*switch\\s*\\(.*"),
+            Pattern.compile(".*case\\s+.*->.*"),
+            // try/catch for policy invocation
+            Pattern.compile(".*try\\s*\\{.*"),
+            Pattern.compile(".*catch\\s*\\(Throwable.*"),
+            Pattern.compile(".*return;.*"),
+            // Timeout variable for Wait branch
+            Pattern.compile(".*Duration timeout.*"),
+            // getRequiredWorkersMaxWait reference
+            Pattern.compile(".*getRequiredWorkersMaxWait.*"),
+            // startExecution call (moved into switch branch)
+            Pattern.compile(".*startExecution.*"),
+            // Standard control flow elements
+            Pattern.compile(".*if\\s*\\(.*"),
+            Pattern.compile(".*transitionToFailed.*"),
+            // TrinoException / StandardErrorCode additions
+            Pattern.compile(".*TrinoException.*"),
+            Pattern.compile(".*StandardErrorCode.*"),
+            Pattern.compile(".*GENERIC_INSUFFICIENT_RESOURCES.*"),
+            // ctx variable
+            Pattern.compile(".*ctx.*"),
+            // minimum-worker future wiring carried into the Wait branch
+            Pattern.compile(".*minimumWorkerFuture.*"),
+            Pattern.compile(".*clusterSizeMonitor.*"),
+            Pattern.compile(".*stateMachine.*"),
+            // buildAdmissionContext reads session fields
+            Pattern.compile(".*session\\..*"),
+            // execution min-count local
+            Pattern.compile(".*minCount.*"),
+            // vendor release-condition path: await a policy-supplied CompletableFuture
+            Pattern.compile(".*releaseCondition.*"),
+            Pattern.compile(".*CompletableFuture.*"),
+            Pattern.compile(".*toListenableFuture.*"),
+            Pattern.compile(".*queryExecutor.*"),
+            Pattern.compile(".*gate.*"),
+            Pattern.compile(".*addSuccessCallback.*"),
+            Pattern.compile(".*addExceptionCallback.*"),
+            // closing lambda/braces such as "});"
+            Pattern.compile("\\s*[)}]+;?\\s*"));
+
+    private static Path repoRoot;
+
+    @BeforeAll
+    static void verifyGitAvailable()
+            throws Exception
+    {
+        // Skip the entire test class if .git is unavailable (e.g. in some CI envs)
+        Path currentDir = Path.of("").toAbsolutePath();
+        Path candidate = currentDir;
+        while (candidate != null) {
+            if (Files.isDirectory(candidate.resolve(".git"))) {
+                repoRoot = candidate;
+                break;
+            }
+            candidate = candidate.getParent();
+        }
+        assumeTrue(repoRoot != null, ".git directory not found; skipping pick-friendly diff check");
+
+        // Also verify git command is available
+        try {
+            Process process = new ProcessBuilder("git", "--version")
+                    .directory(repoRoot.toFile())
+                    .redirectErrorStream(true)
+                    .start();
+            int exitCode = process.waitFor();
+            assumeTrue(exitCode == 0, "git command not available; skipping pick-friendly diff check");
+        }
+        catch (IOException e) {
+            assumeTrue(false, "git command not available; skipping pick-friendly diff check");
+        }
+    }
+
+    @Test
+    @DisplayName("Protected engine files have zero-line diff against origin/master")
+    public void protectedFilesHaveZeroDiff()
+            throws Exception
+    {
+        String mergeBase = getMergeBase();
+
+        for (String protectedFile : PROTECTED_FILES) {
+            String diff = gitDiff(mergeBase, protectedFile);
+            assertThat(diff)
+                    .as("Protected file %s must have zero diff against origin/master", protectedFile)
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    @DisplayName("LocalDispatchQuery.java diff matches the admission-integration allowlist")
+    public void localDispatchQueryDiffMatchesAllowlist()
+            throws Exception
+    {
+        String mergeBase = getMergeBase();
+        String diff = gitDiff(mergeBase, "core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java");
+
+        if (diff.isEmpty()) {
+            // No changes to LocalDispatchQuery yet — acceptable if the feature hasn't been applied
+            return;
+        }
+
+        // Extract added/removed content lines (skip diff metadata lines starting with @@, ---, +++)
+        List<String> contentLines = diff.lines()
+                .filter(line -> (line.startsWith("+") || line.startsWith("-"))
+                        && !line.startsWith("+++")
+                        && !line.startsWith("---"))
+                .map(line -> line.substring(1)) // strip the leading +/-
+                .filter(line -> !line.isBlank()) // ignore blank lines
+                .toList();
+
+        for (String line : contentLines) {
+            boolean matched = LOCAL_DISPATCH_QUERY_ALLOWLIST.stream()
+                    .anyMatch(pattern -> pattern.matcher(line).matches());
+            assertThat(matched)
+                    .as("LocalDispatchQuery.java diff line not in allowlist: '%s'", line)
+                    .isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("CoordinatorModule.java diff is one install line plus its import")
+    public void coordinatorModuleDiffIsExactlyOneBinderInstallLine()
+            throws Exception
+    {
+        String mergeBase = getMergeBase();
+        String diff = gitDiff(mergeBase, "core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java");
+
+        if (diff.isEmpty()) {
+            // No changes yet — acceptable if the feature hasn't been applied
+            return;
+        }
+
+        // Extract only added lines (non-metadata). Installing the module requires a
+        // matching import, so the diff legitimately contains the AdmissionPolicyModule
+        // import plus exactly one install line.
+        List<String> addedLines = diff.lines()
+                .filter(line -> line.startsWith("+") && !line.startsWith("+++"))
+                .map(line -> line.substring(1))
+                .filter(line -> !line.isBlank())
+                .toList();
+
+        List<String> nonImportLines = addedLines.stream()
+                .filter(line -> !line.strip().startsWith("import "))
+                .toList();
+        List<String> importLines = addedLines.stream()
+                .filter(line -> line.strip().startsWith("import "))
+                .toList();
+
+        assertThat(importLines)
+                .as("CoordinatorModule.java should only add the AdmissionPolicyModule import, got: %s", importLines)
+                .allMatch(line -> line.contains("io.trino.execution.admission.AdmissionPolicyModule"));
+        assertThat(nonImportLines)
+                .as("CoordinatorModule.java should have exactly one non-blank, non-import added line")
+                .hasSize(1);
+        assertThat(COORDINATOR_MODULE_LINE_PATTERN.matcher(nonImportLines.getFirst()).matches())
+                .as("CoordinatorModule.java added line must match install(new AdmissionPolicyModule()); pattern, got: '%s'", nonImportLines.getFirst())
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("Plugin.java diff is exactly one default method")
+    public void pluginJavaDiffIsExactlyOneDefaultMethod()
+            throws Exception
+    {
+        String mergeBase = getMergeBase();
+        String diff = gitDiff(mergeBase, "core/trino-spi/src/main/java/io/trino/spi/Plugin.java");
+
+        if (diff.isEmpty()) {
+            // No changes yet — acceptable if the feature hasn't been applied
+            return;
+        }
+
+        // Extract added lines (non-metadata, non-blank)
+        List<String> addedLines = diff.lines()
+                .filter(line -> line.startsWith("+") && !line.startsWith("+++"))
+                .map(line -> line.substring(1))
+                .filter(line -> !line.isBlank())
+                .toList();
+
+        // The diff should contain the default method signature
+        boolean hasMethodSignature = addedLines.stream()
+                .anyMatch(line -> PLUGIN_DEFAULT_METHOD_PATTERN.matcher(line).find());
+        assertThat(hasMethodSignature)
+                .as("Plugin.java diff must contain the getAdmissionPolicyFactories() default method signature")
+                .isTrue();
+
+        // Verify it's a single method addition: look for exactly one method signature
+        long methodSignatureCount = addedLines.stream()
+                .filter(line -> line.contains("default ") && line.contains("("))
+                .count();
+        assertThat(methodSignatureCount)
+                .as("Plugin.java diff should contain exactly one default method addition")
+                .isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("All newly added .java files under src/main/ are in allowed directories")
+    public void newlyAddedFilesAreInAllowedDirectories()
+            throws Exception
+    {
+        String mergeBase = getMergeBase();
+
+        // List newly added files (status 'A' in diff)
+        List<String> addedFiles = gitDiffNameStatus(mergeBase);
+
+        List<String> newMainJavaFiles = addedFiles.stream()
+                .filter(file -> file.endsWith(".java"))
+                .filter(file -> file.contains("src/main/"))
+                .toList();
+
+        for (String file : newMainJavaFiles) {
+            boolean inAllowedDir = file.startsWith(ALLOWED_SPI_PATH_PREFIX)
+                    || file.startsWith(ALLOWED_MAIN_PATH_PREFIX);
+            assertThat(inAllowedDir)
+                    .as("Newly added file '%s' must be under '%s' or '%s'",
+                            file,
+                            ALLOWED_SPI_PATH_PREFIX,
+                            ALLOWED_MAIN_PATH_PREFIX)
+                    .isTrue();
+        }
+    }
+
+    // ---- Git helpers ----
+
+    private static String getMergeBase()
+            throws Exception
+    {
+        // Fetch origin/master if not already available (best effort, don't fail if remote is missing)
+        try {
+            runGit("fetch", "origin", "master");
+        }
+        catch (Exception _) {
+            // If fetch fails (e.g., offline), try with what's available locally
+        }
+
+        String mergeBase = runGit("merge-base", "HEAD", "origin/master").trim();
+        assumeTrue(!mergeBase.isBlank(), "Could not determine merge base with origin/master");
+        return mergeBase;
+    }
+
+    private static String gitDiff(String mergeBase, String filePath)
+            throws Exception
+    {
+        return runGit("diff", mergeBase, "--", filePath);
+    }
+
+    private static List<String> gitDiffNameStatus(String mergeBase)
+            throws Exception
+    {
+        String output = runGit("diff", "--name-status", "--diff-filter=A", mergeBase);
+        if (output.isBlank()) {
+            return List.of();
+        }
+        return output.lines()
+                .map(line -> {
+                    // Format: "A\tpath/to/file.java"
+                    String[] parts = line.split("\t", 2);
+                    return parts.length == 2 ? parts[1] : line;
+                })
+                .toList();
+    }
+
+    private static String runGit(String... args)
+            throws Exception
+    {
+        String[] command = Stream.concat(Stream.of("git", "-P"), Stream.of(args))
+                .toArray(String[]::new);
+        Process process = new ProcessBuilder(command)
+                .directory(repoRoot.toFile())
+                .redirectErrorStream(true)
+                .start();
+        String output = new String(process.getInputStream().readAllBytes(), UTF_8);
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new RuntimeException("git command failed (exit " + exitCode + "): " + String.join(" ", command) + "\n" + output);
+        }
+        return output;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/admission/TestStubPolicyOverride.java
+++ b/core/trino-main/src/test/java/io/trino/execution/admission/TestStubPolicyOverride.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.dispatcher;
+package io.trino.execution.admission;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -25,6 +25,7 @@ import io.trino.connector.ConnectorCatalogServiceProvider;
 import io.trino.connector.ConnectorServices;
 import io.trino.connector.ConnectorServicesProvider;
 import io.trino.cost.StatsAndCosts;
+import io.trino.dispatcher.LocalDispatchQuery;
 import io.trino.event.QueryMonitor;
 import io.trino.event.QueryMonitorConfig;
 import io.trino.eventlistener.EventListenerConfig;
@@ -65,6 +66,7 @@ import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Statement;
 import io.trino.transaction.TransactionManager;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
@@ -73,6 +75,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
@@ -88,16 +92,22 @@ import static io.trino.transaction.InMemoryTransactionManager.createTestTransact
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestLocalDispatchQuery
+/**
+ * Verifies that binding a stub {@link AdmissionPolicy} returning
+ * {@link WaitDecision.ProceedNow} causes queries to proceed without invoking
+ * {@link ClusterSizeMonitor#waitForMinimumWorkers(int, Duration)}.
+ */
+public class TestStubPolicyOverride
 {
-    private CountDownLatch countDownLatch;
-
     @Test
-    public void testSubmittedForDispatchedQuery()
+    @DisplayName("Stub policy override → ClusterSizeMonitor.waitForMinimumWorkers is never called")
+    public void testProceedNowSkipsWaitForMinimumWorkers()
             throws InterruptedException
     {
-        countDownLatch = new CountDownLatch(1);
-        Executor executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
+        // No-op stub policy: always proceeds.
+        AdmissionPolicy stubPolicy = _ -> new WaitDecision.ProceedNow("stub-proceed");
+
+        Executor executor = newCachedThreadPool(daemonThreadsNamed("admission-stub-test-%s"));
         Metadata metadata = createTestingMetadataManager();
         TransactionManager transactionManager = createTestTransactionManager();
         AccessControlManager accessControl = new AccessControlManager(
@@ -109,12 +119,13 @@ public class TestLocalDispatchQuery
                 new SecretsResolver(ImmutableMap.of()),
                 DefaultSystemAccessControl.NAME);
         accessControl.setSystemAccessControls(List.of(AllowAllSystemAccessControl.INSTANCE));
+
         QueryStateMachine queryStateMachine = QueryStateMachine.begin(
                 Optional.empty(),
                 "sql",
                 Optional.empty(),
                 TEST_SESSION,
-                URI.create("fake://fake-query"),
+                URI.create("fake://stub-policy-override"),
                 new ResourceGroupId("test"),
                 false,
                 transactionManager,
@@ -128,6 +139,7 @@ public class TestLocalDispatchQuery
                 true,
                 Optional.empty(),
                 new NodeVersion("test"));
+
         QueryMonitor queryMonitor = new QueryMonitor(
                 jsonCodec(StagesInfo.class),
                 jsonCodec(OperatorStats.class),
@@ -146,35 +158,76 @@ public class TestLocalDispatchQuery
                                 () -> { throw new UnsupportedOperationException(); }),
                         LanguageFunctionProvider.DISABLED),
                 new QueryMonitorConfig());
+
         CreateTable createTable = new CreateTable(new NodeLocation(1, 1), QualifiedName.of("table"), ImmutableList.of(), FAIL, ImmutableList.of(), Optional.empty());
         QueryPreparer.PreparedQuery preparedQuery = new QueryPreparer.PreparedQuery(createTable, ImmutableList.of(), Optional.empty());
-        DataDefinitionExecution.DataDefinitionExecutionFactory dataDefinitionExecutionFactory = new DataDefinitionExecution.DataDefinitionExecutionFactory(
-                ImmutableMap.<Class<? extends Statement>, DataDefinitionTask<?>>of(CreateTable.class, new TestCreateTableTask()));
-        DataDefinitionExecution dataDefinitionExecution = dataDefinitionExecutionFactory.createQueryExecution(
+        DataDefinitionExecution.DataDefinitionExecutionFactory dataDefinitionExecutionFactory =
+                new DataDefinitionExecution.DataDefinitionExecutionFactory(
+                        ImmutableMap.<Class<? extends Statement>, DataDefinitionTask<?>>of(CreateTable.class, new ImmediateCreateTableTask()));
+        DataDefinitionExecution<?> dataDefinitionExecution = dataDefinitionExecutionFactory.createQueryExecution(
                 preparedQuery,
                 queryStateMachine,
                 Slug.createNew(),
                 WarningCollector.NOOP,
                 null);
+
+        CountingClusterSizeMonitor clusterSizeMonitor = new CountingClusterSizeMonitor(
+                TestingInternalNodeManager.createDefault(),
+                new NodeSchedulerConfig());
+
+        CountDownLatch dispatchedLatch = new CountDownLatch(1);
+        queryStateMachine.addStateChangeListener(state -> {
+            if (state.ordinal() >= QueryState.DISPATCHING.ordinal()) {
+                dispatchedLatch.countDown();
+            }
+        });
+
         LocalDispatchQuery localDispatchQuery = new LocalDispatchQuery(
                 queryStateMachine,
                 Futures.immediateFuture(dataDefinitionExecution),
                 queryMonitor,
-                new TestClusterSizeMonitor(TestingInternalNodeManager.createDefault(), new NodeSchedulerConfig()),
-                (AdmissionPolicy) _ -> WaitDecision.Wait.forClusterCapacity(java.time.Duration.ZERO, "test"),
+                clusterSizeMonitor,
+                stubPolicy,
                 executor,
                 _ -> dataDefinitionExecution.start());
-        queryStateMachine.addStateChangeListener(state -> {
-            if (state.ordinal() >= QueryState.PLANNING.ordinal()) {
-                countDownLatch.countDown();
-            }
-        });
+
         localDispatchQuery.startWaitingForResources();
-        countDownLatch.await();
-        assertThat(localDispatchQuery.getDispatchInfo().getCoordinatorLocation()).isPresent();
+
+        boolean dispatched = dispatchedLatch.await(30, TimeUnit.SECONDS);
+        assertThat(dispatched)
+                .as("query must transition to DISPATCHING (or beyond) when the stub policy returns ProceedNow")
+                .isTrue();
+        assertThat(clusterSizeMonitor.waitCallCount.get())
+                .as("ClusterSizeMonitor.waitForMinimumWorkers must NOT be invoked when policy returns ProceedNow")
+                .isZero();
+        assertThat(queryStateMachine.getQueryState())
+                .as("query must not be FAILED")
+                .isNotEqualTo(QueryState.FAILED);
     }
 
-    private static class NoConnectorServicesProvider
+    /**
+     * Stub {@link ClusterSizeMonitor} that flags any invocation of
+     * {@link #waitForMinimumWorkers(int, Duration)}.
+     */
+    private static final class CountingClusterSizeMonitor
+            extends ClusterSizeMonitor
+    {
+        final AtomicInteger waitCallCount = new AtomicInteger();
+
+        CountingClusterSizeMonitor(InternalNodeManager nodeManager, NodeSchedulerConfig nodeSchedulerConfig)
+        {
+            super(nodeManager, nodeSchedulerConfig);
+        }
+
+        @Override
+        public synchronized ListenableFuture<Void> waitForMinimumWorkers(int executionMinCount, Duration executionMaxWait)
+        {
+            waitCallCount.incrementAndGet();
+            return immediateVoidFuture();
+        }
+    }
+
+    private static final class NoConnectorServicesProvider
             implements ConnectorServicesProvider
     {
         @Override
@@ -202,7 +255,7 @@ public class TestLocalDispatchQuery
         }
     }
 
-    private static class TestCreateTableTask
+    private static final class ImmediateCreateTableTask
             implements DataDefinitionTask<CreateTable>
     {
         @Override
@@ -217,29 +270,6 @@ public class TestLocalDispatchQuery
                 QueryStateMachine stateMachine,
                 List<Expression> parameters,
                 WarningCollector warningCollector)
-        {
-            while (true) {
-                try {
-                    Thread.sleep(10_000L);
-                }
-                catch (InterruptedException e) {
-                    break;
-                }
-            }
-            return null;
-        }
-    }
-
-    private static class TestClusterSizeMonitor
-            extends ClusterSizeMonitor
-    {
-        public TestClusterSizeMonitor(InternalNodeManager nodeManager, NodeSchedulerConfig nodeSchedulerConfig)
-        {
-            super(nodeManager, nodeSchedulerConfig);
-        }
-
-        @Override
-        public synchronized ListenableFuture<Void> waitForMinimumWorkers(int executionMinCount, Duration executionMaxWait)
         {
             return immediateVoidFuture();
         }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -156,6 +156,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <scope>test</scope>

--- a/core/trino-spi/src/main/java/io/trino/spi/Plugin.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Plugin.java
@@ -13,6 +13,7 @@
  */
 package io.trino.spi;
 
+import io.trino.spi.admission.AdmissionPolicyFactory;
 import io.trino.spi.block.BlockEncoding;
 import io.trino.spi.cache.BlobCacheManagerFactory;
 import io.trino.spi.catalog.CatalogStoreFactory;
@@ -38,6 +39,11 @@ import static java.util.Collections.emptySet;
 
 public interface Plugin
 {
+    default Iterable<AdmissionPolicyFactory> getAdmissionPolicyFactories()
+    {
+        return emptyList();
+    }
+
     default Iterable<CatalogStoreFactory> getCatalogStoreFactories()
     {
         return emptyList();

--- a/core/trino-spi/src/main/java/io/trino/spi/admission/AdmissionPolicy.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/admission/AdmissionPolicy.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.admission;
+
+/**
+ * Decides whether a query should wait for cluster capacity before dispatch.
+ *
+ * <p>Loaded via Trino's standard {@code Plugin} / {@code ServiceLoader} mechanism.
+ * The coordinator binds exactly one {@code AdmissionPolicy} per startup, selected
+ * by config key {@code query-manager.admission-policy.name}. The bound instance
+ * is retained for the lifetime of the coordinator process; runtime hot-swap is
+ * not supported.
+ *
+ * <p>Implementations MUST be safe for concurrent invocation from multiple threads
+ * without external synchronization. The engine may invoke
+ * {@link #shouldQueryWait(QueryAdmissionContext)} from any dispatcher thread.
+ *
+ * <p>Implementations MUST NOT block inside {@link #shouldQueryWait}. The method
+ * is expected to return promptly with a {@link WaitDecision}; any waiting is
+ * performed by the engine according to the returned decision.
+ */
+public interface AdmissionPolicy
+{
+    /**
+     * Decide whether the given query should wait, and for how long.
+     *
+     * <p>Called exactly once per query, at the moment the query enters
+     * {@code WAITING_FOR_RESOURCES}. The return value is acted on immediately by
+     * the engine; this method MUST NOT block.
+     *
+     * <p>Returning {@code null} or throwing any {@link Throwable} is treated as a
+     * policy failure: the engine fails the query with
+     * {@code GENERIC_INSUFFICIENT_RESOURCES}.
+     *
+     * @param query non-null context describing the query
+     * @return non-null decision; never {@code null}
+     */
+    WaitDecision shouldQueryWait(QueryAdmissionContext query);
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/admission/AdmissionPolicyFactory.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/admission/AdmissionPolicyFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.admission;
+
+import java.util.Map;
+
+/**
+ * Factory for {@link AdmissionPolicy}. Discovered via
+ * {@code io.trino.spi.Plugin.getAdmissionPolicyFactories()} and selected at
+ * coordinator startup by matching {@link #getName()} (case-sensitive) against
+ * the configured {@code query-manager.admission-policy.name}.
+ */
+public interface AdmissionPolicyFactory
+{
+    /**
+     * Stable name used by operators in
+     * {@code etc/config.properties:query-manager.admission-policy.name}.
+     * MUST be non-null, non-empty, and stable across releases of the plugin.
+     */
+    String getName();
+
+    /**
+     * Build an {@link AdmissionPolicy} from the operator-supplied properties map
+     * (parsed from {@code etc/admission-policy.properties}; an empty map is passed
+     * when the file is absent).
+     *
+     * <p>Returning {@code null} or throwing any {@link Throwable} is treated as a
+     * coordinator startup failure; the coordinator surfaces an error naming this
+     * factory and the underlying cause.
+     *
+     * @param config non-null property map, possibly empty
+     * @return non-null policy instance
+     */
+    AdmissionPolicy create(Map<String, String> config);
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/admission/QueryAdmissionContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/admission/QueryAdmissionContext.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.admission;
+
+import io.trino.spi.QueryId;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Engine-supplied query context handed to
+ * {@link AdmissionPolicy#shouldQueryWait(QueryAdmissionContext)}.
+ *
+ * <p>Intentionally narrow. Does NOT expose the engine's query execution, the
+ * session, the plan, or any coordinator-internal type. Vendor policies needing
+ * cluster-state signals (e.g. observed memory, plan-cost-derived thresholds)
+ * maintain their own observers; those observers are an implementation detail of
+ * the policy plugin, not part of the SPI surface.
+ *
+ * @param queryId non-null query identifier
+ * @param userName non-null submitting user name
+ * @param resourceGroupId optional resource group identifier (string form)
+ * @param sessionProperties immutable view of the session property map at the
+ *         moment of admission; never {@code null}
+ */
+public record QueryAdmissionContext(
+        QueryId queryId,
+        String userName,
+        Optional<String> resourceGroupId,
+        Map<String, String> sessionProperties) {}

--- a/core/trino-spi/src/main/java/io/trino/spi/admission/WaitDecision.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/admission/WaitDecision.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.admission;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Decision returned by {@link AdmissionPolicy#shouldQueryWait}.
+ *
+ * <p>Two terminal cases:
+ * <ul>
+ *   <li>{@link ProceedNow} — skip the gate; start execution immediately.</li>
+ *   <li>{@link Wait} — gate the query until its release condition is satisfied
+ *       or {@code maxWait} elapses, after which the engine fails the query with
+ *       {@code GENERIC_INSUFFICIENT_RESOURCES}.</li>
+ * </ul>
+ *
+ * <p>A {@link Wait} carries an optional {@code releaseCondition} future. When
+ * present, the engine admits the query once that future completes normally
+ * (and fails it if the future completes exceptionally or {@code maxWait}
+ * elapses). When empty, the engine applies its built-in cluster-capacity gate
+ * (wait for the minimum required workers) — this is the behavior used by the
+ * default {@code min-workers} policy. Custom policies that need to gate on a
+ * different signal (memory headroom, a concurrency slot, an external quota,
+ * ...) complete their own future and return it via {@link Wait#forCondition}.
+ *
+ * <p>Each variant exposes a non-null {@link #reason()} string of length
+ * {@code [1, 256]} intended for observability (logs, events, UI).
+ */
+public sealed interface WaitDecision
+        permits WaitDecision.ProceedNow, WaitDecision.Wait
+{
+    /**
+     * Human-readable reason. Non-null; length in {@code [1, 256]}.
+     */
+    String reason();
+
+    /**
+     * Skip the admission gate entirely.
+     */
+    record ProceedNow(String reason)
+            implements WaitDecision
+    {
+        public ProceedNow
+        {
+            validateReason(reason);
+        }
+    }
+
+    /**
+     * Gate the query until its release condition is satisfied or {@code maxWait}
+     * elapses.
+     *
+     * <p>Prefer the {@link #forClusterCapacity} and {@link #forCondition}
+     * factories over the canonical constructor.
+     *
+     * @param releaseCondition when present, the future the engine awaits before
+     *         admitting the query; when empty, the engine uses its built-in
+     *         cluster-capacity gate. Never {@code null}.
+     * @param maxWait non-null, non-negative upper bound on the wait. For the
+     *         built-in cluster-capacity gate the engine may apply its own
+     *         configured timeout instead.
+     * @param reason non-null reason string of length {@code [1, 256]}
+     */
+    record Wait(Optional<CompletableFuture<Void>> releaseCondition, Duration maxWait, String reason)
+            implements WaitDecision
+    {
+        public Wait
+        {
+            requireNonNull(releaseCondition, "releaseCondition is null");
+            requireNonNull(maxWait, "maxWait is null");
+            if (maxWait.isNegative()) {
+                throw new IllegalArgumentException("maxWait must be non-negative");
+            }
+            validateReason(reason);
+        }
+
+        /**
+         * Gate on the engine's built-in cluster-capacity condition (wait for the
+         * minimum required workers). Used by the default {@code min-workers}
+         * policy; available to any policy that wants today's behavior.
+         */
+        public static Wait forClusterCapacity(Duration maxWait, String reason)
+        {
+            return new Wait(Optional.empty(), maxWait, reason);
+        }
+
+        /**
+         * Gate on a policy-supplied condition. The engine admits the query when
+         * {@code releaseCondition} completes normally, and fails it if the future
+         * completes exceptionally or {@code maxWait} elapses first. The engine
+         * cancels the future if the query is cancelled or otherwise finishes.
+         */
+        public static Wait forCondition(CompletableFuture<Void> releaseCondition, Duration maxWait, String reason)
+        {
+            return new Wait(Optional.of(requireNonNull(releaseCondition, "releaseCondition is null")), maxWait, reason);
+        }
+    }
+
+    private static void validateReason(String reason)
+    {
+        requireNonNull(reason, "reason is null");
+        int length = reason.length();
+        if (length < 1 || length > 256) {
+            throw new IllegalArgumentException("reason length must be in [1, 256], got " + length);
+        }
+    }
+}

--- a/core/trino-spi/src/main/java/module-info.java
+++ b/core/trino-spi/src/main/java/module-info.java
@@ -20,6 +20,7 @@ module trino.spi {
     requires jdk.incubator.vector;
 
     exports io.trino.spi;
+    exports io.trino.spi.admission;
     exports io.trino.spi.block;
     exports io.trino.spi.catalog;
     exports io.trino.spi.cache;

--- a/core/trino-spi/src/test/java/io/trino/spi/admission/TestWaitDecisionConstruction.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/admission/TestWaitDecisionConstruction.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.admission;
+
+// Validates WaitDecision construction. We use junit-jupiter-params @ParameterizedTest with
+// @MethodSource to generate 100+ deterministic cases per branch (seeded java.util.Random for
+// reproducibility). The constructors accept iff (reason != null && reason.length() in [1, 256])
+// and, for Wait, additionally (releaseCondition != null && maxWait != null && !maxWait.isNegative());
+// other inputs throw IllegalArgumentException or NullPointerException. The two factories are also
+// checked: forClusterCapacity yields an empty releaseCondition; forCondition yields a present one.
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("WaitDecision construction validates input")
+final class TestWaitDecisionConstruction
+{
+    private static final long SEED = 0xA1D_F00DL; // deterministic across runs
+    private static final int VALID_REASON_CASES = 120;
+    private static final int INVALID_LENGTH_REASON_CASES = 120;
+    private static final int VALID_WAIT_CASES = 120;
+    private static final int INVALID_WAIT_DURATION_CASES = 60;
+
+    // ---------------- ProceedNow: valid reason accepted ----------------
+
+    static List<String> validReasons()
+    {
+        Random random = new Random(SEED);
+        List<String> values = new ArrayList<>(VALID_REASON_CASES);
+        // Cover boundaries explicitly.
+        values.add("a");                                // length 1 (lower bound)
+        values.add(repeatChar('x', 256));               // length 256 (upper bound)
+        values.add(repeatChar(' ', 1));                 // whitespace, length 1
+        values.add(repeatChar('Z', 128));               // mid-range
+        while (values.size() < VALID_REASON_CASES) {
+            int len = 1 + random.nextInt(256); // length in [1, 256]
+            values.add(randomString(random, len));
+        }
+        return values;
+    }
+
+    @ParameterizedTest(name = "ProceedNow accepts reason of length {0}")
+    @MethodSource("validReasons")
+    void proceedNowAcceptsValidReason(String reason)
+    {
+        WaitDecision.ProceedNow decision = new WaitDecision.ProceedNow(reason);
+        assertThat(decision.reason()).isEqualTo(reason);
+        assertThat(((WaitDecision) decision).reason()).isEqualTo(reason);
+    }
+
+    // ---------------- Wait: valid (reason, maxWait) accepted via both factories ----------------
+
+    static List<WaitArgs> validWaitArgs()
+    {
+        Random random = new Random(SEED ^ 0x55AAL);
+        List<WaitArgs> values = new ArrayList<>(VALID_WAIT_CASES);
+        // Boundary cases.
+        values.add(new WaitArgs(Duration.ZERO, "x"));
+        values.add(new WaitArgs(Duration.ofNanos(0), repeatChar('a', 256)));
+        values.add(new WaitArgs(Duration.ofNanos(1), "boundary-just-above-zero"));
+        values.add(new WaitArgs(Duration.ofMillis(1), repeatChar('b', 1)));
+        values.add(new WaitArgs(Duration.ofNanos((long) 1e15), "large-but-finite-ns"));
+        while (values.size() < VALID_WAIT_CASES) {
+            // Any non-negative java.time.Duration is a valid input; the Wait constructor
+            // rejects only null and negative durations. Generate non-negative magnitudes
+            // across a wide dynamic range.
+            int reasonLen = 1 + random.nextInt(256);
+            values.add(new WaitArgs(randomNonNegativeDuration(random), randomString(random, reasonLen)));
+        }
+        return values;
+    }
+
+    @ParameterizedTest(name = "Wait.forClusterCapacity accepts maxWait={0} reason length={1}")
+    @MethodSource("validWaitArgs")
+    void forClusterCapacityAcceptsValidArgsAndHasEmptyReleaseCondition(WaitArgs args)
+    {
+        WaitDecision.Wait decision = WaitDecision.Wait.forClusterCapacity(args.maxWait(), args.reason());
+        assertThat(decision.releaseCondition()).isEmpty();
+        assertThat(decision.maxWait()).isEqualTo(args.maxWait());
+        assertThat(decision.reason()).isEqualTo(args.reason());
+        assertThat(decision.maxWait().isNegative()).isFalse();
+        assertThat(((WaitDecision) decision).reason()).isEqualTo(args.reason());
+    }
+
+    @ParameterizedTest(name = "Wait.forCondition accepts maxWait={0} reason length={1}")
+    @MethodSource("validWaitArgs")
+    void forConditionAcceptsValidArgsAndHasPresentReleaseCondition(WaitArgs args)
+    {
+        CompletableFuture<Void> condition = new CompletableFuture<>();
+        WaitDecision.Wait decision = WaitDecision.Wait.forCondition(condition, args.maxWait(), args.reason());
+        assertThat(decision.releaseCondition()).containsSame(condition);
+        assertThat(decision.maxWait()).isEqualTo(args.maxWait());
+        assertThat(decision.reason()).isEqualTo(args.reason());
+    }
+
+    // ---------------- ProceedNow / Wait: null argument rejected ----------------
+
+    @Test
+    void proceedNowRejectsNullReason()
+    {
+        assertThatThrownBy(() -> new WaitDecision.ProceedNow(null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void waitRejectsNullReason()
+    {
+        assertThatThrownBy(() -> WaitDecision.Wait.forClusterCapacity(Duration.ZERO, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void waitRejectsNullMaxWait()
+    {
+        assertThatThrownBy(() -> WaitDecision.Wait.forClusterCapacity(null, "reason"))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void waitRejectsNullReleaseConditionOptional()
+    {
+        assertThatThrownBy(() -> new WaitDecision.Wait(null, Duration.ZERO, "reason"))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void forConditionRejectsNullFuture()
+    {
+        assertThatThrownBy(() -> WaitDecision.Wait.forCondition(null, Duration.ZERO, "reason"))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    // ---------------- ProceedNow / Wait: out-of-bounds reason length rejected ----------------
+
+    static List<String> invalidLengthReasons()
+    {
+        Random random = new Random(SEED ^ 0xC0FFEEL);
+        List<String> values = new ArrayList<>(INVALID_LENGTH_REASON_CASES);
+        // Boundaries: empty (length 0) and length 257 (one past upper bound).
+        values.add("");
+        values.add(repeatChar('a', 257));
+        values.add(repeatChar('z', 1024));
+        while (values.size() < INVALID_LENGTH_REASON_CASES) {
+            // Pick lengths outside [1, 256]: 0, or in (256, 4096].
+            boolean tooLong = random.nextBoolean();
+            int len = tooLong ? 257 + random.nextInt(4096 - 257 + 1) : 0;
+            values.add(randomString(random, len));
+        }
+        return values;
+    }
+
+    @ParameterizedTest(name = "ProceedNow rejects reason of length {0}")
+    @MethodSource("invalidLengthReasons")
+    void proceedNowRejectsInvalidLengthReason(String reason)
+    {
+        assertThatThrownBy(() -> new WaitDecision.ProceedNow(reason))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest(name = "Wait rejects reason of length {0}")
+    @MethodSource("invalidLengthReasons")
+    void waitRejectsInvalidLengthReason(String reason)
+    {
+        assertThatThrownBy(() -> WaitDecision.Wait.forClusterCapacity(Duration.ZERO, reason))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ---------------- Wait: negative maxWait rejected ----------------
+    //
+    // The contract under test is:
+    //   Wait accepts iff maxWait != null && !maxWait.isNegative().
+    // Unlike io.airlift.units.Duration, java.time.Duration permits negative values, so a
+    // negative Duration is a well-formed object that reaches the Wait constructor. The
+    // constructor's own negativity guard must reject it with IllegalArgumentException.
+
+    static List<Duration> invalidNegativeDurations()
+    {
+        Random random = new Random(SEED ^ 0xDEADBEEFL);
+        List<Duration> values = new ArrayList<>(INVALID_WAIT_DURATION_CASES);
+        values.add(Duration.ofMillis(-1));
+        values.add(Duration.ofNanos(-1));
+        values.add(Duration.ofSeconds(-1));
+        values.add(Duration.ofNanos(Long.MIN_VALUE));
+        while (values.size() < INVALID_WAIT_DURATION_CASES) {
+            // Strictly negative magnitudes only.
+            values.add(Duration.ofNanos(-(1 + (random.nextLong() >>> 1) % (long) 1e12)));
+        }
+        return values;
+    }
+
+    @ParameterizedTest(name = "Wait rejects negative maxWait {0}")
+    @MethodSource("invalidNegativeDurations")
+    void waitRejectsNegativeMaxWait(Duration negativeMaxWait)
+    {
+        assertThatThrownBy(() -> WaitDecision.Wait.forClusterCapacity(negativeMaxWait, "reason"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> WaitDecision.Wait.forCondition(new CompletableFuture<>(), negativeMaxWait, "reason"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ---------------- helpers ----------------
+
+    /**
+     * Args record for the Wait parameterized tests.
+     */
+    record WaitArgs(Duration maxWait, String reason)
+    {
+        @Override
+        public String toString()
+        {
+            return maxWait + ", len=" + reason.length();
+        }
+    }
+
+    private static String randomString(Random random, int length)
+    {
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            // Restrict to printable ASCII to keep failure messages readable.
+            sb.append((char) (32 + random.nextInt(95))); // [' ', '~']
+        }
+        return sb.toString();
+    }
+
+    private static String repeatChar(char c, int n)
+    {
+        char[] buf = new char[n];
+        Arrays.fill(buf, c);
+        return new String(buf);
+    }
+
+    private static Duration randomNonNegativeDuration(Random random)
+    {
+        // Produce a finite, non-negative duration with a wide dynamic range. Cap the
+        // magnitude well below Long.MAX_VALUE nanoseconds so toNanos()/toMillis() stay
+        // in range while still exercising non-trivial values.
+        double exponent = random.nextDouble() * 15.0; // 0..15 → up to 1e15 ns (~11.6 days)
+        long nanos = (long) (random.nextDouble() * Math.pow(10.0, exponent));
+        return Duration.ofNanos(nanos);
+    }
+}

--- a/docs/src/main/sphinx/develop.md
+++ b/docs/src/main/sphinx/develop.md
@@ -27,5 +27,6 @@ develop/certificate-authenticator
 develop/header-authenticator
 develop/group-provider
 develop/event-listener
+develop/admission-policy
 develop/client-protocol
 ```

--- a/docs/src/main/sphinx/develop/admission-policy.md
+++ b/docs/src/main/sphinx/develop/admission-policy.md
@@ -1,0 +1,275 @@
+# Admission policy
+
+Trino lets you plug in a custom admission policy that decides whether a query
+should wait for cluster capacity before dispatch. The engine invokes the bound
+policy exactly once per query, at the moment the query enters the
+`WAITING_FOR_RESOURCES` state, and acts on the returned decision.
+
+This SPI replaces the single hard-coded gate that previously called
+`ClusterSizeMonitor.waitForMinimumWorkers(...)`. Vanilla Trino installations
+keep that behavior — the default policy, named `min-workers`, wraps the
+existing wait so upgrading is a no-op for operators who do nothing.
+
+## SPI surface
+
+The admission SPI lives in the `io.trino.spi.admission` package of the
+`trino-spi` module. It is composed of four types: one decision interface, one
+factory interface, one engine-supplied context record, and one sealed return
+type with two variants.
+
+### `AdmissionPolicy`
+
+The decision interface declares one method. Implementations must be
+thread-safe and must not block.
+
+```java
+public interface AdmissionPolicy
+{
+    WaitDecision shouldQueryWait(QueryAdmissionContext query);
+}
+```
+
+Returning `null` or throwing any `Throwable` is treated as a policy failure;
+the engine fails the query with `GENERIC_INSUFFICIENT_RESOURCES` and preserves
+the thrown exception as the failure cause.
+
+### `AdmissionPolicyFactory`
+
+A factory exposes a stable name and builds policy instances from the
+operator-supplied properties map.
+
+```java
+public interface AdmissionPolicyFactory
+{
+    String getName();
+
+    AdmissionPolicy create(Map<String, String> config);
+}
+```
+
+The name is matched case-sensitively against the
+`query-manager.admission-policy.name` configuration key. Returning `null` or
+throwing from `create()` fails coordinator startup with an error naming the
+factory and the underlying cause.
+
+### `QueryAdmissionContext`
+
+The engine hands the policy a narrow record describing the query. It does not
+expose the session, the plan, or any coordinator-internal type — vendor
+policies that need cluster-state signals maintain their own observers.
+
+```java
+public record QueryAdmissionContext(
+        QueryId queryId,
+        String userName,
+        Optional<String> resourceGroupId,
+        Map<String, String> sessionProperties) {}
+```
+
+### `WaitDecision`
+
+The return type is a sealed interface with exactly two variants.
+
+```java
+public sealed interface WaitDecision
+        permits WaitDecision.ProceedNow, WaitDecision.Wait
+{
+    String reason();
+
+    record ProceedNow(String reason) implements WaitDecision { /* ... */ }
+
+    record Wait(Optional<CompletableFuture<Void>> releaseCondition, Duration maxWait, String reason)
+            implements WaitDecision
+    {
+        // gate on the engine's built-in cluster-capacity condition
+        static Wait forClusterCapacity(Duration maxWait, String reason) { /* ... */ }
+
+        // gate on a policy-supplied release condition
+        static Wait forCondition(CompletableFuture<Void> releaseCondition, Duration maxWait, String reason) { /* ... */ }
+    }
+}
+```
+
+`ProceedNow` skips the gate and starts the query immediately.
+
+`Wait` gates the query until its release condition is satisfied or `maxWait`
+elapses; if the timeout elapses first, the engine fails the query with
+`GENERIC_INSUFFICIENT_RESOURCES`. There are two ways to build a `Wait`:
+
+- `Wait.forClusterCapacity(maxWait, reason)` gates on the engine's built-in
+  cluster-capacity condition (wait for the minimum required workers). This is
+  what the default `min-workers` policy uses. The engine applies its own
+  configured wait timeout for this path.
+- `Wait.forCondition(releaseCondition, maxWait, reason)` gates on a
+  policy-supplied `CompletableFuture<Void>`. The engine admits the query when
+  the future completes normally, fails it if the future completes
+  exceptionally or `maxWait` elapses, and cancels the future if the query is
+  cancelled or otherwise finishes. Complete the future yourself when your
+  condition (memory headroom, a concurrency slot, an external quota, ...) is
+  met.
+
+Each variant carries a non-null `reason` string of length 1 to 256 for
+observability. The constructors validate their arguments: `releaseCondition`
+and `maxWait` must be non-null, `maxWait` must be non-negative, and `reason`
+must be non-null with length in `[1, 256]`.
+
+## Plugin discovery
+
+A plugin exposes its admission-policy factories by overriding the default
+method on `io.trino.spi.Plugin`:
+
+```java
+public interface Plugin
+{
+    default Iterable<AdmissionPolicyFactory> getAdmissionPolicyFactories()
+    {
+        return emptyList();
+    }
+    // ... other factory accessors
+}
+```
+
+The coordinator iterates this method on every loaded plugin and registers each
+factory. Two factories sharing a name (case-sensitive) is a startup error
+naming both source plugins.
+
+## Configuration
+
+Operators select the bound policy with a single configuration key in
+`etc/config.properties`:
+
+```text
+query-manager.admission-policy.name=min-workers
+```
+
+The default value is `min-workers`, the OSS implementation that preserves
+existing behavior. Setting the key to a value that does not match any
+registered factory is a startup error; the engine never silently falls back to
+the default.
+
+When the selected factory needs additional properties, place them in
+`etc/admission-policy.properties`:
+
+```text
+custom-property1=custom-value1
+custom-property2=custom-value2
+```
+
+The contents of the file are parsed into a `Map<String, String>` and passed to
+`AdmissionPolicyFactory.create()`. The file is optional — when absent, the
+factory receives an empty map. Vanilla operators do not need to create it.
+
+The bound policy is retained for the lifetime of the coordinator process;
+runtime hot-swap is not supported. Restart the coordinator to switch policies.
+
+## Worked example
+
+A minimal policy that admits every query immediately:
+
+```java
+package com.example.admission;
+
+import io.trino.spi.admission.AdmissionPolicy;
+import io.trino.spi.admission.QueryAdmissionContext;
+import io.trino.spi.admission.WaitDecision;
+
+public class AlwaysProceedPolicy
+        implements AdmissionPolicy
+{
+    @Override
+    public WaitDecision shouldQueryWait(QueryAdmissionContext query)
+    {
+        return new WaitDecision.ProceedNow("no admission gate configured");
+    }
+}
+```
+
+The factory exposes the policy by name:
+
+```java
+package com.example.admission;
+
+import io.trino.spi.admission.AdmissionPolicy;
+import io.trino.spi.admission.AdmissionPolicyFactory;
+
+import java.util.Map;
+
+public class AlwaysProceedPolicyFactory
+        implements AdmissionPolicyFactory
+{
+    @Override
+    public String getName()
+    {
+        return "always-proceed";
+    }
+
+    @Override
+    public AdmissionPolicy create(Map<String, String> config)
+    {
+        return new AlwaysProceedPolicy();
+    }
+}
+```
+
+The plugin returns the factory from `getAdmissionPolicyFactories()`:
+
+```java
+package com.example.admission;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Plugin;
+import io.trino.spi.admission.AdmissionPolicyFactory;
+
+public class AlwaysProceedPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<AdmissionPolicyFactory> getAdmissionPolicyFactories()
+    {
+        return ImmutableList.of(new AlwaysProceedPolicyFactory());
+    }
+}
+```
+
+After installing the plugin, the operator selects it in
+`etc/config.properties`:
+
+```text
+query-manager.admission-policy.name=always-proceed
+```
+
+No `etc/admission-policy.properties` file is required for this example. If the
+factory needed properties, the operator would create that file alongside
+`config.properties`.
+
+## Default policy
+
+The `min-workers` factory is bundled with the coordinator and is selected by
+default. Its policy returns `WaitDecision.Wait.forClusterCapacity(...)`, so the
+engine handles that decision exactly as today's
+`ClusterSizeMonitor.waitForMinimumWorkers(...)` call site did — applying the
+existing `query-manager.required-workers` and
+`query-manager.required-workers-max-wait` configuration keys without
+modification. Operators upgrading to a release that ships this SPI see no
+behavior change unless they explicitly bind a different policy.
+
+## Gating on a custom condition
+
+A policy that gates on its own signal returns
+`WaitDecision.Wait.forCondition(...)` with a future it completes when the query
+may proceed:
+
+```java
+@Override
+public WaitDecision shouldQueryWait(QueryAdmissionContext query)
+{
+    CompletableFuture<Void> ready = new CompletableFuture<>();
+    // Register the future with your own observer; complete it (or complete it
+    // exceptionally) when your admission condition is decided. Do not block here.
+    capacityObserver.whenCapacityAvailable(query.queryId(), ready);
+    return WaitDecision.Wait.forCondition(ready, Duration.ofMinutes(5), "waiting for vendor capacity signal");
+}
+```
+
+The `shouldQueryWait` method itself must return quickly and must not block; the
+waiting happens on the future the engine awaits.


### PR DESCRIPTION
## Description

Replace the hard-coded `ClusterSizeMonitor.waitForMinimumWorkers(...)` gate in
`LocalDispatchQuery` with a pluggable `AdmissionPolicy` SPI. Vendors can now
ship custom admission logic — including their own release condition — as a
Trino plugin without forking the engine.

The SPI lives in `io.trino.spi.admission` and declares one decision method:

```java
WaitDecision shouldQueryWait(QueryAdmissionContext query)
```

`WaitDecision` is a sealed interface with two variants:

- `ProceedNow` — skip the gate, start execution immediately
- `Wait` — gate the query until its release condition is met or `maxWait` elapses

A `Wait` is built with one of two factories:

- `Wait.forClusterCapacity(maxWait, reason)` — gate on the engine's built-in
  cluster-capacity condition (wait for the minimum required workers). This is
  what the default `min-workers` policy uses; behavior is preserved
  byte-for-byte.
- `Wait.forCondition(releaseCondition, maxWait, reason)` — gate on a
  policy-supplied `CompletableFuture<Void>`. The engine admits the query when
  the future completes, fails it (with `GENERIC_INSUFFICIENT_RESOURCES`) if the
  future fails or `maxWait` elapses, and cancels the future if the query is
  cancelled. This lets a vendor gate on memory headroom, a concurrency slot, an
  external quota, or any other signal.

Operators see no change unless they explicitly bind a different policy via
`query-manager.admission-policy.name`.

The SPI introduces **no new `trino-spi` dependency**: `WaitDecision` uses only
`java.time.Duration` and `java.util.concurrent.CompletableFuture` (both
`java.base`).

### Admission decision flow

```mermaid
flowchart TD
    A[LocalDispatchQuery starts query] --> B[buildAdmissionContext]
    B --> C["admissionPolicy.shouldQueryWait(context)"]
    C -->|throws or returns null| F["Fail query: GENERIC_INSUFFICIENT_RESOURCES (cause preserved)"]
    C --> D{WaitDecision}
    D -->|ProceedNow| G[startExecution]
    D -->|Wait| E{releaseCondition present?}
    E -->|"empty (built-in gate)"| H["clusterSizeMonitor.waitForMinimumWorkers(minCount, configured timeout)"]
    E -->|"present (vendor gate)"| I["await policy CompletableFuture, bounded by maxWait"]
    H -->|workers available| G
    H -->|timeout or error| F
    I -->|future completes| G
    I -->|maxWait elapses / future fails| F
    style I fill:#fff3cd,stroke:#d39e00,color:#000
```

A custom policy chooses its gating behavior entirely: `ProceedNow` to admit
immediately, `Wait.forClusterCapacity(...)` to reuse the built-in worker gate,
or `Wait.forCondition(...)` (highlighted) to await its own release condition.
The built-in worker gate stays in the engine because it needs the per-query
`executionMinCount`, which the policy does not have.

### Plugin discovery and wiring

Follows the existing Trino pattern (`getEventListenerFactories`,
`getAccessControlFactories`, etc.):

```mermaid
flowchart LR
    P["Plugin.getAdmissionPolicyFactories()"] --> PM[PluginManager]
    PM -->|"addAdmissionPolicyFactory (every node)"| MGR["AdmissionPolicyManager<br/>(registry, bound in ServerMainModule)"]
    DEF["MinWorkersAdmissionPolicy.Factory"] --> MB["Multibinder&lt;AdmissionPolicyFactory&gt;<br/>(AdmissionPolicyModule, coordinator)"]
    MGR --> PROV["@Provides AdmissionPolicy<br/>(AdmissionPolicyModule)"]
    MB --> PROV
    CFG["query-manager.admission-policy.name"] --> PROV
    PROV --> POL["Bound AdmissionPolicy singleton"]
```

1. Plugin implements `getAdmissionPolicyFactories()` returning factory instances
2. `PluginManager` registers them into `AdmissionPolicyManager` on every node
3. `AdmissionPolicyModule` (coordinator) merges the default-factory multibinder
   with the registered plugin factories, resolves the configured name, invokes
   the factory, and binds the resulting singleton `AdmissionPolicy`

`AdmissionPolicyManager` (the factory registry) is bound server-wide in
`ServerMainModule` because `PluginManager` populates it on both the coordinator
and workers. Policy selection and dispatch remain coordinator-only in
`AdmissionPolicyModule`.

### Engine-file diff

The change to existing engine files is kept small and reviewable:

- **Zero edits** to `ClusterSizeMonitor`, `QueryManagerConfig`,
  `SystemSessionProperties`, `ClusterMemoryManager`
- `LocalDispatchQuery` — the unconditional min-workers wait is replaced by
  admission dispatch: `ProceedNow`, the built-in cluster-capacity `Wait`
  (behavior unchanged), and the vendor release-condition `Wait`
- `CoordinatorModule` — one `install(new AdmissionPolicyModule())` line added (plus its import)
- `ServerMainModule` — one binding added for the server-wide `AdmissionPolicyManager` registry (plus its import)
- `Plugin.java` — one default method added (`getAdmissionPolicyFactories()`)
- `PluginManager.java` — one collection loop added (parallel to existing SPI dispatches)
- All new production code lives under `io.trino.spi.admission/` or
  `io.trino.execution.admission/`

### Failure semantics

- Policy throws or returns null → query fails with `GENERIC_INSUFFICIENT_RESOURCES`,
  cause preserved
- Vendor release condition fails or times out (`maxWait`) → query fails with
  `GENERIC_INSUFFICIENT_RESOURCES`
- Unknown policy name at startup → coordinator fails with a clear error naming
  the requested value and the registered set
- Duplicate factory names → startup failure naming both sources

## Additional context and related issues

Related to #29598.

It's a set of two independent PRs. The second (#29940) adds policy-agnostic JMX
gauges (`WaitingQueryCount`, `LongestWaitingQueryDurationSeconds`) with no
dependency on this PR.

The existing engine tests (`TestMinWorkerRequirement`, `TestClusterSizeMonitor`)
pass unmodified with the default policy bound. `TestLocalDispatchQuery` is
updated for the new `AdmissionPolicy` constructor parameter.

## Release notes

(x) Release notes are required, with the following suggested text:

### SPI
* Add a pluggable admission policy SPI (`io.trino.spi.admission.AdmissionPolicy`) that lets plugins decide whether a query should wait for cluster capacity before dispatch, including gating on a plugin-supplied release condition. The default `min-workers` policy preserves existing behavior. See {doc}`/develop/admission-policy`.
