### PR TITLE
Fix incorrect results from varchar equality pushdown on SQL Server and MySQL

### DIFF
--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -45,6 +45,7 @@ import io.trino.plugin.jdbc.LongWriteFunction;
 import io.trino.plugin.jdbc.ObjectReadFunction;
 import io.trino.plugin.jdbc.ObjectWriteFunction;
 import io.trino.plugin.jdbc.PredicatePushdownController;
+import io.trino.plugin.jdbc.PredicatePushdownController.DomainPushdownResult;
 import io.trino.plugin.jdbc.PreparedQuery;
 import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
@@ -268,6 +269,27 @@ public class MySqlClient
             return DISABLE_PUSHDOWN.apply(session, domain);
         }
         return FULL_PUSHDOWN.apply(session, simplifiedDomain);
+    };
+
+    private static final PredicatePushdownController MYSQL_VARCHAR_PUSHDOWN = (session, domain) -> {
+        // MySQL's legacy collations compare varchar with PAD SPACE semantics: trailing spaces are not significant, so a
+        // pushed equality or IN predicate can match values that differ only in trailing spaces, returning more rows than
+        // Trino's NO PAD comparison. Push equality / IN down only as a superset pre-filter and keep the engine filter to
+        // re-apply the exact comparison; disable inequality and range, which cannot be expressed as a safe superset.
+        if (domain.isOnlyNull()) {
+            return FULL_PUSHDOWN.apply(session, domain);
+        }
+
+        if (!domain.getValues().isDiscreteSet()) {
+            return DISABLE_PUSHDOWN.apply(session, domain);
+        }
+
+        Domain simplifiedDomain = domain.simplify(getDomainCompactionThreshold(session));
+        if (!simplifiedDomain.getValues().isDiscreteSet()) {
+            // Domain#simplify can turn a discrete set into a range predicate
+            return DISABLE_PUSHDOWN.apply(session, domain);
+        }
+        return new DomainPushdownResult(simplifiedDomain, domain);
     };
 
     @Inject
@@ -652,7 +674,7 @@ public class MySqlClient
     private static ColumnMapping mySqlVarcharColumnMapping(VarcharType varcharType, Optional<CaseSensitivity> caseSensitivity)
     {
         PredicatePushdownController pushdownController = caseSensitivity.orElse(CASE_INSENSITIVE) == CASE_SENSITIVE
-                ? MYSQL_CHARACTER_PUSHDOWN
+                ? MYSQL_VARCHAR_PUSHDOWN
                 : CASE_INSENSITIVE_CHARACTER_PUSHDOWN;
         return ColumnMapping.sliceMapping(varcharType, varcharReadFunction(varcharType), varcharWriteFunction(), pushdownController);
     }

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
@@ -479,6 +479,26 @@ public abstract class BaseMySqlConnectorTest
     }
 
     @Test
+    @Override
+    public void testVarcharEqualityPushdownIgnoresTrailingSpaces()
+    {
+        // Uses a case-sensitive legacy collation (latin1_general_cs): it is PAD SPACE and uses full predicate pushdown,
+        // so it exercises the re-check path. The default utf8mb4_0900_ai_ci collation is NO PAD and would not.
+        try (TestTable table = new TestTable(
+                onRemoteDatabase(),
+                "tpch.test_varchar_pad_space",
+                "(v varchar(5) CHARACTER SET latin1 COLLATE latin1_general_cs)",
+                List.of("'a'", "'a '"))) {
+            assertThat(query("SELECT v FROM " + table.getName() + " WHERE v = 'a'"))
+                    .skippingTypesCheck()
+                    .matches("VALUES 'a'");
+            assertThat(query("SELECT v FROM " + table.getName() + " WHERE v = 'a '"))
+                    .skippingTypesCheck()
+                    .matches("VALUES 'a '");
+        }
+    }
+
+    @Test
     public void testPredicatePushdown()
     {
         // varchar like
@@ -576,11 +596,11 @@ public abstract class BaseMySqlConnectorTest
 
         // varchar inequality
         assertThat(query(format("SELECT regionkey, nationkey, name FROM %s WHERE name != 'ROMANIA' AND name != 'ALGERIA'", objectName)))
-                .isFullyPushedDown();
+                .isNotFullyPushedDown(FilterNode.class);
 
         // varchar equality
         assertThat(query(format("SELECT regionkey, nationkey, name FROM %s WHERE name = 'ROMANIA'", objectName)))
-                .isFullyPushedDown();
+                .isNotFullyPushedDown(FilterNode.class);
 
         // varchar range
         assertThat(query(format("SELECT regionkey, nationkey, name FROM %s WHERE name BETWEEN 'POLAND' AND 'RPA'", objectName)))
@@ -590,7 +610,7 @@ public abstract class BaseMySqlConnectorTest
 
         // varchar NOT IN
         assertThat(query(format("SELECT regionkey, nationkey, name FROM %s WHERE name NOT IN ('POLAND', 'ROMANIA', 'VIETNAM')", objectName)))
-                .isFullyPushedDown();
+                .isNotFullyPushedDown(FilterNode.class);
 
         // varchar NOT IN with small compaction threshold
         assertThat(query(
@@ -613,7 +633,7 @@ public abstract class BaseMySqlConnectorTest
                 .matches("VALUES " +
                         "(BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(255))), " +
                         "(BIGINT '2', BIGINT '21', CAST('VIETNAM' AS varchar(255)))")
-                .isFullyPushedDown();
+                .isNotFullyPushedDown(FilterNode.class);
 
         // varchar IN with small compaction threshold
         assertThat(query(
@@ -636,7 +656,7 @@ public abstract class BaseMySqlConnectorTest
         // varchar different case
         assertThat(query(format("SELECT regionkey, nationkey, name FROM %s WHERE name = 'romania'", objectName)))
                 .returnsEmptyResult()
-                .isFullyPushedDown();
+                .isNotFullyPushedDown(FilterNode.class);
 
         Session joinPushdownEnabled = joinPushdownEnabled(getSession());
         // join on varchar columns

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -52,6 +52,7 @@ import io.trino.plugin.jdbc.LongWriteFunction;
 import io.trino.plugin.jdbc.ObjectReadFunction;
 import io.trino.plugin.jdbc.ObjectWriteFunction;
 import io.trino.plugin.jdbc.PredicatePushdownController;
+import io.trino.plugin.jdbc.PredicatePushdownController.DomainPushdownResult;
 import io.trino.plugin.jdbc.PreparedQuery;
 import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
@@ -272,6 +273,27 @@ public class SqlServerClient
             return DISABLE_PUSHDOWN.apply(session, domain);
         }
         return FULL_PUSHDOWN.apply(session, simplifiedDomain);
+    };
+
+    private static final PredicatePushdownController SQLSERVER_VARCHAR_PUSHDOWN = (session, domain) -> {
+        // SQL Server compares varchar with PAD SPACE semantics: trailing spaces are not significant, so a pushed
+        // equality or IN predicate can match values that differ only in trailing spaces, returning more rows than
+        // Trino's NO PAD comparison. Push equality / IN down only as a superset pre-filter and keep the engine filter
+        // to re-apply the exact comparison; disable inequality and range, which cannot be expressed as a safe superset.
+        if (domain.isOnlyNull()) {
+            return FULL_PUSHDOWN.apply(session, domain);
+        }
+
+        if (!domain.getValues().isDiscreteSet()) {
+            return DISABLE_PUSHDOWN.apply(session, domain);
+        }
+
+        Domain simplifiedDomain = domain.simplify(getDomainCompactionThreshold(session));
+        if (!simplifiedDomain.getValues().isDiscreteSet()) {
+            // Domain#simplify can turn a discrete set into a range predicate
+            return DISABLE_PUSHDOWN.apply(session, domain);
+        }
+        return new DomainPushdownResult(simplifiedDomain, domain);
     };
 
     // Dates prior to the Gregorian calendar switch in 1582 can cause incorrect results when pushed down,
@@ -1324,7 +1346,7 @@ public class SqlServerClient
                 varcharType,
                 varcharReadFunction(varcharType),
                 varcharWriteFunction(),
-                isCaseSensitive ? SQLSERVER_CHARACTER_PUSHDOWN : CASE_INSENSITIVE_CHARACTER_PUSHDOWN);
+                isCaseSensitive ? SQLSERVER_VARCHAR_PUSHDOWN : CASE_INSENSITIVE_CHARACTER_PUSHDOWN);
     }
 
     private ColumnMapping jsonColumnMapping()

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -34,6 +34,7 @@ import java.util.OptionalInt;
 import static io.trino.plugin.sqlserver.DataCompression.NONE;
 import static io.trino.plugin.sqlserver.DataCompression.PAGE;
 import static io.trino.plugin.sqlserver.DataCompression.ROW;
+import static io.trino.spi.connector.ConnectorMetadata.MODIFYING_ROWS_MESSAGE;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.testing.TestingNames.randomNameSuffix;
@@ -50,6 +51,9 @@ public abstract class BaseSqlServerConnectorTest
     {
         return switch (connectorBehavior) {
             case SUPPORTS_JOIN_PUSHDOWN -> true;
+            // Equality predicates over varchar are pushed only as a superset pre-filter (PAD SPACE), so this derived
+            // behavior is off; a column-to-column join is unaffected, so re-enable the join behavior it would cascade off.
+            case SUPPORTS_JOIN_PUSHDOWN_WITH_VARCHAR_EQUALITY -> true;
             case SUPPORTS_ADD_COLUMN_WITH_COMMENT,
                  SUPPORTS_ADD_COLUMN_WITH_POSITION,
                  SUPPORTS_AGGREGATION_PUSHDOWN_CORRELATION,
@@ -66,6 +70,9 @@ public abstract class BaseSqlServerConnectorTest
                  SUPPORTS_JOIN_PUSHDOWN_WITH_DISTINCT_FROM,
                  SUPPORTS_MAP_TYPE,
                  SUPPORTS_NEGATIVE_DATE,
+                 // varchar equality/inequality are pushed only as a superset pre-filter (or not at all) under SQL Server's
+                 // PAD SPACE comparison, with the exact predicate re-applied by the engine, so neither is fully pushed
+                 SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_EQUALITY,
                  SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY,
                  SUPPORTS_RENAME_SCHEMA,
                  SUPPORTS_RENAME_TABLE_ACROSS_SCHEMAS,
@@ -159,12 +166,12 @@ public abstract class BaseSqlServerConnectorTest
     {
         // varchar inequality
         assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE name != 'ROMANIA' AND name != 'ALGERIA'"))
-                .isFullyPushedDown();
+                .isNotFullyPushedDown(FilterNode.class);
 
         // varchar equality
         assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE name = 'ROMANIA'"))
                 .matches("VALUES (BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(25)))")
-                .isFullyPushedDown();
+                .isNotFullyPushedDown(FilterNode.class);
 
         // varchar range
         assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE name BETWEEN 'POLAND' AND 'RPA'"))
@@ -174,7 +181,7 @@ public abstract class BaseSqlServerConnectorTest
 
         // varchar NOT IN
         assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE name NOT IN ('POLAND', 'ROMANIA', 'VIETNAM')"))
-                .isFullyPushedDown();
+                .isNotFullyPushedDown(FilterNode.class);
 
         // varchar NOT IN with small compaction threshold
         assertThat(query(
@@ -197,7 +204,7 @@ public abstract class BaseSqlServerConnectorTest
                 .matches("VALUES " +
                         "(BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(25))), " +
                         "(BIGINT '2', BIGINT '21', CAST('VIETNAM' AS varchar(25)))")
-                .isFullyPushedDown();
+                .isNotFullyPushedDown(FilterNode.class);
 
         // varchar IN with small compaction threshold
         assertThat(query(
@@ -221,14 +228,16 @@ public abstract class BaseSqlServerConnectorTest
         // varchar different case
         assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE name = 'romania'"))
                 .returnsEmptyResult()
-                .isFullyPushedDown();
+                // SQL Server's varchar comparison is PAD SPACE, so equality is pushed only as a superset pre-filter
+                .isNotFullyPushedDown(FilterNode.class);
 
         // varchar predicate over join
         Session joinPushdownEnabled = joinPushdownEnabled(getSession());
         assertThat(query(joinPushdownEnabled, "SELECT c.name, n.name FROM customer c JOIN nation n ON c.custkey = n.nationkey WHERE n.name = 'POLAND'"))
-                .isFullyPushedDown();
+                // the varchar equality predicate leaves a residual filter that prevents full pushdown
+                .isNotFullyPushedDown(FilterNode.class);
 
-        // join on varchar columns
+        // join on varchar columns is unaffected: a column-to-column join is not pushed via the domain pushdown path
         assertThat(query(joinPushdownEnabled, "SELECT n.name, n2.regionkey FROM nation n JOIN nation n2 ON n.name = n2.name"))
                 .isFullyPushedDown();
 
@@ -372,12 +381,11 @@ public abstract class BaseSqlServerConnectorTest
     @Test
     public void testDeleteWithVarcharInequalityPredicate()
     {
-        // Override this because by enabling this flag SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY,
-        // we assume that we also support range pushdowns, but for now we only support 'not equal' pushdown,
-        // so cannot enable this flag for now
+        // SQL Server compares varchar with PAD SPACE semantics, so the inequality predicate cannot be pushed down as an
+        // exact filter. Without pushdown the delete falls back to a row-level merge, which this connector does not
+        // support, so the statement fails instead of deleting rows.
         try (TestTable table = newTrinoTable("test_delete_varchar", "(col varchar(1))", ImmutableList.of("'a'", "'A'", "null"))) {
-            assertUpdate("DELETE FROM " + table.getName() + " WHERE col != 'A'", 1);
-            assertQuery("SELECT * FROM " + table.getName(), "VALUES 'A', null");
+            assertQueryFails("DELETE FROM " + table.getName() + " WHERE col != 'A'", MODIFYING_ROWS_MESSAGE);
         }
     }
 
@@ -847,10 +855,9 @@ public abstract class BaseSqlServerConnectorTest
     @Override
     public void testConstantUpdateWithVarcharInequalityPredicates()
     {
-        // Sql Server supports push down predicate for not equal operator
+        // SQL Server no longer pushes down varchar inequality (PAD SPACE), so the update falls back to an unsupported row-level merge and fails
         try (TestTable table = newTrinoTable("test_update_varchar", "(col1 INT, col2 varchar(1))", ImmutableList.of("1, 'a'", "2, 'A'"))) {
-            assertUpdate("UPDATE " + table.getName() + " SET col1 = 20 WHERE col2 != 'A'", 1);
-            assertQuery("SELECT * FROM " + table.getName(), "VALUES (20, 'a'), (2, 'A')");
+            assertQueryFails("UPDATE " + table.getName() + " SET col1 = 20 WHERE col2 != 'A'", MODIFYING_ROWS_MESSAGE);
         }
     }
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -5433,6 +5433,23 @@ public abstract class BaseConnectorTest
     }
 
     @Test
+    public void testVarcharEqualityPushdownIgnoresTrailingSpaces()
+    {
+        skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE_WITH_DATA));
+
+        // Trino compares varchar with NO PAD, so 'a' and 'a ' are distinct; equality must return only the exact match
+        // even when pushed to a remote that compares with PAD SPACE.
+        try (TestTable table = newTrinoTable("test_varchar_pad_space", "(v varchar(5))", ImmutableList.of("'a'", "'a '"))) {
+            assertThat(query("SELECT v FROM " + table.getName() + " WHERE v = 'a'"))
+                    .skippingTypesCheck()
+                    .matches("VALUES 'a'");
+            assertThat(query("SELECT v FROM " + table.getName() + " WHERE v = 'a '"))
+                    .skippingTypesCheck()
+                    .matches("VALUES 'a '");
+        }
+    }
+
+    @Test
     public void testDeleteWithVarcharPredicate()
     {
         skipTestUnless(hasBehavior(SUPPORTS_DELETE));


### PR DESCRIPTION
## Description

SQL Server and MySQL compare `varchar` with **PAD SPACE** semantics: trailing spaces are not significant, so `'a' = 'a '` on the remote. Trino compares `varchar` with **NO PAD**, so `'a'` and `'a '` are distinct. When a `varchar` equality or `IN` predicate is pushed down as the only filter, the remote also matches rows that differ only in trailing spaces, so the query returns more rows than Trino's comparison would — the result depends on whether the predicate was pushed.

It reproduces on a plain `varchar` column:

- **SQL Server** — varchar `=` is PAD SPACE regardless of collation.
- **MySQL** — only on **case-sensitive PAD-SPACE collations** (e.g. `latin1_general_cs`, `utf8_bin`), which use full predicate pushdown. The default `utf8mb4_0900_ai_ci` is NO PAD and case-insensitive, so it is unaffected.

`char` is **not** affected: Trino stores `char` trim-normalized and the remotes compare `char` PAD SPACE, so the two agree — `char` equality stays fully pushed.

### Fix

Push `varchar` equality and `IN` predicates to these remotes only as a **superset pre-filter**: the remote narrows the scan and the engine re-applies the exact predicate. `varchar` inequality and range predicates are no longer pushed down, since they cannot be expressed as a safe superset under PAD SPACE. This mirrors the connectors' existing handling of case-insensitive remote collations.

One user-visible consequence: on SQL Server a `DELETE` or `UPDATE` with a `varchar` inequality predicate (e.g. `WHERE col <> 'x'`) previously executed via pushdown; with inequality no longer pushed it falls back to a row-level merge the connector does not support, so the statement now fails. Previously it could act on the wrong rows for values differing only in trailing spaces.

### Tests

Adds result-level regression tests (`testVarcharEqualityPushdownIgnoresTrailingSpaces`): a column holding `'a'` and `'a '`, queried with `WHERE v = 'a'`, expecting only `'a'`. They fail without the change (returning `'a'` and `'a '`) and pass with it; the MySQL test uses a `latin1_general_cs` column to exercise the affected path. The existing `testPredicatePushdownWithCollation` equality assertions move from `isFullyPushedDown()` to `isNotFullyPushedDown(...)` accordingly.

## Additional context and related issues

No existing tracking issue; the added regression tests reproduce the bug on current `master`.

## Release notes

```markdown
# SQL Server connector
* Fix incorrect results when filtering a `VARCHAR` column with an equality or `IN` predicate where stored values differ only in trailing spaces.
* A `DELETE` or `UPDATE` with a `VARCHAR` inequality predicate (for example `WHERE col <> 'x'`) now fails instead of executing, because the predicate is no longer pushed down and the connector does not support row-level modification.
# MySQL connector
* Fix incorrect results when filtering a `VARCHAR` column with an equality or `IN` predicate where stored values differ only in trailing spaces.
```
