### PR TITLE
Support implicit casts for nested character types on write

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -95,7 +95,6 @@ import io.trino.spi.security.GroupProvider;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.ViewExpression;
 import io.trino.spi.type.ArrayType;
-import io.trino.spi.type.CharType;
 import io.trino.spi.type.DateType;
 import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.spi.type.MapType;
@@ -104,7 +103,6 @@ import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeNotFoundException;
-import io.trino.spi.type.VarcharType;
 import io.trino.sql.InterpretedFunctionInvoker;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.analyzer.Analysis.CorrespondingAnalysis;
@@ -799,52 +797,16 @@ class StatementAnalyzer
                 return false;
             }
 
-            /*
-            TODO enable coercions based on type compatibility for INSERT of structural types containing nested bounded character types.
-            It might require defining a new range of cast operators and changes in GlobalFunctionCatalog to ensure proper handling
-            of nested types.
-            Currently, INSERT for such structural types is only allowed in the case of strict type coercibility.
-            INSERT for other types is allowed in all cases described by the Standard. It is obtained
-            by emulating a "guarded cast" in LogicalPlanner, and without any changes to the actual operators.
-            */
+            // A value is assignable to a column whenever the two types are compatible. The planner emulates a
+            // "guarded cast" (see LogicalPlanner#noTruncationCast) that fails rather than silently truncating
+            // non-space characters, recursing through array, map and row to reach nested character types.
             for (int i = 0; i < tableTypes.size(); i++) {
-                if (hasNestedBoundedCharacterType(tableTypes.get(i))) {
-                    if (!typeCoercion.canCoerce(queryTypes.get(i), tableTypes.get(i))) {
-                        return false;
-                    }
-                }
-                else if (!typeCoercion.isCompatible(queryTypes.get(i), tableTypes.get(i))) {
+                if (!typeCoercion.isCompatible(queryTypes.get(i), tableTypes.get(i))) {
                     return false;
                 }
             }
 
             return true;
-        }
-
-        private boolean hasNestedBoundedCharacterType(Type type)
-        {
-            if (type instanceof ArrayType arrayType) {
-                return hasBoundedCharacterType(arrayType.getElementType());
-            }
-
-            if (type instanceof MapType mapType) {
-                return hasBoundedCharacterType(mapType.getKeyType()) || hasBoundedCharacterType(mapType.getValueType());
-            }
-
-            if (type instanceof RowType rowType) {
-                for (Type fieldType : rowType.getFieldTypes()) {
-                    if (hasBoundedCharacterType(fieldType)) {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        private boolean hasBoundedCharacterType(Type type)
-        {
-            return type instanceof CharType || (type instanceof VarcharType varcharType && !varcharType.isUnbounded()) || hasNestedBoundedCharacterType(type);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -54,7 +54,11 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.statistics.TableStatisticsMetadata;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
+import io.trino.spi.type.FunctionType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import io.trino.sql.PlannerContext;
@@ -69,6 +73,9 @@ import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.Comparison;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.FieldReference;
+import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.Lambda;
 import io.trino.sql.ir.Row;
 import io.trino.sql.planner.StatisticsAggregationPlanner.TableStatisticAggregation;
 import io.trino.sql.planner.iterative.IterativeOptimizer;
@@ -543,7 +550,7 @@ public class LogicalPlanner
                 if (column.getDefaultValue().isPresent()) {
                     io.trino.sql.tree.Expression defaultExpression = defaultColumnValues.get(columnHandle);
                     expression = planBuilder.rewrite(defaultExpression);
-                    expression = noTruncationCast(metadata, expression, expression.type(), tableType);
+                    expression = noTruncationCast(metadata, symbolAllocator, expression, expression.type(), tableType);
                 }
                 else {
                     expression = new Constant(column.getType(), null);
@@ -637,7 +644,7 @@ public class LogicalPlanner
         if (queryType.equals(tableType)) {
             return fieldMapping.toSymbolReference();
         }
-        return noTruncationCast(metadata, fieldMapping.toSymbolReference(), queryType, tableType);
+        return noTruncationCast(metadata, symbolAllocator, fieldMapping.toSymbolReference(), queryType, tableType);
     }
 
     private Expression createNullNotAllowedFailExpression(String columnName, Type type)
@@ -815,11 +822,79 @@ public class LogicalPlanner
     TODO Once BINARY and parametric VARBINARY types are supported, they should be handled here.
     TODO This workaround is insufficient to handle structural types
      */
-    public static Expression noTruncationCast(Metadata metadata, Expression expression, Type fromType, Type toType)
+    /**
+     * Casts {@code expression} from {@code fromType} to {@code toType} for a write (INSERT, UPDATE, MERGE),
+     * failing rather than silently dropping non-space characters when a character value does not fit the target
+     * length. The check recurses through {@code array}, {@code map} and {@code row} so that character types nested
+     * inside structural types are guarded the same way as top-level character columns.
+     */
+    public static Expression noTruncationCast(Metadata metadata, SymbolAllocator symbolAllocator, Expression expression, Type fromType, Type toType)
     {
-        if (fromType instanceof UnknownType || (!(toType instanceof VarcharType) && !(toType instanceof CharType))) {
+        if (fromType.equals(toType) || fromType instanceof UnknownType || !containsBoundedCharacterType(toType)) {
+            // Nothing can be silently truncated, so an ordinary cast suffices.
             return new Cast(expression, toType);
         }
+
+        if (toType instanceof CharType || toType instanceof VarcharType) {
+            return characterNoTruncationCast(metadata, expression, fromType, toType);
+        }
+
+        if (fromType instanceof ArrayType fromArray && toType instanceof ArrayType toArray) {
+            Type fromElement = fromArray.getElementType();
+            Type toElement = toArray.getElementType();
+            Symbol element = symbolAllocator.newSymbol("element", fromElement);
+            Expression body = noTruncationCast(metadata, symbolAllocator, element.toSymbolReference(), fromElement, toElement);
+            // transform(array, element -> guarded cast of element)
+            return BuiltinFunctionCallBuilder.resolve(metadata)
+                    .setName("transform")
+                    .addArgument(fromType, expression)
+                    .addArgument(new FunctionType(ImmutableList.of(fromElement), toElement), new Lambda(ImmutableList.of(element), body))
+                    .build();
+        }
+
+        if (fromType instanceof MapType fromMap && toType instanceof MapType toMap) {
+            Expression result = expression;
+            if (!fromMap.getValueType().equals(toMap.getValueType())) {
+                MapType currentType = (MapType) result.type();
+                Symbol key = symbolAllocator.newSymbol("key", currentType.getKeyType());
+                Symbol value = symbolAllocator.newSymbol("value", currentType.getValueType());
+                Expression body = noTruncationCast(metadata, symbolAllocator, value.toSymbolReference(), currentType.getValueType(), toMap.getValueType());
+                result = BuiltinFunctionCallBuilder.resolve(metadata)
+                        .setName("transform_values")
+                        .addArgument(currentType, result)
+                        .addArgument(new FunctionType(ImmutableList.of(currentType.getKeyType(), currentType.getValueType()), toMap.getValueType()), new Lambda(ImmutableList.of(key, value), body))
+                        .build();
+            }
+            if (!fromMap.getKeyType().equals(toMap.getKeyType())) {
+                MapType currentType = (MapType) result.type();
+                Symbol key = symbolAllocator.newSymbol("key", currentType.getKeyType());
+                Symbol value = symbolAllocator.newSymbol("value", currentType.getValueType());
+                Expression body = noTruncationCast(metadata, symbolAllocator, key.toSymbolReference(), currentType.getKeyType(), toMap.getKeyType());
+                result = BuiltinFunctionCallBuilder.resolve(metadata)
+                        .setName("transform_keys")
+                        .addArgument(currentType, result)
+                        .addArgument(new FunctionType(ImmutableList.of(currentType.getKeyType(), currentType.getValueType()), toMap.getKeyType()), new Lambda(ImmutableList.of(key, value), body))
+                        .build();
+            }
+            return result;
+        }
+
+        if (fromType instanceof RowType fromRow && toType instanceof RowType toRow) {
+            List<Type> fromFields = fromRow.getTypeParameters();
+            List<Type> toFields = toRow.getTypeParameters();
+            ImmutableList.Builder<Expression> items = ImmutableList.builderWithExpectedSize(fromFields.size());
+            for (int i = 0; i < fromFields.size(); i++) {
+                items.add(noTruncationCast(metadata, symbolAllocator, new FieldReference(expression, i), fromFields.get(i), toFields.get(i)));
+            }
+            // Rebuild the row field by field, but keep a null row null rather than turning it into a row of nulls.
+            return ifExpression(new IsNull(expression), new Constant(toType, null), new Row(items.build(), toType));
+        }
+
+        return new Cast(expression, toType);
+    }
+
+    private static Expression characterNoTruncationCast(Metadata metadata, Expression expression, Type fromType, Type toType)
+    {
         int targetLength;
         if (toType instanceof VarcharType varcharType) {
             if (varcharType.isUnbounded()) {
@@ -851,6 +926,26 @@ public class LogicalPlanner
                                 fromType.getDisplayName(),
                                 toType.getDisplayName())),
                         toType));
+    }
+
+    private static boolean containsBoundedCharacterType(Type type)
+    {
+        if (type instanceof CharType) {
+            return true;
+        }
+        if (type instanceof VarcharType varcharType) {
+            return !varcharType.isUnbounded();
+        }
+        if (type instanceof ArrayType arrayType) {
+            return containsBoundedCharacterType(arrayType.getElementType());
+        }
+        if (type instanceof MapType mapType) {
+            return containsBoundedCharacterType(mapType.getKeyType()) || containsBoundedCharacterType(mapType.getValueType());
+        }
+        if (type instanceof RowType rowType) {
+            return rowType.getTypeParameters().stream().anyMatch(LogicalPlanner::containsBoundedCharacterType);
+        }
+        return false;
     }
 
     private RelationPlan createDeletePlan(Analysis analysis, Delete node)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -845,7 +845,7 @@ class QueryPlanner
                         if (defaultColumnValues.containsKey(dataColumnHandle)) {
                             io.trino.sql.tree.Expression defaultExpression = defaultColumnValues.get(dataColumnHandle);
                             expression = subPlan.rewrite(defaultExpression);
-                            expression = noTruncationCast(metadata, expression, expression.type(), columnSchema.getType());
+                            expression = noTruncationCast(metadata, symbolAllocator, expression, expression.type(), columnSchema.getType());
                         }
                         if (nonNullableColumnHandles.contains(dataColumnHandle)) {
                             String columnName = columnSchema.getName();

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -2470,9 +2470,8 @@ public class TestAnalyzer
         assertFails("INSERT INTO t8 (unbounded_varchar_column) VALUES (1)")
                 .hasErrorCode(TYPE_MISMATCH);
 
-        // coercion with potential loss is not allowed for nested bounded character string types
-        assertFails("INSERT INTO t8 (nested_bounded_varchar_column) VALUES (ROW(ROW(CAST('aa' AS varchar(10)))))")
-                .hasErrorCode(TYPE_MISMATCH);
+        // a value is assignable to a nested bounded character string type; truncation of non-space characters is checked at run time
+        analyze("INSERT INTO t8 (nested_bounded_varchar_column) VALUES (ROW(ROW(CAST('aa' AS varchar(10)))))");
     }
 
     @Test

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractDistributedEngineOnlyQueries.java
@@ -292,6 +292,46 @@ public abstract class AbstractDistributedEngineOnlyQueries
     }
 
     @Test
+    public void testInsertWithCoercionIntoNestedCharacterType()
+    {
+        String tableName = "test_insert_nested_char_coercion_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " (" +
+                "array_column array(char(3)), " +
+                "map_column map(char(3), char(3)), " +
+                "row_column row(field char(3)))");
+
+        // varchar values are assignable to character types nested in array, map and row, trimming/padding to the target length
+        assertUpdate("INSERT INTO " + tableName + " VALUES (" +
+                "ARRAY[VARCHAR 'aa     ', NULL], " +
+                "MAP(ARRAY[VARCHAR 'k'], ARRAY[VARCHAR 'v     ']), " +
+                "CAST(ROW(VARCHAR 'r') AS row(field varchar)))", 1);
+        // a null structural value stays null rather than becoming a structure of null fields
+        assertUpdate("INSERT INTO " + tableName + " VALUES (NULL, NULL, NULL)", 1);
+
+        assertThat(query("SELECT * FROM " + tableName))
+                .skippingTypesCheck()
+                .matches("VALUES " +
+                        "(ARRAY[CAST('aa' AS char(3)), NULL], MAP(ARRAY[CAST('k' AS char(3))], ARRAY[CAST('v' AS char(3))]), CAST(ROW('r') AS row(field char(3)))), " +
+                        "(NULL, NULL, NULL)");
+
+        // the no-truncation guard recurses into character types nested in array, map and row, covering every branch:
+        // the array element, the map value (transform_values), the map key (transform_keys) and the row field
+        assertQueryFails("INSERT INTO " + tableName + " (array_column) VALUES (ARRAY['abcd'])",
+                "\\QCannot truncate non-space characters when casting from varchar(4) to char(3) on INSERT");
+        assertQueryFails("INSERT INTO " + tableName + " (map_column) VALUES (MAP(ARRAY['k'], ARRAY['abcd']))",
+                "\\QCannot truncate non-space characters when casting from varchar(4) to char(3) on INSERT");
+        assertQueryFails("INSERT INTO " + tableName + " (map_column) VALUES (MAP(ARRAY['abcd'], ARRAY['k']))",
+                "\\QCannot truncate non-space characters when casting from varchar(4) to char(3) on INSERT");
+        // the row field is exercised via a full-table INSERT: a single-column VALUES of a one-field row would flatten to
+        // the field type, so the other (non-truncating) columns are supplied to keep the row value a row
+        assertQueryFails("INSERT INTO " + tableName + " VALUES (ARRAY[VARCHAR 'a'], MAP(ARRAY[VARCHAR 'k'], ARRAY[VARCHAR 'v']), CAST(ROW('abcd') AS row(field varchar(4))))",
+                "\\QCannot truncate non-space characters when casting from varchar(4) to char(3) on INSERT");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
     public void testCreateTableAsTable()
     {
         // Ensure CTA works when the table exposes hidden fields


### PR DESCRIPTION
## Description

`INSERT`, `UPDATE` and `MERGE` allowed assigning a value to a column of a bounded character type only when the source type was strictly coercible to the target. For top-level character columns the analyzer instead relied on type compatibility, and the planner synthesized a guarded cast that fails rather than silently truncating non-space characters. Nested character types (inside `ARRAY`, `MAP` and `ROW`) had no such guarded cast, so they were restricted to strict coercibility and an otherwise-valid assignment was rejected.

Make the guarded cast recurse through `ARRAY`, `MAP` and `ROW` so that a value can be assigned to a column whenever the types are compatible, applying the no-truncation check at every character leaf.

## Additional context and related issues

Brings nested character store assignment in line with top-level columns; no behavior change for non-character or already-coercible types.

## Release notes

```markdown
# General
* Allow `INSERT`, `UPDATE` and `MERGE` to assign values to columns containing character types nested in `ARRAY`, `MAP` or `ROW` whenever the value is assignable to the column type, consistent with top-level character columns.
```
