### PR TITLE
Mark most cassandra CQLs idempotent

### DIFF
--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraRecordCursor.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraRecordCursor.java
@@ -15,6 +15,7 @@ package io.trino.plugin.cassandra;
 
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.Statement;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.trino.plugin.cassandra.CassandraType.Kind;
@@ -42,13 +43,18 @@ public class CassandraRecordCursor
     private final ResultSet rs;
     private Row currentRow;
 
-    public CassandraRecordCursor(CassandraSession cassandraSession, CassandraTypeManager cassandraTypeManager, List<String> columnNames, List<CassandraType> cassandraTypes, String cql)
+    public CassandraRecordCursor(
+            CassandraSession cassandraSession,
+            CassandraTypeManager cassandraTypeManager,
+            List<String> columnNames,
+            List<CassandraType> cassandraTypes,
+            Statement<?> statement)
     {
         this.columnNames = ImmutableList.copyOf(requireNonNull(columnNames, "columnNames is null"));
         this.cassandraTypes = cassandraTypes;
         checkArgument(columnNames.size() == cassandraTypes.size(), "columnNames and cassandraTypes sizes don't match");
         this.cassandraTypeManager = cassandraTypeManager;
-        rs = cassandraSession.execute(cql);
+        rs = cassandraSession.execute(statement);
         currentRow = null;
     }
 

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraRecordSet.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraRecordSet.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.cassandra;
 
+import com.datastax.oss.driver.api.core.cql.Statement;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.RecordSet;
 import io.trino.spi.type.Type;
@@ -28,16 +29,17 @@ public class CassandraRecordSet
 {
     private final CassandraSession cassandraSession;
     private final CassandraTypeManager cassandraTypeManager;
-    private final String cql;
+    private final Statement<?> statement;
+
     private final List<String> cassandraNames;
     private final List<CassandraType> cassandraTypes;
     private final List<Type> columnTypes;
 
-    public CassandraRecordSet(CassandraSession cassandraSession, CassandraTypeManager cassandraTypeManager, String cql, List<CassandraColumnHandle> cassandraColumns)
+    public CassandraRecordSet(CassandraSession cassandraSession, CassandraTypeManager cassandraTypeManager, Statement<?> statement, List<CassandraColumnHandle> cassandraColumns)
     {
         this.cassandraSession = requireNonNull(cassandraSession, "cassandraSession is null");
         this.cassandraTypeManager = requireNonNull(cassandraTypeManager, "cassandraTypeManager is null");
-        this.cql = requireNonNull(cql, "cql is null");
+        this.statement = requireNonNull(statement, "statement is null");
 
         requireNonNull(cassandraColumns, "cassandraColumns is null");
         this.cassandraNames = transformList(cassandraColumns, CassandraColumnHandle::name);
@@ -54,7 +56,7 @@ public class CassandraRecordSet
     @Override
     public RecordCursor cursor()
     {
-        return new CassandraRecordCursor(cassandraSession, cassandraTypeManager, cassandraNames, cassandraTypes, cql);
+        return new CassandraRecordCursor(cassandraSession, cassandraTypeManager, cassandraNames, cassandraTypes, statement);
     }
 
     private static <T, R> List<R> transformList(List<T> list, Function<T, R> function)

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraRecordSetProvider.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraRecordSetProvider.java
@@ -13,8 +13,8 @@
  */
 package io.trino.plugin.cassandra;
 
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.google.inject.Inject;
-import io.airlift.log.Logger;
 import io.trino.plugin.cassandra.util.CassandraCqlUtils;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorRecordSetProvider;
@@ -32,8 +32,6 @@ import static java.util.stream.Collectors.toList;
 public class CassandraRecordSetProvider
         implements ConnectorRecordSetProvider
 {
-    private static final Logger log = Logger.get(CassandraRecordSetProvider.class);
-
     private final CassandraSession cassandraSession;
     private final CassandraTypeManager cassandraTypeManager;
 
@@ -55,18 +53,19 @@ public class CassandraRecordSetProvider
                 .collect(toList());
 
         if (cassandraTable.relationHandle() instanceof CassandraQueryRelationHandle queryRelationHandle) {
-            return new CassandraRecordSet(cassandraSession, cassandraTypeManager, queryRelationHandle.getQuery(), cassandraColumns);
+            return new CassandraRecordSet(
+                    cassandraSession,
+                    cassandraTypeManager,
+                    SimpleStatement.newInstance(queryRelationHandle.getQuery()),
+                    cassandraColumns);
         }
-
-        String selectCql = CassandraCqlUtils.selectFrom(cassandraTable.getRequiredNamedRelation(), cassandraColumns).asCql();
-        StringBuilder sb = new StringBuilder(selectCql);
-        if (sb.charAt(sb.length() - 1) == ';') {
-            sb.setLength(sb.length() - 1);
-        }
-        sb.append(cassandraSplit.getWhereClause());
-        String cql = sb.toString();
-        log.debug("Creating record set: %s", cql);
-
-        return new CassandraRecordSet(cassandraSession, cassandraTypeManager, cql, cassandraColumns);
+        return new CassandraRecordSet(
+                cassandraSession,
+                cassandraTypeManager,
+                CassandraCqlUtils.selectFrom(cassandraTable.getRequiredNamedRelation(), cassandraColumns)
+                        .whereRaw(cassandraSplit.getWhereClause())
+                        .build()
+                        .setIdempotent(true),
+                cassandraColumns);
     }
 }

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplit.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplit.java
@@ -56,13 +56,13 @@ public record CassandraSplit(String partitionId, String splitCondition, List<Hos
     {
         if (partitionId.equals(CassandraPartition.UNPARTITIONED_ID)) {
             if (splitCondition != null) {
-                return " WHERE " + splitCondition;
+                return splitCondition;
             }
             return "";
         }
         if (splitCondition != null) {
-            return " WHERE " + partitionId + " AND " + splitCondition;
+            return partitionId + " AND " + splitCondition;
         }
-        return " WHERE " + partitionId;
+        return partitionId;
     }
 }

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraSplit.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraSplit.java
@@ -51,12 +51,12 @@ public class TestCassandraSplit
                 CassandraPartition.UNPARTITIONED_ID,
                 "token(k) >= 0 AND token(k) <= 2",
                 addresses);
-        assertThat(split.getWhereClause()).isEqualTo(" WHERE token(k) >= 0 AND token(k) <= 2");
+        assertThat(split.getWhereClause()).isEqualTo("token(k) >= 0 AND token(k) <= 2");
 
         split = new CassandraSplit(
                 "key = 123",
                 null,
                 addresses);
-        assertThat(split.getWhereClause()).isEqualTo(" WHERE key = 123");
+        assertThat(split.getWhereClause()).isEqualTo("key = 123");
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Some clients had flaky ReadTimeout errors.
Specifically ...
```
Caused by: com.datastax.oss.driver.api.core.servererrors.ReadTimeoutException: Cassandra timeout during read query at consistency TWO (2 responses were required but only 0 replica responded)
```

https://docs.datastax.com/en/developer/java-driver/4.14/manual/core/retries/index.html#on-read-timeout-verdict

It seems the driver has retries built-in for these expected errors, but it needs to know the statement is idempotent.
Nearly all our requests are (except passthrough queries) because ...
 * they select just columns, no function calls here
 * the function we use in the where-clause: token() is deterministic

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

[Datastax help article on idempotency](https://docs.datastax.com/en/developer/java-driver/4.14/manual/core/idempotence/index.html).

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
