### PR TITLE
Fix non-canonical NUMBER representation after precision-cap rounding

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/NumberType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/NumberType.java
@@ -153,7 +153,7 @@ public class NumberType
     }
 
     @ScalarOperator(value = EQUAL, neverFails = true)
-    private static boolean equalOperator(TrinoNumber left, TrinoNumber right)
+    static boolean equalOperator(TrinoNumber left, TrinoNumber right)
     {
         if (left.isNaN() || right.isNaN()) {
             // NaN is not equal to any value, including itself
@@ -163,7 +163,7 @@ public class NumberType
     }
 
     @ScalarOperator(value = IDENTICAL, neverFails = true)
-    private static boolean identicalOperator(@SqlNullable TrinoNumber left, @SqlNullable TrinoNumber right)
+    static boolean identicalOperator(@SqlNullable TrinoNumber left, @SqlNullable TrinoNumber right)
     {
         if (left == null || right == null) {
             return left == right;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TrinoNumber.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TrinoNumber.java
@@ -165,9 +165,11 @@ public class TrinoNumber
             case BigDecimalValue(BigDecimal bigDecimal) -> {
                 BigDecimal normalized = bigDecimal.stripTrailingZeros();
                 if (normalized.precision() > maxDecimalPrecision) {
-                    normalized = normalized.setScale(
-                            normalized.scale() - (normalized.precision() - maxDecimalPrecision),
-                            HALF_UP);
+                    normalized = normalized
+                            .setScale(
+                                    normalized.scale() - (normalized.precision() - maxDecimalPrecision),
+                                    HALF_UP)
+                            .stripTrailingZeros();
                 }
                 BigInteger unscaledValue = normalized.unscaledValue();
                 boolean negated = unscaledValue.signum() < 0;

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestTrinoNumber.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestTrinoNumber.java
@@ -112,6 +112,23 @@ class TestTrinoNumber
                 new BigDecimal("4445556667778889995556667778890000000000").stripTrailingZeros());
     }
 
+    @Test
+    void testMaxPrecisionRoundingTrailingZeroes()
+    {
+        TrinoNumber rounded = TrinoNumber.from(new BigDecimalValue(new BigDecimal("100003")), 5);
+        TrinoNumber canonical = TrinoNumber.from(new BigDecimalValue(new BigDecimal("1e5")), 5);
+
+        // Sanity check: rounded and canonical are the same numeric value
+        assertThat(((BigDecimalValue) rounded.toBigDecimal()).value())
+                .isEqualByComparingTo(((BigDecimalValue) canonical.toBigDecimal()).value());
+
+        assertThat(NumberType.equalOperator(rounded, canonical)).as("equalOperator").isTrue();
+        assertThat(NumberType.identicalOperator(rounded, canonical)).as("identicalOperator").isTrue();
+
+        // In fact, they are byte-equal
+        assertThat(rounded.bytes()).isEqualTo(canonical.bytes());
+    }
+
     private void assertRoundTrip(BigDecimal jdkBigDecimal)
     {
         assertRoundTrip(jdkBigDecimal, jdkBigDecimal);


### PR DESCRIPTION
## Description
`TrinoNumber.from()` strips trailing zeros to so that numerically equal values share the same binary representation (relied on by the byte-based operators). But when a value exceeds the internal precision cap, the `setScale(HALF_UP)` rounding can re-introduce trailing zeros (e.g. a value ending in 03 rounds to one ending in 00, or 99 rounds up to 100) and the result was not re-stripped.

When the above rounding happens, two numerically equal NUMBER values may get different bytes, so `=`, `DISTINCT`, `GROUP BY`,etc treat them as different while `ORDER BY`/ comparison treat them as equal - which produce silent inconsistent/wrong results. For example:
```SQL
trino>   SELECT count(*) FROM (
    ->     SELECT NUMBER '1e200' + NUMBER '3' AS n
    ->     UNION ALL
    ->     SELECT NUMBER '1e200'
    ->   ) t
    ->   GROUP BY n;
 _col0
-------
     1
     1
(2 rows)

Query 20260617_092118_00013_irgbm, FINISHED, 1 node
Splits: 26 total, 26 done (100.00%)
0.15 [0 rows, 236B] [0 rows/s, 1.52KiB/s]
```

**The fix**: call `stripTrailingZeros()` again after the cap rounding.

## Additional context and related issues

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix non-canonical NUMBER representation after precision-cap rounding
```
