### PR TITLE
Make TestIcebergBigLakeMetastoreConnectorSmokeTest non-parallel

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
@@ -30,6 +30,7 @@ import io.trino.testing.TestingConnectorBehavior;
 import org.apache.iceberg.BaseTable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -44,7 +45,9 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.abort;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
+@Execution(SAME_THREAD) // to prevent exceeding BigLake requests quota
 final class TestIcebergBigLakeMetastoreConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {


### PR DESCRIPTION
## Description
When running TestIcebergBigLakeMetastoreConnectorSmokeTest we sometimes encounter read request quota limit from GCP biglake (1200r/min). 
We tried to increment the quota but for now we need to live with it as is.
This PR makes TestIcebergBigLakeMetastoreConnectorSmokeTest cases to be run one by one to spread the load on BigLake a bit.
We might do too much request, but this is a subject for a separate research.

## Additional context and related issues

```
Error:  io.trino.plugin.iceberg.catalog.rest.TestIcebergBigLakeMetastoreConnectorSmokeTest.testIcebergTablesSystemTable -- Time elapsed: 98.76 s <<< ERROR!
io.trino.testing.QueryFailedException: Failed to list tables
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:644)
	at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:620)
	at io.trino.sql.query.QueryAssertions$QueryAssert.lambda$new$1(QueryAssertions.java:331)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:194)
	at io.trino.sql.query.QueryAssertions$QueryAssert.result(QueryAssertions.java:456)
	at io.trino.sql.query.QueryAssertions$QueryAssert.matches(QueryAssertions.java:377)
	at io.trino.sql.query.QueryAssertions$QueryAssert.matches(QueryAssertions.java:371)
	at io.trino.plugin.iceberg.BaseIcebergConnectorSmokeTest.testIcebergTablesSystemTable(BaseIcebergConnectorSmokeTest.java:1002)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.tryRemoveAndExec(ForkJoinPool.java:1490)
	at java.base/java.util.concurrent.ForkJoinPool.helpJoin(ForkJoinPool.java:2248)
	at java.base/java.util.concurrent.ForkJoinTask.awaitDone(ForkJoinTask.java:499)
	at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:666)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
	Suppressed: java.lang.Exception: SQL: SELECT * FROM iceberg.system.iceberg_tables WHERE table_schema in ('first_schema_t37zcc3w6z', 'second_schema_m1avjfd6bl')
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:651)
		... 17 more
Caused by: io.trino.spi.TrinoException: Failed to list tables
	at io.trino.plugin.iceberg.catalog.rest.TrinoRestCatalog.lambda$listIcebergTables$0(TrinoRestCatalog.java:372)
	at io.trino.plugin.iceberg.catalog.rest.TrinoRestCatalog.listTableIdentifiers(TrinoRestCatalog.java:410)
	at io.trino.plugin.iceberg.catalog.rest.TrinoRestCatalog.listIcebergTables(TrinoRestCatalog.java:367)
	at io.trino.plugin.iceberg.system.IcebergTablesSystemTable.cursor(IcebergTablesSystemTable.java:93)
	at io.trino.connector.system.SystemPageSourceProvider$1.cursor(SystemPageSourceProvider.java:201)
	at io.trino.plugin.base.MappedRecordSet.cursor(MappedRecordSet.java:53)
	at io.trino.spi.connector.RecordPageSource.<init>(RecordPageSource.java:37)
	at io.trino.connector.system.SystemPageSourceProvider.createPageSource(SystemPageSourceProvider.java:169)
	at io.trino.split.PageSourceManager$PageSourceProviderInstance.createPageSource(PageSourceManager.java:145)
	at io.trino.split.TableAwarePageSourceProvider.lambda$createPageSource$1(TableAwarePageSourceProvider.java:80)
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
	at io.trino.split.TableAwarePageSourceProvider.createPageSource(TableAwarePageSourceProvider.java:80)
	at io.trino.operator.ScanFilterAndProjectOperator$SplitToPages.process(ScanFilterAndProjectOperator.java:251)
	at io.trino.operator.ScanFilterAndProjectOperator$SplitToPages.process(ScanFilterAndProjectOperator.java:188)
	at io.trino.operator.WorkProcessorUtils$3.process(WorkProcessorUtils.java:359)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:426)
	at io.trino.operator.WorkProcessorUtils$3.process(WorkProcessorUtils.java:346)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:426)
	at io.trino.operator.WorkProcessorUtils.getNextState(WorkProcessorUtils.java:261)
	at io.trino.operator.WorkProcessorUtils.lambda$processStateMonitor$0(WorkProcessorUtils.java:240)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:426)
	at io.trino.operator.WorkProcessorUtils.getNextState(WorkProcessorUtils.java:261)
	at io.trino.operator.WorkProcessorUtils.lambda$finishWhen$0(WorkProcessorUtils.java:255)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:426)
	at io.trino.operator.WorkProcessorSourceOperatorAdapter.getOutput(WorkProcessorSourceOperatorAdapter.java:125)
	at io.trino.operator.OutputValidatingSourceOperator.getOutput(OutputValidatingSourceOperator.java:70)
	at io.trino.operator.Driver.processInternal(Driver.java:400)
	at io.trino.operator.Driver.lambda$process$0(Driver.java:303)
	at io.trino.operator.Driver.tryWithLock(Driver.java:706)
	at io.trino.operator.Driver.process(Driver.java:295)
	at io.trino.operator.Driver.processForDuration(Driver.java:266)
	at io.trino.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:852)
	at io.trino.execution.executor.timesharing.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:187)
	at io.trino.execution.executor.timesharing.TimeSharingTaskExecutor$TaskRunner.run(TimeSharingTaskExecutor.java:564)
	at io.trino.$gen.Trino_testversion____20260608_203149_4560.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: org.apache.iceberg.exceptions.RESTException: Unable to process (code: 429, type: null): Quota exceeded for quota metric 'Iceberg REST Catalog read requests' and limit 'Iceberg REST Catalog read requests per minute' of service 'biglake.googleapis.com' for consumer 'project_number:abc'.
	at org.apache.iceberg.rest.ErrorHandlers.createRESTException(ErrorHandlers.java:115)
	at org.apache.iceberg.rest.ErrorHandlers$DefaultErrorHandler.accept(ErrorHandlers.java:357)
	at org.apache.iceberg.rest.ErrorHandlers$NamespaceErrorHandler.accept(ErrorHandlers.java:285)
	at org.apache.iceberg.rest.ErrorHandlers$NamespaceErrorHandler.accept(ErrorHandlers.java:266)
	at org.apache.iceberg.rest.HTTPClient.throwFailure(HTTPClient.java:242)
	at org.apache.iceberg.rest.HTTPClient.execute(HTTPClient.java:347)
	at org.apache.iceberg.rest.HTTPClient.execute(HTTPClient.java:299)
	at org.apache.iceberg.rest.BaseHTTPClient.get(BaseHTTPClient.java:77)
	at org.apache.iceberg.rest.RESTSessionCatalog.listTables(RESTSessionCatalog.java:325)
	at io.trino.plugin.iceberg.catalog.rest.TrinoRestCatalog.lambda$listIcebergTables$0(TrinoRestCatalog.java:369)
	... 37 more
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
