### PR TITLE
Fix incorrect neverFails=true on array_union and array_intersect

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayIntersectFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayIntersectFunction.java
@@ -32,7 +32,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.IDENTICAL;
 
-@ScalarFunction(value = "array_intersect", neverFails = true)
+@ScalarFunction(value = "array_intersect")
 @Description("Intersects elements of the two given arrays")
 public final class ArrayIntersectFunction
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayUnionFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayUnionFunction.java
@@ -36,7 +36,7 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.IDENTICAL;
 import static io.trino.spi.type.BigintType.BIGINT;
 
-@ScalarFunction(value = "array_union", neverFails = true)
+@ScalarFunction(value = "array_union")
 @Description("Union elements of the two given arrays")
 public final class ArrayUnionFunction
 {

--- a/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
@@ -300,6 +300,24 @@ public class TestArrayOperators
     }
 
     @Test
+    public void testArrayUnionSize()
+    {
+        int size = toIntExact(MAX_FUNCTION_MEMORY.toBytes() + 1);
+        assertTrinoExceptionThrownBy(
+                () -> assertions.expression("array_union(ARRAY[lpad('', %1$s , 'x')], ARRAY[lpad('', %1$s , 'y'), lpad('', %1$s , 'z')])".formatted(size)).evaluate())
+                .hasErrorCode(EXCEEDED_FUNCTION_MEMORY_LIMIT);
+    }
+
+    @Test
+    public void testArrayIntersectSize()
+    {
+        int size = toIntExact(MAX_FUNCTION_MEMORY.toBytes() + 1);
+        assertTrinoExceptionThrownBy(
+                () -> assertions.expression("array_intersect(ARRAY[lpad('', %1$s , 'x'), lpad('', %1$s , 'y')], ARRAY[lpad('', %1$s , 'x'), lpad('', %1$s , 'y')])".formatted(size)).evaluate())
+                .hasErrorCode(EXCEEDED_FUNCTION_MEMORY_LIMIT);
+    }
+
+    @Test
     public void testArrayToJsonSmoke()
     {
         assertThat(assertions.expression("CAST(a AS JSON)")


### PR DESCRIPTION
## Description
 `array_union` and `array_intersect` were declared `neverFails`=true, but both write their output set through `BlockSet.getAllWithSizeLimit`, which throws `EXCEEDED_FUNCTION_MEMORY_LIMIT` when the result exceeds the 4 MB per-call limit - the same path for which `array_distinct` had neverFails=true removed in #29864. 
Removes the incorrect declaration from both and adds tests (`testArrayUnionSize`, `testArrayIntersectSize`) mirroring the existing `array_distinct` testArraySize coverage, which is what the #29864 runtime validator needed to detect the violation.


## Additional context and related issues
Relates to #29864

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
