### PR TITLE
Add Floci GCS filesystem tests

### DIFF
--- a/lib/trino-filesystem-gcs/pom.xml
+++ b/lib/trino-filesystem-gcs/pom.xml
@@ -150,6 +150,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-containers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-testing-services</artifactId>
             <scope>test</scope>
         </dependency>
@@ -169,6 +175,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystem.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystem.java
@@ -19,6 +19,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.Storage.SignUrlOption;
 import com.google.cloud.storage.StorageBatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -38,6 +39,7 @@ import io.trino.filesystem.UriLocation;
 import io.trino.filesystem.encryption.EncryptionKey;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.Instant;
@@ -56,6 +58,7 @@ import static com.google.cloud.storage.Storage.BlobListOption.matchGlob;
 import static com.google.cloud.storage.Storage.BlobListOption.pageSize;
 import static com.google.cloud.storage.Storage.BlobListOption.startOffset;
 import static com.google.cloud.storage.Storage.SignUrlOption.withExtHeaders;
+import static com.google.cloud.storage.Storage.SignUrlOption.withHostName;
 import static com.google.cloud.storage.Storage.SignUrlOption.withV4Signature;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -78,8 +81,9 @@ public class GcsFileSystem
     private final long writeBlockSizeBytes;
     private final int pageSize;
     private final int batchSize;
+    private final Optional<String> endpoint;
 
-    public GcsFileSystem(ListeningExecutorService executorService, Storage storage, int readBlockSizeBytes, long writeBlockSizeBytes, int pageSize, int batchSize)
+    public GcsFileSystem(ListeningExecutorService executorService, Storage storage, int readBlockSizeBytes, long writeBlockSizeBytes, int pageSize, int batchSize, Optional<String> endpoint)
     {
         this.executorService = requireNonNull(executorService, "executorService is null");
         this.storage = requireNonNull(storage, "storage is null");
@@ -87,6 +91,7 @@ public class GcsFileSystem
         this.writeBlockSizeBytes = writeBlockSizeBytes;
         this.pageSize = pageSize;
         this.batchSize = batchSize;
+        this.endpoint = requireNonNull(endpoint, "endpoint is null");
     }
 
     @Override
@@ -371,7 +376,11 @@ public class GcsFileSystem
                 .build();
 
         Map<String, String> extHeaders = preSignedHeaders(key);
-        URL url = storage.signUrl(blobInfo, ttl.toMillis(), MILLISECONDS, withV4Signature(), withExtHeaders(extHeaders));
+        List<SignUrlOption> options = new ArrayList<>();
+        options.add(withV4Signature());
+        options.add(withExtHeaders(extHeaders));
+        endpoint.ifPresent(uri -> options.add(withHostName(URI.create(uri).getAuthority())));
+        URL url = storage.signUrl(blobInfo, ttl.toMillis(), MILLISECONDS, options.toArray(SignUrlOption[]::new));
         try {
             return Optional.of(new UriLocation(url.toURI(), toMultiMap(extHeaders)));
         }

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystemFactory.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystemFactory.java
@@ -20,6 +20,8 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.spi.security.ConnectorIdentity;
 import jakarta.annotation.PreDestroy;
 
+import java.util.Optional;
+
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.lang.Math.toIntExact;
@@ -33,6 +35,7 @@ public class GcsFileSystemFactory
     private final long writeBlockSizeBytes;
     private final int pageSize;
     private final int batchSize;
+    private final Optional<String> endpoint;
     private final ListeningExecutorService executorService;
     private final GcsStorageFactory storageFactory;
 
@@ -43,6 +46,7 @@ public class GcsFileSystemFactory
         this.writeBlockSizeBytes = config.getWriteBlockSize().toBytes();
         this.pageSize = config.getPageSize();
         this.batchSize = config.getBatchSize();
+        this.endpoint = config.getEndpoint();
         this.storageFactory = requireNonNull(storageFactory, "storageFactory is null");
         this.executorService = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("trino-filesystem-gcs-%S")));
     }
@@ -56,6 +60,6 @@ public class GcsFileSystemFactory
     @Override
     public TrinoFileSystem create(ConnectorIdentity identity)
     {
-        return new GcsFileSystem(executorService, storageFactory.create(identity), readBlockSizeBytes, writeBlockSizeBytes, pageSize, batchSize);
+        return new GcsFileSystem(executorService, storageFactory.create(identity), readBlockSizeBytes, writeBlockSizeBytes, pageSize, batchSize, endpoint);
     }
 }

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/AbstractTestGcsFileSystem.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/AbstractTestGcsFileSystem.java
@@ -60,9 +60,14 @@ public abstract class AbstractTestGcsFileSystem
         // create/get/list/delete blob
         // For gcp testing this corresponds to the Cluster Storage Admin and Cluster Storage Object Admin roles
         byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
-        GcsFileSystemConfig config = new GcsFileSystemConfig();
         GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig().setJsonKey(new String(jsonKeyBytes, UTF_8));
-        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new GcsServiceAccountAuth(authConfig));
+        initialize(new GcsFileSystemConfig(), new GcsServiceAccountAuth(authConfig));
+    }
+
+    protected void initialize(GcsFileSystemConfig config, GcsAuth gcsAuth)
+            throws IOException
+    {
+        GcsStorageFactory storageFactory = new GcsStorageFactory(config, gcsAuth);
         this.gcsFileSystemFactory = new GcsFileSystemFactory(config, storageFactory);
         this.storage = storageFactory.create(ConnectorIdentity.ofUser("test"));
         String bucket = RemoteStorageHelper.generateBucketName();

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemFloci.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemFloci.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.gcs;
+
+import io.trino.testing.containers.FlociGcp;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Optional;
+
+import static io.trino.testing.containers.FlociGcp.FLOCI_GCP_PROJECT_ID;
+
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestGcsFileSystemFloci
+        extends AbstractTestGcsFileSystem
+{
+    @Container
+    private static final FlociGcp FLOCI_GCP = new FlociGcp();
+
+    @BeforeAll
+    void setup()
+            throws IOException, GeneralSecurityException
+    {
+        TestingSigningCredentials credentials = new TestingSigningCredentials();
+        GcsAuth gcsAuth = (builder, _) -> builder.setCredentials(credentials);
+        initialize(
+                new GcsFileSystemConfig()
+                        .setEndpoint(Optional.of(FLOCI_GCP.getEndpoint().toString()))
+                        .setProjectId(FLOCI_GCP_PROJECT_ID),
+                gcsAuth);
+    }
+}

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemFlociWithEncryption.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemFlociWithEncryption.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.gcs;
+
+public class TestGcsFileSystemFlociWithEncryption
+        extends TestGcsFileSystemFloci
+{
+    @Override
+    protected boolean useServerSideEncryptionWithCustomerKey()
+    {
+        return true;
+    }
+}

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestingSigningCredentials.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestingSigningCredentials.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.gcs;
+
+import com.google.auth.Credentials;
+import com.google.auth.ServiceAccountSigner;
+
+import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.util.List;
+import java.util.Map;
+
+public final class TestingSigningCredentials
+        extends Credentials
+        implements ServiceAccountSigner
+{
+    private final PrivateKey privateKey;
+
+    public TestingSigningCredentials()
+            throws GeneralSecurityException
+    {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        this.privateKey = generator.generateKeyPair().getPrivate();
+    }
+
+    @Override
+    public String getAuthenticationType()
+    {
+        return "no-auth";
+    }
+
+    @Override
+    public Map<String, List<String>> getRequestMetadata(URI uri)
+    {
+        return Map.of();
+    }
+
+    @Override
+    public boolean hasRequestMetadata()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean hasRequestMetadataOnly()
+    {
+        return true;
+    }
+
+    @Override
+    public void refresh() {}
+
+    @Override
+    public String getAccount()
+    {
+        return "test-signer@test-project.iam.gserviceaccount.com";
+    }
+
+    @Override
+    public byte[] sign(byte[] toSign)
+    {
+        try {
+            Signature signature = Signature.getInstance("SHA256withRSA");
+            signature.initSign(privateKey);
+            signature.update(toSign);
+            return signature.sign();
+        }
+        catch (GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/FlociGcp.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/FlociGcp.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.containers;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.net.URI;
+
+public final class FlociGcp
+        extends GenericContainer<FlociGcp>
+{
+    public static final String FLOCI_GCP_IMAGE = "floci/floci-gcp:0.3.0";
+    public static final String FLOCI_GCP_PROJECT_ID = "floci-local";
+
+    private static final int FLOCI_GCP_PORT = 4588;
+
+    public FlociGcp()
+    {
+        super(DockerImageName.parse(FLOCI_GCP_IMAGE));
+        addExposedPort(FLOCI_GCP_PORT);
+        waitingFor(Wait.forLogMessage(".*=== floci-gcp Ready ===.*\\n", 1));
+    }
+
+    public URI getEndpoint()
+    {
+        return URI.create("http://%s:%s".formatted(getHost(), getMappedPort(FLOCI_GCP_PORT)));
+    }
+}


### PR DESCRIPTION
## Description

Adds [Floci](https://floci.io)-backed GCS filesystem tests, including coverage for encrypted operations and pre-signed URIs.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
