### PR TITLE
Preserve Iceberg table metadata on ambiguous HMS create failure

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog.hms;
 
+import io.airlift.log.Logger;
 import io.trino.annotation.NotThreadSafe;
 import io.trino.metastore.PrincipalPrivileges;
 import io.trino.metastore.Table;
@@ -25,6 +26,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.TableNotFoundException;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.io.FileIO;
 
 import java.util.Optional;
@@ -39,6 +41,7 @@ import static io.trino.plugin.hive.util.HiveUtil.isIcebergTable;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergTableName.isMaterializedViewStorage;
 import static io.trino.plugin.iceberg.IcebergTableName.tableNameFrom;
+import static io.trino.plugin.iceberg.IcebergUtil.fixBrokenMetadataLocation;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -53,6 +56,8 @@ import static org.apache.iceberg.TableProperties.CURRENT_SNAPSHOT_TIMESTAMP;
 public abstract class AbstractMetastoreTableOperations
         extends AbstractIcebergTableOperations
 {
+    private static final Logger log = Logger.get(AbstractMetastoreTableOperations.class);
+
     protected final CachingHiveMetastore metastore;
 
     protected AbstractMetastoreTableOperations(
@@ -126,11 +131,67 @@ public abstract class AbstractMetastoreTableOperations
             metastore.createTable(table, privileges);
         }
         catch (Exception e) {
-            // clean up metadata file corresponding to the current transaction
-            io().deleteFile(newMetadataLocation);
-            // wrap exception in CleanableFailure to ensure that manifest list Avro files are also cleaned up
-            throw new CreateTableException(e, getSchemaTableName());
+            // The metastore call can fail even though the table was actually created, e.g. when the response is lost
+            // on a timeout, or when a retried request observes the table that the first (successful) attempt created
+            // and reports AlreadyExists. Deleting the new metadata file in that case would corrupt the just-created
+            // table, so the actual commit outcome is verified before any cleanup is performed.
+            switch (checkNewTableCommitStatus(newMetadataLocation)) {
+                // The table exists and references the metadata we wrote: the commit succeeded despite the exception.
+                case SUCCESS -> {
+                    log.warn(e, "Received an error from metastore while creating table %s, but the table was actually created; treating the commit as successful", getSchemaTableName());
+                    return;
+                }
+                // Cannot determine whether the create was applied. Preserve every new file (metadata file, manifest
+                // list, manifests, data) so the table remains recoverable; CommitStateUnknownException stops the
+                // Iceberg transaction layer from cleaning them up.
+                case UNKNOWN -> throw new CommitStateUnknownException(e);
+                // The create did not happen (or another writer owns the name); the new metadata file is orphaned.
+                // Clean it up and wrap the failure in CleanableFailure so Iceberg also removes the manifest list
+                // and any data files.
+                case FAILURE -> {
+                    io().deleteFile(newMetadataLocation);
+                    throw new CreateTableException(e, getSchemaTableName());
+                }
+            }
         }
+    }
+
+    /**
+     * Determines whether a failed {@code createTable} call actually applied the commit, by re-reading the table from
+     * the metastore and comparing its metadata location against the one this operation wrote. {@code newMetadataLocation}
+     * carries a freshly generated UUID, so an equal value can only mean this very operation created the table.
+     * <p>
+     * The check is biased towards {@link CommitStatus#UNKNOWN}: an orphaned metadata file is cheap to clean up later
+     * (e.g. via {@code remove_orphan_files}), whereas deleting a file the metastore still references is an
+     * unrecoverable data-integrity issue. A single read is enough because the metastore client already retries
+     * transient failures internally.
+     */
+    private CommitStatus checkNewTableCommitStatus(String newMetadataLocation)
+    {
+        Optional<Table> table;
+        try {
+            metastore.invalidateTable(database, tableName);
+            table = metastore.getTable(database, tableName);
+        }
+        catch (RuntimeException e) {
+            log.error(e, "Could not determine commit status for new table %s; treating commit state as unknown", getSchemaTableName());
+            return CommitStatus.UNKNOWN;
+        }
+        if (table.isEmpty()) {
+            // The metastore is reachable and the table is absent: the create was not applied.
+            return CommitStatus.FAILURE;
+        }
+        String committedLocation = table.get().getParameters().get(METADATA_LOCATION_PROP);
+        // A matching location proves this operation committed; a different (or missing) location means another writer owns the name.
+        boolean committed = committedLocation != null && newMetadataLocation.equals(fixBrokenMetadataLocation(committedLocation));
+        return committed ? CommitStatus.SUCCESS : CommitStatus.FAILURE;
+    }
+
+    private enum CommitStatus
+    {
+        SUCCESS,
+        FAILURE,
+        UNKNOWN,
     }
 
     protected Table.Builder updateMetastoreTable(Table.Builder builder, TableMetadata metadata, String metadataLocation, Optional<String> previousMetadataLocation)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestIcebergFileMetastoreCreateTableFailure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestIcebergFileMetastoreCreateTableFailure.java
@@ -27,6 +27,7 @@ import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -55,7 +57,14 @@ public class TestIcebergFileMetastoreCreateTableFailure
 
     private Path dataDirectory;
     private HiveMetastore metastore;
-    private final AtomicReference<RuntimeException> testException = new AtomicReference<>();
+    private final AtomicReference<RuntimeException> createTableFailure = new AtomicReference<>();
+    // When set, the metastore persists the table before raising createTableFailure, simulating a commit that
+    // actually landed but whose response was lost (e.g. a timeout, or a retried request observing AlreadyExists).
+    private final AtomicBoolean createTableCommitsBeforeFailure = new AtomicBoolean();
+    // When set, the metastore becomes unreachable once a createTable has been attempted, simulating a metastore that
+    // is unavailable during the post-failure commit-status check (but reachable for the initial existence check).
+    private final AtomicBoolean metastoreUnavailableAfterCreate = new AtomicBoolean();
+    private final AtomicBoolean metastoreUnavailable = new AtomicBoolean();
 
     @Override
     protected DistributedQueryRunner createQueryRunner()
@@ -73,9 +82,27 @@ public class TestIcebergFileMetastoreCreateTableFailure
             @Override
             public synchronized void createTable(Table table, PrincipalPrivileges principalPrivileges)
             {
-                if (testException.get() != null) {
-                    throw testException.get();
+                RuntimeException failure = createTableFailure.get();
+                // Persist the table on a normal create, and also when simulating a commit that landed before the
+                // injected failure (createTableCommitsBeforeFailure), so the metastore actually holds the table.
+                if (failure == null || createTableCommitsBeforeFailure.get()) {
+                    super.createTable(table, principalPrivileges);
                 }
+                if (metastoreUnavailableAfterCreate.get()) {
+                    metastoreUnavailable.set(true);
+                }
+                if (failure != null) {
+                    throw failure;
+                }
+            }
+
+            @Override
+            public synchronized Optional<Table> getTable(String databaseName, String tableName)
+            {
+                if (metastoreUnavailable.get()) {
+                    throw new RuntimeException("simulated metastore unavailable");
+                }
+                return super.getTable(databaseName, tableName);
             }
         };
 
@@ -104,22 +131,92 @@ public class TestIcebergFileMetastoreCreateTableFailure
         }
     }
 
+    @BeforeEach
+    public void resetMetastoreBehavior()
+    {
+        createTableFailure.set(null);
+        createTableCommitsBeforeFailure.set(false);
+        metastoreUnavailableAfterCreate.set(false);
+        metastoreUnavailable.set(false);
+    }
+
     @Test
     public void testCreateTableFailureMetadataCleanedUp()
     {
-        testException.set(new SchemaNotFoundException("simulated_test_schema"));
+        // The metastore is reachable and confirms the table was not created, so the orphaned metadata file is removed.
         String tableName = "test_create_failure_" + randomNameSuffix();
-        String tableLocation = "local:///" + tableName;
-        String createTableSql = "CREATE TABLE " + tableName + " (a varchar) WITH (location = '" + tableLocation + "')";
-        assertThatThrownBy(() -> getQueryRunner().execute(createTableSql))
-                .hasMessageContaining("Schema simulated_test_schema not found");
+        createTableFailure.set(new SchemaNotFoundException("simulated_test_schema"));
+        try {
+            String tableLocation = "local:///" + tableName;
+            String createTableSql = "CREATE TABLE " + tableName + " (a varchar) WITH (location = '" + tableLocation + "')";
+            assertThatThrownBy(() -> getQueryRunner().execute(createTableSql))
+                    .hasMessageContaining("Schema simulated_test_schema not found");
 
-        Path metadataDirectory = dataDirectory.resolve(tableName, "metadata");
-        assertThat(metadataDirectory).as("Metadata file should not exist").isEmptyDirectory();
+            Path metadataDirectory = dataDirectory.resolve(tableName, "metadata");
+            assertThat(metadataDirectory).as("Metadata file should not exist").isEmptyDirectory();
 
-        // it should be possible to create a table with the same name after the failure
-        testException.set(null);
-        getQueryRunner().execute(createTableSql);
-        assertThat(metadataDirectory).as("Metadata file should not exist").isNotEmptyDirectory();
+            // it should be possible to create a table with the same name after the failure
+            createTableFailure.set(null);
+            getQueryRunner().execute(createTableSql);
+            assertThat(metadataDirectory).as("Metadata file should not exist").isNotEmptyDirectory();
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testCreateTableMetadataPreservedWhenCommitActuallySucceeded()
+    {
+        // The metastore applied the create but the client observed a failure (lost response / retried AlreadyExists).
+        // The commit-status check finds the table pointing at our metadata, so the create is treated as successful.
+        String tableName = "test_create_succeeded_" + randomNameSuffix();
+        createTableCommitsBeforeFailure.set(true);
+        createTableFailure.set(new RuntimeException("simulated metastore response loss"));
+        try {
+            String tableLocation = "local:///" + tableName;
+            String createTableSql = "CREATE TABLE " + tableName + " (a integer) WITH (location = '" + tableLocation + "')";
+
+            // The statement must not fail and must not delete the metadata of the table that was actually created.
+            getQueryRunner().execute(createTableSql);
+
+            Path metadataDirectory = dataDirectory.resolve(tableName, "metadata");
+            assertThat(metadataDirectory).as("Metadata file should be preserved").isNotEmptyDirectory();
+            // The table is fully usable.
+            assertThat(getQueryRunner().execute("SELECT * FROM " + tableName).getRowCount()).isEqualTo(0);
+        }
+        finally {
+            getQueryRunner().execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testCreateTableMetadataPreservedWhenCommitStateUnknown()
+    {
+        // The metastore applied the create but the response was lost, and the follow-up commit-status check cannot
+        // reach the metastore either. The outcome is unknown, so all new files must be preserved.
+        String tableName = "test_create_unknown_" + randomNameSuffix();
+        createTableCommitsBeforeFailure.set(true);
+        createTableFailure.set(new RuntimeException("simulated metastore response loss"));
+        metastoreUnavailableAfterCreate.set(true);
+        try {
+            String tableLocation = "local:///" + tableName;
+            String createTableSql = "CREATE TABLE " + tableName + " (a integer) WITH (location = '" + tableLocation + "')";
+
+            assertThatThrownBy(() -> getQueryRunner().execute(createTableSql))
+                    .hasMessageContaining("Cannot determine whether the commit was successful");
+
+            Path metadataDirectory = dataDirectory.resolve(tableName, "metadata");
+            assertThat(metadataDirectory).as("Metadata file should be preserved when commit state is unknown").isNotEmptyDirectory();
+
+            // Once the metastore is reachable again the table created by the (actually successful) commit is usable.
+            metastoreUnavailable.set(false);
+            assertThat(getQueryRunner().execute("SELECT * FROM " + tableName).getRowCount()).isEqualTo(0);
+        }
+        finally {
+            // Restore metastore reachability (an earlier assertion may have failed before it was reset) so the table can be dropped.
+            metastoreUnavailable.set(false);
+            getQueryRunner().execute("DROP TABLE IF EXISTS " + tableName);
+        }
     }
 }


### PR DESCRIPTION
AbstractMetastoreTableOperations.commitNewTable deleted the freshly written metadata.json on any exception from metastore.createTable. When the create actually succeeded on HMS but the response was lost (timeout, transport error, or a retried request observing AlreadyExists), this deleted a file the metastore now references, leaving the table pointing at missing metadata - an unrecoverable data-integrity issue. CREATE TABLE / CTAS go through this path, while existing-table commits (INSERT/MERGE) already convert ambiguous replaceTable failures into CommitStateUnknownException and keep their files.

Verify the commit outcome before cleaning up: re-read the table and compare its metadata location against the one just written (a freshly generated UUID, so a match proves this operation committed).

  SUCCESS - the create landed; log the swallowed error and succeed.
  UNKNOWN - cannot reach the metastore to decide; throw
            CommitStateUnknownException so Iceberg preserves all new
            files (metadata, manifest list, manifests, data).
  FAILURE - the table is absent (or owned by another writer); delete the
            orphaned metadata and throw CreateTableException so Iceberg
            also removes the manifest list and data files.

The check is biased towards UNKNOWN: an orphaned file is cheap to remove later, while deleting a referenced file is not recoverable.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Fix possible loss of table metadata when a `CREATE TABLE` commit to the Hive metastore catalog fails after the table was actually created. ({issue}`NNNNN`)
```
