### PR TITLE
Close CLI segment HTTP client

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
@@ -13,14 +13,18 @@
  */
 package io.trino.cli;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.trino.client.ClientCapabilities;
 import io.trino.client.ClientSession;
 import io.trino.client.StatementClient;
 import io.trino.client.uri.HttpClientFactory;
 import io.trino.client.uri.TrinoUri;
+import okhttp3.Cache;
 import okhttp3.OkHttpClient;
 
 import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -50,11 +54,26 @@ public class QueryRunner
 
     public QueryRunner(TrinoUri uri, ClientSession session, boolean debug, int maxQueuedRows, int maxBufferedRows)
     {
+        this(session,
+                debug,
+                HttpClientFactory.toHttpClientBuilder(uri, USER_AGENT).build(),
+                HttpClientFactory.unauthenticatedClientBuilder(uri, USER_AGENT).build(),
+                maxQueuedRows,
+                maxBufferedRows);
+    }
+
+    @VisibleForTesting
+    QueryRunner(
+            ClientSession session,
+            boolean debug,
+            OkHttpClient httpClient,
+            OkHttpClient segmentHttpClient,
+            int maxQueuedRows,
+            int maxBufferedRows)
+    {
         this.session = new AtomicReference<>(requireNonNull(session, "session is null"));
-        this.httpClient = HttpClientFactory.toHttpClientBuilder(uri, USER_AGENT).build();
-        this.segmentHttpClient = HttpClientFactory
-                .unauthenticatedClientBuilder(uri, USER_AGENT)
-                .build();
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.segmentHttpClient = requireNonNull(segmentHttpClient, "segmentHttpClient is null");
         this.debug = debug;
         this.maxQueuedRows = maxQueuedRows;
         this.maxBufferedRows = maxBufferedRows;
@@ -93,7 +112,42 @@ public class QueryRunner
     @Override
     public void close()
     {
-        httpClient.dispatcher().executorService().shutdown();
-        httpClient.connectionPool().evictAll();
+        closeAll(httpClient, segmentHttpClient);
+    }
+
+    private static void closeAll(OkHttpClient... clients)
+    {
+        RuntimeException failure = null;
+        for (OkHttpClient client : clients) {
+            try {
+                closeClient(client);
+            }
+            catch (RuntimeException e) {
+                if (failure == null) {
+                    failure = e;
+                }
+                else {
+                    failure.addSuppressed(e);
+                }
+            }
+        }
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private static void closeClient(OkHttpClient client)
+    {
+        client.dispatcher().executorService().shutdown();
+        client.connectionPool().evictAll();
+        Cache cache = client.cache();
+        if (cache != null) {
+            try {
+                cache.close();
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
     }
 }

--- a/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
@@ -27,10 +27,14 @@ import io.trino.client.uri.TrinoUri;
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import mockwebserver3.junit5.StartStop;
+import okhttp3.Cache;
+import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.PrintStream;
+import java.nio.file.Path;
 import java.time.ZoneId;
 import java.util.Locale;
 import java.util.Optional;
@@ -58,6 +62,9 @@ public class TestQueryRunner
 
     @StartStop
     private final MockWebServer server = new MockWebServer();
+
+    @TempDir
+    private Path tempDirectory;
 
     @Test
     public void testCookie()
@@ -89,6 +96,27 @@ public class TestQueryRunner
         assertThat(server.takeRequest().getHeaders().get("Cookie")).isNull();
         assertThat(server.takeRequest().getHeaders().get("Cookie")).isEqualTo("a=apple");
         assertThat(server.takeRequest().getHeaders().get("Cookie")).isEqualTo("a=apple");
+    }
+
+    @Test
+    public void testCloseClosesAllHttpClients()
+    {
+        OkHttpClient httpClient = newClientWithCache("http-client");
+        OkHttpClient segmentHttpClient = newClientWithCache("segment-http-client");
+        QueryRunner queryRunner = new QueryRunner(
+                createClientSession(server),
+                false,
+                httpClient,
+                segmentHttpClient,
+                1000,
+                500);
+
+        queryRunner.close();
+
+        assertThat(httpClient.dispatcher().executorService().isShutdown()).isTrue();
+        assertThat(segmentHttpClient.dispatcher().executorService().isShutdown()).isTrue();
+        assertThat(httpClient.cache().isClosed()).isTrue();
+        assertThat(segmentHttpClient.cache().isClosed()).isTrue();
     }
 
     static TrinoUri createTrinoUri(MockWebServer server, boolean insecureSsl)
@@ -151,5 +179,12 @@ public class TestQueryRunner
     static PrintStream nullPrintStream()
     {
         return new PrintStream(nullOutputStream());
+    }
+
+    private OkHttpClient newClientWithCache(String cacheDirectory)
+    {
+        return new OkHttpClient.Builder()
+                .cache(new Cache(tempDirectory.resolve(cacheDirectory).toFile(), 1024))
+                .build();
     }
 }


### PR DESCRIPTION
## Summary
- close both OkHttp clients owned by CLI `QueryRunner`
- shut down the dispatcher, evict the connection pool, and close the cache when present
- add a regression test that verifies `QueryRunner.close()` shuts down both the main and segment clients

## Testing
- `JAVA_HOME=/Users/hoangvu/.local/share/jdks/jdk-25.0.3+9/Contents/Home PATH=/Users/hoangvu/.local/share/jdks/jdk-25.0.3+9/Contents/Home/bin:$PATH ./mvnw -pl client/trino-cli -Dtest=TestQueryRunner --no-transfer-progress test`