### PR TITLE
Fix neverFails on array_sort/greatest/least functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -144,6 +144,7 @@ import io.trino.operator.scalar.GenericLessThanOperator;
 import io.trino.operator.scalar.GenericLessThanOrEqualOperator;
 import io.trino.operator.scalar.GenericReadValueOperator;
 import io.trino.operator.scalar.GenericXxHash64Operator;
+import io.trino.operator.scalar.Greatest;
 import io.trino.operator.scalar.HmacFunctions;
 import io.trino.operator.scalar.HyperLogLogFunctions;
 import io.trino.operator.scalar.IpAddressFunctions;
@@ -152,6 +153,7 @@ import io.trino.operator.scalar.JoniRegexpFunctions;
 import io.trino.operator.scalar.JoniRegexpReplaceLambdaFunction;
 import io.trino.operator.scalar.JsonFunctions;
 import io.trino.operator.scalar.JsonOperators;
+import io.trino.operator.scalar.Least;
 import io.trino.operator.scalar.LegacyCharToVarcharCast;
 import io.trino.operator.scalar.LuhnCheckFunction;
 import io.trino.operator.scalar.MapCardinalityFunction;
@@ -307,7 +309,6 @@ import static io.trino.operator.scalar.ConcatFunction.VARCHAR_CONCAT;
 import static io.trino.operator.scalar.ConcatWsFunction.CONCAT_WS;
 import static io.trino.operator.scalar.ElementToArrayConcatFunction.ELEMENT_TO_ARRAY_CONCAT_FUNCTION;
 import static io.trino.operator.scalar.FormatFunction.FORMAT_FUNCTION;
-import static io.trino.operator.scalar.Greatest.GREATEST;
 import static io.trino.operator.scalar.IdentityCast.IDENTITY_CAST;
 import static io.trino.operator.scalar.JsonStringArrayExtractScalar.JSON_STRING_ARRAY_EXTRACT_SCALAR;
 import static io.trino.operator.scalar.JsonStringToArrayCast.JSON_STRING_TO_ARRAY;
@@ -316,7 +317,6 @@ import static io.trino.operator.scalar.JsonStringToRowCast.JSON_STRING_TO_ROW;
 import static io.trino.operator.scalar.JsonToArrayCast.JSON_TO_ARRAY;
 import static io.trino.operator.scalar.JsonToMapCast.JSON_TO_MAP;
 import static io.trino.operator.scalar.JsonToRowCast.JSON_TO_ROW;
-import static io.trino.operator.scalar.Least.LEAST;
 import static io.trino.operator.scalar.MapConstructor.MAP_CONSTRUCTOR;
 import static io.trino.operator.scalar.MapElementAtFunction.MAP_ELEMENT_AT;
 import static io.trino.operator.scalar.MapFilterFunction.MAP_FILTER_FUNCTION;
@@ -609,7 +609,7 @@ public final class SystemFunctionBundle
                 .aggregates(Histogram.class)
                 .aggregates(ChecksumAggregationFunction.class)
                 .aggregates(ArbitraryAggregationFunction.class)
-                .functions(GREATEST, LEAST)
+                .functions(new Greatest(typeOperators), new Least(typeOperators))
                 .aggregates(MinAggregationFunction.class)
                 .aggregates(MaxAggregationFunction.class)
                 .aggregates(MinByAggregationFunction.class)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/AbstractGreatestLeast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/AbstractGreatestLeast.java
@@ -31,6 +31,7 @@ import io.trino.spi.function.FunctionDependencyDeclaration;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
 import io.trino.sql.gen.CallSiteBinder;
 
 import java.lang.invoke.MethodHandle;
@@ -74,7 +75,7 @@ public abstract class AbstractGreatestLeast
 {
     private final boolean min;
 
-    protected AbstractGreatestLeast(boolean min, String description)
+    protected AbstractGreatestLeast(TypeOperators typeOperators, boolean min, String description)
     {
         super(FunctionMetadata.scalarBuilder(min ? "least" : "greatest")
                 .signature(Signature.builder()
@@ -84,7 +85,10 @@ public abstract class AbstractGreatestLeast
                         .variableArity()
                         .build())
                 .nullable()
-                .neverFails()
+                .neverFails(boundSignature -> (min
+                        ? typeOperators.getComparisonUnorderedLastOperatorHandle(boundSignature.getArgumentType(0), simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL))
+                        : typeOperators.getComparisonUnorderedFirstOperatorHandle(boundSignature.getArgumentType(0), simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL)))
+                        .isNeverFails())
                 .argumentNullability(true)
                 .description(description)
                 .build());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArraySortFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArraySortFunction.java
@@ -27,7 +27,11 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
 
-@ScalarFunction(value = "array_sort", neverFails = true)
+// TODO https://github.com/trinodb/trino/issues/30009: derive fallibility from the element type.
+//  array_sort is infallible for the majority of element types; only types whose comparison can fail
+//  (e.g. ROW/ARRAY with nested NULL elements) make it fallible, but it is currently declared fallible
+//  for all element types.
+@ScalarFunction(value = "array_sort")
 @Description("Sorts the given array in ascending order according to the natural ordering of its elements.")
 public final class ArraySortFunction
 {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/Greatest.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/Greatest.java
@@ -13,13 +13,13 @@
  */
 package io.trino.operator.scalar;
 
+import io.trino.spi.type.TypeOperators;
+
 public final class Greatest
         extends AbstractGreatestLeast
 {
-    public static final Greatest GREATEST = new Greatest();
-
-    public Greatest()
+    public Greatest(TypeOperators typeOperators)
     {
-        super(false, "Get the largest of the given values");
+        super(typeOperators, false, "Get the largest of the given values");
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/Least.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/Least.java
@@ -13,13 +13,13 @@
  */
 package io.trino.operator.scalar;
 
+import io.trino.spi.type.TypeOperators;
+
 public final class Least
         extends AbstractGreatestLeast
 {
-    public static final Least LEAST = new Least();
-
-    public Least()
+    public Least(TypeOperators typeOperators)
     {
-        super(true, "Get the smallest of the given values");
+        super(typeOperators, true, "Get the smallest of the given values");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
@@ -28,6 +28,7 @@ import java.math.BigDecimal;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.StandardErrorCode.TOO_MANY_ARGUMENTS;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -3243,6 +3244,29 @@ public class TestMathFunctions
         assertThat(assertions.function("greatest", "ARRAY[CAST(NaN() as REAL)]", "ARRAY[CAST(NaN() as REAL)]", "ARRAY[CAST(NaN() as REAL)]"))
                 .hasType(new ArrayType(REAL))
                 .isEqualTo(ImmutableList.of(Float.NaN));
+
+        // comparison of nested types with null elements fails (greatest is not infallible for these element types)
+        assertTrinoExceptionThrownBy(() -> assertions.expression("greatest(ROW(1, NULL), ROW(1, 2))").evaluate())
+                .hasErrorCode(NOT_SUPPORTED);
+        assertTrinoExceptionThrownBy(() -> assertions.expression("greatest(ARRAY[1, NULL], ARRAY[1, 2])").evaluate())
+                .hasErrorCode(NOT_SUPPORTED);
+
+        // Fallibility is derived from the argument type, not the runtime values. greatest over a type whose
+        // comparison can fail (e.g. ROW or ARRAY) is marked fallible even when the specific arguments don't fail.
+        assertThat(assertions.function("greatest", "ROW(1, 2)", "ROW(1, 3)"))
+                .couldFail();
+        assertThat(assertions.function("greatest", "ARRAY[1, 2]", "ARRAY[1, 3]"))
+                .couldFail();
+
+        // greatest over a type whose comparison is infallible is marked infallible.
+        assertThat(assertions.function("greatest", "1", "2"))
+                .neverFails();
+        assertThat(assertions.function("greatest", "DOUBLE '1.5'", "DOUBLE '2.5'"))
+                .neverFails();
+        assertThat(assertions.function("greatest", "REAL '1.5'", "REAL '2.5'"))
+                .neverFails();
+        assertThat(assertions.function("greatest", "VARCHAR 'a'", "VARCHAR 'b'"))
+                .neverFails();
     }
 
     @Test
@@ -3571,6 +3595,29 @@ public class TestMathFunctions
         assertThat(assertions.function("least", "ARRAY[CAST(NaN() as REAL)]", "ARRAY[CAST(NaN() as REAL)]", "ARRAY[CAST(NaN() as REAL)]"))
                 .hasType(new ArrayType(REAL))
                 .isEqualTo(ImmutableList.of(Float.NaN));
+
+        // comparison of nested types with null elements fails (least is not infallible for these element types)
+        assertTrinoExceptionThrownBy(() -> assertions.expression("least(ROW(1, NULL), ROW(1, 2))").evaluate())
+                .hasErrorCode(NOT_SUPPORTED);
+        assertTrinoExceptionThrownBy(() -> assertions.expression("least(ARRAY[1, NULL], ARRAY[1, 2])").evaluate())
+                .hasErrorCode(NOT_SUPPORTED);
+
+        // Fallibility is derived from the argument type, not the runtime values. least over a type whose
+        // comparison can fail (e.g. ROW or ARRAY) is marked fallible even when the specific arguments don't fail.
+        assertThat(assertions.function("least", "ROW(1, 2)", "ROW(1, 3)"))
+                .couldFail();
+        assertThat(assertions.function("least", "ARRAY[1, 2]", "ARRAY[1, 3]"))
+                .couldFail();
+
+        // least over a type whose comparison is infallible is marked infallible.
+        assertThat(assertions.function("least", "1", "2"))
+                .neverFails();
+        assertThat(assertions.function("least", "DOUBLE '1.5'", "DOUBLE '2.5'"))
+                .neverFails();
+        assertThat(assertions.function("least", "REAL '1.5'", "REAL '2.5'"))
+                .neverFails();
+        assertThat(assertions.function("least", "VARCHAR 'a'", "VARCHAR 'b'"))
+                .neverFails();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
@@ -3574,6 +3574,13 @@ public class TestArrayOperators
                 .hasType(new ArrayType(INTEGER))
                 .isEqualTo(asList(-1, 0, 1, null, null));
 
+        // sorting elements whose comparison fails on null nested fields/elements (array_sort is not infallible)
+        assertTrinoExceptionThrownBy(() -> assertions.expression("array_sort(ARRAY[ROW(1, NULL), ROW(1, 2)])").evaluate())
+                .hasErrorCode(NOT_SUPPORTED);
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("array_sort(ARRAY[ARRAY[1, NULL], ARRAY[1, 2]])").evaluate())
+                .hasErrorCode(NOT_SUPPORTED);
+
         // invalid functions
         assertTrinoExceptionThrownBy(assertions.function("array_sort", "ARRAY[color('red'), color('blue')]")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND);


### PR DESCRIPTION
## Description
`array_sort`/`greatest`/`least` declares `neverFails=true` but they are not.

`array_sort` is annotation-based, so the fix follows what we do in
- https://github.com/trinodb/trino/pull/29965 

recently (Technically we may consider extending the fallibility per call site to support annotation-based but it might not be worth it)
`greatest`/`least` can use the new `declare fallibility per call site` feature introduced in 

- https://github.com/trinodb/trino/pull/29876

## Additional context and related issues
Some related PRs about `neverFails`:
- https://github.com/trinodb/trino/pull/29965
- https://github.com/trinodb/trino/pull/29880
- https://github.com/trinodb/trino/pull/29876
- https://github.com/trinodb/trino/pull/29908

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
