### PR TITLE
Add varchar and char methods

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -16,6 +16,13 @@ grammar SqlBase;
 
 options { caseInsensitive = true; }
 
+@parser::members {
+    private boolean isKeyword()
+    {
+        return SqlKeywords.isKeyword(_input.LT(1).getType());
+    }
+}
+
 tokens {
     DELIMITER
 }
@@ -607,8 +614,8 @@ primaryExpression
         filter? over?                                                                     #functionCall
     | processingMode? qualifiedName '(' (setQuantifier? argument (',' argument)*)?
         orderBy? ')' filter? (nullTreatment? over)?                                       #functionCall
-    | qualifiedName '::' identifier '(' (argument (',' argument)*)? ')'                   #staticMethodCall
-    | primaryExpression '.' identifier '(' (argument (',' argument)*)? ')'                #methodCall
+    | qualifiedName '::' methodName '(' (argument (',' argument)*)? ')'                   #staticMethodCall
+    | primaryExpression '.' methodName '(' (argument (',' argument)*)? ')'                #methodCall
     | identifier over                                                                     #measure
     | identifier '->' expression                                                          #lambda
     | '(' (identifier (',' identifier)*)? ')' '->' expression                             #lambda
@@ -1038,6 +1045,11 @@ identifier
     | nonReserved            #unquotedIdentifier
     | BACKQUOTED_IDENTIFIER  #backQuotedIdentifier
     | DIGIT_IDENTIFIER       #digitIdentifier
+    ;
+
+methodName
+    : identifier
+    | {isKeyword()}? .
     ;
 
 number

--- a/core/trino-grammar/src/main/java/io/trino/grammar/sql/SqlKeywords.java
+++ b/core/trino-grammar/src/main/java/io/trino/grammar/sql/SqlKeywords.java
@@ -28,6 +28,20 @@ public final class SqlKeywords
 
     private SqlKeywords() {}
 
+    /**
+     * Whether the token type denotes a keyword: a token whose literal name in the
+     * vocabulary is a quoted bare word ('SELECT'), unlike operator literals ('=')
+     * and tokens defined by patterns, which have no literal name.
+     */
+    public static boolean isKeyword(int tokenType)
+    {
+        if (tokenType < 0) {
+            return false;
+        }
+        String name = nullToEmpty(SqlBaseLexer.VOCABULARY.getLiteralName(tokenType));
+        return IDENTIFIER.matcher(name).matches();
+    }
+
     public static Set<String> sqlKeywords()
     {
         ImmutableSet.Builder<String> names = ImmutableSet.builder();

--- a/core/trino-main/src/main/java/io/trino/metadata/BuiltinFunctionResolver.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/BuiltinFunctionResolver.java
@@ -167,6 +167,7 @@ class BuiltinFunctionResolver
     private Collection<CatalogFunctionMetadata> getBuiltinFunctions(String functionName)
     {
         return globalFunctionCatalog.getBuiltInFunctions(functionName).stream()
+                .filter(function -> !function.isMethod())
                 .map(function -> new CatalogFunctionMetadata(GlobalSystemConnector.CATALOG_HANDLE, BUILTIN_SCHEMA, function))
                 .collect(toImmutableList());
     }

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
@@ -230,7 +230,9 @@ public class FunctionResolver
                 functionBinding.functionBinding(),
                 functionBinding.boundFunctionMetadata(),
                 dependencies,
-                catalogSchemaFunctionName -> metadata.getFunctions(session, catalogSchemaFunctionName),
+                catalogSchemaFunctionName -> filterCandidates(
+                        metadata.getFunctions(session, catalogSchemaFunctionName),
+                        candidate -> !candidate.functionMetadata().isMethod()),
                 catalogFunctionBinding -> resolve(session, catalogFunctionBinding, accessControl));
     }
 

--- a/core/trino-main/src/main/java/io/trino/metadata/GlobalFunctionCatalog.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/GlobalFunctionCatalog.java
@@ -52,6 +52,7 @@ import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.metadata.OperatorNameUtil.isOperatorName;
 import static io.trino.metadata.OperatorNameUtil.mangleOperatorName;
@@ -149,7 +150,9 @@ public class GlobalFunctionCatalog
 
     public List<FunctionMetadata> listFunctions()
     {
-        return functions.list();
+        return functions.list().stream()
+                .filter(function -> !function.isMethod())
+                .collect(toImmutableList());
     }
 
     public Collection<FunctionMetadata> getBuiltInFunctions(String functionName)

--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -123,6 +123,7 @@ import io.trino.operator.scalar.ArrayUnionFunction;
 import io.trino.operator.scalar.ArrayVectorFunctions;
 import io.trino.operator.scalar.ArraysOverlapFunction;
 import io.trino.operator.scalar.BitwiseFunctions;
+import io.trino.operator.scalar.CharMethods;
 import io.trino.operator.scalar.CharacterStringCasts;
 import io.trino.operator.scalar.ColorFunctions;
 import io.trino.operator.scalar.CombineHashFunction;
@@ -176,6 +177,7 @@ import io.trino.operator.scalar.TryFunction;
 import io.trino.operator.scalar.TypeOfFunction;
 import io.trino.operator.scalar.UrlFunctions;
 import io.trino.operator.scalar.VarbinaryFunctions;
+import io.trino.operator.scalar.VarcharMethods;
 import io.trino.operator.scalar.VersionFunction;
 import io.trino.operator.scalar.WilsonInterval;
 import io.trino.operator.scalar.WordStemFunction;
@@ -453,6 +455,8 @@ public final class SystemFunctionBundle
                 .scalars(SequenceFunction.class)
                 .scalars(SessionFunctions.class)
                 .scalars(StringFunctions.class)
+                .scalars(VarcharMethods.class)
+                .scalars(CharMethods.class)
                 .scalars(WordStemFunction.class)
                 .scalar(SplitToMapFunction.class)
                 .scalar(SplitToMultimapFunction.class)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/CharMethods.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/CharMethods.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.InstanceMethod;
+import io.trino.spi.function.LiteralParameter;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+
+public final class CharMethods
+{
+    private CharMethods() {}
+
+    @Description("Count of code points of the given string")
+    @ScalarFunction(value = "length", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType(StandardTypes.BIGINT)
+    public static long length(@LiteralParameter("x") long x, @SqlType("char(x)") Slice slice)
+    {
+        return StringFunctions.charLength(x, slice);
+    }
+
+    @Description("Reverse all code points in a given string")
+    @ScalarFunction(value = "reverse", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("char(x)")
+    public static Slice reverse(@LiteralParameter("x") long x, @SqlType("char(x)") Slice slice)
+    {
+        return StringFunctions.charReverse(x, slice);
+    }
+
+    @Description("Suffix starting at given index")
+    @ScalarFunction(value = "substring", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("varchar(x)")
+    public static Slice substring(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start)
+    {
+        return StringFunctions.charSubstring(x, utf8, start);
+    }
+
+    @Description("Substring of given length starting at an index")
+    @ScalarFunction(value = "substring", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("varchar(x)")
+    public static Slice substring(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start, @SqlType(StandardTypes.BIGINT) long length)
+    {
+        return StringFunctions.charSubstr(x, utf8, start, length);
+    }
+
+    @Description("Converts the string to lower case")
+    @ScalarFunction(value = "lower", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("char(x)")
+    public static Slice lower(@SqlType("char(x)") Slice slice)
+    {
+        return StringFunctions.charLower(slice);
+    }
+
+    @Description("Converts the string to upper case")
+    @ScalarFunction(value = "upper", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("char(x)")
+    public static Slice upper(@SqlType("char(x)") Slice slice)
+    {
+        return StringFunctions.charUpper(slice);
+    }
+
+    @Description("Pads a string on the left")
+    @ScalarFunction("lpad")
+    @InstanceMethod
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice leftPad(@LiteralParameter("x") long x, @SqlType("char(x)") Slice text, @SqlType(StandardTypes.BIGINT) long targetLength, @SqlType("varchar(y)") Slice padString)
+    {
+        return StringFunctions.leftPad(x, text, targetLength, padString);
+    }
+
+    @Description("Encodes the string to UTF-8")
+    @ScalarFunction(value = "to_utf8", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice toUtf8(@LiteralParameter("x") long x, @SqlType("char(x)") Slice slice)
+    {
+        return StringFunctions.toUtf8(x, slice);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ScalarHeader.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ScalarHeader.java
@@ -35,6 +35,7 @@ import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.metadata.OperatorNameUtil.mangleOperatorName;
 import static io.trino.operator.annotations.FunctionsParserHelper.parseDescription;
+import static io.trino.sql.analyzer.TypeDescriptorTranslator.hasTypeParameters;
 import static io.trino.sql.analyzer.TypeDescriptorTranslator.parseTypeDescriptor;
 import static java.util.Objects.requireNonNull;
 
@@ -99,9 +100,9 @@ public class ScalarHeader
             String baseName = scalarFunction.value().isEmpty() ? camelToSnake(annotatedName(annotated)) : scalarFunction.value();
             Optional<TypeTemplate> receiverType = Optional.empty();
             if (staticMethod != null) {
+                checkArgument(!hasTypeParameters(staticMethod.value()), "@StaticMethod receiver type must not have parameters: %s", staticMethod.value());
                 TypeDescriptor parsed = parseTypeDescriptor(staticMethod.value());
-                checkArgument(parsed.getParameters().isEmpty(), "@StaticMethod receiver type must not have parameters: %s", staticMethod.value());
-                receiverType = Optional.of(TypeTemplates.fromTypeDescriptor(parsed));
+                receiverType = Optional.of(TypeTemplates.fromTypeDescriptor(new TypeDescriptor(parsed.getBase())));
             }
             builder.add(new ScalarHeader(baseName, ImmutableSet.copyOf(scalarFunction.alias()), description, scalarFunction.hidden(), scalarFunction.deterministic(), scalarFunction.neverFails(), receiverType, instanceMethod != null));
         }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/VarcharMethods.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/VarcharMethods.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.block.Block;
+import io.trino.spi.function.Constraint;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.InstanceMethod;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.function.StaticMethod;
+import io.trino.spi.type.StandardTypes;
+import io.trino.type.CodePointsType;
+
+public final class VarcharMethods
+{
+    private VarcharMethods() {}
+
+    @Description("Count of code points of the given string")
+    @ScalarFunction(value = "length", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType(StandardTypes.BIGINT)
+    public static long length(@SqlType("varchar(x)") Slice slice)
+    {
+        return StringFunctions.length(slice);
+    }
+
+    @Description("Greedily removes occurrences of a pattern in a string")
+    @ScalarFunction(value = "replace", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters({"x", "y"})
+    @SqlType("varchar(x)")
+    public static Slice replace(@SqlType("varchar(x)") Slice str, @SqlType("varchar(y)") Slice search)
+    {
+        return StringFunctions.replace(str, search);
+    }
+
+    @Description("Greedily replaces occurrences of a pattern with a string")
+    @ScalarFunction(value = "replace", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters({"x", "y", "z", "u"})
+    @Constraint(variable = "u", expression = "min(2147483647, x + z * (x + 1))")
+    @SqlType("varchar(u)")
+    public static Slice replace(@SqlType("varchar(x)") Slice str, @SqlType("varchar(y)") Slice search, @SqlType("varchar(z)") Slice replace)
+    {
+        return StringFunctions.replace(str, search, replace);
+    }
+
+    @Description("Reverse all code points in a given string")
+    @ScalarFunction(value = "reverse", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("varchar(x)")
+    public static Slice reverse(@SqlType("varchar(x)") Slice slice)
+    {
+        return StringFunctions.reverse(slice);
+    }
+
+    @Description("Returns index of first occurrence of a substring (or 0 if not found)")
+    @ScalarFunction("strpos")
+    @InstanceMethod
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.BIGINT)
+    public static long stringPosition(@SqlType("varchar(x)") Slice string, @SqlType("varchar(y)") Slice substring)
+    {
+        return StringFunctions.stringPosition(string, substring);
+    }
+
+    @Description("Returns index of n-th occurrence of a substring (or 0 if not found)")
+    @ScalarFunction("strpos")
+    @InstanceMethod
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.BIGINT)
+    public static long stringPosition(@SqlType("varchar(x)") Slice string, @SqlType("varchar(y)") Slice substring, @SqlType(StandardTypes.BIGINT) long instance)
+    {
+        return StringFunctions.stringPosition(string, substring, instance);
+    }
+
+    @Description("Suffix starting at given index")
+    @ScalarFunction(value = "substring", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("varchar(x)")
+    public static Slice substring(@SqlType("varchar(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start)
+    {
+        return StringFunctions.substring(utf8, start);
+    }
+
+    @Description("Substring of given length starting at an index")
+    @ScalarFunction(value = "substring", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("varchar(x)")
+    public static Slice substring(@SqlType("varchar(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start, @SqlType(StandardTypes.BIGINT) long length)
+    {
+        return StringFunctions.substring(utf8, start, length);
+    }
+
+    @ScalarFunction("split")
+    @InstanceMethod
+    @LiteralParameters({"x", "y"})
+    @SqlType("array(varchar(x))")
+    public static Block split(@SqlType("varchar(x)") Slice string, @SqlType("varchar(y)") Slice delimiter)
+    {
+        return StringFunctions.split(string, delimiter);
+    }
+
+    @ScalarFunction("split")
+    @InstanceMethod
+    @LiteralParameters({"x", "y"})
+    @SqlType("array(varchar(x))")
+    public static Block split(@SqlType("varchar(x)") Slice string, @SqlType("varchar(y)") Slice delimiter, @SqlType(StandardTypes.BIGINT) long limit)
+    {
+        return StringFunctions.split(string, delimiter, limit);
+    }
+
+    @Description("Removes whitespace from the beginning and end of a string")
+    @ScalarFunction(value = "trim", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("varchar(x)")
+    public static Slice trim(@SqlType("varchar(x)") Slice slice)
+    {
+        return StringFunctions.trim(slice);
+    }
+
+    @Description("Remove the longest string containing only given characters from the beginning and end of a string")
+    @ScalarFunction(value = "trim", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("varchar(x)")
+    public static Slice trim(@SqlType("varchar(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
+    {
+        return StringFunctions.trim(slice, codePointsToTrim);
+    }
+
+    @Description("Removes whitespace from the beginning of a string")
+    @ScalarFunction(value = "ltrim", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("varchar(x)")
+    public static Slice leftTrim(@SqlType("varchar(x)") Slice slice)
+    {
+        return StringFunctions.leftTrim(slice);
+    }
+
+    @Description("Remove the longest string containing only given characters from the beginning of a string")
+    @ScalarFunction(value = "ltrim", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("varchar(x)")
+    public static Slice leftTrim(@SqlType("varchar(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
+    {
+        return StringFunctions.leftTrim(slice, codePointsToTrim);
+    }
+
+    @Description("Removes whitespace from the end of a string")
+    @ScalarFunction(value = "rtrim", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("varchar(x)")
+    public static Slice rightTrim(@SqlType("varchar(x)") Slice slice)
+    {
+        return StringFunctions.rightTrim(slice);
+    }
+
+    @Description("Remove the longest string containing only given characters from the end of a string")
+    @ScalarFunction(value = "rtrim", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("varchar(x)")
+    public static Slice rightTrim(@SqlType("varchar(x)") Slice slice, @SqlType(CodePointsType.NAME) int[] codePointsToTrim)
+    {
+        return StringFunctions.rightTrim(slice, codePointsToTrim);
+    }
+
+    @Description("Converts the string to lower case")
+    @ScalarFunction(value = "lower", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("varchar(x)")
+    public static Slice lower(@SqlType("varchar(x)") Slice slice)
+    {
+        return StringFunctions.lower(slice);
+    }
+
+    @Description("Converts the string to upper case")
+    @ScalarFunction(value = "upper", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType("varchar(x)")
+    public static Slice upper(@SqlType("varchar(x)") Slice slice)
+    {
+        return StringFunctions.upper(slice);
+    }
+
+    @Description("Pads a string on the left")
+    @ScalarFunction("lpad")
+    @InstanceMethod
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice leftPad(@SqlType("varchar(x)") Slice text, @SqlType(StandardTypes.BIGINT) long targetLength, @SqlType("varchar(y)") Slice padString)
+    {
+        return StringFunctions.leftPad(text, targetLength, padString);
+    }
+
+    @Description("Pads a string on the right")
+    @ScalarFunction("rpad")
+    @InstanceMethod
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice rightPad(@SqlType("varchar(x)") Slice text, @SqlType(StandardTypes.BIGINT) long targetLength, @SqlType("varchar(y)") Slice padString)
+    {
+        return StringFunctions.rightPad(text, targetLength, padString);
+    }
+
+    @Description("Encodes the string to UTF-8")
+    @ScalarFunction(value = "to_utf8", neverFails = true)
+    @InstanceMethod
+    @LiteralParameters("x")
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice toUtf8(@SqlType("varchar(x)") Slice slice)
+    {
+        return StringFunctions.toUtf8(slice);
+    }
+
+    @Description("Determine whether source starts with prefix or not")
+    @ScalarFunction("starts_with")
+    @InstanceMethod
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean startsWith(@SqlType("varchar(x)") Slice source, @SqlType("varchar(y)") Slice prefix)
+    {
+        return StringFunctions.startsWith(source, prefix);
+    }
+
+    @Description("Translate characters from the source string based on original and translations strings")
+    @ScalarFunction("translate")
+    @InstanceMethod
+    @LiteralParameters({"x", "y", "z"})
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice translate(@SqlType("varchar(x)") Slice source, @SqlType("varchar(y)") Slice from, @SqlType("varchar(z)") Slice to)
+    {
+        return StringFunctions.translate(source, from, to);
+    }
+
+    @Description("Convert Unicode code point to a string")
+    @ScalarFunction
+    @StaticMethod(StandardTypes.VARCHAR)
+    @SqlType("varchar(1)")
+    public static Slice chr(@SqlType(StandardTypes.BIGINT) long codepoint)
+    {
+        return StringFunctions.chr(codepoint);
+    }
+
+    @Description("Decodes the UTF-8 encoded string")
+    @ScalarFunction
+    @StaticMethod(StandardTypes.VARCHAR)
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice fromUtf8(@SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        return StringFunctions.fromUtf8(slice);
+    }
+
+    @Description("Decodes the UTF-8 encoded string")
+    @ScalarFunction
+    @StaticMethod(StandardTypes.VARCHAR)
+    @LiteralParameters("x")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice fromUtf8(@SqlType(StandardTypes.VARBINARY) Slice slice, @SqlType("varchar(x)") Slice replacementCharacter)
+    {
+        return StringFunctions.fromUtf8(slice, replacementCharacter);
+    }
+
+    @Description("Decodes the UTF-8 encoded string")
+    @ScalarFunction
+    @StaticMethod(StandardTypes.VARCHAR)
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice fromUtf8(@SqlType(StandardTypes.VARBINARY) Slice slice, @SqlType(StandardTypes.BIGINT) long replacementCodePoint)
+    {
+        return StringFunctions.fromUtf8(slice, replacementCodePoint);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/TypeDescriptorTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/TypeDescriptorTranslator.java
@@ -377,4 +377,12 @@ public final class TypeDescriptorTranslator
     {
         return SQL_PARSER.createType(signature);
     }
+
+    /// Whether a type signature is written with explicit parameters, distinguishing `varchar(10)` from a
+    /// bare `varchar`. The written form is inspected directly, so an unbounded `varchar` -- which lowers
+    /// to a magic length parameter -- is reported as having none.
+    public static boolean hasTypeParameters(String signature)
+    {
+        return !(parseDataType(signature) instanceof GenericDataType genericDataType) || !genericDataType.getArguments().isEmpty();
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestCharMethods.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestCharMethods.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestCharMethods
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testLength()
+    {
+        assertThat(assertions.expression("CAST('ab' AS char(4)).length()"))
+                .matches("length(CAST('ab' AS char(4)))");
+    }
+
+    @Test
+    public void testReverse()
+    {
+        assertThat(assertions.expression("CAST('abc' AS char(3)).reverse()"))
+                .matches("reverse(CAST('abc' AS char(3)))");
+    }
+
+    @Test
+    public void testSubstring()
+    {
+        assertThat(assertions.expression("CAST('hello' AS char(5)).substring(2)"))
+                .matches("substring(CAST('hello' AS char(5)), 2)");
+        assertThat(assertions.expression("CAST('hello' AS char(5)).substring(2, 3)"))
+                .matches("substring(CAST('hello' AS char(5)), 2, 3)");
+    }
+
+    @Test
+    public void testLowerUpper()
+    {
+        assertThat(assertions.expression("CAST('AbC' AS char(3)).lower()"))
+                .matches("lower(CAST('AbC' AS char(3)))");
+        assertThat(assertions.expression("CAST('AbC' AS char(3)).upper()"))
+                .matches("upper(CAST('AbC' AS char(3)))");
+    }
+
+    @Test
+    public void testPad()
+    {
+        assertThat(assertions.expression("CAST('hi' AS char(2)).lpad(5, '*')"))
+                .matches("lpad(CAST('hi' AS char(2)), 5, '*')");
+    }
+
+    @Test
+    public void testToUtf8()
+    {
+        assertThat(assertions.expression("CAST('abc' AS char(3)).to_utf8()"))
+                .matches("to_utf8(CAST('abc' AS char(3)))");
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestVarcharMethods.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestVarcharMethods.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestVarcharMethods
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testLength()
+    {
+        assertThat(assertions.expression("'foo'.length()"))
+                .matches("length('foo')");
+    }
+
+    @Test
+    public void testReplace()
+    {
+        assertThat(assertions.expression("'abcba'.replace('b')"))
+                .matches("replace('abcba', 'b')");
+        assertThat(assertions.expression("'abc'.replace('b', 'xx')"))
+                .matches("replace('abc', 'b', 'xx')");
+    }
+
+    @Test
+    public void testReverse()
+    {
+        assertThat(assertions.expression("'abc'.reverse()"))
+                .matches("reverse('abc')");
+    }
+
+    @Test
+    public void testStrpos()
+    {
+        assertThat(assertions.expression("'hello'.strpos('l')"))
+                .matches("strpos('hello', 'l')");
+        assertThat(assertions.expression("'hello'.strpos('l', 2)"))
+                .matches("strpos('hello', 'l', 2)");
+    }
+
+    @Test
+    public void testSubstring()
+    {
+        assertThat(assertions.expression("'hello'.substring(2)"))
+                .matches("substring('hello', 2)");
+        assertThat(assertions.expression("'hello'.substring(2, 3)"))
+                .matches("substring('hello', 2, 3)");
+    }
+
+    @Test
+    public void testSplit()
+    {
+        assertThat(assertions.expression("'a,b,c'.split(',')"))
+                .matches("split('a,b,c', ',')");
+        assertThat(assertions.expression("'a,b,c'.split(',', 2)"))
+                .matches("split('a,b,c', ',', 2)");
+    }
+
+    @Test
+    public void testTrims()
+    {
+        assertThat(assertions.expression("'  x '.trim()"))
+                .matches("trim('  x ')");
+        assertThat(assertions.expression("'xxhixx'.trim('x')"))
+                .matches("trim('xxhixx', 'x')");
+        assertThat(assertions.expression("'  x '.ltrim()"))
+                .matches("ltrim('  x ')");
+        assertThat(assertions.expression("'  x '.rtrim()"))
+                .matches("rtrim('  x ')");
+        assertThat(assertions.expression("'xxhixx'.ltrim('x')"))
+                .matches("ltrim('xxhixx', 'x')");
+        assertThat(assertions.expression("'xxhixx'.rtrim('x')"))
+                .matches("rtrim('xxhixx', 'x')");
+    }
+
+    @Test
+    public void testLowerUpper()
+    {
+        assertThat(assertions.expression("'AbC'.lower()"))
+                .matches("lower('AbC')");
+        assertThat(assertions.expression("'AbC'.upper()"))
+                .matches("upper('AbC')");
+    }
+
+    @Test
+    public void testPad()
+    {
+        assertThat(assertions.expression("'hi'.lpad(5, '*')"))
+                .matches("lpad('hi', 5, '*')");
+        assertThat(assertions.expression("'hi'.rpad(5, '*')"))
+                .matches("rpad('hi', 5, '*')");
+    }
+
+    @Test
+    public void testToUtf8()
+    {
+        assertThat(assertions.expression("'abc'.to_utf8()"))
+                .matches("to_utf8('abc')");
+    }
+
+    @Test
+    public void testStartsWith()
+    {
+        assertThat(assertions.expression("'hello'.starts_with('he')"))
+                .matches("starts_with('hello', 'he')");
+    }
+
+    @Test
+    public void testTranslate()
+    {
+        assertThat(assertions.expression("'abcd'.translate('ac', 'xy')"))
+                .matches("translate('abcd', 'ac', 'xy')");
+    }
+
+    @Test
+    public void testVarcharStatics()
+    {
+        assertThat(assertions.expression("varchar::chr(65)"))
+                .matches("chr(65)");
+        assertThat(assertions.expression("varchar::from_utf8(to_utf8('hello'))"))
+                .matches("from_utf8(to_utf8('hello'))");
+        assertThat(assertions.expression("varchar::from_utf8(X'58BF', '#')"))
+                .matches("from_utf8(X'58BF', '#')");
+        assertThat(assertions.expression("varchar::from_utf8(X'58BF', 35)"))
+                .matches("from_utf8(X'58BF', 35)");
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -444,7 +444,7 @@ public final class ExpressionFormatter
         protected String visitIdentifier(Identifier node, Void context)
         {
             if (node.isDelimited() || reserved(node.getValue())) {
-                return '"' + node.getValue().replace("\"", "\"\"") + '"';
+                return quoteIdentifier(node.getValue());
             }
             return node.getValue();
         }
@@ -531,13 +531,26 @@ public final class ExpressionFormatter
         @Override
         protected String visitStaticMethodCall(StaticMethodCall node, Void context)
         {
-            return formatName(node.getType()) + "::" + formatExpression(node.getMethod()) + "(" + joinCallArguments(node.getArguments()) + ")";
+            return formatName(node.getType()) + "::" + formatMethodName(node.getMethod()) + "(" + joinCallArguments(node.getArguments()) + ")";
         }
 
         @Override
         protected String visitMethodCall(MethodCall node, Void context)
         {
-            return "(" + formatExpression(node.getReceiver()) + ")." + formatExpression(node.getMethod()) + "(" + joinCallArguments(node.getArguments()) + ")";
+            return "(" + formatExpression(node.getReceiver()) + ")." + formatMethodName(node.getMethod()) + "(" + joinCallArguments(node.getArguments()) + ")";
+        }
+
+        private static String formatMethodName(Identifier name)
+        {
+            if (name.isDelimited()) {
+                return quoteIdentifier(name.getValue());
+            }
+            return name.getValue();
+        }
+
+        private static String quoteIdentifier(String value)
+        {
+            return '"' + value.replace("\"", "\"\"") + '"';
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -3179,7 +3179,7 @@ class AstBuilder
         return new StaticMethodCall(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
-                (Identifier) visit(context.identifier()),
+                (Identifier) visit(context.methodName()),
                 visit(context.argument(), CallArgument.class));
     }
 
@@ -3189,8 +3189,18 @@ class AstBuilder
         return new MethodCall(
                 getLocation(context),
                 (Expression) visit(context.primaryExpression()),
-                (Identifier) visit(context.identifier()),
+                (Identifier) visit(context.methodName()),
                 visit(context.argument(), CallArgument.class));
+    }
+
+    @Override
+    public Node visitMethodName(SqlBaseParser.MethodNameContext context)
+    {
+        if (context.identifier() != null) {
+            return visit(context.identifier());
+        }
+        // a keyword used as a method name
+        return new Identifier(getLocation(context), context.getText(), false);
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/ErrorHandler.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/ErrorHandler.java
@@ -27,6 +27,7 @@ import org.antlr.v4.runtime.atn.ATN;
 import org.antlr.v4.runtime.atn.ATNState;
 import org.antlr.v4.runtime.atn.NotSetTransition;
 import org.antlr.v4.runtime.atn.PrecedencePredicateTransition;
+import org.antlr.v4.runtime.atn.PredicateTransition;
 import org.antlr.v4.runtime.atn.RuleStartState;
 import org.antlr.v4.runtime.atn.RuleStopState;
 import org.antlr.v4.runtime.atn.RuleTransition;
@@ -41,6 +42,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.IntPredicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -56,12 +58,14 @@ class ErrorHandler
     private final Map<Integer, String> specialRules;
     private final Map<Integer, String> specialTokens;
     private final Set<Integer> ignoredRules;
+    private final Map<Integer, IntPredicate> tokenPredicates;
 
-    private ErrorHandler(Map<Integer, String> specialRules, Map<Integer, String> specialTokens, Set<Integer> ignoredRules)
+    private ErrorHandler(Map<Integer, String> specialRules, Map<Integer, String> specialTokens, Set<Integer> ignoredRules, Map<Integer, IntPredicate> tokenPredicates)
     {
         this.specialRules = new HashMap<>(specialRules);
         this.specialTokens = specialTokens;
         this.ignoredRules = new HashSet<>(ignoredRules);
+        this.tokenPredicates = new HashMap<>(tokenPredicates);
     }
 
     @Override
@@ -91,7 +95,7 @@ class ErrorHandler
                 context = parser.getContext();
             }
 
-            Analyzer analyzer = new Analyzer(parser, specialRules, specialTokens, ignoredRules);
+            Analyzer analyzer = new Analyzer(parser, specialRules, specialTokens, ignoredRules, tokenPredicates);
             Result result = analyzer.process(currentState, currentToken.getTokenIndex(), context);
 
             // pick the candidate tokens associated largest token index processed (i.e., the path that consumed the most input)
@@ -99,7 +103,12 @@ class ErrorHandler
                     .sorted()
                     .collect(Collectors.joining(", "));
 
-            message = "mismatched input '%s'. Expecting: %s".formatted(parser.getTokenStream().get(result.getErrorTokenIndex()).getText(), expected);
+            Token errorToken = parser.getTokenStream().get(result.getErrorTokenIndex());
+            message = "mismatched input '%s'. Expecting: %s".formatted(errorToken.getText(), expected);
+            // point at the token the message names: the parser may have failed
+            // further ahead on a speculative path the analyzer rejected
+            line = errorToken.getLine();
+            charPositionInLine = errorToken.getCharPositionInLine();
         }
         catch (Exception exception) {
             LOG.log(SEVERE, "Unexpected failure when handling parsing error. This is likely a bug in the implementation", exception);
@@ -174,6 +183,7 @@ class ErrorHandler
         private final Map<Integer, String> specialRules;
         private final Map<Integer, String> specialTokens;
         private final Set<Integer> ignoredRules;
+        private final Map<Integer, IntPredicate> tokenPredicates;
         private final TokenStream stream;
 
         private int furthestTokenIndex = -1;
@@ -185,7 +195,8 @@ class ErrorHandler
                 Parser parser,
                 Map<Integer, String> specialRules,
                 Map<Integer, String> specialTokens,
-                Set<Integer> ignoredRules)
+                Set<Integer> ignoredRules,
+                Map<Integer, IntPredicate> tokenPredicates)
         {
             this.parser = parser;
             this.stream = parser.getTokenStream();
@@ -194,6 +205,7 @@ class ErrorHandler
             this.specialRules = specialRules;
             this.specialTokens = specialTokens;
             this.ignoredRules = ignoredRules;
+            this.tokenPredicates = tokenPredicates;
         }
 
         public Result process(ATNState currentState, int tokenIndex, RuleContext context)
@@ -304,11 +316,24 @@ class ErrorHandler
                             activeStates.push(new ParsingState(transition.target, tokenIndex, suppressed, parser));
                         }
                     }
+                    else if (transition instanceof PredicateTransition predicateTransition) {
+                        // evaluate registered token-lookahead predicates at the simulated
+                        // position, mirroring what prediction does at the real position;
+                        // unknown predicates are assumed true, like other epsilons
+                        IntPredicate predicate = tokenPredicates.get(predicateTransition.ruleIndex);
+                        if (predicate == null || predicate.test(stream.get(tokenIndex).getType())) {
+                            activeStates.push(new ParsingState(transition.target, tokenIndex, suppressed, parser));
+                        }
+                    }
                     else if (transition.isEpsilon()) {
                         activeStates.push(new ParsingState(transition.target, tokenIndex, suppressed, parser));
                     }
                     else if (transition instanceof WildcardTransition) {
-                        throw new UnsupportedOperationException("not yet implemented: wildcard transition");
+                        // a wildcard matches any token, so it contributes no expected
+                        // tokens; it only fails to advance at the end of the buffer
+                        if (tokenIndex < stream.size() - 1) {
+                            activeStates.push(new ParsingState(transition.target, tokenIndex + 1, false, parser));
+                        }
                     }
                     else {
                         IntervalSet labels = transition.label();
@@ -381,6 +406,7 @@ class ErrorHandler
     {
         private final Map<Integer, String> specialRules = new HashMap<>();
         private final Map<Integer, String> specialTokens = new HashMap<>();
+        private final Map<Integer, IntPredicate> tokenPredicates = new HashMap<>();
         private final Set<Integer> ignoredRules = new HashSet<>();
 
         public Builder specialRule(int ruleId, String name)
@@ -395,6 +421,17 @@ class ErrorHandler
             return this;
         }
 
+        /**
+         * Registers the token-lookahead semantic predicate guarding alternatives of
+         * the given rule, so the analyzer can follow only the paths that prediction
+         * would have followed.
+         */
+        public Builder tokenPredicate(int ruleId, IntPredicate predicate)
+        {
+            tokenPredicates.put(ruleId, predicate);
+            return this;
+        }
+
         public Builder ignoredRule(int ruleId)
         {
             ignoredRules.add(ruleId);
@@ -403,7 +440,7 @@ class ErrorHandler
 
         public ErrorHandler build()
         {
-            return new ErrorHandler(specialRules, specialTokens, ignoredRules);
+            return new ErrorHandler(specialRules, specialTokens, ignoredRules, tokenPredicates);
         }
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/SqlParser.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/SqlParser.java
@@ -16,6 +16,7 @@ package io.trino.sql.parser;
 import io.trino.grammar.sql.SqlBaseBaseListener;
 import io.trino.grammar.sql.SqlBaseLexer;
 import io.trino.grammar.sql.SqlBaseParser;
+import io.trino.grammar.sql.SqlKeywords;
 import io.trino.sql.tree.DataType;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.FunctionSpecification;
@@ -71,6 +72,8 @@ public class SqlParser
             .specialRule(SqlBaseParser.RULE_primaryExpression, "<expression>")
             .specialRule(SqlBaseParser.RULE_predicate, "<predicate>")
             .specialRule(SqlBaseParser.RULE_identifier, "<identifier>")
+            .specialRule(SqlBaseParser.RULE_methodName, "<identifier>")
+            .tokenPredicate(SqlBaseParser.RULE_methodName, SqlKeywords::isKeyword)
             .specialRule(SqlBaseParser.RULE_string, "<string>")
             .specialRule(SqlBaseParser.RULE_query, "<query>")
             .specialRule(SqlBaseParser.RULE_type, "<type>")

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -383,6 +383,14 @@ public class TestSqlParser
                         new Identifier(location(1, 9), "parse", false),
                         ImmutableList.of(new CallArgument(location(1, 15), Optional.of(new Identifier(location(1, 15), "value", false)), new StringLiteral(location(1, 24), "42")))));
 
+        // A reserved keyword may be used as a static method name.
+        assertThat(expression("t::values()"))
+                .isEqualTo(new StaticMethodCall(
+                        location(1, 1),
+                        QualifiedName.of(ImmutableList.of(new Identifier(location(1, 1), "t", false))),
+                        new Identifier(location(1, 4), "values", false),
+                        ImmutableList.of()));
+
         // Parametric receiver types are not allowed in the grammar.
         assertInvalidExpression("varchar(5)::parse('42')", "mismatched input '::'.*");
     }
@@ -484,6 +492,14 @@ public class TestSqlParser
                         QualifiedName.of(ImmutableList.of(
                                 new Identifier(location(1, 1), "x", false),
                                 new Identifier(location(1, 3), "length", false))),
+                        ImmutableList.of()));
+
+        // A reserved keyword may be used as a method name.
+        assertThat(expression("('a').trim()"))
+                .isEqualTo(new MethodCall(
+                        location(1, 1),
+                        new StringLiteral(location(1, 2), "a"),
+                        new Identifier(location(1, 7), "trim", false),
                         ImmutableList.of()));
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/function/FunctionMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/FunctionMetadata.java
@@ -172,6 +172,16 @@ public class FunctionMetadata
     }
 
     /**
+     * Whether this is a method -- an instance or static method invoked through
+     * {@code receiver.method(args)} or {@code type::method(args)} -- rather than a
+     * plain function. Equivalent to {@link #getReceiverType()} being present.
+     */
+    public boolean isMethod()
+    {
+        return receiverType.isPresent();
+    }
+
+    /**
      * Whether this is an instance method (receiver passed as the first
      * argument) rather than a static method. Only meaningful when
      * {@link #getReceiverType()} is present.

--- a/docs/src/main/sphinx/language/types.md
+++ b/docs/src/main/sphinx/language/types.md
@@ -200,6 +200,296 @@ you need to use `\+01F600` for a grinning face emoji.
 Single quotes in string literals can be escaped by using another single quote: 
 `'I am big, it''s the pictures that got small!'`
 
+#### Methods
+
+The following instance methods are available on `VARCHAR` values. Each returns a
+new value; the receiver is never modified. The related plain function is linked
+from each entry.
+
+:::{function} string.length() -> bigint
+:noindex: true
+
+Returns the number of Unicode code points in `string`. Related: {func}`length`.
+
+```
+SELECT 'Hello, World!'.length();
+-- 13
+```
+:::
+
+:::{function} string.lower() -> varchar
+:noindex: true
+
+Returns `string` with every character converted to lower case. Related:
+{func}`lower`.
+
+```
+SELECT 'HELLO'.lower();
+-- hello
+```
+:::
+
+:::{function} string.upper() -> varchar
+:noindex: true
+
+Returns `string` with every character converted to upper case. Related:
+{func}`upper`.
+
+```
+SELECT 'hello'.upper();
+-- HELLO
+```
+:::
+
+:::{function} string.replace(search) -> varchar
+:noindex: true
+
+Returns `string` with every occurrence of the substring `search` removed.
+Related: {func}`replace`.
+
+```
+SELECT 'a.b.c'.replace('.');
+-- abc
+```
+:::
+
+:::{function} string.replace(search, replacement) -> varchar
+:noindex: true
+
+Returns `string` with every occurrence of the substring `search` replaced by
+`replacement`. Related: {func}`replace`.
+
+```
+SELECT 'a.b.c'.replace('.', '-');
+-- a-b-c
+```
+:::
+
+:::{function} string.reverse() -> varchar
+:noindex: true
+
+Returns `string` with its code points in reverse order. Related: {func}`reverse`.
+
+```
+SELECT 'Trino'.reverse();
+-- onirT
+```
+:::
+
+:::{function} string.split(delimiter) -> array(varchar)
+:noindex: true
+
+Splits `string` on each occurrence of `delimiter` and returns the pieces as an
+array. Related: {func}`split`.
+
+```
+SELECT 'a,b,c'.split(',');
+-- [a, b, c]
+```
+:::
+
+:::{function} string.split(delimiter, limit) -> array(varchar)
+:noindex: true
+
+Splits `string` on `delimiter` into at most `limit` pieces; the last piece holds
+the unsplit remainder. Related: {func}`split`.
+
+```
+SELECT 'a,b,c'.split(',', 2);
+-- [a, b,c]
+```
+:::
+
+:::{function} string.starts_with(prefix) -> boolean
+:noindex: true
+
+Returns `true` when `string` begins with `prefix`, otherwise `false`. Related:
+{func}`starts_with`.
+
+```
+SELECT 'apple'.starts_with('app');
+-- true
+```
+:::
+
+:::{function} string.strpos(substring) -> bigint
+:noindex: true
+
+Returns the 1-based index of the first occurrence of `substring` in `string`, or
+`0` when it does not occur. Related: {func}`strpos`.
+
+```
+SELECT 'hello'.strpos('l');
+-- 3
+```
+:::
+
+:::{function} string.strpos(substring, instance) -> bigint
+:noindex: true
+
+Returns the 1-based index of the `instance`-th occurrence of `substring` in
+`string`, or `0` when there are fewer than `instance` occurrences. Related:
+{func}`strpos`.
+
+```
+SELECT 'hello'.strpos('l', 2);
+-- 4
+```
+:::
+
+:::{function} string.substring(start) -> varchar
+:noindex: true
+
+Returns the part of `string` from the 1-based index `start` to the end. Related:
+{func}`substring`.
+
+```
+SELECT 'Trino'.substring(2);
+-- rino
+```
+:::
+
+:::{function} string.substring(start, length) -> varchar
+:noindex: true
+
+Returns the `length` code points of `string` beginning at the 1-based index
+`start`. Related: {func}`substring`.
+
+```
+SELECT 'Trino'.substring(2, 2);
+-- ri
+```
+:::
+
+:::{function} string.translate(from, to) -> varchar
+:noindex: true
+
+Returns `string` with each character that occurs in `from` replaced by the
+character at the same position in `to`, and removed when `to` is shorter.
+Related: {func}`translate`.
+
+```
+SELECT 'abcd'.translate('ac', 'xy');
+-- xbyd
+```
+:::
+
+:::{function} string.trim() -> varchar
+:noindex: true
+
+Returns `string` with whitespace removed from both ends. Related: {func}`trim`.
+
+```
+SELECT '  hi  '.trim();
+-- hi
+```
+:::
+
+:::{function} string.trim(chars) -> varchar
+:noindex: true
+
+Returns `string` with any of the characters in `chars` removed from both ends.
+Related: {func}`trim`.
+
+```
+SELECT '##hi##'.trim('#');
+-- hi
+```
+:::
+
+:::{function} string.ltrim() -> varchar
+:noindex: true
+
+Returns `string` with whitespace removed from the start. Related: {func}`ltrim`.
+:::
+
+:::{function} string.ltrim(chars) -> varchar
+:noindex: true
+
+Returns `string` with any of the characters in `chars` removed from the start.
+Related: {func}`ltrim`.
+:::
+
+:::{function} string.rtrim() -> varchar
+:noindex: true
+
+Returns `string` with whitespace removed from the end. Related: {func}`rtrim`.
+:::
+
+:::{function} string.rtrim(chars) -> varchar
+:noindex: true
+
+Returns `string` with any of the characters in `chars` removed from the end.
+Related: {func}`rtrim`.
+:::
+
+:::{function} string.lpad(size, padstring) -> varchar
+:noindex: true
+
+Returns `string` padded on the left with copies of `padstring` until it is `size`
+code points long, or truncated to `size` when already longer. Related:
+{func}`lpad`.
+
+```
+SELECT '7'.lpad(3, '0');
+-- 007
+```
+:::
+
+:::{function} string.rpad(size, padstring) -> varchar
+:noindex: true
+
+Returns `string` padded on the right with copies of `padstring` until it is
+`size` code points long, or truncated to `size` when already longer. Related:
+{func}`rpad`.
+
+```
+SELECT '7'.rpad(3, '0');
+-- 700
+```
+:::
+
+:::{function} string.to_utf8() -> varbinary
+:noindex: true
+
+Returns the UTF-8 encoding of `string` as a `VARBINARY` value. Related:
+{func}`to_utf8`.
+:::
+
+The following static methods construct `VARCHAR` values:
+
+:::{function} varchar::chr(n) -> varchar
+:noindex: true
+
+Returns the one-character string whose only character has Unicode code point `n`.
+Related: {func}`chr`.
+
+```
+SELECT varchar::chr(65);
+-- A
+```
+:::
+
+:::{function} varchar::from_utf8(binary) -> varchar
+:noindex: true
+
+Returns the string decoded from the UTF-8 bytes in `binary`, with invalid byte
+sequences replaced by the Unicode replacement character. Related:
+{func}`from_utf8`.
+
+```
+SELECT varchar::from_utf8(X'48656C6C6F');
+-- Hello
+```
+:::
+
+:::{function} varchar::from_utf8(binary, replace) -> varchar
+:noindex: true
+
+Returns the string decoded from the UTF-8 bytes in `binary`, with invalid byte
+sequences replaced by the string `replace`. Related: {func}`from_utf8`.
+:::
+
 ### `CHAR`
 
 Fixed length character data. A `CHAR` type without length specified has a
@@ -215,6 +505,66 @@ SELECT CHAR 'All right, Mr. DeMille, I''m ready for my close-up.'
 ```
 
 Example type definitions: `char`, `char(20)`
+
+#### Methods
+
+The following instance methods are available on `CHAR` values. Each returns a
+new value; the receiver is never modified.
+
+:::{function} string.length() -> bigint
+:noindex: true
+
+Returns the number of Unicode code points in `string`. Related: {func}`length`.
+:::
+
+:::{function} string.lower() -> char
+:noindex: true
+
+Returns `string` with every character converted to lower case. Related:
+{func}`lower`.
+:::
+
+:::{function} string.upper() -> char
+:noindex: true
+
+Returns `string` with every character converted to upper case. Related:
+{func}`upper`.
+:::
+
+:::{function} string.reverse() -> char
+:noindex: true
+
+Returns `string` with its code points in reverse order. Related: {func}`reverse`.
+:::
+
+:::{function} string.substring(start) -> char
+:noindex: true
+
+Returns the part of `string` from the 1-based index `start` to the end. Related:
+{func}`substring`.
+:::
+
+:::{function} string.substring(start, length) -> char
+:noindex: true
+
+Returns the `length` code points of `string` beginning at the 1-based index
+`start`. Related: {func}`substring`.
+:::
+
+:::{function} string.lpad(size, padstring) -> varchar
+:noindex: true
+
+Returns `string` padded on the left with copies of `padstring` until it is `size`
+code points long, or truncated to `size` when already longer. Related:
+{func}`lpad`.
+:::
+
+:::{function} string.to_utf8() -> varbinary
+:noindex: true
+
+Returns the UTF-8 encoding of `string` as a `VARBINARY` value. Related:
+{func}`to_utf8`.
+:::
 
 ### `VARBINARY`
 


### PR DESCRIPTION
## Description

Exposes the core string functions as SQL:2023 methods on `varchar` and `char`
receivers, building on the method-invocation framework already in master.
`value.length()`, `value.trim()`, `value.substring(2, 3)`,
`'abc'.replace('b', 'x')`, and the static constructors `varchar::chr(65)` and
`varchar::from_utf8(...)` resolve to the same implementations as the plain
functions. Functions and methods resolve in separate namespaces, so every
existing call keeps working.

Four commits:

1. **Allow reserved keywords as method names** — the grammar accepted only an
   `identifier` after `.` and `::`, so methods whose names are reserved keywords
   (`trim`, `substring`, `values`) could not be written. A `methodName` rule now
   accepts an identifier or, via a semantic predicate over the lexer vocabulary,
   any keyword token. The parser error analyzer learns to evaluate the predicate
   so "mismatched input" messages stay accurate, and the expression formatter
   renders a keyword method name unquoted so the printed form round-trips.

2. **Match `@StaticMethod` parameterized receiver on its base type** — a
   `@StaticMethod` receiver written as a parameterized type such as `varchar`
   parses with a default length parameter, so it is matched on its base type
   alone (the static-method namespace), not a specific parameterization.

3. **Resolve methods in a separate namespace from functions** — a method can
   share a name and signature with a plain function (`trim`, `strpos`) but is
   invoked only through method syntax. Functions carrying a receiver type are
   excluded from builtin function resolution, from declared `@FunctionDependency`
   resolution, and from the function listing, so an existing `TRIM(...)`, a
   function depending on `strpos`, and `SHOW FUNCTIONS` are all unaffected.

4. **Add varchar and char methods** — `VarcharMethods` / `CharMethods`
   delegation classes, their registration, tests, and the type-reference docs.

## Additional context and related issues

Continues the SQL:2023 method-invocation rollout that landed the framework in
master. Only `varchar` and `char` are covered here; other types are follow-ups.

## Release notes

(x) Release notes are required, with the following suggested text:

```
# General
* Add method-invocation syntax for `varchar` and `char` string functions, such
  as `value.length()`, `value.trim()`, and `varchar::chr(65)`.
```
