### PR TITLE
Test non-existing schema filter in iceberg_tables function

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -896,6 +896,13 @@ public abstract class BaseIcebergConnectorSmokeTest
                     .matches("SELECT table_schema, table_name FROM iceberg.information_schema.tables WHERE table_schema='%s'".formatted(firstSchema));
             assertThat(query("SELECT * FROM iceberg.system.iceberg_tables WHERE table_schema in ('%s', '%s')".formatted(firstSchema, secondSchema)))
                     .matches("SELECT table_schema, table_name FROM iceberg.information_schema.tables WHERE table_schema IN ('%s', '%s')".formatted(firstSchema, secondSchema));
+
+            // Specify a non-existing schema in WHERE clause
+            String nonExistingSchema = "non_existing_schema_" + randomNameSuffix();
+            assertThat(query("SELECT * FROM iceberg.system.iceberg_tables WHERE table_schema = '%s'".formatted(nonExistingSchema)))
+                    .returnsEmptyResult();
+            assertThat(query("SELECT * FROM iceberg.system.iceberg_tables WHERE table_schema in ('%s', '%s')".formatted(firstSchema, nonExistingSchema)))
+                    .matches("SELECT table_schema, table_name FROM iceberg.information_schema.tables WHERE table_schema='%s'".formatted(firstSchema));
         }
         finally {
             dropSchema(firstSchema);


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

