### PR TITLE
Fix exception during columns/comments listing with Iceberg Glue

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -849,6 +849,7 @@
                                 <exclude>**/TestIcebergGlueCatalogMaterializedView.java</exclude>
                                 <exclude>**/TestIcebergGlueCreateTableFailure.java</exclude>
                                 <exclude>**/TestIcebergGlueTableOperationsInsertFailure.java</exclude>
+                                <exclude>**/TestIcebergGlueAccessDeniedException.java</exclude>
                                 <exclude>**/TestIcebergGlueCatalogSkipArchive.java</exclude>
                                 <exclude>**/TestIcebergS3AndGlueMetastoreTest.java</exclude>
                                 <exclude>**/TestIcebergS3TablesConnectorSmokeTest.java</exclude>
@@ -921,6 +922,7 @@
                                 <include>**/TestIcebergGlueCatalogMaterializedView.java</include>
                                 <include>**/TestIcebergGlueCreateTableFailure.java</include>
                                 <include>**/TestIcebergGlueTableOperationsInsertFailure.java</include>
+                                <include>**/TestIcebergGlueAccessDeniedException.java</include>
                                 <include>**/TestIcebergGlueCatalogSkipArchive.java</include>
                                 <include>**/TestIcebergS3AndGlueMetastoreTest.java</include>
                                 <include>**/TestIcebergS3TablesConnectorSmokeTest.java</include>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -400,7 +400,7 @@ public class TrinoGlueCatalog
         Map<SchemaTableName, Table> unprocessed = new HashMap<>();
 
         listNamespaces(session, namespace).stream()
-                .flatMap(glueNamespace -> glueClient.streamTables(glueNamespace)
+                .flatMap(glueNamespace -> getGlueTablesWithExceptionHandling(glueNamespace)
                         .map(table -> entry(new SchemaTableName(glueNamespace, table.name()), table)))
                 .forEach(entry -> {
                     SchemaTableName name = entry.getKey();
@@ -493,7 +493,7 @@ public class TrinoGlueCatalog
         Map<SchemaTableName, Table> unprocessed = new HashMap<>();
 
         listNamespaces(session, namespace).stream()
-                .flatMap(glueNamespace -> glueClient.streamTables(glueNamespace)
+                .flatMap(glueNamespace -> getGlueTablesWithExceptionHandling(glueNamespace)
                         .map(table -> entry(new SchemaTableName(glueNamespace, table.name()), table)))
                 .forEach(entry -> {
                     SchemaTableName name = entry.getKey();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueAccessDeniedException.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueAccessDeniedException.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.glue;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.multibindings.ProvidesIntoSet;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.Session;
+import io.trino.metastore.Database;
+import io.trino.plugin.hive.metastore.glue.ForGlueHiveMetastore;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastore;
+import io.trino.plugin.iceberg.TestingIcebergPlugin;
+import io.trino.plugin.iceberg.catalog.IcebergCatalogModule;
+import io.trino.spi.security.PrincipalType;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.StandaloneQueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.glue.model.AccessDeniedException;
+import software.amazon.awssdk.services.glue.model.GetTablesRequest;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static io.trino.plugin.hive.metastore.glue.TestingGlueHiveMetastore.createTestingGlueHiveMetastore;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+final class TestIcebergGlueAccessDeniedException
+        extends AbstractTestQueryFramework
+{
+    private final String schemaName = "test_iceberg_glue_" + randomNameSuffix();
+
+    private GlueHiveMetastore glueHiveMetastore;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("iceberg")
+                .setSchema(schemaName)
+                .build();
+        QueryRunner queryRunner = new StandaloneQueryRunner(session);
+
+        Path dataDirectory = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data");
+        dataDirectory.toFile().deleteOnExit();
+
+        queryRunner.installPlugin(new TestingIcebergPlugin(dataDirectory, () -> Optional.of(new TestingGlueCatalogModule())));
+        queryRunner.createCatalog("iceberg", "iceberg", ImmutableMap.<String, String>builder()
+                .put("iceberg.catalog.type", "glue")
+                .put("fs.hadoop.enabled", "true")
+                .buildOrThrow());
+
+        glueHiveMetastore = createTestingGlueHiveMetastore(dataDirectory, this::closeAfterClass);
+
+        Database database = Database.builder()
+                .setDatabaseName(schemaName)
+                .setOwnerName(Optional.of("public"))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
+                .setLocation(Optional.of(dataDirectory.toString()))
+                .build();
+        glueHiveMetastore.createDatabase(database);
+
+        return queryRunner;
+    }
+
+    @AfterAll
+    void cleanup()
+    {
+        if (glueHiveMetastore != null) {
+            // Data is on the local disk and will be deleted by the deleteOnExit hook
+            glueHiveMetastore.dropDatabase(schemaName, false);
+            glueHiveMetastore.shutdown();
+        }
+    }
+
+    @Test
+    void testInformationSchemaColumns()
+    {
+        assertQueryReturnsEmptyResult("SELECT * FROM information_schema.columns WHERE table_schema = '" + schemaName + "'");
+    }
+
+    @Test
+    void testMetadataTableComments()
+    {
+        assertQueryReturnsEmptyResult("SELECT * FROM system.metadata.table_comments WHERE schema_name = '" + schemaName + "'");
+    }
+
+    private static class TestingGlueCatalogModule
+            extends AbstractConfigurationAwareModule
+    {
+        @Override
+        protected void setup(Binder binder)
+        {
+            install(new IcebergCatalogModule());
+        }
+
+        @ProvidesIntoSet
+        @ForGlueHiveMetastore
+        public ExecutionInterceptor createExecutionInterceptor()
+        {
+            return new ExecutionInterceptor()
+            {
+                @Override
+                public void afterExecution(Context.AfterExecution context, ExecutionAttributes executionAttributes)
+                {
+                    if (context.request() instanceof GetTablesRequest) {
+                        throw AccessDeniedException.builder().build();
+                    }
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes failure when `AccessDeniedException` happens during columns or comments listing:

```
io.trino.testing.QueryFailedException: Error listing table columns for catalog iceberg: null

	at io.trino.testing.TestingDirectTrinoClient.toMaterializedRows(TestingDirectTrinoClient.java:79)
	at io.trino.testing.TestingDirectTrinoClient.lambda$execute$0(TestingDirectTrinoClient.java:67)
	at io.trino.testing.StandaloneQueryRunner.execute(StandaloneQueryRunner.java:112)
	at io.trino.sql.query.QueryAssertions$QueryAssert.lambda$new$1(QueryAssertions.java:295)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:194)
	at io.trino.sql.query.QueryAssertions$QueryAssert.result(QueryAssertions.java:420)
	at io.trino.sql.query.QueryAssertions$QueryAssert.returnsEmptyResult(QueryAssertions.java:373)
	at io.trino.testing.AbstractTestQueryFramework.assertQueryReturnsEmptyResult(AbstractTestQueryFramework.java:467)
	at io.trino.plugin.iceberg.catalog.glue.TestIcebergGlueAccessDeniedException.testInformationSchemaColumns(TestIcebergGlueAccessDeniedException.java:100)
Caused by: io.trino.spi.TrinoException: Error listing table columns for catalog iceberg: null
	at io.trino.metadata.MetadataListing.handleListingException(MetadataListing.java:374)
	at io.trino.metadata.MetadataListing.listTableColumns(MetadataListing.java:271)
	at io.trino.connector.informationschema.InformationSchemaPageSource.addColumnsRecords(InformationSchemaPageSource.java:227)
	at io.trino.connector.informationschema.InformationSchemaPageSource.buildPages(InformationSchemaPageSource.java:210)
	at io.trino.connector.informationschema.InformationSchemaPageSource.getNextSourcePage(InformationSchemaPageSource.java:178)
	at io.trino.spi.connector.MemoryUsageReportingPageSource.getNextSourcePage(MemoryUsageReportingPageSource.java:71)
	at io.trino.operator.ScanFilterAndProjectOperator$ConnectorPageSourceToPages.process(ScanFilterAndProjectOperator.java:333)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:426)
```

## Release notes

```markdown
## Iceberg
* Fix failure when listing columns or table comments with Glue catalog. ({issue}`29995`)
```
