### PR TITLE
Add support for IS TRUE/FALSE/UNKNOWN boolean predicates

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -586,6 +586,7 @@ predicate[ParserRuleContext value]
     | NOT? IN '(' query ')'                                               #inSubquery
     | NOT? LIKE pattern=valueExpression (ESCAPE escape=valueExpression)?  #like
     | IS NOT? NULL                                                        #nullPredicate
+    | IS NOT? truthValue=(TRUE | FALSE | UNKNOWN)                         #booleanTest
     | IS NOT? DISTINCT FROM right=valueExpression                         #distinctFrom
     | MATCH UNIQUE? matchType=(SIMPLE | PARTIAL | FULL)? '(' query ')'    #match
     ;

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -83,6 +83,7 @@ import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
 import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.BooleanTestPredicate;
 import io.trino.sql.tree.CallArgument;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.CoalesceExpression;
@@ -951,6 +952,7 @@ public class ExpressionAnalyzer
         {
             return switch (node.getPredicate()) {
                 case BetweenPredicate predicate -> analyzeBetween(node.getValue(), predicate, node, context);
+                case BooleanTestPredicate _ -> analyzeBooleanTest(node.getValue(), node, context);
                 case ComparisonPredicate predicate -> analyzeComparison(node.getValue(), predicate, node, context);
                 case DistinctFromPredicate predicate -> analyzeDistinctFrom(node.getValue(), predicate, node, context);
                 case InPredicate predicate -> analyzeIn(node.getValue(), predicate, node, context);
@@ -1008,6 +1010,12 @@ public class ExpressionAnalyzer
         private Type analyzeIsNull(Expression value, Expression anchor, Context context)
         {
             process(value, context);
+            return setExpressionType(anchor, BOOLEAN);
+        }
+
+        private Type analyzeBooleanTest(Expression value, Expression anchor, Context context)
+        {
+            coerceType(context, value, BOOLEAN, "Boolean test value");
             return setExpressionType(anchor, BOOLEAN);
         }
 
@@ -1098,6 +1106,7 @@ public class ExpressionAnalyzer
                 if (whenClause.getMatch() instanceof WhenClause.Partial(Predicate predicate)) {
                     switch (predicate) {
                         case BetweenPredicate fragment -> analyzeBetween(operand, fragment, whenClause, context);
+                        case BooleanTestPredicate _ -> analyzeBooleanTest(operand, whenClause, context);
                         case ComparisonPredicate fragment -> analyzeComparison(operand, fragment, whenClause, context);
                         case DistinctFromPredicate fragment -> analyzeDistinctFrom(operand, fragment, whenClause, context);
                         case InPredicate fragment -> analyzeIn(operand, fragment, whenClause, context);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -62,6 +62,7 @@ import io.trino.sql.tree.AtTimeZone;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
 import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.BooleanTestPredicate;
 import io.trino.sql.tree.CallArgument;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.CoalesceExpression;
@@ -634,6 +635,17 @@ public class TranslationMap
             case IsNullPredicate predicate -> {
                 io.trino.sql.ir.Expression isNull = new IsNull(value);
                 yield predicate.isNegated() ? not(plannerContext.getMetadata(), isNull) : isNull;
+            }
+            case BooleanTestPredicate predicate -> {
+                // value IS [NOT] TRUE/FALSE is null-safe equality against the truth constant
+                // (IDENTICAL yields FALSE rather than NULL when value is NULL); IS [NOT] UNKNOWN
+                // is the null test. Either way the result is a non-NULL boolean.
+                io.trino.sql.ir.Expression test = switch (predicate.getTruthValue()) {
+                    case TRUE -> comparison(plannerContext.getMetadata(), IDENTICAL, value, TRUE);
+                    case FALSE -> comparison(plannerContext.getMetadata(), IDENTICAL, value, FALSE);
+                    case UNKNOWN -> new IsNull(value);
+                };
+                yield predicate.isNegated() ? not(plannerContext.getMetadata(), test) : test;
             }
             case LikePredicate predicate -> translateLike(value, predicate);
             case MatchPredicate _ -> throw new IllegalStateException("MATCH predicate should have been planned by SubqueryPlanner");

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestConditions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestConditions.java
@@ -190,6 +190,44 @@ public class TestConditions
     }
 
     @Test
+    public void testBooleanTest()
+    {
+        // IS TRUE
+        assertThat(assertions.expression("a IS TRUE").binding("a", "true")).isEqualTo(true);
+        assertThat(assertions.expression("a IS TRUE").binding("a", "false")).isEqualTo(false);
+        assertThat(assertions.expression("a IS TRUE").binding("a", "cast(null as boolean)")).isEqualTo(false);
+
+        // IS NOT TRUE
+        assertThat(assertions.expression("a IS NOT TRUE").binding("a", "true")).isEqualTo(false);
+        assertThat(assertions.expression("a IS NOT TRUE").binding("a", "false")).isEqualTo(true);
+        assertThat(assertions.expression("a IS NOT TRUE").binding("a", "cast(null as boolean)")).isEqualTo(true);
+
+        // IS FALSE
+        assertThat(assertions.expression("a IS FALSE").binding("a", "true")).isEqualTo(false);
+        assertThat(assertions.expression("a IS FALSE").binding("a", "false")).isEqualTo(true);
+        assertThat(assertions.expression("a IS FALSE").binding("a", "cast(null as boolean)")).isEqualTo(false);
+
+        // IS NOT FALSE
+        assertThat(assertions.expression("a IS NOT FALSE").binding("a", "true")).isEqualTo(true);
+        assertThat(assertions.expression("a IS NOT FALSE").binding("a", "false")).isEqualTo(false);
+        assertThat(assertions.expression("a IS NOT FALSE").binding("a", "cast(null as boolean)")).isEqualTo(true);
+
+        // IS UNKNOWN
+        assertThat(assertions.expression("a IS UNKNOWN").binding("a", "true")).isEqualTo(false);
+        assertThat(assertions.expression("a IS UNKNOWN").binding("a", "false")).isEqualTo(false);
+        assertThat(assertions.expression("a IS UNKNOWN").binding("a", "cast(null as boolean)")).isEqualTo(true);
+
+        // IS NOT UNKNOWN
+        assertThat(assertions.expression("a IS NOT UNKNOWN").binding("a", "true")).isEqualTo(true);
+        assertThat(assertions.expression("a IS NOT UNKNOWN").binding("a", "false")).isEqualTo(true);
+        assertThat(assertions.expression("a IS NOT UNKNOWN").binding("a", "cast(null as boolean)")).isEqualTo(false);
+
+        // the operand is evaluated as an arbitrary boolean expression, not just a reference
+        assertThat(assertions.expression("(a > 1) IS TRUE").binding("a", "2")).isEqualTo(true);
+        assertThat(assertions.expression("(a > 1) IS TRUE").binding("a", "0")).isEqualTo(false);
+    }
+
+    @Test
     public void testBetween()
     {
         // between

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -4368,6 +4368,23 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testBooleanTest()
+    {
+        // boolean operand accepted in all forms
+        analyze("SELECT a IS TRUE FROM (VALUES true) t(a)");
+        analyze("SELECT a IS NOT TRUE FROM (VALUES true) t(a)");
+        analyze("SELECT a IS FALSE FROM (VALUES true) t(a)");
+        analyze("SELECT a IS NOT FALSE FROM (VALUES true) t(a)");
+        analyze("SELECT a IS UNKNOWN FROM (VALUES true) t(a)");
+        analyze("SELECT a IS NOT UNKNOWN FROM (VALUES true) t(a)");
+
+        // non-boolean operand rejected
+        assertFails("SELECT 1 IS TRUE FROM t1")
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessage("line 1:8: Boolean test value must evaluate to a boolean (actual: integer)");
+    }
+
+    @Test
     public void testJoinUnnest()
     {
         // Lateral references are only allowed in INNER and LEFT join.

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestExtendedCase.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestExtendedCase.java
@@ -147,6 +147,31 @@ public class TestExtendedCase
     }
 
     @Test
+    public void testBooleanTest()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT CASE x
+                            WHEN IS TRUE THEN 1
+                            WHEN IS FALSE THEN 2
+                            WHEN IS UNKNOWN THEN 3
+                       END
+                FROM (VALUES true, false, CAST(NULL AS boolean)) t(x)
+                """))
+                .matches("VALUES 1, 2, 3");
+
+        assertThat(assertions.query(
+                """
+                SELECT CASE x
+                            WHEN IS NOT TRUE THEN 1
+                            ELSE 0
+                       END
+                FROM (VALUES true, false, CAST(NULL AS boolean)) t(x)
+                """))
+                .matches("VALUES 0, 1, 1");
+    }
+
+    @Test
     public void testLike()
     {
         assertThat(assertions.query(

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -27,6 +27,7 @@ import io.trino.sql.tree.AutoGroupBy;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
 import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.BooleanTestPredicate;
 import io.trino.sql.tree.CallArgument;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.CoalesceExpression;
@@ -628,6 +629,12 @@ public final class ExpressionFormatter
         protected String visitIsNullPredicate(IsNullPredicate node, Void context)
         {
             return node.isNegated() ? "IS NOT NULL" : "IS NULL";
+        }
+
+        @Override
+        protected String visitBooleanTestPredicate(BooleanTestPredicate node, Void context)
+        {
+            return (node.isNegated() ? "IS NOT " : "IS ") + node.getTruthValue();
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -40,6 +40,8 @@ import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BetweenPredicate.Symmetry;
 import io.trino.sql.tree.BinaryLiteral;
 import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.BooleanTestPredicate;
+import io.trino.sql.tree.BooleanTestPredicate.TruthValue;
 import io.trino.sql.tree.Call;
 import io.trino.sql.tree.CallArgument;
 import io.trino.sql.tree.CaseStatement;
@@ -2366,6 +2368,19 @@ class AstBuilder
     public Node visitNullPredicate(SqlBaseParser.NullPredicateContext context)
     {
         return new IsNullPredicate(getLocation(context), context.NOT() != null);
+    }
+
+    @Override
+    public Node visitBooleanTest(SqlBaseParser.BooleanTestContext context)
+    {
+        TruthValue truthValue = switch (context.truthValue.getType()) {
+            case SqlBaseLexer.TRUE -> TruthValue.TRUE;
+            case SqlBaseLexer.FALSE -> TruthValue.FALSE;
+            case SqlBaseLexer.UNKNOWN -> TruthValue.UNKNOWN;
+            default -> throw new IllegalArgumentException("Unsupported truth value: " + context.truthValue.getText());
+        };
+
+        return new BooleanTestPredicate(getLocation(context), context.NOT() != null, truthValue);
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -467,6 +467,11 @@ public abstract class AstVisitor<R, C>
         return visitPredicate(node, context);
     }
 
+    protected R visitBooleanTestPredicate(BooleanTestPredicate node, C context)
+    {
+        return visitPredicate(node, context);
+    }
+
     protected R visitLikePredicate(LikePredicate node, C context)
     {
         return visitPredicate(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/BooleanTestPredicate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/BooleanTestPredicate.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/// SQL spec `<boolean test> ::= <boolean primary> IS [NOT] <truth value>`, where
+/// `<truth value> ::= TRUE | FALSE | UNKNOWN`. Tests the three-valued result of a boolean
+/// operand against a truth value and always yields a non-NULL boolean. The in-place `NOT`
+/// (i.e. `IS NOT TRUE`) is recorded via [#isNegated()]; an outer `NOT (x IS TRUE)` is a
+/// separate [NotExpression] wrapping a non-negated `BooleanTestPredicate`.
+///
+/// Modeled as a [Predicate] subtype because, like the null predicate, it has a left-hand-side
+/// operand and reduces to a non-NULL boolean. The operand is therefore the [Predicated] value.
+public final class BooleanTestPredicate
+        extends Predicate
+{
+    public enum TruthValue
+    {
+        TRUE,
+        FALSE,
+        UNKNOWN,
+    }
+
+    private final boolean negated;
+    private final TruthValue truthValue;
+
+    public BooleanTestPredicate(NodeLocation location, boolean negated, TruthValue truthValue)
+    {
+        super(location);
+        this.negated = negated;
+        this.truthValue = requireNonNull(truthValue, "truthValue is null");
+    }
+
+    public boolean isNegated()
+    {
+        return negated;
+    }
+
+    public TruthValue getTruthValue()
+    {
+        return truthValue;
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return List.of();
+    }
+
+    @Override
+    protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitBooleanTestPredicate(this, context);
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        if (!sameClass(this, other)) {
+            return false;
+        }
+        BooleanTestPredicate that = (BooleanTestPredicate) other;
+        return negated == that.negated && truthValue == that.truthValue;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        return o instanceof BooleanTestPredicate that
+                && negated == that.negated
+                && truthValue == that.truthValue;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(negated, truthValue);
+    }
+
+    @Override
+    public String toString()
+    {
+        return (negated ? "IS NOT " : "IS ") + truthValue;
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
@@ -296,6 +296,7 @@ public final class ExpressionTreeRewriter<C>
                     yield valueList == predicate.getValueList() ? predicate : new InPredicate(predicate.getLocation().orElseThrow(), predicate.isNegated(), valueList);
                 }
                 case IsNullPredicate predicate -> predicate;
+                case BooleanTestPredicate predicate -> predicate;
                 case LikePredicate predicate -> {
                     Expression pattern = rewrite(predicate.getPattern(), context.get());
                     Optional<Expression> rewrittenEscape = predicate.getEscape().map(escape -> rewrite(escape, context.get()));

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Predicate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Predicate.java
@@ -15,14 +15,15 @@ package io.trino.sql.tree;
 
 /// The `<predicate part 2>` fragment of the SQL spec: the operator and right-hand side(s)
 /// of a predicate, without the LHS value. Concrete subtypes parallel the spec's per-predicate
-/// part-2 productions (comparison, between, in, like, null, distinct, quantified-comparison,
-/// match).
+/// part-2 productions (comparison, between, in, like, null, boolean-test, distinct,
+/// quantified-comparison, match).
 ///
 /// Used in two positions: as the `clause` of a [Predicated], and as a SQL:2023 F262
 /// extended `CASE` WHEN operand where the LHS is the case operand.
 public abstract sealed class Predicate
         extends Node
         permits BetweenPredicate,
+                BooleanTestPredicate,
                 ComparisonPredicate,
                 DistinctFromPredicate,
                 InPredicate,

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -32,6 +32,8 @@ import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BetweenPredicate.Symmetry;
 import io.trino.sql.tree.BinaryLiteral;
 import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.BooleanTestPredicate;
+import io.trino.sql.tree.BooleanTestPredicate.TruthValue;
 import io.trino.sql.tree.Call;
 import io.trino.sql.tree.CallArgument;
 import io.trino.sql.tree.Cast;
@@ -1207,6 +1209,46 @@ public class TestSqlParser
                                 Optional.of(Symmetry.SYMMETRIC),
                                 new LongLiteral(location(1, 25), "2"),
                                 new LongLiteral(location(1, 31), "3"))));
+    }
+
+    @Test
+    public void testBooleanTest()
+    {
+        assertThat(expression("a IS TRUE"))
+                .isEqualTo(new Predicated(
+                        location(1, 3),
+                        new Identifier(location(1, 1), "a", false),
+                        new BooleanTestPredicate(location(1, 3), false, TruthValue.TRUE)));
+
+        assertThat(expression("a IS NOT TRUE"))
+                .isEqualTo(new Predicated(
+                        location(1, 3),
+                        new Identifier(location(1, 1), "a", false),
+                        new BooleanTestPredicate(location(1, 3), true, TruthValue.TRUE)));
+
+        assertThat(expression("a IS FALSE"))
+                .isEqualTo(new Predicated(
+                        location(1, 3),
+                        new Identifier(location(1, 1), "a", false),
+                        new BooleanTestPredicate(location(1, 3), false, TruthValue.FALSE)));
+
+        assertThat(expression("a IS NOT FALSE"))
+                .isEqualTo(new Predicated(
+                        location(1, 3),
+                        new Identifier(location(1, 1), "a", false),
+                        new BooleanTestPredicate(location(1, 3), true, TruthValue.FALSE)));
+
+        assertThat(expression("a IS UNKNOWN"))
+                .isEqualTo(new Predicated(
+                        location(1, 3),
+                        new Identifier(location(1, 1), "a", false),
+                        new BooleanTestPredicate(location(1, 3), false, TruthValue.UNKNOWN)));
+
+        assertThat(expression("a IS NOT UNKNOWN"))
+                .isEqualTo(new Predicated(
+                        location(1, 3),
+                        new Identifier(location(1, 1), "a", false),
+                        new BooleanTestPredicate(location(1, 3), true, TruthValue.UNKNOWN)));
     }
 
     @Test

--- a/docs/src/main/sphinx/functions/comparison.md
+++ b/docs/src/main/sphinx/functions/comparison.md
@@ -119,6 +119,33 @@ But any other constant does not:
 SELECT 3.0 IS NULL; -- false
 ```
 
+(is-boolean-test)=
+## IS TRUE, IS FALSE, and IS UNKNOWN
+
+The `IS [NOT] TRUE`, `IS [NOT] FALSE`, and `IS [NOT] UNKNOWN` operators test the
+three-valued result of a boolean expression. Unlike a direct comparison against
+`TRUE` or `FALSE`, these operators always return a non-null boolean, treating a
+`NULL` (unknown) operand as a known value. `IS UNKNOWN` is equivalent to `IS NULL`
+on a boolean operand:
+
+```sql
+SELECT (1 > 0) IS TRUE; -- true
+
+SELECT (1 > 2) IS FALSE; -- true
+
+SELECT (NULL > 0) IS UNKNOWN; -- true
+
+SELECT (NULL > 0) IS NOT TRUE; -- true
+```
+
+The following truth table demonstrates the handling of each truth value:
+
+| a       | a IS TRUE | a IS FALSE | a IS UNKNOWN | a IS NOT TRUE | a IS NOT FALSE | a IS NOT UNKNOWN |
+| ------- | --------- | ---------- | ------------ | ------------- | -------------- | ---------------- |
+| `TRUE`  | `TRUE`    | `FALSE`    | `FALSE`      | `FALSE`       | `TRUE`         | `TRUE`           |
+| `FALSE` | `FALSE`   | `TRUE`     | `FALSE`      | `TRUE`        | `FALSE`        | `TRUE`           |
+| `NULL`  | `FALSE`   | `FALSE`    | `TRUE`       | `TRUE`        | `TRUE`         | `FALSE`          |
+
 (is-distinct-operator)=
 ## IS DISTINCT FROM and IS NOT DISTINCT FROM
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

() This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## SQL
* Add support to boolean predicates IS (NOT) TRUE/FALSE/UNKNOWN ({issue}`issuenumber`)
```
