### PR TITLE
Fix trailing slash in ADLS test directory causing double slashes in paths

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsStorage.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsStorage.java
@@ -64,7 +64,7 @@ public class TestDeltaLakeAdlsStorage
         this.accessKey = requiredNonEmptySystemProperty("testing.azure-abfs-access-key");
 
         String directoryBase = format("abfs://%s@%s.dfs.core.windows.net", container, account);
-        adlsDirectory = format("%s/tpch-tiny-%s/", directoryBase, randomUUID());
+        adlsDirectory = format("%s/tpch-tiny-%s", directoryBase, randomUUID());
     }
 
     @Override


### PR DESCRIPTION
…aths

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The trailing / in adlsDirectory produced unintentionally `//` when sub-paths were appended.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
