### PR TITLE
Add instance methods to number types

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -162,6 +162,7 @@ import io.trino.operator.scalar.MapToMapCast;
 import io.trino.operator.scalar.MapTransformKeysFunction;
 import io.trino.operator.scalar.MapValues;
 import io.trino.operator.scalar.MathFunctions;
+import io.trino.operator.scalar.MathMethods;
 import io.trino.operator.scalar.MultimapFromEntriesFunction;
 import io.trino.operator.scalar.QuantileDigestFunctions;
 import io.trino.operator.scalar.Re2JRegexpFunctions;
@@ -474,6 +475,15 @@ public final class SystemFunctionBundle
                 .scalar(MathFunctions.IsFinite.class)
                 .scalar(MathFunctions.IsInfinite.class)
                 .scalar(MathFunctions.IsNan.class)
+                .scalars(MathMethods.class)
+                .scalar(MathMethods.Abs.class)
+                .scalar(MathMethods.Sign.class)
+                .scalar(MathMethods.Round.class)
+                .scalar(MathMethods.RoundN.class)
+                .scalar(MathMethods.Truncate.class)
+                .scalar(MathMethods.TruncateN.class)
+                .scalar(MathMethods.Ceiling.class)
+                .scalar(MathMethods.Floor.class)
                 .scalars(BitwiseFunctions.class)
                 .scalars(DateTimeFunctions.class)
                 .scalar(DateTimeFunctions.FromUnixtimeNanosDecimal.class)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MathMethods.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MathMethods.java
@@ -1,0 +1,1088 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.block.Block;
+import io.trino.spi.function.Constraint;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.InstanceMethod;
+import io.trino.spi.function.LiteralParameter;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.function.StaticMethod;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.TrinoNumber;
+
+/**
+ * Exposes the core math functions as SQL:2023 methods on numeric receivers, so
+ * {@code value.abs()}, {@code value.round(2)}, {@code (2e0).sqrt()}, and
+ * {@code double::pi()} resolve to the same implementations as the plain
+ * functions in {@link MathFunctions}. Functions and methods resolve in separate
+ * namespaces, so every existing call keeps working.
+ *
+ * <p>An instance method is matched on the exact base type of its receiver, so
+ * each entry mirrors the receiver type of the corresponding {@code MathFunctions}
+ * overload one-to-one. A double-only function such as {@code sqrt} is therefore
+ * a method on {@code double} receivers only; use the plain function (or cast the
+ * receiver) for other numeric types.
+ */
+public final class MathMethods
+{
+    private MathMethods() {}
+
+    @Description("Absolute value")
+    @ScalarFunction("abs")
+    @InstanceMethod
+    @SqlType(StandardTypes.TINYINT)
+    public static long absTinyint(@SqlType(StandardTypes.TINYINT) long num)
+    {
+        return MathFunctions.absTinyint(num);
+    }
+
+    @Description("Absolute value")
+    @ScalarFunction("abs")
+    @InstanceMethod
+    @SqlType(StandardTypes.SMALLINT)
+    public static long absSmallint(@SqlType(StandardTypes.SMALLINT) long num)
+    {
+        return MathFunctions.absSmallint(num);
+    }
+
+    @Description("Absolute value")
+    @ScalarFunction("abs")
+    @InstanceMethod
+    @SqlType(StandardTypes.INTEGER)
+    public static long absInteger(@SqlType(StandardTypes.INTEGER) long num)
+    {
+        return MathFunctions.absInteger(num);
+    }
+
+    @Description("Absolute value")
+    @ScalarFunction("abs")
+    @InstanceMethod
+    @SqlType(StandardTypes.BIGINT)
+    public static long abs(@SqlType(StandardTypes.BIGINT) long num)
+    {
+        return MathFunctions.abs(num);
+    }
+
+    @Description("Absolute value")
+    @ScalarFunction(value = "abs", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double abs(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.abs(num);
+    }
+
+    @Description("Absolute value")
+    @ScalarFunction(value = "abs", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber abs(@SqlType(StandardTypes.NUMBER) TrinoNumber num)
+    {
+        return MathFunctions.abs(num);
+    }
+
+    @Description("Absolute value")
+    @ScalarFunction(value = "abs", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.REAL)
+    public static long absReal(@SqlType(StandardTypes.REAL) long num)
+    {
+        return MathFunctions.absReal(num);
+    }
+
+    @ScalarFunction(value = "abs", neverFails = true)
+    @InstanceMethod
+    @Description("Absolute value")
+    public static final class Abs
+    {
+        private Abs() {}
+
+        @LiteralParameters({"p", "s"})
+        @SqlType("decimal(p, s)")
+        public static long absShort(@SqlType("decimal(p, s)") long arg)
+        {
+            return MathFunctions.Abs.absShort(arg);
+        }
+
+        @LiteralParameters({"p", "s"})
+        @SqlType("decimal(p, s)")
+        public static Int128 absLong(@SqlType("decimal(p, s)") Int128 value)
+        {
+            return MathFunctions.Abs.absLong(value);
+        }
+    }
+
+    @Description("Round up to nearest integer")
+    @ScalarFunction(value = "ceiling", alias = "ceil", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.TINYINT)
+    public static long ceilingTinyint(@SqlType(StandardTypes.TINYINT) long num)
+    {
+        return MathFunctions.ceilingTinyint(num);
+    }
+
+    @Description("Round up to nearest integer")
+    @ScalarFunction(value = "ceiling", alias = "ceil", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.SMALLINT)
+    public static long ceilingSmallint(@SqlType(StandardTypes.SMALLINT) long num)
+    {
+        return MathFunctions.ceilingSmallint(num);
+    }
+
+    @Description("Round up to nearest integer")
+    @ScalarFunction(value = "ceiling", alias = "ceil", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.INTEGER)
+    public static long ceilingInteger(@SqlType(StandardTypes.INTEGER) long num)
+    {
+        return MathFunctions.ceilingInteger(num);
+    }
+
+    @Description("Round up to nearest integer")
+    @ScalarFunction(value = "ceiling", alias = "ceil", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.BIGINT)
+    public static long ceiling(@SqlType(StandardTypes.BIGINT) long num)
+    {
+        return MathFunctions.ceiling(num);
+    }
+
+    @Description("Round up to nearest integer")
+    @ScalarFunction(value = "ceiling", alias = "ceil", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double ceiling(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.ceiling(num);
+    }
+
+    @Description("Round up to nearest integer")
+    @ScalarFunction(value = "ceiling", alias = "ceil", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.REAL)
+    public static long ceilingReal(@SqlType(StandardTypes.REAL) long num)
+    {
+        return MathFunctions.ceilingReal(num);
+    }
+
+    @Description("Round up to nearest integer")
+    @ScalarFunction(value = "ceiling", alias = "ceil", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber ceiling(@SqlType(StandardTypes.NUMBER) TrinoNumber num)
+    {
+        return MathFunctions.ceiling(num);
+    }
+
+    @ScalarFunction(value = "ceiling", alias = "ceil", neverFails = true)
+    @InstanceMethod
+    @Description("Round up to nearest integer")
+    public static final class Ceiling
+    {
+        private Ceiling() {}
+
+        @LiteralParameters({"p", "s", "rp"})
+        @SqlType("decimal(rp,0)")
+        @Constraint(variable = "rp", expression = "p - s + min(s, 1)")
+        public static long ceilingShort(@LiteralParameter("s") long numScale, @SqlType("decimal(p, s)") long num)
+        {
+            return MathFunctions.Ceiling.ceilingShort(numScale, num);
+        }
+
+        @LiteralParameters({"p", "s", "rp"})
+        @SqlType("decimal(rp,0)")
+        @Constraint(variable = "rp", expression = "p - s + min(s, 1)")
+        public static Int128 ceilingLong(@LiteralParameter("s") long numScale, @SqlType("decimal(p, s)") Int128 num)
+        {
+            return MathFunctions.Ceiling.ceilingLong(numScale, num);
+        }
+
+        @LiteralParameters({"p", "s", "rp"})
+        @SqlType("decimal(rp,0)")
+        @Constraint(variable = "rp", expression = "p - s + min(s, 1)")
+        public static long ceilingLongShort(@LiteralParameter("s") long numScale, @SqlType("decimal(p, s)") Int128 num)
+        {
+            return MathFunctions.Ceiling.ceilingLongShort(numScale, num);
+        }
+    }
+
+    @Description("Round down to nearest integer")
+    @ScalarFunction(value = "floor", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.TINYINT)
+    public static long floorTinyint(@SqlType(StandardTypes.TINYINT) long num)
+    {
+        return MathFunctions.floorTinyint(num);
+    }
+
+    @Description("Round down to nearest integer")
+    @ScalarFunction(value = "floor", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.SMALLINT)
+    public static long floorSmallint(@SqlType(StandardTypes.SMALLINT) long num)
+    {
+        return MathFunctions.floorSmallint(num);
+    }
+
+    @Description("Round down to nearest integer")
+    @ScalarFunction(value = "floor", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.INTEGER)
+    public static long floorInteger(@SqlType(StandardTypes.INTEGER) long num)
+    {
+        return MathFunctions.floorInteger(num);
+    }
+
+    @Description("Round down to nearest integer")
+    @ScalarFunction(value = "floor", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.BIGINT)
+    public static long floor(@SqlType(StandardTypes.BIGINT) long num)
+    {
+        return MathFunctions.floor(num);
+    }
+
+    @Description("Round down to nearest integer")
+    @ScalarFunction(value = "floor", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double floor(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.floor(num);
+    }
+
+    @Description("Round down to nearest integer")
+    @ScalarFunction(value = "floor", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber floor(@SqlType(StandardTypes.NUMBER) TrinoNumber num)
+    {
+        return MathFunctions.floor(num);
+    }
+
+    @Description("Round down to nearest integer")
+    @ScalarFunction(value = "floor", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.REAL)
+    public static long floorReal(@SqlType(StandardTypes.REAL) long num)
+    {
+        return MathFunctions.floorReal(num);
+    }
+
+    @ScalarFunction(value = "floor", neverFails = true)
+    @InstanceMethod
+    @Description("Round down to nearest integer")
+    public static final class Floor
+    {
+        private Floor() {}
+
+        @LiteralParameters({"p", "s", "rp"})
+        @SqlType("decimal(rp,0)")
+        @Constraint(variable = "rp", expression = "p - s + min(s, 1)")
+        public static long floorShort(@LiteralParameter("s") long numScale, @SqlType("decimal(p, s)") long num)
+        {
+            return MathFunctions.Floor.floorShort(numScale, num);
+        }
+
+        @LiteralParameters({"p", "s", "rp"})
+        @SqlType("decimal(rp,0)")
+        @Constraint(variable = "rp", expression = "p - s + min(s, 1)")
+        public static Int128 floorLong(@LiteralParameter("s") long numScale, @SqlType("decimal(p, s)") Int128 num)
+        {
+            return MathFunctions.Floor.floorLong(numScale, num);
+        }
+
+        @LiteralParameters({"p", "s", "rp"})
+        @SqlType("decimal(rp,0)")
+        @Constraint(variable = "rp", expression = "p - s + min(s, 1)")
+        public static long floorLongShort(@LiteralParameter("s") long numScale, @SqlType("decimal(p, s)") Int128 num)
+        {
+            return MathFunctions.Floor.floorLongShort(numScale, num);
+        }
+    }
+
+    @Description("Round to nearest integer")
+    @ScalarFunction(value = "round", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.TINYINT)
+    public static long roundTinyint(@SqlType(StandardTypes.TINYINT) long num)
+    {
+        return MathFunctions.roundTinyint(num);
+    }
+
+    @Description("Round to nearest integer")
+    @ScalarFunction(value = "round", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.SMALLINT)
+    public static long roundSmallint(@SqlType(StandardTypes.SMALLINT) long num)
+    {
+        return MathFunctions.roundSmallint(num);
+    }
+
+    @Description("Round to nearest integer")
+    @ScalarFunction(value = "round", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.INTEGER)
+    public static long roundInteger(@SqlType(StandardTypes.INTEGER) long num)
+    {
+        return MathFunctions.roundInteger(num);
+    }
+
+    @Description("Round to nearest integer")
+    @ScalarFunction(value = "round", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.BIGINT)
+    public static long round(@SqlType(StandardTypes.BIGINT) long num)
+    {
+        return MathFunctions.round(num);
+    }
+
+    @Description("Round to nearest integer")
+    @ScalarFunction("round")
+    @InstanceMethod
+    @SqlType(StandardTypes.TINYINT)
+    public static long roundTinyint(@SqlType(StandardTypes.TINYINT) long num, @SqlType(StandardTypes.INTEGER) long decimals)
+    {
+        return MathFunctions.roundTinyint(num, decimals);
+    }
+
+    @Description("Round to nearest integer")
+    @ScalarFunction("round")
+    @InstanceMethod
+    @SqlType(StandardTypes.SMALLINT)
+    public static long roundSmallint(@SqlType(StandardTypes.SMALLINT) long num, @SqlType(StandardTypes.INTEGER) long decimals)
+    {
+        return MathFunctions.roundSmallint(num, decimals);
+    }
+
+    @Description("Round to nearest integer")
+    @ScalarFunction("round")
+    @InstanceMethod
+    @SqlType(StandardTypes.INTEGER)
+    public static long roundInteger(@SqlType(StandardTypes.INTEGER) long num, @SqlType(StandardTypes.INTEGER) long decimals)
+    {
+        return MathFunctions.roundInteger(num, decimals);
+    }
+
+    @Description("Round to nearest integer")
+    @ScalarFunction("round")
+    @InstanceMethod
+    @SqlType(StandardTypes.BIGINT)
+    public static long round(@SqlType(StandardTypes.BIGINT) long num, @SqlType(StandardTypes.INTEGER) long decimals)
+    {
+        return MathFunctions.round(num, decimals);
+    }
+
+    @Description("Round to nearest integer")
+    @ScalarFunction(value = "round", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double round(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.round(num);
+    }
+
+    @Description("Round to given number of decimal places")
+    @ScalarFunction(value = "round", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.REAL)
+    public static long roundReal(@SqlType(StandardTypes.REAL) long num)
+    {
+        return MathFunctions.roundReal(num);
+    }
+
+    @Description("Round to given number of decimal places")
+    @ScalarFunction(value = "round", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double round(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.INTEGER) long decimals)
+    {
+        return MathFunctions.round(num, decimals);
+    }
+
+    @Description("Round to given number of decimal places")
+    @ScalarFunction(value = "round", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.REAL)
+    public static long roundReal(@SqlType(StandardTypes.REAL) long num, @SqlType(StandardTypes.INTEGER) long decimals)
+    {
+        return MathFunctions.roundReal(num, decimals);
+    }
+
+    @Description("Round to nearest integer")
+    @ScalarFunction(value = "round", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber round(@SqlType(StandardTypes.NUMBER) TrinoNumber num)
+    {
+        return MathFunctions.round(num);
+    }
+
+    @Description("Round to given number of decimal places")
+    @ScalarFunction(value = "round", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber round(@SqlType(StandardTypes.NUMBER) TrinoNumber num, @SqlType(StandardTypes.INTEGER) long decimals)
+    {
+        return MathFunctions.round(num, decimals);
+    }
+
+    @ScalarFunction(value = "round", neverFails = true)
+    @InstanceMethod
+    @Description("Round to nearest integer")
+    public static final class Round
+    {
+        private Round() {}
+
+        @LiteralParameters({"p", "s", "rp", "rs"})
+        @SqlType("decimal(rp, rs)")
+        @Constraint(variable = "rp", expression = "min(38, p - s + min(1, s))")
+        @Constraint(variable = "rs", expression = "0")
+        public static long roundShort(@LiteralParameter("s") long numScale, @SqlType("decimal(p, s)") long num)
+        {
+            return MathFunctions.Round.roundShort(numScale, num);
+        }
+
+        @LiteralParameters({"p", "s", "rp", "rs"})
+        @SqlType("decimal(rp, rs)")
+        @Constraint(variable = "rp", expression = "min(38, p - s + min(1, s))")
+        @Constraint(variable = "rs", expression = "0")
+        public static Int128 roundLongLong(@LiteralParameter("s") long numScale, @SqlType("decimal(p, s)") Int128 num)
+        {
+            return MathFunctions.Round.roundLongLong(numScale, num);
+        }
+
+        @LiteralParameters({"p", "s", "rp", "rs"})
+        @SqlType("decimal(rp, rs)")
+        @Constraint(variable = "rp", expression = "min(38, p - s + min(1, s))")
+        @Constraint(variable = "rs", expression = "0")
+        public static long roundLongShort(@LiteralParameter("s") long numScale, @SqlType("decimal(p, s)") Int128 num)
+        {
+            return MathFunctions.Round.roundLongShort(numScale, num);
+        }
+    }
+
+    @ScalarFunction("round")
+    @InstanceMethod
+    @Description("Round to given number of decimal places")
+    public static final class RoundN
+    {
+        private RoundN() {}
+
+        @LiteralParameters({"p", "s", "rp"})
+        @SqlType("decimal(rp, s)")
+        @Constraint(variable = "rp", expression = "min(38, p + 1)")
+        public static long roundNShort(
+                @LiteralParameter("p") long numPrecision,
+                @LiteralParameter("s") long numScale,
+                @SqlType("decimal(p, s)") long num,
+                @SqlType(StandardTypes.INTEGER) long decimals)
+        {
+            return MathFunctions.RoundN.roundNShort(numPrecision, numScale, num, decimals);
+        }
+
+        @LiteralParameters({"p", "s", "rp"})
+        @SqlType("decimal(rp, s)")
+        @Constraint(variable = "rp", expression = "min(38, p + 1)")
+        public static Int128 roundNLong(
+                @LiteralParameter("s") long numScale,
+                @LiteralParameter("rp") long resultPrecision,
+                @SqlType("decimal(p, s)") Int128 num,
+                @SqlType(StandardTypes.INTEGER) long decimals)
+        {
+            return MathFunctions.RoundN.roundNLong(numScale, resultPrecision, num, decimals);
+        }
+
+        @LiteralParameters({"p", "s", "rp"})
+        @SqlType("decimal(rp, s)")
+        @Constraint(variable = "rp", expression = "min(38, p + 1)")
+        public static Int128 roundNShortLong(
+                @LiteralParameter("s") long numScale,
+                @LiteralParameter("rp") long resultPrecision,
+                @SqlType("decimal(p, s)") long num,
+                @SqlType(StandardTypes.INTEGER) long decimals)
+        {
+            return MathFunctions.RoundN.roundNShortLong(numScale, resultPrecision, num, decimals);
+        }
+    }
+
+    @Description("Round to integer by dropping digits after decimal point")
+    @ScalarFunction(value = "truncate", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double truncate(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.truncate(num);
+    }
+
+    @Description("Round to integer by dropping digits after decimal point")
+    @ScalarFunction(value = "truncate", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.REAL)
+    public static long truncate(@SqlType(StandardTypes.REAL) long num)
+    {
+        return MathFunctions.truncate(num);
+    }
+
+    @Description("Round to integer by dropping digits after decimal point")
+    @ScalarFunction(value = "truncate", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber truncate(@SqlType(StandardTypes.NUMBER) TrinoNumber num)
+    {
+        return MathFunctions.truncate(num);
+    }
+
+    @ScalarFunction(value = "truncate", neverFails = true)
+    @InstanceMethod
+    @Description("Round to integer by dropping digits after decimal point")
+    public static final class Truncate
+    {
+        private Truncate() {}
+
+        @LiteralParameters({"p", "s", "rp"})
+        @SqlType("decimal(rp,0)")
+        @Constraint(variable = "rp", expression = "max(1, p - s)")
+        public static long truncateShort(@LiteralParameter("s") long numScale, @SqlType("decimal(p, s)") long num)
+        {
+            return MathFunctions.Truncate.truncateShort(numScale, num);
+        }
+
+        @LiteralParameters({"p", "s", "rp"})
+        @SqlType("decimal(rp,0)")
+        @Constraint(variable = "rp", expression = "max(1, p - s)")
+        public static Int128 truncateLong(@LiteralParameter("s") long numScale, @SqlType("decimal(p, s)") Int128 num)
+        {
+            return MathFunctions.Truncate.truncateLong(numScale, num);
+        }
+
+        @LiteralParameters({"p", "s", "rp"})
+        @SqlType("decimal(rp,0)")
+        @Constraint(variable = "rp", expression = "max(1, p - s)")
+        public static long truncateLongShort(@LiteralParameter("s") long numScale, @SqlType("decimal(p, s)") Int128 num)
+        {
+            return MathFunctions.Truncate.truncateLongShort(numScale, num);
+        }
+    }
+
+    @ScalarFunction(value = "truncate", neverFails = true)
+    @InstanceMethod
+    @Description("Round to integer by dropping given number of digits after decimal point")
+    public static final class TruncateN
+    {
+        private TruncateN() {}
+
+        @LiteralParameters({"p", "s"})
+        @SqlType("decimal(p, s)")
+        public static long truncateShort(
+                @LiteralParameter("p") long numPrecision,
+                @LiteralParameter("s") long numScale,
+                @SqlType("decimal(p, s)") long num,
+                @SqlType(StandardTypes.INTEGER) long roundScale)
+        {
+            return MathFunctions.TruncateN.truncateShort(numPrecision, numScale, num, roundScale);
+        }
+
+        @LiteralParameters({"p", "s"})
+        @SqlType("decimal(p, s)")
+        public static Int128 truncateLong(
+                @LiteralParameter("p") long numPrecision,
+                @LiteralParameter("s") long numScale,
+                @SqlType("decimal(p, s)") Int128 num,
+                @SqlType(StandardTypes.INTEGER) long roundScale)
+        {
+            return MathFunctions.TruncateN.truncateLong(numPrecision, numScale, num, roundScale);
+        }
+    }
+
+    @Description("Signum")
+    @ScalarFunction(value = "sign", neverFails = true)
+    @InstanceMethod
+    public static final class Sign
+    {
+        private Sign() {}
+
+        @LiteralParameters({"p", "s"})
+        @SqlType("decimal(1,0)")
+        public static long signDecimalShort(@SqlType("decimal(p, s)") long num)
+        {
+            return MathFunctions.Sign.signDecimalShort(num);
+        }
+
+        @LiteralParameters({"p", "s"})
+        @SqlType("decimal(1,0)")
+        public static long signDecimalLong(@SqlType("decimal(p, s)") Int128 num)
+        {
+            return MathFunctions.Sign.signDecimalLong(num);
+        }
+    }
+
+    @Description("Signum")
+    @ScalarFunction(value = "sign", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.BIGINT)
+    public static long sign(@SqlType(StandardTypes.BIGINT) long num)
+    {
+        return MathFunctions.sign(num);
+    }
+
+    @Description("Signum")
+    @ScalarFunction(value = "sign", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.INTEGER)
+    public static long signInteger(@SqlType(StandardTypes.INTEGER) long num)
+    {
+        return MathFunctions.signInteger(num);
+    }
+
+    @Description("Signum")
+    @ScalarFunction(value = "sign", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.SMALLINT)
+    public static long signSmallint(@SqlType(StandardTypes.SMALLINT) long num)
+    {
+        return MathFunctions.signSmallint(num);
+    }
+
+    @Description("Signum")
+    @ScalarFunction(value = "sign", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.TINYINT)
+    public static long signTinyint(@SqlType(StandardTypes.TINYINT) long num)
+    {
+        return MathFunctions.signTinyint(num);
+    }
+
+    @Description("Signum")
+    @ScalarFunction(value = "sign", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double sign(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.sign(num);
+    }
+
+    @Description("Signum")
+    @ScalarFunction(value = "sign", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.REAL)
+    public static long signReal(@SqlType(StandardTypes.REAL) long num)
+    {
+        return MathFunctions.signReal(num);
+    }
+
+    @Description("Signum")
+    @ScalarFunction(value = "sign", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber sign(@SqlType(StandardTypes.NUMBER) TrinoNumber num)
+    {
+        return MathFunctions.sign(num);
+    }
+
+    @Description("Square root")
+    @ScalarFunction(value = "sqrt", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double sqrt(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.sqrt(num);
+    }
+
+    @Description("Cube root")
+    @ScalarFunction(value = "cbrt", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double cbrt(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.cbrt(num);
+    }
+
+    @Description("Euler's number raised to the given power")
+    @ScalarFunction(value = "exp", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double exp(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.exp(num);
+    }
+
+    @Description("Natural logarithm")
+    @ScalarFunction(value = "ln", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double ln(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.ln(num);
+    }
+
+    @Description("Logarithm to given base")
+    @ScalarFunction(value = "log", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double log(@SqlType(StandardTypes.DOUBLE) double base, @SqlType(StandardTypes.DOUBLE) double number)
+    {
+        return MathFunctions.log(base, number);
+    }
+
+    @Description("Logarithm to base 2")
+    @ScalarFunction(value = "log2", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double log2(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.log2(num);
+    }
+
+    @Description("Logarithm to base 10")
+    @ScalarFunction(value = "log10", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double log10(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.log10(num);
+    }
+
+    @Description("Value raised to the power of exponent")
+    @ScalarFunction(value = "power", alias = "pow", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double power(@SqlType(StandardTypes.DOUBLE) double num, @SqlType(StandardTypes.DOUBLE) double exponent)
+    {
+        return MathFunctions.power(num, exponent);
+    }
+
+    @Description("Sine")
+    @ScalarFunction(value = "sin", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double sin(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.sin(num);
+    }
+
+    @Description("Hyperbolic sine")
+    @ScalarFunction(value = "sinh", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double sinh(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.sinh(num);
+    }
+
+    @Description("Cosine")
+    @ScalarFunction(value = "cos", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double cos(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.cos(num);
+    }
+
+    @Description("Hyperbolic cosine")
+    @ScalarFunction(value = "cosh", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double cosh(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.cosh(num);
+    }
+
+    @Description("Tangent")
+    @ScalarFunction(value = "tan", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double tan(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.tan(num);
+    }
+
+    @Description("Hyperbolic tangent")
+    @ScalarFunction(value = "tanh", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double tanh(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.tanh(num);
+    }
+
+    @Description("Arc sine")
+    @ScalarFunction(value = "asin", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double asin(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.asin(num);
+    }
+
+    @Description("Arc cosine")
+    @ScalarFunction(value = "acos", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double acos(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.acos(num);
+    }
+
+    @Description("Arc tangent")
+    @ScalarFunction(value = "atan", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double atan(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.atan(num);
+    }
+
+    @Description("Arc tangent of given fraction")
+    @ScalarFunction(value = "atan2", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double atan2(@SqlType(StandardTypes.DOUBLE) double num1, @SqlType(StandardTypes.DOUBLE) double num2)
+    {
+        return MathFunctions.atan2(num1, num2);
+    }
+
+    @Description("Converts an angle in radians to degrees")
+    @ScalarFunction(value = "degrees", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double degrees(@SqlType(StandardTypes.DOUBLE) double radians)
+    {
+        return MathFunctions.degrees(radians);
+    }
+
+    @Description("Converts an angle in degrees to radians")
+    @ScalarFunction(value = "radians", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double radians(@SqlType(StandardTypes.DOUBLE) double degrees)
+    {
+        return MathFunctions.radians(degrees);
+    }
+
+    @Description("Remainder of given quotient")
+    @ScalarFunction(value = "mod", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.TINYINT)
+    public static long modTinyint(@SqlType(StandardTypes.TINYINT) long num1, @SqlType(StandardTypes.TINYINT) long num2)
+    {
+        return MathFunctions.modTinyint(num1, num2);
+    }
+
+    @Description("Remainder of given quotient")
+    @ScalarFunction(value = "mod", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.SMALLINT)
+    public static long modSmallint(@SqlType(StandardTypes.SMALLINT) long num1, @SqlType(StandardTypes.SMALLINT) long num2)
+    {
+        return MathFunctions.modSmallint(num1, num2);
+    }
+
+    @Description("Remainder of given quotient")
+    @ScalarFunction(value = "mod", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.INTEGER)
+    public static long modInteger(@SqlType(StandardTypes.INTEGER) long num1, @SqlType(StandardTypes.INTEGER) long num2)
+    {
+        return MathFunctions.modInteger(num1, num2);
+    }
+
+    @Description("Remainder of given quotient")
+    @ScalarFunction(value = "mod", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.BIGINT)
+    public static long mod(@SqlType(StandardTypes.BIGINT) long num1, @SqlType(StandardTypes.BIGINT) long num2)
+    {
+        return MathFunctions.mod(num1, num2);
+    }
+
+    @Description("Remainder of given quotient")
+    @ScalarFunction(value = "mod", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.DOUBLE)
+    public static double mod(@SqlType(StandardTypes.DOUBLE) double num1, @SqlType(StandardTypes.DOUBLE) double num2)
+    {
+        return MathFunctions.mod(num1, num2);
+    }
+
+    @Description("Remainder of given quotient")
+    @ScalarFunction(value = "mod", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.REAL)
+    public static long modReal(@SqlType(StandardTypes.REAL) long num1, @SqlType(StandardTypes.REAL) long num2)
+    {
+        return MathFunctions.modReal(num1, num2);
+    }
+
+    @Description("Remainder of given quotient")
+    @ScalarFunction(value = "mod", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.NUMBER)
+    public static TrinoNumber mod(@SqlType(StandardTypes.NUMBER) TrinoNumber num1, @SqlType(StandardTypes.NUMBER) TrinoNumber num2)
+    {
+        return MathFunctions.mod(num1, num2);
+    }
+
+    @Description("Test if value is not-a-number")
+    @ScalarFunction(value = "is_nan", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean isNaN(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.isNaN(num);
+    }
+
+    @Description("Test if value is not-a-number")
+    @ScalarFunction(value = "is_nan", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean isNaNReal(@SqlType(StandardTypes.REAL) long value)
+    {
+        return MathFunctions.isNaNReal(value);
+    }
+
+    @Description("Test if value is not-a-number")
+    @ScalarFunction(value = "is_nan", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean isNaN(@SqlType(StandardTypes.NUMBER) TrinoNumber num)
+    {
+        return MathFunctions.isNaN(num);
+    }
+
+    @Description("Test if value is finite")
+    @ScalarFunction(value = "is_finite", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean isFinite(@SqlType(StandardTypes.REAL) long num)
+    {
+        return MathFunctions.isFinite(num);
+    }
+
+    @Description("Test if value is finite")
+    @ScalarFunction(value = "is_finite", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean isFinite(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.isFinite(num);
+    }
+
+    @Description("Test if value is finite")
+    @ScalarFunction(value = "is_finite", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean isFinite(@SqlType(StandardTypes.NUMBER) TrinoNumber num)
+    {
+        return MathFunctions.isFinite(num);
+    }
+
+    @Description("Test if value is infinite")
+    @ScalarFunction(value = "is_infinite", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean isInfinite(@SqlType(StandardTypes.DOUBLE) double num)
+    {
+        return MathFunctions.isInfinite(num);
+    }
+
+    @Description("Test if value is infinite")
+    @ScalarFunction(value = "is_infinite", neverFails = true)
+    @InstanceMethod
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean isInfinite(@SqlType(StandardTypes.NUMBER) TrinoNumber num)
+    {
+        return MathFunctions.isInfinite(num);
+    }
+
+    @Description("The bucket number of a value given a lower and upper bound and the number of buckets")
+    @ScalarFunction("width_bucket")
+    @InstanceMethod
+    @SqlType(StandardTypes.BIGINT)
+    public static long widthBucket(@SqlType(StandardTypes.DOUBLE) double operand, @SqlType(StandardTypes.DOUBLE) double bound1, @SqlType(StandardTypes.DOUBLE) double bound2, @SqlType(StandardTypes.BIGINT) long bucketCount)
+    {
+        return MathFunctions.widthBucket(operand, bound1, bound2, bucketCount);
+    }
+
+    @Description("The bucket number of a value given an array of bins")
+    @ScalarFunction("width_bucket")
+    @InstanceMethod
+    @SqlType(StandardTypes.BIGINT)
+    public static long widthBucket(@SqlType(StandardTypes.DOUBLE) double operand, @SqlType("array(double)") Block bins)
+    {
+        return MathFunctions.widthBucket(operand, bins);
+    }
+
+    @Description("Convert a number to a string in the given base")
+    @ScalarFunction("to_base")
+    @InstanceMethod
+    @SqlType("varchar(64)")
+    public static Slice toBase(@SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.BIGINT) long radix)
+    {
+        return MathFunctions.toBase(value, radix);
+    }
+
+    @Description("The constant Pi")
+    @ScalarFunction(value = "pi", neverFails = true)
+    @StaticMethod(StandardTypes.DOUBLE)
+    @SqlType(StandardTypes.DOUBLE)
+    public static double pi()
+    {
+        return MathFunctions.pi();
+    }
+
+    @Description("Euler's number")
+    @ScalarFunction(value = "e", neverFails = true)
+    @StaticMethod(StandardTypes.DOUBLE)
+    @SqlType(StandardTypes.DOUBLE)
+    public static double e()
+    {
+        return MathFunctions.e();
+    }
+
+    @Description("Constant representing not-a-number")
+    @ScalarFunction(value = "nan", neverFails = true)
+    @StaticMethod(StandardTypes.DOUBLE)
+    @SqlType(StandardTypes.DOUBLE)
+    public static double nan()
+    {
+        return MathFunctions.nan();
+    }
+
+    @Description("Infinity")
+    @ScalarFunction(value = "infinity", neverFails = true)
+    @StaticMethod(StandardTypes.DOUBLE)
+    @SqlType(StandardTypes.DOUBLE)
+    public static double infinity()
+    {
+        return MathFunctions.infinity();
+    }
+
+    @Description("Convert a string in the given base to a number")
+    @ScalarFunction("from_base")
+    @StaticMethod(StandardTypes.BIGINT)
+    @LiteralParameters("x")
+    @SqlType(StandardTypes.BIGINT)
+    public static long fromBase(@SqlType("varchar(x)") Slice value, @SqlType(StandardTypes.BIGINT) long radix)
+    {
+        return MathFunctions.fromBase(value, radix);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathMethods.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathMethods.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestMathMethods
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testAbs()
+    {
+        assertThat(assertions.expression("a.abs()")
+                .binding("a", "TINYINT '-7'"))
+                .matches("abs(TINYINT '-7')");
+        assertThat(assertions.expression("a.abs()")
+                .binding("a", "SMALLINT '-7'"))
+                .matches("abs(SMALLINT '-7')");
+        assertThat(assertions.expression("a.abs()")
+                .binding("a", "INTEGER '-7'"))
+                .matches("abs(INTEGER '-7')");
+        assertThat(assertions.expression("a.abs()")
+                .binding("a", "BIGINT '-7'"))
+                .matches("abs(BIGINT '-7')");
+        assertThat(assertions.expression("a.abs()")
+                .binding("a", "REAL '-7.5'"))
+                .matches("abs(REAL '-7.5')");
+        assertThat(assertions.expression("a.abs()")
+                .binding("a", "DOUBLE '-7.5'"))
+                .matches("abs(DOUBLE '-7.5')");
+        assertThat(assertions.expression("a.abs()")
+                .binding("a", "DECIMAL '-7.50'"))
+                .matches("abs(DECIMAL '-7.50')");
+    }
+
+    @Test
+    public void testCeiling()
+    {
+        assertThat(assertions.expression("a.ceiling()")
+                .binding("a", "DOUBLE '3.1'"))
+                .matches("ceiling(DOUBLE '3.1')");
+        assertThat(assertions.expression("a.ceil()")
+                .binding("a", "DOUBLE '3.1'"))
+                .matches("ceil(DOUBLE '3.1')");
+        assertThat(assertions.expression("a.ceiling()")
+                .binding("a", "DECIMAL '3.12'"))
+                .matches("ceiling(DECIMAL '3.12')");
+    }
+
+    @Test
+    public void testFloor()
+    {
+        assertThat(assertions.expression("a.floor()")
+                .binding("a", "DOUBLE '3.9'"))
+                .matches("floor(DOUBLE '3.9')");
+        assertThat(assertions.expression("a.floor()")
+                .binding("a", "DECIMAL '3.99'"))
+                .matches("floor(DECIMAL '3.99')");
+    }
+
+    @Test
+    public void testRound()
+    {
+        assertThat(assertions.expression("a.round()")
+                .binding("a", "DOUBLE '3.5'"))
+                .matches("round(DOUBLE '3.5')");
+        assertThat(assertions.expression("a.round(b)")
+                .binding("a", "DOUBLE '3.14159'")
+                .binding("b", "2"))
+                .matches("round(DOUBLE '3.14159', 2)");
+        assertThat(assertions.expression("a.round()")
+                .binding("a", "DECIMAL '3.56'"))
+                .matches("round(DECIMAL '3.56')");
+        assertThat(assertions.expression("a.round(b)")
+                .binding("a", "DECIMAL '3.567'")
+                .binding("b", "2"))
+                .matches("round(DECIMAL '3.567', 2)");
+    }
+
+    @Test
+    public void testTruncate()
+    {
+        assertThat(assertions.expression("a.truncate()")
+                .binding("a", "DOUBLE '3.99'"))
+                .matches("truncate(DOUBLE '3.99')");
+        assertThat(assertions.expression("a.truncate()")
+                .binding("a", "DECIMAL '3.99'"))
+                .matches("truncate(DECIMAL '3.99')");
+        assertThat(assertions.expression("a.truncate(b)")
+                .binding("a", "DECIMAL '3.987'")
+                .binding("b", "1"))
+                .matches("truncate(DECIMAL '3.987', 1)");
+    }
+
+    @Test
+    public void testSign()
+    {
+        assertThat(assertions.expression("a.sign()")
+                .binding("a", "BIGINT '-7'"))
+                .matches("sign(BIGINT '-7')");
+        assertThat(assertions.expression("a.sign()")
+                .binding("a", "DOUBLE '-7.5'"))
+                .matches("sign(DOUBLE '-7.5')");
+        assertThat(assertions.expression("a.sign()")
+                .binding("a", "DECIMAL '-7.50'"))
+                .matches("sign(DECIMAL '-7.50')");
+    }
+
+    @Test
+    public void testDoubleUnaryMethods()
+    {
+        assertThat(assertions.expression("a.sqrt()")
+                .binding("a", "DOUBLE '16'"))
+                .matches("sqrt(DOUBLE '16')");
+        assertThat(assertions.expression("a.cbrt()")
+                .binding("a", "DOUBLE '27'"))
+                .matches("cbrt(DOUBLE '27')");
+        assertThat(assertions.expression("a.exp()")
+                .binding("a", "DOUBLE '1'"))
+                .matches("exp(DOUBLE '1')");
+        assertThat(assertions.expression("a.ln()")
+                .binding("a", "DOUBLE '2.718281828459045'"))
+                .matches("ln(DOUBLE '2.718281828459045')");
+        assertThat(assertions.expression("a.log2()")
+                .binding("a", "DOUBLE '8'"))
+                .matches("log2(DOUBLE '8')");
+        assertThat(assertions.expression("a.log10()")
+                .binding("a", "DOUBLE '1000'"))
+                .matches("log10(DOUBLE '1000')");
+        assertThat(assertions.expression("a.sin()")
+                .binding("a", "DOUBLE '1'"))
+                .matches("sin(DOUBLE '1')");
+        assertThat(assertions.expression("a.cos()")
+                .binding("a", "DOUBLE '1'"))
+                .matches("cos(DOUBLE '1')");
+        assertThat(assertions.expression("a.tan()")
+                .binding("a", "DOUBLE '1'"))
+                .matches("tan(DOUBLE '1')");
+        assertThat(assertions.expression("a.degrees()")
+                .binding("a", "DOUBLE '3.141592653589793'"))
+                .matches("degrees(DOUBLE '3.141592653589793')");
+        assertThat(assertions.expression("a.radians()")
+                .binding("a", "DOUBLE '180'"))
+                .matches("radians(DOUBLE '180')");
+    }
+
+    @Test
+    public void testBinaryMethods()
+    {
+        assertThat(assertions.expression("a.power(b)")
+                .binding("a", "DOUBLE '2'")
+                .binding("b", "DOUBLE '10'"))
+                .matches("power(DOUBLE '2', DOUBLE '10')");
+        assertThat(assertions.expression("a.pow(b)")
+                .binding("a", "DOUBLE '2'")
+                .binding("b", "DOUBLE '10'"))
+                .matches("pow(DOUBLE '2', DOUBLE '10')");
+        assertThat(assertions.expression("a.log(b)")
+                .binding("a", "DOUBLE '2'")
+                .binding("b", "DOUBLE '8'"))
+                .matches("log(DOUBLE '2', DOUBLE '8')");
+        assertThat(assertions.expression("a.atan2(b)")
+                .binding("a", "DOUBLE '1'")
+                .binding("b", "DOUBLE '1'"))
+                .matches("atan2(DOUBLE '1', DOUBLE '1')");
+        assertThat(assertions.expression("a.mod(b)")
+                .binding("a", "BIGINT '10'")
+                .binding("b", "BIGINT '3'"))
+                .matches("mod(BIGINT '10', BIGINT '3')");
+        assertThat(assertions.expression("a.mod(b)")
+                .binding("a", "DOUBLE '10'")
+                .binding("b", "DOUBLE '3'"))
+                .matches("mod(DOUBLE '10', DOUBLE '3')");
+    }
+
+    @Test
+    public void testPredicateMethods()
+    {
+        assertThat(assertions.expression("a.is_nan()")
+                .binding("a", "nan()"))
+                .matches("is_nan(nan())");
+        assertThat(assertions.expression("a.is_finite()")
+                .binding("a", "DOUBLE '1'"))
+                .matches("is_finite(DOUBLE '1')");
+        assertThat(assertions.expression("a.is_infinite()")
+                .binding("a", "infinity()"))
+                .matches("is_infinite(infinity())");
+    }
+
+    @Test
+    public void testWidthBucket()
+    {
+        assertThat(assertions.expression("a.width_bucket(b, c, d)")
+                .binding("a", "DOUBLE '3.14'")
+                .binding("b", "DOUBLE '0'")
+                .binding("c", "DOUBLE '4'")
+                .binding("d", "BIGINT '4'"))
+                .matches("width_bucket(DOUBLE '3.14', DOUBLE '0', DOUBLE '4', BIGINT '4')");
+    }
+
+    @Test
+    public void testToBase()
+    {
+        assertThat(assertions.expression("a.to_base(b)")
+                .binding("a", "BIGINT '255'")
+                .binding("b", "BIGINT '16'"))
+                .matches("to_base(BIGINT '255', BIGINT '16')");
+    }
+
+    @Test
+    public void testStaticMethods()
+    {
+        assertThat(assertions.expression("double::pi()"))
+                .matches("pi()");
+        assertThat(assertions.expression("double::e()"))
+                .matches("e()");
+        assertThat(assertions.expression("double::nan()"))
+                .matches("nan()");
+        assertThat(assertions.expression("double::infinity()"))
+                .matches("infinity()");
+        assertThat(assertions.expression("bigint::from_base(a, b)")
+                .binding("a", "'ff'")
+                .binding("b", "BIGINT '16'"))
+                .matches("from_base('ff', BIGINT '16')");
+    }
+
+    @Test
+    public void testMethodNotResolvableAsFunction()
+    {
+        // The plain function namespace must not expose the receiver-less method as a function call.
+        // (Spot-check via an instance method that has no like-named plain function arity.)
+        assertTrinoExceptionThrownBy(() -> assertions.expression("a.nope()")
+                .binding("a", "DOUBLE '1'")
+                .evaluate())
+                .hasErrorCode(FUNCTION_NOT_FOUND);
+    }
+
+    @Test
+    public void testReceiverNotCoercibleAcrossBaseType()
+    {
+        // sqrt is a method on DOUBLE receivers only; an integer receiver has no sqrt method
+        // (the receiver is matched on its exact base type, with no cross-type coercion).
+        assertTrinoExceptionThrownBy(() -> assertions.expression("a.sqrt()")
+                .binding("a", "INTEGER '16'")
+                .evaluate())
+                .hasErrorCode(FUNCTION_NOT_FOUND);
+    }
+}

--- a/docs/src/main/sphinx/language/types.md
+++ b/docs/src/main/sphinx/language/types.md
@@ -176,6 +176,285 @@ Example type definitions: `DECIMAL(10,3)`, `DECIMAL(20)`
 
 Example literals: `DECIMAL '10.3'`, `DECIMAL '1234567890'`, `1.1`
 
+(numeric-methods)=
+## Numeric methods
+
+The core {doc}`math functions </functions/math>` are also available as SQL:2023
+methods on numeric receivers, so `value.abs()`, `value.round(2)`, and
+`(2e0).sqrt()` resolve to the same implementations as the plain functions.
+Methods and functions resolve in separate namespaces, so every existing function
+call keeps working, and each method returns a new value without modifying the
+receiver.
+
+A method is matched on the *exact* base type of its receiver, with no implicit
+cross-type coercion of the receiver. A function defined only for `DOUBLE`, such
+as {func}`sqrt`, is therefore a method on `DOUBLE` receivers only; use the plain
+function or cast the receiver — for example `(CAST(16 AS double)).sqrt()` or
+`(16e0).sqrt()` — to apply it to another numeric type. Because a bare decimal
+literal such as `2.0` is itself a method receiver candidate, wrap the receiver in
+parentheses, as in `(2.0).floor()`.
+
+### Methods on every numeric type
+
+These methods are available on all numeric receivers (`TINYINT`, `SMALLINT`,
+`INTEGER`, `BIGINT`, `REAL`, `DOUBLE`, `DECIMAL`, and `NUMBER`).
+
+:::{function} number.abs() -> [same as input]
+:noindex: true
+
+Returns the absolute value of `number`. Related: {func}`abs`.
+
+```
+SELECT (DECIMAL '-7.50').abs();
+-- 7.50
+```
+:::
+
+:::{function} number.ceiling() -> [same as input]
+:noindex: true
+
+Returns `number` rounded up to the nearest integer. Also available as
+`number.ceil()`. Related: {func}`ceiling`.
+
+```
+SELECT (2.1).ceiling();
+-- 3
+```
+:::
+
+:::{function} number.floor() -> [same as input]
+:noindex: true
+
+Returns `number` rounded down to the nearest integer. Related: {func}`floor`.
+
+```
+SELECT (2.9).floor();
+-- 2
+```
+:::
+
+:::{function} number.round() -> [same as input]
+:noindex: true
+
+Returns `number` rounded to the nearest integer. Related: {func}`round`.
+:::
+
+:::{function} number.round(decimals) -> [same as input]
+:noindex: true
+
+Returns `number` rounded to `decimals` decimal places. Related: {func}`round`.
+
+```
+SELECT (3.14159).round(2);
+-- 3.14
+```
+:::
+
+:::{function} number.sign() -> [same as input]
+:noindex: true
+
+Returns the signum of `number`. Related: {func}`sign`.
+:::
+
+### Methods on REAL, DOUBLE, DECIMAL, and NUMBER
+
+:::{function} number.truncate() -> [same as input]
+:noindex: true
+
+Returns `number` rounded toward zero to an integer. Related: {func}`truncate`.
+
+```
+SELECT (DOUBLE '-42.7').truncate();
+-- -42.0
+```
+:::
+
+`DECIMAL` receivers additionally support `number.truncate(decimals)`, which drops
+digits beyond `decimals` decimal places.
+
+### Methods on integer, floating-point, and NUMBER types
+
+:::{function} number.mod(divisor) -> [same as input]
+:noindex: true
+
+Returns the remainder of `number` divided by `divisor`. Available on `TINYINT`,
+`SMALLINT`, `INTEGER`, `BIGINT`, `REAL`, `DOUBLE`, and `NUMBER` receivers.
+Related: {func}`mod`.
+
+```
+SELECT (10).mod(3);
+-- 1
+```
+:::
+
+### Methods on DOUBLE values
+
+The following methods are available on `DOUBLE` receivers, matching the
+floating-point math functions.
+
+:::{function} double.sqrt() -> double
+:noindex: true
+
+Returns the square root of the receiver. Related: {func}`sqrt`.
+
+```
+SELECT (16e0).sqrt();
+-- 4.0
+```
+:::
+
+:::{function} double.cbrt() -> double
+:noindex: true
+
+Returns the cube root of the receiver. Related: {func}`cbrt`.
+:::
+
+:::{function} double.exp() -> double
+:noindex: true
+
+Returns Euler's number raised to the receiver. Related: {func}`exp`.
+:::
+
+:::{function} double.ln() -> double
+:noindex: true
+
+Returns the natural logarithm of the receiver. Related: {func}`ln`.
+:::
+
+:::{function} double.log2() -> double
+:noindex: true
+
+Returns the base-2 logarithm of the receiver. Related: {func}`log2`.
+:::
+
+:::{function} double.log10() -> double
+:noindex: true
+
+Returns the base-10 logarithm of the receiver. Related: {func}`log10`.
+:::
+
+:::{function} double.log(number) -> double
+:noindex: true
+
+Returns the logarithm of `number` to the base of the receiver. Related:
+{func}`log`.
+
+```
+SELECT (2e0).log(8e0);
+-- 3.0
+```
+:::
+
+:::{function} double.power(exponent) -> double
+:noindex: true
+
+Returns the receiver raised to the power of `exponent`. Also available as
+`double.pow(exponent)`. Related: {func}`power`.
+
+```
+SELECT (2e0).power(10e0);
+-- 1024.0
+```
+:::
+
+:::{function} double.sin() -> double
+:noindex: true
+
+Returns the sine of the receiver. The methods `cos`, `tan`, `sinh`, `cosh`,
+`tanh`, `asin`, `acos`, and `atan` are available in the same way. Related:
+{func}`sin`.
+:::
+
+:::{function} double.atan2(x) -> double
+:noindex: true
+
+Returns the arc tangent of the receiver divided by `x`. Related: {func}`atan2`.
+:::
+
+:::{function} double.degrees() -> double
+:noindex: true
+
+Converts the receiver from radians to degrees. Related: {func}`degrees`.
+:::
+
+:::{function} double.radians() -> double
+:noindex: true
+
+Converts the receiver from degrees to radians. Related: {func}`radians`.
+:::
+
+:::{function} double.is_nan() -> boolean
+:noindex: true
+
+Returns whether the receiver is not-a-number. Also available on `REAL` and
+`NUMBER` receivers. Related: {func}`is_nan`.
+:::
+
+:::{function} double.is_finite() -> boolean
+:noindex: true
+
+Returns whether the receiver is finite. Also available on `REAL` and `NUMBER`
+receivers. Related: {func}`is_finite`.
+:::
+
+:::{function} double.is_infinite() -> boolean
+:noindex: true
+
+Returns whether the receiver is infinite. Also available on `NUMBER` receivers.
+Related: {func}`is_infinite`.
+:::
+
+:::{function} double.width_bucket(bound1, bound2, n) -> bigint
+:noindex: true
+
+Returns the bin number of the receiver for `n` equi-width bins between `bound1`
+and `bound2`. An overload taking a sorted `array(double)` of bins is also
+available. Related: {func}`width_bucket`.
+:::
+
+### Methods on BIGINT values
+
+:::{function} bigint.to_base(radix) -> varchar
+:noindex: true
+
+Returns the base-`radix` string representation of the receiver. Related:
+{func}`to_base`.
+
+```
+SELECT (255).to_base(16);
+-- ff
+```
+:::
+
+### Static methods
+
+The numeric constructors and constants are available as static methods, invoked
+with the `type::method(...)` syntax.
+
+:::{function} double::pi() -> double
+:noindex: true
+
+Returns the constant Pi. The constants `e`, `nan`, and `infinity` are available
+the same way. Related: {func}`pi`.
+
+```
+SELECT double::pi();
+-- 3.141592653589793
+```
+:::
+
+:::{function} bigint::from_base(string, radix) -> bigint
+:noindex: true
+
+Returns the value of `string` interpreted as a base-`radix` number. Related:
+{func}`from_base`.
+
+```
+SELECT bigint::from_base('ff', 16);
+-- 255
+```
+:::
+
 (string-data-types)=
 ## String
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## General
* Add support for math instance methods to number types ({issue}`issuenumber`)
```
