### PR TITLE
Fallback to inlining when segment fails to spool

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/OutputSpoolingOperatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OutputSpoolingOperatorFactory.java
@@ -15,6 +15,7 @@ package io.trino.operator;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -31,6 +32,7 @@ import io.trino.spi.spool.SpooledSegmentHandle;
 import io.trino.spi.spool.SpoolingContext;
 import io.trino.spi.spool.SpoolingManager;
 import io.trino.sql.planner.plan.PlanNodeId;
+import org.assertj.core.util.VisibleForTesting;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -147,7 +149,9 @@ public class OutputSpoolingOperatorFactory
     static class OutputSpoolingOperator
             implements Operator
     {
-        private static final long SPOOLING_THRESHOLD = DataSize.of(2, MEGABYTE).toBytes(); // this roughly translates to 400 KB compressed segment
+        private static final Logger log = Logger.get(OutputSpoolingOperator.class);
+        @VisibleForTesting
+        static final long SPOOLING_THRESHOLD = DataSize.of(2, MEGABYTE).toBytes(); // this roughly translates to 400 KB compressed segment
 
         private final SpoolingController controller;
         private final ZoneId clientZoneId;
@@ -298,34 +302,60 @@ public class OutputSpoolingOperatorFactory
                     continue;
                 }
 
-                // Spool the partition as it is large enough
-                SpooledSegmentHandle segmentHandle = spoolingManager.create(new SpoolingContext(
-                        queryDataEncoder.encoding(),
-                        operatorContext.getDriverContext().getSession().getQueryId(),
-                        rows,
-                        size));
-
-                OperationTimer overallTimer = new OperationTimer(false);
-                try (OutputStream output = spoolingManager.createOutputStream(segmentHandle)) {
-                    spooledSegmentsCount.incrementAndGet();
-                    DataAttributes attributes = queryDataEncoder.encodeTo(output, partition)
-                            .toBuilder()
-                            .set(ROWS_COUNT, rows)
-                            .set(EXPIRES_AT, ZonedDateTime.ofInstant(segmentHandle.expirationTime(), clientZoneId).toLocalDateTime().toString())
-                            .build();
-                    spooledEncodedBytes.addAndGet(attributes.get(SEGMENT_SIZE, Integer.class));
-                    // This page is small (hundreds of bytes) so there is no point in tracking its memory usage
-                    spooledMetadataBuilder.add(SpooledMetadataBlock.forSpooledLocation(spoolingManager.location(segmentHandle), attributes));
+                // Spool the partition as it is large enough, falling back to inlining on recoverable failures
+                try {
+                    spooledMetadataBuilder.add(spool(partition, rows, size));
                 }
                 catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-                finally {
-                    overallTimer.end(spoolingTiming);
+                    if (!inliningEnabled || !spoolingManager.isRecoverableException(e)) {
+                        throw new UncheckedIOException(e);
+                    }
+                    log.warn(e, "Failed to spool segment of %s rows (%s bytes), falling back to inlining", rows, size);
+                    spooledMetadataBuilder.addAll(inlineFallback(partition));
                 }
             }
 
             return serialize(spooledMetadataBuilder.build());
+        }
+
+        // Spools a single partition and returns its metadata. The segment is recorded only after the stream
+        // is closed and the location resolved, so a failure at any step here can safely fall back to inlining.
+        private SpooledMetadataBlock spool(List<Page> partition, long rows, long size)
+                throws IOException
+        {
+            SpooledSegmentHandle segmentHandle = spoolingManager.create(new SpoolingContext(
+                    queryDataEncoder.encoding(),
+                    operatorContext.getDriverContext().getSession().getQueryId(),
+                    rows,
+                    size));
+
+            OperationTimer overallTimer = new OperationTimer(false);
+            DataAttributes attributes;
+            try (OutputStream output = spoolingManager.createOutputStream(segmentHandle)) {
+                attributes = queryDataEncoder.encodeTo(output, partition)
+                        .toBuilder()
+                        .set(ROWS_COUNT, rows)
+                        .set(EXPIRES_AT, ZonedDateTime.ofInstant(segmentHandle.expirationTime(), clientZoneId).toLocalDateTime().toString())
+                        .build();
+            }
+            finally {
+                overallTimer.end(spoolingTiming);
+            }
+
+            SpooledMetadataBlock block = SpooledMetadataBlock.forSpooledLocation(spoolingManager.location(segmentHandle), attributes);
+            spooledSegmentsCount.incrementAndGet();
+            spooledEncodedBytes.addAndGet(attributes.get(SEGMENT_SIZE, Integer.class));
+            return block;
+        }
+
+        // Splits a partition that failed to spool into chunks small enough to inline as individual segments.
+        private List<SpooledMetadataBlock> inlineFallback(List<Page> partition)
+        {
+            ImmutableList.Builder<SpooledMetadataBlock> builder = ImmutableList.builder();
+            for (List<Page> chunk : SpoolingPagePartitioner.partition(partition, SPOOLING_THRESHOLD)) {
+                builder.addAll(inline(chunk));
+            }
+            return builder.build();
         }
 
         private List<SpooledMetadataBlock> inline(List<Page> pages)

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpoolingManagerBridge.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/SpoolingManagerBridge.java
@@ -119,6 +119,12 @@ public class SpoolingManagerBridge
         return delegate().handle(fromUri(secretKey, identifier), headers);
     }
 
+    @Override
+    public boolean isRecoverableException(IOException exception)
+    {
+        return delegate().isRecoverableException(exception);
+    }
+
     private SpoolingManager delegate()
     {
         return registry

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/TracingSpoolingManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/TracingSpoolingManager.java
@@ -109,6 +109,12 @@ public class TracingSpoolingManager
         return delegate.handle(identifier, headers);
     }
 
+    @Override
+    public boolean isRecoverableException(IOException exception)
+    {
+        return delegate.isRecoverableException(exception);
+    }
+
     public static <E extends Exception> void withTracing(Span span, CheckedRunnable<E> runnable)
             throws E
     {

--- a/core/trino-main/src/test/java/io/trino/operator/TestOutputSpoolingOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestOutputSpoolingOperator.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.trino.Session;
+import io.trino.client.spooling.DataAttributes;
+import io.trino.metadata.SessionPropertyManager;
+import io.trino.server.protocol.spooling.QueryDataEncoder;
+import io.trino.server.protocol.spooling.SpooledMetadataBlock;
+import io.trino.server.protocol.spooling.SpoolingConfig;
+import io.trino.server.protocol.spooling.SpoolingSessionProperties;
+import io.trino.spi.Page;
+import io.trino.spi.spool.SpooledLocation;
+import io.trino.spi.spool.SpooledLocation.DirectLocation;
+import io.trino.spi.spool.SpooledSegmentHandle;
+import io.trino.spi.spool.SpoolingContext;
+import io.trino.spi.spool.SpoolingManager;
+import io.trino.sql.planner.plan.PlanNodeId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.SequencePageBuilder.createSequencePage;
+import static io.trino.client.spooling.DataAttribute.ROWS_COUNT;
+import static io.trino.client.spooling.DataAttribute.SEGMENT_SIZE;
+import static io.trino.operator.OutputSpoolingOperatorFactory.OutputSpoolingOperator.SPOOLING_THRESHOLD;
+import static io.trino.server.protocol.spooling.SpooledMetadataBlockSerde.deserialize;
+import static io.trino.server.protocol.spooling.SpoolingSessionProperties.INITIAL_SEGMENT_SIZE;
+import static io.trino.server.protocol.spooling.SpoolingSessionProperties.INLINING_ENABLED;
+import static io.trino.server.protocol.spooling.SpoolingSessionProperties.MAX_SEGMENT_SIZE;
+import static io.trino.spi.spool.SpooledLocation.coordinatorLocation;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.testing.TestingTaskContext.createTaskContext;
+import static java.lang.Math.toIntExact;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
+
+@TestInstance(PER_METHOD)
+public class TestOutputSpoolingOperator
+{
+    private ExecutorService executor;
+    private ScheduledExecutorService scheduledExecutor;
+
+    @BeforeEach
+    public void setUp()
+    {
+        executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed(getClass().getSimpleName() + "-scheduledExecutor-%s"));
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        executor.shutdownNow();
+        scheduledExecutor.shutdownNow();
+    }
+
+    // ~6 MB of BIGINT data: too many rows/bytes to be inlined proactively, and several times the 2 MB
+    // inlining threshold so the spooled segment is split into multiple inlined segments on fallback.
+    private static final int LARGE_ROW_COUNT = 700_000;
+
+    @Test
+    public void testSpoolsWhenStorageIsAvailable()
+    {
+        // The segment is spooled as a single segment when the spooling storage works
+        List<SpooledMetadataBlock> segments = process(new TestingSpoolingManager(), largeInput(), true);
+
+        assertThat(segments).hasSize(1);
+        assertThat(segments).allMatch(SpooledMetadataBlock.Spooled.class::isInstance);
+    }
+
+    @Test
+    public void testFallbackSplitsLargeSegmentIntoSmallerInlinedSegments()
+    {
+        // When the spooling storage is transiently down, the segment that failed to spool is split into
+        // several smaller inlined segments, each below the 2 MB inlining threshold
+        List<SpooledMetadataBlock> segments = process(new RecoverableFailingSpoolingManager(), largeInput(), true);
+
+        assertThat(segments).hasSize(4);
+        assertThat(segments).allMatch(SpooledMetadataBlock.Inlined.class::isInstance);
+        assertThat(segments).allMatch(segment -> segment.attributes().get(SEGMENT_SIZE, Integer.class) < SPOOLING_THRESHOLD);
+        assertThat(segments).allMatch(segment -> segment.attributes().get(ROWS_COUNT, Long.class) < 235_000); // ~SPOOLING_THRESHOLD of BIGINT values
+        // No data is lost: the rows of the failed segment are preserved across the inlined segments
+        assertThat(totalRows(segments)).isEqualTo(LARGE_ROW_COUNT);
+    }
+
+    @Test
+    public void testFailsWhenSpoolingFailsWithUnrecoverableError()
+    {
+        // An unrecoverable failure (e.g. invalid credentials) is not masked by inlining even when
+        // inlining is enabled - the query fails so the underlying problem is surfaced
+        assertThatThrownBy(() -> process(new UnrecoverableFailingSpoolingManager(), largeInput(), true))
+                .isInstanceOf(UncheckedIOException.class)
+                .hasMessageContaining("invalid credentials");
+    }
+
+    @Test
+    public void testFailsWhenSpoolingFailsAndInliningDisabled()
+    {
+        // With inlining disabled there is no fallback, so even a recoverable spooling failure fails the query
+        assertThatThrownBy(() -> process(new RecoverableFailingSpoolingManager(), largeInput(), false))
+                .isInstanceOf(UncheckedIOException.class)
+                .hasMessageContaining("spooling storage is unavailable");
+    }
+
+    private static List<Page> largeInput()
+    {
+        return List.of(createSequencePage(List.of(BIGINT), LARGE_ROW_COUNT));
+    }
+
+    private List<SpooledMetadataBlock> process(SpoolingManager spoolingManager, List<Page> input, boolean inliningEnabled)
+    {
+        Session session = testSessionBuilder(spoolingSessionPropertyManager())
+                .setSystemProperty(INLINING_ENABLED, Boolean.toString(inliningEnabled))
+                // Keep all input in a single segment so the fallback has to split it
+                .setSystemProperty(INITIAL_SEGMENT_SIZE, "64MB")
+                .setSystemProperty(MAX_SEGMENT_SIZE, "64MB")
+                .build();
+
+        DriverContext driverContext = createTaskContext(executor, scheduledExecutor, session)
+                .addPipelineContext(0, true, true, false)
+                .addDriverContext();
+
+        OutputSpoolingOperatorFactory factory = new OutputSpoolingOperatorFactory(0, new PlanNodeId("test"), TestOutputSpoolingOperator::rawSizeEncoder, spoolingManager);
+        Operator operator = factory.createOperator(driverContext);
+
+        ImmutableList.Builder<SpooledMetadataBlock> segments = ImmutableList.builder();
+        for (Page page : input) {
+            assertThat(operator.needsInput()).isTrue();
+            operator.addInput(page);
+            collect(operator, segments);
+        }
+
+        operator.finish();
+        while (!operator.isFinished()) {
+            collect(operator, segments);
+        }
+        return segments.build();
+    }
+
+    private static void collect(Operator operator, ImmutableList.Builder<SpooledMetadataBlock> segments)
+    {
+        Page output = operator.getOutput();
+        if (output != null) {
+            segments.addAll(deserialize(output));
+        }
+    }
+
+    private static long totalRows(List<SpooledMetadataBlock> segments)
+    {
+        return segments.stream()
+                .mapToLong(segment -> segment.attributes().get(ROWS_COUNT, Long.class))
+                .sum();
+    }
+
+    private static SessionPropertyManager spoolingSessionPropertyManager()
+    {
+        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager();
+        sessionPropertyManager.addSystemSessionProperties(new SpoolingSessionProperties(new SpoolingConfig()).getSessionProperties());
+        return sessionPropertyManager;
+    }
+
+    /**
+     * Minimal encoder that writes one byte per row and reports that as the segment size. The actual
+     * bytes are irrelevant for these tests - only the segment sizing and row counts matter.
+     */
+    private static QueryDataEncoder rawSizeEncoder()
+    {
+        return new QueryDataEncoder()
+        {
+            @Override
+            public DataAttributes encodeTo(OutputStream output, List<Page> pages)
+                    throws IOException
+            {
+                int rows = toIntExact(pages.stream().mapToLong(Page::getPositionCount).sum());
+                output.write(new byte[rows]);
+                return DataAttributes.builder()
+                        .set(SEGMENT_SIZE, rows)
+                        .build();
+            }
+
+            @Override
+            public String encoding()
+            {
+                return "test";
+            }
+
+            @Override
+            public void close() {}
+        };
+    }
+
+    private static class TestingSpoolingManager
+            implements SpoolingManager
+    {
+        @Override
+        public SpooledSegmentHandle create(SpoolingContext context)
+        {
+            return new TestingSpooledSegmentHandle("segment", context.encoding(), Instant.ofEpochSecond(0));
+        }
+
+        @Override
+        public OutputStream createOutputStream(SpooledSegmentHandle handle)
+                throws IOException
+        {
+            return OutputStream.nullOutputStream();
+        }
+
+        @Override
+        public SpooledLocation location(SpooledSegmentHandle handle)
+        {
+            return coordinatorLocation(utf8Slice(handle.identifier()), Map.of());
+        }
+
+        @Override
+        public InputStream openInputStream(SpooledSegmentHandle handle)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void acknowledge(SpooledSegmentHandle handle)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<DirectLocation> directLocation(SpooledSegmentHandle handle)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SpooledSegmentHandle handle(Slice identifier, Map<String, List<String>> headers)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isRecoverableException(IOException exception)
+        {
+            return false;
+        }
+    }
+
+    private static class RecoverableFailingSpoolingManager
+            extends TestingSpoolingManager
+    {
+        @Override
+        public OutputStream createOutputStream(SpooledSegmentHandle handle)
+                throws IOException
+        {
+            throw new IOException("spooling storage is unavailable");
+        }
+
+        @Override
+        public boolean isRecoverableException(IOException exception)
+        {
+            return true;
+        }
+    }
+
+    private static class UnrecoverableFailingSpoolingManager
+            extends TestingSpoolingManager
+    {
+        @Override
+        public OutputStream createOutputStream(SpooledSegmentHandle handle)
+                throws IOException
+        {
+            throw new IOException("invalid credentials");
+        }
+    }
+
+    private record TestingSpooledSegmentHandle(String identifier, String encoding, Instant expirationTime)
+            implements SpooledSegmentHandle {}
+}

--- a/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestSpoolingManagerBridge.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestSpoolingManagerBridge.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling;
+
+import io.trino.spi.spool.SpoolingManager;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+
+class TestSpoolingManagerBridge
+{
+    @Test
+    void testSpoolingManagerBridgeDelegatesAllMethods()
+    {
+        assertAllMethodsOverridden(SpoolingManager.class, SpoolingManagerBridge.class);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestTracingSpoolingManager.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/spooling/TestTracingSpoolingManager.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.spooling;
+
+import io.trino.spi.spool.SpoolingManager;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+
+class TestTracingSpoolingManager
+{
+    @Test
+    void testTracingSpoolingManagerDelegatesAllMethods()
+    {
+        assertAllMethodsOverridden(SpoolingManager.class, TracingSpoolingManager.class);
+    }
+}

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -326,6 +326,11 @@
                                     <code>java.method.visibilityIncreased</code>
                                     <old>method boolean[] io.trino.spi.block.VariableWidthBlock::getRawValueIsNull()</old>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.addedToInterface</code>
+                                    <new>method boolean io.trino.spi.spool.SpoolingManager::isRecoverableException(java.io.IOException)</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/spool/SpoolingManager.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/spool/SpoolingManager.java
@@ -45,4 +45,11 @@ public interface SpoolingManager
 
     // Converts spooled location back to the handle
     SpooledSegmentHandle handle(Slice identifier, Map<String, List<String>> headers);
+
+    /**
+     * Whether a segment that failed to spool with the given exception can be inlined instead of failing
+     * the query. Transient failures (e.g. storage temporarily unavailable) are recoverable; unrecoverable
+     * ones (e.g. invalid credentials) are not and must fail the query rather than be masked by inlining.
+     */
+    boolean isRecoverableException(IOException exception);
 }

--- a/plugin/trino-spooling-filesystem/src/main/java/io/trino/spooling/filesystem/FileSystemSpoolingManager.java
+++ b/plugin/trino-spooling-filesystem/src/main/java/io/trino/spooling/filesystem/FileSystemSpoolingManager.java
@@ -211,6 +211,12 @@ public class FileSystemSpoolingManager
     }
 
     @Override
+    public boolean isRecoverableException(IOException exception)
+    {
+        return !TrinoFileSystem.isUnrecoverableException(exception);
+    }
+
+    @Override
     public SpooledSegmentHandle handle(Slice identifier, Map<String, List<String>> headers)
     {
         BasicSliceInput input = identifier.getInput();

--- a/testing/trino-testing/src/main/java/io/trino/testing/LocalSpoolingManager.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/LocalSpoolingManager.java
@@ -123,6 +123,12 @@ public class LocalSpoolingManager
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public boolean isRecoverableException(IOException exception)
+    {
+        return false;
+    }
+
     @PreDestroy
     public void close()
     {


### PR DESCRIPTION
When spooling storage is unavailable or segment fails to spool instead of failing a query, split the pages into smaller chunks and inline them so that client can still retrieve segments, but only do that if the inlining is not explicitly disabled (either by the config or a session property).

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Spooling protocol
* Inline segments when inlining is enabled and spooling storage is unavailable ({issue}`issuenumber`)
```
