### PR TITLE
Fix Hive JSON format failure on duplicate top-level keys

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonDeserializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonDeserializer.java
@@ -688,8 +688,9 @@ public class JsonDeserializer
         public void decode(JsonParser parser, PageBuilder builder)
                 throws IOException
         {
+            int currentPosition = builder.getPositionCount();
             builder.declarePosition();
-            decodeValue(parser, builder.getPositionCount(), builder::getBlockBuilder);
+            decodeValue(parser, currentPosition, builder::getBlockBuilder);
         }
 
         @Override

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/json/TestJsonFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/json/TestJsonFormat.java
@@ -111,6 +111,42 @@ public class TestJsonFormat
     private static final CharType CHAR_3 = createCharType(3);
 
     @Test
+    public void testTopLevelDuplicateKeys()
+            throws Exception
+    {
+        List<Column> columns = ImmutableList.of(
+                new Column("a", BIGINT, 0),
+                new Column("b", BIGINT, 1),
+                new Column("c", BIGINT, 2));
+
+        // last value wins for duplicate top-level keys, matching Hive
+        assertLineMatchesHive(columns, "{\"a\": 1, \"a\": 2}", Arrays.asList(2L, null, null));
+        assertLineMatchesHive(columns, "{\"a\": 1, \"b\": 2, \"a\": 3}", Arrays.asList(3L, 2L, null));
+        assertLineMatchesHive(columns, "{\"a\": 1, \"b\": 2, \"a\": 3, \"b\": 4}", Arrays.asList(3L, 4L, null));
+        assertLineMatchesHive(columns, "{\"a\": 1, \"a\": 2, \"a\": 3}", Arrays.asList(3L, null, null));
+
+        // duplicate of non-first column
+        assertLineMatchesHive(columns, "{\"b\": 1, \"b\": 2}", Arrays.asList(null, 2L, null));
+
+        // duplicate with unknown fields skipped
+        assertLineMatchesHive(columns, "{\"x\": 99, \"a\": 1, \"a\": 2}", Arrays.asList(2L, null, null));
+
+        // last value wins even when the last value is null
+        assertLineMatchesHive(columns, "{\"a\": 1, \"a\": null}", Arrays.asList(null, null, null));
+
+        // multiple rows into the same PageBuilder
+        LineDeserializer deserializer = new JsonDeserializerFactory().create(columns, createJsonProperties(ImmutableList.of()));
+        PageBuilder pageBuilder = new PageBuilder(3, deserializer.getTypes());
+        deserializer.deserialize(createLineBuffer("{\"a\": 1, \"b\": 2}"), pageBuilder);
+        deserializer.deserialize(createLineBuffer("{\"a\": 10, \"a\": 20}"), pageBuilder);
+        deserializer.deserialize(createLineBuffer("{\"a\": 100, \"b\": 200, \"c\": 300}"), pageBuilder);
+        Page page = pageBuilder.build();
+        assertThat(readTrinoValues(columns, page, 0)).isEqualTo(Arrays.asList(1L, 2L, null));
+        assertThat(readTrinoValues(columns, page, 1)).isEqualTo(Arrays.asList(20L, null, null));
+        assertThat(readTrinoValues(columns, page, 2)).isEqualTo(ImmutableList.of(100L, 200L, 300L));
+    }
+
+    @Test
     public void testStruct()
             throws Exception
     {
@@ -945,6 +981,26 @@ public class TestJsonFormat
         for (boolean hcatalog : ImmutableList.of(true, false)) {
             actualValue = readHiveLine(columns, trinoLine, ImmutableList.of(), hcatalog).get(0);
             assertColumnValueEquals(type, actualValue, expectedValue);
+        }
+    }
+
+    /**
+     * Asserts that Trino reads the line as expected, and that both Hive JSON SerDes agree, so the
+     * expected values are pinned to Hive's behavior rather than to hardcoded constants.
+     */
+    private static void assertLineMatchesHive(List<Column> columns, String jsonLine, List<Object> expectedValues)
+            throws Exception
+    {
+        assertValues(columns, readTrinoLine(jsonLine, columns, ImmutableList.of()), expectedValues);
+        for (boolean hcatalog : ImmutableList.of(true, false)) {
+            assertValues(columns, readHiveLine(columns, jsonLine, ImmutableList.of(), hcatalog), expectedValues);
+        }
+    }
+
+    private static void assertValues(List<Column> columns, List<Object> actualValues, List<Object> expectedValues)
+    {
+        for (int i = 0; i < columns.size(); i++) {
+            assertColumnValueEquals(columns.get(i).type(), actualValues.get(i), expectedValues.get(i));
         }
     }
 

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TestJsonFileHiveTable.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TestJsonFileHiveTable.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+import io.trino.testing.containers.HdfsClient;
+import io.trino.testing.containers.environment.ProductTest;
+import io.trino.testing.containers.environment.QueryResult;
+import io.trino.testing.containers.environment.RequiresEnvironment;
+import io.trino.tests.product.TestGroup;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.testing.containers.environment.QueryResultAssert.assertThat;
+import static io.trino.testing.containers.environment.Row.row;
+import static java.lang.String.format;
+
+/**
+ * Tests for JSON format Hive tables.
+ */
+@ProductTest
+@RequiresEnvironment(HiveStorageFormatsEnvironment.class)
+@TestGroup.StorageFormatsDetailed
+class TestJsonFileHiveTable
+{
+    /**
+     * Six rows in a single file, so every line lands in the same PageBuilder. A JSON object with a
+     * duplicate top-level key must not shift the declared position of the columns that follow.
+     */
+    private static final String DUPLICATE_KEYS_CONTENT =
+            """
+            {"id":1,"a":1,"a":2,"b":"x"}
+            {"id":2,"a":10,"b":"first","a":20}
+            {"id":3,"a":30,"unknown":99,"a":40,"b":"y"}
+            {"id":4,"b":"one","b":"two"}
+            {"id":5,"a":50,"a":null}
+            {"id":6,"a":60,"b":"z"}
+            """;
+
+    @Test
+    void testDuplicateTopLevelKeysMatchHive(HiveStorageFormatsEnvironment env)
+    {
+        // Hive and Trino share a metastore, so the two tables need distinct names even though they
+        // read the same files
+        String hiveTableName = "test_json_duplicate_keys_hive";
+        String trinoTableName = "test_json_duplicate_keys_trino";
+        String tablePath = "/tmp/test_json_duplicate_keys";
+
+        HdfsClient hdfsClient = env.createHdfsClient();
+        hdfsClient.createDirectory(tablePath);
+        // duplicate keys cannot be produced by INSERT, so the file has to be staged directly
+        hdfsClient.saveFile(tablePath + "/data.json", DUPLICATE_KEYS_CONTENT);
+
+        env.executeHiveUpdate("DROP TABLE IF EXISTS " + hiveTableName);
+        env.executeTrinoUpdate("DROP TABLE IF EXISTS hive.default." + trinoTableName);
+        try {
+            // external table, so dropping it never deletes the staged file
+            env.executeHiveUpdate(
+                    """
+                    CREATE EXTERNAL TABLE %s(id INT, a INT, b STRING)
+                    ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.JsonSerDe'
+                    STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat'
+                    OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+                    LOCATION '%s'
+                    """.formatted(hiveTableName, tablePath));
+
+            // a plain SELECT runs as a fetch task, while ORDER BY would launch MapReduce
+            QueryResult hiveResult = env.executeHive(format("SELECT id, a, b FROM %s", hiveTableName));
+
+            // Hive keeps the last value of a duplicate top-level key. Asserting it here documents the
+            // behavior being pinned, and makes a future change in Hive fail loudly.
+            assertThat(hiveResult)
+                    .hasRowsCount(6)
+                    .containsOnly(
+                            // adjacent duplicate
+                            row(1, 2, "x"),
+                            // duplicate separated by another column, which must not be clobbered
+                            row(2, 20, "first"),
+                            // unknown field between the duplicates
+                            row(3, 40, "y"),
+                            // duplicate on a variable width column, and a missing column
+                            row(4, null, "two"),
+                            // last value wins even when it is null
+                            row(5, null, null),
+                            // control row exercising the normal path
+                            row(6, 60, "z"));
+
+            env.executeTrinoUpdate(format(
+                    "CREATE TABLE hive.default.%s (id integer, a integer, b varchar) " +
+                            "WITH (format = 'JSON', external_location = '%s')",
+                    trinoTableName,
+                    tablePath));
+
+            // pin Trino to Hive: the expectation is Hive's own output rather than a constant
+            assertThat(env.executeTrino(format("SELECT id, a, b FROM hive.default.%s", trinoTableName)))
+                    .hasSameRowsAs(hiveResult);
+        }
+        finally {
+            env.executeTrinoUpdate("DROP TABLE IF EXISTS hive.default." + trinoTableName);
+            env.executeHiveUpdate("DROP TABLE IF EXISTS " + hiveTableName);
+            hdfsClient.delete(tablePath);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fix regression where reading a Hive `JSON` format table fails when a JSON object contains duplicate top-level keys. Previously (before v440), the last value was used (last-wins semantics). After the JSON reader optimization in #19816, duplicate keys cause an `IllegalStateException` due to a position count mismatch across block builders.

**Root cause:** In `JsonDeserializer.RowDecoder.decode()`, `declarePosition()` increments the PageBuilder's position count *before* `getPositionCount()` is captured as `currentPosition`. This makes `currentPosition` one too high, so `resetTo(currentPosition)` is a no-op — the duplicate value is appended as an extra entry instead of replacing the previous one.

**Fix:** Capture the position count before `declarePosition()` so `resetTo()` correctly rolls back to the pre-row position. The nested `RowBlockBuilder` path is unaffected — it already passes the correct value.

## Additional context and related issues

- Fixes #29983

## Release notes

(x) Release notes are required, with the following suggested text:

## Hive connector

* Fix failure when reading JSON tables with duplicate top-level keys. ({issue}`29983`)
