### PR TITLE
Fix AsyncResultIterator blocking indefinitely

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/AsyncResultIterator.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/AsyncResultIterator.java
@@ -67,8 +67,8 @@ public class AsyncResultIterator
         this.cancelled = false;
         this.finished = false;
         this.future = executorService.submit(() -> {
+            int rowsProcessed = 0;
             try {
-                int rowsProcessed = 0;
                 do {
                     QueryStatusInfo results = client.currentStatusInfo();
                     progressCallback.accept(QueryStats.create(results.getId(), results.getStats()));
@@ -84,6 +84,7 @@ public class AsyncResultIterator
                 while (!cancelled && client.advance());
                 if (rowsProcessed > 0) {
                     semaphore.release(rowsProcessed);
+                    rowsProcessed = 0;
                 }
 
                 verify(client.isFinished());
@@ -99,6 +100,9 @@ public class AsyncResultIterator
                 throw new RuntimeException(new SQLException("ResultSet thread was interrupted", e));
             }
             finally {
+                if (rowsProcessed > 0) {
+                    semaphore.release(rowsProcessed);
+                }
                 finished = true;
                 semaphore.release();
             }

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestAsyncResultIterator.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestAsyncResultIterator.java
@@ -45,6 +45,7 @@ import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TestAsyncResultIterator
 {
@@ -109,6 +110,24 @@ class TestAsyncResultIterator
         while (!iterator.isBackgroundThreadFinished()) {
             TimeUnit.MILLISECONDS.sleep(10);
         }
+    }
+
+    @Test
+    @Timeout(10)
+    public void testIteratorPropagatesAdvanceException()
+    {
+        RuntimeException exception = new RuntimeException();
+        AsyncResultIterator iterator = new AsyncResultIterator(
+                new MockStatementClientThrowingOnAdvance(() -> fromList(ImmutableList.of(ImmutableList.of(new Object()))), exception),
+                ignored -> {},
+                new WarningsManager(),
+                Optional.empty());
+
+        assertThatThrownBy(() -> {
+            while (iterator.next() != null) {
+                // Iterate until exception
+            }
+        }).isSameAs(exception);
     }
 
     private static class MockStatementClient
@@ -281,6 +300,24 @@ class TestAsyncResultIterator
         public void close()
         {
             // do nothing
+        }
+    }
+
+    private static class MockStatementClientThrowingOnAdvance
+            extends MockStatementClient
+    {
+        private final RuntimeException exception;
+
+        public MockStatementClientThrowingOnAdvance(Supplier<ResultRows> queryData, RuntimeException exception)
+        {
+            super(queryData);
+            this.exception = requireNonNull(exception, "exception is null");
+        }
+
+        @Override
+        public boolean advance()
+        {
+            throw exception;
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Updates AsyncResultIterator to release semaphore permits for processed rows when an exception occurs, to prevent calls to computeNext() from blocking indefinitely.

Previously, calls to computeNext() could block indefinitely on semaphore.acquire() if an exception occurred, because not enough permits had been released for the number of rows in the rowQueue.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/trinodb/trino/issues/30007


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:



```markdown
## Section
* Fix JDBC queries getting stuck indefinitely ({issue}`issuenumber`)
```
