### PR TITLE
Add extra_properties to Delta Lake table properties

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -193,6 +193,10 @@ values. Typical usage does not require you to configure them.
 * - `delta.deletion-vectors-enabled`
   - Set to `true` for enabling deletion vectors by default when creating new tables.
   - `false`
+* - `delta.allowed-extra-properties`
+  - List of extra properties that are allowed to be set on Delta Lake tables.
+    Use `*` to allow all otherwise valid, non-protected properties.
+  - `[]`
 * - `delta.metadata.parallelism`
   - Number of threads used for retrieving metadata. Currently, only table loading 
     is parallelized.
@@ -788,9 +792,22 @@ The following table properties are available for use:
     Defaults to `NONE`.
 * - `deletion_vectors_enabled`
   - Enables deletion vectors.
+* - `extra_properties`
+  - Additional properties added to the `configuration` field of the Delta Lake
+    table metadata. The properties are not included in the output of `SHOW
+    CREATE TABLE` statements. Allowed property names are configured with
+    `delta.allowed-extra-properties`. Properties managed by another table
+    property, requiring Delta protocol feature changes, or controlling read/write
+    behavior that Trino cannot enforce this way cannot be set.
+    Trino stores extra properties as supplied; their effect depends on whether
+    Trino or another Delta engine recognizes them.
+    When altering a table, supplied extra property keys are added or updated,
+    and omitted keys are preserved.
+    When replacing a table, extra properties that are not specified are removed.
 :::
 
-The following example uses all available table properties:
+The following example uses all available table properties and assumes the
+catalog sets `delta.allowed-extra-properties=delta.checkpoint.writeStatsAsJson`:
 
 ```sql
 CREATE TABLE example.default.example_partitioned_table
@@ -800,7 +817,8 @@ WITH (
   checkpoint_interval = 5,
   change_data_feed_enabled = false,
   column_mapping_mode = 'name',
-  deletion_vectors_enabled = false
+  deletion_vectors_enabled = false,
+  extra_properties = MAP(ARRAY['delta.checkpoint.writeStatsAsJson'], ARRAY['false'])
 )
 AS SELECT name, comment, regionkey FROM tpch.tiny.nation;
 ```

--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -195,7 +195,7 @@ values. Typical usage does not require you to configure them.
   - `false`
 * - `delta.allowed-extra-properties`
   - List of extra properties that are allowed to be set on Delta Lake tables.
-    Use `*` to allow all otherwise valid, non-protected properties.
+    Each property must be listed explicitly, and matching is case-sensitive.
   - `[]`
 * - `delta.metadata.parallelism`
   - Number of threads used for retrieving metadata. Currently, only table loading 
@@ -796,9 +796,8 @@ The following table properties are available for use:
   - Additional properties added to the `configuration` field of the Delta Lake
     table metadata. The properties are not included in the output of `SHOW
     CREATE TABLE` statements. Allowed property names are configured with
-    `delta.allowed-extra-properties`. Properties managed by another table
-    property, requiring Delta protocol feature changes, or controlling read/write
-    behavior that Trino cannot enforce this way cannot be set.
+    `delta.allowed-extra-properties`. Some connector-managed and
+    protocol-sensitive Delta properties are always rejected.
     Trino stores extra properties as supplied; their effect depends on whether
     Trino or another Delta engine recognizes them.
     When altering a table, supplied extra property keys are added or updated,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.deltalake;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigHidden;
@@ -31,10 +32,12 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import org.joda.time.DateTimeZone;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.TimeUnit.DAYS;
@@ -96,6 +99,7 @@ public class DeltaLakeConfig
     private int metadataParallelism = 8;
     private int checkpointProcessingParallelism = 4;
     private boolean loadMetadataFromChecksumFile = true;
+    private List<String> allowedExtraProperties = ImmutableList.of();
 
     public Duration getMetadataCacheTtl()
     {
@@ -599,6 +603,21 @@ public class DeltaLakeConfig
     public DeltaLakeConfig setLoadMetadataFromChecksumFile(boolean loadMetadataFromChecksumFile)
     {
         this.loadMetadataFromChecksumFile = loadMetadataFromChecksumFile;
+        return this;
+    }
+
+    public List<String> getAllowedExtraProperties()
+    {
+        return allowedExtraProperties;
+    }
+
+    @Config("delta.allowed-extra-properties")
+    @ConfigDescription("List of extra properties that are allowed to be set on Delta Lake tables")
+    public DeltaLakeConfig setAllowedExtraProperties(List<String> allowedExtraProperties)
+    {
+        checkArgument(!allowedExtraProperties.contains("*") || allowedExtraProperties.size() == 1,
+                "Wildcard * should be the only element in the list");
+        this.allowedExtraProperties = ImmutableList.copyOf(allowedExtraProperties);
         return this;
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
@@ -615,8 +615,7 @@ public class DeltaLakeConfig
     @ConfigDescription("List of extra properties that are allowed to be set on Delta Lake tables")
     public DeltaLakeConfig setAllowedExtraProperties(List<String> allowedExtraProperties)
     {
-        checkArgument(!allowedExtraProperties.contains("*") || allowedExtraProperties.size() == 1,
-                "Wildcard * should be the only element in the list");
+        checkArgument(!allowedExtraProperties.contains("*"), "Wildcard * is not supported");
         this.allowedExtraProperties = ImmutableList.copyOf(allowedExtraProperties);
         return this;
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -199,6 +199,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -261,14 +262,18 @@ import static io.trino.plugin.deltalake.DeltaLakeTableProperties.CHANGE_DATA_FEE
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.CHECKPOINT_INTERVAL_PROPERTY;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.COLUMN_MAPPING_MODE_PROPERTY;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.DELETION_VECTORS_ENABLED_PROPERTY;
+import static io.trino.plugin.deltalake.DeltaLakeTableProperties.EXTRA_PROPERTIES_PROPERTY;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.LOCATION_PROPERTY;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.PARTITIONED_BY_PROPERTY;
+import static io.trino.plugin.deltalake.DeltaLakeTableProperties.addExtraProperties;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getChangeDataFeedEnabled;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getCheckpointInterval;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getColumnMappingMode;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getDeletionVectorsEnabled;
+import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getExtraProperties;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getLocation;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getPartitionedBy;
+import static io.trino.plugin.deltalake.DeltaLakeTableProperties.verifyExtraProperties;
 import static io.trino.plugin.deltalake.metastore.DeltaLakeTableMetadataScheduler.containsSchemaString;
 import static io.trino.plugin.deltalake.metastore.DeltaLakeTableMetadataScheduler.getLastTransactionVersion;
 import static io.trino.plugin.deltalake.metastore.DeltaLakeTableMetadataScheduler.isSameTransactionVersion;
@@ -447,7 +452,9 @@ public class DeltaLakeMetadata
             .add(NUMBER_OF_NON_NULL_VALUES)
             .build();
     private static final String ENABLE_NON_CONCURRENT_WRITES_CONFIGURATION_KEY = "delta.enable-non-concurrent-writes";
-    public static final Set<String> UPDATABLE_TABLE_PROPERTIES = ImmutableSet.of(CHANGE_DATA_FEED_ENABLED_PROPERTY);
+    public static final Set<String> UPDATABLE_TABLE_PROPERTIES = ImmutableSet.of(
+            CHANGE_DATA_FEED_ENABLED_PROPERTY,
+            EXTRA_PROPERTIES_PROPERTY);
 
     public static final Set<String> CHANGE_DATA_FEED_COLUMN_NAMES = ImmutableSet.<String>builder()
             .add("_change_type")
@@ -492,6 +499,7 @@ public class DeltaLakeMetadata
     private final ConnectorExpressionEvaluator evaluator;
     private final DeltaLakeTableCredentialsProvider tableCredentialsProvider;
     private final Map<VendedCredentialsHandle, Optional<DeltaLakeTableCredentials>> tableCredentialsMap = new ConcurrentHashMap<>();
+    private final Predicate<String> allowedExtraProperties;
 
     private record QueriedTable(SchemaTableName schemaTableName, long version)
     {
@@ -524,7 +532,8 @@ public class DeltaLakeMetadata
             Executor metadataFetchingExecutor,
             TransactionLogReaderFactory transactionLogReaderFactory,
             ConnectorExpressionEvaluator evaluator,
-            DeltaLakeTableCredentialsProvider tableCredentialsProvider)
+            DeltaLakeTableCredentialsProvider tableCredentialsProvider,
+            Predicate<String> allowedExtraProperties)
     {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.transactionLogAccess = requireNonNull(transactionLogAccess, "transactionLogAccess is null");
@@ -550,6 +559,7 @@ public class DeltaLakeMetadata
         this.transactionLogReaderFactory = requireNonNull(transactionLogReaderFactory, "transactionLogLoaderFactory");
         this.evaluator = requireNonNull(evaluator, "evaluator is null");
         this.tableCredentialsProvider = requireNonNull(tableCredentialsProvider, "tableCredentialsProvider is null");
+        this.allowedExtraProperties = requireNonNull(allowedExtraProperties, "allowedExtraProperties is null");
     }
 
     private TableSnapshot getSnapshot(ConnectorSession session, DeltaLakeTableHandle table)
@@ -1472,6 +1482,8 @@ public class DeltaLakeMetadata
 
         boolean external = true;
         String location = getLocation(tableMetadata.getProperties());
+        Map<String, String> extraProperties = getExtraProperties(tableMetadata.getProperties()).orElseGet(ImmutableMap::of);
+        verifyExtraProperties(ImmutableSet.of(), extraProperties, allowedExtraProperties);
         ConnectorTableHandle connectorTableHandle = getTableHandle(session, tableMetadata.getTable(), Optional.empty(), Optional.empty());
         DeltaLakeTableHandle tableHandle = null;
         if (connectorTableHandle != null) {
@@ -1523,6 +1535,11 @@ public class DeltaLakeMetadata
             maxFieldId = OptionalInt.of(fieldId.get());
         }
 
+        Map<String, String> configuration = addExtraProperties(
+                configurationForNewTable(checkpointInterval, changeDataFeedEnabled, deletionVectorsEnabled, columnMappingMode, maxFieldId),
+                extraProperties,
+                allowedExtraProperties);
+
         String schemaString = serializeSchemaAsJson(deltaTable.build());
         try {
             TrinoFileSystem fileSystem = fileSystemFactory.create(session, location);
@@ -1558,9 +1575,9 @@ public class DeltaLakeMetadata
 
                 MetadataEntry metadataEntry = MetadataEntry.builder()
                         .setDescription(tableMetadata.getComment())
-                        .setSchemaString(serializeSchemaAsJson(deltaTable.build()))
+                        .setSchemaString(schemaString)
                         .setPartitionColumns(getPartitionedBy(tableMetadata.getProperties()))
-                        .setConfiguration(configurationForNewTable(checkpointInterval, changeDataFeedEnabled, deletionVectorsEnabled, columnMappingMode, maxFieldId))
+                        .setConfiguration(configuration)
                         .build();
                 appendTableEntries(
                         commitVersion,
@@ -1665,6 +1682,11 @@ public class DeltaLakeMetadata
             handle = checkValidTableHandle(connectorTableHandle);
         }
         List<String> partitionedBy = getPartitionedBy(tableMetadata.getProperties());
+        Optional<Long> checkpointInterval = getCheckpointInterval(tableMetadata.getProperties());
+        Optional<Boolean> changeDataFeedEnabled = getChangeDataFeedEnabled(tableMetadata.getProperties());
+        boolean deletionVectorsEnabled = getDeletionVectorsEnabled(tableMetadata.getProperties());
+        Map<String, String> extraProperties = getExtraProperties(tableMetadata.getProperties()).orElseGet(ImmutableMap::of);
+        verifyExtraProperties(ImmutableSet.of(), extraProperties, allowedExtraProperties);
 
         boolean replaceExistingTable = handle != null && replace;
 
@@ -1731,6 +1753,10 @@ public class DeltaLakeMetadata
         if (columnMappingMode == ID || columnMappingMode == NAME) {
             maxFieldId = OptionalInt.of(fieldId.get());
         }
+        verifyExtraProperties(
+                configurationForNewTable(checkpointInterval, changeDataFeedEnabled, deletionVectorsEnabled, columnMappingMode, maxFieldId).keySet(),
+                extraProperties,
+                allowedExtraProperties);
 
         OptionalLong readVersion = OptionalLong.empty();
         ProtocolEntry protocolEntry;
@@ -1753,18 +1779,19 @@ public class DeltaLakeMetadata
                 tableName,
                 columnHandles.build(),
                 location,
-                getCheckpointInterval(tableMetadata.getProperties()),
+                checkpointInterval,
                 external,
                 tableMetadata.getComment(),
-                getChangeDataFeedEnabled(tableMetadata.getProperties()),
-                getDeletionVectorsEnabled(tableMetadata.getProperties()),
+                changeDataFeedEnabled,
+                deletionVectorsEnabled,
                 serializeSchemaAsJson(deltaTable.build()),
                 columnMappingMode,
                 maxFieldId,
                 replace,
                 existingColumns,
                 readVersion,
-                protocolEntry);
+                protocolEntry,
+                extraProperties);
     }
 
     private Optional<String> getSchemaLocation(Database database)
@@ -1929,6 +1956,10 @@ public class DeltaLakeMetadata
                 }
                 transactionLogWriter = transactionLogWriterFactory.createFileSystemWriter(session, location, tableCredentials);
             }
+            Map<String, String> configuration = addExtraProperties(
+                    configurationForNewTable(handle.checkpointInterval(), handle.changeDataFeedEnabled(), handle.deletionVectorsEnabled(), columnMappingMode, handle.maxColumnId()),
+                    handle.extraProperties(),
+                    allowedExtraProperties);
             appendTableEntries(
                     commitVersion,
                     transactionLogWriter,
@@ -1939,7 +1970,7 @@ public class DeltaLakeMetadata
                             .setDescription(handle.comment())
                             .setSchemaString(schemaString)
                             .setPartitionColumns(handle.partitionedBy())
-                            .setConfiguration(configurationForNewTable(handle.checkpointInterval(), handle.changeDataFeedEnabled(), handle.deletionVectorsEnabled(), columnMappingMode, handle.maxColumnId()))
+                            .setConfiguration(configuration)
                             .build());
             appendAddFileEntries(transactionLogWriter, dataFileInfos, physicalPartitionNames, columnNames, true);
             if (handle.readVersion().isPresent()) {
@@ -3569,6 +3600,7 @@ public class DeltaLakeMetadata
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void setTableProperties(ConnectorSession session, ConnectorTableHandle tableHandle, Map<String, Optional<Object>> properties)
     {
         DeltaLakeTableHandle handle = checkValidTableHandle(tableHandle);
@@ -3576,13 +3608,12 @@ public class DeltaLakeMetadata
         if (!unsupportedProperties.isEmpty()) {
             throw new TrinoException(NOT_SUPPORTED, "The following properties cannot be updated: " + String.join(", ", unsupportedProperties));
         }
-
         ProtocolEntry currentProtocolEntry = handle.getProtocolEntry();
 
         long createdTime = Instant.now().toEpochMilli();
 
         int requiredWriterVersion = currentProtocolEntry.minWriterVersion();
-        Optional<MetadataEntry> metadataEntry = Optional.empty();
+        Map<String, String> configuration = new HashMap<>(handle.getMetadataEntry().getConfiguration());
         if (properties.containsKey(CHANGE_DATA_FEED_ENABLED_PROPERTY)) {
             boolean changeDataFeedEnabled = (Boolean) properties.get(CHANGE_DATA_FEED_ENABLED_PROPERTY)
                     .orElseThrow(() -> new IllegalArgumentException("The change_data_feed_enabled property cannot be empty"));
@@ -3594,10 +3625,18 @@ public class DeltaLakeMetadata
                 }
                 requiredWriterVersion = max(requiredWriterVersion, CDF_SUPPORTED_WRITER_VERSION);
             }
-            Map<String, String> configuration = new HashMap<>(handle.getMetadataEntry().getConfiguration());
             configuration.put(DELTA_CHANGE_DATA_FEED_ENABLED_PROPERTY, String.valueOf(changeDataFeedEnabled));
-            metadataEntry = Optional.of(buildMetadataEntry(handle.getMetadataEntry(), configuration, createdTime));
         }
+
+        if (properties.containsKey(EXTRA_PROPERTIES_PROPERTY)) {
+            checkWriteAllowed(session, handle);
+            checkWriteSupported(handle);
+            Map<String, String> extraProperties = (Map<String, String>) properties.get(EXTRA_PROPERTIES_PROPERTY)
+                    .orElseThrow(() -> new IllegalArgumentException("The extra_properties property cannot be empty"));
+            verifyExtraProperties(properties.keySet(), extraProperties, allowedExtraProperties);
+            configuration.putAll(extraProperties);
+        }
+        MetadataEntry metadataEntry = buildMetadataEntry(handle.getMetadataEntry(), configuration, createdTime);
 
         long readVersion = handle.getReadVersion();
         long commitVersion = readVersion + 1;
@@ -3611,8 +3650,7 @@ public class DeltaLakeMetadata
             TransactionLogWriter transactionLogWriter = transactionLogWriterFactory.createWriter(session, handle, getTableCredentials(handle.toCredentialsHandle()));
             transactionLogWriter.appendCommitInfoEntry(getCommitInfoEntry(session, IsolationLevel.WRITESERIALIZABLE, commitVersion, createdTime, SET_TBLPROPERTIES_OPERATION, readVersion, true));
             protocolEntry.ifPresent(transactionLogWriter::appendProtocolEntry);
-
-            metadataEntry.ifPresent(transactionLogWriter::appendMetadataEntry);
+            transactionLogWriter.appendMetadataEntry(metadataEntry);
 
             transactionLogWriter.flush();
             enqueueUpdateInfo(
@@ -3620,8 +3658,8 @@ public class DeltaLakeMetadata
                     handle.getSchemaName(),
                     handle.getTableName(),
                     commitVersion,
-                    metadataEntry.orElseThrow().getSchemaString(),
-                    Optional.ofNullable(metadataEntry.orElseThrow().getDescription()));
+                    metadataEntry.getSchemaString(),
+                    Optional.ofNullable(metadataEntry.getDescription()));
         }
         catch (IOException e) {
             throw new TrinoException(DELTA_LAKE_BAD_WRITE, "Failed to write Delta Lake transaction log entry", e);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
@@ -13,6 +13,8 @@
  */
 package io.trino.plugin.deltalake;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.json.JsonCodec;
@@ -37,6 +39,7 @@ import io.trino.spi.type.TypeManager;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Predicate;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.trino.metastore.cache.CachingHiveMetastore.createPerTransactionCache;
@@ -68,6 +71,7 @@ public class DeltaLakeMetadataFactory
     private final TransactionLogReaderFactory transactionLogReaderFactory;
     private final ConnectorExpressionEvaluator evaluator;
     private final DeltaLakeTableCredentialsProvider tableCredentialsProvider;
+    private final Predicate<String> allowedExtraProperties;
 
     @Inject
     public DeltaLakeMetadataFactory(
@@ -120,6 +124,12 @@ public class DeltaLakeMetadataFactory
         this.transactionLogReaderFactory = requireNonNull(transactionLogReaderFactory, "transactionLogLoaderFactory is null");
         this.evaluator = requireNonNull(evaluator, "evaluator is null");
         this.tableCredentialsProvider = requireNonNull(tableCredentialsProvider, "tableCredentialsProvider is null");
+        if (deltaLakeConfig.getAllowedExtraProperties().equals(ImmutableList.of("*"))) {
+            this.allowedExtraProperties = _ -> true;
+        }
+        else {
+            this.allowedExtraProperties = ImmutableSet.copyOf(requireNonNull(deltaLakeConfig.getAllowedExtraProperties(), "allowedExtraProperties is null"))::contains;
+        }
     }
 
     public DeltaLakeMetadata create(ConnectorIdentity identity)
@@ -160,6 +170,7 @@ public class DeltaLakeMetadataFactory
                 metadataFetchingExecutor,
                 transactionLogReaderFactory,
                 evaluator,
-                tableCredentialsProvider);
+                tableCredentialsProvider,
+                allowedExtraProperties);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadataFactory.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.deltalake;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.concurrent.BoundedExecutor;
@@ -124,12 +123,7 @@ public class DeltaLakeMetadataFactory
         this.transactionLogReaderFactory = requireNonNull(transactionLogReaderFactory, "transactionLogLoaderFactory is null");
         this.evaluator = requireNonNull(evaluator, "evaluator is null");
         this.tableCredentialsProvider = requireNonNull(tableCredentialsProvider, "tableCredentialsProvider is null");
-        if (deltaLakeConfig.getAllowedExtraProperties().equals(ImmutableList.of("*"))) {
-            this.allowedExtraProperties = _ -> true;
-        }
-        else {
-            this.allowedExtraProperties = ImmutableSet.copyOf(requireNonNull(deltaLakeConfig.getAllowedExtraProperties(), "allowedExtraProperties is null"))::contains;
-        }
+        this.allowedExtraProperties = ImmutableSet.copyOf(requireNonNull(deltaLakeConfig.getAllowedExtraProperties(), "allowedExtraProperties is null"))::contains;
     }
 
     public DeltaLakeMetadata create(ConnectorIdentity identity)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
@@ -14,12 +14,14 @@
 package io.trino.plugin.deltalake;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.deltalake.metastore.VendedCredentialsHandle;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.ColumnMappingMode;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -44,9 +46,47 @@ public record DeltaLakeOutputTableHandle(
         boolean replace,
         Optional<List<DeltaLakeColumnHandle>> existingColumns,
         OptionalLong readVersion,
-        ProtocolEntry protocolEntry)
+        ProtocolEntry protocolEntry,
+        Map<String, String> extraProperties)
         implements ConnectorOutputTableHandle
 {
+    public DeltaLakeOutputTableHandle(
+            String schemaName,
+            String tableName,
+            List<DeltaLakeColumnHandle> inputColumns,
+            String location,
+            Optional<Long> checkpointInterval,
+            boolean external,
+            Optional<String> comment,
+            Optional<Boolean> changeDataFeedEnabled,
+            boolean deletionVectorsEnabled,
+            String schemaString,
+            ColumnMappingMode columnMappingMode,
+            OptionalInt maxColumnId,
+            boolean replace,
+            Optional<List<DeltaLakeColumnHandle>> existingColumns,
+            OptionalLong readVersion,
+            ProtocolEntry protocolEntry)
+    {
+        this(schemaName,
+                tableName,
+                inputColumns,
+                location,
+                checkpointInterval,
+                external,
+                comment,
+                changeDataFeedEnabled,
+                deletionVectorsEnabled,
+                schemaString,
+                columnMappingMode,
+                maxColumnId,
+                replace,
+                existingColumns,
+                readVersion,
+                protocolEntry,
+                ImmutableMap.of());
+    }
+
     public DeltaLakeOutputTableHandle
     {
         requireNonNull(schemaName, "schemaName is null");
@@ -62,6 +102,7 @@ public record DeltaLakeOutputTableHandle(
         requireNonNull(existingColumns, "existingColumns is null");
         requireNonNull(readVersion, "readVersion is null");
         requireNonNull(protocolEntry, "protocolEntry is null");
+        extraProperties = ImmutableMap.copyOf(requireNonNull(extraProperties, "extraProperties is null"));
     }
 
     public List<String> partitionedBy()

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableProperties.java
@@ -14,19 +14,28 @@
 package io.trino.plugin.deltalake;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.ColumnMappingMode;
 import io.trino.spi.TrinoException;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.TypeManager;
 
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Sets.intersection;
 import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.longProperty;
@@ -34,6 +43,7 @@ import static io.trino.spi.session.PropertyMetadata.stringProperty;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 public class DeltaLakeTableProperties
 {
@@ -43,13 +53,78 @@ public class DeltaLakeTableProperties
     public static final String CHANGE_DATA_FEED_ENABLED_PROPERTY = "change_data_feed_enabled";
     public static final String COLUMN_MAPPING_MODE_PROPERTY = "column_mapping_mode";
     public static final String DELETION_VECTORS_ENABLED_PROPERTY = "deletion_vectors_enabled";
+    public static final String EXTRA_PROPERTIES_PROPERTY = "extra_properties";
+
+    private static final String TABLE_COMMENT_PROPERTY = "comment";
+    private static final Set<String> SUPPORTED_PROPERTIES = ImmutableSet.of(
+            LOCATION_PROPERTY,
+            PARTITIONED_BY_PROPERTY,
+            CHECKPOINT_INTERVAL_PROPERTY,
+            CHANGE_DATA_FEED_ENABLED_PROPERTY,
+            COLUMN_MAPPING_MODE_PROPERTY,
+            DELETION_VECTORS_ENABLED_PROPERTY,
+            EXTRA_PROPERTIES_PROPERTY);
+
+    // These properties are connector-managed, require protocol actions, or have read/write semantics that Trino cannot enforce through extra_properties.
+    private static final Set<String> PROTECTED_DELTA_PROPERTIES = ImmutableSet.of(
+            "delta.appendOnly",
+            "delta.checkpointInterval",
+            "delta.checkpointPolicy",
+            "delta.columnMapping.maxColumnId",
+            "delta.columnMapping.mode",
+            "delta.compatibility.symlinkFormatManifest.enabled",
+            "delta.dataSkippingNumIndexedCols",
+            "delta.dataSkippingStatsColumns",
+            "delta.dataSkippingStringPrefixLength",
+            "delta.enableChangeDataCapture",
+            "delta.enableChangeDataFeed",
+            "delta.enableDeletionVectors",
+            "delta.enableIcebergCompatV1",
+            "delta.enableIcebergCompatV2",
+            "delta.enableIcebergCompatV3",
+            "delta.enableIcebergWriterCompatV1",
+            "delta.enableIcebergWriterCompatV3",
+            "delta.enableInCommitTimestamps",
+            "delta.enableInCommitTimestamps-preview",
+            "delta.enableMaterializePartitionColumnsFeature",
+            "delta.enableRowTracking",
+            "delta.enableTypeWidening",
+            "delta.enableVariantShredding",
+            "delta.ignoreProtocolDefaults",
+            "delta.inCommitTimestampEnablementTimestamp",
+            "delta.inCommitTimestampEnablementVersion",
+            "delta.isolationLevel",
+            "delta.minReaderVersion",
+            "delta.minWriterVersion",
+            "delta.parquet.compression.codec",
+            "delta.parquet.format.version",
+            "delta.redirectReaderWriter-preview",
+            "delta.redirectWriterOnly-preview",
+            "delta.requireCheckpointProtectionBeforeVersion",
+            "delta.randomPrefixLength",
+            "delta.randomizeFilePrefixes",
+            "delta.rowTracking.materializedRowCommitVersionColumnName",
+            "delta.rowTracking.materializedRowIdColumnName",
+            "delta.rowTrackingSuspended",
+            "delta.universalFormat.enabledFormats",
+            "delta.universalFormat.iceberg.atomicConversion.supported",
+            "delta.writePartitionColumnsToParquet");
+    private static final Set<String> PROTECTED_DELTA_PROPERTY_PREFIXES = ImmutableSet.of(
+            "delta.columnMapping.",
+            "delta.coordinatedCommits.",
+            "delta.constraints.",
+            "delta.feature.",
+            "delta.identity.",
+            "delta.rowTracking.");
 
     private final List<PropertyMetadata<?>> tableProperties;
 
     @SuppressWarnings("unchecked")
     @Inject
-    public DeltaLakeTableProperties(DeltaLakeConfig config)
+    public DeltaLakeTableProperties(DeltaLakeConfig config, TypeManager typeManager)
     {
+        requireNonNull(config, "config is null");
+        requireNonNull(typeManager, "typeManager is null");
         tableProperties = ImmutableList.<PropertyMetadata<?>>builder()
                 .add(stringProperty(
                         LOCATION_PROPERTY,
@@ -94,7 +169,31 @@ public class DeltaLakeTableProperties
                         "Enables deletion vectors",
                         config.isDeletionVectorsEnabled(),
                         false))
+                .add(new PropertyMetadata<>(
+                        EXTRA_PROPERTIES_PROPERTY,
+                        "Extra table properties",
+                        new MapType(VARCHAR, VARCHAR, typeManager.getTypeOperators()),
+                        Map.class,
+                        null,
+                        true,
+                        value -> {
+                            Map<String, String> extraProperties = (Map<String, String>) value;
+                            if (extraProperties.containsValue(null)) {
+                                throw new TrinoException(INVALID_TABLE_PROPERTY, "Extra table property value cannot be null '%s'".formatted(extraProperties));
+                            }
+                            if (extraProperties.containsKey(null)) {
+                                throw new TrinoException(INVALID_TABLE_PROPERTY, "Extra table property key cannot be null '%s'".formatted(extraProperties));
+                            }
+                            return ImmutableMap.copyOf(extraProperties);
+                        },
+                        value -> value))
                 .build();
+
+        checkState(SUPPORTED_PROPERTIES.containsAll(tableProperties.stream()
+                        .map(PropertyMetadata::getName)
+                        .collect(toImmutableList())),
+                "%s does not contain all supported properties",
+                SUPPORTED_PROPERTIES);
     }
 
     public List<PropertyMetadata<?>> getTableProperties()
@@ -138,5 +237,48 @@ public class DeltaLakeTableProperties
     public static boolean getDeletionVectorsEnabled(Map<String, Object> tableProperties)
     {
         return (boolean) tableProperties.getOrDefault(DELETION_VECTORS_ENABLED_PROPERTY, false);
+    }
+
+    public static Optional<Map<String, String>> getExtraProperties(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((Map<String, String>) tableProperties.get(EXTRA_PROPERTIES_PROPERTY));
+    }
+
+    public static void verifyExtraProperties(Set<String> basePropertyKeys, Map<String, String> extraProperties, Predicate<String> allowedExtraProperties)
+    {
+        Set<String> illegalExtraProperties = ImmutableSet.<String>builder()
+                .addAll(intersection(
+                        ImmutableSet.<String>builder()
+                                .add(TABLE_COMMENT_PROPERTY)
+                                .addAll(basePropertyKeys)
+                                .addAll(SUPPORTED_PROPERTIES)
+                                .build(),
+                        extraProperties.keySet()))
+                .addAll(extraProperties.keySet().stream()
+                        .filter(DeltaLakeTableProperties::isProtectedDeltaProperty)
+                        .collect(toImmutableSet()))
+                .addAll(extraProperties.keySet().stream()
+                        .filter(name -> !allowedExtraProperties.test(name))
+                        .collect(toImmutableSet()))
+                .build();
+
+        if (!illegalExtraProperties.isEmpty()) {
+            throw new TrinoException(INVALID_TABLE_PROPERTY, "Illegal keys in extra_properties: %s".formatted(illegalExtraProperties));
+        }
+    }
+
+    private static boolean isProtectedDeltaProperty(String name)
+    {
+        return PROTECTED_DELTA_PROPERTIES.stream().anyMatch(name::equalsIgnoreCase) ||
+                PROTECTED_DELTA_PROPERTY_PREFIXES.stream().anyMatch(prefix -> name.regionMatches(true, 0, prefix, 0, prefix.length()));
+    }
+
+    public static Map<String, String> addExtraProperties(Map<String, String> baseProperties, Map<String, String> extraProperties, Predicate<String> allowedExtraProperties)
+    {
+        verifyExtraProperties(baseProperties.keySet(), extraProperties, allowedExtraProperties);
+        return ImmutableMap.<String, String>builder()
+                .putAll(baseProperties)
+                .putAll(extraProperties)
+                .buildOrThrow();
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableProperties.java
@@ -65,57 +65,21 @@ public class DeltaLakeTableProperties
             DELETION_VECTORS_ENABLED_PROPERTY,
             EXTRA_PROPERTIES_PROPERTY);
 
-    // These properties are connector-managed, require protocol actions, or have read/write semantics that Trino cannot enforce through extra_properties.
     private static final Set<String> PROTECTED_DELTA_PROPERTIES = ImmutableSet.of(
             "delta.appendOnly",
             "delta.checkpointInterval",
-            "delta.checkpointPolicy",
-            "delta.columnMapping.maxColumnId",
-            "delta.columnMapping.mode",
-            "delta.compatibility.symlinkFormatManifest.enabled",
-            "delta.dataSkippingNumIndexedCols",
-            "delta.dataSkippingStatsColumns",
-            "delta.dataSkippingStringPrefixLength",
-            "delta.enableChangeDataCapture",
             "delta.enableChangeDataFeed",
             "delta.enableDeletionVectors",
-            "delta.enableIcebergCompatV1",
-            "delta.enableIcebergCompatV2",
-            "delta.enableIcebergCompatV3",
-            "delta.enableIcebergWriterCompatV1",
-            "delta.enableIcebergWriterCompatV3",
-            "delta.enableInCommitTimestamps",
-            "delta.enableInCommitTimestamps-preview",
-            "delta.enableMaterializePartitionColumnsFeature",
-            "delta.enableRowTracking",
-            "delta.enableTypeWidening",
-            "delta.enableVariantShredding",
-            "delta.ignoreProtocolDefaults",
-            "delta.inCommitTimestampEnablementTimestamp",
-            "delta.inCommitTimestampEnablementVersion",
-            "delta.isolationLevel",
             "delta.minReaderVersion",
-            "delta.minWriterVersion",
-            "delta.parquet.compression.codec",
-            "delta.parquet.format.version",
-            "delta.redirectReaderWriter-preview",
-            "delta.redirectWriterOnly-preview",
-            "delta.requireCheckpointProtectionBeforeVersion",
-            "delta.randomPrefixLength",
-            "delta.randomizeFilePrefixes",
-            "delta.rowTracking.materializedRowCommitVersionColumnName",
-            "delta.rowTracking.materializedRowIdColumnName",
-            "delta.rowTrackingSuspended",
-            "delta.universalFormat.enabledFormats",
-            "delta.universalFormat.iceberg.atomicConversion.supported",
-            "delta.writePartitionColumnsToParquet");
+            "delta.minWriterVersion");
     private static final Set<String> PROTECTED_DELTA_PROPERTY_PREFIXES = ImmutableSet.of(
             "delta.columnMapping.",
             "delta.coordinatedCommits.",
             "delta.constraints.",
+            "delta.enable",
             "delta.feature.",
             "delta.identity.",
-            "delta.rowTracking.");
+            "delta.rowTracking");
 
     private final List<PropertyMetadata<?>> tableProperties;
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.deltalake;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -33,6 +34,8 @@ import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestDeltaLakeConfig
 {
@@ -76,7 +79,8 @@ public class TestDeltaLakeConfig
                 .setDeltaLogFileSystemCacheDisabled(false)
                 .setMetadataParallelism(8)
                 .setCheckpointProcessingParallelism(4)
-                .setLoadMetadataFromChecksumFile(true));
+                .setLoadMetadataFromChecksumFile(true)
+                .setAllowedExtraProperties(ImmutableList.of()));
     }
 
     @Test
@@ -120,6 +124,7 @@ public class TestDeltaLakeConfig
                 .put("delta.metadata.parallelism", "10")
                 .put("delta.checkpoint-processing.parallelism", "8")
                 .put("delta.load-metadata-from-checksum-file", "false")
+                .put("delta.allowed-extra-properties", "propX,propY")
                 .buildOrThrow();
 
         DeltaLakeConfig expected = new DeltaLakeConfig()
@@ -159,8 +164,21 @@ public class TestDeltaLakeConfig
                 .setDeltaLogFileSystemCacheDisabled(true)
                 .setMetadataParallelism(10)
                 .setCheckpointProcessingParallelism(8)
-                .setLoadMetadataFromChecksumFile(false);
+                .setLoadMetadataFromChecksumFile(false)
+                .setAllowedExtraProperties(ImmutableList.of("propX", "propY"));
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testAllowedExtraPropertiesWildcard()
+    {
+        new DeltaLakeConfig().setAllowedExtraProperties(ImmutableList.of("*"));
+
+        DeltaLakeConfig config = new DeltaLakeConfig().setAllowedExtraProperties(ImmutableList.of("property"));
+        assertThatThrownBy(() -> config.setAllowedExtraProperties(ImmutableList.of("*", "property")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Wildcard * should be the only element in the list");
+        assertThat(config.getAllowedExtraProperties()).containsExactly("property");
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
@@ -171,14 +171,12 @@ public class TestDeltaLakeConfig
     }
 
     @Test
-    public void testAllowedExtraPropertiesWildcard()
+    public void testAllowedExtraPropertiesWildcardNotSupported()
     {
-        new DeltaLakeConfig().setAllowedExtraProperties(ImmutableList.of("*"));
-
         DeltaLakeConfig config = new DeltaLakeConfig().setAllowedExtraProperties(ImmutableList.of("property"));
-        assertThatThrownBy(() -> config.setAllowedExtraProperties(ImmutableList.of("*", "property")))
+        assertThatThrownBy(() -> config.setAllowedExtraProperties(ImmutableList.of("*")))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Wildcard * should be the only element in the list");
+                .hasMessage("Wildcard * is not supported");
         assertThat(config.getAllowedExtraProperties()).containsExactly("property");
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeExtraProperties.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeExtraProperties.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestDeltaLakeExtraProperties
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        QueryRunner queryRunner = DeltaLakeQueryRunner.builder()
+                .addDeltaProperty("delta.enable-non-concurrent-writes", "true")
+                .addDeltaProperty("delta.allowed-extra-properties", "custom.property.one,custom.property.two,custom.property.three,custom.CaseSensitive,delta.appendOnly,delta.checkpoint.writeStatsAsJson,delta.enableChangeDataFeed,delta.feature.timestampNtz")
+                .build();
+        queryRunner.createCatalog(
+                "delta_wildcard",
+                DeltaLakeConnectorFactory.CONNECTOR_NAME,
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore", "file")
+                        .put("hive.metastore.catalog.dir", queryRunner.getCoordinator().getBaseDataDir().resolve("wildcard-metastore").toUri().toString())
+                        .put("hive.metastore.disable-location-checks", "true")
+                        .put("fs.hadoop.enabled", "true")
+                        .put("delta.enable-non-concurrent-writes", "true")
+                        .put("delta.allowed-extra-properties", "*")
+                        .buildOrThrow());
+        queryRunner.execute("CREATE SCHEMA delta_wildcard.test WITH (location = '" + queryRunner.getCoordinator().getBaseDataDir().resolve("wildcard-data").toUri() + "')");
+        return queryRunner;
+    }
+
+    @Test
+    void testExtraProperties()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_extra_properties_",
+                "(value integer) WITH (extra_properties = MAP(ARRAY['custom.property.one', 'custom.CaseSensitive', 'delta.checkpoint.writeStatsAsJson'], ARRAY['one', 'case-sensitive', 'false']))")) {
+            assertThat(getTableProperties(table.getName()))
+                    .containsEntry("custom.property.one", "one")
+                    .containsEntry("custom.CaseSensitive", "case-sensitive")
+                    .containsEntry("delta.checkpoint.writeStatsAsJson", "false");
+
+            assertUpdate("ALTER TABLE " + table.getName() + " SET PROPERTIES extra_properties = MAP(ARRAY['custom.property.one'], ARRAY['updated'])");
+            assertThat(getTableProperties(table.getName()))
+                    .containsEntry("custom.property.one", "updated")
+                    .containsEntry("custom.CaseSensitive", "case-sensitive");
+
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + table.getName()))
+                    .doesNotContain("extra_properties =", "custom.property.one", "custom.CaseSensitive");
+        }
+    }
+
+    @Test
+    void testReplaceTableExtraProperties()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_replace_extra_properties_",
+                "(value integer) WITH (extra_properties = MAP(ARRAY['custom.property.one', 'custom.property.two'], ARRAY['one', 'two']))")) {
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " (value integer) WITH (extra_properties = MAP(ARRAY['custom.property.three'], ARRAY['three']))");
+            assertThat(getTableProperties(table.getName()))
+                    .containsEntry("custom.property.three", "three")
+                    .doesNotContainKeys("custom.property.one", "custom.property.two");
+
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " WITH (extra_properties = MAP(ARRAY['custom.property.one'], ARRAY['ctas'])) AS SELECT 1 value", 1);
+            assertThat(getTableProperties(table.getName()))
+                    .containsEntry("custom.property.one", "ctas")
+                    .doesNotContainKeys("custom.property.two", "custom.property.three");
+        }
+    }
+
+    @Test
+    void testCreateTableAsSelectWithExtraProperties()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_ctas_extra_properties_",
+                "WITH (extra_properties = MAP(ARRAY['custom.property.one', 'delta.checkpoint.writeStatsAsJson'], ARRAY['one', 'false'])) AS SELECT 1 value")) {
+            assertThat(getTableProperties(table.getName()))
+                    .containsEntry("custom.property.one", "one")
+                    .containsEntry("delta.checkpoint.writeStatsAsJson", "false");
+        }
+    }
+
+    @Test
+    void testNullExtraProperty()
+    {
+        assertQueryFails(
+                "CREATE TABLE test_null_extra_property (value integer) WITH (extra_properties = MAP(ARRAY['custom.property.one'], ARRAY[null]))",
+                ".*\\QUnable to set catalog 'delta' table property 'extra_properties' to [MAP(ARRAY['custom.property.one'], ARRAY[null])]: Extra table property value cannot be null '{custom.property.one=null}'\\E");
+        assertQueryFails(
+                "CREATE TABLE test_ctas_null_extra_property WITH (extra_properties = MAP(ARRAY['custom.property.one'], ARRAY[null])) AS SELECT 1 value",
+                ".*\\QUnable to set catalog 'delta' table property 'extra_properties' to [MAP(ARRAY['custom.property.one'], ARRAY[null])]: Extra table property value cannot be null '{custom.property.one=null}'\\E");
+    }
+
+    @Test
+    void testIllegalExtraPropertyKey()
+    {
+        assertQueryFails(
+                "CREATE TABLE test_protected_extra_property (value integer) WITH (extra_properties = MAP(ARRAY['delta.enableChangeDataFeed'], ARRAY['true']))",
+                "\\QIllegal keys in extra_properties: [delta.enableChangeDataFeed]");
+        assertQueryFails(
+                "CREATE TABLE test_feature_extra_property (value integer) WITH (extra_properties = MAP(ARRAY['delta.appendOnly'], ARRAY['true']))",
+                "\\QIllegal keys in extra_properties: [delta.appendOnly]");
+        assertQueryFails(
+                "CREATE TABLE test_synthetic_extra_property (value integer) WITH (extra_properties = MAP(ARRAY['delta.feature.timestampNtz'], ARRAY['supported']))",
+                "\\QIllegal keys in extra_properties: [delta.feature.timestampNtz]");
+        assertQueryFails(
+                "CREATE TABLE test_nested_extra_property WITH (extra_properties = MAP(ARRAY['extra_properties'], ARRAY['value'])) AS SELECT 1 value",
+                "\\QIllegal keys in extra_properties: [extra_properties]");
+        assertQueryFails(
+                "CREATE TABLE test_comment_extra_property WITH (extra_properties = MAP(ARRAY['comment'], ARRAY['value'])) AS SELECT 1 value",
+                "\\QIllegal keys in extra_properties: [comment]");
+        assertQueryFails(
+                "CREATE TABLE test_not_allowed_extra_property WITH (extra_properties = MAP(ARRAY['not.allowed'], ARRAY['value'])) AS SELECT 1 value",
+                "\\QIllegal keys in extra_properties: [not.allowed]");
+        assertQueryFails(
+                "CREATE TABLE test_case_sensitive_extra_property WITH (extra_properties = MAP(ARRAY['custom.casesensitive'], ARRAY['value'])) AS SELECT 1 value",
+                "\\QIllegal keys in extra_properties: [custom.casesensitive]");
+    }
+
+    @Test
+    void testSetIllegalExtraPropertyKey()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_set_illegal_extra_property_", "(value integer)")) {
+            assertQueryFails(
+                    "ALTER TABLE " + table.getName() + " SET PROPERTIES extra_properties = MAP(ARRAY['delta.enableChangeDataFeed'], ARRAY['true'])",
+                    "\\QIllegal keys in extra_properties: [delta.enableChangeDataFeed]");
+            assertQueryFails(
+                    "ALTER TABLE " + table.getName() + " SET PROPERTIES extra_properties = MAP(ARRAY['not.allowed'], ARRAY['value'])",
+                    "\\QIllegal keys in extra_properties: [not.allowed]");
+        }
+    }
+
+    @Test
+    void testSetExtraPropertiesWithChangeDataFeed()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_set_extra_property_with_cdf_", "(value integer)")) {
+            assertUpdate("ALTER TABLE " + table.getName() + " SET PROPERTIES change_data_feed_enabled = true, extra_properties = MAP(ARRAY['custom.property.one'], ARRAY['value'])");
+
+            assertThat(getTableProperties(table.getName()))
+                    .containsEntry("custom.property.one", "value")
+                    .containsEntry("delta.enableChangeDataFeed", "true")
+                    .containsEntry("delta.minWriterVersion", "4");
+        }
+    }
+
+    @Test
+    void testWildcardAllowsExtraProperties()
+    {
+        String tableName = "delta_wildcard.test.test_wildcard_extra_property";
+        try {
+            assertUpdate("CREATE TABLE " + tableName + " (value integer) WITH (extra_properties = MAP(ARRAY['unknown.property', 'delta.universalformat.config.TargetTable'], ARRAY['value', 'target']))");
+            assertQuery(
+                    "SELECT value FROM delta_wildcard.test.\"test_wildcard_extra_property$properties\" WHERE key = 'unknown.property'",
+                    "VALUES 'value'");
+            assertQuery(
+                    "SELECT value FROM delta_wildcard.test.\"test_wildcard_extra_property$properties\" WHERE key = 'delta.universalformat.config.TargetTable'",
+                    "VALUES 'target'");
+            assertWildcardExtraPropertyRejected("delta.checkpointPolicy", "v2");
+            assertWildcardExtraPropertyRejected("delta.compatibility.symlinkFormatManifest.enabled", "true");
+            assertWildcardExtraPropertyRejected("delta.dataSkippingNumIndexedCols", "1");
+            assertWildcardExtraPropertyRejected("delta.dataSkippingStatsColumns", "value");
+            assertWildcardExtraPropertyRejected("DELTA.DATASKIPPINGSTRINGPREFIXLENGTH", "16");
+            assertWildcardExtraPropertyRejected("DELTA.CONSTRAINTS.positive", "value > 0");
+            assertWildcardExtraPropertyRejected("delta.enableChangeDataCapture", "true");
+            assertWildcardExtraPropertyRejected("DELTA.ENABLECHANGEDATAFEED", "true");
+            assertWildcardExtraPropertyRejected("delta.enableIcebergCompatV3", "true");
+            assertWildcardExtraPropertyRejected("delta.enableIcebergWriterCompatV1", "true");
+            assertWildcardExtraPropertyRejected("delta.enableIcebergWriterCompatV3", "true");
+            assertWildcardExtraPropertyRejected("delta.enableInCommitTimestamps-preview", "true");
+            assertWildcardExtraPropertyRejected("delta.enableMaterializePartitionColumnsFeature", "true");
+            assertWildcardExtraPropertyRejected("delta.ignoreProtocolDefaults", "true");
+            assertWildcardExtraPropertyRejected("delta.isolationLevel", "Serializable");
+            assertWildcardExtraPropertyRejected("delta.parquet.compression.codec", "snappy");
+            assertWildcardExtraPropertyRejected("delta.randomPrefixLength", "3");
+            assertWildcardExtraPropertyRejected("delta.randomizeFilePrefixes", "false");
+            assertWildcardExtraPropertyRejected("delta.coordinatedCommits.commitCoordinator-preview", "coordinator");
+            assertWildcardExtraPropertyRejected("delta.redirectReaderWriter-preview", "target");
+            assertWildcardExtraPropertyRejected("delta.redirectWriterOnly-preview", "target");
+            assertWildcardExtraPropertyRejected("delta.requireCheckpointProtectionBeforeVersion", "1");
+            assertWildcardExtraPropertyRejected("delta.writePartitionColumnsToParquet", "true");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+            assertUpdate("DROP TABLE IF EXISTS delta_wildcard.test.test_wildcard_rejected_extra_property");
+        }
+    }
+
+    private void assertWildcardExtraPropertyRejected(String property, String value)
+    {
+        assertQueryFails(
+                "CREATE TABLE delta_wildcard.test.test_wildcard_rejected_extra_property (value integer) WITH (extra_properties = MAP(ARRAY['" + property + "'], ARRAY['" + value + "']))",
+                "\\QIllegal keys in extra_properties: [" + property + "]");
+    }
+
+    private Map<String, String> getTableProperties(String tableName)
+    {
+        return computeActual("SELECT key, value FROM \"" + tableName + "$properties\"").getMaterializedRows().stream()
+                .collect(toImmutableMap(row -> (String) row.getField(0), row -> (String) row.getField(1)));
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeExtraProperties.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeExtraProperties.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.deltalake;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.TestTable;
@@ -33,20 +32,8 @@ final class TestDeltaLakeExtraProperties
     {
         QueryRunner queryRunner = DeltaLakeQueryRunner.builder()
                 .addDeltaProperty("delta.enable-non-concurrent-writes", "true")
-                .addDeltaProperty("delta.allowed-extra-properties", "custom.property.one,custom.property.two,custom.property.three,custom.CaseSensitive,delta.appendOnly,delta.checkpoint.writeStatsAsJson,delta.enableChangeDataFeed,delta.feature.timestampNtz")
+                .addDeltaProperty("delta.allowed-extra-properties", "custom.property.one,custom.property.two,custom.property.three,custom.CaseSensitive,delta.appendOnly,delta.checkpoint.writeStatsAsJson,delta.enableChangeDataFeed,DELTA.ENABLETYPEWIDENING,DELTA.FEATURE.timestampNtz,DELTA.ROWTRACKINGSUSPENDED")
                 .build();
-        queryRunner.createCatalog(
-                "delta_wildcard",
-                DeltaLakeConnectorFactory.CONNECTOR_NAME,
-                ImmutableMap.<String, String>builder()
-                        .put("hive.metastore", "file")
-                        .put("hive.metastore.catalog.dir", queryRunner.getCoordinator().getBaseDataDir().resolve("wildcard-metastore").toUri().toString())
-                        .put("hive.metastore.disable-location-checks", "true")
-                        .put("fs.hadoop.enabled", "true")
-                        .put("delta.enable-non-concurrent-writes", "true")
-                        .put("delta.allowed-extra-properties", "*")
-                        .buildOrThrow());
-        queryRunner.execute("CREATE SCHEMA delta_wildcard.test WITH (location = '" + queryRunner.getCoordinator().getBaseDataDir().resolve("wildcard-data").toUri() + "')");
         return queryRunner;
     }
 
@@ -125,8 +112,14 @@ final class TestDeltaLakeExtraProperties
                 "CREATE TABLE test_feature_extra_property (value integer) WITH (extra_properties = MAP(ARRAY['delta.appendOnly'], ARRAY['true']))",
                 "\\QIllegal keys in extra_properties: [delta.appendOnly]");
         assertQueryFails(
-                "CREATE TABLE test_synthetic_extra_property (value integer) WITH (extra_properties = MAP(ARRAY['delta.feature.timestampNtz'], ARRAY['supported']))",
-                "\\QIllegal keys in extra_properties: [delta.feature.timestampNtz]");
+                "CREATE TABLE test_synthetic_extra_property (value integer) WITH (extra_properties = MAP(ARRAY['DELTA.FEATURE.timestampNtz'], ARRAY['supported']))",
+                "\\QIllegal keys in extra_properties: [DELTA.FEATURE.timestampNtz]");
+        assertQueryFails(
+                "CREATE TABLE test_feature_enablement_extra_property (value integer) WITH (extra_properties = MAP(ARRAY['DELTA.ENABLETYPEWIDENING'], ARRAY['true']))",
+                "\\QIllegal keys in extra_properties: [DELTA.ENABLETYPEWIDENING]");
+        assertQueryFails(
+                "CREATE TABLE test_row_tracking_extra_property (value integer) WITH (extra_properties = MAP(ARRAY['DELTA.ROWTRACKINGSUSPENDED'], ARRAY['true']))",
+                "\\QIllegal keys in extra_properties: [DELTA.ROWTRACKINGSUSPENDED]");
         assertQueryFails(
                 "CREATE TABLE test_nested_extra_property WITH (extra_properties = MAP(ARRAY['extra_properties'], ARRAY['value'])) AS SELECT 1 value",
                 "\\QIllegal keys in extra_properties: [extra_properties]");
@@ -165,55 +158,6 @@ final class TestDeltaLakeExtraProperties
                     .containsEntry("delta.enableChangeDataFeed", "true")
                     .containsEntry("delta.minWriterVersion", "4");
         }
-    }
-
-    @Test
-    void testWildcardAllowsExtraProperties()
-    {
-        String tableName = "delta_wildcard.test.test_wildcard_extra_property";
-        try {
-            assertUpdate("CREATE TABLE " + tableName + " (value integer) WITH (extra_properties = MAP(ARRAY['unknown.property', 'delta.universalformat.config.TargetTable'], ARRAY['value', 'target']))");
-            assertQuery(
-                    "SELECT value FROM delta_wildcard.test.\"test_wildcard_extra_property$properties\" WHERE key = 'unknown.property'",
-                    "VALUES 'value'");
-            assertQuery(
-                    "SELECT value FROM delta_wildcard.test.\"test_wildcard_extra_property$properties\" WHERE key = 'delta.universalformat.config.TargetTable'",
-                    "VALUES 'target'");
-            assertWildcardExtraPropertyRejected("delta.checkpointPolicy", "v2");
-            assertWildcardExtraPropertyRejected("delta.compatibility.symlinkFormatManifest.enabled", "true");
-            assertWildcardExtraPropertyRejected("delta.dataSkippingNumIndexedCols", "1");
-            assertWildcardExtraPropertyRejected("delta.dataSkippingStatsColumns", "value");
-            assertWildcardExtraPropertyRejected("DELTA.DATASKIPPINGSTRINGPREFIXLENGTH", "16");
-            assertWildcardExtraPropertyRejected("DELTA.CONSTRAINTS.positive", "value > 0");
-            assertWildcardExtraPropertyRejected("delta.enableChangeDataCapture", "true");
-            assertWildcardExtraPropertyRejected("DELTA.ENABLECHANGEDATAFEED", "true");
-            assertWildcardExtraPropertyRejected("delta.enableIcebergCompatV3", "true");
-            assertWildcardExtraPropertyRejected("delta.enableIcebergWriterCompatV1", "true");
-            assertWildcardExtraPropertyRejected("delta.enableIcebergWriterCompatV3", "true");
-            assertWildcardExtraPropertyRejected("delta.enableInCommitTimestamps-preview", "true");
-            assertWildcardExtraPropertyRejected("delta.enableMaterializePartitionColumnsFeature", "true");
-            assertWildcardExtraPropertyRejected("delta.ignoreProtocolDefaults", "true");
-            assertWildcardExtraPropertyRejected("delta.isolationLevel", "Serializable");
-            assertWildcardExtraPropertyRejected("delta.parquet.compression.codec", "snappy");
-            assertWildcardExtraPropertyRejected("delta.randomPrefixLength", "3");
-            assertWildcardExtraPropertyRejected("delta.randomizeFilePrefixes", "false");
-            assertWildcardExtraPropertyRejected("delta.coordinatedCommits.commitCoordinator-preview", "coordinator");
-            assertWildcardExtraPropertyRejected("delta.redirectReaderWriter-preview", "target");
-            assertWildcardExtraPropertyRejected("delta.redirectWriterOnly-preview", "target");
-            assertWildcardExtraPropertyRejected("delta.requireCheckpointProtectionBeforeVersion", "1");
-            assertWildcardExtraPropertyRejected("delta.writePartitionColumnsToParquet", "true");
-        }
-        finally {
-            assertUpdate("DROP TABLE IF EXISTS " + tableName);
-            assertUpdate("DROP TABLE IF EXISTS delta_wildcard.test.test_wildcard_rejected_extra_property");
-        }
-    }
-
-    private void assertWildcardExtraPropertyRejected(String property, String value)
-    {
-        assertQueryFails(
-                "CREATE TABLE delta_wildcard.test.test_wildcard_rejected_extra_property (value integer) WITH (extra_properties = MAP(ARRAY['" + property + "'], ARRAY['" + value + "']))",
-                "\\QIllegal keys in extra_properties: [" + property + "]");
     }
 
     private Map<String, String> getTableProperties(String tableName)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableProperties.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableProperties.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.session.PropertyMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.trino.plugin.deltalake.DeltaLakeTableProperties.EXTRA_PROPERTIES_PROPERTY;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestDeltaLakeTableProperties
+{
+    private final PropertyMetadata<?> extraProperties = new DeltaLakeTableProperties(new DeltaLakeConfig(), TESTING_TYPE_MANAGER).getTableProperties().stream()
+            .filter(property -> property.getName().equals(EXTRA_PROPERTIES_PROPERTY))
+            .findFirst()
+            .orElseThrow();
+
+    @Test
+    void testExtraPropertiesPreserveCaseAndAreImmutable()
+    {
+        Map<String, String> input = new HashMap<>();
+        input.put("custom.CaseSensitive", "value");
+
+        Map<?, ?> decoded = (Map<?, ?>) extraProperties.decode(input);
+        assertThat(decoded).isEqualTo(ImmutableMap.of("custom.CaseSensitive", "value"));
+        assertThatThrownBy(decoded::clear).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void testNullExtraPropertyKey()
+    {
+        Map<String, String> input = new HashMap<>();
+        input.put(null, "value");
+
+        assertThatThrownBy(() -> extraProperties.decode(input))
+                .hasMessage("Extra table property key cannot be null '{null=value}'");
+    }
+
+    @Test
+    void testNullExtraPropertyValue()
+    {
+        Map<String, String> input = new HashMap<>();
+        input.put("property", null);
+
+        assertThatThrownBy(() -> extraProperties.decode(input))
+                .hasMessage("Extra table property value cannot be null '{property=null}'");
+    }
+}


### PR DESCRIPTION
## Description

Adds support for `extra_properties` to the Delta Lake connector, following the existing Iceberg connector pattern. Catalog administrators explicitly allow properties with `delta.allowed-extra-properties`; matching is case-sensitive and wildcards are not accepted. The default is `[]`.

Delta Lake tables may contain application-, engine-, or deployment-specific properties that Trino does not recognize. Today, these properties cannot be specified through Trino and can be omitted when `CREATE OR REPLACE TABLE` rebuilds the table metadata. Exposing them through an administrator-controlled allowlist enables interoperability and allows users to preserve them explicitly.

Extra properties are stored in Delta table metadata with their original key casing. They are supported for `CREATE TABLE`, CTAS, `CREATE OR REPLACE`, and `ALTER TABLE SET PROPERTIES`. They appear in the `$properties` metadata table but are intentionally omitted from `SHOW CREATE TABLE`. Some connector-managed and protocol-sensitive Delta properties are always rejected.

When replacing a table, extra properties omitted from the replacement definition are removed.

## Additional context and related issues

Fixes #17428.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake
* Add support for setting allowlisted Delta Lake table properties with `extra_properties`. ({issue}`17428`)
```
