### PR TITLE
Support comparison of ROW and ARRAY values with null elements

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
@@ -414,7 +414,7 @@ public final class TypeRegistry
     private boolean hasLessThanMethod(Type type)
     {
         try {
-            typeOperators.getLessThanOperator(type, simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL));
+            typeOperators.getLessThanOperator(type, simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL));
             return true;
         }
         catch (UnsupportedOperationException e) {
@@ -425,7 +425,7 @@ public final class TypeRegistry
     private boolean hasLessThanOrEqualMethod(Type type)
     {
         try {
-            typeOperators.getLessThanOrEqualOperator(type, simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL));
+            typeOperators.getLessThanOrEqualOperator(type, simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL));
             return true;
         }
         catch (UnsupportedOperationException e) {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOperator.java
@@ -24,7 +24,7 @@ import io.trino.spi.type.TypeOperators;
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -45,7 +45,8 @@ public class GenericLessThanOperator
                         .argumentType(typeVariable("T"))
                         .argumentType(typeVariable("T"))
                         .build())
-                .neverFails(boundSignature -> typeOperators.getLessThanOperatorHandle(boundSignature.getArgumentType(0), simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL)).isNeverFails())
+                .nullable()
+                .neverFails(boundSignature -> typeOperators.getLessThanOperatorHandle(boundSignature.getArgumentType(0), simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL)).isNeverFails())
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOrEqualOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOrEqualOperator.java
@@ -24,7 +24,7 @@ import io.trino.spi.type.TypeOperators;
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -45,7 +45,8 @@ public class GenericLessThanOrEqualOperator
                         .argumentType(typeVariable("T"))
                         .argumentType(typeVariable("T"))
                         .build())
-                .neverFails(boundSignature -> typeOperators.getLessThanOrEqualOperatorHandle(boundSignature.getArgumentType(0), simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL)).isNeverFails())
+                .nullable()
+                .neverFails(boundSignature -> typeOperators.getLessThanOrEqualOperatorHandle(boundSignature.getArgumentType(0), simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL)).isNeverFails())
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
@@ -50,7 +50,7 @@ import static io.trino.metadata.OperatorNameUtil.isOperatorName;
 import static io.trino.metadata.OperatorNameUtil.unmangleOperator;
 import static io.trino.spi.block.RowValueBuilder.buildRowValue;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.function.OperatorType.DIVIDE;
 import static io.trino.spi.function.OperatorType.MODULO;
@@ -491,7 +491,7 @@ public final class IrExpressions
     {
         TypeOperators typeOperators = plannerContext.getTypeOperators();
         Type operandType = comparison.left().type();
-        InvocationConvention convention = simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL);
+        InvocationConvention convention = simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL);
         return switch (comparison.operator()) {
             // Required to be infallible
             case EQUAL, NOT_EQUAL, IDENTICAL -> false;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
@@ -386,8 +386,9 @@ public class EffectivePredicateExtractor
                                     return TRUE;
                                 }
                                 if (hasNestedNulls(type, ((Constant) item).value())) {
-                                    // Workaround solution to deal with array and row comparisons don't support null elements currently.
-                                    // TODO: remove when comparisons are fixed
+                                    // A structural value containing a null element has three-valued equality (it is not
+                                    // even equal to itself), so it cannot be represented as an exact value in a Domain.
+                                    // Skip predicate extraction for it rather than producing an unsound predicate.
                                     return TRUE;
                                 }
                                 if (isFloatingPointNaN(type, ((Constant) item).value())) {
@@ -420,8 +421,9 @@ public class EffectivePredicateExtractor
                                 return TRUE;
                             }
                             if (hasNestedNulls(type, item)) {
-                                // Workaround solution to deal with array and row comparisons don't support null elements currently.
-                                // TODO: remove when comparisons are fixed
+                                // A structural value containing a null element has three-valued equality (it is not
+                                // even equal to itself), so it cannot be represented as an exact value in a Domain.
+                                // Skip predicate extraction for it rather than producing an unsound predicate.
                                 return TRUE;
                             }
                             if (isFloatingPointNaN(type, item)) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -779,7 +779,6 @@ public final class PropertyDerivations
                 // We want to use a symbol resolver that looks up in the constants from the input subplan
                 // to take advantage of constant-folding for complex expressions
                 // However, that currently causes errors when those expressions operate on arrays or row types
-                // ("ROW comparison not supported for fields with null elements", etc)
                 Expression value = optimizer.process(expression, session, symbolAllocator, ImmutableMap.of()).orElse(expression);
 
                 if (value instanceof Reference) {

--- a/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
@@ -5931,79 +5931,170 @@ public class TestArrayOperators
     public void testOperatorsOnArrayWithNullElement()
     {
         String arrayWithNull = "ARRAY[1, CAST(NULL AS INTEGER)]";
+        String arrayWithLeadingNull = "ARRAY[CAST(NULL AS INTEGER), 1]";
         String arrayConcrete = "ARRAY[1, 2]";
         String arrayConcreteOther = "ARRAY[3, 4]";
 
-        // EQUAL — returns NULL when comparison hits a NULL element; GenericEqualOperator declares neverFails=true.
-        // Runtime — SQL form
-        assertThat(assertions.expression("a = b").binding("a", arrayWithNull).binding("b", arrayConcrete))
+        // EQUAL — three-valued; a NULL element makes equality unknown
+        assertThat(assertions.expression("a = b")
+                .binding("a", arrayWithNull)
+                .binding("b", arrayConcrete))
                 .isNull(BOOLEAN);
-        // Runtime — mangled form
         assertThat(assertions.operator(EQUAL, arrayWithNull, arrayConcrete))
                 .isNull(BOOLEAN);
-        // Planner belief
         assertThat(assertions.operator(EQUAL, arrayConcrete, arrayConcreteOther))
                 .neverFails();
 
-        // IDENTICAL — NULL-aware; GenericIdenticalOperator declares neverFails=true.
-        assertThat(assertions.expression("a IS NOT DISTINCT FROM b").binding("a", arrayWithNull).binding("b", arrayWithNull))
+        // IDENTICAL — NULL-aware (NULL ≡ NULL is TRUE)
+        assertThat(assertions.expression("a IS NOT DISTINCT FROM b")
+                .binding("a", arrayWithNull)
+                .binding("b", arrayWithNull))
                 .isEqualTo(true);
         assertThat(assertions.operator(IDENTICAL, arrayWithNull, arrayWithNull))
                 .isEqualTo(true);
         assertThat(assertions.operator(IDENTICAL, arrayConcrete, arrayConcreteOther))
                 .neverFails();
 
-        // INDETERMINATE — detects NULL; GenericIndeterminateOperator declares neverFails=true.
+        // INDETERMINATE — detects the NULL element
         assertThat(assertions.operator(INDETERMINATE, arrayWithNull))
                 .isEqualTo(true);
         assertThat(assertions.operator(INDETERMINATE, arrayConcrete))
                 .neverFails();
 
-        // LESS_THAN — array ordering must skip past NULL elements; GenericLessThanOperator does NOT declare neverFails (correct).
-        // ARRAY ordering currently throws NOT_SUPPORTED when a NULL element forces comparison.
-        assertTrinoExceptionThrownBy(assertions.expression("a < b").binding("a", arrayWithNull).binding("b", arrayConcrete)::evaluate)
-                .hasErrorCode(NOT_SUPPORTED);
-        assertTrinoExceptionThrownBy(assertions.operator(LESS_THAN, arrayWithNull, arrayConcrete)::evaluate)
-                .hasErrorCode(NOT_SUPPORTED);
+        // LESS_THAN — three-valued: unknown when the NULL element decides, decided by an earlier element otherwise
+        assertThat(assertions.expression("a < b")
+                .binding("a", arrayWithNull)
+                .binding("b", arrayConcrete))
+                .isNull(BOOLEAN);
+        assertThat(assertions.expression("a < b")
+                .binding("a", arrayWithNull)
+                .binding("b", arrayConcreteOther))
+                .isEqualTo(true);
+        assertThat(assertions.expression("a < b")
+                .binding("a", arrayConcreteOther)
+                .binding("b", arrayWithNull))
+                .isEqualTo(false);
+        assertThat(assertions.expression("a < b")
+                .binding("a", arrayWithLeadingNull)
+                .binding("b", arrayConcrete))
+                .isNull(BOOLEAN);
+        assertThat(assertions.operator(LESS_THAN, arrayWithNull, arrayConcrete))
+                .isNull(BOOLEAN);
         assertThat(assertions.operator(LESS_THAN, arrayConcrete, arrayConcreteOther))
-                .couldFail();
+                .neverFails();
 
-        // LESS_THAN_OR_EQUAL — same as LESS_THAN. Declaration was fixed in 72cdd389025.
-        assertTrinoExceptionThrownBy(assertions.expression("a <= b").binding("a", arrayWithNull).binding("b", arrayConcrete)::evaluate)
-                .hasErrorCode(NOT_SUPPORTED);
-        assertTrinoExceptionThrownBy(assertions.operator(LESS_THAN_OR_EQUAL, arrayWithNull, arrayConcrete)::evaluate)
-                .hasErrorCode(NOT_SUPPORTED);
+        // LESS_THAN_OR_EQUAL — same three-valued logic, true when the arrays are equal
+        assertThat(assertions.expression("a <= b")
+                .binding("a", arrayWithNull)
+                .binding("b", arrayConcrete))
+                .isNull(BOOLEAN);
+        assertThat(assertions.expression("a <= b")
+                .binding("a", arrayConcrete)
+                .binding("b", arrayConcrete))
+                .isEqualTo(true);
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, arrayWithNull, arrayConcrete))
+                .isNull(BOOLEAN);
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, arrayConcrete, arrayConcreteOther))
-                .couldFail();
+                .neverFails();
 
-        // COMPARISON_UNORDERED_FIRST — throws NOT_SUPPORTED at runtime. GenericComparisonUnorderedFirstOperator
-        // routes its neverFails declaration through TypeOperators per binding, so for ARRAY (whose comparison
-        // implementation is not declared neverFails) the planner correctly believes the operator may fail.
-        assertTrinoExceptionThrownBy(assertions.operator(COMPARISON_UNORDERED_FIRST, arrayWithNull, arrayConcrete)::evaluate)
-                .hasErrorCode(NOT_SUPPORTED);
-        assertThat(assertions.operator(COMPARISON_UNORDERED_FIRST, arrayConcrete, arrayConcreteOther))
-                .couldFail();
+        // COMPARISON_UNORDERED_FIRST / LAST — total ordering, never fails on a NULL element
+        assertThat(assertions.operator(COMPARISON_UNORDERED_FIRST, arrayWithNull, arrayConcrete))
+                .neverFails();
+        assertThat(assertions.operator(COMPARISON_UNORDERED_LAST, arrayWithNull, arrayConcrete))
+                .neverFails();
 
-        // COMPARISON_UNORDERED_LAST — same as above.
-        assertTrinoExceptionThrownBy(assertions.operator(COMPARISON_UNORDERED_LAST, arrayWithNull, arrayConcrete)::evaluate)
-                .hasErrorCode(NOT_SUPPORTED);
-        assertThat(assertions.operator(COMPARISON_UNORDERED_LAST, arrayConcrete, arrayConcreteOther))
-                .couldFail();
-
-        // BETWEEN
-        assertTrinoExceptionThrownBy(assertions.expression("a BETWEEN b AND c")
-                .binding("a", arrayWithNull).binding("b", arrayConcrete).binding("c", arrayConcreteOther)::evaluate)
-                .hasErrorCode(NOT_SUPPORTED);
+        // BETWEEN — desugars to two ordering comparisons, so it is three-valued too
         assertThat(assertions.expression("a BETWEEN b AND c")
-                .binding("a", arrayConcrete).binding("b", arrayConcrete).binding("c", arrayConcreteOther))
-                .couldFail();
+                .binding("a", arrayWithNull)
+                .binding("b", arrayConcrete)
+                .binding("c", arrayConcreteOther))
+                .isNull(BOOLEAN);
+        assertThat(assertions.expression("a BETWEEN b AND c")
+                .binding("a", arrayConcrete)
+                .binding("b", arrayConcrete)
+                .binding("c", arrayConcreteOther))
+                .isEqualTo(true);
 
-        // HASH_CODE — hashing tolerates NULL elements. GenericHashCodeOperator declares neverFails=true.
+        // HASH_CODE / XX_HASH_64 — tolerate NULL elements
         assertThat(assertions.operator(HASH_CODE, arrayWithNull))
                 .neverFails();
-
-        // XX_HASH_64 — same as HASH_CODE.
         assertThat(assertions.operator(XX_HASH_64, arrayWithNull))
                 .neverFails();
+    }
+
+    @Test
+    public void testArrayOrderingWithNullElement()
+    {
+        // ORDER BY uses the total array comparison: a NULL element sorts last in ascending order,
+        // examined only after the preceding elements tie
+        assertThat(assertions.query(
+                """
+                SELECT x
+                FROM (VALUES
+                        ARRAY[1, 2],
+                        ARRAY[1, CAST(NULL AS INTEGER)],
+                        ARRAY[1, 1],
+                        ARRAY[CAST(NULL AS INTEGER), 9]) t(x)
+                ORDER BY x"""))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            ARRAY[1, 1],
+                            ARRAY[1, 2],
+                            ARRAY[1, CAST(NULL AS INTEGER)],
+                            ARRAY[CAST(NULL AS INTEGER), 9]""");
+
+        // a shorter array sorts before a longer one that shares its prefix, regardless of trailing nulls
+        assertThat(assertions.query(
+                """
+                SELECT x
+                FROM (VALUES
+                        ARRAY[1, 2],
+                        ARRAY[1],
+                        ARRAY[1, CAST(NULL AS INTEGER)]) t(x)
+                ORDER BY x"""))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            ARRAY[1],
+                            ARRAY[1, 2],
+                            ARRAY[1, CAST(NULL AS INTEGER)]""");
+    }
+
+    @Test
+    public void testArrayComparisonWithNanAndNegativeZero()
+    {
+        // NaN and -0.0 follow the element type's semantics and coexist with NULL handling
+        assertThat(assertions.expression("a = b")
+                .binding("a", "ARRAY[nan()]")
+                .binding("b", "ARRAY[nan()]"))
+                .isEqualTo(false);
+        assertThat(assertions.expression("a < b")
+                .binding("a", "ARRAY[nan()]")
+                .binding("b", "ARRAY[1e0]"))
+                .isEqualTo(false);
+        assertThat(assertions.expression("a <= b")
+                .binding("a", "ARRAY[-0e0]")
+                .binding("b", "ARRAY[0e0]"))
+                .isEqualTo(true);
+
+        // ordering treats NaN as the largest non-null value and a NULL element as last
+        assertThat(assertions.query(
+                """
+                SELECT x
+                FROM (VALUES
+                        ARRAY[nan()],
+                        ARRAY[1e0],
+                        ARRAY[CAST(NULL AS DOUBLE)]) t(x)
+                ORDER BY x"""))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            ARRAY[1e0],
+                            ARRAY[nan()],
+                            ARRAY[CAST(NULL AS DOUBLE)]""");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
@@ -785,6 +785,7 @@ public class TestRowOperators
 
         for (int i = 1; i < 128; i += 10) {
             assertEqualOperator(i);
+            assertComparisonOperator(i);
         }
     }
 
@@ -935,6 +936,17 @@ public class TestRowOperators
                     .binding("b", alternateRowLiteralWithNulls))
                     .isEqualTo(true);
         }
+    }
+
+    private void assertComparisonOperator(int fieldCount)
+    {
+        // the rows differ only in their last field, so the comparison must look past the leading equal fields
+        String rowLiteral = toRowLiteral(largeRow(fieldCount, false));
+        String alternateRowLiteral = toRowLiteral(largeRow(fieldCount, false, true));
+        assertThat(assertions.expression("(a < b) <> (b < a)")
+                .binding("a", rowLiteral)
+                .binding("b", alternateRowLiteral))
+                .isEqualTo(true);
     }
 
     private void assertRowHashOperator(int fieldCount, boolean nulls)

--- a/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Lists;
 import io.airlift.slice.Slice;
 import io.trino.metadata.InternalFunctionBundle;
 import io.trino.operator.scalar.CombineHashFunction;
-import io.trino.spi.StandardErrorCode;
 import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
@@ -45,7 +44,6 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
-import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
@@ -746,14 +744,15 @@ public class TestRowOperators
                 .hasErrorCode(TYPE_MISMATCH)
                 .hasMessage("line 1:75: Cannot apply operator: row(boolean, array(integer), map(integer, double)) < row(boolean, array(integer), map(integer, double))");
 
-        assertTrinoExceptionThrownBy(assertions.expression("row(1, CAST(NULL AS INTEGER)) < row(1, 2)")::evaluate)
-                .hasErrorCode(StandardErrorCode.NOT_SUPPORTED);
+        // a NULL field that decides the comparison yields an unknown (NULL) result, per SQL three-valued logic
+        assertThat(assertions.expression("row(1, CAST(NULL AS INTEGER)) < row(1, 2)"))
+                .isNull(BOOLEAN);
 
-        assertTrinoExceptionThrownBy(assertions.expression("row(1, CAST(NULL AS INTEGER)) <= row(1, 2)")::evaluate)
-                .hasErrorCode(StandardErrorCode.NOT_SUPPORTED);
+        assertThat(assertions.expression("row(1, CAST(NULL AS INTEGER)) <= row(1, 2)"))
+                .isNull(BOOLEAN);
 
-        assertTrinoExceptionThrownBy(assertions.expression("row(1, CAST(NULL AS INTEGER)) >= row(1, 2)")::evaluate)
-                .hasErrorCode(StandardErrorCode.NOT_SUPPORTED);
+        assertThat(assertions.expression("row(1, CAST(NULL AS INTEGER)) >= row(1, 2)"))
+                .isNull(BOOLEAN);
 
         assertComparisonCombination("row(1.0E0, ARRAY [1,2,3], row(2, 2.0E0))", "row(1.0E0, ARRAY [1,3,3], row(2, 2.0E0))");
         assertComparisonCombination("row(TRUE, ARRAY [1])", "row(TRUE, ARRAY [1, 2])");
@@ -1043,100 +1042,205 @@ public class TestRowOperators
         return types;
     }
 
-    /**
-     * Probe every {@code Generic*Operator} class on a ROW with a NULL field, in both SQL form
-     * (when one exists) and the mangled {@code "$operator$x"(...)} form. The assertions document
-     * which {@code Generic*Operator.neverFails} declarations match the operator's actual runtime
-     * behavior. A mismatch (planner-belief {@code .neverFails()} passing while the runtime
-     * assertion proves the operator can throw) indicates the declaration is incorrect — see
-     * https://github.com/trinodb/trino/issues/29891.
-     *
-     * Note: the planner's fallibility belief is type-driven, not value-driven, so the planner-belief
-     * assertions use a NULL-free row of the same type — they would be unreachable on a value that
-     * actually throws.
-     */
     @Test
     public void testOperatorsOnRowWithNullField()
     {
         String rowWithNull = "row(1, CAST(NULL AS INTEGER))";
+        String rowWithLeadingNull = "row(CAST(NULL AS INTEGER), 1)";
         String rowConcrete = "row(1, 2)";
         String rowConcreteOther = "row(3, 4)";
 
-        // EQUAL — returns NULL per SQL standard; GenericEqualOperator declares neverFails=true (correct).
-        // Runtime — SQL form
-        assertThat(assertions.expression("a = b").binding("a", rowWithNull).binding("b", rowConcrete))
+        // EQUAL — three-valued; a NULL field makes equality unknown
+        assertThat(assertions.expression("a = b")
+                .binding("a", rowWithNull)
+                .binding("b", rowConcrete))
                 .isNull(BOOLEAN);
-        // Runtime — mangled form
         assertThat(assertions.operator(EQUAL, rowWithNull, rowConcrete))
                 .isNull(BOOLEAN);
-        // Planner belief (uses NULL-free input; planner reasons type-wise)
         assertThat(assertions.operator(EQUAL, rowConcrete, rowConcreteOther))
                 .neverFails();
 
-        // IDENTICAL — NULL-aware (NULL ≡ NULL is TRUE); GenericIdenticalOperator declares neverFails=true (correct).
-        assertThat(assertions.expression("a IS NOT DISTINCT FROM b").binding("a", rowWithNull).binding("b", rowWithNull))
+        // IDENTICAL — NULL-aware (NULL ≡ NULL is TRUE)
+        assertThat(assertions.expression("a IS NOT DISTINCT FROM b")
+                .binding("a", rowWithNull)
+                .binding("b", rowWithNull))
                 .isEqualTo(true);
         assertThat(assertions.operator(IDENTICAL, rowWithNull, rowWithNull))
                 .isEqualTo(true);
         assertThat(assertions.operator(IDENTICAL, rowConcrete, rowConcreteOther))
                 .neverFails();
 
-        // INDETERMINATE — exists to detect NULL; GenericIndeterminateOperator declares neverFails=true (correct).
-        // No SQL form.
+        // INDETERMINATE — detects the NULL field
         assertThat(assertions.operator(INDETERMINATE, rowWithNull))
                 .isEqualTo(true);
         assertThat(assertions.operator(INDETERMINATE, rowConcrete))
                 .neverFails();
 
-        // LESS_THAN — throws NOT_SUPPORTED when NULL ordering is reached; GenericLessThanOperator does NOT declare neverFails (correct).
-        // Runtime — SQL form
-        assertTrinoExceptionThrownBy(assertions.expression("a < b").binding("a", rowWithNull).binding("b", rowConcrete)::evaluate)
-                .hasErrorCode(NOT_SUPPORTED);
-        // Runtime — mangled form
-        assertTrinoExceptionThrownBy(assertions.operator(LESS_THAN, rowWithNull, rowConcrete)::evaluate)
-                .hasErrorCode(NOT_SUPPORTED);
-        // Planner belief (uses NULL-free input; planner is type-driven and conservative for this op)
+        // LESS_THAN — three-valued: unknown when the NULL field decides, decided by an earlier field otherwise
+        assertThat(assertions.expression("a < b")
+                .binding("a", rowWithNull)
+                .binding("b", rowConcrete))
+                .isNull(BOOLEAN);
+        assertThat(assertions.expression("a < b")
+                .binding("a", rowWithNull)
+                .binding("b", rowConcreteOther))
+                .isEqualTo(true);
+        assertThat(assertions.expression("a < b")
+                .binding("a", rowConcreteOther)
+                .binding("b", rowWithNull))
+                .isEqualTo(false);
+        assertThat(assertions.expression("a < b")
+                .binding("a", rowWithLeadingNull)
+                .binding("b", rowConcrete))
+                .isNull(BOOLEAN);
+        assertThat(assertions.operator(LESS_THAN, rowWithNull, rowConcrete))
+                .isNull(BOOLEAN);
         assertThat(assertions.operator(LESS_THAN, rowConcrete, rowConcreteOther))
-                .couldFail();
+                .neverFails();
 
-        // LESS_THAN_OR_EQUAL — same as LESS_THAN; declaration fixed in 72cdd389025 to omit neverFails (correct).
-        assertTrinoExceptionThrownBy(assertions.expression("a <= b").binding("a", rowWithNull).binding("b", rowConcrete)::evaluate)
-                .hasErrorCode(NOT_SUPPORTED);
-        assertTrinoExceptionThrownBy(assertions.operator(LESS_THAN_OR_EQUAL, rowWithNull, rowConcrete)::evaluate)
-                .hasErrorCode(NOT_SUPPORTED);
+        // LESS_THAN_OR_EQUAL — same three-valued logic, true when every field is equal
+        assertThat(assertions.expression("a <= b")
+                .binding("a", rowWithNull)
+                .binding("b", rowConcrete))
+                .isNull(BOOLEAN);
+        assertThat(assertions.expression("a <= b")
+                .binding("a", rowConcrete)
+                .binding("b", rowConcrete))
+                .isEqualTo(true);
+        assertThat(assertions.operator(LESS_THAN_OR_EQUAL, rowWithNull, rowConcrete))
+                .isNull(BOOLEAN);
         assertThat(assertions.operator(LESS_THAN_OR_EQUAL, rowConcrete, rowConcreteOther))
-                .couldFail();
+                .neverFails();
 
-        // COMPARISON_UNORDERED_FIRST — throws NOT_SUPPORTED at runtime. GenericComparisonUnorderedFirstOperator
-        // routes its neverFails declaration through TypeOperators per binding, so for ROW (whose comparison
-        // implementation is not declared neverFails) the planner correctly believes the operator may fail.
-        // No SQL form.
-        assertTrinoExceptionThrownBy(assertions.operator(COMPARISON_UNORDERED_FIRST, rowWithNull, rowConcrete)::evaluate)
-                .hasErrorCode(NOT_SUPPORTED);
-        assertThat(assertions.operator(COMPARISON_UNORDERED_FIRST, rowConcrete, rowConcreteOther))
-                .couldFail();
+        // COMPARISON_UNORDERED_FIRST / LAST — total ordering, never fails on a NULL field
+        assertThat(assertions.operator(COMPARISON_UNORDERED_FIRST, rowWithNull, rowConcrete))
+                .neverFails();
+        assertThat(assertions.operator(COMPARISON_UNORDERED_LAST, rowWithNull, rowConcrete))
+                .neverFails();
 
-        // COMPARISON_UNORDERED_LAST — same as above. No SQL form.
-        assertTrinoExceptionThrownBy(assertions.operator(COMPARISON_UNORDERED_LAST, rowWithNull, rowConcrete)::evaluate)
-                .hasErrorCode(NOT_SUPPORTED);
-        assertThat(assertions.operator(COMPARISON_UNORDERED_LAST, rowConcrete, rowConcreteOther))
-                .couldFail();
-
-        // BETWEEN
-        assertTrinoExceptionThrownBy(assertions.expression("a BETWEEN b AND c")
-                .binding("a", rowWithNull).binding("b", rowConcrete).binding("c", rowConcreteOther)::evaluate)
-                .hasErrorCode(NOT_SUPPORTED);
+        // BETWEEN — desugars to two ordering comparisons, so it is three-valued too
         assertThat(assertions.expression("a BETWEEN b AND c")
-                .binding("a", rowConcrete).binding("b", rowConcrete).binding("c", rowConcreteOther))
-                .couldFail();
+                .binding("a", rowWithNull)
+                .binding("b", rowConcrete)
+                .binding("c", rowConcreteOther))
+                .isNull(BOOLEAN);
+        assertThat(assertions.expression("a BETWEEN b AND c")
+                .binding("a", rowConcrete)
+                .binding("b", rowConcrete)
+                .binding("c", rowConcreteOther))
+                .isEqualTo(true);
 
-        // HASH_CODE — hashing tolerates NULL fields; GenericHashCodeOperator declares neverFails=true. No SQL form.
+        // HASH_CODE / XX_HASH_64 — tolerate NULL fields
         assertThat(assertions.operator(HASH_CODE, rowWithNull))
                 .neverFails();
-
-        // XX_HASH_64 — same as HASH_CODE. No SQL form.
         assertThat(assertions.operator(XX_HASH_64, rowWithNull))
                 .neverFails();
+    }
+
+    @Test
+    public void testRowOrderingWithNullField()
+    {
+        // ORDER BY uses the total row comparison: a NULL field sorts last in ascending order,
+        // examined only after the preceding fields tie
+        assertThat(assertions.query(
+                """
+                SELECT x
+                FROM (VALUES
+                        ROW(row(1, 2)),
+                        ROW(row(1, CAST(NULL AS INTEGER))),
+                        ROW(row(1, 1)),
+                        ROW(row(CAST(NULL AS INTEGER), 9))) t(x)
+                ORDER BY x"""))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            ROW(row(1, 1)),
+                            ROW(row(1, 2)),
+                            ROW(row(1, CAST(NULL AS INTEGER))),
+                            ROW(row(CAST(NULL AS INTEGER), 9))""");
+
+        // DISTINCT groups rows that are identical, treating null fields as equal
+        assertThat(assertions.query(
+                """
+                SELECT DISTINCT x
+                FROM (VALUES
+                        ROW(row(1, CAST(NULL AS INTEGER))),
+                        ROW(row(1, CAST(NULL AS INTEGER))),
+                        ROW(row(1, 2))) t(x)
+                ORDER BY x"""))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            ROW(row(1, 2)),
+                            ROW(row(1, CAST(NULL AS INTEGER)))""");
+    }
+
+    @Test
+    public void testMegamorphicRowComparisonWithNullField()
+    {
+        // rows wider than RowType.MEGAMORPHIC_FIELD_COUNT (64) take the megamorphic comparison and
+        // less-than paths, whose null handling the two-field cases above do not reach
+        String allPresent = largeIntegerRow(70, -1);
+        String nullInside = largeIntegerRow(70, 65);
+
+        // less-than is unknown when the first not-equal field is null, even deep into the row
+        assertThat(assertions.expression("a < b")
+                .binding("a", allPresent)
+                .binding("b", nullInside))
+                .isNull(BOOLEAN);
+
+        // total ordering places the null field last, after the leading equal fields
+        assertThat(assertions.query("SELECT x FROM (VALUES ROW(%s), ROW(%s)) t(x) ORDER BY x".formatted(nullInside, allPresent)))
+                .ordered()
+                .matches("VALUES ROW(%s), ROW(%s)".formatted(allPresent, nullInside));
+    }
+
+    @Test
+    public void testRowComparisonWithNanAndNegativeZero()
+    {
+        // NaN and -0.0 follow the element type's semantics and coexist with NULL handling
+        assertThat(assertions.expression("a = b")
+                .binding("a", "row(nan())")
+                .binding("b", "row(nan())"))
+                .isEqualTo(false);
+        assertThat(assertions.expression("a < b")
+                .binding("a", "row(nan())")
+                .binding("b", "row(1e0)"))
+                .isEqualTo(false);
+        assertThat(assertions.expression("a <= b")
+                .binding("a", "row(-0e0)")
+                .binding("b", "row(0e0)"))
+                .isEqualTo(true);
+
+        // ordering treats NaN as the largest non-null value and a NULL field as last
+        assertThat(assertions.query(
+                """
+                SELECT x
+                FROM (VALUES
+                        ROW(row(nan())),
+                        ROW(row(1e0)),
+                        ROW(row(CAST(NULL AS DOUBLE)))) t(x)
+                ORDER BY x"""))
+                .ordered()
+                .matches(
+                        """
+                        VALUES
+                            ROW(row(1e0)),
+                            ROW(row(nan())),
+                            ROW(row(CAST(NULL AS DOUBLE)))""");
+    }
+
+    private static String largeIntegerRow(int fieldCount, int nullField)
+    {
+        List<String> values = new ArrayList<>(fieldCount);
+        List<String> types = new ArrayList<>(fieldCount);
+        for (int i = 0; i < fieldCount; i++) {
+            values.add(i == nullField ? "null" : Integer.toString(i));
+            types.add("INTEGER");
+        }
+        return "cast(ROW(" + Joiner.on(", ").join(values) + ") AS ROW(" + Joiner.on(", ").join(types) + "))";
     }
 
     private void assertComparisonCombination(String base, String greater)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ArrayType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ArrayType.java
@@ -33,7 +33,6 @@ import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.BiFunction;
 
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.FLAT;
@@ -46,7 +45,6 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.type.TypeUtils.NULL_HASH_CODE;
-import static io.trino.spi.type.TypeUtils.checkElementNotNull;
 import static java.lang.Math.toIntExact;
 import static java.lang.invoke.MethodHandles.insertArguments;
 import static java.util.Collections.emptyList;
@@ -67,6 +65,7 @@ public class ArrayType
     private static final InvocationConvention IDENTICAL_CONVENTION = simpleConvention(FAIL_ON_NULL, BOXED_NULLABLE, BOXED_NULLABLE);
     private static final InvocationConvention INDETERMINATE_CONVENTION = simpleConvention(FAIL_ON_NULL, NULL_FLAG);
     private static final InvocationConvention COMPARISON_CONVENTION = simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL);
+    private static final InvocationConvention LESS_THAN_CONVENTION = simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL);
 
     private static final MethodHandle READ_FLAT;
     private static final MethodHandle READ_FLAT_TO_BLOCK;
@@ -76,6 +75,7 @@ public class ArrayType
     private static final MethodHandle IDENTICAL;
     private static final MethodHandle INDETERMINATE;
     private static final MethodHandle COMPARISON;
+    private static final MethodHandle LESS_THAN;
 
     static {
         try {
@@ -87,14 +87,13 @@ public class ArrayType
             HASH_CODE = lookup.findStatic(ArrayType.class, "hashOperator", MethodType.methodType(long.class, MethodHandle.class, Block.class));
             IDENTICAL = lookup.findStatic(ArrayType.class, "identicalOperator", MethodType.methodType(boolean.class, MethodHandle.class, Block.class, Block.class));
             INDETERMINATE = lookup.findStatic(ArrayType.class, "indeterminateOperator", MethodType.methodType(boolean.class, MethodHandle.class, Block.class, boolean.class));
-            COMPARISON = lookup.findStatic(ArrayType.class, "comparisonOperator", MethodType.methodType(long.class, MethodHandle.class, Block.class, Block.class));
+            COMPARISON = lookup.findStatic(ArrayType.class, "comparisonOperator", MethodType.methodType(long.class, boolean.class, MethodHandle.class, Block.class, Block.class));
+            LESS_THAN = lookup.findStatic(ArrayType.class, "lessThanOperator", MethodType.methodType(Boolean.class, boolean.class, MethodHandle.class, MethodHandle.class, Block.class, Block.class));
         }
         catch (NoSuchMethodException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
     }
-
-    private static final String ARRAY_NULL_ELEMENT_MSG = "ARRAY comparison not supported for arrays with null elements";
 
     private final Type elementType;
 
@@ -129,8 +128,10 @@ public class ArrayType
                 .addXxHash64Operators(getXxHash64OperatorMethodHandles(typeOperators, elementType))
                 .addIdenticalOperators(getIdenticalOperatorInvokers(typeOperators, elementType))
                 .addIndeterminateOperators(getIndeterminateOperatorInvokers(typeOperators, elementType))
-                .addComparisonUnorderedLastOperators(getComparisonOperatorInvokers(typeOperators::getComparisonUnorderedLastOperator, elementType))
-                .addComparisonUnorderedFirstOperators(getComparisonOperatorInvokers(typeOperators::getComparisonUnorderedFirstOperator, elementType))
+                .addComparisonUnorderedLastOperators(getComparisonOperatorInvokers(typeOperators, elementType, false))
+                .addComparisonUnorderedFirstOperators(getComparisonOperatorInvokers(typeOperators, elementType, true))
+                .addLessThanOperators(getLessThanOperatorInvokers(typeOperators, elementType, false))
+                .addLessThanOrEqualOperators(getLessThanOperatorInvokers(typeOperators, elementType, true))
                 .build();
     }
 
@@ -193,13 +194,31 @@ public class ArrayType
         return singletonList(new OperatorMethodHandle(INDETERMINATE_CONVENTION, INDETERMINATE.bindTo(elementIndeterminateOperator)));
     }
 
-    private static List<OperatorMethodHandle> getComparisonOperatorInvokers(BiFunction<Type, InvocationConvention, MethodHandle> comparisonOperatorFactory, Type elementType)
+    private static List<OperatorMethodHandle> getComparisonOperatorInvokers(TypeOperators typeOperators, Type elementType, boolean nullsFirst)
     {
         if (!elementType.isOrderable()) {
             return emptyList();
         }
-        MethodHandle elementComparisonOperator = comparisonOperatorFactory.apply(elementType, simpleConvention(FAIL_ON_NULL, VALUE_BLOCK_POSITION_NOT_NULL, VALUE_BLOCK_POSITION_NOT_NULL));
-        return singletonList(new OperatorMethodHandle(COMPARISON_CONVENTION, COMPARISON.bindTo(elementComparisonOperator)));
+        InvocationConvention elementConvention = simpleConvention(FAIL_ON_NULL, VALUE_BLOCK_POSITION_NOT_NULL, VALUE_BLOCK_POSITION_NOT_NULL);
+        // compare non-null elements with the same null ordering, so nested nulls are ordered consistently
+        OperatorMethodHandle elementComparison = nullsFirst
+                ? typeOperators.getComparisonUnorderedFirstOperatorHandle(elementType, elementConvention)
+                : typeOperators.getComparisonUnorderedLastOperatorHandle(elementType, elementConvention);
+        MethodHandle comparison = insertArguments(COMPARISON, 0, nullsFirst, elementComparison.getMethodHandle());
+        return singletonList(new OperatorMethodHandle(COMPARISON_CONVENTION, comparison, elementComparison.isNeverFails()));
+    }
+
+    private static List<OperatorMethodHandle> getLessThanOperatorInvokers(TypeOperators typeOperators, Type elementType, boolean orEqual)
+    {
+        if (!elementType.isOrderable()) {
+            return emptyList();
+        }
+        InvocationConvention elementConvention = simpleConvention(NULLABLE_RETURN, VALUE_BLOCK_POSITION_NOT_NULL, VALUE_BLOCK_POSITION_NOT_NULL);
+        // equality is total over all comparable types, so it never affects neverFails
+        MethodHandle elementEqual = typeOperators.getEqualOperator(elementType, elementConvention);
+        OperatorMethodHandle elementLessThan = typeOperators.getLessThanOperatorHandle(elementType, elementConvention);
+        MethodHandle lessThan = insertArguments(LESS_THAN, 0, orEqual, elementEqual, elementLessThan.getMethodHandle());
+        return singletonList(new OperatorMethodHandle(LESS_THAN_CONVENTION, lessThan, elementLessThan.isNeverFails()));
     }
 
     public Type getElementType()
@@ -633,19 +652,26 @@ public class ArrayType
         throw new IllegalArgumentException("Unsupported block type: " + array.getClass().getName());
     }
 
-    private static long comparisonOperator(MethodHandle comparisonOperator, Block leftArray, Block rightArray)
+    private static long comparisonOperator(boolean nullsFirst, MethodHandle comparisonOperator, Block leftArray, Block rightArray)
             throws Throwable
     {
         ValueBlock leftValues = leftArray.getUnderlyingValueBlock();
         ValueBlock rightValues = rightArray.getUnderlyingValueBlock();
 
-        int len = Math.min(leftArray.getPositionCount(), rightArray.getPositionCount());
-        for (int position = 0; position < len; position++) {
-            checkElementNotNull(leftArray.isNull(position), ARRAY_NULL_ELEMENT_MSG);
-            checkElementNotNull(rightArray.isNull(position), ARRAY_NULL_ELEMENT_MSG);
-
+        int length = Math.min(leftArray.getPositionCount(), rightArray.getPositionCount());
+        for (int position = 0; position < length; position++) {
             int leftIndex = leftArray.getUnderlyingValuePosition(position);
             int rightIndex = rightArray.getUnderlyingValuePosition(position);
+
+            boolean leftIsNull = leftValues.isNull(leftIndex);
+            boolean rightIsNull = rightValues.isNull(rightIndex);
+            if (leftIsNull || rightIsNull) {
+                long nullComparison = compareNullElements(nullsFirst, leftIsNull, rightIsNull);
+                if (nullComparison != 0) {
+                    return nullComparison;
+                }
+                continue;
+            }
 
             long result = (long) comparisonOperator.invokeExact(leftValues, leftIndex, rightValues, rightIndex);
             if (result != 0) {
@@ -654,5 +680,53 @@ public class ArrayType
         }
 
         return Integer.compare(leftArray.getPositionCount(), rightArray.getPositionCount());
+    }
+
+    /// Total ordering for an element where at least one side is null. Nulls sort first when
+    /// `nullsFirst` is set (`COMPARISON_UNORDERED_FIRST`) and last otherwise
+    /// (`COMPARISON_UNORDERED_LAST`); two nulls compare equal.
+    private static long compareNullElements(boolean nullsFirst, boolean leftIsNull, boolean rightIsNull)
+    {
+        if (leftIsNull && rightIsNull) {
+            return 0;
+        }
+        if (leftIsNull) {
+            return nullsFirst ? -1 : 1;
+        }
+        return nullsFirst ? 1 : -1;
+    }
+
+    private static Boolean lessThanOperator(boolean orEqual, MethodHandle elementEqual, MethodHandle elementLessThan, Block leftArray, Block rightArray)
+            throws Throwable
+    {
+        ValueBlock leftValues = leftArray.getUnderlyingValueBlock();
+        ValueBlock rightValues = rightArray.getUnderlyingValueBlock();
+
+        int length = Math.min(leftArray.getPositionCount(), rightArray.getPositionCount());
+        for (int position = 0; position < length; position++) {
+            int leftIndex = leftArray.getUnderlyingValuePosition(position);
+            int rightIndex = rightArray.getUnderlyingValuePosition(position);
+
+            if (leftValues.isNull(leftIndex) || rightValues.isNull(rightIndex)) {
+                // a null element is the deciding one, so the result is unknown
+                return null;
+            }
+
+            Boolean elementsEqual = (Boolean) elementEqual.invokeExact(leftValues, leftIndex, rightValues, rightIndex);
+            if (elementsEqual == null) {
+                return null;
+            }
+            if (!elementsEqual) {
+                // the first unequal element decides the result, which is itself unknown if that element's comparison is
+                return (Boolean) elementLessThan.invokeExact(leftValues, leftIndex, rightValues, rightIndex);
+            }
+        }
+
+        // the common prefix is equal: the shorter array sorts first
+        int lengthComparison = Integer.compare(leftArray.getPositionCount(), rightArray.getPositionCount());
+        if (lengthComparison == 0) {
+            return orEqual;
+        }
+        return lengthComparison < 0;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RowType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RowType.java
@@ -878,7 +878,7 @@ public class RowType
 
             MethodHandle comparisonOperator = comparisonOperators.get(fieldIndex);
             long result = (long) comparisonOperator.invoke(leftFieldBlock, leftRawIndex, rightFieldBlock, rightRawIndex);
-            if (result == 0) {
+            if (result != 0) {
                 return result;
             }
         }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RowType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RowType.java
@@ -13,8 +13,6 @@
  */
 package io.trino.spi.type;
 
-import io.trino.spi.StandardErrorCode;
-import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.BlockBuilderStatus;
@@ -31,7 +29,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static io.trino.spi.block.RowValueBuilder.buildRowValue;
@@ -51,6 +48,7 @@ import static java.lang.Boolean.TRUE;
 import static java.lang.invoke.MethodHandles.collectArguments;
 import static java.lang.invoke.MethodHandles.constant;
 import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.filterReturnValue;
 import static java.lang.invoke.MethodHandles.insertArguments;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.lang.invoke.MethodHandles.permuteArguments;
@@ -75,6 +73,15 @@ public class RowType
     private static final InvocationConvention IDENTICAL_CONVENTION = simpleConvention(FAIL_ON_NULL, BOXED_NULLABLE, BOXED_NULLABLE);
     private static final InvocationConvention INDETERMINATE_CONVENTION = simpleConvention(FAIL_ON_NULL, BOXED_NULLABLE);
     private static final InvocationConvention COMPARISON_CONVENTION = simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL);
+    private static final InvocationConvention LESS_THAN_CONVENTION = simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL);
+
+    // State of a field-by-field less-than walk: all fields so far are equal (keep going), or a
+    // deciding field has been found that is less, greater, or whose comparison is unknown (a null
+    // is involved). Encoded as int constants so the walk can be composed with MethodHandles.
+    private static final int LESS_THAN_FIELDS_EQUAL = 0;
+    private static final int LESS_THAN_FIELD_LESS = 1;
+    private static final int LESS_THAN_FIELD_GREATER = 2;
+    private static final int LESS_THAN_FIELD_UNKNOWN = 3;
 
     private static final MethodHandle READ_FLAT;
     private static final MethodHandle READ_FLAT_TO_BLOCK;
@@ -90,6 +97,9 @@ public class RowType
     private static final MethodHandle CHAIN_INDETERMINATE;
     private static final MethodHandle COMPARISON;
     private static final MethodHandle CHAIN_COMPARISON;
+    private static final MethodHandle LESS_THAN;
+    private static final MethodHandle CHAIN_LESS_THAN;
+    private static final MethodHandle LESS_THAN_RESULT;
     private static final int MEGAMORPHIC_FIELD_COUNT = 64;
 
     // this field is used in double-checked locking
@@ -111,8 +121,11 @@ public class RowType
             CHAIN_IDENTICAL = lookup.findStatic(RowType.class, "chainIdentical", methodType(boolean.class, boolean.class, int.class, MethodHandle.class, SqlRow.class, SqlRow.class));
             INDETERMINATE = lookup.findStatic(RowType.class, "megamorphicIndeterminateOperator", methodType(boolean.class, List.class, SqlRow.class));
             CHAIN_INDETERMINATE = lookup.findStatic(RowType.class, "chainIndeterminate", methodType(boolean.class, boolean.class, int.class, MethodHandle.class, SqlRow.class));
-            COMPARISON = lookup.findStatic(RowType.class, "megamorphicComparisonOperator", methodType(long.class, List.class, SqlRow.class, SqlRow.class));
-            CHAIN_COMPARISON = lookup.findStatic(RowType.class, "chainComparison", methodType(long.class, long.class, int.class, MethodHandle.class, SqlRow.class, SqlRow.class));
+            COMPARISON = lookup.findStatic(RowType.class, "megamorphicComparisonOperator", methodType(long.class, boolean.class, List.class, SqlRow.class, SqlRow.class));
+            CHAIN_COMPARISON = lookup.findStatic(RowType.class, "chainComparison", methodType(long.class, long.class, boolean.class, int.class, MethodHandle.class, SqlRow.class, SqlRow.class));
+            LESS_THAN = lookup.findStatic(RowType.class, "megamorphicLessThanOperator", methodType(Boolean.class, boolean.class, List.class, List.class, SqlRow.class, SqlRow.class));
+            CHAIN_LESS_THAN = lookup.findStatic(RowType.class, "chainLessThan", methodType(int.class, int.class, int.class, MethodHandle.class, MethodHandle.class, SqlRow.class, SqlRow.class));
+            LESS_THAN_RESULT = lookup.findStatic(RowType.class, "lessThanResult", methodType(Boolean.class, boolean.class, int.class));
         }
         catch (NoSuchMethodException | IllegalAccessException e) {
             throw new RuntimeException(e);
@@ -381,8 +394,10 @@ public class RowType
                 .addXxHash64Operators(getXxHash64OperatorMethodHandles(typeOperators, fields))
                 .addIdenticalOperators(getIdenticalOperatorInvokers(typeOperators, fields))
                 .addIndeterminateOperators(getIndeterminateOperatorInvokers(typeOperators, fields))
-                .addComparisonUnorderedLastOperators(getComparisonOperatorInvokers(typeOperators::getComparisonUnorderedLastOperator, fields))
-                .addComparisonUnorderedFirstOperators(getComparisonOperatorInvokers(typeOperators::getComparisonUnorderedFirstOperator, fields))
+                .addComparisonUnorderedLastOperators(getComparisonOperatorInvokers(typeOperators, fields, false))
+                .addComparisonUnorderedFirstOperators(getComparisonOperatorInvokers(typeOperators, fields, true))
+                .addLessThanOperators(getLessThanOperatorInvokers(typeOperators, fields, false))
+                .addLessThanOrEqualOperators(getLessThanOperatorInvokers(typeOperators, fields, true))
                 .build();
     }
 
@@ -826,44 +841,46 @@ public class RowType
         return (boolean) currentFieldIndeterminateOperator.invokeExact(fieldBlock, rawIndex);
     }
 
-    private static List<OperatorMethodHandle> getComparisonOperatorInvokers(BiFunction<Type, InvocationConvention, MethodHandle> comparisonOperatorFactory, List<Field> fields)
+    private static List<OperatorMethodHandle> getComparisonOperatorInvokers(TypeOperators typeOperators, List<Field> fields, boolean nullsFirst)
     {
         boolean orderable = fields.stream().allMatch(field -> field.getType().isOrderable());
         if (!orderable) {
             return emptyList();
         }
 
+        boolean neverFails = true;
+        List<MethodHandle> comparisonOperators = new ArrayList<>(fields.size());
+        for (Field field : fields) {
+            InvocationConvention fieldConvention = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL);
+            // compare non-null field values with the same null ordering, so nested nulls are ordered consistently
+            OperatorMethodHandle fieldComparison = nullsFirst
+                    ? typeOperators.getComparisonUnorderedFirstOperatorHandle(field.getType(), fieldConvention)
+                    : typeOperators.getComparisonUnorderedLastOperatorHandle(field.getType(), fieldConvention);
+            neverFails = neverFails && fieldComparison.isNeverFails();
+            comparisonOperators.add(fieldComparison.getMethodHandle());
+        }
+
         // for large rows, use a generic loop with a megamorphic call site
         if (fields.size() > MEGAMORPHIC_FIELD_COUNT) {
-            List<MethodHandle> comparisonOperators = fields.stream()
-                    .map(field -> comparisonOperatorFactory.apply(field.getType(), simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL)))
-                    .toList();
-            return singletonList(new OperatorMethodHandle(COMPARISON_CONVENTION, COMPARISON.bindTo(comparisonOperators)));
+            return singletonList(new OperatorMethodHandle(COMPARISON_CONVENTION, insertArguments(COMPARISON, 0, nullsFirst, comparisonOperators), neverFails));
         }
 
-        // (SqlRow, SqlRow):Boolean
+        // (SqlRow, SqlRow):long
         MethodHandle comparison = dropArguments(constant(long.class, 0), 0, SqlRow.class, SqlRow.class);
         for (int fieldId = 0; fieldId < fields.size(); fieldId++) {
-            Field field = fields.get(fieldId);
-            // (SqlRow, SqlRow, int, MethodHandle, SqlRow, SqlRow):Boolean
-            comparison = collectArguments(
-                    CHAIN_COMPARISON,
-                    0,
-                    comparison);
+            // (SqlRow, SqlRow, boolean, int, MethodHandle, SqlRow, SqlRow):long
+            comparison = collectArguments(CHAIN_COMPARISON, 0, comparison);
 
-            // field comparison
-            MethodHandle fieldComparisonOperator = comparisonOperatorFactory.apply(field.getType(), simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL));
+            // (SqlRow, SqlRow, SqlRow, SqlRow):long
+            comparison = insertArguments(comparison, 2, nullsFirst, fieldId, comparisonOperators.get(fieldId));
 
-            // (SqlRow, SqlRow, SqlRow, SqlRow):Boolean
-            comparison = insertArguments(comparison, 2, fieldId, fieldComparisonOperator);
-
-            // (SqlRow, SqlRow):Boolean
+            // (SqlRow, SqlRow):long
             comparison = permuteArguments(comparison, methodType(long.class, SqlRow.class, SqlRow.class), 0, 1, 0, 1);
         }
-        return singletonList(new OperatorMethodHandle(COMPARISON_CONVENTION, comparison));
+        return singletonList(new OperatorMethodHandle(COMPARISON_CONVENTION, comparison, neverFails));
     }
 
-    private static long megamorphicComparisonOperator(List<MethodHandle> comparisonOperators, SqlRow leftRow, SqlRow rightRow)
+    private static long megamorphicComparisonOperator(boolean nullsFirst, List<MethodHandle> comparisonOperators, SqlRow leftRow, SqlRow rightRow)
             throws Throwable
     {
         int leftRawIndex = leftRow.getRawIndex();
@@ -873,11 +890,17 @@ public class RowType
             Block leftFieldBlock = leftRow.getRawFieldBlock(fieldIndex);
             Block rightFieldBlock = rightRow.getRawFieldBlock(fieldIndex);
 
-            checkElementNotNull(leftFieldBlock.isNull(leftRawIndex));
-            checkElementNotNull(rightFieldBlock.isNull(rightRawIndex));
+            boolean leftIsNull = leftFieldBlock.isNull(leftRawIndex);
+            boolean rightIsNull = rightFieldBlock.isNull(rightRawIndex);
+            if (leftIsNull || rightIsNull) {
+                long nullComparison = compareNullFields(nullsFirst, leftIsNull, rightIsNull);
+                if (nullComparison != 0) {
+                    return nullComparison;
+                }
+                continue;
+            }
 
-            MethodHandle comparisonOperator = comparisonOperators.get(fieldIndex);
-            long result = (long) comparisonOperator.invoke(leftFieldBlock, leftRawIndex, rightFieldBlock, rightRawIndex);
+            long result = (long) comparisonOperators.get(fieldIndex).invoke(leftFieldBlock, leftRawIndex, rightFieldBlock, rightRawIndex);
             if (result != 0) {
                 return result;
             }
@@ -885,7 +908,7 @@ public class RowType
         return 0;
     }
 
-    private static long chainComparison(long previousFieldsResult, int fieldIndex, MethodHandle nextFieldComparison, SqlRow leftRow, SqlRow rightRow)
+    private static long chainComparison(long previousFieldsResult, boolean nullsFirst, int fieldIndex, MethodHandle nextFieldComparison, SqlRow leftRow, SqlRow rightRow)
             throws Throwable
     {
         if (previousFieldsResult != 0) {
@@ -897,16 +920,138 @@ public class RowType
         Block leftFieldBlock = leftRow.getRawFieldBlock(fieldIndex);
         Block rightFieldBlock = rightRow.getRawFieldBlock(fieldIndex);
 
-        checkElementNotNull(leftFieldBlock.isNull(leftRawIndex));
-        checkElementNotNull(rightFieldBlock.isNull(rightRawIndex));
+        boolean leftIsNull = leftFieldBlock.isNull(leftRawIndex);
+        boolean rightIsNull = rightFieldBlock.isNull(rightRawIndex);
+        if (leftIsNull || rightIsNull) {
+            return compareNullFields(nullsFirst, leftIsNull, rightIsNull);
+        }
 
         return (long) nextFieldComparison.invokeExact(leftFieldBlock, leftRawIndex, rightFieldBlock, rightRawIndex);
     }
 
-    private static void checkElementNotNull(boolean isNull)
+    /// Total ordering for a field where at least one side is null. Nulls sort first when
+    /// `nullsFirst` is set (`COMPARISON_UNORDERED_FIRST`) and last otherwise
+    /// (`COMPARISON_UNORDERED_LAST`); two nulls compare equal.
+    private static long compareNullFields(boolean nullsFirst, boolean leftIsNull, boolean rightIsNull)
     {
-        if (isNull) {
-            throw new TrinoException(StandardErrorCode.NOT_SUPPORTED, "ROW comparison not supported for fields with null elements");
+        if (leftIsNull && rightIsNull) {
+            return 0;
         }
+        if (leftIsNull) {
+            return nullsFirst ? -1 : 1;
+        }
+        return nullsFirst ? 1 : -1;
+    }
+
+    private static List<OperatorMethodHandle> getLessThanOperatorInvokers(TypeOperators typeOperators, List<Field> fields, boolean orEqual)
+    {
+        boolean orderable = fields.stream().allMatch(field -> field.getType().isOrderable());
+        if (!orderable) {
+            return emptyList();
+        }
+
+        boolean neverFails = true;
+        List<MethodHandle> equalOperators = new ArrayList<>(fields.size());
+        List<MethodHandle> lessThanOperators = new ArrayList<>(fields.size());
+        for (Field field : fields) {
+            InvocationConvention fieldConvention = simpleConvention(NULLABLE_RETURN, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL);
+            // equality is total over all comparable types, so it never affects neverFails
+            equalOperators.add(typeOperators.getEqualOperator(field.getType(), fieldConvention));
+            OperatorMethodHandle fieldLessThan = typeOperators.getLessThanOperatorHandle(field.getType(), fieldConvention);
+            neverFails = neverFails && fieldLessThan.isNeverFails();
+            lessThanOperators.add(fieldLessThan.getMethodHandle());
+        }
+
+        // for large rows, use a generic loop with a megamorphic call site
+        if (fields.size() > MEGAMORPHIC_FIELD_COUNT) {
+            return singletonList(new OperatorMethodHandle(LESS_THAN_CONVENTION, insertArguments(LESS_THAN, 0, orEqual, equalOperators, lessThanOperators), neverFails));
+        }
+
+        // (SqlRow, SqlRow):int
+        MethodHandle lessThan = dropArguments(constant(int.class, LESS_THAN_FIELDS_EQUAL), 0, SqlRow.class, SqlRow.class);
+        for (int fieldId = 0; fieldId < fields.size(); fieldId++) {
+            // (SqlRow, SqlRow, int, MethodHandle, MethodHandle, SqlRow, SqlRow):int
+            lessThan = collectArguments(CHAIN_LESS_THAN, 0, lessThan);
+
+            // (SqlRow, SqlRow, SqlRow, SqlRow):int
+            lessThan = insertArguments(lessThan, 2, fieldId, equalOperators.get(fieldId), lessThanOperators.get(fieldId));
+
+            // (SqlRow, SqlRow):int
+            lessThan = permuteArguments(lessThan, methodType(int.class, SqlRow.class, SqlRow.class), 0, 1, 0, 1);
+        }
+        // (SqlRow, SqlRow):Boolean
+        MethodHandle lessThanResult = filterReturnValue(lessThan, insertArguments(LESS_THAN_RESULT, 0, orEqual));
+        return singletonList(new OperatorMethodHandle(LESS_THAN_CONVENTION, lessThanResult, neverFails));
+    }
+
+    private static Boolean megamorphicLessThanOperator(boolean orEqual, List<MethodHandle> equalOperators, List<MethodHandle> lessThanOperators, SqlRow leftRow, SqlRow rightRow)
+            throws Throwable
+    {
+        int leftRawIndex = leftRow.getRawIndex();
+        int rightRawIndex = rightRow.getRawIndex();
+
+        for (int fieldIndex = 0; fieldIndex < equalOperators.size(); fieldIndex++) {
+            Block leftFieldBlock = leftRow.getRawFieldBlock(fieldIndex);
+            Block rightFieldBlock = rightRow.getRawFieldBlock(fieldIndex);
+
+            if (leftFieldBlock.isNull(leftRawIndex) || rightFieldBlock.isNull(rightRawIndex)) {
+                // a null field is the deciding one, so the result is unknown
+                return null;
+            }
+
+            Boolean fieldEqual = (Boolean) equalOperators.get(fieldIndex).invoke(leftFieldBlock, leftRawIndex, rightFieldBlock, rightRawIndex);
+            if (fieldEqual == null) {
+                return null;
+            }
+            if (!fieldEqual) {
+                // the first unequal field decides the result, which is itself unknown if that field's comparison is
+                return (Boolean) lessThanOperators.get(fieldIndex).invoke(leftFieldBlock, leftRawIndex, rightFieldBlock, rightRawIndex);
+            }
+        }
+        // every field is equal
+        return orEqual ? TRUE : FALSE;
+    }
+
+    private static int chainLessThan(int previousFieldsState, int fieldIndex, MethodHandle fieldEqual, MethodHandle fieldLessThan, SqlRow leftRow, SqlRow rightRow)
+            throws Throwable
+    {
+        if (previousFieldsState != LESS_THAN_FIELDS_EQUAL) {
+            return previousFieldsState;
+        }
+
+        int leftRawIndex = leftRow.getRawIndex();
+        int rightRawIndex = rightRow.getRawIndex();
+        Block leftFieldBlock = leftRow.getRawFieldBlock(fieldIndex);
+        Block rightFieldBlock = rightRow.getRawFieldBlock(fieldIndex);
+
+        if (leftFieldBlock.isNull(leftRawIndex) || rightFieldBlock.isNull(rightRawIndex)) {
+            return LESS_THAN_FIELD_UNKNOWN;
+        }
+
+        Boolean fieldEqualResult = (Boolean) fieldEqual.invokeExact(leftFieldBlock, leftRawIndex, rightFieldBlock, rightRawIndex);
+        if (fieldEqualResult == null) {
+            return LESS_THAN_FIELD_UNKNOWN;
+        }
+        if (fieldEqualResult) {
+            return LESS_THAN_FIELDS_EQUAL;
+        }
+
+        Boolean fieldLessThanResult = (Boolean) fieldLessThan.invokeExact(leftFieldBlock, leftRawIndex, rightFieldBlock, rightRawIndex);
+        if (fieldLessThanResult == null) {
+            return LESS_THAN_FIELD_UNKNOWN;
+        }
+        return fieldLessThanResult ? LESS_THAN_FIELD_LESS : LESS_THAN_FIELD_GREATER;
+    }
+
+    private static Boolean lessThanResult(boolean orEqual, int fieldsState)
+    {
+        return switch (fieldsState) {
+            case LESS_THAN_FIELD_LESS -> TRUE;
+            case LESS_THAN_FIELD_GREATER -> FALSE;
+            case LESS_THAN_FIELD_UNKNOWN -> null;
+            // every field is equal: strict less-than is false, less-than-or-equal is true
+            case LESS_THAN_FIELDS_EQUAL -> orEqual ? TRUE : FALSE;
+            default -> throw new IllegalStateException("Unexpected less-than state: " + fieldsState);
+        };
     }
 }

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestRowType.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestRowType.java
@@ -59,9 +59,9 @@ final class TestRowType
                 .invokeExact(singleEmptyRow, 0, singleEmptyRow, 0)).isTrue();
         assertThat((boolean) typeOperators.getIdenticalOperator(emptyRowType, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL))
                 .invokeExact(singleEmptyRow, 0, singleEmptyRow, 0)).isTrue();
-        assertThat((boolean) typeOperators.getLessThanOperator(emptyRowType, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL))
+        assertThat((Boolean) typeOperators.getLessThanOperator(emptyRowType, simpleConvention(NULLABLE_RETURN, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL))
                 .invokeExact(singleEmptyRow, 0, singleEmptyRow, 0)).isFalse();
-        assertThat((boolean) typeOperators.getLessThanOrEqualOperator(emptyRowType, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL))
+        assertThat((Boolean) typeOperators.getLessThanOrEqualOperator(emptyRowType, simpleConvention(NULLABLE_RETURN, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL))
                 .invokeExact(singleEmptyRow, 0, singleEmptyRow, 0)).isTrue();
         assertThat((long) typeOperators.getComparisonUnorderedFirstOperator(emptyRowType, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL))
                 .invokeExact(singleEmptyRow, 0, singleEmptyRow, 0)).isZero();


### PR DESCRIPTION
## Description

Comparing `ROW` and `ARRAY` values that contain null **elements** previously failed at runtime with
`NOT_SUPPORTED` ("ROW/ARRAY comparison not supported for ... null elements"). This made `ORDER BY`,
`DISTINCT`, `GROUP BY`, set operations, `min`/`max`, and the `<` `<=` `>` `>=` / `BETWEEN` predicates
unusable on rows and arrays whose elements can be null — even though equality and
`IS [NOT] DISTINCT FROM` already worked.

This implements SQL-standard, null-aware comparison (matching PostgreSQL):

* **Ordering comparison** (`COMPARISON_UNORDERED_LAST/FIRST`, used by sort / group / `min` / `max`)
  becomes **total**: a null element sorts last for `UNORDERED_LAST` and first for `UNORDERED_FIRST`,
  and never throws.
* **Boolean comparison** (`<` `<=` `>` `>=`) follows **three-valued logic**: it returns `NULL` when a
  null element is the deciding one, mirroring how row/array equality already behaves. For example
  `ROW(1, NULL) < ROW(1, 2)` is `NULL`, while `ROW(1, NULL) < ROW(2, 5)` is `TRUE` (decided by the
  first field — the null is never examined). `>` / `>=` / `BETWEEN` canonicalize to `<` / `<=`.

`MAP` needs no change: it is not orderable, and its equality is already three-valued.

The work is split into self-contained commits:

1. **Fix megamorphic ROW comparison discarding unequal fields** — a pre-existing bug, independent of
   nulls: the comparison path for rows wider than 64 fields returned on the first *equal* field and
   discarded every non-zero result, so it always reported large rows as equal (silently breaking
   sort / group / `min` / `max`). The large-row test previously covered only equality.
2. **Allow type operators to declare nullable `LESS_THAN` / `LESS_THAN_OR_EQUAL`** — framework
   enabler, mirroring `EQUAL`. Additive; no behavior change on its own.
3. **Support ROW comparison with null fields**.
4. **Support ARRAY comparison with null elements**.
5. **Correct stale rationale** for the planner guard that still (for a different reason — three-valued
   self-equality) excludes null-containing structural values from `Domain` extraction.

## Release notes

(x) Release notes are required, with the following suggested text:

```
# General
* Allow comparing and ordering `ROW` and `ARRAY` values that contain null elements, for example in
  `ORDER BY`, `DISTINCT`, `min`, `max`, and `<` / `>` comparisons. Previously these failed with
  "comparison not supported for ... null elements". ({issue}`29891`)
* Fix incorrect ordering, grouping, and aggregation of `ROW` values with more than 64 fields.
```
