### PR TITLE
Use getAccessControl to detect Azure HNS

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
@@ -26,7 +26,6 @@ import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.models.UserDelegationKey;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
-import com.azure.storage.blob.specialized.BlockBlobClient;
 import com.azure.storage.common.sas.SasProtocol;
 import com.azure.storage.file.datalake.DataLakeDirectoryClient;
 import com.azure.storage.file.datalake.DataLakeFileClient;
@@ -38,6 +37,7 @@ import com.azure.storage.file.datalake.models.DataLakeStorageException;
 import com.azure.storage.file.datalake.models.ListPathsOptions;
 import com.azure.storage.file.datalake.models.PathItem;
 import com.azure.storage.file.datalake.options.DataLakePathDeleteOptions;
+import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
@@ -650,10 +650,24 @@ public class AzureFileSystem
             throws IOException
     {
         try {
-            BlockBlobClient blockBlobClient = createBlobContainerClient(location, Optional.empty())
-                    .getBlobClient("/")
-                    .getBlockBlobClient();
-            return blockBlobClient.exists();
+            // Normalize consecutive slashes: the Azure DataLake getAccessControl API returns HTTP 400
+            // for paths containing "//", while other APIs like listPaths silently canonicalize them
+            String canonicalPath = CharMatcher.is('/').collapseFrom(
+                    CharMatcher.is('/').trimTrailingFrom(location.path()), '/');
+            DataLakeFileSystemClient fileSystemClient = createFileSystemClient(location, Optional.empty());
+            fileSystemClient.getDirectoryClient(canonicalPath).getAccessControl();
+            return true;
+        }
+        catch (DataLakeStorageException e) {
+            // getAccessControl() is only supported on HNS-enabled accounts; flat namespace returns HierarchicalNamespaceNotEnabled
+            if ("HierarchicalNamespaceNotEnabled".equals(e.getErrorCode())) {
+                return false;
+            }
+            // Path does not exist yet (e.g. creating a new nested directory), but the account supports HNS
+            if (e.getStatusCode() == 404) {
+                return true;
+            }
+            throw new IOException("Checking whether hierarchical namespace is enabled for the location %s failed".formatted(location), e);
         }
         catch (RuntimeException e) {
             throw new IOException("Checking whether hierarchical namespace is enabled for the location %s failed".formatted(location), e);
@@ -703,8 +717,11 @@ public class AzureFileSystem
         azureAuth.setAuth(location.account(), builder);
         DataLakeServiceClient client = builder.buildClient();
         DataLakeFileSystemClient fileSystemClient = client.getFileSystemClient(location.container().orElseThrow());
-        if (!fileSystemClient.exists()) {
-            throw new IllegalArgumentException();
+        // SAS tokens are scoped to an existing container; directory-scoped tokens cannot perform container-level operations
+        if (!(azureAuth instanceof AzureAuthSasToken)) {
+            if (!fileSystemClient.exists()) {
+                throw new IllegalArgumentException();
+            }
         }
         return fileSystemClient;
     }


### PR DESCRIPTION
The previous approach checked universally for the existence of a "/" blob via the Blob Storage API, which fails with vended credentials scoped to a subtree.

Make use of `getAccessControl()` call on the DataLake API, which returns `HierarchicalNamespaceNotEnabled` error code on flat namespace accounts and either succeeds or returns 404 on HNS-enabled accounts.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

https://github.com/trinodb/trino/pull/29947


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
