### PR TITLE
Store authenticated OAuth2 access token in session extra credentials

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContextFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContextFactory.java
@@ -60,6 +60,7 @@ import static com.google.common.net.HttpHeaders.USER_AGENT;
 import static io.trino.client.ProtocolHeaders.detectProtocol;
 import static io.trino.server.ServletSecurityUtils.authenticatedIdentity;
 import static io.trino.spi.security.AccessDeniedException.denySetRole;
+import static io.trino.spi.security.ExtraCredentials.isInternalExtraCredential;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.ENGLISH;
@@ -259,11 +260,15 @@ public class HttpRequestSessionContextFactory
         if (systemRole.getType() == Type.ROLE) {
             systemEnabledRoles.add(systemRole.getRole().orElseThrow());
         }
+        // Authenticated credentials (placed by the server-side authenticator under internal$*
+        // keys) take precedence over client-supplied credentials with the same name.
+        Map<String, String> extraCredentials = new HashMap<>(parseExtraCredentials(protocolHeaders, headers));
+        authenticatedIdentity.map(Identity::getExtraCredentials).ifPresent(extraCredentials::putAll);
         Identity newIdentity = authenticatedIdentity
                 .map(identity -> Identity.from(identity).withUser(user))
                 .orElseGet(() -> Identity.forUser(user))
                 .withAdditionalConnectorRoles(parseConnectorRoleHeaders(protocolHeaders, headers))
-                .withAdditionalExtraCredentials(parseExtraCredentials(protocolHeaders, headers))
+                .withExtraCredentials(extraCredentials)
                 .withAdditionalGroups(groupProvider.getGroups(user))
                 .withEnabledRoles(systemEnabledRoles.build())
                 .build();
@@ -343,7 +348,7 @@ public class HttpRequestSessionContextFactory
     {
         Map<String, String> credentials = parseProperty(headers, protocolHeaders.requestExtraCredential());
         for (String name : credentials.keySet()) {
-            assertRequest(!name.startsWith("internal$"), "Invalid extra credential name: %s", name);
+            assertRequest(!isInternalExtraCredential(name), "Invalid extra credential name");
         }
         return credentials;
     }

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -18,6 +18,7 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.net.MediaType;
@@ -126,6 +127,7 @@ import static io.trino.server.remotetask.RequestErrorTracker.logError;
 import static io.trino.spi.HostAddress.fromUri;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.REMOTE_TASK_ERROR;
+import static io.trino.spi.security.ExtraCredentials.isInternalExtraCredential;
 import static io.trino.util.Failures.toFailure;
 import static java.lang.Math.addExact;
 import static java.lang.Math.clamp;
@@ -142,6 +144,7 @@ public final class HttpRemoteTask
     private final TaskId taskId;
 
     private final Session session;
+    private final Map<String, String> workerExtraCredentials;
     private final Span stageSpan;
     private final String nodeId;
     private final AtomicBoolean speculative;
@@ -266,6 +269,7 @@ public final class HttpRemoteTask
         try (SetThreadName _ = new SetThreadName("HttpRemoteTask-" + taskId)) {
             this.taskId = taskId;
             this.session = session;
+            this.workerExtraCredentials = extraCredentialsForWorker(session.getIdentity().getExtraCredentials());
             this.stageSpan = stageSpan;
             this.nodeId = node.getNodeIdentifier();
             this.speculative = new AtomicBoolean(speculative);
@@ -777,7 +781,7 @@ public final class HttpRemoteTask
         Optional<PlanFragment> fragment = sendPlan.get() ? Optional.of(planFragment.withoutEmbeddedJsonRepresentation()) : Optional.empty();
         TaskUpdateRequest updateRequest = new TaskUpdateRequest(
                 session.toSessionRepresentation(),
-                session.getIdentity().getExtraCredentials(),
+                workerExtraCredentials,
                 stageSpan,
                 fragment,
                 tableCredentials,
@@ -818,6 +822,11 @@ public final class HttpRemoteTask
                 future,
                 new SimpleHttpResponseHandler<>(new UpdateResponseHandler(splitAssignments, dynamicFilterDomains.getVersion(), System.nanoTime(), currentPendingRequestsCounter), request.getUri(), stats),
                 executor);
+    }
+
+    private static Map<String, String> extraCredentialsForWorker(Map<String, String> extraCredentials)
+    {
+        return ImmutableMap.copyOf(Maps.filterKeys(extraCredentials, key -> !isInternalExtraCredential(key)));
     }
 
     private synchronized List<SplitAssignment> getSplitAssignments(int currentSplitBatchSize)

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
@@ -13,6 +13,7 @@
  */
 package io.trino.server.security.oauth2;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.trino.server.security.AbstractBearerAuthenticator;
@@ -34,6 +35,7 @@ import java.util.UUID;
 import static io.trino.server.security.UserMapping.createUserMapping;
 import static io.trino.server.security.oauth2.OAuth2TokenExchangeResource.getInitiateUri;
 import static io.trino.server.security.oauth2.OAuth2TokenExchangeResource.getTokenUri;
+import static io.trino.spi.security.ExtraCredentials.authenticatedExtraCredentialName;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -46,14 +48,17 @@ public class OAuth2Authenticator
     private final UserMapping userMapping;
     private final TokenPairSerializer tokenPairSerializer;
     private final TokenRefresher tokenRefresher;
+    private final Optional<String> accessTokenExtraCredentialName;
 
     @Inject
     public OAuth2Authenticator(OAuth2Client client, OAuth2Config config, TokenRefresher tokenRefresher, TokenPairSerializer tokenPairSerializer)
     {
+        requireNonNull(config, "config is null");
         this.client = requireNonNull(client, "service is null");
         this.principalField = config.getPrincipalField();
         this.tokenRefresher = requireNonNull(tokenRefresher, "tokenRefresher is null");
         this.tokenPairSerializer = requireNonNull(tokenPairSerializer, "tokenPairSerializer is null");
+        this.accessTokenExtraCredentialName = config.getAccessTokenExtraCredentialName();
         userMapping = createUserMapping(config.getUserMappingPattern(), config.getUserMappingFile());
     }
 
@@ -80,6 +85,9 @@ public class OAuth2Authenticator
         }
         Identity.Builder builder = Identity.forUser(userMapping.mapUser(principal.get()));
         builder.withPrincipal(new BasicPrincipal(principal.get()));
+        accessTokenExtraCredentialName.ifPresent(name -> builder.withAdditionalExtraCredentials(ImmutableMap.of(
+                name, tokenPair.accessToken(),
+                authenticatedExtraCredentialName(name), tokenPair.accessToken())));
         return Optional.of(builder.build());
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Config.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Config.java
@@ -22,6 +22,7 @@ import io.airlift.configuration.LegacyConfig;
 import io.airlift.configuration.validation.FileExists;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 
 import java.io.File;
@@ -31,7 +32,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.base.Strings.emptyToNull;
 import static io.trino.server.security.oauth2.OAuth2Service.OPENID_SCOPE;
+import static io.trino.spi.security.ExtraCredentials.isInternalExtraCredential;
 
 public class OAuth2Config
 {
@@ -47,6 +50,7 @@ public class OAuth2Config
     private Optional<String> jwtType = Optional.empty();
     private Optional<String> userMappingPattern = Optional.empty();
     private Optional<File> userMappingFile = Optional.empty();
+    private Optional<String> accessTokenExtraCredentialName = Optional.empty();
     private boolean enableRefreshTokens;
     private boolean enableDiscovery = true;
 
@@ -216,6 +220,36 @@ public class OAuth2Config
     {
         this.userMappingFile = Optional.ofNullable(userMappingFile);
         return this;
+    }
+
+    public Optional<String> getAccessTokenExtraCredentialName()
+    {
+        return accessTokenExtraCredentialName;
+    }
+
+    @Config("http-server.authentication.oauth2.access-token-extra-credential-name")
+    @ConfigDescription("Extra credential name for storing the authenticated OAuth2 access token")
+    public OAuth2Config setAccessTokenExtraCredentialName(String accessTokenExtraCredentialName)
+    {
+        this.accessTokenExtraCredentialName = Optional.ofNullable(emptyToNull(accessTokenExtraCredentialName));
+        return this;
+    }
+
+    @AssertTrue(message = "OAuth2 access token extra credential name must not start with internal$")
+    public boolean isAccessTokenExtraCredentialNameNotInternal()
+    {
+        return accessTokenExtraCredentialName
+                .map(name -> !isInternalExtraCredential(name))
+                .orElse(true);
+    }
+
+    @AssertTrue(message = "OAuth2 access token extra credential name must not contain whitespace, comma, or equals")
+    public boolean isAccessTokenExtraCredentialNameValid()
+    {
+        return accessTokenExtraCredentialName
+                .map(name -> name.chars().noneMatch(character ->
+                        Character.isWhitespace(character) || character == ',' || character == '='))
+                .orElse(true);
     }
 
     public boolean isEnableRefreshTokens()

--- a/core/trino-main/src/test/java/io/trino/server/TestHttpRequestSessionContextFactory.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestHttpRequestSessionContextFactory.java
@@ -107,6 +107,28 @@ public class TestHttpRequestSessionContextFactory
     }
 
     @Test
+    public void testAuthenticatedExtraCredentialsOverrideRequestExtraCredentials()
+    {
+        MultivaluedMap<String, String> headers = new GuavaMultivaluedMap<>(ImmutableListMultimap.<String, String>builder()
+                .put(TRINO_HEADERS.requestUser(), "testUser")
+                .put(TRINO_HEADERS.requestExtraCredential(), "token=request-token")
+                .put(TRINO_HEADERS.requestExtraCredential(), "request-only=request-value")
+                .build());
+
+        SessionContext context = sessionContextFactory(TRINO_HEADERS).createSessionContext(
+                headers,
+                Optional.of("testRemote"),
+                Optional.of(Identity.forUser("testUser")
+                        .withExtraCredentials(ImmutableMap.of("token", "authenticated-token", "authenticated-only", "authenticated-value"))
+                        .build()));
+
+        assertThat(context.getIdentity().getExtraCredentials()).isEqualTo(ImmutableMap.of(
+                "token", "authenticated-token",
+                "request-only", "request-value",
+                "authenticated-only", "authenticated-value"));
+    }
+
+    @Test
     public void testMappedUser()
     {
         assertMappedUser(TRINO_HEADERS);
@@ -186,7 +208,7 @@ public class TestHttpRequestSessionContextFactory
                 .build());
 
         assertInvalidSession(TRINO_HEADERS, headers)
-                .hasMessage("Invalid extra credential name: internal$abc");
+                .hasMessage("Invalid extra credential name");
     }
 
     private static AbstractThrowableAssert<?, ? extends Throwable> assertInvalidSession(ProtocolHeaders protocolHeaders, MultivaluedMap<String, String> headers)

--- a/core/trino-main/src/test/java/io/trino/server/remotetask/TestHttpRemoteTask.java
+++ b/core/trino-main/src/test/java/io/trino/server/remotetask/TestHttpRemoteTask.java
@@ -71,6 +71,7 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.security.Identity;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeDescriptor;
 import io.trino.spi.type.TypeManager;
@@ -139,6 +140,7 @@ import static io.trino.server.InternalHeaders.TRINO_CURRENT_VERSION;
 import static io.trino.server.InternalHeaders.TRINO_MAX_WAIT;
 import static io.trino.spi.StandardErrorCode.REMOTE_TASK_ERROR;
 import static io.trino.spi.StandardErrorCode.REMOTE_TASK_MISMATCH;
+import static io.trino.spi.security.ExtraCredentials.authenticatedExtraCredentialName;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
@@ -216,6 +218,38 @@ public class TestHttpRemoteTask
         remoteTask.cancel();
         poll(() -> remoteTask.getTaskStatus().state().isDone());
         poll(() -> remoteTask.getTaskInfo().taskStatus().state().isDone());
+
+        httpRemoteTaskFactory.stop();
+    }
+
+    @Test
+    @Timeout(30)
+    public void testInternalExtraCredentialsAreNotSentToWorkers()
+            throws Exception
+    {
+        AtomicLong lastActivityNanos = new AtomicLong(System.nanoTime());
+        TestingTaskResource testingTaskResource = new TestingTaskResource(lastActivityNanos, FailureScenario.NO_FAILURE);
+        HttpRemoteTaskFactory httpRemoteTaskFactory = createHttpRemoteTaskFactory(testingTaskResource);
+        Session session = Session.builder(TEST_SESSION)
+                .setIdentity(Identity.forUser(TEST_SESSION.getUser())
+                        .withExtraCredentials(ImmutableMap.of(
+                                "token", "access-token",
+                                authenticatedExtraCredentialName("token"), "access-token"))
+                        .build())
+                .build();
+        RemoteTask remoteTask = createRemoteTask(httpRemoteTaskFactory, ImmutableSet.of(), session);
+
+        testingTaskResource.setInitialTaskInfo(remoteTask.getTaskInfo());
+        remoteTask.start();
+        remoteTask.addSplits(ImmutableMultimap.of(TABLE_SCAN_NODE_ID, new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit())));
+
+        poll(() -> testingTaskResource.getLatestExtraCredentials().containsKey("token"));
+        assertThat(testingTaskResource.getLatestExtraCredentials())
+                .containsEntry("token", "access-token")
+                .doesNotContainKey(authenticatedExtraCredentialName("token"));
+
+        remoteTask.cancel();
+        poll(() -> remoteTask.getTaskStatus().state().isDone());
 
         httpRemoteTaskFactory.stop();
     }
@@ -781,6 +815,7 @@ public class TestHttpRemoteTask
         private TaskState taskState;
         private long taskInstanceId = INITIAL_TASK_INSTANCE_ID;
         private Map<DynamicFilterId, Domain> latestDynamicFilterFromCoordinator = ImmutableMap.of();
+        private Map<String, String> latestExtraCredentials = ImmutableMap.of();
 
         private long statusFetchCounter;
         private long createOrUpdateCounter;
@@ -830,6 +865,7 @@ public class TestHttpRemoteTask
                 dynamicFiltersSentCounter++;
                 latestDynamicFilterFromCoordinator = taskUpdateRequest.dynamicFilterDomains();
             }
+            latestExtraCredentials = taskUpdateRequest.extraCredentials();
             createOrUpdateCounter++;
             lastActivityNanos.set(System.nanoTime());
             return buildTaskInfo();
@@ -942,6 +978,11 @@ public class TestHttpRemoteTask
         public synchronized long getCreateOrUpdateCounter()
         {
             return createOrUpdateCounter;
+        }
+
+        public synchronized Map<String, String> getLatestExtraCredentials()
+        {
+            return latestExtraCredentials;
         }
 
         public synchronized long getDynamicFiltersFetchCounter()

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -36,6 +36,7 @@ import io.trino.server.ProtocolConfig;
 import io.trino.server.protocol.PreparedStatementEncoder;
 import io.trino.server.protocol.spooling.QueryDataEncoder;
 import io.trino.server.security.oauth2.ChallengeFailedException;
+import io.trino.server.security.oauth2.OAuth2Authenticator;
 import io.trino.server.security.oauth2.OAuth2Client;
 import io.trino.server.security.oauth2.TokenPairSerializer;
 import io.trino.server.security.oauth2.TokenPairSerializer.TokenPair;
@@ -106,6 +107,7 @@ import static io.trino.server.ui.OAuthIdTokenCookie.ID_TOKEN_COOKIE;
 import static io.trino.server.ui.OAuthWebUiCookie.OAUTH2_COOKIE;
 import static io.trino.spi.security.AccessDeniedException.denyImpersonateUser;
 import static io.trino.spi.security.AccessDeniedException.denyReadSystemInformationAccess;
+import static io.trino.spi.security.ExtraCredentials.authenticatedExtraCredentialName;
 import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static jakarta.servlet.http.HttpServletResponse.SC_SEE_OTHER;
@@ -630,6 +632,57 @@ public class TestResourceSecurity
         verifyOAuth2Authenticator(true, false, Optional.of("custom-principal"));
         verifyOAuth2Authenticator(false, false, Optional.of("custom-principal"));
         verifyOAuth2Authenticator(false, true, Optional.empty());
+    }
+
+    @Test
+    public void testOAuth2AccessTokenExtraCredential()
+            throws Exception
+    {
+        assertOAuth2AccessTokenExtraCredential("token");
+        assertOAuth2AccessTokenExtraCredential("credential");
+    }
+
+    private void assertOAuth2AccessTokenExtraCredential(String credentialName)
+            throws Exception
+    {
+        CookieManager cookieManager = new CookieManager();
+        OkHttpClient client = this.client.newBuilder()
+                .cookieJar(new JavaNetCookieJar(cookieManager))
+                .build();
+
+        try (TokenServer tokenServer = new TokenServer(Optional.empty());
+                TestingTrinoServer server = TestingTrinoServer.builder()
+                        .setProperties(ImmutableMap.<String, String>builder()
+                                .putAll(SECURE_PROPERTIES)
+                                .put("web-ui.enabled", "false")
+                                .put("http-server.authentication.type", "oauth2")
+                                .putAll(getOAuth2Properties(tokenServer))
+                                .put("http-server.authentication.oauth2.access-token-extra-credential-name", credentialName)
+                                .buildOrThrow())
+                        .setAdditionalModule(oauth2Module(tokenServer))
+                        .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
+                        .build()) {
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+            URI baseUri = httpServerInfo.getHttpsUri();
+
+            OAuthBearer bearer = assertAuthenticateOAuth2Bearer(client, getAuthorizedUserLocation(baseUri), "http://example.com/authorize");
+            assertOk(
+                    client,
+                    uriBuilderFrom(baseUri)
+                            .replacePath("/oauth2/callback/")
+                            .addParameter("code", "TEST_CODE")
+                            .addParameter("state", bearer.state())
+                            .toString());
+
+            String oauthToken = getOauthToken(client, bearer.tokenServer());
+            List<Authenticator> authenticators = server.getInstance(new Key<>() {});
+            assertThat(authenticators).hasSize(1);
+            assertThat(authenticators.get(0)).isInstanceOf(OAuth2Authenticator.class);
+            Identity identity = ((OAuth2Authenticator) authenticators.get(0)).authenticate(null, oauthToken);
+            assertThat(identity.getExtraCredentials())
+                    .containsEntry(credentialName, tokenServer.getAccessToken())
+                    .containsEntry(authenticatedExtraCredentialName(credentialName), tokenServer.getAccessToken());
+        }
     }
 
     private void verifyOAuth2Authenticator(boolean webUiEnabled, boolean refreshTokensEnabled, Optional<String> principalField)

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2Config.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2Config.java
@@ -16,6 +16,7 @@ package io.trino.server.security.oauth2;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
+import jakarta.validation.constraints.AssertTrue;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -28,6 +29,7 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -49,6 +51,7 @@ public class TestOAuth2Config
                 .setJwtType(null)
                 .setUserMappingPattern(null)
                 .setUserMappingFile(null)
+                .setAccessTokenExtraCredentialName(null)
                 .setEnableRefreshTokens(false)
                 .setEnableDiscovery(true));
     }
@@ -71,6 +74,7 @@ public class TestOAuth2Config
                 .put("http-server.authentication.oauth2.jwt-type", "at+jwt")
                 .put("http-server.authentication.oauth2.user-mapping.pattern", "(.*)@something")
                 .put("http-server.authentication.oauth2.user-mapping.file", userMappingFile.toString())
+                .put("http-server.authentication.oauth2.access-token-extra-credential-name", "token")
                 .put("http-server.authentication.oauth2.refresh-tokens", "true")
                 .put("http-server.authentication.oauth2.oidc.discovery", "false")
                 .buildOrThrow();
@@ -88,9 +92,26 @@ public class TestOAuth2Config
                 .setJwtType("at+jwt")
                 .setUserMappingPattern("(.*)@something")
                 .setUserMappingFile(userMappingFile.toFile())
+                .setAccessTokenExtraCredentialName("token")
                 .setEnableRefreshTokens(true)
                 .setEnableDiscovery(false);
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testInvalidAccessTokenExtraCredentialName()
+    {
+        assertFailsValidation(
+                new OAuth2Config().setAccessTokenExtraCredentialName("internal$token"),
+                "accessTokenExtraCredentialNameNotInternal",
+                "OAuth2 access token extra credential name must not start with internal$",
+                AssertTrue.class);
+
+        assertFailsValidation(
+                new OAuth2Config().setAccessTokenExtraCredentialName("bad token"),
+                "accessTokenExtraCredentialNameValid",
+                "OAuth2 access token extra credential name must not contain whitespace, comma, or equals",
+                AssertTrue.class);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/security/ExtraCredentials.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/ExtraCredentials.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ExtraCredentials
+{
+    private static final String INTERNAL_EXTRA_CREDENTIAL_PREFIX = "internal$";
+    private static final String AUTHENTICATED_EXTRA_CREDENTIAL_PREFIX = INTERNAL_EXTRA_CREDENTIAL_PREFIX + "authenticated:";
+
+    private ExtraCredentials() {}
+
+    public static boolean isInternalExtraCredential(String name)
+    {
+        return requireNonNull(name, "name is null").startsWith(INTERNAL_EXTRA_CREDENTIAL_PREFIX);
+    }
+
+    public static String authenticatedExtraCredentialName(String name)
+    {
+        return AUTHENTICATED_EXTRA_CREDENTIAL_PREFIX + requireNonNull(name, "name is null");
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/Identity.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/Identity.java
@@ -160,7 +160,7 @@ public class Identity
         }
         // Do not print any internal credential keys
         List<String> filteredCredentials = extraCredentials.keySet().stream()
-                .filter(key -> !key.contains("$internal"))
+                .filter(key -> !ExtraCredentials.isInternalExtraCredential(key))
                 .collect(toCollection(ArrayList::new));
         if (filteredCredentials.size() != extraCredentials.size()) {
             filteredCredentials.add("...");

--- a/core/trino-spi/src/test/java/io/trino/spi/security/TestIdentity.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/security/TestIdentity.java
@@ -80,4 +80,20 @@ class TestIdentity
         assertThat(otherIdentity.hashCode())
                 .isEqualTo(TEST_IDENTITY.hashCode());
     }
+
+    @Test
+    public void testToStringHidesInternalExtraCredentials()
+    {
+        Identity identity = Identity.forUser("user")
+                .withExtraCredentials(ImmutableMap.of(
+                        "token", "credential",
+                        ExtraCredentials.authenticatedExtraCredentialName("token"), "credential"))
+                .build();
+
+        assertThat(identity.toString())
+                .contains("token")
+                .contains("...")
+                .doesNotContain(ExtraCredentials.authenticatedExtraCredentialName("token"))
+                .doesNotContain("credential");
+    }
 }

--- a/docs/src/main/sphinx/security/oauth2.md
+++ b/docs/src/main/sphinx/security/oauth2.md
@@ -151,6 +151,11 @@ The following configuration properties are available:
   - The field of the access token used for the Trino user principal. Defaults to
     `sub`. Other commonly used fields include `sAMAccountName`, `name`,
     `upn`, and `email`.
+* - `http-server.authentication.oauth2.access-token-extra-credential-name`
+  - Extra credential name used to store the authenticated OAuth2 access token
+    in the session `Identity`. The value must not use the reserved `internal$`
+    prefix, and must not contain whitespace, commas, or equals signs. Disabled
+    by default.
 * - `http-server.authentication.oauth2.oidc.discovery`
   - Enable reading the [OIDC provider metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata).
     Default is `true`.
@@ -168,6 +173,36 @@ The following configuration properties are available:
     browser is redirected to so that End-User is logged out from the
     authentication server when logging out from Trino.
 :::
+
+### Access token extra credential
+
+
+Some connectors can use an end-user OAuth2 access token when they communicate
+with downstream services. This supports deployments where the downstream service
+authorizes the user token directly, or uses it as input to a token exchange
+flow. Trino stores and forwards the authenticated access token; it does not
+perform token exchange itself. Set
+`http-server.authentication.oauth2.access-token-extra-credential-name` to add
+the authenticated OAuth2 access token to the session `Identity` extra
+credentials using the configured name. Use `token` when a connector forwards
+the access token directly. Use `credential` when a connector uses the token as
+input to a token exchange flow:
+
+```properties
+http-server.authentication.oauth2.access-token-extra-credential-name=token
+```
+
+```properties
+http-server.authentication.oauth2.access-token-extra-credential-name=credential
+```
+
+Only enable this for deployments where the configured connectors are trusted to
+receive the user's OAuth2 access token. If a client also supplies an extra
+credential with the same name, the authenticated OAuth2 token takes precedence.
+
+Connectors can retrieve the token from extra credentials using the
+``internal$authenticated:`` prefix via the
+``ExtraCredentials.authenticatedExtraCredentialName()`` SPI utility.
 
 (trino-oauth2-refresh-tokens)=
 ### Refresh tokens


### PR DESCRIPTION
## Description

Add an optional OAuth2 authenticator setting that stores the authenticated access token in session extra credentials, making it available to connectors for per-user authorization flows (e.g., token forwarding or token exchange against downstream catalogs).

New coordinator property:

```properties
http-server.authentication.oauth2.access-token-extra-credential-name
```

When set, the OAuth2 authenticator stores the access token under both the configured name and a tamper-proof `internal$authenticated:<name>` key in `Identity.extraCredentials`. Connectors read the authenticated key to distinguish server-placed credentials from client-supplied ones.

### Security model

- **New SPI utility** (`ExtraCredentials`): formalizes the `internal$` prefix convention for server-placed credentials. Clients submitting `internal$`-prefixed extra credentials are rejected at the coordinator.
- **Authenticated credential precedence**: if a client also submits an extra credential with the same name, the server-authenticated value wins.
- **Worker credential stripping**: `internal$`-prefixed credentials are filtered from `TaskUpdateRequest` so they never leave the coordinator.
- **Hidden from logging**: `internal$`-prefixed credentials are excluded from `Identity.toString()`.

### Not a breaking change

The new setting is unset by default. Existing OAuth2 authentication configurations behave as before.

## Additional context and related issues

This PR splits [https://github.com/trinodb/trino/pull/29758](https://github.com/trinodb/trino/pull/29758) into 2. It provides the generic server-side credential mechanism.


Once this PR is merged, [https://github.com/trinodb/trino/pull/29758](https://github.com/trinodb/trino/pull/29758) will be modified to only add the Iceberg REST catalog consumer that uses these authenticated credentials for per-user catalog sessions.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Security
* Add `access-token-extra-credential-name` OAuth2 setting to store the authenticated token in session extra credentials for connector use. ({issue}`issuenumber`)
```