### PR TITLE
Protect against empty where clauses

### DIFF
--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraRecordSetProvider.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraRecordSetProvider.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.cassandra;
 
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.querybuilder.select.Select;
 import com.google.inject.Inject;
 import io.trino.plugin.cassandra.util.CassandraCqlUtils;
 import io.trino.spi.connector.ColumnHandle;
@@ -59,13 +60,16 @@ public class CassandraRecordSetProvider
                     SimpleStatement.newInstance(queryRelationHandle.getQuery()),
                     cassandraColumns);
         }
+
+        String where = cassandraSplit.getWhereClause();
+        Select select = CassandraCqlUtils.selectFrom(cassandraTable.getRequiredNamedRelation(), cassandraColumns);
+        if (!where.isBlank()) {
+            select = select.whereRaw(where);
+        }
         return new CassandraRecordSet(
                 cassandraSession,
                 cassandraTypeManager,
-                CassandraCqlUtils.selectFrom(cassandraTable.getRequiredNamedRelation(), cassandraColumns)
-                        .whereRaw(cassandraSplit.getWhereClause())
-                        .build()
-                        .setIdempotent(true),
+                select.build().setIdempotent(true),
                 cassandraColumns);
     }
 }

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnector.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnector.java
@@ -37,6 +37,7 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.DynamicFilterSnapshot;
 import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.connector.RecordSet;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
@@ -89,6 +90,7 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
@@ -180,6 +182,38 @@ public class TestCassandraConnector
         assertThat(metadata.getTableHandle(SESSION, new SchemaTableName("totally_invalid_database_name", "dual"), Optional.empty(), Optional.empty())).isNull();
         assertThat(metadata.listTables(SESSION, Optional.of("totally_invalid_database_name"))).isEqualTo(ImmutableList.of());
         assertThat(metadata.streamRelationColumns(SESSION, Optional.of("totally_invalid_database_name"), names -> names).hasNext()).isEqualTo(false);
+    }
+
+    @Test
+    public void testGetRecordsEmptyWhereClause()
+    {
+        ConnectorTransactionHandle transaction = CassandraTransactionHandle.INSTANCE;
+        ConnectorTableHandle tableHandle = getTableHandle(table);
+        List<ConnectorSplit> splits = getAllSplits(splitManager.getSplits(
+                transaction,
+                SESSION,
+                tableHandle,
+                ImmutableSet.of(),
+                Constraint.alwaysTrue()));
+        CassandraSplit cassandraSplit = assertThat(splits)
+                .singleElement()
+                .asInstanceOf(type(CassandraSplit.class)).actual();
+        assertThat(cassandraSplit.partitionId()).isEqualTo(CassandraPartition.UNPARTITIONED_ID);
+        CassandraSplit syntheticSplit = new CassandraSplit(
+                CassandraPartition.UNPARTITIONED_ID,
+                null,
+                cassandraSplit.addresses());
+        RecordSet recordSet = recordSetProvider.getRecordSet(
+                transaction,
+                SESSION,
+                syntheticSplit,
+                tableHandle,
+                ImmutableList.copyOf(metadata.getColumnHandles(SESSION, tableHandle).values()));
+        try (RecordCursor cursor = recordSet.cursor()) {
+            while (cursor.advanceNextPosition()) {
+                // Consume the cursor to ensure CQL works.
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

An LLM caught this error in review. If `getWhereClause` comes back blank ([which it has code to](https://github.com/trinodb/trino/blob/7358100281fd420b2a848be939d96869968d006b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplit.java#L61)) then we use `whereRaw` with an empty string.

This creates CQL that has a floating "WHERE" clause. It errors like this (replace `whereRaw([...])` with `whereRaw("")`)
```
Caused by:
com.datastax.oss.driver.api.core.servererrors.SyntaxError:
line 0:-1 no viable alternative at input '<EOF>'
  at com.datastax.oss.driver.api.core.servererrors.SyntaxError.copy(SyntaxError.java:48)
```

That same LLM that found the error couldn't find a reproducing case. There were a few code branches and I couldn't find it either. So this change likely doesn't fix a real production scenario, (wasn't exercised by any of our tests) but protects us in the future.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Small follow-up to a [this change](https://github.com/trinodb/trino/pull/29960) I got merged recently. Apologies for the messiness.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* N.A
```
