### PR TITLE
Disallow wildcard imports with error-prone

### DIFF
--- a/.mvn/errorprone.config
+++ b/.mvn/errorprone.config
@@ -116,3 +116,4 @@
 -Xep:UnusedMethod:OFF
 -Xep:UnusedVariable:ERROR
 -Xep:UseEnumSwitch:ERROR
+-Xep:WildcardImport:ERROR


### PR DESCRIPTION
Currently, checkstyle (we don't use `AvoidStarImport`) and airstyle do not forbid such imports, but they should be disallowed nonetheless.

If we merge the following, this PR is not needed, but doesn't harm anyway
- https://github.com/airlift/airbase/pull/1271 