### PR TITLE
Skip already-terminating tasks when failing abandoned tasks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -678,7 +678,7 @@ public class SqlTaskManager
             TaskId taskId = sqlTask.getTaskId();
             try {
                 TaskState taskState = sqlTask.getTaskState();
-                if (taskState.isDone()) {
+                if (taskState.isTerminatingOrDone()) {
                     continue;
                 }
                 Instant lastHeartbeat = sqlTask.lastHeartbeat();


### PR DESCRIPTION
## Description

`SqlTaskManager.failAbandonedTasks()` runs every 200ms and skips tasks only when `taskState.isDone()`. A task whose abort never completes stays in a terminating-but-not-done state (`FAILING`/`ABORTING`/`CANCELING`) indefinitely, so it is re-selected on every tick: re-logged as `Failing abandoned task ...` and re-failed via `SqlTask.failed(...)`, which appends to the task's failure cause list on each call. Over hours this produces a steady log flood and unbounded growth of the per-task failure causes.

This was observed on a worker where SQL Server source tasks hung in an uninterruptible socket read and never reached a terminal state, keeping the worker from completing graceful shutdown.

The guard now uses the existing `isTerminatingOrDone()` predicate, so a task already terminating is left alone.

## Additional context and related issues

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.