### PR TITLE
Mark comparison operators as infallible

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedFirstOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedFirstOperator.java
@@ -23,9 +23,6 @@ import io.trino.spi.type.TypeOperators;
 
 import java.lang.invoke.MethodHandle;
 
-import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
-import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_FIRST;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TypeTemplates.typeVariable;
@@ -45,7 +42,7 @@ public class GenericComparisonUnorderedFirstOperator
                         .argumentType(typeVariable("T"))
                         .argumentType(typeVariable("T"))
                         .build())
-                .neverFails(boundSignature -> typeOperators.getComparisonUnorderedFirstOperatorHandle(boundSignature.getArgumentType(0), simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL)).isNeverFails())
+                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedLastOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericComparisonUnorderedLastOperator.java
@@ -23,9 +23,6 @@ import io.trino.spi.type.TypeOperators;
 
 import java.lang.invoke.MethodHandle;
 
-import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
-import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TypeTemplates.typeVariable;
@@ -45,7 +42,7 @@ public class GenericComparisonUnorderedLastOperator
                         .argumentType(typeVariable("T"))
                         .argumentType(typeVariable("T"))
                         .build())
-                .neverFails(boundSignature -> typeOperators.getComparisonUnorderedLastOperatorHandle(boundSignature.getArgumentType(0), simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL)).isNeverFails())
+                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOperator.java
@@ -23,9 +23,6 @@ import io.trino.spi.type.TypeOperators;
 
 import java.lang.invoke.MethodHandle;
 
-import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
-import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.TypeTemplates.typeVariable;
@@ -46,7 +43,7 @@ public class GenericLessThanOperator
                         .argumentType(typeVariable("T"))
                         .build())
                 .nullable()
-                .neverFails(boundSignature -> typeOperators.getLessThanOperatorHandle(boundSignature.getArgumentType(0), simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL)).isNeverFails())
+                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOrEqualOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericLessThanOrEqualOperator.java
@@ -23,9 +23,6 @@ import io.trino.spi.type.TypeOperators;
 
 import java.lang.invoke.MethodHandle;
 
-import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
-import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.TypeTemplates.typeVariable;
@@ -46,7 +43,7 @@ public class GenericLessThanOrEqualOperator
                         .argumentType(typeVariable("T"))
                         .build())
                 .nullable()
-                .neverFails(boundSignature -> typeOperators.getLessThanOrEqualOperatorHandle(boundSignature.getArgumentType(0), simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL)).isNeverFails())
+                .neverFails()
                 .build());
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ScalarHeader.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ScalarHeader.java
@@ -51,11 +51,6 @@ public class ScalarHeader
     private final Optional<TypeTemplate> receiverType;
     private final boolean instanceMethod;
 
-    public ScalarHeader(String name, Set<String> aliases, Optional<String> description, boolean hidden, boolean deterministic, boolean neverFails)
-    {
-        this(name, aliases, description, hidden, deterministic, neverFails, Optional.empty(), false);
-    }
-
     public ScalarHeader(String name, Set<String> aliases, Optional<String> description, boolean hidden, boolean deterministic, boolean neverFails, Optional<TypeTemplate> receiverType, boolean instanceMethod)
     {
         this.name = requireNonNull(name, "name is null");

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ScalarHeader.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ScalarHeader.java
@@ -109,6 +109,9 @@ public class ScalarHeader
         }
 
         if (scalarOperator != null) {
+            if (scalarOperator.value().neverFails() && scalarOperator.neverFails()) {
+                throw new IllegalArgumentException("@ScalarOperator(neverFails = true) is redundant for %s operator which is always infallible: %s".formatted(scalarOperator.value(), annotated));
+            }
             builder.add(new ScalarHeader(scalarOperator.value(), description, scalarOperator.neverFails()));
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.spi.function.CatalogSchemaFunctionName;
-import io.trino.spi.function.InvocationConvention;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.DecimalType;
@@ -31,7 +30,6 @@ import io.trino.spi.type.SmallintType;
 import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.TrinoNumber;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeOperators;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
@@ -49,9 +47,6 @@ import static io.trino.metadata.GlobalFunctionCatalog.isBuiltinFunctionName;
 import static io.trino.metadata.OperatorNameUtil.isOperatorName;
 import static io.trino.metadata.OperatorNameUtil.unmangleOperator;
 import static io.trino.spi.block.RowValueBuilder.buildRowValue;
-import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
-import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.function.OperatorType.DIVIDE;
 import static io.trino.spi.function.OperatorType.MODULO;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -472,7 +467,7 @@ public final class IrExpressions
             case Array e -> e.elements().stream().anyMatch(element -> mayFail(plannerContext, element));
             case Call e -> switch (matchComparison(e)) {
                 case null -> mayFail(e) || e.arguments().stream().anyMatch(argument -> mayFail(plannerContext, argument));
-                case Comparison comparison -> mayFail(plannerContext, comparison) || mayFail(plannerContext, comparison.left()) || mayFail(plannerContext, comparison.right());
+                case Comparison comparison -> mayFail(plannerContext, comparison.left()) || mayFail(plannerContext, comparison.right());
             };
             case Case e -> e.whenClauses().stream().anyMatch(clause -> mayFail(plannerContext, clause.getOperand()) || mayFail(plannerContext, clause.getResult())) ||
                     mayFail(plannerContext, e.defaultValue());
@@ -485,19 +480,6 @@ public final class IrExpressions
             case Row e -> e.items().stream().anyMatch(argument -> mayFail(plannerContext, argument));
             case Match e -> mayFail(plannerContext, e.operand()) || e.clauses().stream().anyMatch(clause -> mayFail(plannerContext, clause.lambda().body()) || mayFail(plannerContext, clause.result())) ||
                     mayFail(plannerContext, e.defaultValue());
-        };
-    }
-
-    private static boolean mayFail(PlannerContext plannerContext, Comparison comparison)
-    {
-        TypeOperators typeOperators = plannerContext.getTypeOperators();
-        Type operandType = comparison.left().type();
-        InvocationConvention convention = simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL);
-        return switch (comparison.operator()) {
-            // Required to be infallible
-            case EQUAL, NOT_EQUAL, IDENTICAL -> false;
-            case LESS_THAN, GREATER_THAN -> !typeOperators.getLessThanOperatorHandle(operandType, convention).isNeverFails();
-            case LESS_THAN_OR_EQUAL, GREATER_THAN_OR_EQUAL -> !typeOperators.getLessThanOrEqualOperatorHandle(operandType, convention).isNeverFails();
         };
     }
 

--- a/core/trino-main/src/main/java/io/trino/type/IpAddressType.java
+++ b/core/trino-main/src/main/java/io/trino/type/IpAddressType.java
@@ -203,7 +203,7 @@ public class IpAddressType
         value.getBytes(0, fixedSizeSlice, fixedSizeOffset, INT128_BYTES);
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(Slice left, Slice right)
     {
         return equal(
@@ -213,7 +213,7 @@ public class IpAddressType
                 right.getLong(SIZE_OF_LONG));
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(@BlockPosition Int128ArrayBlock leftBlock, @BlockIndex int leftPosition, @BlockPosition Int128ArrayBlock rightBlock, @BlockIndex int rightPosition)
     {
         return equal(
@@ -223,7 +223,7 @@ public class IpAddressType
                 rightBlock.getInt128Low(rightPosition));
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(
             @FlatFixed byte[] leftFixedSizeSlice,
             @FlatFixedOffset int leftFixedSizeOffset,
@@ -244,19 +244,19 @@ public class IpAddressType
         return leftLow == rightLow && leftHigh == rightHigh;
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(Slice value)
     {
         return xxHash64(value.getLong(0), value.getLong(SIZE_OF_LONG));
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(@BlockPosition Int128ArrayBlock block, @BlockIndex int position)
     {
         return xxHash64(block.getInt128High(position), block.getInt128Low(position));
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -273,7 +273,7 @@ public class IpAddressType
         return XxHash64.hash(low) ^ XxHash64.hash(high);
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(Slice left, Slice right)
     {
         return compareBigEndian(
@@ -283,7 +283,7 @@ public class IpAddressType
                 right.getLong(SIZE_OF_LONG));
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(@BlockPosition Int128ArrayBlock leftBlock, @BlockIndex int leftPosition, @BlockPosition Int128ArrayBlock rightBlock, @BlockIndex int rightPosition)
     {
         return compareBigEndian(

--- a/core/trino-main/src/main/java/io/trino/type/UnknownType.java
+++ b/core/trino-main/src/main/java/io/trino/type/UnknownType.java
@@ -139,7 +139,7 @@ public final class UnknownType
         return 0;
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static boolean readFlat(
             @FlatFixed byte[] unusedFixedSizeSlice,
             @FlatFixedOffset int unusedFixedSizeOffset,
@@ -149,7 +149,7 @@ public final class UnknownType
         throw new AssertionError("value of unknown type should all be NULL");
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             boolean unusedValue,
             byte[] unusedFixedSizeSlice,
@@ -160,19 +160,19 @@ public final class UnknownType
         throw new AssertionError("value of unknown type should all be NULL");
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(boolean unusedLeft, boolean unusedRight)
     {
         throw new AssertionError("value of unknown type should all be NULL");
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(boolean unusedValue)
     {
         throw new AssertionError("value of unknown type should all be NULL");
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(boolean unusedLeft, boolean unusedRight)
     {
         throw new AssertionError("value of unknown type should all be NULL");

--- a/core/trino-spi/src/main/java/io/trino/spi/function/OperatorMethodHandle.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/OperatorMethodHandle.java
@@ -21,19 +21,11 @@ public class OperatorMethodHandle
 {
     private final InvocationConvention callingConvention;
     private final MethodHandle methodHandle;
-    private final boolean neverFails;
 
-    @Deprecated
     public OperatorMethodHandle(InvocationConvention callingConvention, MethodHandle methodHandle)
-    {
-        this(callingConvention, methodHandle, false);
-    }
-
-    public OperatorMethodHandle(InvocationConvention callingConvention, MethodHandle methodHandle, boolean neverFails)
     {
         this.callingConvention = requireNonNull(callingConvention, "callingConvention is null");
         this.methodHandle = requireNonNull(methodHandle, "methodHandle is null");
-        this.neverFails = neverFails;
     }
 
     public InvocationConvention getCallingConvention()
@@ -44,14 +36,5 @@ public class OperatorMethodHandle
     public MethodHandle getMethodHandle()
     {
         return methodHandle;
-    }
-
-    /**
-     * Whether the underlying method handle guarantees it does not throw for any input
-     * of the declared signature. Used by the planner to reason about expression fallibility.
-     */
-    public boolean isNeverFails()
-    {
-        return neverFails;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/function/OperatorType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/OperatorType.java
@@ -13,42 +13,46 @@
  */
 package io.trino.spi.function;
 
+import io.trino.spi.Unstable;
+
 public enum OperatorType
 {
-    ADD("+", 2),
-    SUBTRACT("-", 2),
-    MULTIPLY("*", 2),
-    DIVIDE("/", 2),
-    MODULO("%", 2),
-    NEGATION("-", 1),
-    EQUAL("=", 2),
+    ADD("+", 2, false),
+    SUBTRACT("-", 2, false),
+    MULTIPLY("*", 2, false),
+    DIVIDE("/", 2, false),
+    MODULO("%", 2, false),
+    NEGATION("-", 1, false),
+    EQUAL("=", 2, true),
     /**
      * Normal comparison operator, but unordered values such as NaN are placed after all normal values.
      */
-    COMPARISON_UNORDERED_LAST("COMPARISON_UNORDERED_LAST", 2),
+    COMPARISON_UNORDERED_LAST("COMPARISON_UNORDERED_LAST", 2, true),
     /**
      * Normal comparison operator, but unordered values such as NaN are placed before all normal values.
      */
-    COMPARISON_UNORDERED_FIRST("COMPARISON_UNORDERED_FIRST", 2),
-    LESS_THAN("<", 2),
-    LESS_THAN_OR_EQUAL("<=", 2),
-    CAST("CAST", 1),
-    SUBSCRIPT("[]", 2),
-    HASH_CODE("HASH CODE", 1),
-    SATURATED_FLOOR_CAST("SATURATED FLOOR CAST", 1),
-    IDENTICAL("IDENTICAL", 2),
-    XX_HASH_64("XX HASH 64", 1),
-    INDETERMINATE("INDETERMINATE", 1),
-    READ_VALUE("READ VALUE", 1),
+    COMPARISON_UNORDERED_FIRST("COMPARISON_UNORDERED_FIRST", 2, true),
+    LESS_THAN("<", 2, true),
+    LESS_THAN_OR_EQUAL("<=", 2, true),
+    CAST("CAST", 1, false),
+    SUBSCRIPT("[]", 2, false),
+    HASH_CODE("HASH CODE", 1, true),
+    SATURATED_FLOOR_CAST("SATURATED FLOOR CAST", 1, false),
+    IDENTICAL("IDENTICAL", 2, true),
+    XX_HASH_64("XX HASH 64", 1, true),
+    INDETERMINATE("INDETERMINATE", 1, true),
+    READ_VALUE("READ VALUE", 1, true),
     /**/;
 
     private final String operator;
     private final int argumentCount;
+    private final boolean neverFails;
 
-    OperatorType(String operator, int argumentCount)
+    OperatorType(String operator, int argumentCount, boolean neverFails)
     {
         this.operator = operator;
         this.argumentCount = argumentCount;
+        this.neverFails = neverFails;
     }
 
     public String getOperator()
@@ -59,5 +63,11 @@ public enum OperatorType
     public int getArgumentCount()
     {
         return argumentCount;
+    }
+
+    @Unstable
+    public boolean neverFails()
+    {
+        return neverFails;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractIntType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractIntType.java
@@ -141,7 +141,7 @@ public abstract class AbstractIntType
         return new IntArrayBlockBuilder(null, positionCount);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long read(@BlockPosition IntArrayBlock block, @BlockIndex int position)
     {
         return readInt(block, position);
@@ -152,7 +152,7 @@ public abstract class AbstractIntType
         return block.getInt(position);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -162,7 +162,7 @@ public abstract class AbstractIntType
         return (int) INT_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             long value,
             @FlatFixed byte[] fixedSizeSlice,
@@ -173,39 +173,39 @@ public abstract class AbstractIntType
         INT_HANDLE.set(fixedSizeSlice, fixedSizeOffset, (int) value);
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(long left, long right)
     {
         return left == right;
     }
 
     @SuppressWarnings("UnnecessaryLongToIntConversion")
-    @ScalarOperator(value = HASH_CODE, neverFails = true)
+    @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(long value)
     {
         return AbstractLongType.hash((int) value);
     }
 
     @SuppressWarnings("UnnecessaryLongToIntConversion")
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash((int) value);
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(long left, long right)
     {
         return Integer.compare((int) left, (int) right);
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(long left, long right)
     {
         return ((int) left) < ((int) right);
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(long left, long right)
     {
         return ((int) left) <= ((int) right);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractLongType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractLongType.java
@@ -124,13 +124,13 @@ public abstract class AbstractLongType
         return rotateLeft(value * 0xC2B2AE3D27D4EB4FL, 31) * 0x9E3779B185EBCA87L;
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long read(@BlockPosition LongArrayBlock block, @BlockIndex int position)
     {
         return block.getLong(position);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -140,7 +140,7 @@ public abstract class AbstractLongType
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             long value,
             @FlatFixed byte[] fixedSizeSlice,
@@ -151,37 +151,37 @@ public abstract class AbstractLongType
         LONG_HANDLE.set(fixedSizeSlice, fixedSizeOffset, value);
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(long left, long right)
     {
         return left == right;
     }
 
-    @ScalarOperator(value = HASH_CODE, neverFails = true)
+    @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(long value)
     {
         return hash(value);
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash(value);
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(long left, long right)
     {
         return Long.compare(left, right);
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(long left, long right)
     {
         return left < right;
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(long left, long right)
     {
         return left <= right;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractVariableWidthType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractVariableWidthType.java
@@ -251,13 +251,13 @@ public abstract class AbstractVariableWidthType
 
     private static class DefaultComparableOperators
     {
-        @ScalarOperator(value = EQUAL, neverFails = true)
+        @ScalarOperator(EQUAL)
         private static boolean equalOperator(Slice left, Slice right)
         {
             return left.equals(right);
         }
 
-        @ScalarOperator(value = EQUAL, neverFails = true)
+        @ScalarOperator(EQUAL)
         private static boolean equalOperator(@BlockPosition VariableWidthBlock leftBlock, @BlockIndex int leftPosition, @BlockPosition VariableWidthBlock rightBlock, @BlockIndex int rightPosition)
         {
             Slice leftRawSlice = leftBlock.getRawSlice();
@@ -271,13 +271,13 @@ public abstract class AbstractVariableWidthType
             return leftRawSlice.equals(leftRawSliceOffset, leftLength, rightRawSlice, rightRawSliceOffset, rightLength);
         }
 
-        @ScalarOperator(value = EQUAL, neverFails = true)
+        @ScalarOperator(EQUAL)
         private static boolean equalOperator(Slice left, @BlockPosition VariableWidthBlock rightBlock, @BlockIndex int rightPosition)
         {
             return equalOperator(rightBlock, rightPosition, left);
         }
 
-        @ScalarOperator(value = EQUAL, neverFails = true)
+        @ScalarOperator(EQUAL)
         private static boolean equalOperator(@BlockPosition VariableWidthBlock leftBlock, @BlockIndex int leftPosition, Slice right)
         {
             Slice leftRawSlice = leftBlock.getRawSlice();
@@ -366,13 +366,13 @@ public abstract class AbstractVariableWidthType
             return rightRawSlice.equals(rightRawSliceOffset, rightLength, leftBytes, leftOffset, leftLength);
         }
 
-        @ScalarOperator(value = XX_HASH_64, neverFails = true)
+        @ScalarOperator(XX_HASH_64)
         private static long xxHash64Operator(Slice value)
         {
             return XxHash64.hash(value);
         }
 
-        @ScalarOperator(value = XX_HASH_64, neverFails = true)
+        @ScalarOperator(XX_HASH_64)
         private static long xxHash64Operator(@BlockPosition VariableWidthBlock block, @BlockIndex int position)
         {
             return XxHash64.hash(block.getRawSlice(), block.getRawSliceOffset(position), block.getSliceLength(position));
@@ -402,13 +402,13 @@ public abstract class AbstractVariableWidthType
 
     private static class DefaultOrderingOperators
     {
-        @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+        @ScalarOperator(COMPARISON_UNORDERED_LAST)
         private static long comparisonOperator(Slice left, Slice right)
         {
             return left.compareTo(right);
         }
 
-        @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+        @ScalarOperator(COMPARISON_UNORDERED_LAST)
         private static long comparisonOperator(@BlockPosition VariableWidthBlock leftBlock, @BlockIndex int leftPosition, @BlockPosition VariableWidthBlock rightBlock, @BlockIndex int rightPosition)
         {
             Slice leftRawSlice = leftBlock.getRawSlice();
@@ -422,7 +422,7 @@ public abstract class AbstractVariableWidthType
             return leftRawSlice.compareTo(leftRawSliceOffset, leftLength, rightRawSlice, rightRawSliceOffset, rightLength);
         }
 
-        @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+        @ScalarOperator(COMPARISON_UNORDERED_LAST)
         private static long comparisonOperator(@BlockPosition VariableWidthBlock leftBlock, @BlockIndex int leftPosition, Slice right)
         {
             Slice leftRawSlice = leftBlock.getRawSlice();
@@ -432,7 +432,7 @@ public abstract class AbstractVariableWidthType
             return leftRawSlice.compareTo(leftRawSliceOffset, leftLength, right, 0, right.length());
         }
 
-        @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+        @ScalarOperator(COMPARISON_UNORDERED_LAST)
         private static long comparisonOperator(Slice left, @BlockPosition VariableWidthBlock rightBlock, @BlockIndex int rightPosition)
         {
             Slice rightRawSlice = rightBlock.getRawSlice();

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ArrayType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ArrayType.java
@@ -201,11 +201,11 @@ public class ArrayType
         }
         InvocationConvention elementConvention = simpleConvention(FAIL_ON_NULL, VALUE_BLOCK_POSITION_NOT_NULL, VALUE_BLOCK_POSITION_NOT_NULL);
         // compare non-null elements with the same null ordering, so nested nulls are ordered consistently
-        OperatorMethodHandle elementComparison = nullsFirst
-                ? typeOperators.getComparisonUnorderedFirstOperatorHandle(elementType, elementConvention)
-                : typeOperators.getComparisonUnorderedLastOperatorHandle(elementType, elementConvention);
-        MethodHandle comparison = insertArguments(COMPARISON, 0, nullsFirst, elementComparison.getMethodHandle());
-        return singletonList(new OperatorMethodHandle(COMPARISON_CONVENTION, comparison, elementComparison.isNeverFails()));
+        MethodHandle elementComparison = nullsFirst
+                ? typeOperators.getComparisonUnorderedFirstOperator(elementType, elementConvention)
+                : typeOperators.getComparisonUnorderedLastOperator(elementType, elementConvention);
+        MethodHandle comparison = insertArguments(COMPARISON, 0, nullsFirst, elementComparison);
+        return singletonList(new OperatorMethodHandle(COMPARISON_CONVENTION, comparison));
     }
 
     private static List<OperatorMethodHandle> getLessThanOperatorInvokers(TypeOperators typeOperators, Type elementType, boolean orEqual)
@@ -214,11 +214,10 @@ public class ArrayType
             return emptyList();
         }
         InvocationConvention elementConvention = simpleConvention(NULLABLE_RETURN, VALUE_BLOCK_POSITION_NOT_NULL, VALUE_BLOCK_POSITION_NOT_NULL);
-        // equality is total over all comparable types, so it never affects neverFails
         MethodHandle elementEqual = typeOperators.getEqualOperator(elementType, elementConvention);
-        OperatorMethodHandle elementLessThan = typeOperators.getLessThanOperatorHandle(elementType, elementConvention);
-        MethodHandle lessThan = insertArguments(LESS_THAN, 0, orEqual, elementEqual, elementLessThan.getMethodHandle());
-        return singletonList(new OperatorMethodHandle(LESS_THAN_CONVENTION, lessThan, elementLessThan.isNeverFails()));
+        MethodHandle elementLessThan = typeOperators.getLessThanOperator(elementType, elementConvention);
+        MethodHandle lessThan = insertArguments(LESS_THAN, 0, orEqual, elementEqual, elementLessThan);
+        return singletonList(new OperatorMethodHandle(LESS_THAN_CONVENTION, lessThan));
     }
 
     public Type getElementType()

--- a/core/trino-spi/src/main/java/io/trino/spi/type/BooleanType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/BooleanType.java
@@ -164,13 +164,13 @@ public final class BooleanType
         return getClass().hashCode();
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static boolean read(@BlockPosition ByteArrayBlock block, @BlockIndex int position)
     {
         return block.getByte(position) != 0;
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static boolean readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -180,7 +180,7 @@ public final class BooleanType
         return fixedSizeSlice[fixedSizeOffset] != 0;
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             boolean value,
             @FlatFixed byte[] fixedSizeSlice,
@@ -191,31 +191,31 @@ public final class BooleanType
         fixedSizeSlice[fixedSizeOffset] = (byte) (value ? 1 : 0);
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(boolean left, boolean right)
     {
         return left == right;
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(boolean value)
     {
         return value ? TRUE_XX_HASH : FALSE_XX_HASH;
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(boolean left, boolean right)
     {
         return Boolean.compare(left, right);
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(boolean left, boolean right)
     {
         return !left && right;
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(boolean left, boolean right)
     {
         return !left || right;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/CharType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/CharType.java
@@ -221,7 +221,7 @@ public final class CharType
         return (length * 31) + getClass().hashCode();
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(Slice left, Slice right)
     {
         return compareChars(left, right);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DoubleType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DoubleType.java
@@ -162,13 +162,13 @@ public final class DoubleType
         return Optional.empty();
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static double read(@BlockPosition LongArrayBlock block, @BlockIndex int position)
     {
         return longBitsToDouble(block.getLong(position));
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static double readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -178,7 +178,7 @@ public final class DoubleType
         return (double) DOUBLE_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             double value,
             @FlatFixed byte[] fixedSizeSlice,
@@ -190,13 +190,13 @@ public final class DoubleType
     }
 
     @SuppressWarnings("FloatingPointEquality")
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(double left, double right)
     {
         return left == right;
     }
 
-    @ScalarOperator(value = HASH_CODE, neverFails = true)
+    @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(double value)
     {
         if (value == 0) {
@@ -205,7 +205,7 @@ public final class DoubleType
         return AbstractLongType.hash(doubleToLongBits(value));
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64(double value)
     {
         if (value == 0) {
@@ -215,7 +215,7 @@ public final class DoubleType
     }
 
     @SuppressWarnings("FloatingPointEquality")
-    @ScalarOperator(value = IDENTICAL, neverFails = true)
+    @ScalarOperator(IDENTICAL)
     private static boolean identical(double left, @IsNull boolean leftNull, double right, @IsNull boolean rightNull)
     {
         if (leftNull || rightNull) {
@@ -228,13 +228,13 @@ public final class DoubleType
         return left == right;
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonUnorderedLastOperator(double left, double right)
     {
         return compare(left, right);
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_FIRST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_FIRST)
     private static long comparisonUnorderedFirstOperator(double left, double right)
     {
         // Double compare puts NaN last, so we must handle NaNs manually
@@ -251,13 +251,13 @@ public final class DoubleType
         return compare(left, right);
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(double left, double right)
     {
         return left < right;
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(double left, double right)
     {
         return left <= right;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongDecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongDecimalType.java
@@ -121,13 +121,13 @@ final class LongDecimalType
         return INT128_BYTES;
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static Int128 read(@BlockPosition Int128ArrayBlock block, @BlockIndex int position)
     {
         return block.getInt128(position);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static Int128 readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -139,7 +139,7 @@ final class LongDecimalType
                 (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset + SIZE_OF_LONG));
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void readFlatToBlock(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -152,7 +152,7 @@ final class LongDecimalType
                 (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset + SIZE_OF_LONG));
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             Int128 value,
             @FlatFixed byte[] fixedSizeSlice,
@@ -164,7 +164,7 @@ final class LongDecimalType
         LONG_HANDLE.set(fixedSizeSlice, fixedSizeOffset + SIZE_OF_LONG, value.getLow());
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeBlockToFlat(
             @BlockPosition Int128ArrayBlock block,
             @BlockIndex int position,
@@ -177,20 +177,20 @@ final class LongDecimalType
         LONG_HANDLE.set(fixedSizeSlice, fixedSizeOffset + SIZE_OF_LONG, block.getInt128Low(position));
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(Int128 left, Int128 right)
     {
         return left.equals(right);
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(@BlockPosition Int128ArrayBlock leftBlock, @BlockIndex int leftPosition, @BlockPosition Int128ArrayBlock rightBlock, @BlockIndex int rightPosition)
     {
         return leftBlock.getInt128High(leftPosition) == rightBlock.getInt128High(rightPosition) &&
                 leftBlock.getInt128Low(leftPosition) == rightBlock.getInt128Low(rightPosition);
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(
             @FlatFixed byte[] leftFixedSizeSlice,
             @FlatFixedOffset int leftFixedSizeOffset,
@@ -203,19 +203,19 @@ final class LongDecimalType
                 && ((long) LONG_HANDLE.get(leftFixedSizeSlice, leftFixedSizeOffset + SIZE_OF_LONG)) == rightBlock.getInt128Low(rightPosition);
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(Int128 value)
     {
         return xxHash64(value.getHigh(), value.getLow());
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(@BlockPosition Int128ArrayBlock block, @BlockIndex int position)
     {
         return xxHash64(block.getInt128High(position), block.getInt128Low(position));
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -232,13 +232,13 @@ final class LongDecimalType
         return XxHash64.hash(high) ^ XxHash64.hash(low);
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(Int128 left, Int128 right)
     {
         return left.compareTo(right);
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(@BlockPosition Int128ArrayBlock leftBlock, @BlockIndex int leftPosition, @BlockPosition Int128ArrayBlock rightBlock, @BlockIndex int rightPosition)
     {
         return Int128.compare(

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimeWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimeWithTimeZoneType.java
@@ -142,7 +142,7 @@ final class LongTimeWithTimeZoneType
         return block.getFixed12Second(position);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static LongTimeWithTimeZone readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -154,7 +154,7 @@ final class LongTimeWithTimeZoneType
                 (int) INT_HANDLE.get(fixedSizeSlice, fixedSizeOffset + Long.BYTES));
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void readFlatToBlock(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -167,7 +167,7 @@ final class LongTimeWithTimeZoneType
                 (int) INT_HANDLE.get(fixedSizeSlice, fixedSizeOffset + Long.BYTES));
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             LongTimeWithTimeZone value,
             @FlatFixed byte[] fixedSizeSlice,
@@ -179,7 +179,7 @@ final class LongTimeWithTimeZoneType
         INT_HANDLE.set(fixedSizeSlice, fixedSizeOffset + SIZE_OF_LONG, value.getOffsetMinutes());
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeBlockFlat(
             @BlockPosition Fixed12Block block,
             @BlockIndex int position,
@@ -192,7 +192,7 @@ final class LongTimeWithTimeZoneType
         INT_HANDLE.set(fixedSizeSlice, fixedSizeOffset + SIZE_OF_LONG, getOffsetMinutes(block, position));
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(LongTimeWithTimeZone left, LongTimeWithTimeZone right)
     {
         return equal(
@@ -202,7 +202,7 @@ final class LongTimeWithTimeZoneType
                 right.getOffsetMinutes());
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(@BlockPosition Fixed12Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Fixed12Block rightBlock, @BlockIndex int rightPosition)
     {
         return equal(
@@ -212,7 +212,7 @@ final class LongTimeWithTimeZoneType
                 getOffsetMinutes(rightBlock, rightPosition));
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -233,19 +233,19 @@ final class LongTimeWithTimeZoneType
         return normalizePicos(leftPicos, leftOffsetMinutes) == normalizePicos(rightPicos, rightOffsetMinutes);
     }
 
-    @ScalarOperator(value = HASH_CODE, neverFails = true)
+    @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(LongTimeWithTimeZone value)
     {
         return hashCodeOperator(value.getPicoseconds(), value.getOffsetMinutes());
     }
 
-    @ScalarOperator(value = HASH_CODE, neverFails = true)
+    @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(@BlockPosition Fixed12Block block, @BlockIndex int position)
     {
         return hashCodeOperator(getPicos(block, position), getOffsetMinutes(block, position));
     }
 
-    @ScalarOperator(value = HASH_CODE, neverFails = true)
+    @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -260,19 +260,19 @@ final class LongTimeWithTimeZoneType
         return AbstractLongType.hash(normalizePicos(picos, offsetMinutes));
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(LongTimeWithTimeZone value)
     {
         return xxHash64(value.getPicoseconds(), value.getOffsetMinutes());
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(@BlockPosition Fixed12Block block, @BlockIndex int position)
     {
         return xxHash64(getPicos(block, position), getOffsetMinutes(block, position));
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -289,7 +289,7 @@ final class LongTimeWithTimeZoneType
         return XxHash64.hash(normalizePicos(picos, offsetMinutes));
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(LongTimeWithTimeZone left, LongTimeWithTimeZone right)
     {
         return comparison(
@@ -299,7 +299,7 @@ final class LongTimeWithTimeZoneType
                 right.getOffsetMinutes());
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(@BlockPosition Fixed12Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Fixed12Block rightBlock, @BlockIndex int rightPosition)
     {
         return comparison(
@@ -314,7 +314,7 @@ final class LongTimeWithTimeZoneType
         return Long.compare(normalizePicos(leftPicos, leftOffsetMinutes), normalizePicos(rightPicos, rightOffsetMinutes));
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(LongTimeWithTimeZone left, LongTimeWithTimeZone right)
     {
         return lessThan(
@@ -324,7 +324,7 @@ final class LongTimeWithTimeZoneType
                 right.getOffsetMinutes());
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(@BlockPosition Fixed12Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Fixed12Block rightBlock, @BlockIndex int rightPosition)
     {
         return lessThan(
@@ -339,7 +339,7 @@ final class LongTimeWithTimeZoneType
         return normalizePicos(leftPicos, leftOffsetMinutes) < normalizePicos(rightPicos, rightOffsetMinutes);
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(LongTimeWithTimeZone left, LongTimeWithTimeZone right)
     {
         return lessThanOrEqual(
@@ -349,7 +349,7 @@ final class LongTimeWithTimeZoneType
                 right.getOffsetMinutes());
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(@BlockPosition Fixed12Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Fixed12Block rightBlock, @BlockIndex int rightPosition)
     {
         return lessThanOrEqual(

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampType.java
@@ -194,7 +194,7 @@ final class LongTimestampType
         return Optional.of(new LongTimestamp(epochMicros, picosOfMicro));
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static LongTimestamp readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -206,7 +206,7 @@ final class LongTimestampType
                 (int) INT_HANDLE.get(fixedSizeSlice, fixedSizeOffset + Long.BYTES));
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void readFlatToBlock(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -219,7 +219,7 @@ final class LongTimestampType
                 (int) INT_HANDLE.get(fixedSizeSlice, fixedSizeOffset + SIZE_OF_LONG));
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             LongTimestamp value,
             @FlatFixed byte[] fixedSizeSlice,
@@ -231,7 +231,7 @@ final class LongTimestampType
         INT_HANDLE.set(fixedSizeSlice, fixedSizeOffset + SIZE_OF_LONG, value.getPicosOfMicro());
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeBlockFlat(
             @BlockPosition Fixed12Block block,
             @BlockIndex int position,
@@ -244,7 +244,7 @@ final class LongTimestampType
         INT_HANDLE.set(fixedSizeSlice, fixedSizeOffset + SIZE_OF_LONG, getFraction(block, position));
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(LongTimestamp left, LongTimestamp right)
     {
         return equal(
@@ -254,7 +254,7 @@ final class LongTimestampType
                 right.getPicosOfMicro());
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(@BlockPosition Fixed12Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Fixed12Block rightBlock, @BlockIndex int rightPosition)
     {
         return equal(
@@ -264,7 +264,7 @@ final class LongTimestampType
                 getFraction(rightBlock, rightPosition));
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(
             @FlatFixed byte[] leftFixedSizeSlice,
             @FlatFixedOffset int leftFixedSizeOffset,
@@ -285,13 +285,13 @@ final class LongTimestampType
         return leftEpochMicros == rightEpochMicros && leftFraction == rightFraction;
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(LongTimestamp value)
     {
         return xxHash64(value.getEpochMicros(), value.getPicosOfMicro());
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(@BlockPosition Fixed12Block block, @BlockIndex int position)
     {
         return xxHash64(
@@ -299,7 +299,7 @@ final class LongTimestampType
                 getFraction(block, position));
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(
             @FlatFixed byte[] leftFixedSizeSlice,
             @FlatFixedOffset int leftFixedSizeOffset,
@@ -316,13 +316,13 @@ final class LongTimestampType
         return XxHash64.hash(epochMicros) ^ XxHash64.hash(fraction);
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(LongTimestamp left, LongTimestamp right)
     {
         return comparison(left.getEpochMicros(), left.getPicosOfMicro(), right.getEpochMicros(), right.getPicosOfMicro());
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(@BlockPosition Fixed12Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Fixed12Block rightBlock, @BlockIndex int rightPosition)
     {
         return comparison(
@@ -341,13 +341,13 @@ final class LongTimestampType
         return Integer.compare(leftPicosOfMicro, rightPicosOfMicro);
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(LongTimestamp left, LongTimestamp right)
     {
         return lessThan(left.getEpochMicros(), left.getPicosOfMicro(), right.getEpochMicros(), right.getPicosOfMicro());
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(@BlockPosition Fixed12Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Fixed12Block rightBlock, @BlockIndex int rightPosition)
     {
         return lessThan(
@@ -363,13 +363,13 @@ final class LongTimestampType
                 ((leftEpochMicros == rightEpochMicros) && (leftPicosOfMicro < rightPicosOfMicro));
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(LongTimestamp left, LongTimestamp right)
     {
         return lessThanOrEqual(left.getEpochMicros(), left.getPicosOfMicro(), right.getEpochMicros(), right.getPicosOfMicro());
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(@BlockPosition Fixed12Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Fixed12Block rightBlock, @BlockIndex int rightPosition)
     {
         return lessThanOrEqual(

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZoneType.java
@@ -203,7 +203,7 @@ final class LongTimestampWithTimeZoneType
         return block.getFixed12Second(position);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static LongTimestampWithTimeZone readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -215,7 +215,7 @@ final class LongTimestampWithTimeZoneType
         return LongTimestampWithTimeZone.fromEpochMillisAndFraction(unpackMillisUtc(packedEpochMillis), picosOfMilli, unpackZoneKey(packedEpochMillis));
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void readFlatToBlock(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -228,7 +228,7 @@ final class LongTimestampWithTimeZoneType
                 (int) INT_HANDLE.get(fixedSizeSlice, fixedSizeOffset + Long.BYTES));
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             LongTimestampWithTimeZone value,
             @FlatFixed byte[] fixedSizeSlice,
@@ -240,7 +240,7 @@ final class LongTimestampWithTimeZoneType
         INT_HANDLE.set(fixedSizeSlice, fixedSizeOffset + SIZE_OF_LONG, value.getPicosOfMilli());
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeBlockFlat(
             @BlockPosition Fixed12Block block,
             @BlockIndex int position,
@@ -253,7 +253,7 @@ final class LongTimestampWithTimeZoneType
         INT_HANDLE.set(fixedSizeSlice, fixedSizeOffset + SIZE_OF_LONG, getPicosOfMilli(block, position));
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(LongTimestampWithTimeZone left, LongTimestampWithTimeZone right)
     {
         return equal(
@@ -263,7 +263,7 @@ final class LongTimestampWithTimeZoneType
                 right.getPicosOfMilli());
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(@BlockPosition Fixed12Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Fixed12Block rightBlock, @BlockIndex int rightPosition)
     {
         return equal(
@@ -273,7 +273,7 @@ final class LongTimestampWithTimeZoneType
                 getPicosOfMilli(rightBlock, rightPosition));
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(
             @FlatFixed byte[] leftFixedSizeSlice,
             @FlatFixedOffset int leftFixedSizeOffset,
@@ -295,13 +295,13 @@ final class LongTimestampWithTimeZoneType
                 leftPicosOfMilli == rightPicosOfMilli;
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(LongTimestampWithTimeZone value)
     {
         return xxHash64(value.getEpochMillis(), value.getPicosOfMilli());
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(@BlockPosition Fixed12Block block, @BlockIndex int position)
     {
         return xxHash64(
@@ -309,7 +309,7 @@ final class LongTimestampWithTimeZoneType
                 getPicosOfMilli(block, position));
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -326,13 +326,13 @@ final class LongTimestampWithTimeZoneType
         return XxHash64.hash(epochMillis) ^ XxHash64.hash(picosOfMilli);
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(LongTimestampWithTimeZone left, LongTimestampWithTimeZone right)
     {
         return comparison(left.getEpochMillis(), left.getPicosOfMilli(), right.getEpochMillis(), right.getPicosOfMilli());
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(@BlockPosition Fixed12Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Fixed12Block rightBlock, @BlockIndex int rightPosition)
     {
         return comparison(
@@ -351,13 +351,13 @@ final class LongTimestampWithTimeZoneType
         return Integer.compare(leftPicosOfMilli, rightPicosOfMilli);
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(LongTimestampWithTimeZone left, LongTimestampWithTimeZone right)
     {
         return lessThan(left.getEpochMillis(), left.getPicosOfMilli(), right.getEpochMillis(), right.getPicosOfMilli());
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(@BlockPosition Fixed12Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Fixed12Block rightBlock, @BlockIndex int rightPosition)
     {
         return lessThan(
@@ -373,13 +373,13 @@ final class LongTimestampWithTimeZoneType
                 ((leftEpochMillis == rightEpochMillis) && (leftPicosOfMilli < rightPicosOfMilli));
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(LongTimestampWithTimeZone left, LongTimestampWithTimeZone right)
     {
         return lessThanOrEqual(left.getEpochMillis(), left.getPicosOfMilli(), right.getEpochMillis(), right.getPicosOfMilli());
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(@BlockPosition Fixed12Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Fixed12Block rightBlock, @BlockIndex int rightPosition)
     {
         return lessThanOrEqual(

--- a/core/trino-spi/src/main/java/io/trino/spi/type/NumberType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/NumberType.java
@@ -152,7 +152,7 @@ public class NumberType
         return getClass().hashCode();
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     static boolean equalOperator(TrinoNumber left, TrinoNumber right)
     {
         if (left.isNaN() || right.isNaN()) {
@@ -162,7 +162,7 @@ public class NumberType
         return left.bytes().equals(right.bytes());
     }
 
-    @ScalarOperator(value = IDENTICAL, neverFails = true)
+    @ScalarOperator(IDENTICAL)
     static boolean identicalOperator(@SqlNullable TrinoNumber left, @SqlNullable TrinoNumber right)
     {
         if (left == null || right == null) {
@@ -193,7 +193,7 @@ public class NumberType
         return fixedSizeSlice[fixedSizeOffset] & 0xFF;
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static TrinoNumber readFlatToStack(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -204,7 +204,7 @@ public class NumberType
         return new TrinoNumber(wrappedBuffer(variableSizeSlice, variableSizeOffset, length));
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void readFlatToBlock(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -216,7 +216,7 @@ public class NumberType
         ((VariableWidthBlockBuilder) blockBuilder).writeEntry(variableSizeSlice, variableSizeOffset, length);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlatFromStack(
             TrinoNumber value,
             @FlatFixed byte[] fixedSizeSlice,
@@ -231,7 +231,7 @@ public class NumberType
         bytes.getBytes(0, variableSizeSlice, variableSizeOffset, length);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlatFromBlock(
             @BlockPosition VariableWidthBlock block,
             @BlockIndex int position,
@@ -252,7 +252,7 @@ public class NumberType
     // TODO EQUAL with block, position, block, position
     // TODO EQUAL with flat slice, block position
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(TrinoNumber value)
     {
         Slice slice = value.bytes();
@@ -262,7 +262,7 @@ public class NumberType
     // TODO XX_HASH_64 with block, position
     // TODO XX_HASH_64 with flat slice
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(TrinoNumber left, TrinoNumber right)
     {
         return COMPARE_NAN_LAST.compare(left.toBigDecimal(), right.toBigDecimal());
@@ -270,7 +270,7 @@ public class NumberType
 
     // TODO COMPARISON_UNORDERED_LAST with block, position, block, position
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(TrinoNumber left, TrinoNumber right)
     {
         if (left.isNaN() || right.isNaN()) {
@@ -282,7 +282,7 @@ public class NumberType
 
     // TODO LESS_THAN with block, position, block, position
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(TrinoNumber left, TrinoNumber right)
     {
         if (left.isNaN() || right.isNaN()) {

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
@@ -120,7 +120,7 @@ public final class RealType
         return Optional.empty();
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -130,7 +130,7 @@ public final class RealType
         return (int) INT_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             long value,
             @FlatFixed byte[] fixedSizeSlice,
@@ -142,13 +142,13 @@ public final class RealType
     }
 
     @SuppressWarnings("FloatingPointEquality")
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(long left, long right)
     {
         return intBitsToFloat((int) left) == intBitsToFloat((int) right);
     }
 
-    @ScalarOperator(value = HASH_CODE, neverFails = true)
+    @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(long value)
     {
         float realValue = intBitsToFloat((int) value);
@@ -158,7 +158,7 @@ public final class RealType
         return AbstractLongType.hash(floatToIntBits(realValue));
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(long value)
     {
         float realValue = intBitsToFloat((int) value);
@@ -169,7 +169,7 @@ public final class RealType
     }
 
     @SuppressWarnings("FloatingPointEquality")
-    @ScalarOperator(value = IDENTICAL, neverFails = true)
+    @ScalarOperator(IDENTICAL)
     private static boolean identical(long left, @IsNull boolean leftNull, long right, @IsNull boolean rightNull)
     {
         if (leftNull || rightNull) {
@@ -184,13 +184,13 @@ public final class RealType
         return leftFloat == rightFloat;
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonUnorderedLastOperator(long left, long right)
     {
         return compare(intBitsToFloat((int) left), intBitsToFloat((int) right));
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_FIRST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_FIRST)
     private static long comparisonUnorderedFirstOperator(long leftBits, long rightBits)
     {
         // Float compare puts NaN last, so we must handle NaNs manually
@@ -208,13 +208,13 @@ public final class RealType
         return compare(left, right);
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(long left, long right)
     {
         return intBitsToFloat((int) left) < intBitsToFloat((int) right);
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(long left, long right)
     {
         return intBitsToFloat((int) left) <= intBitsToFloat((int) right);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RowType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RowType.java
@@ -848,21 +848,19 @@ public class RowType
             return emptyList();
         }
 
-        boolean neverFails = true;
         List<MethodHandle> comparisonOperators = new ArrayList<>(fields.size());
         for (Field field : fields) {
             InvocationConvention fieldConvention = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL);
             // compare non-null field values with the same null ordering, so nested nulls are ordered consistently
-            OperatorMethodHandle fieldComparison = nullsFirst
-                    ? typeOperators.getComparisonUnorderedFirstOperatorHandle(field.getType(), fieldConvention)
-                    : typeOperators.getComparisonUnorderedLastOperatorHandle(field.getType(), fieldConvention);
-            neverFails = neverFails && fieldComparison.isNeverFails();
-            comparisonOperators.add(fieldComparison.getMethodHandle());
+            MethodHandle fieldComparison = nullsFirst
+                    ? typeOperators.getComparisonUnorderedFirstOperator(field.getType(), fieldConvention)
+                    : typeOperators.getComparisonUnorderedLastOperator(field.getType(), fieldConvention);
+            comparisonOperators.add(fieldComparison);
         }
 
         // for large rows, use a generic loop with a megamorphic call site
         if (fields.size() > MEGAMORPHIC_FIELD_COUNT) {
-            return singletonList(new OperatorMethodHandle(COMPARISON_CONVENTION, insertArguments(COMPARISON, 0, nullsFirst, comparisonOperators), neverFails));
+            return singletonList(new OperatorMethodHandle(COMPARISON_CONVENTION, insertArguments(COMPARISON, 0, nullsFirst, comparisonOperators)));
         }
 
         // (SqlRow, SqlRow):long
@@ -877,7 +875,7 @@ public class RowType
             // (SqlRow, SqlRow):long
             comparison = permuteArguments(comparison, methodType(long.class, SqlRow.class, SqlRow.class), 0, 1, 0, 1);
         }
-        return singletonList(new OperatorMethodHandle(COMPARISON_CONVENTION, comparison, neverFails));
+        return singletonList(new OperatorMethodHandle(COMPARISON_CONVENTION, comparison));
     }
 
     private static long megamorphicComparisonOperator(boolean nullsFirst, List<MethodHandle> comparisonOperators, SqlRow leftRow, SqlRow rightRow)
@@ -950,21 +948,17 @@ public class RowType
             return emptyList();
         }
 
-        boolean neverFails = true;
         List<MethodHandle> equalOperators = new ArrayList<>(fields.size());
         List<MethodHandle> lessThanOperators = new ArrayList<>(fields.size());
         for (Field field : fields) {
             InvocationConvention fieldConvention = simpleConvention(NULLABLE_RETURN, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL);
-            // equality is total over all comparable types, so it never affects neverFails
             equalOperators.add(typeOperators.getEqualOperator(field.getType(), fieldConvention));
-            OperatorMethodHandle fieldLessThan = typeOperators.getLessThanOperatorHandle(field.getType(), fieldConvention);
-            neverFails = neverFails && fieldLessThan.isNeverFails();
-            lessThanOperators.add(fieldLessThan.getMethodHandle());
+            lessThanOperators.add(typeOperators.getLessThanOperator(field.getType(), fieldConvention));
         }
 
         // for large rows, use a generic loop with a megamorphic call site
         if (fields.size() > MEGAMORPHIC_FIELD_COUNT) {
-            return singletonList(new OperatorMethodHandle(LESS_THAN_CONVENTION, insertArguments(LESS_THAN, 0, orEqual, equalOperators, lessThanOperators), neverFails));
+            return singletonList(new OperatorMethodHandle(LESS_THAN_CONVENTION, insertArguments(LESS_THAN, 0, orEqual, equalOperators, lessThanOperators)));
         }
 
         // (SqlRow, SqlRow):int
@@ -981,7 +975,7 @@ public class RowType
         }
         // (SqlRow, SqlRow):Boolean
         MethodHandle lessThanResult = filterReturnValue(lessThan, insertArguments(LESS_THAN_RESULT, 0, orEqual));
-        return singletonList(new OperatorMethodHandle(LESS_THAN_CONVENTION, lessThanResult, neverFails));
+        return singletonList(new OperatorMethodHandle(LESS_THAN_CONVENTION, lessThanResult));
     }
 
     private static Boolean megamorphicLessThanOperator(boolean orEqual, List<MethodHandle> equalOperators, List<MethodHandle> lessThanOperators, SqlRow leftRow, SqlRow rightRow)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortDecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortDecimalType.java
@@ -182,13 +182,13 @@ final class ShortDecimalType
         return Optional.of(value + 1);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long read(@BlockPosition LongArrayBlock block, @BlockIndex int position)
     {
         return block.getLong(position);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -198,7 +198,7 @@ final class ShortDecimalType
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             long value,
             @FlatFixed byte[] fixedSizeSlice,
@@ -209,7 +209,7 @@ final class ShortDecimalType
         LONG_HANDLE.set(fixedSizeSlice, fixedSizeOffset, value);
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(
             @FlatFixed byte[] leftFixedSizeSlice,
             @FlatFixedOffset int leftFixedSizeOffset,
@@ -221,37 +221,37 @@ final class ShortDecimalType
         return equalOperator((long) LONG_HANDLE.get(leftFixedSizeSlice, leftFixedSizeOffset), rightBlock.getLong(rightPosition));
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(long left, long right)
     {
         return left == right;
     }
 
-    @ScalarOperator(value = HASH_CODE, neverFails = true)
+    @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(long value)
     {
         return AbstractLongType.hash(value);
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash(value);
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(long left, long right)
     {
         return Long.compare(left, right);
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(long left, long right)
     {
         return left < right;
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(long left, long right)
     {
         return left <= right;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimeWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimeWithTimeZoneType.java
@@ -127,13 +127,13 @@ final class ShortTimeWithTimeZoneType
         return Long.BYTES;
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long read(@BlockPosition LongArrayBlock block, @BlockIndex int position)
     {
         return block.getLong(position);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -143,7 +143,7 @@ final class ShortTimeWithTimeZoneType
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             long value,
             @FlatFixed byte[] fixedSizeSlice,
@@ -154,37 +154,37 @@ final class ShortTimeWithTimeZoneType
         LONG_HANDLE.set(fixedSizeSlice, fixedSizeOffset, value);
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(long leftPackedTime, long rightPackedTime)
     {
         return normalizePackedTime(leftPackedTime) == normalizePackedTime(rightPackedTime);
     }
 
-    @ScalarOperator(value = HASH_CODE, neverFails = true)
+    @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(long packedTime)
     {
         return AbstractLongType.hash(normalizePackedTime(packedTime));
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(long packedTime)
     {
         return XxHash64.hash(normalizePackedTime(packedTime));
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(long left, long right)
     {
         return Long.compare(normalizePackedTime(left), normalizePackedTime(right));
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(long left, long right)
     {
         return normalizePackedTime(left) < normalizePackedTime(right);
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(long left, long right)
     {
         return normalizePackedTime(left) <= normalizePackedTime(right);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampType.java
@@ -162,13 +162,13 @@ final class ShortTimestampType
         return Optional.of((long) value + rescale(1_000_000, getPrecision(), 0));
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long read(@BlockPosition LongArrayBlock block, @BlockIndex int position)
     {
         return block.getLong(position);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -178,7 +178,7 @@ final class ShortTimestampType
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             long value,
             @FlatFixed byte[] fixedSizeSlice,
@@ -189,37 +189,37 @@ final class ShortTimestampType
         LONG_HANDLE.set(fixedSizeSlice, fixedSizeOffset, value);
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(long left, long right)
     {
         return left == right;
     }
 
-    @ScalarOperator(value = HASH_CODE, neverFails = true)
+    @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(long value)
     {
         return AbstractLongType.hash(value);
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash(value);
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(long left, long right)
     {
         return Long.compare(left, right);
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(long left, long right)
     {
         return left < right;
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(long left, long right)
     {
         return left <= right;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampWithTimeZoneType.java
@@ -127,13 +127,13 @@ final class ShortTimestampWithTimeZoneType
         return Long.BYTES;
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long read(@BlockPosition LongArrayBlock block, @BlockIndex int position)
     {
         return block.getLong(position);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -143,7 +143,7 @@ final class ShortTimestampWithTimeZoneType
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             long value,
             byte[] fixedSizeSlice,
@@ -154,7 +154,7 @@ final class ShortTimestampWithTimeZoneType
         LONG_HANDLE.set(fixedSizeSlice, fixedSizeOffset, value);
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(long left, long right)
     {
         long leftValue = unpackMillisUtc(left);
@@ -162,31 +162,31 @@ final class ShortTimestampWithTimeZoneType
         return leftValue == rightValue;
     }
 
-    @ScalarOperator(value = HASH_CODE, neverFails = true)
+    @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(long value)
     {
         return AbstractLongType.hash(unpackMillisUtc(value));
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash(unpackMillisUtc(value));
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(long left, long right)
     {
         return Long.compare(unpackMillisUtc(left), unpackMillisUtc(right));
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(long left, long right)
     {
         return unpackMillisUtc(left) < unpackMillisUtc(right);
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(long left, long right)
     {
         return unpackMillisUtc(left) <= unpackMillisUtc(right);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/SmallintType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SmallintType.java
@@ -210,7 +210,7 @@ public final class SmallintType
         return getClass().hashCode();
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long read(@BlockPosition ShortArrayBlock block, @BlockIndex int position)
     {
         return readShort(block, position);
@@ -221,7 +221,7 @@ public final class SmallintType
         return block.getShort(position);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -231,7 +231,7 @@ public final class SmallintType
         return (short) SHORT_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             long value,
             byte[] fixedSizeSlice,
@@ -242,37 +242,37 @@ public final class SmallintType
         SHORT_HANDLE.set(fixedSizeSlice, fixedSizeOffset, (short) value);
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(long left, long right)
     {
         return left == right;
     }
 
-    @ScalarOperator(value = HASH_CODE, neverFails = true)
+    @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(long value)
     {
         return AbstractLongType.hash((short) value);
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash((short) value);
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(long left, long right)
     {
         return Short.compare((short) left, (short) right);
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(long left, long right)
     {
         return ((short) left) < ((short) right);
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(long left, long right)
     {
         return ((short) left) <= ((short) right);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimeType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimeType.java
@@ -138,7 +138,7 @@ public final class TimeType
         return Optional.of(value + rescale(PICOSECONDS_PER_SECOND, getPrecision(), 0));
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -148,7 +148,7 @@ public final class TimeType
         return (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             long value,
             @FlatFixed byte[] fixedSizeSlice,
@@ -159,37 +159,37 @@ public final class TimeType
         LONG_HANDLE.set(fixedSizeSlice, fixedSizeOffset, value);
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(long left, long right)
     {
         return left == right;
     }
 
-    @ScalarOperator(value = HASH_CODE, neverFails = true)
+    @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(long value)
     {
         return AbstractLongType.hash(value);
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash(value);
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(long left, long right)
     {
         return Long.compare(left, right);
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThan(long left, long right)
     {
         return left < right;
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqual(long left, long right)
     {
         return left <= right;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TinyintType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TinyintType.java
@@ -205,7 +205,7 @@ public final class TinyintType
         return getClass().hashCode();
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long read(@BlockPosition ByteArrayBlock block, @BlockIndex int position)
     {
         return readByte(block, position);
@@ -216,7 +216,7 @@ public final class TinyintType
         return block.getByte(position);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static long readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -226,7 +226,7 @@ public final class TinyintType
         return fixedSizeSlice[fixedSizeOffset];
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             long value,
             byte[] fixedSizeSlice,
@@ -237,37 +237,37 @@ public final class TinyintType
         fixedSizeSlice[fixedSizeOffset] = (byte) value;
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(long left, long right)
     {
         return left == right;
     }
 
-    @ScalarOperator(value = HASH_CODE, neverFails = true)
+    @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(long value)
     {
         return AbstractLongType.hash((byte) value);
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash((byte) value);
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(long left, long right)
     {
         return Byte.compare((byte) left, (byte) right);
     }
 
-    @ScalarOperator(value = LESS_THAN, neverFails = true)
+    @ScalarOperator(LESS_THAN)
     private static boolean lessThanOperator(long left, long right)
     {
         return ((byte) left) < ((byte) right);
     }
 
-    @ScalarOperator(value = LESS_THAN_OR_EQUAL, neverFails = true)
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
     private static boolean lessThanOrEqualOperator(long left, long right)
     {
         return ((byte) left) <= ((byte) right);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
@@ -376,6 +376,9 @@ public final class TypeOperatorDeclaration
                     continue;
                 }
                 OperatorType operatorType = scalarOperator.value();
+                if (operatorType.neverFails() && scalarOperator.neverFails()) {
+                    throw new IllegalArgumentException("@ScalarOperator(neverFails = true) is redundant for %s operator which is always infallible: %s".formatted(operatorType, method));
+                }
 
                 MethodHandle methodHandle;
                 try {

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
@@ -385,48 +385,37 @@ public final class TypeOperatorDeclaration
                     throw new RuntimeException(e);
                 }
 
-                boolean neverFails = scalarOperator.neverFails();
                 switch (operatorType) {
                     case READ_VALUE -> addReadValueOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, typeJavaType),
-                            methodHandle,
-                            neverFails));
+                            methodHandle));
                     case EQUAL -> addEqualOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle,
-                            neverFails));
+                            methodHandle));
                     case HASH_CODE -> addHashCodeOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, long.class),
-                            methodHandle,
-                            neverFails));
+                            methodHandle));
                     case XX_HASH_64 -> addXxHash64Operator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, long.class),
-                            methodHandle,
-                            neverFails));
+                            methodHandle));
                     case IDENTICAL -> addIdenticalOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle,
-                            neverFails));
+                            methodHandle));
                     case INDETERMINATE -> addIndeterminateOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle,
-                            neverFails));
+                            methodHandle));
                     case COMPARISON_UNORDERED_LAST -> addComparisonUnorderedLastOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, long.class),
-                            methodHandle,
-                            neverFails));
+                            methodHandle));
                     case COMPARISON_UNORDERED_FIRST -> addComparisonUnorderedFirstOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, long.class),
-                            methodHandle,
-                            neverFails));
+                            methodHandle));
                     case LESS_THAN -> addLessThanOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle,
-                            neverFails));
+                            methodHandle));
                     case LESS_THAN_OR_EQUAL -> addLessThanOrEqualOperator(new OperatorMethodHandle(
                             parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle,
-                            neverFails));
+                            methodHandle));
                     default -> throw new IllegalArgumentException(operatorType + " operator is not supported: " + method);
                 }
                 addedOperator = true;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
@@ -95,7 +95,7 @@ public class TypeOperators
 
     public MethodHandle getReadValueOperator(Type type, InvocationConvention callingConvention)
     {
-        return getOperatorAdaptor(type, callingConvention, READ_VALUE).get().getMethodHandle();
+        return getOperatorAdaptor(type, callingConvention, READ_VALUE).get();
     }
 
     public MethodHandle getEqualOperator(Type type, InvocationConvention callingConvention)
@@ -103,7 +103,7 @@ public class TypeOperators
         if (!type.isComparable()) {
             throw new UnsupportedOperationException(type + " is not comparable");
         }
-        return getOperatorAdaptor(type, callingConvention, EQUAL).get().getMethodHandle();
+        return getOperatorAdaptor(type, callingConvention, EQUAL).get();
     }
 
     public MethodHandle getHashCodeOperator(Type type, InvocationConvention callingConvention)
@@ -111,7 +111,7 @@ public class TypeOperators
         if (!type.isComparable()) {
             throw new UnsupportedOperationException(type + " is not comparable");
         }
-        return getOperatorAdaptor(type, callingConvention, OperatorType.HASH_CODE).get().getMethodHandle();
+        return getOperatorAdaptor(type, callingConvention, OperatorType.HASH_CODE).get();
     }
 
     public MethodHandle getXxHash64Operator(Type type, InvocationConvention callingConvention)
@@ -119,7 +119,7 @@ public class TypeOperators
         if (!type.isComparable()) {
             throw new UnsupportedOperationException(type + " is not comparable");
         }
-        return getOperatorAdaptor(type, callingConvention, OperatorType.XX_HASH_64).get().getMethodHandle();
+        return getOperatorAdaptor(type, callingConvention, OperatorType.XX_HASH_64).get();
     }
 
     public MethodHandle getIdenticalOperator(Type type, InvocationConvention callingConvention)
@@ -127,7 +127,7 @@ public class TypeOperators
         if (!type.isComparable()) {
             throw new UnsupportedOperationException(type + " is not comparable");
         }
-        return getOperatorAdaptor(type, callingConvention, OperatorType.IDENTICAL).get().getMethodHandle();
+        return getOperatorAdaptor(type, callingConvention, OperatorType.IDENTICAL).get();
     }
 
     public MethodHandle getIndeterminateOperator(Type type, InvocationConvention callingConvention)
@@ -135,15 +135,10 @@ public class TypeOperators
         if (!type.isComparable()) {
             throw new UnsupportedOperationException(type + " is not comparable");
         }
-        return getOperatorAdaptor(type, callingConvention, OperatorType.INDETERMINATE).get().getMethodHandle();
+        return getOperatorAdaptor(type, callingConvention, OperatorType.INDETERMINATE).get();
     }
 
     public MethodHandle getComparisonUnorderedLastOperator(Type type, InvocationConvention callingConvention)
-    {
-        return getComparisonUnorderedLastOperatorHandle(type, callingConvention).getMethodHandle();
-    }
-
-    public OperatorMethodHandle getComparisonUnorderedLastOperatorHandle(Type type, InvocationConvention callingConvention)
     {
         if (!type.isOrderable()) {
             throw new UnsupportedOperationException(type + " is not orderable");
@@ -152,11 +147,6 @@ public class TypeOperators
     }
 
     public MethodHandle getComparisonUnorderedFirstOperator(Type type, InvocationConvention callingConvention)
-    {
-        return getComparisonUnorderedFirstOperatorHandle(type, callingConvention).getMethodHandle();
-    }
-
-    public OperatorMethodHandle getComparisonUnorderedFirstOperatorHandle(Type type, InvocationConvention callingConvention)
     {
         if (!type.isOrderable()) {
             throw new UnsupportedOperationException(type + " is not orderable");
@@ -170,15 +160,10 @@ public class TypeOperators
             throw new UnsupportedOperationException(type + " is not orderable");
         }
         OperatorType comparisonType = sortOrder.isNullsFirst() ? COMPARISON_UNORDERED_FIRST : COMPARISON_UNORDERED_LAST;
-        return getOperatorAdaptor(type, Optional.of(sortOrder), callingConvention, comparisonType).get().getMethodHandle();
+        return getOperatorAdaptor(type, Optional.of(sortOrder), callingConvention, comparisonType).get();
     }
 
     public MethodHandle getLessThanOperator(Type type, InvocationConvention callingConvention)
-    {
-        return getLessThanOperatorHandle(type, callingConvention).getMethodHandle();
-    }
-
-    public OperatorMethodHandle getLessThanOperatorHandle(Type type, InvocationConvention callingConvention)
     {
         if (!type.isOrderable()) {
             throw new UnsupportedOperationException(type + " is not orderable");
@@ -187,11 +172,6 @@ public class TypeOperators
     }
 
     public MethodHandle getLessThanOrEqualOperator(Type type, InvocationConvention callingConvention)
-    {
-        return getLessThanOrEqualOperatorHandle(type, callingConvention).getMethodHandle();
-    }
-
-    public OperatorMethodHandle getLessThanOrEqualOperatorHandle(Type type, InvocationConvention callingConvention)
     {
         if (!type.isOrderable()) {
             throw new UnsupportedOperationException(type + " is not orderable");
@@ -213,14 +193,14 @@ public class TypeOperators
     private class OperatorAdaptor
     {
         private final OperatorConvention operatorConvention;
-        private volatile OperatorMethodHandle adapted;
+        private volatile MethodHandle adapted;
 
         public OperatorAdaptor(OperatorConvention operatorConvention)
         {
             this.operatorConvention = operatorConvention;
         }
 
-        public OperatorMethodHandle get()
+        public MethodHandle get()
         {
             if (adapted == null) {
                 synchronized (this) {
@@ -232,11 +212,10 @@ public class TypeOperators
             return adapted;
         }
 
-        private OperatorMethodHandle adaptOperator(OperatorConvention operatorConvention)
+        private MethodHandle adaptOperator(OperatorConvention operatorConvention)
         {
             OperatorMethodHandle operatorMethodHandle = selectOperatorMethodHandleToAdapt(operatorConvention);
-            MethodHandle methodHandle = adaptOperator(operatorConvention, operatorMethodHandle);
-            return new OperatorMethodHandle(operatorConvention.callingConvention(), methodHandle, operatorMethodHandle.isNeverFails());
+            return adaptOperator(operatorConvention, operatorMethodHandle);
         }
 
         private static MethodHandle adaptOperator(OperatorConvention operatorConvention, OperatorMethodHandle operatorMethodHandle)
@@ -404,7 +383,8 @@ public class TypeOperators
             // if none of the arguments are nullable, return "equal"
             if (argumentConventions.stream().noneMatch(InvocationArgumentConvention::isNullable)) {
                 InvocationConvention convention = new InvocationConvention(argumentConventions, FAIL_ON_NULL, false, false);
-                return adaptOperator(new OperatorConvention(operatorConvention.type(), EQUAL, Optional.empty(), convention));
+                MethodHandle equalMethodHandle = adaptOperator(new OperatorConvention(operatorConvention.type(), EQUAL, Optional.empty(), convention));
+                return new OperatorMethodHandle(convention, equalMethodHandle);
             }
 
             // one or both of the arguments are nullable
@@ -434,7 +414,7 @@ public class TypeOperators
                     operatorConvention.type(),
                     EQUAL,
                     Optional.empty(),
-                    new InvocationConvention(equalArgumentConventions, FAIL_ON_NULL, false, false))).getMethodHandle();
+                    new InvocationConvention(equalArgumentConventions, FAIL_ON_NULL, false, false)));
             // add the unused null flag if necessary
             if (rightDistinctConvention == NULL_FLAG) {
                 equalMethodHandle = dropArguments(equalMethodHandle, equalMethodHandle.type().parameterCount(), boolean.class);
@@ -504,11 +484,11 @@ public class TypeOperators
             }
 
             OperatorConvention comparisonOperator = new OperatorConvention(operatorConvention.type(), COMPARISON_UNORDERED_LAST, Optional.empty(), comparisonCallingConvention);
-            OperatorMethodHandle comparison = adaptOperator(comparisonOperator);
+            MethodHandle comparisonMethod = adaptOperator(comparisonOperator);
             if (orEqual) {
-                return adaptComparisonToLessThanOrEqual(comparison);
+                return adaptComparisonToLessThanOrEqual(new OperatorMethodHandle(comparisonCallingConvention, comparisonMethod));
             }
-            return adaptComparisonToLessThan(comparison);
+            return adaptComparisonToLessThan(new OperatorMethodHandle(comparisonCallingConvention, comparisonMethod));
         }
 
         private OperatorMethodHandle generateOrderingOperator(OperatorConvention operatorConvention)
@@ -522,11 +502,13 @@ public class TypeOperators
                         Optional.empty(),
                         // null positions are handled separately in adaptBlockPositionComparisonToOrdering and not used in the comparison
                         simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL));
-                return adaptBlockPositionComparisonToOrdering(sortOrder, adaptOperator(comparisonOperator));
+                MethodHandle comparisonInvoker = adaptOperator(comparisonOperator);
+                return adaptBlockPositionComparisonToOrdering(sortOrder, comparisonInvoker);
             }
 
             OperatorConvention comparisonOperator = new OperatorConvention(operatorConvention.type(), comparisonType, Optional.empty(), simpleConvention(FAIL_ON_NULL, NULL_FLAG, NULL_FLAG));
-            return adaptNeverNullComparisonToOrdering(sortOrder, adaptOperator(comparisonOperator));
+            MethodHandle comparisonInvoker = adaptOperator(comparisonOperator);
+            return adaptNeverNullComparisonToOrdering(sortOrder, comparisonInvoker);
         }
 
         private static Type getOperatorReturnType(OperatorConvention operatorConvention)
@@ -659,24 +641,23 @@ public class TypeOperators
     // Adapt comparison to ordering
     //
 
-    private static OperatorMethodHandle adaptNeverNullComparisonToOrdering(SortOrder sortOrder, OperatorMethodHandle neverNullComparison)
+    private static OperatorMethodHandle adaptNeverNullComparisonToOrdering(SortOrder sortOrder, MethodHandle neverNullComparison)
     {
-        MethodHandle comparisonHandle = neverNullComparison.getMethodHandle();
         MethodType finalSignature = MethodType.methodType(
                 int.class,
                 boolean.class,
-                comparisonHandle.type().parameterType(0),
+                neverNullComparison.type().parameterType(0),
                 boolean.class,
-                comparisonHandle.type().parameterType(1));
+                neverNullComparison.type().parameterType(1));
 
         // (leftIsNull, rightIsNull, leftValue, rightValue)::int
-        MethodHandle order = adaptComparisonToOrdering(sortOrder, comparisonHandle);
+        MethodHandle order = adaptComparisonToOrdering(sortOrder, neverNullComparison);
         // (leftIsNull, leftValue, rightIsNull, rightValue)::int
         order = permuteArguments(order, finalSignature, 0, 2, 1, 3);
-        return new OperatorMethodHandle(simpleConvention(FAIL_ON_NULL, NULL_FLAG, NULL_FLAG), order, neverNullComparison.isNeverFails());
+        return new OperatorMethodHandle(simpleConvention(FAIL_ON_NULL, NULL_FLAG, NULL_FLAG), order);
     }
 
-    private static OperatorMethodHandle adaptBlockPositionComparisonToOrdering(SortOrder sortOrder, OperatorMethodHandle blockPositionComparison)
+    private static OperatorMethodHandle adaptBlockPositionComparisonToOrdering(SortOrder sortOrder, MethodHandle blockPositionComparison)
     {
         MethodType finalSignature = MethodType.methodType(
                 int.class,
@@ -686,14 +667,14 @@ public class TypeOperators
                 int.class);
 
         // (leftIsNull, rightIsNull, leftBlock, leftPosition, rightBlock, rightPosition)::int
-        MethodHandle order = adaptComparisonToOrdering(sortOrder, blockPositionComparison.getMethodHandle());
+        MethodHandle order = adaptComparisonToOrdering(sortOrder, blockPositionComparison);
         // (leftBlock, leftPosition, rightBlock, rightPosition, leftBlock, leftPosition, rightBlock, rightPosition)::int
         order = collectArguments(order, 1, BLOCK_IS_NULL);
         order = collectArguments(order, 0, BLOCK_IS_NULL);
         // (leftBlock, leftPosition, rightBlock, rightPosition)::int
         order = permuteArguments(order, finalSignature, 0, 1, 2, 3, 0, 1, 2, 3);
 
-        return new OperatorMethodHandle(simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION), order, blockPositionComparison.isNeverFails());
+        return new OperatorMethodHandle(simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION), order);
     }
 
     // input: (args)::int
@@ -751,7 +732,7 @@ public class TypeOperators
         if (returnConvention != FAIL_ON_NULL) {
             throw new IllegalArgumentException("Return convention must be " + FAIL_ON_NULL + ", but is " + returnConvention);
         }
-        return new OperatorMethodHandle(invoker.getCallingConvention(), filterReturnValue(invoker.getMethodHandle(), IS_COMPARISON_LESS_THAN), invoker.isNeverFails());
+        return new OperatorMethodHandle(invoker.getCallingConvention(), filterReturnValue(invoker.getMethodHandle(), IS_COMPARISON_LESS_THAN));
     }
 
     private static boolean isComparisonLessThan(long comparisonResult)
@@ -765,7 +746,7 @@ public class TypeOperators
         if (returnConvention != FAIL_ON_NULL) {
             throw new IllegalArgumentException("Return convention must be " + FAIL_ON_NULL + ", but is " + returnConvention);
         }
-        return new OperatorMethodHandle(invoker.getCallingConvention(), filterReturnValue(invoker.getMethodHandle(), IS_COMPARISON_LESS_THAN_OR_EQUAL), invoker.isNeverFails());
+        return new OperatorMethodHandle(invoker.getCallingConvention(), filterReturnValue(invoker.getMethodHandle(), IS_COMPARISON_LESS_THAN_OR_EQUAL));
     }
 
     private static boolean isComparisonLessThanOrEqual(long comparisonResult)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
@@ -650,10 +650,6 @@ public class TypeOperators
 
     private static OperatorMethodHandle defaultIndeterminateOperator(Class<?> javaType)
     {
-        // boolean distinctFrom(T value, boolean valueIsNull)
-        // {
-        //     return valueIsNull;
-        // }
         MethodHandle methodHandle = identity(boolean.class);
         methodHandle = dropArguments(methodHandle, 0, javaType);
         return new OperatorMethodHandle(simpleConvention(FAIL_ON_NULL, NULL_FLAG), methodHandle);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/UuidType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/UuidType.java
@@ -177,7 +177,7 @@ public class UuidType
                 reverseBytes(uuid.getLong(SIZE_OF_LONG)));
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static Slice read(@BlockPosition Int128ArrayBlock block, @BlockIndex int position)
     {
         Slice value = Slices.allocate(INT128_BYTES);
@@ -186,7 +186,7 @@ public class UuidType
         return value;
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static Slice readFlat(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -196,7 +196,7 @@ public class UuidType
         return wrappedBuffer(fixedSizeSlice, fixedSizeOffset, INT128_BYTES);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void writeFlat(
             Slice sourceSlice,
             @FlatFixed byte[] fixedSizeSlice,
@@ -207,7 +207,7 @@ public class UuidType
         sourceSlice.getBytes(0, fixedSizeSlice, fixedSizeOffset, INT128_BYTES);
     }
 
-    @ScalarOperator(value = READ_VALUE, neverFails = true)
+    @ScalarOperator(READ_VALUE)
     private static void readFlatToBlock(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -220,7 +220,7 @@ public class UuidType
                 (long) LONG_HANDLE.get(fixedSizeSlice, fixedSizeOffset + SIZE_OF_LONG));
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(Slice left, Slice right)
     {
         return equal(
@@ -230,7 +230,7 @@ public class UuidType
                 right.getLong(SIZE_OF_LONG));
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(@BlockPosition Int128ArrayBlock leftBlock, @BlockIndex int leftPosition, @BlockPosition Int128ArrayBlock rightBlock, @BlockIndex int rightPosition)
     {
         return equal(
@@ -240,7 +240,7 @@ public class UuidType
                 rightBlock.getInt128Low(rightPosition));
     }
 
-    @ScalarOperator(value = EQUAL, neverFails = true)
+    @ScalarOperator(EQUAL)
     private static boolean equalOperator(
             @FlatFixed byte[] leftFixedSizeSlice,
             @FlatFixedOffset int leftFixedSizeOffset,
@@ -261,19 +261,19 @@ public class UuidType
         return leftLow == rightLow && leftHigh == rightHigh;
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(Slice value)
     {
         return xxHash64(value.getLong(0), value.getLong(SIZE_OF_LONG));
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(@BlockPosition Int128ArrayBlock block, @BlockIndex int position)
     {
         return xxHash64(block.getInt128High(position), block.getInt128Low(position));
     }
 
-    @ScalarOperator(value = XX_HASH_64, neverFails = true)
+    @ScalarOperator(XX_HASH_64)
     private static long xxHash64Operator(
             @FlatFixed byte[] fixedSizeSlice,
             @FlatFixedOffset int fixedSizeOffset,
@@ -290,7 +290,7 @@ public class UuidType
         return XxHash64.hash(low) ^ XxHash64.hash(high);
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(Slice left, Slice right)
     {
         return compareLittleEndian(
@@ -300,7 +300,7 @@ public class UuidType
                 right.getLong(SIZE_OF_LONG));
     }
 
-    @ScalarOperator(value = COMPARISON_UNORDERED_LAST, neverFails = true)
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonOperator(@BlockPosition Int128ArrayBlock leftBlock, @BlockIndex int leftPosition, @BlockPosition Int128ArrayBlock rightBlock, @BlockIndex int rightPosition)
     {
         return compareLittleEndian(


### PR DESCRIPTION
Since 5e1d4ebd04f2bbabb12249a194f166becd394b34 and eef1a798234a756fffe3e12c9825eaacbff60a9e (https://github.com/trinodb/trino/pull/30013), comparisons are infallible.

- follows https://github.com/trinodb/trino/pull/29977#issuecomment-4790354555
- follows https://github.com/trinodb/trino/pull/30013