### PR TITLE
Operator-level fallibility coverage for array_sort/greatest/least

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
@@ -3276,6 +3276,20 @@ public class TestMathFunctions
         assertThat(assertions.function("greatest", "ARRAY[CAST(NaN() as REAL)]", "ARRAY[CAST(NaN() as REAL)]", "ARRAY[CAST(NaN() as REAL)]"))
                 .hasType(new ArrayType(REAL))
                 .isEqualTo(ImmutableList.of(Float.NaN));
+
+        assertThat(assertions.expression("greatest(ROW(1, NULL), ROW(1, 2)) IS NOT DISTINCT FROM ROW(1, 2)"))
+                .isEqualTo(true);
+        assertThat(assertions.expression("greatest(ARRAY[1, NULL], ARRAY[1, 2])"))
+                .matches("ARRAY[1, 2]");
+
+        assertThat(assertions.function("greatest", "ROW(1, 2)", "ROW(1, 3)"))
+                .neverFails();
+        assertThat(assertions.function("greatest", "ARRAY[1, 2]", "ARRAY[1, 3]"))
+                .neverFails();
+        assertThat(assertions.function("greatest", "1", "2"))
+                .neverFails();
+        assertThat(assertions.function("greatest", "VARCHAR 'a'", "VARCHAR 'b'"))
+                .neverFails();
     }
 
     @Test
@@ -3604,6 +3618,20 @@ public class TestMathFunctions
         assertThat(assertions.function("least", "ARRAY[CAST(NaN() as REAL)]", "ARRAY[CAST(NaN() as REAL)]", "ARRAY[CAST(NaN() as REAL)]"))
                 .hasType(new ArrayType(REAL))
                 .isEqualTo(ImmutableList.of(Float.NaN));
+
+        assertThat(assertions.expression("least(ROW(1, NULL), ROW(1, 2)) IS NOT DISTINCT FROM ROW(1, 2)"))
+                .isEqualTo(true);
+        assertThat(assertions.expression("least(ARRAY[1, NULL], ARRAY[1, 2])"))
+                .matches("ARRAY[1, 2]");
+
+        assertThat(assertions.function("least", "ROW(1, 2)", "ROW(1, 3)"))
+                .neverFails();
+        assertThat(assertions.function("least", "ARRAY[1, 2]", "ARRAY[1, 3]"))
+                .neverFails();
+        assertThat(assertions.function("least", "1", "2"))
+                .neverFails();
+        assertThat(assertions.function("least", "VARCHAR 'a'", "VARCHAR 'b'"))
+                .neverFails();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
@@ -3574,6 +3574,15 @@ public class TestArrayOperators
                 .hasType(new ArrayType(INTEGER))
                 .isEqualTo(asList(-1, 0, 1, null, null));
 
+        assertThat(assertions.function("array_sort", "ARRAY[ROW(1, 2), ROW(1, 3)]"))
+                .neverFails();
+        assertThat(assertions.function("array_sort", "ARRAY[ARRAY[1, 2], ARRAY[1, 3]]"))
+                .neverFails();
+        assertThat(assertions.expression("array_sort(ARRAY[ROW(1, NULL), ROW(1, 2)])"))
+                .matches("ARRAY[ROW(1, 2), ROW(1, NULL)]");
+        assertThat(assertions.expression("array_sort(ARRAY[ARRAY[1, NULL], ARRAY[1, 2]])"))
+                .matches("ARRAY[ARRAY[1, 2], ARRAY[1, NULL]]");
+
         // invalid functions
         assertTrinoExceptionThrownBy(assertions.function("array_sort", "ARRAY[color('red'), color('blue')]")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND);


### PR DESCRIPTION
## Description
Operator-level fallibility coverage for `array_sort`, `greatest`, and `least`, extracted from #29977 (superseded by #30013).

#30013 made `ROW`/`ARRAY` comparison with null elements total, which makes these three functions correctly infallible over such types — the mis-declared fallibility that #29977 set out to fix is now consistent with runtime. #30013 tests the comparison operators directly but never exercises these functions. For each function these tests assert both halves of the fallibility contract:
- the planner treats it as infallible over a totally-ordered `ROW`/`ARRAY` type (`neverFails`), and
- at runtime a null sub-field/sub-element no longer throws `NOT_SUPPORTED`.

## Release notes
(X) This is not user-visible or is docs only, and no release notes are required.
