### PR TITLE
Close/release resources on spooling retrieval failure

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/OkHttpSegmentLoader.java
+++ b/client/trino-client/src/main/java/io/trino/client/OkHttpSegmentLoader.java
@@ -64,6 +64,8 @@ public class OkHttpSegmentLoader
         if (response.isSuccessful()) {
             return response.body().byteStream();
         }
+
+        response.close();
         throw new IOException(format("Could not open segment for streaming, got error '%s' with code %d", response.message(), response.code()));
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/spooling/SpooledSegmentIterator.java
+++ b/client/trino-client/src/main/java/io/trino/client/spooling/SpooledSegmentIterator.java
@@ -66,6 +66,12 @@ class SpooledSegmentIterator
             loaded = true;
         }
         catch (IOException e) {
+            try {
+                closer.close();
+            }
+            catch (IOException closeException) {
+                e.addSuppressed(closeException);
+            }
             closed = true;
             throw new UncheckedIOException(e);
         }

--- a/client/trino-client/src/test/java/io/trino/client/spooling/TestSpooledSegmentIterator.java
+++ b/client/trino-client/src/test/java/io/trino/client/spooling/TestSpooledSegmentIterator.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.spooling;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.client.CloseableIterator;
+import io.trino.client.QueryDataDecoder;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.util.List;
+
+import static io.trino.client.spooling.DataAttribute.ROWS_COUNT;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestSpooledSegmentIterator
+{
+    private static final SpooledSegment SEGMENT = new SpooledSegment(
+            URI.create("http://localhost/data"),
+            URI.create("http://localhost/ack"),
+            DataAttributes.builder().set(ROWS_COUNT, 1L).build(),
+            ImmutableMap.of());
+
+    @Test
+    void testClosesStreamAndAcknowledgesSegmentWhenDecodingFails()
+    {
+        TrackingInputStream stream = new TrackingInputStream();
+        RecordingSegmentLoader loader = new RecordingSegmentLoader(stream);
+        IOException decodeFailure = new IOException("decode failed");
+
+        SpooledSegmentIterator iterator = new SpooledSegmentIterator(SEGMENT, loader, failingDecoder(decodeFailure));
+
+        assertThatThrownBy(iterator::load)
+                .isInstanceOf(UncheckedIOException.class)
+                .hasCause(decodeFailure);
+
+        assertThat(stream.closed).isTrue();
+        assertThat(loader.acknowledgedSegment).isEqualTo(SEGMENT);
+
+        assertThatThrownBy(iterator::load)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Iterator is already closed");
+    }
+
+    @Test
+    void testSuppressesCloseFailureWhenDecodingFails()
+    {
+        IOException closeFailure = new IOException("close failed");
+        TrackingInputStream stream = new TrackingInputStream(closeFailure);
+        RecordingSegmentLoader loader = new RecordingSegmentLoader(stream);
+        IOException decodeFailure = new IOException("decode failed");
+
+        SpooledSegmentIterator iterator = new SpooledSegmentIterator(SEGMENT, loader, failingDecoder(decodeFailure));
+
+        assertThatThrownBy(iterator::load)
+                .isInstanceOf(UncheckedIOException.class)
+                .cause()
+                .isSameAs(decodeFailure)
+                .satisfies(cause -> assertThat(cause.getSuppressed()).contains(closeFailure));
+    }
+
+    private static QueryDataDecoder failingDecoder(IOException failure)
+    {
+        return new QueryDataDecoder()
+        {
+            @Override
+            public CloseableIterator<List<Object>> decode(InputStream input, DataAttributes segmentAttributes)
+                    throws IOException
+            {
+                throw failure;
+            }
+
+            @Override
+            public String encoding()
+            {
+                return "failing";
+            }
+        };
+    }
+
+    private static class RecordingSegmentLoader
+            implements SegmentLoader
+    {
+        private final InputStream stream;
+        private SpooledSegment acknowledgedSegment;
+
+        private RecordingSegmentLoader(InputStream stream)
+        {
+            this.stream = requireNonNull(stream, "stream is null");
+        }
+
+        @Override
+        public InputStream load(SpooledSegment segment)
+        {
+            return stream;
+        }
+
+        @Override
+        public void acknowledge(SpooledSegment segment)
+        {
+            this.acknowledgedSegment = requireNonNull(segment, "segment is null");
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static class TrackingInputStream
+            extends InputStream
+    {
+        private final IOException closeFailure;
+        private boolean closed;
+
+        private TrackingInputStream()
+        {
+            this(null);
+        }
+
+        private TrackingInputStream(IOException closeFailure)
+        {
+            this.closeFailure = closeFailure;
+        }
+
+        @Override
+        public int read()
+        {
+            return -1;
+        }
+
+        @Override
+        public void close()
+                throws IOException
+        {
+            closed = true;
+            if (closeFailure != null) {
+                throw closeFailure;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fixes https://github.com/trinodb/trino/issues/30048

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## CLI/JDBC
* Handle segment retrieval errors gracefully ({issue}`issuenumber`)
```
