### PR TITLE
Avoid scheduler sleep when only some stages are blocked

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
@@ -1335,9 +1335,11 @@ public class PipelinedQueryScheduler
                         futures.addAll(blockedStages);
                         // allow for schedule to resume scheduling (e.g. when some active stage completes
                         // and dependent stages can be started)
-                        stagesScheduleResult.getRescheduleFuture().ifPresent(futures::add);
-                        try (TimeStat.BlockTimer _ = schedulerStats.getSleepTime().time()) {
-                            tryGetFutureValue(whenAnyComplete(futures.build()), 1, SECONDS);
+                        if (blockedStages.size() == stagesScheduleResult.getStagesToSchedule().size()) {
+                            stagesScheduleResult.getRescheduleFuture().ifPresent(futures::add);
+                            try (TimeStat.BlockTimer _ = schedulerStats.getSleepTime().time()) {
+                                tryGetFutureValue(whenAnyComplete(futures.build()), 1, SECONDS);
+                            }
                         }
                         for (ListenableFuture<Void> blockedStage : blockedStages) {
                             blockedStage.cancel(true);


### PR DESCRIPTION
The pipelined scheduler waited up to one second on blocked stage futures whenever any stage reported blocked, even when other stages in the same scheduling iteration could still make progress. This added needless scheduling latency.

Only wait when every stage to schedule is blocked. When some stages are still progressing, cancel the blocked futures and reschedule immediately instead of sleeping.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
