### PR TITLE
Fix revapi violations after 482 release

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -612,6 +612,27 @@
                                     <old>class io.trino.spi.type.TypeParameter.Variable</old>
                                     <justification>A TypeSignature is now always ground; variables live only in TypeTemplate, so the Variable type parameter is removed.</justification>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
+                                    <old>method io.trino.spi.type.TypeTemplate io.trino.spi.type.TypeTemplates::type(java.lang.String, io.trino.spi.type.NumericExpression[])</old>
+                                    <new>method io.trino.spi.type.TypeTemplate io.trino.spi.type.TypeTemplates::type(java.lang.String, io.trino.spi.type.NumericExpression[])</new>
+                                    <justification>Revapi detects this by mistake</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
+                                    <old>method io.trino.spi.type.TypeTemplate io.trino.spi.type.TypeTemplates::type(java.lang.String, io.trino.spi.type.TemplateParameter[])</old>
+                                    <new>method io.trino.spi.type.TypeTemplate io.trino.spi.type.TypeTemplates::type(java.lang.String, io.trino.spi.type.TemplateParameter[])</new>
+                                    <justification>Revapi detects this by mistake</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
+                                    <old>method io.trino.spi.type.TypeTemplate io.trino.spi.type.TypeTemplates::type(java.lang.String, io.trino.spi.type.TypeTemplate[])</old>
+                                    <new>method io.trino.spi.type.TypeTemplate io.trino.spi.type.TypeTemplates::type(java.lang.String, io.trino.spi.type.TypeTemplate[])</new>
+                                    <justification>Revapi detects this by mistake</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>


### PR DESCRIPTION
Seems that revapi has an issue and detects violations that were previously ignored

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
