### PR TITLE
Disable revapi varargs check

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -203,6 +203,10 @@
                                 <item>
                                     <code>java.annotation.added</code>
                                 </item>
+                                <item>
+                                    <!-- Disabled due to too many false positives -->
+                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
+                                </item>
                                 <!-- Allow changing enum constant order (e.g., StandardErrorCode) -->
                                 <item>
                                     <code>java.field.enumConstantOrderChanged</code>
@@ -226,81 +230,6 @@
                                     </old>
                                 </item>
                                 <!-- Backwards incompatible changes since the previous release -->
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
-                                    <new>method io.trino.spi.function.Signature.Builder io.trino.spi.function.Signature.Builder::argumentTypes(io.trino.spi.type.TypeDescriptor[])</new>
-                                    <justification>argumentTypes deliberately overloads on TypeDescriptor... and TypeTemplate... so call sites keep a stable shape across the ground/open split.</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
-                                    <new>method io.trino.spi.function.Signature.Builder io.trino.spi.function.Signature.Builder::argumentTypes(io.trino.spi.type.TypeTemplate[])</new>
-                                    <justification>argumentTypes deliberately overloads on TypeDescriptor... and TypeTemplate... so call sites keep a stable shape across the ground/open split.</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
-                                    <old>method io.opentelemetry.api.common.AttributesBuilder io.opentelemetry.api.common.AttributesBuilder::put(java.lang.String, boolean[])</old>
-                                    <new>method io.opentelemetry.api.common.AttributesBuilder io.opentelemetry.api.common.AttributesBuilder::put(java.lang.String, boolean[])</new>
-                                    <justification>Revapi now detects new API changes to vararg args</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
-                                    <old>method io.opentelemetry.api.common.AttributesBuilder io.opentelemetry.api.common.AttributesBuilder::put(java.lang.String, double[])</old>
-                                    <new>method io.opentelemetry.api.common.AttributesBuilder io.opentelemetry.api.common.AttributesBuilder::put(java.lang.String, double[])</new>
-                                    <justification>Revapi now detects new API changes to vararg args</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
-                                    <old>method io.opentelemetry.api.common.AttributesBuilder io.opentelemetry.api.common.AttributesBuilder::put(java.lang.String, java.lang.String[])</old>
-                                    <new>method io.opentelemetry.api.common.AttributesBuilder io.opentelemetry.api.common.AttributesBuilder::put(java.lang.String, java.lang.String[])</new>
-                                    <justification>Revapi now detects new API changes to vararg args</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
-                                    <old>method io.opentelemetry.api.common.AttributesBuilder io.opentelemetry.api.common.AttributesBuilder::put(java.lang.String, long[])</old>
-                                    <new>method io.opentelemetry.api.common.AttributesBuilder io.opentelemetry.api.common.AttributesBuilder::put(java.lang.String, long[])</new>
-                                    <justification>Revapi now detects new API changes to vararg args</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
-                                    <old>method io.opentelemetry.api.common.Value&lt;java.util.List&lt;io.opentelemetry.api.common.KeyValue&gt;&gt; io.opentelemetry.api.common.Value&lt;T&gt;::of(io.opentelemetry.api.common.KeyValue[])</old>
-                                    <new>method io.opentelemetry.api.common.Value&lt;java.util.List&lt;io.opentelemetry.api.common.KeyValue&gt;&gt; io.opentelemetry.api.common.Value&lt;T&gt;::of(io.opentelemetry.api.common.KeyValue[])</new>
-                                    <justification>Revapi now detects new API changes to vararg args</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
-                                    <old>method io.opentelemetry.api.common.Value&lt;java.util.List&lt;io.opentelemetry.api.common.Value&lt;?&gt;&gt;&gt; io.opentelemetry.api.common.Value&lt;T&gt;::of(io.opentelemetry.api.common.Value&lt;?&gt;[])</old>
-                                    <new>method io.opentelemetry.api.common.Value&lt;java.util.List&lt;io.opentelemetry.api.common.Value&lt;?&gt;&gt;&gt; io.opentelemetry.api.common.Value&lt;T&gt;::of(io.opentelemetry.api.common.Value&lt;?&gt;[])</new>
-                                    <justification>Revapi now detects new API changes to vararg args</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
-                                    <old>method io.trino.spi.type.TypeTemplate io.trino.spi.type.TypeTemplates::type(java.lang.String, io.trino.spi.type.NumericExpression[])</old>
-                                    <new>method io.trino.spi.type.TypeTemplate io.trino.spi.type.TypeTemplates::type(java.lang.String, io.trino.spi.type.NumericExpression[])</new>
-                                    <justification>Revapi detects this by mistake</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
-                                    <old>method io.trino.spi.type.TypeTemplate io.trino.spi.type.TypeTemplates::type(java.lang.String, io.trino.spi.type.TemplateParameter[])</old>
-                                    <new>method io.trino.spi.type.TypeTemplate io.trino.spi.type.TypeTemplates::type(java.lang.String, io.trino.spi.type.TemplateParameter[])</new>
-                                    <justification>Revapi detects this by mistake</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.varargOverloadsOnlyDifferInVarargParameter</code>
-                                    <old>method io.trino.spi.type.TypeTemplate io.trino.spi.type.TypeTemplates::type(java.lang.String, io.trino.spi.type.TypeTemplate[])</old>
-                                    <new>method io.trino.spi.type.TypeTemplate io.trino.spi.type.TypeTemplates::type(java.lang.String, io.trino.spi.type.TypeTemplate[])</new>
-                                    <justification>Revapi detects this by mistake</justification>
-                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>


### PR DESCRIPTION
`varargOverloadsOnlyDifferInVarargParameter` revapi check inspects API methods that differ only in varargs params, which can lead to ambiguous call sites. It is independent from revapi's primary job of verifying API *changes*. The check, however, has false positives

- flags methods which will never be called with zero arguments (like builder methods)
- flags unambiguously designed APIs where varargs methods are complemented with a non-varargs method.
