### PR TITLE
Add a requireNonNull guard for DynamicFilterSnapshot currentPredicate

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/DynamicFilterSnapshot.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/DynamicFilterSnapshot.java
@@ -15,6 +15,8 @@ package io.trino.spi.connector;
 
 import io.trino.spi.predicate.TupleDomain;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A per-batch snapshot of the engine's dynamic filter state, passed to
  * {@link ConnectorSplitSource#getNextBatch(int, DynamicFilterSnapshot)}.
@@ -22,4 +24,9 @@ import io.trino.spi.predicate.TupleDomain;
 public record DynamicFilterSnapshot(TupleDomain<ColumnHandle> currentPredicate, boolean isComplete)
 {
     public static final DynamicFilterSnapshot EMPTY = new DynamicFilterSnapshot(TupleDomain.all(), true);
+
+    public DynamicFilterSnapshot
+    {
+        requireNonNull(currentPredicate, "currentPredicate is null");
+    }
 }


### PR DESCRIPTION
## Description

Add a compact canonical constructor to `DynamicFilterSnapshot` that null-checks `currentPredicate`, so a null predicate is rejected at construction rather than surfacing later as an NPE.

## Additional context and related issues

No behavioral change for existing callers — none pass a null `currentPredicate` today.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.