### PR TITLE
Add requireNonNull check to DynamicFilterSnapshot

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/DynamicFilterSnapshot.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/DynamicFilterSnapshot.java
@@ -15,6 +15,8 @@ package io.trino.spi.connector;
 
 import io.trino.spi.predicate.TupleDomain;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A per-batch snapshot of the engine's dynamic filter state, passed to
  * {@link ConnectorSplitSource#getNextBatch(int, DynamicFilterSnapshot)}.
@@ -22,4 +24,9 @@ import io.trino.spi.predicate.TupleDomain;
 public record DynamicFilterSnapshot(TupleDomain<ColumnHandle> currentPredicate, boolean isComplete)
 {
     public static final DynamicFilterSnapshot EMPTY = new DynamicFilterSnapshot(TupleDomain.all(), true);
+
+    public DynamicFilterSnapshot
+    {
+        requireNonNull(currentPredicate, "currentPredicate is null");
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Add a compact constructor to the `DynamicFilterSnapshot` record that performs a `requireNonNull` check on `currentPredicate`, so a null predicate fails fast at construction with a clear message rather than surfacing later as an opaque NPE.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

`DynamicFilterSnapshot` is a per-batch snapshot of the engine's dynamic filter state passed to `ConnectorSplitSource#getNextBatch`. The check follows the codebase convention of validating record/constructor arguments with `requireNonNull`. `isComplete` is a primitive `boolean` and needs no null check.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.