### PR TITLE
Pass specsById to ManifestFiles.read for data manifests

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -1369,7 +1369,7 @@ public final class IcebergUtil
     public static ManifestReader<? extends ContentFile<?>> readerForManifest(ManifestFile manifest, FileIO fileIO, Map<Integer, PartitionSpec> specsById)
     {
         return switch (manifest.content()) {
-            case DATA -> ManifestFiles.read(manifest, fileIO);
+            case DATA -> ManifestFiles.read(manifest, fileIO, specsById);
             case DELETES -> ManifestFiles.readDeleteManifest(manifest, fileIO, specsById);
         };
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
@@ -782,7 +782,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(METADATA_JSON, "InputFile.newStream"))
                         .addCopies(new FileOperation(SNAPSHOT, "InputFile.length"), 4)
                         .addCopies(new FileOperation(SNAPSHOT, "InputFile.newStream"), 4)
-                        .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 5)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 3)
                         .build());
 
         assertUpdate("DROP TABLE " + tableName);


### PR DESCRIPTION
## Summary

`ManifestFiles.read(manifest, fileIO)` (the 2-arg form) was deprecated in Iceberg 1.11.0. Callers should pass `specsById` to avoid the `ManifestReader` falling back to reading the partition spec from file metadata on every manifest read.

`IcebergUtil.readerForManifest` already passed `specsById` for delete manifests but was missing it for data manifests.

## Changes

- `IcebergUtil.readerForManifest`: pass `specsById` to `ManifestFiles.read` for the `DATA` case, matching the existing `DELETES` branch.

## Testing

Existing tests cover the manifest reading path. No new tests needed — this is a one-line correctness fix that silences the deprecation warning and prepares for Iceberg 1.12.0 which removes the 2-arg form.