### PR TITLE
Incorrect query result due to dropped negation in DomainTranslator Let extraction

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -373,7 +373,7 @@ public final class DomainTranslator
             if (result.getTupleDomain().isAll()) {
                 // Nothing was extracted; keep the original Let as the remainder so the residual
                 // predicate still evaluates the bound value exactly once.
-                return new ExtractionResult(TupleDomain.all(), node);
+                return new ExtractionResult(TupleDomain.all(), complementIfNecessary(node, complement));
             }
             return result;
         }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
@@ -191,6 +191,9 @@ public class TestDomainTranslator
                         greaterThanOrEqual(new Reference(BIGINT, "v"), bigintLiteral(1L)),
                         lessThanOrEqual(new Reference(BIGINT, "v"), bigintLiteral(10L))));
         assertPredicateTranslates(let, TupleDomain.all(), let);
+
+        Expression notLet = not(let);
+        assertPredicateTranslates(notLet, TupleDomain.all(), notLet);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestPredicatePushdown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestPredicatePushdown.java
@@ -13,11 +13,19 @@
  */
 package io.trino.sql.query;
 
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.StandaloneQueryRunner;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
+import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -26,7 +34,19 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @Execution(CONCURRENT)
 public class TestPredicatePushdown
 {
-    private final QueryAssertions assertions = new QueryAssertions();
+    private final QueryAssertions assertions;
+
+    public TestPredicatePushdown()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(TEST_CATALOG_NAME)
+                .setSchema(TINY_SCHEMA_NAME)
+                .build();
+        QueryRunner runner = new StandaloneQueryRunner(session);
+        runner.installPlugin(new TpchPlugin());
+        runner.createCatalog(TEST_CATALOG_NAME, "tpch", ImmutableMap.of("tpch.splits-per-node", "1"));
+        assertions = new QueryAssertions(runner);
+    }
 
     @AfterAll
     public void teardown()
@@ -89,5 +109,63 @@ public class TestPredicatePushdown
                         ") " +
                         "WHERE k = 1 AND r <> 0"))
                 .matches("VALUES (1, 1)");
+    }
+
+    @Test
+    public void testNotBetweenOverExpression()
+    {
+        // The CAST in the SQLs below keeps the operand non-trivial so BETWEEN lowers to a Let; a bare column would inline and bypass the negation-dropping path under test.
+        assertThat(assertions.query(
+                """
+                SELECT count(*) FROM orders
+                WHERE CAST(orderdate AS timestamp(6)) BETWEEN TIMESTAMP '1995-03-01 00:00:00' AND TIMESTAMP '1995-03-31 23:59:59.999999'
+                """))
+                .matches(
+                        """
+                        SELECT count(*) FROM orders
+                        WHERE CAST(orderdate AS timestamp(6)) >= TIMESTAMP '1995-03-01 00:00:00'
+                            AND CAST(orderdate AS timestamp(6)) <= TIMESTAMP '1995-03-31 23:59:59.999999'
+                        """);
+
+        assertThat(assertions.query(
+                """
+                SELECT count(*) FROM orders
+                WHERE CAST(orderdate AS timestamp(6)) NOT BETWEEN TIMESTAMP '1995-03-01 00:00:00' AND TIMESTAMP '1995-03-31 23:59:59.999999'
+                """))
+                .matches(
+                        """
+                        SELECT count(*) FROM orders
+                        WHERE CAST(orderdate AS timestamp(6)) < TIMESTAMP '1995-03-01 00:00:00'
+                            OR CAST(orderdate AS timestamp(6)) > TIMESTAMP '1995-03-31 23:59:59.999999'
+                        """);
+    }
+
+    @Test
+    public void testNotNullIfOverExpression()
+    {
+        // The CAST in the SQLs below keeps the operand non-trivial so NULLIF lowers to a Let; a bare column would inline and bypass the negation-dropping path under test.
+        assertThat(assertions.query(
+                """
+                SELECT count(*) FROM orders
+                WHERE NULLIF(CAST(orderdate AS timestamp(6)) = TIMESTAMP '1995-03-01 00:00:00', true)
+                """))
+                .matches(
+                        """
+                        SELECT count(*) FROM orders
+                        WHERE CASE WHEN CAST(orderdate AS timestamp(6)) = TIMESTAMP '1995-03-01 00:00:00' THEN NULL
+                            ELSE CAST(orderdate AS timestamp(6)) = TIMESTAMP '1995-03-01 00:00:00' END
+                        """);
+
+        assertThat(assertions.query(
+                """
+                SELECT count(*) FROM orders
+                WHERE NOT NULLIF(CAST(orderdate AS timestamp(6)) = TIMESTAMP '1995-03-01 00:00:00', true)
+                """))
+                .matches(
+                        """
+                        SELECT count(*) FROM orders
+                        WHERE NOT(CASE WHEN CAST(orderdate AS timestamp(6)) = TIMESTAMP '1995-03-01 00:00:00' THEN NULL
+                            ELSE CAST(orderdate AS timestamp(6)) = TIMESTAMP '1995-03-01 00:00:00' END)
+                        """);
     }
 }


### PR DESCRIPTION
## Description
`visitLet` drops the complement in the special-case early return branch.

In master, the below queries with `BETWEEN` and `NOT BETWEEN` return the same number of rows (both are `181`):
```SQL
trino> SELECT count(*) FROM tpch.tiny.orders;
 _col0
-------
 15000
(1 row)

Query 20260626_203804_00000_rrj25, FINISHED, 1 node
Splits: 13 total, 13 done (100.00%)
1.95 [15K rows, 172B] [7.7K rows/s, 88B/s]

trino> SELECT count(*) FROM tpch.tiny.orders
    -> WHERE CAST(o_orderdate AS timestamp(6))
    ->     NOT  BETWEEN TIMESTAMP '1995-03-01 00:00:00' AND TIMESTAMP '1995-03-31 23:59:59.999999';
 _col0
-------
   181
(1 row)

Query 20260626_203809_00001_rrj25, FINISHED, 1 node
Splits: 13 total, 13 done (100.00%)
0.91 [15K rows, 172B] [16.4K rows/s, 188B/s]

trino> SELECT count(*) FROM tpch.tiny.orders
    -> WHERE CAST(o_orderdate AS timestamp(6))
    ->       BETWEEN TIMESTAMP '1995-03-01 00:00:00' AND TIMESTAMP '1995-03-31 23:59:59.999999';
 _col0
-------
   181
(1 row)

Query 20260626_203816_00002_rrj25, FINISHED, 1 node
Splits: 13 total, 13 done (100.00%)
0.14 [15K rows, 172B] [108K rows/s, 1.21KiB/s]
```

With the fix, it shows the correct result (`181` vs `14819`):
```SQL
trino> SELECT count(*) FROM tpch.tiny.orders;
 _col0
-------
 15000
(1 row)

Query 20260626_214216_00000_4fsw2, FINISHED, 1 node
Splits: 13 total, 13 done (100.00%)
2.02 [15K rows, 172B] [7.42K rows/s, 85B/s]

trino> SELECT count(*) FROM tpch.tiny.orders
    -> WHERE CAST(o_orderdate AS timestamp(6))
    ->       BETWEEN TIMESTAMP '1995-03-01 00:00:00' AND TIMESTAMP '1995-03-31 23:59:59.999999';
 _col0
-------
   181
(1 row)

Query 20260626_214222_00001_4fsw2, FINISHED, 1 node
Splits: 13 total, 13 done (100.00%)
0.92 [15K rows, 172B] [16.4K rows/s, 188B/s]

trino> SELECT count(*) FROM tpch.tiny.orders
    -> WHERE CAST(o_orderdate AS timestamp(6))
    ->     NOT  BETWEEN TIMESTAMP '1995-03-01 00:00:00' AND TIMESTAMP '1995-03-31 23:59:59.999999';
 _col0
-------
 14819
(1 row)

Query 20260626_214232_00002_4fsw2, FINISHED, 1 node
Splits: 13 total, 13 done (100.00%)
0.15 [15K rows, 172B] [103K rows/s, 1.15KiB/s]
```

## Additional context and related issues



## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix incorrect results due to dropped nagation)
```
