### PR TITLE
Restrict Hive DROP COLUMN to supported SerDes

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveClassNames.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveClassNames.java
@@ -34,6 +34,7 @@ public final class HiveClassNames
     public static final String LAZY_SIMPLE_SERDE_CLASS = "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe";
     public static final String MAPRED_PARQUET_INPUT_FORMAT_CLASS = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat";
     public static final String MAPRED_PARQUET_OUTPUT_FORMAT_CLASS = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat";
+    public static final String METADATA_TYPED_COLUMNSET_SERDE_CLASS = "org.apache.hadoop.hive.serde2.MetadataTypedColumnsetSerDe";
     public static final String OPENCSV_SERDE_CLASS = "org.apache.hadoop.hive.serde2.OpenCSVSerde";
     public static final String ORC_INPUT_FORMAT_CLASS = "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat";
     public static final String ORC_OUTPUT_FORMAT_CLASS = "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat";

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -175,6 +175,10 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.hive.formats.HiveClassNames.COLUMNAR_SERDE_CLASS;
+import static io.trino.hive.formats.HiveClassNames.LAZY_SIMPLE_SERDE_CLASS;
+import static io.trino.hive.formats.HiveClassNames.METADATA_TYPED_COLUMNSET_SERDE_CLASS;
+import static io.trino.hive.formats.HiveClassNames.PARQUET_HIVE_SERDE_CLASS;
 import static io.trino.metastore.HiveBasicStatistics.createEmptyStatistics;
 import static io.trino.metastore.HiveBasicStatistics.createZeroStatistics;
 import static io.trino.metastore.HiveType.HIVE_STRING;
@@ -1543,6 +1547,7 @@ public class HiveMetadata
     {
         HiveTableHandle hiveTableHandle = (HiveTableHandle) tableHandle;
         failIfAvroSchemaIsSet(hiveTableHandle);
+        failIfSerdeNotSupportedForDropColumn(hiveTableHandle);
         HiveColumnHandle columnHandle = (HiveColumnHandle) column;
 
         metastore.dropColumn(hiveTableHandle.getSchemaName(), hiveTableHandle.getTableName(), columnHandle.getName());
@@ -1563,6 +1568,23 @@ public class HiveMetadata
         }
         if (table.getParameters().containsKey(AVRO_SCHEMA_LITERAL_KEY) || table.getStorage().getSerdeParameters().containsKey(AVRO_SCHEMA_LITERAL_KEY)) {
             throw new TrinoException(NOT_SUPPORTED, "ALTER TABLE not supported when Avro schema literal is set");
+        }
+    }
+
+    // Package-private so test code can assert against the same set without duplicating it.
+    static final Set<String> DROP_COLUMN_SUPPORTED_SERDES = ImmutableSet.of(
+            COLUMNAR_SERDE_CLASS,
+            LAZY_SIMPLE_SERDE_CLASS,
+            METADATA_TYPED_COLUMNSET_SERDE_CLASS,
+            PARQUET_HIVE_SERDE_CLASS);
+
+    private void failIfSerdeNotSupportedForDropColumn(HiveTableHandle handle)
+    {
+        Table table = metastore.getTable(handle.getSchemaName(), handle.getTableName())
+                .orElseThrow(() -> new TableNotFoundException(handle.getSchemaTableName()));
+        String serde = table.getStorage().getStorageFormat().getSerDeNullable();
+        if (serde == null || !DROP_COLUMN_SUPPORTED_SERDES.contains(serde)) {
+            throw new TrinoException(NOT_SUPPORTED, format("Dropping columns is not supported by table SerDe: %s", serde));
         }
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -155,7 +155,6 @@ import static io.trino.plugin.hive.HiveQueryRunner.TPCH_SCHEMA;
 import static io.trino.plugin.hive.HiveQueryRunner.createBucketedSession;
 import static io.trino.plugin.hive.HiveStorageFormat.ESRI;
 import static io.trino.plugin.hive.HiveStorageFormat.ESRI_GEO_JSON;
-import static io.trino.plugin.hive.HiveStorageFormat.ORC;
 import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveStorageFormat.REGEX;
 import static io.trino.plugin.hive.HiveStorageFormat.SEQUENCEFILE_PROTOBUF;
@@ -5183,38 +5182,140 @@ public abstract class BaseHiveConnectorTest
     @Test
     public void testDropColumnHiveSpecific()
     {
-        // Additional tests for hive partition columns invariants
-        @Language("SQL") String createTable = "" +
-                "CREATE TABLE test_drop_column\n" +
-                "WITH (\n" +
-                "  partitioned_by = ARRAY ['orderstatus']\n" +
-                ")\n" +
-                "AS\n" +
-                "SELECT custkey, orderkey, orderstatus FROM orders";
+        // Additional tests for hive partition columns invariants, iterated over every Hive storage
+        // format that supports CREATE TABLE AS with partition columns (i.e. everything writable via
+        // `WITH (format = ...)` — this excludes CSV/REGEX/ESRI/ESRI_GEO_JSON/SEQUENCEFILE_PROTOBUF,
+        // which are read-only or column-type-restricted; see getAllTestingHiveStorageFormat()).
+        //
+        // For formats whose SerDe is in HiveMetadata.DROP_COLUMN_SUPPORTED_SERDES, the full set of
+        // partition/hidden/only-non-partition-column invariants is asserted. For the others, the
+        // SerDe guard fires before any of those checks can run, so we assert its message instead.
+        // (The unsupported-format rejection is also covered on non-partitioned tables in
+        // testDropColumnUnsupportedSerdeFormats.)
+        List<HiveStorageFormat> writableFormats = ImmutableList.of(
+                HiveStorageFormat.ORC,
+                HiveStorageFormat.PARQUET,
+                HiveStorageFormat.AVRO,
+                HiveStorageFormat.RCBINARY,
+                HiveStorageFormat.RCTEXT,
+                HiveStorageFormat.SEQUENCEFILE,
+                HiveStorageFormat.JSON,
+                HiveStorageFormat.OPENX_JSON,
+                HiveStorageFormat.TEXTFILE);
+        for (HiveStorageFormat format : writableFormats) {
+            String tableName = "test_drop_column_" + format.name().toLowerCase(Locale.ROOT) + "_" + randomNameSuffix();
+            @Language("SQL") String createTable = format(
+                    """
+                    CREATE TABLE %s
+                    WITH (
+                      format = '%s',
+                      partitioned_by = ARRAY ['orderstatus']
+                    )
+                    AS
+                    SELECT custkey, orderkey, orderstatus FROM orders""",
+                    tableName,
+                    format);
+            assertUpdate(createTable, "SELECT count(*) FROM orders");
+            try {
+                assertQuery("SELECT orderkey, orderstatus FROM " + tableName, "SELECT orderkey, orderstatus FROM orders");
+                if (dropColumnSupported(format)) {
+                    assertQueryFails("ALTER TABLE " + tableName + " DROP COLUMN \"$path\"", ".* Cannot drop hidden column");
+                    assertQueryFails("ALTER TABLE " + tableName + " DROP COLUMN orderstatus", "Cannot drop partition column.*");
+                    assertUpdate("ALTER TABLE " + tableName + " DROP COLUMN orderkey");
+                    assertQueryFails("ALTER TABLE " + tableName + " DROP COLUMN custkey", "Cannot drop the only non-partition column in a table.*");
+                    assertQuery("SELECT * FROM " + tableName, "SELECT custkey, orderstatus FROM orders");
+                }
+                else {
+                    // SerDe guard runs before the hidden/partition/only-column checks; verify a
+                    // representative DROP attempt fails with the guard message.
+                    assertQueryFails(
+                            "ALTER TABLE " + tableName + " DROP COLUMN orderkey",
+                            "Dropping columns is not supported by table SerDe:.*");
+                }
+            }
+            finally {
+                assertUpdate("DROP TABLE IF EXISTS " + tableName);
+            }
+        }
+    }
 
-        assertUpdate(createTable, "SELECT count(*) FROM orders");
-        assertQuery("SELECT orderkey, orderstatus FROM test_drop_column", "SELECT orderkey, orderstatus FROM orders");
-
-        assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN \"$path\"", ".* Cannot drop hidden column");
-        assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN orderstatus", "Cannot drop partition column.*");
-        assertUpdate("ALTER TABLE test_drop_column DROP COLUMN orderkey");
-        assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN custkey", "Cannot drop the only non-partition column in a table.*");
-        assertQuery("SELECT * FROM test_drop_column", "SELECT custkey, orderstatus FROM orders");
-
-        assertUpdate("DROP TABLE test_drop_column");
+    @Test
+    public void testDropColumnUnsupportedSerdeFormats()
+    {
+        // Formats whose SerDe is NOT in HiveMetadata.DROP_COLUMN_SUPPORTED_SERDES — every iteration
+        // must reject ALTER TABLE ... DROP COLUMN. ADD COLUMN is asserted to still work, since the
+        // guard is narrowly scoped to DROP (a future regression that adds a SerDe guard to addColumn
+        // will turn the ADD assertion red here).
+        // Columns are VARCHAR-only so the same CREATE template works for CSV (which only supports VARCHAR).
+        List<HiveStorageFormat> unsupportedFormats = ImmutableList.of(
+                HiveStorageFormat.ORC,
+                HiveStorageFormat.AVRO,
+                HiveStorageFormat.JSON,
+                HiveStorageFormat.RCBINARY,
+                HiveStorageFormat.CSV,
+                HiveStorageFormat.OPENX_JSON);
+        for (HiveStorageFormat format : unsupportedFormats) {
+            String tableName = "test_drop_col_unsupported_" + format.name().toLowerCase(Locale.ROOT) + "_" + randomNameSuffix();
+            assertUpdate(format("CREATE TABLE %s (a VARCHAR, b VARCHAR) WITH (format = '%s')", tableName, format));
+            try {
+                // ADD COLUMN must still succeed — guard is DROP-only.
+                assertUpdate(format("ALTER TABLE %s ADD COLUMN c VARCHAR", tableName));
+                assertQueryFails(
+                        format("ALTER TABLE %s DROP COLUMN b", tableName),
+                        "Dropping columns is not supported by table SerDe:.*");
+            }
+            finally {
+                assertUpdate("DROP TABLE IF EXISTS " + tableName);
+            }
+        }
     }
 
     @Test
     @Override
     public void testDropAndAddColumnWithSameName()
     {
-        // Override because Hive connector can access old data after dropping and adding a column with same name
-        assertThatThrownBy(super::testDropAndAddColumnWithSameName)
-                .hasMessageContaining(
-                        """
-                        Actual rows (up to 100 of 1 extra rows shown, 1 rows in total):
-                            [1, 2]\
-                        """);
+        // Override because the Hive connector can access old data after dropping and adding a column
+        // with the same name. Uses Parquet explicitly because Orc doesn't support dropping columns.
+        // Inlines the parent test rather than delegating to super, because super creates a table without a format.
+        try (TestTable table = newTrinoTable("test_drop_add_column", "WITH (format = 'PARQUET') AS SELECT 1 x, 2 y, 3 z")) {
+            assertUpdate("ALTER TABLE " + table.getName() + " DROP COLUMN y");
+            assertQuery("SELECT * FROM " + table.getName(), "VALUES (1, 3)");
+
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN y int");
+            // Old 'y' data (=2) is still visible after ADD COLUMN with the same name, rather than the
+            // expected NULL — the Hive-specific quirk this override documents.
+            assertQuery("SELECT * FROM " + table.getName(), "VALUES (1, 3, 2)");
+        }
+    }
+
+    @Test
+    @Override
+    public void testDropColumn()
+    {
+        // Override because Hive's connector default (ORC) has a SerDe not in
+        // HiveMetadata.DROP_COLUMN_SUPPORTED_SERDES; pin to PARQUET so DROP COLUMN can run.
+        // Retains only assertions not already covered by testDropColumnHiveSpecific / testUseColumnAddDrop:
+        // DROP COLUMN IF EXISTS, post-drop SELECT resolution failure, and the engine-wide
+        // "Cannot drop the only column in a table" message.
+        try (TestTable table = newTrinoTable("test_drop_column_", "WITH (format = 'PARQUET') AS SELECT 123 x, 456 y, 111 a")) {
+            String tableName = table.getName();
+            assertUpdate("ALTER TABLE " + tableName + " DROP COLUMN x");
+            assertUpdate("ALTER TABLE " + tableName + " DROP COLUMN IF EXISTS y");
+            assertUpdate("ALTER TABLE " + tableName + " DROP COLUMN IF EXISTS notExistColumn");
+            assertQueryFails("SELECT x FROM " + tableName, ".* Column 'x' cannot be resolved");
+            assertQueryFails("SELECT y FROM " + tableName, ".* Column 'y' cannot be resolved");
+
+            assertQueryFails("ALTER TABLE " + tableName + " DROP COLUMN a", ".* Cannot drop the only column in a table");
+        }
+    }
+
+    @Override
+    protected String createTableSqlForAddingAndDroppingColumn(String tableName, String columnNameInSql)
+    {
+        // Override because Hive's connector default (ORC) has a SerDe not in
+        // HiveMetadata.DROP_COLUMN_SUPPORTED_SERDES; pin to PARQUET so testAddAndDropColumnName's
+        // DROP COLUMN step can run.
+        return "CREATE TABLE " + tableName + "(" + columnNameInSql + " varchar(50), value varchar(50)) WITH (format = 'PARQUET')";
     }
 
     @Test
@@ -5674,6 +5775,11 @@ public abstract class BaseHiveConnectorTest
 
     private void testSchemaMismatchesWithDereferenceProjections(Session session, HiveStorageFormat format)
     {
+        // The schema-mismatch scenarios below all require DROP COLUMN followed by ADD COLUMN to set up
+        // the mismatch; skip formats whose SerDe is not in HiveMetadata.DROP_COLUMN_SUPPORTED_SERDES.
+        if (!dropColumnSupported(format)) {
+            return;
+        }
         // Verify reordering of subfields between a partition column and a table column is not supported
         // eg. table column: a row(c varchar, b bigint), partition column: a row(b bigint, c varchar)
         String tableName = "evolve_test_" + randomNameSuffix();
@@ -5722,11 +5828,10 @@ public abstract class BaseHiveConnectorTest
     {
         testWithAllStorageFormats(this::testReadWithPartitionSchemaMismatch);
 
-        // test ORC in non-default configuration with by-name column mapping
-        Session orcUsingColumnNames = Session.builder(getSession())
-                .setCatalogSessionProperty(catalog, "orc_use_column_names", "true")
-                .build();
-        testWithStorageFormat(new TestingHiveStorageFormat(orcUsingColumnNames, ORC), this::testReadWithPartitionSchemaMismatchByName);
+        // The previous "ORC in non-default by-name configuration" coverage was removed when the
+        // DROP COLUMN allowlist landed: ORC's SerDe (OrcSerde) is not in
+        // HiveMetadata.DROP_COLUMN_SUPPORTED_SERDES, so the by-name helper's DROP COLUMN step
+        // would always fail. testDropColumnUnsupportedSerdeFormats now asserts that rejection.
 
         // test PARQUET in non-default configuration with by-index column mapping
         Session parquetUsingColumnIndex = Session.builder(getSession())
@@ -5737,7 +5842,10 @@ public abstract class BaseHiveConnectorTest
 
     private void testReadWithPartitionSchemaMismatch(Session session, HiveStorageFormat format)
     {
-        if (isMappingByName(format)) {
+        // testReadWithPartitionSchemaMismatchByName runs DROP COLUMN; route formats whose SerDe is
+        // not in HiveMetadata.DROP_COLUMN_SUPPORTED_SERDES through the index-based helper instead,
+        // which only exercises ADD COLUMN semantics.
+        if (isMappingByName(format) && dropColumnSupported(format)) {
             testReadWithPartitionSchemaMismatchByName(session, format);
         }
         else {
@@ -5763,6 +5871,11 @@ public abstract class BaseHiveConnectorTest
             case ESRI -> true;
             case ESRI_GEO_JSON -> true;
         };
+    }
+
+    private static boolean dropColumnSupported(HiveStorageFormat format)
+    {
+        return HiveMetadata.DROP_COLUMN_SUPPORTED_SERDES.contains(format.getSerde());
     }
 
     private void testReadWithPartitionSchemaMismatchByName(Session session, HiveStorageFormat format)
@@ -5814,8 +5927,11 @@ public abstract class BaseHiveConnectorTest
     @Test
     public void testSubfieldReordering()
     {
-        // Validate for formats for which subfield access is name based
-        List<HiveStorageFormat> formats = ImmutableList.of(HiveStorageFormat.ORC, HiveStorageFormat.PARQUET, HiveStorageFormat.AVRO);
+        // Validate for formats for which subfield access is name based. ORC and AVRO were previously
+        // covered here but were removed when the DROP COLUMN allowlist landed: their SerDes are not in
+        // HiveMetadata.DROP_COLUMN_SUPPORTED_SERDES, and this test's body relies on DROP COLUMN + ADD COLUMN
+        // to set up the subfield reorder. testDropColumnUnsupportedSerdeFormats asserts that rejection.
+        List<HiveStorageFormat> formats = ImmutableList.of(HiveStorageFormat.PARQUET);
         String tableName = "evolve_test_" + randomNameSuffix();
 
         for (HiveStorageFormat format : formats) {
@@ -9224,13 +9340,11 @@ public abstract class BaseHiveConnectorTest
     @Test
     public void testUseColumnAddDrop()
     {
-        testUseColumnAddDrop(HiveStorageFormat.ORC, true);
-        testUseColumnAddDrop(HiveStorageFormat.ORC, false);
+        // Only formats whose SerDe is in HiveMetadata.DROP_COLUMN_SUPPORTED_SERDES are exercised here.
+        // ORC, AVRO, JSON, and RCBINARY were previously covered but were removed when the allowlist landed;
+        // testDropColumnUnsupportedSerdeFormats now asserts the rejection for those formats.
         testUseColumnAddDrop(HiveStorageFormat.PARQUET, true);
         testUseColumnAddDrop(HiveStorageFormat.PARQUET, false);
-        testUseColumnAddDrop(HiveStorageFormat.AVRO, false);
-        testUseColumnAddDrop(HiveStorageFormat.JSON, false);
-        testUseColumnAddDrop(HiveStorageFormat.RCBINARY, false);
         testUseColumnAddDrop(HiveStorageFormat.RCTEXT, false);
         testUseColumnAddDrop(HiveStorageFormat.SEQUENCEFILE, false);
         testUseColumnAddDrop(HiveStorageFormat.TEXTFILE, false);

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TestHiveDropColumnSerdeRestriction.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TestHiveDropColumnSerdeRestriction.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+import io.trino.testing.containers.environment.ProductTest;
+import io.trino.testing.containers.environment.RequiresEnvironment;
+import io.trino.tests.product.TestGroup;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.containers.environment.QueryResultAssert.assertThat;
+import static io.trino.testing.containers.environment.Row.row;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Cross-engine coverage of the DROP COLUMN SerDe allowlist in HiveMetadata. Trino rejects
+ * DROP COLUMN for tables whose row-format SerDe is not in
+ * {@code HiveMetadata.DROP_COLUMN_SUPPORTED_SERDES} because positional column resolution in
+ * those SerDes silently corrupts data on schema change. This test verifies that:
+ * <ul>
+ *     <li>For unsupported SerDes (ORC, AVRO, JSON, RCBINARY) Trino rejects the operation with
+ *         the guard message, and neither Trino nor Hive observes any schema change afterwards.</li>
+ *     <li>For supported SerDes (PARQUET, RCTEXT, SEQUENCEFILE, TEXTFILE) Trino performs the
+ *         DROP and Hive observes the reduced schema — i.e., Trino's post-drop metastore state
+ *         is consistent with what Hive sees.</li>
+ * </ul>
+ */
+@ProductTest
+@RequiresEnvironment(HiveStorageFormatsEnvironment.class)
+public class TestHiveDropColumnSerdeRestriction
+{
+    static Stream<String> unsupportedSerdeFormats()
+    {
+        return Stream.of("ORC", "AVRO", "JSON", "RCBINARY");
+    }
+
+    static Stream<String> supportedSerdeFormats()
+    {
+        return Stream.of("PARQUET", "RCTEXT", "SEQUENCEFILE", "TEXTFILE");
+    }
+
+    @ParameterizedTest
+    @MethodSource("unsupportedSerdeFormats")
+    @TestGroup.StorageFormats
+    @TestGroup.ProfileSpecificTests
+    public void testTrinoRejectsDropColumnForUnsupportedSerdeFormat(String storageFormat, HiveStorageFormatsEnvironment env)
+    {
+        String tableName = "test_drop_col_unsupported_" + storageFormat.toLowerCase(ENGLISH) + "_" + randomNameSuffix();
+        try {
+            env.executeTrinoUpdate(format(
+                    "CREATE TABLE %s (id BIGINT, name VARCHAR, state VARCHAR) WITH (format = '%s')",
+                    tableName,
+                    storageFormat));
+            env.executeTrinoUpdate("INSERT INTO " + tableName + " VALUES (1, 'Katy', 'CA'), (2, 'Joe', 'WA')");
+
+            // Sanity: both engines see the initial three-column row set.
+            assertThat(env.executeTrino("SELECT * FROM " + tableName))
+                    .containsOnly(row(1L, "Katy", "CA"), row(2L, "Joe", "WA"));
+            assertThat(env.executeHive("SELECT * FROM " + tableName))
+                    .containsOnly(row(1L, "Katy", "CA"), row(2L, "Joe", "WA"));
+
+            // Trino's SerDe guard rejects the DROP.
+            assertThatThrownBy(() -> env.executeTrino("ALTER TABLE " + tableName + " DROP COLUMN state"))
+                    .hasMessageContaining("Dropping columns is not supported by table SerDe:");
+
+            // No schema change occurred — the state column is still readable from both engines.
+            assertThat(env.executeTrino("SELECT * FROM " + tableName))
+                    .containsOnly(row(1L, "Katy", "CA"), row(2L, "Joe", "WA"));
+            assertThat(env.executeHive("SELECT * FROM " + tableName))
+                    .containsOnly(row(1L, "Katy", "CA"), row(2L, "Joe", "WA"));
+        }
+        finally {
+            env.executeTrinoUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedSerdeFormats")
+    @TestGroup.StorageFormats
+    @TestGroup.ProfileSpecificTests
+    public void testTrinoAndHiveConsistentAfterDropColumnForSupportedSerdeFormat(String storageFormat, HiveStorageFormatsEnvironment env)
+    {
+        String tableName = "test_drop_col_supported_" + storageFormat.toLowerCase(ENGLISH) + "_" + randomNameSuffix();
+        try {
+            env.executeTrinoUpdate(format(
+                    "CREATE TABLE %s (id BIGINT, name VARCHAR, state VARCHAR) WITH (format = '%s')",
+                    tableName,
+                    storageFormat));
+            env.executeTrinoUpdate("INSERT INTO " + tableName + " VALUES (1, 'Katy', 'CA'), (2, 'Joe', 'WA')");
+
+            env.executeTrinoUpdate("ALTER TABLE " + tableName + " DROP COLUMN state");
+
+            // Both engines see the reduced schema (state removed).
+            assertThat(env.executeTrino("SELECT * FROM " + tableName))
+                    .containsOnly(row(1L, "Katy"), row(2L, "Joe"));
+            assertThat(env.executeHive("SELECT * FROM " + tableName))
+                    .containsOnly(row(1L, "Katy"), row(2L, "Joe"));
+        }
+        finally {
+            env.executeTrinoUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+}

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
@@ -846,16 +846,22 @@ class TestHiveTransactionalTable
             env.executeTrinoUpdate(format("INSERT INTO %s VALUES (111, 'Katy', 57, 'CA'), (222, 'Joe', 72, 'WA')", tableName));
             verifySelectForTrinoAndHive(env, "SELECT * FROM " + tableName, row(111L, "Katy", 57, "CA"), row(222L, "Joe", 72, "WA"));
 
-            env.executeTrinoUpdate(format("ALTER TABLE %s DROP COLUMN old_state", tableName));
-            log.info("This shows that neither Trino nor Hive see the old data after a column is dropped");
-            verifySelectForTrinoAndHive(env, "SELECT * FROM " + tableName, row(111L, "Katy", 57), row(222L, "Joe", 72));
-
-            env.executeTrinoUpdate(format("INSERT INTO %s VALUES (333, 'Kelly', 45)", tableName));
-            verifySelectForTrinoAndHive(env, "SELECT * FROM " + tableName, row(111L, "Katy", 57), row(222L, "Joe", 72), row(333L, "Kelly", 45));
+            // ORC's SerDe (OrcSerde) is not in HiveMetadata.DROP_COLUMN_SUPPORTED_SERDES, so DROP COLUMN
+            // is now rejected. ADD COLUMN is still permitted — the guard is narrowly scoped to DROP.
+            // This test used to document the "old data resurfaces after drop-then-add" quirk on ORC;
+            // it is now inverted to assert the rejection and confirm ADD is unaffected.
+            assertThatThrownBy(() -> env.executeTrinoUpdate(format("ALTER TABLE %s DROP COLUMN old_state", tableName)))
+                    .hasMessageContaining("Dropping columns is not supported by table SerDe:");
+            // ADD COLUMN must still succeed — the guard is narrowly scoped to DROP.
 
             env.executeTrinoUpdate(format("ALTER TABLE %s ADD COLUMN new_state VARCHAR", tableName));
-            log.info("This shows that for ORC, Trino and Hive both see data inserted into a dropped column when a column of the same type but different name is added");
-            verifySelectForTrino(env, "SELECT * FROM " + tableName, row(111L, "Katy", 57, "CA"), row(222L, "Joe", 72, "WA"), row(333L, "Kelly", 45, null));
+            env.executeTrinoUpdate(format("INSERT INTO %s VALUES (333, 'Kelly', 45, 'CA', 'CA')", tableName));
+            verifySelectForTrinoAndHive(
+                    env,
+                    "SELECT * FROM " + tableName,
+                    row(111L, "Katy", 57, "CA", null),
+                    row(222L, "Joe", 72, "WA", null),
+                    row(333L, "Kelly", 45, "CA", "CA"));
         });
     }
 

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/iceberg/TestIcebergRedirectionToHive.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/iceberg/TestIcebergRedirectionToHive.java
@@ -410,19 +410,17 @@ class TestIcebergRedirectionToHive
 
         createHiveTable(env, hiveTableName, false);
 
-        env.executeTrinoUpdate("ALTER TABLE " + icebergTableName + " DROP COLUMN comment");
+        // createHiveTable produces an ORC table (connector default). Its SerDe (OrcSerde) is not in
+        // HiveMetadata.DROP_COLUMN_SUPPORTED_SERDES, so DROP COLUMN is rejected. This test used to
+        // exercise the redirection-plus-drop happy path; it is now inverted to prove the redirection
+        // still reaches the Hive connector and surfaces the guard's rejection message.
+        assertThatThrownBy(() -> env.executeTrinoUpdate("ALTER TABLE " + icebergTableName + " DROP COLUMN comment"))
+                .hasMessageContaining("Dropping columns is not supported by table SerDe:");
 
+        // The schema is unchanged after the rejected DROP.
         assertThat(env.executeTrino("DESCRIBE " + icebergTableName).column(1))
-                .containsOnly("nationkey", "name", "regionkey");
+                .containsOnly("nationkey", "name", "comment", "regionkey");
 
-        // After dropping the column from the Hive metastore, access ORC columns by name
-        // Session setting must persist for the query
-        env.executeTrinoInSession(session -> {
-            session.executeUpdate("SET SESSION hive.orc_use_column_names = true");
-            QueryResult hiveResult = session.executeQuery("TABLE " + hiveTableName);
-            QueryResult expected = session.executeQuery("SELECT nationkey, name, regionkey FROM tpch.tiny.nation");
-            assertResultsEqual(hiveResult, expected);
-        });
         env.executeTrinoUpdate("DROP TABLE " + hiveTableName);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Only a few Hive SerDes support dropping columns. This change prevents 
attempts to drop columns from tables using any SerDes other than those
 known to support the operation.

* Fixes #20807 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
The change would have caused an existing test to fail, so this commit 
changes the Hive column-dropping tests to align with the specific SerDes 
that are expected to work. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
