### PR TITLE
Add date_bin() function for fixed-stride timestamp binning

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -193,6 +193,7 @@ import io.trino.operator.scalar.time.TimeToTimestampCast;
 import io.trino.operator.scalar.time.TimeToTimestampWithTimeZoneCast;
 import io.trino.operator.scalar.timestamp.CharToTimestampCast;
 import io.trino.operator.scalar.timestamp.DateAdd;
+import io.trino.operator.scalar.timestamp.DateBin;
 import io.trino.operator.scalar.timestamp.DateDiff;
 import io.trino.operator.scalar.timestamp.DateFormat;
 import io.trino.operator.scalar.timestamp.DateToTimestampCast;
@@ -677,6 +678,7 @@ public final class SystemFunctionBundle
                 .scalar(VarcharToTimestampCast.class)
                 .scalar(CharToTimestampCast.class)
                 .scalar(LocalTimestamp.class)
+                .scalar(DateBin.class)
                 .scalar(DateTrunc.class)
                 .scalar(HumanReadableSeconds.class)
                 .scalar(ToIso8601.class)
@@ -725,6 +727,7 @@ public final class SystemFunctionBundle
                 .scalar(io.trino.operator.scalar.timestamptz.ExtractYearOfWeek.class)
                 .scalar(io.trino.operator.scalar.timestamptz.ToIso8601.class)
                 .scalar(io.trino.operator.scalar.timestamptz.DateAdd.class)
+                .scalar(io.trino.operator.scalar.timestamptz.DateBin.class)
                 .scalar(io.trino.operator.scalar.timestamptz.DateTrunc.class)
                 .scalar(io.trino.operator.scalar.timestamptz.TimeZone.class)
                 .scalar(io.trino.operator.scalar.timestamptz.TimeZoneHour.class)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/DateBin.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/DateBin.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.timestamp;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.StandardTypes;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static java.lang.Math.floorDiv;
+
+@Description("Bins the input timestamp by the given stride interval aligned to the given origin")
+@ScalarFunction("date_bin")
+public final class DateBin
+{
+    private DateBin() {}
+
+    @LiteralParameters("p")
+    @SqlType("timestamp(p)")
+    public static long bin(
+            @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long stride,
+            @SqlType("timestamp(p)") long source,
+            @SqlType("timestamp(p)") long origin)
+    {
+        long strideMicros = stride * 1_000L;
+        if (strideMicros <= 0) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "stride must be positive");
+        }
+        return origin + floorDiv(source - origin, strideMicros) * strideMicros;
+    }
+
+    @LiteralParameters("p")
+    @SqlType("timestamp(p)")
+    public static LongTimestamp bin(
+            @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long stride,
+            @SqlType("timestamp(p)") LongTimestamp source,
+            @SqlType("timestamp(p)") LongTimestamp origin)
+    {
+        long strideMicros = stride * 1_000L;
+        if (strideMicros <= 0) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "stride must be positive");
+        }
+        long epochMicros = origin.getEpochMicros() + floorDiv(source.getEpochMicros() - origin.getEpochMicros(), strideMicros) * strideMicros;
+        return new LongTimestamp(epochMicros, 0);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/DateBin.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/DateBin.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.timestamptz;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.StandardTypes;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static io.trino.spi.type.DateTimeEncoding.updateMillisUtc;
+import static java.lang.Math.floorDiv;
+
+@Description("Bins the input timestamp by the given stride interval aligned to the given origin")
+@ScalarFunction("date_bin")
+public final class DateBin
+{
+    private DateBin() {}
+
+    @LiteralParameters("p")
+    @SqlType("timestamp(p) with time zone")
+    public static long bin(
+            @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long stride,
+            @SqlType("timestamp(p) with time zone") long source,
+            @SqlType("timestamp(p) with time zone") long origin)
+    {
+        if (stride <= 0) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "stride must be positive");
+        }
+        long sourceMillis = unpackMillisUtc(source);
+        long originMillis = unpackMillisUtc(origin);
+        long resultMillis = originMillis + floorDiv(sourceMillis - originMillis, stride) * stride;
+        return updateMillisUtc(resultMillis, source);
+    }
+
+    @LiteralParameters("p")
+    @SqlType("timestamp(p) with time zone")
+    public static LongTimestampWithTimeZone bin(
+            @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long stride,
+            @SqlType("timestamp(p) with time zone") LongTimestampWithTimeZone source,
+            @SqlType("timestamp(p) with time zone") LongTimestampWithTimeZone origin)
+    {
+        if (stride <= 0) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "stride must be positive");
+        }
+        long sourceMillis = source.getEpochMillis();
+        long originMillis = origin.getEpochMillis();
+        long resultMillis = originMillis + floorDiv(sourceMillis - originMillis, stride) * stride;
+        return LongTimestampWithTimeZone.fromEpochMillisAndFraction(resultMillis, 0, source.getTimeZoneKey());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestDateBin.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestDateBin.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.timestamp;
+
+import io.trino.Session;
+import io.trino.sql.query.QueryAssertions;
+import io.trino.testing.TestingSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestDateBin
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        Session session = testSessionBuilder()
+                .setTimeZoneKey(TestingSession.DEFAULT_TIME_ZONE_KEY)
+                .build();
+        assertions = new QueryAssertions(session);
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testDateBin()
+    {
+        // 15-minute bins aligned to 2001-01-01 00:00:00; source falls in [15:30, 15:45)
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17', TIMESTAMP '2001-01-01 00:00:00')")).matches("TIMESTAMP '2020-02-11 15:30:00'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.1', TIMESTAMP '2001-01-01 00:00:00.0')")).matches("TIMESTAMP '2020-02-11 15:30:00.0'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.12', TIMESTAMP '2001-01-01 00:00:00.00')")).matches("TIMESTAMP '2020-02-11 15:30:00.00'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.123', TIMESTAMP '2001-01-01 00:00:00.000')")).matches("TIMESTAMP '2020-02-11 15:30:00.000'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.1234', TIMESTAMP '2001-01-01 00:00:00.0000')")).matches("TIMESTAMP '2020-02-11 15:30:00.0000'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.12345', TIMESTAMP '2001-01-01 00:00:00.00000')")).matches("TIMESTAMP '2020-02-11 15:30:00.00000'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.123456', TIMESTAMP '2001-01-01 00:00:00.000000')")).matches("TIMESTAMP '2020-02-11 15:30:00.000000'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.1234567', TIMESTAMP '2001-01-01 00:00:00.0000000')")).matches("TIMESTAMP '2020-02-11 15:30:00.0000000'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.12345678', TIMESTAMP '2001-01-01 00:00:00.00000000')")).matches("TIMESTAMP '2020-02-11 15:30:00.00000000'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.123456789', TIMESTAMP '2001-01-01 00:00:00.000000000')")).matches("TIMESTAMP '2020-02-11 15:30:00.000000000'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.1234567890', TIMESTAMP '2001-01-01 00:00:00.0000000000')")).matches("TIMESTAMP '2020-02-11 15:30:00.0000000000'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.12345678901', TIMESTAMP '2001-01-01 00:00:00.00000000000')")).matches("TIMESTAMP '2020-02-11 15:30:00.00000000000'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.123456789012', TIMESTAMP '2001-01-01 00:00:00.000000000000')")).matches("TIMESTAMP '2020-02-11 15:30:00.000000000000'");
+    }
+
+    @Test
+    public void testDateBinOnBoundary()
+    {
+        // source exactly on a bin boundary — should return the boundary itself
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:30:00', TIMESTAMP '2001-01-01 00:00:00')")).matches("TIMESTAMP '2020-02-11 15:30:00'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:30:00.000000', TIMESTAMP '2001-01-01 00:00:00.000000')")).matches("TIMESTAMP '2020-02-11 15:30:00.000000'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:30:00.000000000000', TIMESTAMP '2001-01-01 00:00:00.000000000000')")).matches("TIMESTAMP '2020-02-11 15:30:00.000000000000'");
+    }
+
+    @Test
+    public void testDateBinSourceBeforeOrigin()
+    {
+        // source before origin — floorDiv correctly rounds toward negative infinity
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2000-12-31 23:44:17', TIMESTAMP '2001-01-01 00:00:00')")).matches("TIMESTAMP '2000-12-31 23:30:00'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2000-12-31 23:44:17.123456', TIMESTAMP '2001-01-01 00:00:00.000000')")).matches("TIMESTAMP '2000-12-31 23:30:00.000000'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2000-12-31 23:44:17.123456789012', TIMESTAMP '2001-01-01 00:00:00.000000000000')")).matches("TIMESTAMP '2000-12-31 23:30:00.000000000000'");
+    }
+
+    @Test
+    public void testDateBinSubSecondStride()
+    {
+        // 500ms stride — source at .345 falls in [.000, .500)
+        assertThat(assertions.expression("date_bin(INTERVAL '0.5' SECOND, TIMESTAMP '2020-02-11 15:44:17.345', TIMESTAMP '2001-01-01 00:00:00.000')")).matches("TIMESTAMP '2020-02-11 15:44:17.000'");
+        assertThat(assertions.expression("date_bin(INTERVAL '0.5' SECOND, TIMESTAMP '2020-02-11 15:44:17.500', TIMESTAMP '2001-01-01 00:00:00.000')")).matches("TIMESTAMP '2020-02-11 15:44:17.500'");
+        assertThat(assertions.expression("date_bin(INTERVAL '0.5' SECOND, TIMESTAMP '2020-02-11 15:44:17.999', TIMESTAMP '2001-01-01 00:00:00.000')")).matches("TIMESTAMP '2020-02-11 15:44:17.500'");
+    }
+
+    @Test
+    public void testDateBinInvalidStride()
+    {
+        assertTrinoExceptionThrownBy(assertions.expression("date_bin(INTERVAL '0' SECOND, TIMESTAMP '2020-02-11 15:44:17', TIMESTAMP '2001-01-01 00:00:00')")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestDateBin.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestDateBin.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.timestamptz;
+
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestDateBin
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testDateBin()
+    {
+        // 15-minute bins aligned to 2001-01-01 00:00:00; source falls in [15:30, 15:45)
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00 Asia/Kathmandu'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.1 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00.0 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00.0 Asia/Kathmandu'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.12 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00.00 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00.00 Asia/Kathmandu'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.123 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00.000 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00.000 Asia/Kathmandu'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.1234 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00.0000 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00.0000 Asia/Kathmandu'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.12345 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00.00000 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00.00000 Asia/Kathmandu'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.123456 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00.000000 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00.000000 Asia/Kathmandu'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.1234567 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00.0000000 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00.0000000 Asia/Kathmandu'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.12345678 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00.00000000 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00.00000000 Asia/Kathmandu'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.123456789 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00.000000000 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00.000000000 Asia/Kathmandu'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.1234567890 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00.0000000000 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00.0000000000 Asia/Kathmandu'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.12345678901 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00.00000000000 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00.00000000000 Asia/Kathmandu'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17.123456789012 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00.000000000000 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00.000000000000 Asia/Kathmandu'");
+    }
+
+    @Test
+    public void testDateBinOnBoundary()
+    {
+        // source exactly on a bin boundary — should return the boundary itself
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:30:00 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00 Asia/Kathmandu'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:30:00.000000000000 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00.000000000000 Asia/Kathmandu')")).matches("TIMESTAMP '2020-02-11 15:30:00.000000000000 Asia/Kathmandu'");
+    }
+
+    @Test
+    public void testDateBinSourceBeforeOrigin()
+    {
+        // source before origin — floorDiv correctly rounds toward negative infinity
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2000-12-31 23:44:17 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00 Asia/Kathmandu')")).matches("TIMESTAMP '2000-12-31 23:30:00 Asia/Kathmandu'");
+        assertThat(assertions.expression("date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2000-12-31 23:44:17.123456789012 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00.000000000000 Asia/Kathmandu')")).matches("TIMESTAMP '2000-12-31 23:30:00.000000000000 Asia/Kathmandu'");
+    }
+
+    @Test
+    public void testDateBinInvalidStride()
+    {
+        assertTrinoExceptionThrownBy(assertions.expression("date_bin(INTERVAL '0' SECOND, TIMESTAMP '2020-02-11 15:44:17 Asia/Kathmandu', TIMESTAMP '2001-01-01 00:00:00 Asia/Kathmandu')")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
+    }
+}

--- a/docs/src/main/sphinx/functions/datetime.md
+++ b/docs/src/main/sphinx/functions/datetime.md
@@ -310,6 +310,22 @@ SELECT date_trunc('year', TIMESTAMP '2022-10-20 05:10:00');
 ```
 :::
 
+## Binning function
+
+:::{function} date_bin(stride, source, origin) -> [same as input]
+Returns `source` rounded down to the nearest multiple of `stride` aligned to `origin`.
+`stride` must be a positive `INTERVAL DAY TO SECOND` value. Month-based intervals are
+not supported because their length varies.
+
+```
+SELECT date_bin(INTERVAL '15' MINUTE, TIMESTAMP '2020-02-11 15:44:17', TIMESTAMP '2001-01-01 00:00:00');
+-- 2020-02-11 15:30:00.000
+
+SELECT date_bin(INTERVAL '0.5' SECOND, TIMESTAMP '2020-02-11 15:44:17.345', TIMESTAMP '2001-01-01 00:00:00.000');
+-- 2020-02-11 15:44:17.000
+```
+:::
+
 (datetime-interval-functions)=
 ## Interval functions
 


### PR DESCRIPTION
## Summary

- Closes #20428.

Adds a native \`date_bin(stride, source, origin)\` SQL function that bins a timestamp into the nearest fixed-width interval aligned to a given origin — the timestamp equivalent of integer floor division with a configurable stride and origin.

```sql
-- bin into 15-minute buckets aligned to 2001-01-01
SELECT date_bin(INTERVAL '15' MINUTE,
                TIMESTAMP '2020-02-11 15:44:17',
                TIMESTAMP '2001-01-01 00:00:00');
-- 2020-02-11 15:30:00

-- 500ms stride
SELECT date_bin(INTERVAL '0.5' SECOND,
                TIMESTAMP '2020-02-11 15:44:17.345',
                TIMESTAMP '2001-01-01 00:00:00.000');
-- 2020-02-11 15:44:17.000
```

Signature (PostgreSQL-compatible):

```
date_bin(stride INTERVAL DAY TO SECOND, source TIMESTAMP(p), origin TIMESTAMP(p)) -> TIMESTAMP(p)
date_bin(stride INTERVAL DAY TO SECOND, source TIMESTAMP(p) WITH TIME ZONE, origin TIMESTAMP(p) WITH TIME ZONE) -> TIMESTAMP(p) WITH TIME ZONE
```

## Implementation

- Mirrors the \`date_trunc\` structure: per-type classes \`timestamp/DateBin.java\` and \`timestamptz/DateBin.java\`, each with a short (\`long\`) and high-precision (\`LongTimestamp\` / \`LongTimestampWithTimeZone\`) variant for parametric \`TIMESTAMP(p)\`.
- Core algorithm: \`origin + floorDiv(source − origin, strideMicros) × strideMicros\`. Uses \`Math.floorDiv\` so behavior is correct when \`source\` is before \`origin\` (negative floor division, not truncation).
- \`INTERVAL DAY TO SECOND\` is received as \`long\` milliseconds; converted to microseconds (\`× 1000\`) for the plain \`TIMESTAMP(p)\` variants. The \`TIMESTAMP(p) WITH TIME ZONE\` variants work directly in milliseconds.
- Both variants validate that stride is positive and throw \`INVALID_FUNCTION_ARGUMENT\` otherwise.
- Registered in \`SystemFunctionBundle\` alongside the existing \`date_trunc\` entries.

## Tests

Added \`TestDateBin\` in both \`timestamp/\` and \`timestamptz/\` packages covering:

- All 13 timestamp precisions (p = 0 … 12)
- Source exactly on a bin boundary
- Source before origin (relies on \`floorDiv\` rounding toward negative infinity, not zero)
- Sub-second stride (500ms)
- Zero-stride error (\`INVALID_FUNCTION_ARGUMENT\`)

## Acceptance Criteria

- [x] New tests added covering all precision variants, boundary, before-origin, sub-second stride, and error cases
- [x] All existing tests pass — CI 99/99 ✓ on commit 46caab8
- [x] Style guide passes — \`maven-checks\` (airstyle formatter) green across Java 25/26/27-ea
- [x] No breaking changes — new function only, no modifications to existing functions or types
- [x] Documentation added — new "Binning function" section in \`docs/src/main/sphinx/functions/datetime.md\`

## Notes

Documentation is included in commit e53e217 — a new "Binning function" section in \`datetime.md\` with two SQL examples. The \`syntax-needs-review\` label is on the issue; the proposed signature above matches PostgreSQL's \`date_bin\` exactly.