### PR TITLE
Fix empty <p> tag warning

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/PagesIndexOrdering.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesIndexOrdering.java
@@ -40,7 +40,6 @@ public class PagesIndexOrdering
     /**
      * Sorts the specified range of elements using the specified swapper and according to the order induced by the specified
      * comparator using quickSort.
-     * <p/>
      * <p>The sorting algorithm is a tuned quickSort adapted from Jon L. Bentley and M. Douglas
      * McIlroy, &ldquo;Engineering a Sort Function&rdquo;, <i>Software: Practice and Experience</i>, 23(11), pages
      * 1249&minus;1265, 1993.

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/TimeZone.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/TimeZone.java
@@ -36,7 +36,6 @@ public final class TimeZone
      * Extracts the time zone from a `time(p) with time zone` as a VARCHAR.
      * This function takes a packed long value representing
      * the time with time zone and extracts the associated time zone offset.
-     * <p>
      *
      * @param timeWithTimeZone the packed long
      *         representing a `time(p) with time zone`

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/QueryDataEncoder.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/QueryDataEncoder.java
@@ -51,7 +51,7 @@ public interface QueryDataEncoder
      * Responsible for choosing a {@link Factory} based on the client-provider
      * supported encodings. Encoding that will be used is resolved one time
      * during session creation.
-     * <p></p>
+     * <p>
      * Returning Optional.empty() fallbacks to the previous, direct protocol.
      */
     @FunctionalInterface

--- a/core/trino-main/src/main/java/io/trino/server/protocol/spooling/ServerQueryDataJacksonModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/spooling/ServerQueryDataJacksonModule.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 
 /**
  * Encodes/decodes the QueryData for existing raw and encoded protocols.
- * <p></p>
+ * <p>
  *
  * If the passed QueryData is raw - serialize its' data as a materialized array of array of objects.
  * If the passed QueryData is bytes - just write them directly

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/ColumnarFilter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/ColumnarFilter.java
@@ -29,7 +29,6 @@ import io.trino.spi.connector.SourcePage;
  * don't explicitly handle NULLs or indeterminate values, and just return FALSE for those cases.
  * This will need to change to allow ColumnarFilter implementations to be composed in all cases (e.g. NOT filters).
  * ColumnarFilter implementations are never composed, {@link FilterEvaluator} implementations may be composed.
- * <p>
  */
 public interface ColumnarFilter
 {

--- a/core/trino-spi/src/main/java/io/trino/spi/HostAddress.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/HostAddress.java
@@ -41,7 +41,6 @@ import static java.util.Objects.requireNonNull;
  * hp.getPort();      // returns 80
  * hp.toString();     // returns "[2001:db8::1]:80"
  * </pre>
- * <p>
  * <p>Here are some examples of recognized formats:
  * <ul>
  * <li>example.com
@@ -87,7 +86,6 @@ public class HostAddress
     /**
      * Returns the portion of this {@code HostAddress} instance that should
      * represent the hostname or IPv4/IPv6 literal.
-     * <p>
      * <p>A successful parse does not imply any degree of sanity in this field.
      */
     public String getHostText()
@@ -128,7 +126,6 @@ public class HostAddress
 
     /**
      * Build a HostAddress instance from separate host and port values.
-     * <p>
      * <p>Note: Non-bracketed IPv6 literals are allowed.
      *
      * @param host the host string to parse. Must not contain a port number.

--- a/core/trino-spi/src/main/java/io/trino/spi/type/NumberType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/NumberType.java
@@ -47,7 +47,6 @@ import static java.lang.invoke.MethodHandles.lookup;
  * <p>
  * Stack representation of this type is {@link TrinoNumber} which wraps a slice with the format documented below.
  * <b>Note:</b> the binary format is not stable and may change between releases. Only the Java API is considered stable.
- * <p>
  * <h2>Current unstable binary format</h2>
  * <pre>
  *    ┌───────────────────────┬─────────────────────────┐

--- a/lib/trino-array/src/main/java/io/trino/array/IntBigArrays.java
+++ b/lib/trino-array/src/main/java/io/trino/array/IntBigArrays.java
@@ -88,7 +88,6 @@ public final class IntBigArrays
     /**
      * Sorts the specified range of elements according to the order induced by the specified
      * comparator using quicksort.
-     * <p>
      * <p>The sorting algorithm is a tuned quicksort adapted from Jon L. Bentley and M. Douglas
      * McIlroy, &ldquo;Engineering a Sort Function&rdquo;, <i>Software: Practice and Experience</i>, 23(11), pages
      * 1249&minus;1265, 1993.

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystem.java
@@ -351,7 +351,7 @@ public interface TrinoFileSystem
 
     /**
      * Returns the direct pre-signed URI location for the given storage location.
-     * <p></p>
+     * <p>
      * Pre-signed URIs allow for retrieval of the files directly from the storage location.
      * This is useful for large files where the server would be a bottleneck.
      *


### PR DESCRIPTION
## Description

The example warning: https://github.com/trinodb/trino/actions/runs/28325916745/job/83915798424
```
2026-06-28T14:52:10.1176484Z ##[warning][WARNING] /home/runner/work/trino/trino/core/trino-spi/src/main/java/io/trino/spi/HostAddress.java:44: warning: empty <p> tag
2026-06-28T14:52:10.1189298Z [WARNING] * <p>
2026-06-28T14:52:10.1190009Z [WARNING] ^
2026-06-28T14:52:10.1191604Z ##[warning][WARNING] /home/runner/work/trino/trino/core/trino-spi/src/main/java/io/trino/spi/type/NumberType.java:50: warning: empty <p> tag
2026-06-28T14:52:10.1193066Z [WARNING] * <p>
2026-06-28T14:52:10.1193358Z [WARNING] ^
2026-06-28T14:52:10.1194261Z ##[warning][WARNING] /home/runner/work/trino/trino/core/trino-spi/src/main/java/io/trino/spi/HostAddress.java:90: warning: empty <p> tag
2026-06-28T14:52:10.1195432Z [WARNING] * <p>
2026-06-28T14:52:10.1195711Z [WARNING] ^
2026-06-28T14:52:10.1196563Z ##[warning][WARNING] /home/runner/work/trino/trino/core/trino-spi/src/main/java/io/trino/spi/HostAddress.java:131: warning: empty <p> tag
2026-06-28T14:52:10.1198380Z [WARNING] * <p>
2026-06-28T14:52:25.1931526Z ##[warning][WARNING] /home/runner/work/trino/trino/lib/trino-array/src/main/java/io/trino/array/IntBigArrays.java:91: warning: empty <p> tag
2026-06-28T14:52:25.1982876Z [WARNING] * <p>
main/src/main/java/io/trino/sql/gen/columnar/ColumnarFilter.java:32: warning: empty <p> tag
2026-06-28T14:56:49.8504277Z [WARNING] * <p>
2026-06-28T14:56:49.8504742Z [WARNING] ^
2026-06-28T14:56:49.8506399Z ##[warning][WARNING] /home/runner/work/trino/trino/core/trino-main/src/main/java/io/trino/server/protocol/spooling/QueryDataEncoder.java:54: warning: empty <p> tag
2026-06-28T14:56:49.8508658Z [WARNING] * <p></p>
2026-06-28T14:56:49.8509156Z [WARNING] ^
2026-06-28T14:56:49.8511332Z ##[warning][WARNING] /home/runner/work/trino/trino/core/trino-main/src/main/java/io/trino/server/protocol/spooling/ServerQueryDataJacksonModule.java:31: warning: empty <p> tag
2026-06-28T14:56:49.8513770Z [WARNING] * <p></p>
2026-06-28T14:56:49.8514262Z [WARNING] ^
2026-06-28T14:56:49.8515943Z ##[warning][WARNING] /home/runner/work/trino/trino/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/TimeZone.java:39: warning: empty <p> tag
2026-06-28T14:56:49.8518229Z [WARNING] * <p>
2026-06-28T14:57:54.2513779Z ##[warning][WARNING] /home/runner/work/trino/trino/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystem.java:354: warning: empty <p> tag
2026-06-28T14:57:54.2580143Z [WARNING] * <p></p>
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
