### PR TITLE
Fix query filter checkbox item clicks in preview UI

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryList.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp-preview/src/components/QueryList.tsx
@@ -270,6 +270,7 @@ export const QueryList = () => {
             />
         )
     }
+
     const renderStateTypeSelectItem = (newStateType: keyof typeof STATE_TYPE, filterText: string) => {
         const handleClick = () => {
             setTimeout(() => {
@@ -288,13 +289,8 @@ export const QueryList = () => {
         }
 
         return (
-            <MenuItem key={filterText} value={filterText}>
-                <Checkbox
-                    checked={stateFilters.includes(newStateType)}
-                    size="small"
-                    sx={{ padding: 0 }}
-                    onClick={handleClick}
-                />
+            <MenuItem key={filterText} value={filterText} onClick={handleClick}>
+                <Checkbox checked={stateFilters.includes(newStateType)} size="small" sx={{ padding: 0 }} />
                 <ListItemText primary={<Typography sx={smallFormControlSx}>{filterText}</Typography>} />
             </MenuItem>
         )
@@ -318,13 +314,8 @@ export const QueryList = () => {
         }
 
         return (
-            <MenuItem key={errorTypeText} value={errorTypeText}>
-                <Checkbox
-                    checked={errorTypeFilters.includes(newErrorType)}
-                    size="small"
-                    sx={{ padding: 0 }}
-                    onClick={handleClick}
-                />
+            <MenuItem key={errorTypeText} value={errorTypeText} onClick={handleClick}>
+                <Checkbox checked={errorTypeFilters.includes(newErrorType)} size="small" sx={{ padding: 0 }} />
                 <ListItemText primary={<Typography sx={smallFormControlSx}>Failed - {errorTypeText}</Typography>} />
             </MenuItem>
         )


### PR DESCRIPTION
## Description

Fixes the Preview UI query State filter dropdown so clicking an option’s text or row toggles the checkbox, not only direct clicks on the checkbox itself.

fixes https://github.com/trinodb/trino/issues/30078

## Additional context and related issues

The change keeps the existing nested `handleClick` logic and only moves the click handler to the `MenuItem`, preserving the current filtering behavior and UI structure

The entire dropdown item text is now clickable, not only the checkbox:
<img width="1327" height="1040" alt="image" src="https://github.com/user-attachments/assets/2aeacddc-22e5-409f-aa22-183c7879d18c" />

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix query filter checkbox item clicks in preview UI. ({issue}`30078`)
```
