### PR TITLE
Reduce memory pressure when writing position deletes in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/PositionDeleteWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/PositionDeleteWriter.java
@@ -165,7 +165,6 @@ public class PositionDeleteWriter
         void reset()
         {
             size = 0;
-            positions = new long[positions.length];
         }
     }
 }


### PR DESCRIPTION
## Description

`PositionsList.reset()` was allocating a new `long[]` on every batch flush instead of reusing the existing array. 
For large deletes this triggered repeated GC cycles - one allocation per 4096-row batch.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
