### PR TITLE
Add Azure exchange connection-pool tuning properties

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.md
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.md
@@ -518,6 +518,21 @@ the property may be configured for:
     retry a request.
   - `10`
   - Azure Blob Storage
+* - `exchange.azure.max-connections`
+  - Maximum number of concurrent HTTP connections in the Azure storage
+    connection pool.
+  - `500`
+  - Azure Blob Storage
+* - `exchange.azure.pending-acquire-max-count`
+  - Maximum number of pending connection acquire requests in the Azure
+    storage connection pool.
+  - `1000`
+  - Azure Blob Storage
+* - `exchange.azure.connection-acquisition-timeout`
+  - Maximum time to wait for a connection to be acquired from the Azure
+    storage connection pool.
+  - `1m`
+  - Azure Blob Storage
 * - `exchange.hdfs.block-size`
   - Block [data size](prop-type-data-size) for HDFS storage.
   - `4MB`

--- a/plugin/trino-exchange-filesystem/pom.xml
+++ b/plugin/trino-exchange-filesystem/pom.xml
@@ -25,6 +25,11 @@
 
         <dependency>
             <groupId>com.azure</groupId>
+            <artifactId>azure-core-http-netty</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
             <exclusions>
                 <exclusion>
@@ -205,6 +210,11 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty-core</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/AzureBlobFileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/AzureBlobFileSystemExchangeStorage.java
@@ -13,6 +13,8 @@
  */
 package io.trino.plugin.exchange.filesystem.azure;
 
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
 import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.util.BinaryData;
 import com.azure.identity.DefaultAzureCredentialBuilder;
@@ -64,6 +66,7 @@ import io.trino.plugin.exchange.filesystem.MetricsBuilder.CounterMetricBuilder;
 import jakarta.annotation.PreDestroy;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.netty.resources.ConnectionProvider;
 
 import java.io.IOException;
 import java.net.URI;
@@ -96,6 +99,7 @@ import static io.trino.plugin.exchange.filesystem.MetricsBuilder.SOURCE_FILES_PR
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.lang.System.arraycopy;
+import static java.time.Duration.ofMillis;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElseGet;
 
@@ -115,8 +119,6 @@ public class AzureBlobFileSystemExchangeStorage
         this.blockSize = toIntExact(config.getAzureStorageBlockSize().toBytes());
 
         RequestRetryOptions retryOptions = new RequestRetryOptions(RetryPolicyType.EXPONENTIAL, config.getMaxErrorRetries(), (Integer) null, null, null, null);
-        BlobServiceClientBuilder blobServiceClientBuilder = new BlobServiceClientBuilder()
-                .retryOptions(retryOptions);
         Optional<String> connectionString = config.getAzureStorageConnectionString();
         Optional<String> endpoint = config.getAzureStorageEndpoint();
 
@@ -124,6 +126,9 @@ public class AzureBlobFileSystemExchangeStorage
             throw new IllegalArgumentException("Exactly one of exchange.azure.endpoint or exchange.azure.connection-string must be provided");
         }
 
+        BlobServiceClientBuilder blobServiceClientBuilder = new BlobServiceClientBuilder()
+                .httpClient(buildHttpClient("exchange-azure-blob", config))
+                .retryOptions(retryOptions);
         if (connectionString.isPresent()) {
             blobServiceClientBuilder.connectionString(connectionString.get());
         }
@@ -137,6 +142,7 @@ public class AzureBlobFileSystemExchangeStorage
 
         if (this.isHierarchical) {
             DataLakeServiceClientBuilder dataLakeServiceClientBuilder = new DataLakeServiceClientBuilder()
+                    .httpClient(buildHttpClient("exchange-azure-adls", config))
                     .retryOptions(retryOptions);
             if (connectionString.isPresent()) {
                 dataLakeServiceClientBuilder.connectionString(connectionString.get());
@@ -150,6 +156,17 @@ public class AzureBlobFileSystemExchangeStorage
         else {
             this.dataLakeServiceAsyncClient = Optional.empty();
         }
+    }
+
+    private static HttpClient buildHttpClient(String poolName, ExchangeAzureConfig config)
+    {
+        return new NettyAsyncHttpClientBuilder()
+                .connectionProvider(ConnectionProvider.builder(poolName)
+                        .maxConnections(config.getMaxConnections())
+                        .pendingAcquireMaxCount(config.getPendingAcquireMaxCount())
+                        .pendingAcquireTimeout(ofMillis(config.getConnectionAcquisitionTimeout().toMillis()))
+                        .build())
+                .build();
     }
 
     private boolean isHierarchical(List<URI> baseUris, BlobServiceClient blobServiceClient)

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/ExchangeAzureConfig.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/azure/ExchangeAzureConfig.java
@@ -17,12 +17,14 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
@@ -32,6 +34,9 @@ public class ExchangeAzureConfig
     private Optional<String> azureStorageEndpoint = Optional.empty();
     private DataSize azureStorageBlockSize = DataSize.of(4, MEGABYTE);
     private int maxErrorRetries = 10;
+    private int maxConnections = 500;
+    private int pendingAcquireMaxCount = 1000;
+    private Duration connectionAcquisitionTimeout = new Duration(1, TimeUnit.MINUTES);
 
     public Optional<String> getAzureStorageConnectionString()
     {
@@ -85,6 +90,47 @@ public class ExchangeAzureConfig
     public ExchangeAzureConfig setMaxErrorRetries(int maxErrorRetries)
     {
         this.maxErrorRetries = maxErrorRetries;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxConnections()
+    {
+        return maxConnections;
+    }
+
+    @Config("exchange.azure.max-connections")
+    @ConfigDescription("Maximum number of concurrent HTTP connections in the Azure storage connection pool")
+    public ExchangeAzureConfig setMaxConnections(int maxConnections)
+    {
+        this.maxConnections = maxConnections;
+        return this;
+    }
+
+    @Min(1)
+    public int getPendingAcquireMaxCount()
+    {
+        return pendingAcquireMaxCount;
+    }
+
+    @Config("exchange.azure.pending-acquire-max-count")
+    @ConfigDescription("Maximum number of pending connection acquire requests in the Azure storage connection pool. Should be set to at least exchange.azure.max-connections")
+    public ExchangeAzureConfig setPendingAcquireMaxCount(int pendingAcquireMaxCount)
+    {
+        this.pendingAcquireMaxCount = pendingAcquireMaxCount;
+        return this;
+    }
+
+    public Duration getConnectionAcquisitionTimeout()
+    {
+        return connectionAcquisitionTimeout;
+    }
+
+    @Config("exchange.azure.connection-acquisition-timeout")
+    @ConfigDescription("Maximum time to wait for a connection to be acquired from the Azure storage connection pool")
+    public ExchangeAzureConfig setConnectionAcquisitionTimeout(Duration connectionAcquisitionTimeout)
+    {
+        this.connectionAcquisitionTimeout = connectionAcquisitionTimeout;
         return this;
     }
 }

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/azure/TestExchangeAzureConfig.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/azure/TestExchangeAzureConfig.java
@@ -15,6 +15,7 @@ package io.trino.plugin.exchange.filesystem.azure;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -23,6 +24,8 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestExchangeAzureConfig
 {
@@ -33,7 +36,10 @@ public class TestExchangeAzureConfig
                 .setAzureStorageEndpoint(null)
                 .setAzureStorageConnectionString(null)
                 .setAzureStorageBlockSize(DataSize.of(4, MEGABYTE))
-                .setMaxErrorRetries(10));
+                .setMaxErrorRetries(10)
+                .setMaxConnections(500)
+                .setPendingAcquireMaxCount(1000)
+                .setConnectionAcquisitionTimeout(new Duration(1, MINUTES)));
     }
 
     @Test
@@ -44,13 +50,19 @@ public class TestExchangeAzureConfig
                 .put("exchange.azure.endpoint", "endpoint")
                 .put("exchange.azure.block-size", "8MB")
                 .put("exchange.azure.max-error-retries", "8")
+                .put("exchange.azure.max-connections", "200")
+                .put("exchange.azure.pending-acquire-max-count", "5000")
+                .put("exchange.azure.connection-acquisition-timeout", "30s")
                 .buildOrThrow();
 
         ExchangeAzureConfig expected = new ExchangeAzureConfig()
                 .setAzureStorageConnectionString("connection")
                 .setAzureStorageEndpoint("endpoint")
                 .setAzureStorageBlockSize(DataSize.of(8, MEGABYTE))
-                .setMaxErrorRetries(8);
+                .setMaxErrorRetries(8)
+                .setMaxConnections(200)
+                .setPendingAcquireMaxCount(5000)
+                .setConnectionAcquisitionTimeout(new Duration(30, SECONDS));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Adds three configuration properties to tune the Reactor Netty HTTP connection pool used by the Azure Blob Storage and ADLS exchange clients:
- `exchange.azure.max-connections` (default: 500) – maximum concurrent connections per pool
- `exchange.azure.pending-acquire-max-count` (default: 1000) – maximum pending acquire requests when the pool is exhausted
- `exchange.azure.connection-acquisition-timeout` (default: 1 minute) – maximum time to wait for a connection from the pool
 
Previously each client builder created its own Reactor Netty connection pool with a hardcoded size of 500. This change wires in explicitly configured pools so operators can tune the size for their workload.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Default values match the Azure SDK defaults, so behavior is unchanged unless the properties are explicitly set. The change is relevant for clusters running many concurrent FTE queries against Azure storage where the default connection limit becomes a bottleneck.

`DataLakeServiceClientBuilder` gets its own pool only when the storage account uses hierarchical namespace (ADLS Gen2); flat Blob Storage accounts use only the blob pool.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add `exchange.azure.max-connections`, `exchange.azure.pending-acquire-max-count`, and `exchange.azure.connection-acquisition-timeout` properties to tune the HTTP connection pool for Azure exchange spooling storage.
```
