### PR TITLE
Fix SQL Server limit pushdown dropping hidden columns

### DIFF
--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -1138,7 +1138,11 @@ public class SqlServerClient
     @Override
     protected Optional<BiFunction<String, Long, String>> limitFunction()
     {
-        return Optional.of((sql, limit) -> format("SELECT TOP %s * FROM (%s) o", limit, sql));
+        // Use OFFSET/FETCH rather than wrapping in `SELECT TOP n * FROM (...)`: the wrapping `SELECT *` re-applies
+        // SQL Server's rule that HIDDEN columns (e.g. temporal period columns) are excluded from `SELECT *`, which
+        // drops columns the inner projection selected explicitly and misaligns ordinal-based reads.
+        // ORDER BY (SELECT NULL) satisfies the OFFSET/FETCH requirement for an ORDER BY without imposing an ordering.
+        return Optional.of((sql, limit) -> format("%s ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT %s ROWS ONLY", sql, limit));
     }
 
     @Override

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerConnectorTest.java
@@ -89,6 +89,43 @@ public class TestSqlServerConnectorTest
     }
 
     @Test
+    public void testSelectFromTemporalTableWithHiddenPeriodColumns()
+    {
+        // A table whose PERIOD columns are HIDDEN (system versioning is not required to make them hidden).
+        // With LIMIT pushdown the read query must not be wrapped in `SELECT TOP n * FROM (...)`, because the
+        // wrapping `SELECT *` re-excludes the HIDDEN period columns and misaligns ordinal-based reads.
+        String tableName = "test_temporal_" + randomNameSuffix();
+        onRemoteDatabase().execute(format(
+                """
+                CREATE TABLE dbo.%s (
+                    Id INT NOT NULL PRIMARY KEY,
+                    Name NVARCHAR(50) NOT NULL,
+                    ValidFrom DATETIME2(7) GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+                    ValidTo DATETIME2(7) GENERATED ALWAYS AS ROW END HIDDEN NOT NULL,
+                    IsActive BIT NOT NULL,
+                    PERIOD FOR SYSTEM_TIME (ValidFrom, ValidTo))
+                """,
+                tableName));
+        try {
+            onRemoteDatabase().execute(format("INSERT INTO dbo.%s (Id, Name, IsActive) VALUES (1, 'a', 1)", tableName));
+
+            // The hidden period columns are exposed by DatabaseMetaData.getColumns(), so Trino sees 5 columns.
+            assertThat(computeActual("DESCRIBE " + tableName).getRowCount()).isEqualTo(5);
+
+            // SELECT * with LIMIT exercises the hidden period columns; the IsActive (BIT) column must not be read as a timestamp.
+            assertThat(computeActual("SELECT * FROM " + tableName + " LIMIT 10").getRowCount()).isEqualTo(1);
+            assertThat(query("SELECT * FROM " + tableName + " LIMIT 0")).returnsEmptyResult();
+
+            assertThat(query("SELECT Id, Name, IsActive FROM " + tableName))
+                    .skippingTypesCheck()
+                    .matches("VALUES (1, 'a', true)");
+        }
+        finally {
+            onRemoteDatabase().execute("DROP TABLE dbo." + tableName);
+        }
+    }
+
+    @Test
     public void testInsertWriteBulkiness()
             throws SQLException
     {


### PR DESCRIPTION
## Description

Reading from a SQL Server table that has **hidden columns** fails with an
ordinal-misalignment error when a `LIMIT` is applied.

SQL Server excludes `HIDDEN` columns (for example, temporal table period
columns declared with `GENERATED ALWAYS AS ROW START/END ... HIDDEN`) from
`SELECT *`, but returns them when they are named explicitly. The connector
always builds an explicit projection, so plain reads work. However, `LIMIT`
pushdown wrapped the query as:

    SELECT TOP n * FROM (<explicit projection>) o

The outer `SELECT *` over the derived table re-applies the "hidden columns are
excluded from `SELECT *`" rule and drops the period columns that the inner
query had selected explicitly. The result set then has fewer columns than the
connector's column handles, so ordinal-based reads in `JdbcPageSource` line up
against the wrong columns (e.g. a `bit` column is read with the timestamp read
function).

## Root cause

`SqlServerClient.limitFunction()` implemented `LIMIT` pushdown by wrapping the
query in `SELECT TOP n * FROM (...)`. The `SELECT *` re-projection is the
problem.

## Fix

Push `LIMIT` down with `OFFSET/FETCH` instead of the `SELECT TOP n *` wrapper,
mirroring the existing `topNFunction()`. This appends to the query rather than
re-projecting it, so the explicit column list is preserved and ordinals stay
aligned:

    <query> ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT n ROWS ONLY

`ORDER BY (SELECT NULL)` satisfies SQL Server's requirement that `OFFSET/FETCH`
be preceded by `ORDER BY`, without imposing an ordering (`LIMIT` without
`ORDER BY` is unordered, so any `n` rows are valid).

## How to reproduce

On SQL Server, create a table with hidden period columns and insert a row:

```sql
CREATE TABLE dbo.repro (
    Id INT NOT NULL PRIMARY KEY,
    Name NVARCHAR(50) NOT NULL,
    ValidFrom DATETIME2(7) GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
    ValidTo   DATETIME2(7) GENERATED ALWAYS AS ROW END   HIDDEN NOT NULL,
    IsActive BIT NOT NULL,
    PERIOD FOR SYSTEM_TIME (ValidFrom, ValidTo));

INSERT INTO dbo.repro (Id, Name, IsActive) VALUES (1, 'a', 1);
```

Then from Trino:

```sql
-- Works: explicit projection, no wrapper
SELECT * FROM sqlserver.dbo.repro;

-- Fails before this change: LIMIT pushdown wraps in SELECT TOP n * FROM (...)
SELECT * FROM sqlserver.dbo.repro LIMIT 10;
```

The failing query throws:

```
io.trino.testing.QueryFailedException: The conversion from bit to LOCALDATETIME is unsupported.
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:660)
	at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:636)
	at io.trino.testing.AbstractTestQueryFramework.computeActual(AbstractTestQueryFramework.java:322)
	at io.trino.plugin.sqlserver.TestSqlServerConnectorTest.testSelectFromTemporalTableWithHiddenPeriodColumns(TestSqlServerConnectorTest.java:115)
	Suppressed: java.lang.Exception: SQL: SELECT * FROM test_temporal_xxxxxxxxxx LIMIT 10
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:667)
		... 4 more
Caused by: io.trino.spi.TrinoException: The conversion from bit to LOCALDATETIME is unsupported.
	at io.trino.plugin.jdbc.JdbcPageSource.handleSqlException(JdbcPageSource.java:294)
	at io.trino.plugin.jdbc.JdbcPageSource.getNextSourcePage(JdbcPageSource.java:219)
	at io.trino.operator.TableScanOperator.getOutput(TableScanOperator.java:296)
	at io.trino.operator.Driver.processInternal(Driver.java:400)
	at io.trino.operator.Driver.process(Driver.java:295)
Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: The conversion from bit to LOCALDATETIME is unsupported.
	at com.microsoft.sqlserver.jdbc.SQLServerException.makeFromDriverError(SQLServerException.java:250)
	at com.microsoft.sqlserver.jdbc.DataTypes.throwConversionError(DataTypes.java:1154)
	at com.microsoft.sqlserver.jdbc.ServerDTVImpl.getValue(dtv.java:3770)
	at com.microsoft.sqlserver.jdbc.SQLServerResultSet.getValue(SQLServerResultSet.java:2108)
	at com.microsoft.sqlserver.jdbc.SQLServerResultSet.getLocalDateTime(SQLServerResultSet.java:2720)
```

## Test plan

- Added `TestSqlServerConnectorTest#testSelectFromTemporalTableWithHiddenPeriodColumns`.
- Verified existing limit / TopN / distinct-limit pushdown tests still pass.

## Release notes

(x) Release notes are required, with the following suggested text:

# SQL Server connector
* Fix query failure when reading a table with hidden columns using a `LIMIT`.
