### PR TITLE
Skip catalogs that failed to load when accessing connector services

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/AbstractPropertiesSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/AbstractPropertiesSystemTable.java
@@ -83,6 +83,7 @@ abstract class AbstractPropertiesSystemTable
         InMemoryRecordSet.Builder table = InMemoryRecordSet.builder(tableMetadata);
 
         List<CatalogInfo> catalogInfos = listCatalogs(session, metadata, accessControl).stream()
+                .filter(CatalogInfo::isOperational)
                 .sorted(Comparator.comparing(CatalogInfo::catalogName))
                 .collect(toImmutableList());
 

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/CatalogJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/CatalogJdbcTable.java
@@ -28,7 +28,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 
-import static io.trino.metadata.MetadataListing.listCatalogNames;
+import static io.trino.metadata.MetadataListing.listAllCatalogNames;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
@@ -63,7 +63,7 @@ public class CatalogJdbcTable
     {
         Session session = ((FullConnectorSession) connectorSession).getSession();
         Builder table = InMemoryRecordSet.builder(METADATA);
-        for (String name : listCatalogNames(session, metadata, accessControl, Domain.all(VARCHAR))) {
+        for (String name : listAllCatalogNames(session, metadata, accessControl, Domain.all(VARCHAR))) {
             table.addRow(name);
         }
         return table.build().cursor();

--- a/core/trino-main/src/main/java/io/trino/metadata/CatalogInfo.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/CatalogInfo.java
@@ -16,6 +16,7 @@ package io.trino.metadata;
 import io.trino.connector.CatalogHandle;
 import io.trino.spi.connector.ConnectorName;
 
+import static io.trino.metadata.CatalogStatus.OPERATIONAL;
 import static java.util.Objects.requireNonNull;
 
 public record CatalogInfo(
@@ -30,5 +31,10 @@ public record CatalogInfo(
         requireNonNull(catalogHandle, "catalogHandle is null");
         requireNonNull(connectorName, "connectorName is null");
         requireNonNull(catalogStatus, "catalogStatus is null");
+    }
+
+    public boolean isOperational()
+    {
+        return catalogStatus == OPERATIONAL;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
@@ -56,6 +56,21 @@ public final class MetadataListing
 
     public static SortedSet<String> listCatalogNames(Session session, Metadata metadata, AccessControl accessControl, Domain catalogDomain)
     {
+        Set<String> catalogs = metadata.listCatalogs(session).stream()
+                .filter(CatalogInfo::isOperational)
+                .map(CatalogInfo::catalogName)
+                .filter(stringFilter(catalogDomain))
+                .collect(toImmutableSet());
+        return ImmutableSortedSet.copyOf(accessControl.filterCatalogs(session.toSecurityContext(), catalogs));
+    }
+
+    /**
+     * Like {@link #listCatalogNames(Session, Metadata, AccessControl, Domain)} but also includes catalogs
+     * that failed to load. Use this only when the caller does not access the catalog's connector —
+     * for example, when displaying a catalog list to the user.
+     */
+    public static SortedSet<String> listAllCatalogNames(Session session, Metadata metadata, AccessControl accessControl, Domain catalogDomain)
+    {
         Optional<String> catalogName = tryGetSingleVarcharValue(catalogDomain);
         Set<String> catalogs;
         if (catalogName.isPresent()) {

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -2658,6 +2658,9 @@ public final class MetadataManager
     {
         ImmutableList.Builder<FunctionMetadata> functions = ImmutableList.builder();
         for (CatalogInfo catalog : listCatalogs(session)) {
+            if (!catalog.isOperational()) {
+                continue;
+            }
             functions.addAll(tableFunctionRegistry.listTableFunctions(catalog.catalogHandle()));
         }
         return functions.build();

--- a/core/trino-main/src/main/java/io/trino/metadata/SessionPropertyManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SessionPropertyManager.java
@@ -146,6 +146,9 @@ public final class SessionPropertyManager
         }
 
         for (CatalogInfo catalogInfo : catalogInfos) {
+            if (!catalogInfo.isOperational()) {
+                continue;
+            }
             CatalogHandle catalogHandle = catalogInfo.catalogHandle();
             String catalogName = catalogInfo.catalogName();
             Map<String, String> connectorProperties = session.getCatalogProperties(catalogName);

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -119,7 +119,7 @@ import static io.trino.connector.informationschema.InformationSchemaTable.TABLES
 import static io.trino.connector.informationschema.InformationSchemaTable.TABLE_PRIVILEGES;
 import static io.trino.execution.CreateFunctionTask.defaultFunctionSchema;
 import static io.trino.execution.CreateFunctionTask.qualifiedFunctionName;
-import static io.trino.metadata.MetadataListing.listCatalogNames;
+import static io.trino.metadata.MetadataListing.listAllCatalogNames;
 import static io.trino.metadata.MetadataListing.listCatalogs;
 import static io.trino.metadata.MetadataListing.listSchemas;
 import static io.trino.metadata.MetadataUtil.createCatalogSchemaName;
@@ -421,7 +421,7 @@ public final class ShowQueriesRewrite
         @Override
         protected Node visitShowCatalogs(ShowCatalogs node, Void context)
         {
-            List<Expression> rows = listCatalogNames(session, metadata, accessControl, Domain.all(VARCHAR)).stream()
+            List<Expression> rows = listAllCatalogNames(session, metadata, accessControl, Domain.all(VARCHAR)).stream()
                     .map(name -> row(new StringLiteral(name)))
                     .collect(toImmutableList());
 

--- a/core/trino-main/src/test/java/io/trino/connector/TestBrokenCatalogQueries.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestBrokenCatalogQueries.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.spi.catalog.CatalogName;
+import io.trino.spi.catalog.CatalogProperties;
+import io.trino.spi.catalog.CatalogStore;
+import io.trino.spi.catalog.CatalogStoreFactory;
+import io.trino.spi.connector.CatalogVersion;
+import io.trino.spi.connector.ConnectorName;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.StandaloneQueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestBrokenCatalogQueries
+{
+    private static final String BROKEN_CATALOG = "broken";
+    private static final String HEALTHY_CATALOG = "tpch";
+
+    private QueryRunner queryRunner;
+
+    @BeforeAll
+    public void setUp()
+    {
+        // The broken catalog is present in the catalog store at startup, but its connector cannot be loaded
+        // (it has invalid properties), so loadInitialCatalogs marks it as FAILING.
+        queryRunner = new StandaloneQueryRunner(
+                TEST_SESSION,
+                builder -> builder
+                        .setAdditionalModule(new BrokenCatalogStoreModule())
+                        .addProperty("catalog.store", "broken_at_startup"));
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog(HEALTHY_CATALOG, "tpch", Map.of());
+    }
+
+    @AfterAll
+    public void tearDown()
+    {
+        if (queryRunner != null) {
+            queryRunner.close();
+            queryRunner = null;
+        }
+    }
+
+    @Test
+    public void testBrokenCatalogStaysVisible()
+    {
+        assertThat(queryRunner.execute("SELECT state FROM system.metadata.catalogs WHERE catalog_name = '%s'".formatted(BROKEN_CATALOG)).getOnlyValue())
+                .isEqualTo("FAILING");
+        assertThat(queryRunner.execute("SELECT count(*) FROM system.jdbc.catalogs WHERE table_cat = '%s'".formatted(BROKEN_CATALOG)).getOnlyValue())
+                .isEqualTo(1L);
+    }
+
+    @Test
+    public void testShowCatalogsIncludesBrokenCatalog()
+    {
+        assertThat(queryRunner.execute("SHOW CATALOGS").getMaterializedRows())
+                .extracting(row -> row.getField(0))
+                .contains(HEALTHY_CATALOG, BROKEN_CATALOG);
+    }
+
+    @Test
+    public void testCatalogEnumeratingQueriesIgnoreBrokenCatalog()
+    {
+        // Broken catalog contributes no metadata; healthy catalog still does.
+        assertThat(queryRunner.execute("SELECT count(*) FROM system.jdbc.tables WHERE table_cat = '%s'".formatted(BROKEN_CATALOG)).getOnlyValue())
+                .isEqualTo(0L);
+        assertThat((long) queryRunner.execute("SELECT count(*) FROM system.jdbc.tables WHERE table_cat = '%s'".formatted(HEALTHY_CATALOG)).getOnlyValue())
+                .isGreaterThan(0L);
+
+        assertThat(queryRunner.execute("SELECT count(*) FROM system.jdbc.schemas WHERE table_catalog = '%s'".formatted(BROKEN_CATALOG)).getOnlyValue())
+                .isEqualTo(0L);
+        assertThat((long) queryRunner.execute("SELECT count(*) FROM system.jdbc.schemas WHERE table_catalog = '%s'".formatted(HEALTHY_CATALOG)).getOnlyValue())
+                .isGreaterThan(0L);
+
+        assertThat(queryRunner.execute("SELECT count(*) FROM system.jdbc.columns WHERE table_cat = '%s'".formatted(BROKEN_CATALOG)).getOnlyValue())
+                .isEqualTo(0L);
+        assertThat((long) queryRunner.execute("SELECT count(*) FROM system.jdbc.columns WHERE table_schem = 'tiny'").getOnlyValue())
+                .isGreaterThan(0L);
+
+        assertThat(queryRunner.execute("SELECT count(*) FROM system.metadata.table_comments WHERE catalog_name = '%s'".formatted(BROKEN_CATALOG)).getOnlyValue())
+                .isEqualTo(0L);
+
+        assertThat(queryRunner.execute("SELECT count(*) FROM system.metadata.materialized_views WHERE catalog_name = '%s'".formatted(BROKEN_CATALOG)).getOnlyValue())
+                .isEqualTo(0L);
+
+        // Not catalog-scoped; just verify no exception.
+        assertThatCode(() -> {
+            queryRunner.execute("SHOW SESSION");
+            queryRunner.execute("SHOW FUNCTIONS");
+            queryRunner.execute("SELECT * FROM system.metadata.materialized_view_properties");
+            queryRunner.execute("SELECT * FROM system.metadata.table_properties");
+        }).doesNotThrowAnyException();
+    }
+
+    private static class BrokenCatalogStoreModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder) {}
+
+        @Provides
+        @Singleton
+        public CatalogStoreFactory createCatalogStoreFactory(CatalogStoreManager catalogStoreManager)
+        {
+            CatalogStoreFactory factory = new BrokenCatalogStoreFactory();
+            catalogStoreManager.addCatalogStoreFactory(factory);
+            return factory;
+        }
+    }
+
+    private static class BrokenCatalogStoreFactory
+            implements CatalogStoreFactory
+    {
+        @Override
+        public String getName()
+        {
+            return "broken_at_startup";
+        }
+
+        @Override
+        public CatalogStore create(Map<String, String> config)
+        {
+            return new BrokenCatalogStore();
+        }
+    }
+
+    private static class BrokenCatalogStore
+            implements CatalogStore
+    {
+        private static final CatalogProperties BROKEN_CATALOG_PROPERTIES = new CatalogProperties(
+                new CatalogName(BROKEN_CATALOG),
+                new CatalogVersion("broken"),
+                new ConnectorName("tpch"),
+                Map.of("invalid-property", "value"));
+
+        private final CatalogStore delegate = new InMemoryCatalogStore();
+
+        @Override
+        public Collection<StoredCatalog> getCatalogs()
+        {
+            return ImmutableList.<StoredCatalog>builder()
+                    .add(new StoredCatalog()
+                    {
+                        @Override
+                        public CatalogName name()
+                        {
+                            return new CatalogName(BROKEN_CATALOG);
+                        }
+
+                        @Override
+                        public CatalogProperties loadProperties()
+                        {
+                            return BROKEN_CATALOG_PROPERTIES;
+                        }
+                    })
+                    .addAll(delegate.getCatalogs())
+                    .build();
+        }
+
+        @Override
+        public CatalogProperties createCatalogProperties(CatalogName catalogName, ConnectorName connectorName, Map<String, String> properties)
+        {
+            return delegate.createCatalogProperties(catalogName, connectorName, properties);
+        }
+
+        @Override
+        public void addOrReplaceCatalog(CatalogProperties catalogProperties)
+        {
+            delegate.addOrReplaceCatalog(catalogProperties);
+        }
+
+        @Override
+        public void removeCatalog(CatalogName catalogName)
+        {
+            delegate.removeCatalog(catalogName);
+        }
+    }
+}


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
A dynamic catalog that fails to load is kept as a FAILING catalog so it stays visible in system.metadata.catalogs and
system.metadata.broken_catalog_definitions. It has no connector, so enumerating catalogs and then accessing their connector services threw IllegalArgumentException and failed queries such as SHOW SESSION.

Filter out non-OPERATIONAL catalogs before accessing their connector services, matching the existing pattern in MetadataManager.dropCatalog:
    - CatalogInfo.isActive() centralizes the status check.
    - SessionPropertyManager.getAllSessionProperties and AbstractPropertiesSystemTable skip failed catalogs.
    - MetadataListing.listActiveCatalogNames is used by the JDBC and metadata-reading system tables.
    - MetadataManager.listTableFunctions skips failed catalogs so function resolution during analysis no longer fails.

Pure listing tables (system.metadata.catalogs, system.jdbc.catalogs) keep showing failed catalogs so they remain visible for repair.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
