### PR TITLE
Skip PR CI jobs already validated by previous run

### DIFF
--- a/.github/bin/build-matrix-from-impacted.py
+++ b/.github/bin/build-matrix-from-impacted.py
@@ -30,6 +30,24 @@ def main():
         "as paths, not artifact ids",
     )
     parser.add_argument(
+        "--impacted-prev",
+        type=argparse.FileType("r"),
+        default=None,
+        help="File containing list of impacted modules vs the merge commit of the "
+        "previous PR CI run. When provided together with --prev-non-success-jobs, "
+        "matrix items whose modules are not impacted vs the previous run AND that "
+        "are not on the prev-non-success list are skipped.",
+    )
+    parser.add_argument(
+        "--prev-non-success-jobs",
+        type=argparse.FileType("r"),
+        default=None,
+        help="File containing rendered job names (one per line) for jobs from the "
+        "previous PR CI run whose conclusion was NOT success. Treated as a deny "
+        "list for the prev-run gate: a job whose name is on this list is never "
+        "carried as 'previously validated'.",
+    )
+    parser.add_argument(
         "-o",
         "--output",
         type=argparse.FileType("w"),
@@ -58,133 +76,254 @@ def main():
         sys.argv = [sys.argv[0]]
         unittest.main()
         return
-    build(args.matrix, args.impacted, args.output)
+    build(args.matrix, args.impacted, args.output, args.impacted_prev, args.prev_non_success_jobs)
 
 
-def build(matrix_file, impacted_file, output_file):
+def render(item):
+    """Compute the GHA job name for a matrix item.
+
+    Must match GitHub Actions' default matrix-job naming for the `test` job
+    (`<job_id> (<comma-joined-values-of-present-keys>)`), so this is what the
+    next run's `resolve-prev-run` will see in the jobs API as `name`.
+
+    The item must have its `modules` field normalized to a comma-joined string.
+    """
+    parts = [item["modules"]]
+    if item.get("profile"):
+        parts.append(item["profile"])
+    return f"test ({', '.join(parts)})"
+
+
+def build(matrix_file, impacted_file, output_file, impacted_prev_file=None, prev_non_success_jobs_file=None):
     matrix = yaml.load(matrix_file, Loader=yaml.Loader)
     impacted = list(filter(None, [line.strip() for line in impacted_file.readlines()]))
+    impacted_prev = None
+    if impacted_prev_file is not None:
+        impacted_prev = list(filter(None, [line.strip() for line in impacted_prev_file.readlines()]))
+    prev_non_success = None
+    if prev_non_success_jobs_file is not None:
+        prev_non_success = set(filter(None, [line.strip() for line in prev_non_success_jobs_file.readlines()]))
     logging.info("Read matrix: %s", matrix)
     logging.info("Read impacted: %s", impacted)
+    logging.info("Read impacted_prev: %s", impacted_prev)
+    logging.info("Read prev_non_success (%d names)", len(prev_non_success) if prev_non_success is not None else 0)
+
+    # We compute render(item) for every kept item and assert uniqueness, so the
+    # next run's resolve-prev-run can unambiguously map a job name back to "did
+    # this item run / pass". The workflow uses GHA's default job naming, which
+    # matches render() for the test job; nothing is injected into the matrix.
+    rendered_names = []
 
     modules = []
     for item in matrix.get("modules", []):
-        module = check_modules(item, impacted)
-        if module is None:
+        normalized = _normalize_top_level(item)
+        if not _keep(normalized, impacted, impacted_prev, prev_non_success):
             logging.info("Excluding matrix section: %s", item)
             continue
-        modules.append(module)
+        modules.append(normalized["modules"])  # matrix value must remain a primitive
+        rendered_names.append(render(normalized))
     if "modules" in matrix:
         matrix["modules"] = modules
 
     include = []
     for item in matrix.get("include", []):
-        modules = check_modules(item.get("modules", []), impacted)
-        if modules is None:
+        normalized = _normalize_include(item)
+        if not _keep(normalized, impacted, impacted_prev, prev_non_success):
             logging.info("Excluding matrix section: %s", item)
             continue
-        item["modules"] = modules
-        include.append(item)
+        rendered_names.append(render(normalized))
+        include.append(normalized)
     if "include" in matrix:
         if include:
             matrix["include"] = include
         else:
             del matrix["include"]
 
+    _assert_unique_names(rendered_names)
+
     json.dump(matrix, output_file)
     output_file.write("\n")
 
 
-def check_modules(modules, impacted):
+def _normalize_top_level(modules):
     if isinstance(modules, str):
         modules = [modules]
-    # `impacted` can be empty when GIB detected no changes, but also when GIB was not run at all.
-    # The latter is the case on builds on master branch. For these builds we want to run all tests,
-    # so we don't filter out any modules.
-    if impacted and not any(module in impacted for module in modules):
-        return None
-    # concatenate because matrix values should be primitives
-    return ",".join(modules)
+    return {"modules": ",".join(modules)}
+
+
+def _normalize_include(item):
+    raw = item.get("modules", [])
+    if isinstance(raw, str):
+        raw = [raw]
+    result = dict(item)
+    result["modules"] = ",".join(raw)
+    return result
+
+
+def _keep(item, impacted, impacted_prev, prev_non_success):
+    """Apply both gates. Returns True if the matrix item should be kept."""
+    modules = item["modules"].split(",")
+    # Gate 1: master-side. `impacted` empty means GIB was not run at all (master
+    # builds), in which case keep everything. On PR builds GIB always runs.
+    if impacted and not any(m in impacted for m in modules):
+        return False
+    # Gate 2: prev-run-side. We have prev info only when both inputs are present.
+    # Skip when none of J's modules are impacted vs prev AND J is NOT on the
+    # non-success deny list (i.e., J either succeeded in prev or wasn't in prev's
+    # jobs API at all — both equivalent under the empty-diff invariant).
+    if impacted_prev is not None and prev_non_success is not None:
+        if render(item) not in prev_non_success and not any(m in impacted_prev for m in modules):
+            return False
+    return True
+
+
+def _assert_unique_names(names):
+    if len(names) != len(set(names)):
+        seen = {}
+        dups = set()
+        for n in names:
+            if n in seen:
+                dups.add(n)
+            seen[n] = True
+        raise AssertionError(
+            "render() produced duplicate job names; matching against prev jobs "
+            "API would be ambiguous. Duplicates: " + ", ".join(sorted(dups))
+        )
 
 
 class TestBuild(unittest.TestCase):
-    def test_build(self):
-        cases = [
-            # basic test
-            (
-                {
-                    "modules": ["a", "b"],
-                },
-                ["a"],
-                {
-                    "modules": ["a"],
-                },
-            ),
-            # include adds a new entry
-            (
-                {
-                    "modules": ["a", "b"],
-                    "include": [
-                        {"modules": "c"},
-                        {"modules": "d"},
-                    ],
-                },
-                ["a", "d"],
-                {
-                    "modules": ["a"],
-                    "include": [
-                        {"modules": "d"},
-                    ],
-                },
-            ),
-            # include entry overwrites one in matrix
-            (
-                {
-                    "modules": ["a", "b"],
-                    "include": [
-                        {"modules": "a", "options": "-Pprofile"},
-                    ],
-                },
-                ["a"],
-                {
-                    "modules": ["a"],
-                    "include": [
-                        {"modules": "a", "options": "-Pprofile"},
-                    ],
-                },
-            ),
-            # with excludes
-            (
-                {
-                    "modules": ["a", "b"],
-                    "exclude": ["b"],
-                },
-                ["a"],
-                {
-                    "modules": ["a"],
-                    "exclude": ["b"],
-                },
-            ),
-        ]
-        for matrix, impacted, expected in cases:
-            with self.subTest():
-                # given
-                matrix_file = tempfile.TemporaryFile("w+")
-                yaml.dump(matrix, matrix_file)
-                matrix_file.seek(0)
-                impacted_file = tempfile.TemporaryFile("w+")
-                impacted_file.write("\n".join(impacted))
-                impacted_file.seek(0)
-                output_file = tempfile.TemporaryFile("w+")
-                # when
-                build(matrix_file, impacted_file, output_file)
-                output_file.seek(0)
-                output = json.load(output_file)
-                # then
-                self.assertEqual(output, expected)
-                matrix_file.close()
-                impacted_file.close()
-                output_file.close()
+    def _run(self, matrix, impacted, expected, impacted_prev=None, prev_non_success=None):
+        matrix_file = tempfile.TemporaryFile("w+")
+        yaml.dump(matrix, matrix_file)
+        matrix_file.seek(0)
+        impacted_file = tempfile.TemporaryFile("w+")
+        impacted_file.write("\n".join(impacted))
+        impacted_file.seek(0)
+        impacted_prev_file = None
+        if impacted_prev is not None:
+            impacted_prev_file = tempfile.TemporaryFile("w+")
+            impacted_prev_file.write("\n".join(impacted_prev))
+            impacted_prev_file.seek(0)
+        prev_non_success_file = None
+        if prev_non_success is not None:
+            prev_non_success_file = tempfile.TemporaryFile("w+")
+            prev_non_success_file.write("\n".join(prev_non_success))
+            prev_non_success_file.seek(0)
+        output_file = tempfile.TemporaryFile("w+")
+        build(matrix_file, impacted_file, output_file, impacted_prev_file, prev_non_success_file)
+        output_file.seek(0)
+        output = json.load(output_file)
+        self.assertEqual(output, expected)
+
+    def test_legacy_basic(self):
+        # No prev-run inputs -> classic behavior.
+        self._run(
+            {"include": [{"modules": "a"}, {"modules": "b"}]},
+            ["a"],
+            {"include": [{"modules": "a"}]},
+        )
+
+    def test_legacy_modules_list_joined(self):
+        self._run(
+            {"include": [{"modules": ["a", "b"]}]},
+            ["a"],
+            {"include": [{"modules": "a,b"}]},
+        )
+
+    def test_legacy_include_with_profile(self):
+        self._run(
+            {"include": [{"modules": "a", "profile": "p"}]},
+            ["a"],
+            {"include": [{"modules": "a", "profile": "p"}]},
+        )
+
+    def test_legacy_empty_impacted_keeps_all(self):
+        # Master branch builds: GIB didn't run, impacted is empty, keep all.
+        self._run(
+            {"include": [{"modules": "a"}, {"modules": "b"}]},
+            [],
+            {"include": [{"modules": "a"}, {"modules": "b"}]},
+        )
+
+    def test_prev_skip_when_not_on_deny_list_and_no_diff(self):
+        # J passed in prev (== not on deny list) AND no diff -> skip.
+        self._run(
+            matrix={"include": [{"modules": "a"}, {"modules": "b"}]},
+            impacted=["a", "b"],
+            impacted_prev=[],
+            prev_non_success=[],
+            expected={},  # both items skipped -> include empty -> removed
+        )
+
+    def test_prev_runs_when_diff_present(self):
+        # J's module impacted vs prev -> can't skip even if not on deny list.
+        self._run(
+            matrix={"include": [{"modules": "a"}, {"modules": "b"}]},
+            impacted=["a", "b"],
+            impacted_prev=["a"],
+            prev_non_success=[],
+            expected={"include": [{"modules": "a"}]},
+        )
+
+    def test_prev_runs_when_on_deny_list(self):
+        # J on prev_non_success (failed/cancelled/timed_out etc.) -> must run.
+        self._run(
+            matrix={"include": [{"modules": "a"}, {"modules": "b"}]},
+            impacted=["a", "b"],
+            impacted_prev=[],  # no diff vs prev
+            prev_non_success=["test (a)"],  # a failed last time
+            expected={"include": [{"modules": "a"}]},
+        )
+
+    def test_prev_absent_from_api_treated_as_validated(self):
+        # If a job is in current matrix but wasn't in prev jobs API (absent),
+        # the empty-diff invariant makes it safe to skip — same as if it passed.
+        self._run(
+            matrix={"include": [{"modules": "new-module"}]},
+            impacted=["new-module"],
+            impacted_prev=[],
+            # prev_non_success doesn't mention "test (new-module)" at all
+            prev_non_success=["test (something-else)"],
+            expected={},
+        )
+
+    def test_master_gate_dominates(self):
+        # Module not impacted vs master is dropped even if otherwise eligible.
+        self._run(
+            matrix={"include": [{"modules": "a"}, {"modules": "b"}]},
+            impacted=["a"],
+            impacted_prev=["a", "b"],
+            prev_non_success=[],
+            expected={"include": [{"modules": "a"}]},
+        )
+
+    def test_profile_disambiguates_name(self):
+        # Two items differing only by profile render to distinct names, so the
+        # deny list applies to them independently.
+        self._run(
+            matrix={"include": [{"modules": "a"}, {"modules": "a", "profile": "p"}]},
+            impacted=["a"],
+            impacted_prev=[],
+            prev_non_success=["test (a)"],  # only the unprofiled failed prev
+            expected={
+                "include": [
+                    {"modules": "a"},
+                    # profiled item: not on deny list, no diff -> skipped
+                ],
+            },
+        )
+
+    def test_render_uniqueness_self_check(self):
+        # Two distinct items rendering to the same name -> assertion error.
+        with tempfile.TemporaryFile("w+") as mf, tempfile.TemporaryFile("w+") as imf, \
+                tempfile.TemporaryFile("w+") as outf:
+            # Two entries with identical modules+profile (somehow) -> same render -> conflict.
+            yaml.dump({"include": [{"modules": "a"}, {"modules": "a"}]}, mf)
+            mf.seek(0)
+            imf.write("a")
+            imf.seek(0)
+            with self.assertRaisesRegex(AssertionError, "duplicate"):
+                build(mf, imf, outf)
 
 
 if __name__ == "__main__":

--- a/.github/bin/build-pt-matrix-from-impacted-connectors.py
+++ b/.github/bin/build-pt-matrix-from-impacted-connectors.py
@@ -27,7 +27,26 @@ def main():
         "--impacted-features",
         type=argparse.FileType("r"),
         dest="impacted_features",
-        help="List of impacted features, one per line",
+        help="List of impacted features vs master, one per line",
+    )
+    parser.add_argument(
+        "--impacted-features-prev",
+        type=argparse.FileType("r"),
+        dest="impacted_features_prev",
+        default=None,
+        help="List of impacted features vs the merge commit of the previous PR CI run. "
+        "When provided together with --prev-non-success-jobs, matrix items whose features "
+        "are not impacted vs the previous run AND that are not on the prev-non-success list "
+        "are skipped.",
+    )
+    parser.add_argument(
+        "--prev-non-success-jobs",
+        type=argparse.FileType("r"),
+        dest="prev_non_success_jobs",
+        default=None,
+        help="File containing rendered job names (one per line) for jobs from the "
+        "previous PR CI run whose conclusion was NOT success. Treated as a deny list "
+        "for the prev-run gate.",
     )
     parser.add_argument(
         "-o",
@@ -57,7 +76,23 @@ def main():
         sys.argv = [sys.argv[0]]
         unittest.main()
         return
-    build(args.matrix, args.impacted_features, args.output, "testing/bin/ptl")
+    build(
+        args.matrix,
+        args.impacted_features,
+        args.output,
+        "testing/bin/ptl",
+        impacted_features_prev_file=args.impacted_features_prev,
+        prev_non_success_jobs_file=args.prev_non_success_jobs,
+    )
+
+
+def render(item):
+    """Compute the GHA job name for a PT matrix item.
+
+    Must match the `pt` job's explicit `name:` declaration in ci.yml:
+    `pt (${{ matrix.config }}, ${{ matrix.suite }}, ${{ matrix.jdk }})`.
+    """
+    return "pt ({}, {}, {})".format(item.get("config", ""), item.get("suite", ""), item.get("jdk", ""))
 
 
 def excluded(item, excludes):
@@ -131,7 +166,14 @@ def tested_features(available_features, config, suite):
     return available_features.get((config, suite), [])
 
 
-def build(matrix_file, impacted_file, output_file, ptl_binary_path):
+def build(
+    matrix_file,
+    impacted_file,
+    output_file,
+    ptl_binary_path,
+    impacted_features_prev_file=None,
+    prev_non_success_jobs_file=None,
+):
     matrix = yaml.load(matrix_file, Loader=yaml.Loader)
     logging.info("Read matrix: %s", matrix)
     if impacted_file is None:
@@ -142,6 +184,15 @@ def build(matrix_file, impacted_file, output_file, ptl_binary_path):
 
     impacted_features = list(filter(None, [line.rstrip() for line in impacted_file.readlines()]))
     logging.info("Read impacted_features: %s", impacted_features)
+    impacted_features_prev = None
+    if impacted_features_prev_file is not None:
+        impacted_features_prev = list(filter(None, [line.rstrip() for line in impacted_features_prev_file.readlines()]))
+        logging.info("Read impacted_features_prev: %s", impacted_features_prev)
+    prev_non_success = None
+    if prev_non_success_jobs_file is not None:
+        prev_non_success = set(filter(None, [line.rstrip() for line in prev_non_success_jobs_file.readlines()]))
+        logging.info("Read prev_non_success (%d names)", len(prev_non_success))
+
     result = copy.copy(matrix)
     items = expand_matrix(matrix)
     logging.info("Expanded matrix: %s", items)
@@ -150,26 +201,57 @@ def build(matrix_file, impacted_file, output_file, ptl_binary_path):
     for item in items:
         configToSuiteMap[item.get("config")].append(item.get("suite"))
     available_features = load_available_features(configToSuiteMap, ptl_binary_path)
+    rendered_names = []
     if len(available_features) > 0:
         all_excluded = True
         for item in items:
             features = tested_features(available_features, item.get("config"), item.get("suite"))
             logging.debug("matrix item features: %s", features)
-            if not any(feature in impacted_features for feature in features):
+            if not _keep(item, features, impacted_features, impacted_features_prev, prev_non_success):
                 if "include" in result and item in result["include"]:
                     logging.info("Removing from include list: %s", item)
                     result["include"].remove(item)
                 else:
-                    logging.info("Excluding matrix entry due to features: %s", item)
+                    logging.info("Excluding matrix entry: %s", item)
                     result.setdefault("exclude", []).append(item)
             else:
-                all_excluded = False
-        if all_excluded:
+                rendered_names.append(render(item))
+        if not rendered_names:
             # if every single item in the matrix is excluded, write an empty matrix
             output_file.write("{}\n")
             return
+    _assert_unique_names(rendered_names)
     json.dump(result, output_file)
     output_file.write("\n")
+
+
+def _keep(item, features, impacted_master, impacted_prev, prev_non_success):
+    """Apply both gates. Returns True if the matrix item should be kept."""
+    # Gate 1: master-side. Skip if none of the item's features are impacted vs master.
+    if not any(f in impacted_master for f in features):
+        return False
+    # Gate 2: prev-run-side. Skip when none of the item's features are impacted
+    # vs the prev merge commit AND the item is NOT on the non-success deny list
+    # (i.e., the prev run either succeeded for this item, or didn't run it at
+    # all — both equivalent under the empty-diff invariant).
+    if impacted_prev is not None and prev_non_success is not None:
+        if render(item) not in prev_non_success and not any(f in impacted_prev for f in features):
+            return False
+    return True
+
+
+def _assert_unique_names(names):
+    if len(names) != len(set(names)):
+        seen = {}
+        dups = set()
+        for n in names:
+            if n in seen:
+                dups.add(n)
+            seen[n] = True
+        raise AssertionError(
+            "render() produced duplicate job names; matching against prev jobs "
+            "API would be ambiguous. Duplicates: " + ", ".join(sorted(dups))
+        )
 
 
 class TestBuild(unittest.TestCase):
@@ -393,6 +475,80 @@ class TestBuild(unittest.TestCase):
                     output = json.load(output_file)
                     # then
                     self.assertEqual(output, expected)
+
+    def _run_prev(self, matrix, impacted, impacted_prev, prev_non_success, expected, ptl_binary_path=".github/bin/fake-ptl"):
+        with tempfile.TemporaryFile("w+") as matrix_file, \
+                tempfile.TemporaryFile("w+") as impacted_file, \
+                tempfile.TemporaryFile("w+") as impacted_prev_file, \
+                tempfile.TemporaryFile("w+") as prev_non_success_file, \
+                tempfile.TemporaryFile("w+") as output_file:
+            yaml.dump(matrix, matrix_file)
+            matrix_file.seek(0)
+            impacted_file.write("\n".join(impacted))
+            impacted_file.seek(0)
+            impacted_prev_file.write("\n".join(impacted_prev))
+            impacted_prev_file.seek(0)
+            prev_non_success_file.write("\n".join(prev_non_success))
+            prev_non_success_file.seek(0)
+            build(
+                matrix_file,
+                impacted_file,
+                output_file,
+                ptl_binary_path,
+                impacted_features_prev_file=impacted_prev_file,
+                prev_non_success_jobs_file=prev_non_success_file,
+            )
+            output_file.seek(0)
+            output = json.load(output_file)
+            self.assertEqual(output, expected)
+
+    def test_prev_skip_when_not_on_deny_list_and_no_diff(self):
+        # A:1 and B:2 are present (per fake-ptl mapping); neither failed prev,
+        # no diff vs prev -> both skipped.
+        self._run_prev(
+            matrix={"config": ["A", "B"], "suite": ["1", "2"]},
+            impacted=["A:1", "A:2", "B:1", "B:2"],
+            impacted_prev=[],
+            prev_non_success=[],  # nothing failed prev
+            expected={},
+        )
+
+    def test_prev_runs_when_on_deny_list(self):
+        # B:2 failed (timed_out) in prev -> runs even with no diff.
+        self._run_prev(
+            matrix={"config": ["A", "B"], "suite": ["1", "2"]},
+            impacted=["A:1", "B:2"],
+            impacted_prev=[],
+            prev_non_success=["pt (B, 2, )"],  # rendered name for jdk=""
+            expected={
+                "config": ["A", "B"],
+                "suite": ["1", "2"],
+                "exclude": [
+                    # A:1: master-impacted but no diff vs prev and not on deny -> prev-gate skips it
+                    {"config": "A", "suite": "1"},
+                    {"config": "A", "suite": "2"},  # not impacted vs master
+                    {"config": "B", "suite": "1"},  # not impacted vs master
+                    # B:2 kept: on deny list -> prev-gate doesn't fire -> runs
+                ],
+            },
+        )
+
+    def test_master_gate_dominates_over_prev(self):
+        # A:2 not impacted vs master -> dropped regardless of prev state.
+        self._run_prev(
+            matrix={"config": ["A"], "suite": ["1", "2"]},
+            impacted=["A:1"],  # only A:1 in master-impacted
+            impacted_prev=["A:2"],  # diff present for A:2 but moot
+            prev_non_success=["pt (A, 1, )", "pt (A, 2, )"],
+            expected={
+                "config": ["A"],
+                "suite": ["1", "2"],
+                "exclude": [
+                    # A:1 runs (on deny list, master-impacted)
+                    {"config": "A", "suite": "2"},  # master gate dropped it
+                ],
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,156 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  resolve-prev-run:
+    # Locates a usable "previous" PR CI run and exposes:
+    #  - prev_merge_sha: the merge commit SHA that run was based on, for the
+    #    second GIB pass (gate 2 reference)
+    #  - prev_non_success_jobs: rendered names of jobs from that run whose
+    #    conclusion was anything other than success/skipped — the deny list
+    #    for the prev-run gate.
+    # Also stashes THIS run's merge SHA as an artifact so the *next* push can
+    # find it via the same mechanism.
+    # Skipped (empty outputs) on non-PR events; downstream gates degrade to
+    # first-push behavior in that case.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read  # list workflow runs, fetch jobs, download artifacts
+    outputs:
+      prev_merge_sha: ${{ steps.resolve.outputs.prev_merge_sha }}
+      prev_non_success_jobs: ${{ steps.resolve.outputs.prev_non_success_jobs }}
+    steps:
+      - name: Stash this run's merge SHA for the next push
+        run: |
+          mkdir -p _meta
+          # github.sha for pull_request events is the merge commit SHA the
+          # workflow ran against — not exposed via the workflow_runs API
+          # post-hoc, so we persist it ourselves.
+          printf '%s' "${{ github.sha }}" > _meta/merge_sha
+      - uses: actions/upload-artifact@v7
+        # Soft-degrade if the artifact upload flakes — the worst case is the
+        # next push falling back to first-push semantics, not a broken CI.
+        continue-on-error: true
+        with:
+          name: prev-run-merge-sha
+          path: _meta/
+          retention-days: 14
+      - id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          # Defaults: empty -> first-push semantics downstream
+          {
+            echo "prev_merge_sha="
+            echo "prev_non_success_jobs<<__EOF__"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ -z "${HEAD_REF:-}" ] || [ -z "${HEAD_REPO_OWNER:-}" ]; then
+            echo "Non-PR build or missing head info; skipping prev-run resolution."
+            exit 0
+          fi
+
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "$workdir"' EXIT
+
+          # List recent runs of THIS workflow on this PR head branch+owner.
+          # Filter out the current run.
+          if ! gh api -X GET \
+                "repos/${GH_REPO}/actions/workflows/ci.yml/runs" \
+                -f event=pull_request \
+                -f "branch=${HEAD_REF}" \
+                -f per_page=30 \
+                --jq '[.workflow_runs[]
+                       | select(.head_repository.owner.login == env.HEAD_REPO_OWNER)
+                       | select((.id|tostring) != env.CURRENT_RUN_ID)
+                       | {id, conclusion, status, created_at}]
+                       | sort_by(.created_at) | reverse' \
+                > "$workdir/candidates.json"; then
+            echo "Failed to list workflow runs; using first-push semantics."
+            exit 0
+          fi
+
+          n=$(jq 'length' "$workdir/candidates.json")
+          echo "Considering $n prior runs."
+
+          for i in $(seq 0 $((n - 1))); do
+            run_id=$(jq -r ".[$i].id" "$workdir/candidates.json")
+            conclusion=$(jq -r ".[$i].conclusion" "$workdir/candidates.json")
+            echo "--- candidate $((i+1))/$n: run_id=$run_id conclusion=$conclusion ---"
+
+            # Fetch ALL jobs (paginated) and decide meaningfulness from the same
+            # payload. Without pagination, jobs on pages 2+ would silently be
+            # treated as "absent from API" — i.e., as previously validated —
+            # because the deny list would miss any of their failures.
+            # `--slurp` collects each page's {total_count, jobs:[...]} into an
+            # array; piping through jq flattens all pages back into the
+            # {jobs: [...]} shape the downstream filters expect. (`gh api`
+            # rejects `--slurp` combined with `--jq`, hence the pipe.)
+            if ! gh api --paginate --slurp -X GET "repos/${GH_REPO}/actions/runs/$run_id/jobs" -f per_page=100 \
+                   | jq '{jobs: [.[].jobs[]]}' > "$workdir/jobs-$run_id.json"; then
+              echo "  failed to fetch jobs API; trying older."
+              continue
+            fi
+
+            meaningful=false
+            if [ "$conclusion" = "success" ]; then
+              meaningful=true
+              echo "  workflow conclusion is success -> meaningful."
+            else
+              # >=1 job succeeded AND took >=180s
+              count=$(jq '[.jobs[]
+                          | select(.conclusion == "success")
+                          | select(((.completed_at|fromdateiso8601) - (.started_at|fromdateiso8601)) >= 180)] | length' \
+                          "$workdir/jobs-$run_id.json")
+              if [ "${count:-0}" -ge 1 ]; then
+                meaningful=true
+                echo "  $count successful job(s) lasted >=180s -> meaningful."
+              else
+                echo "  no meaningful successful job; trying older."
+              fi
+            fi
+            [ "$meaningful" = true ] || continue
+
+            # Try to download the merge_sha artifact from that run.
+            rm -rf "$workdir/sha"
+            if ! gh run download "$run_id" -n prev-run-merge-sha -D "$workdir/sha" 2>/dev/null; then
+              echo "  no prev-run-merge-sha artifact on $run_id (may have expired); trying older."
+              continue
+            fi
+            if [ ! -s "$workdir/sha/merge_sha" ]; then
+              echo "  empty merge_sha artifact; trying older."
+              continue
+            fi
+            prev_merge_sha=$(tr -d '\r\n' < "$workdir/sha/merge_sha")
+            echo "  prev_merge_sha=$prev_merge_sha"
+
+            # Build the deny list: names with non-success non-skipped conclusion.
+            jq -r '.jobs[]
+                   | select(.conclusion != "success" and .conclusion != "skipped")
+                   | .name' "$workdir/jobs-$run_id.json" \
+                   | sort -u > "$workdir/non_success.txt"
+            n_deny=$(wc -l < "$workdir/non_success.txt" | tr -d ' ')
+            echo "  prev_non_success_jobs: $n_deny entries"
+
+            # Emit outputs. Multi-line via heredoc.
+            {
+              echo "prev_merge_sha=$prev_merge_sha"
+              echo "prev_non_success_jobs<<__EOF__"
+              cat "$workdir/non_success.txt"
+              echo "__EOF__"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          done
+
+          echo "No usable prior run found; first-push semantics."
+
   path-filters:
     runs-on: ubuntu-latest
     outputs:
@@ -376,8 +526,12 @@ jobs:
         run: .github/bin/cancel-merge-queue-workflow.sh "test-other-modules"
 
   build-test-matrix:
-    needs: path-filters
-    if: github.event_name != 'pull_request' || needs.path-filters.outputs.non_docs == 'true'
+    needs: [path-filters, resolve-prev-run]
+    if: |
+      always() &&
+      needs.path-filters.result == 'success' &&
+      (needs.resolve-prev-run.result == 'success' || needs.resolve-prev-run.result == 'skipped') &&
+      (github.event_name != 'pull_request' || needs.path-filters.outputs.non_docs == 'true')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -406,11 +560,46 @@ jobs:
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           $MAVEN validate ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -Dgib.logImpactedTo=gib-impacted.log -P disable-check-spi-dependencies
+      - name: Maven validate (vs previous run)
+        if: needs.resolve-prev-run.outputs.prev_merge_sha != ''
+        env:
+          PREV_MERGE_SHA: ${{ needs.resolve-prev-run.outputs.prev_merge_sha }}
+        run: |
+          export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
+          # The prev merge commit may have been GC'd by GitHub; that's external
+          # state we tolerate by falling back to first-push semantics. Any
+          # subsequent failure here (Maven / GIB / our own code) is a real bug
+          # and must fail loudly.
+          if ! git -c protocol.version=2 fetch --depth=50 --no-tags origin "$PREV_MERGE_SHA" 2>&1 | tail -3; then
+            echo "Could not fetch prev merge commit; skipping second GIB pass."
+            exit 0
+          fi
+          # -Dgib.referenceBranch last so it overrides MAVEN_GIB's default.
+          $MAVEN validate ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -Dgib.logImpactedTo=gib-impacted-vs-prev.log -P disable-check-spi-dependencies -Dgib.referenceBranch="$PREV_MERGE_SHA"
       - name: Set matrix
         id: set-matrix
+        env:
+          PREV_NON_SUCCESS_JOBS: ${{ needs.resolve-prev-run.outputs.prev_non_success_jobs }}
         run: |
           # GIB doesn't run on master, so make sure the file always exist
           touch gib-impacted.log
+          # Materialize prev-run gate inputs only when both signals are present.
+          prev_flags=()
+          if [ -f gib-impacted-vs-prev.log ] && [ -n "${PREV_NON_SUCCESS_JOBS:-}" ]; then
+            printf '%s\n' "$PREV_NON_SUCCESS_JOBS" > prev-non-success-jobs.txt
+            prev_flags+=(--impacted-prev gib-impacted-vs-prev.log --prev-non-success-jobs prev-non-success-jobs.txt)
+            echo "Prev-run gating enabled:"
+            echo "  impacted-vs-prev modules: $(wc -l < gib-impacted-vs-prev.log) line(s)"
+            echo "  prev non-success jobs:    $(wc -l < prev-non-success-jobs.txt) line(s)"
+          elif [ -f gib-impacted-vs-prev.log ]; then
+            # GIB ran but resolve-prev-run found no non-success jobs (fully-green
+            # prev). Treat the deny list as empty.
+            : > prev-non-success-jobs.txt
+            prev_flags+=(--impacted-prev gib-impacted-vs-prev.log --prev-non-success-jobs prev-non-success-jobs.txt)
+            echo "Prev-run gating enabled (empty deny list — prev was fully green)."
+          else
+            echo "Prev-run gating disabled (first push or unavailable)."
+          fi
           cat <<EOF > .github/test-matrix.yaml
           include:
             - modules:
@@ -488,7 +677,7 @@ jobs:
             - { modules: testing/trino-faulttolerant-tests, profile: test-fault-tolerant-iceberg }
             - { modules: testing/trino-tests }
           EOF
-          ./.github/bin/build-matrix-from-impacted.py -v -i gib-impacted.log -m .github/test-matrix.yaml -o matrix.json
+          ./.github/bin/build-matrix-from-impacted.py -v -i gib-impacted.log -m .github/test-matrix.yaml -o matrix.json "${prev_flags[@]}"
           echo "Matrix: $(jq '.' matrix.json)"
           echo "matrix=$(jq -c '.' matrix.json)" >> $GITHUB_OUTPUT
       - name: Cancel merge queue workflow
@@ -827,8 +1016,12 @@ jobs:
         run: .github/bin/cancel-merge-queue-workflow.sh "test (${{ matrix.modules }}, ${{ matrix.profile }}, ${{ matrix.jdk }})"
 
   build-pt:
-    needs: path-filters
-    if: github.event_name != 'pull_request' || needs.path-filters.outputs.non_docs == 'true'
+    needs: [path-filters, resolve-prev-run]
+    if: |
+      always() &&
+      needs.path-filters.result == 'success' &&
+      (needs.resolve-prev-run.result == 'success' || needs.resolve-prev-run.result == 'skipped') &&
+      (github.event_name != 'pull_request' || needs.path-filters.outputs.non_docs == 'true')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -872,6 +1065,25 @@ jobs:
           testing/trino-plugin-reader/target/trino-plugin-reader-*-executable.jar -i gib-impacted.log -p core/trino-server/target/trino-server-*-hardlinks/plugin > impacted-features.log
           echo "Impacted plugin features:"
           cat impacted-features.log
+      - name: Map impacted plugins to features (vs previous run)
+        if: needs.resolve-prev-run.outputs.prev_merge_sha != ''
+        env:
+          PREV_MERGE_SHA: ${{ needs.resolve-prev-run.outputs.prev_merge_sha }}
+        run: |
+          export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
+          # The prev merge commit may have been GC'd by GitHub; that's external
+          # state we tolerate by falling back to first-push semantics. Any
+          # subsequent failure here (Maven / GIB / trino-plugin-reader / our
+          # own code) is a real bug and must fail loudly.
+          if ! git -c protocol.version=2 fetch --depth=50 --no-tags origin "$PREV_MERGE_SHA" 2>&1 | tail -3; then
+            echo "Could not fetch prev merge commit; skipping second GIB pass."
+            exit 0
+          fi
+          # -Dgib.referenceBranch last so it overrides MAVEN_GIB's default.
+          $MAVEN validate ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -Dgib.logImpactedTo=gib-impacted-vs-prev.log -pl '!:trino-docs,!:trino-tests,!:trino-faulttolerant-tests' -Dgib.referenceBranch="$PREV_MERGE_SHA"
+          testing/trino-plugin-reader/target/trino-plugin-reader-*-executable.jar -i gib-impacted-vs-prev.log -p core/trino-server/target/trino-server-*-hardlinks/plugin > impacted-features-vs-prev.log
+          echo "Impacted plugin features (vs prev run):"
+          cat impacted-features-vs-prev.log
       - name: Product tests artifact
         uses: actions/upload-artifact@v7
         with:
@@ -1011,9 +1223,24 @@ jobs:
           SNOWFLAKE_ROLE: ""
           SNOWFLAKE_WAREHOUSE: ""
           TESTCONTAINERS_NEVER_PULL: true
+          PREV_NON_SUCCESS_JOBS: ${{ needs.resolve-prev-run.outputs.prev_non_success_jobs }}
         run: |
           # converts filtered YAML file into JSON
-          ./.github/bin/build-pt-matrix-from-impacted-connectors.py -v -m .github/test-pt-matrix.yaml -i impacted-features.log -o matrix.json
+          prev_flags=()
+          if [ -f impacted-features-vs-prev.log ]; then
+            if [ -n "${PREV_NON_SUCCESS_JOBS:-}" ]; then
+              printf '%s\n' "$PREV_NON_SUCCESS_JOBS" > prev-non-success-jobs.txt
+            else
+              : > prev-non-success-jobs.txt
+            fi
+            prev_flags+=(--impacted-features-prev impacted-features-vs-prev.log --prev-non-success-jobs prev-non-success-jobs.txt)
+            echo "PT prev-run gating enabled:"
+            echo "  impacted-features-vs-prev: $(wc -l < impacted-features-vs-prev.log) line(s)"
+            echo "  prev non-success jobs:     $(wc -l < prev-non-success-jobs.txt) line(s)"
+          else
+            echo "PT prev-run gating disabled (first push or unavailable)."
+          fi
+          ./.github/bin/build-pt-matrix-from-impacted-connectors.py -v -m .github/test-pt-matrix.yaml -i impacted-features.log -o matrix.json "${prev_flags[@]}"
       - id: set-matrix
         run: |
           echo "Matrix: $(jq '.' matrix.json)"
@@ -1132,6 +1359,7 @@ jobs:
       - maven-checks
       - path-filters
       - pt
+      - resolve-prev-run
       - test
       - test-jdbc-compatibility
       - test-other-modules
@@ -1148,6 +1376,7 @@ jobs:
           echo '${{ needs.maven-checks.result }}' | grep -xE 'success|skipped' || { echo 'Job "maven-checks" failed' >&2; exit 1; }
           echo '${{ needs.path-filters.result }}' | grep -xE 'success|skipped' || { echo 'Job "path-filters" failed' >&2; exit 1; }
           echo '${{ needs.pt.result }}' | grep -xE 'success|skipped' || { echo 'Job "pt" failed' >&2; exit 1; }
+          echo '${{ needs.resolve-prev-run.result }}' | grep -xE 'success|skipped' || { echo 'Job "resolve-prev-run" failed' >&2; exit 1; }
           echo '${{ needs.test.result }}' | grep -xE 'success|skipped' || { echo 'Job "test" failed' >&2; exit 1; }
           echo '${{ needs.test-jdbc-compatibility.result }}' | grep -xE 'success|skipped' || { echo 'Job "test-jdbc-compatibility" failed' >&2; exit 1; }
           echo '${{ needs.test-other-modules.result }}' | grep -xE 'success|skipped' || { echo 'Job "test-other-modules" failed' >&2; exit 1; }


### PR DESCRIPTION
🤖

### LT;DR

Skips PR CI jobs whose modules haven't changed since the previous run validated them. 70 % of PR CI runs are subsequent pushes (1 013 / 1 438 in the last 30 days), and almost all of them re-run jobs that were already green. The skip rule is per-job and conservative — failed jobs always re-run; the existing master-impact gate is unchanged.

Live example (findepi/trino#2): push 2 touched one unrelated module → test+pt matrix went from 36 jobs to 1.

### More concretely:

On a subsequent push to a PR, re-running the full set of jobs impacted vs master wastes CI when most modules haven't changed since the previous run validated them. This adds a per-job gate that skips a job when:

  - its modules are unimpacted vs the previous run's merge commit, AND
  - the job either passed in that run or wasn't on the run's job list (absent-from-API is safe to treat as validated because the byte-identical-tree invariant from the empty diff already makes current_state's tree equivalent to prev_merge's for that job's modules — whatever conclusion prev would have reached applies now).

Cancelled / failed / timed_out conclusions count as "not validated" and force a re-run.

### Mechanism:

  - `resolve-prev-run` job picks the latest prior PR run that is either fully successful or has ≥1 successful job that ran ≥180s. It reads that run's merge SHA from a small artifact the run stashed for the purpose, fetches its jobs API, and exposes:
      * prev_merge_sha          (string output)
      * prev_non_success_jobs   (multiline output — deny list)
    The same job also stashes the current run's `github.sha` for the
    next push to find.
  - `build-test-matrix` / `build-pt` run a second GIB pass with
    `gib.referenceBranch=$prev_merge_sha` to derive
    `gib-impacted-vs-prev.log`, and pass it plus the deny list into the
    matrix scripts as `--impacted-prev` / `--prev-non-success-jobs`.
  - The matrix scripts add `render(item) → name` (matching GHA's default
    job-naming) with a uniqueness self-check, and skip an item only when
    no module of it is impacted vs prev AND its rendered name is not on
    the deny list.

GIB already covers non-Maven-module file changes (e.g. .github/**) by treating them as full-reactor impact, so no separate CI-infra invalidation guard is needed.

The optimization is best-effort throughout: missing prev artifact, GC'd prev commit, jobs API failure, etc. all degrade to first-push behavior without failing CI.


- fixes https://github.com/trinodb/trino/issues/30082