### PR TITLE
Polaris catalog smoke test with vended credentials

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -421,7 +421,7 @@ public abstract class BaseIcebergConnectorSmokeTest
     public void testRegisterTableWithTrailingSpaceInLocation()
     {
         String tableName = "test_create_table_with_trailing_space_" + randomNameSuffix();
-        String tableLocationWithTrailingSpace = schemaPath() + tableName + " ";
+        String tableLocationWithTrailingSpace = schemaPath() + "/" + tableName + " ";
 
         assertQuerySucceeds(format("CREATE TABLE %s WITH (location = '%s') AS SELECT 1 AS a, 'INDIA' AS b, true AS c", tableName, tableLocationWithTrailingSpace));
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -401,21 +401,26 @@ public final class IcebergQueryRunner
         static void main()
                 throws Exception
         {
-            Path warehouseLocation = Files.createTempDirectory(null);
-            warehouseLocation.toFile().deleteOnExit();
+            String bucketName = "test-bucket";
+            String warehouseLocation = "s3://%s/default/".formatted(bucketName);
 
             @SuppressWarnings("resource")
-            TestingPolarisCatalog polarisCatalog = new TestingPolarisCatalog(warehouseLocation.toString());
+            TestingPolarisCatalog polarisCatalog = new TestingPolarisCatalog(warehouseLocation, bucketName);
 
             @SuppressWarnings("resource")
             QueryRunner queryRunner = icebergQueryRunnerMainBuilder()
-                    .setBaseDataDir(Optional.of(warehouseLocation))
                     .addIcebergProperty("iceberg.catalog.type", "rest")
                     .addIcebergProperty("iceberg.rest-catalog.uri", polarisCatalog.restUri() + "/api/catalog")
                     .addIcebergProperty("iceberg.rest-catalog.warehouse", TestingPolarisCatalog.WAREHOUSE)
                     .addIcebergProperty("iceberg.rest-catalog.security", "OAUTH2")
                     .addIcebergProperty("iceberg.rest-catalog.oauth2.credential", TestingPolarisCatalog.CREDENTIAL)
                     .addIcebergProperty("iceberg.rest-catalog.oauth2.scope", "PRINCIPAL_ROLE:ALL")
+                    .addIcebergProperty("iceberg.rest-catalog.http-headers", TestingPolarisCatalog.POLARIS_REALM_HEADER + ": " + TestingPolarisCatalog.POLARIS_REALM_NAME)
+                    .addIcebergProperty("iceberg.rest-catalog.vended-credentials-enabled", "true")
+                    .addIcebergProperty("fs.s3.enabled", "true")
+                    .addIcebergProperty("s3.region", MINIO_REGION)
+                    .addIcebergProperty("s3.endpoint", polarisCatalog.minio().getMinioAddress())
+                    .addIcebergProperty("s3.path-style-access", "true")
                     .setInitialTables(TpchTable.getTables())
                     .build();
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergPolarisCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergPolarisCatalogConnectorSmokeTest.java
@@ -13,7 +13,11 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
+import io.opentelemetry.api.OpenTelemetry;
 import io.trino.filesystem.Location;
+import io.trino.filesystem.s3.S3FileSystemConfig;
+import io.trino.filesystem.s3.S3FileSystemFactory;
+import io.trino.filesystem.s3.S3FileSystemStats;
 import io.trino.plugin.iceberg.BaseIcebergConnectorSmokeTest;
 import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.IcebergConnector;
@@ -23,23 +27,23 @@ import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
+import io.trino.testing.minio.MinioClient;
 import org.apache.iceberg.BaseTable;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Optional;
 
-import static com.google.common.io.MoreFiles.deleteRecursively;
-import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkOrcFileSorting;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
+import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.containers.Minio.MINIO_REGION;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.lang.String.format;
 import static org.apache.iceberg.FileFormat.PARQUET;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,12 +56,15 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 final class TestIcebergPolarisCatalogConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {
+    private final String bucketName;
     private TestingPolarisCatalog polarisCatalog;
-    private Path warehouseLocation;
+    private final String warehouseLocation;
 
     public TestIcebergPolarisCatalogConnectorSmokeTest()
     {
         super(new IcebergConfig().getFileFormat().toIceberg());
+        bucketName = "test-iceberg-vending-polaris-smoke-test-" + randomNameSuffix();
+        warehouseLocation = "s3://%s/default/".formatted(bucketName);
     }
 
     @Override
@@ -74,14 +81,11 @@ final class TestIcebergPolarisCatalogConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        warehouseLocation = Files.createTempDirectory(null);
-        polarisCatalog = closeAfterClass(new TestingPolarisCatalog(warehouseLocation.toString()));
+        polarisCatalog = closeAfterClass(new TestingPolarisCatalog(warehouseLocation, bucketName));
 
         return IcebergQueryRunner.builder()
-                .addIcebergProperty("fs.hadoop.enabled", "true")
-                .setBaseDataDir(Optional.of(warehouseLocation))
+                .addIcebergProperty("fs.s3.enabled", "true")
                 .addIcebergProperty("iceberg.file-format", format.name())
-                .addIcebergProperty("iceberg.register-table-procedure.enabled", "true")
                 .addIcebergProperty("iceberg.writer-sort-buffer-size", "1MB")
                 .addIcebergProperty("iceberg.catalog.type", "rest")
                 .addIcebergProperty("iceberg.rest-catalog.nested-namespace-enabled", "true")
@@ -91,8 +95,27 @@ final class TestIcebergPolarisCatalogConnectorSmokeTest
                 .addIcebergProperty("iceberg.rest-catalog.oauth2.credential", TestingPolarisCatalog.CREDENTIAL)
                 .addIcebergProperty("iceberg.rest-catalog.oauth2.scope", "PRINCIPAL_ROLE:ALL")
                 .addIcebergProperty("iceberg.rest-catalog.http-headers", TestingPolarisCatalog.POLARIS_REALM_HEADER + ": " + TestingPolarisCatalog.POLARIS_REALM_NAME)
+                .addIcebergProperty("iceberg.rest-catalog.vended-credentials-enabled", "true")
+                .addIcebergProperty("s3.region", MINIO_REGION)
+                .addIcebergProperty("s3.endpoint", polarisCatalog.minio().getMinioAddress())
+                .addIcebergProperty("s3.path-style-access", "true")
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
+    }
+
+    @Override
+    @BeforeAll
+    public void initFileSystem()
+    {
+        fileSystem = new S3FileSystemFactory(
+                OpenTelemetry.noop(),
+                new S3FileSystemConfig()
+                        .setRegion(MINIO_REGION)
+                        .setEndpoint(polarisCatalog.minio().getMinioAddress())
+                        .setPathStyleAccess(true)
+                        .setAwsAccessKey(MINIO_ROOT_USER)
+                        .setAwsSecretKey(MINIO_ROOT_PASSWORD),
+                new S3FileSystemStats()).create(SESSION);
     }
 
     @Override
@@ -122,13 +145,17 @@ final class TestIcebergPolarisCatalogConnectorSmokeTest
     @Override
     protected String schemaPath()
     {
-        return format("file://%s/%s", warehouseLocation, getSession().getSchema().orElseThrow());
+        return format("%s%s", warehouseLocation, getSession().getSchema().orElseThrow());
     }
 
     @Override
     protected boolean locationExists(String location)
     {
-        return Files.exists(Path.of(location));
+        try (MinioClient minioClient = polarisCatalog.minio().createMinioClient()) {
+            String prefix = "s3://" + bucketName + "/";
+            String key = location.substring(prefix.length());
+            return !minioClient.listObjects(bucketName, key).isEmpty();
+        }
     }
 
     @Override
@@ -144,7 +171,7 @@ final class TestIcebergPolarisCatalogConnectorSmokeTest
     protected void deleteDirectory(String location)
     {
         try {
-            deleteRecursively(Path.of(location.replaceAll("^file://", "")), ALLOW_INSECURE);
+            fileSystem.deleteDirectory(Location.of(location));
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -184,11 +211,83 @@ final class TestIcebergPolarisCatalogConnectorSmokeTest
 
     @Test
     @Override
-    @Disabled("Disable as register table is broken with S3 in Polaris. More info at https://github.com/trinodb/trino/pull/23099")
+    public void testRegisterTableWithTableLocation()
+    {
+        // register_table procedure with vended credentials is currently not supported
+        assertThatThrownBy(super::testRegisterTableWithTableLocation)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithComments()
+    {
+        // register_table procedure with vended credentials is currently not supported
+        assertThatThrownBy(super::testRegisterTableWithComments)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithShowCreateTable()
+    {
+        // register_table procedure with vended credentials is currently not supported
+        assertThatThrownBy(super::testRegisterTableWithShowCreateTable)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithReInsert()
+    {
+        // register_table procedure with vended credentials is currently not supported
+        assertThatThrownBy(super::testRegisterTableWithReInsert)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
     public void testRegisterTableWithDroppedTable()
     {
+        // register_table procedure with vended credentials is currently not supported
         assertThatThrownBy(super::testRegisterTableWithDroppedTable)
-                .hasStackTraceContaining("Failed to open input stream for file");
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithDifferentTableName()
+    {
+        // register_table procedure with vended credentials is currently not supported
+        assertThatThrownBy(super::testRegisterTableWithDifferentTableName)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithMetadataFile()
+    {
+        // register_table procedure with vended credentials is currently not supported
+        assertThatThrownBy(super::testRegisterTableWithMetadataFile)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testUnregisterTable()
+    {
+        // register_table procedure with vended credentials is currently not supported
+        assertThatThrownBy(super::testUnregisterTable)
+                .hasMessageContaining("register_table procedure is disabled");
+    }
+
+    @Test
+    @Override
+    public void testRepeatUnregisterTable()
+    {
+        // register_table procedure with vended credentials is currently not supported
+        assertThatThrownBy(super::testRepeatUnregisterTable)
+                .hasMessageContaining("register_table procedure is disabled");
     }
 
     @Test
@@ -208,16 +307,9 @@ final class TestIcebergPolarisCatalogConnectorSmokeTest
     @Override
     public void testRegisterTableWithTrailingSpaceInLocation()
     {
+        // register_table procedure with vended credentials is currently not supported
         assertThatThrownBy(super::testRegisterTableWithTrailingSpaceInLocation)
-                .hasStackTraceContaining("Illegal character in path");
-    }
-
-    @Test
-    @Override
-    public void testCreateTableWithTrailingSpaceInLocation()
-    {
-        assertThatThrownBy(super::testCreateTableWithTrailingSpaceInLocation)
-                .hasStackTraceContaining("Illegal character in path");
+                .hasMessageContaining("register_table procedure is disabled");
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergPolarisCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergPolarisCatalogConnectorSmokeTest.java
@@ -127,19 +127,20 @@ final class TestIcebergPolarisCatalogConnectorSmokeTest
     @Override
     protected String getMetadataLocation(String tableName)
     {
-        TrinoCatalogFactory catalogFactory = ((IcebergConnector) getQueryRunner().getCoordinator().getConnector("iceberg")).getInjector().getInstance(TrinoCatalogFactory.class);
-        TrinoCatalog trinoCatalog = catalogFactory.create(getSession().getIdentity().toConnectorIdentity());
-        BaseTable table = trinoCatalog.loadTable(getSession().toConnectorSession(), new SchemaTableName(getSession().getSchema().orElseThrow(), tableName));
-        return table.operations().current().metadataFileLocation();
+        return loadTable(tableName).operations().current().metadataFileLocation();
     }
 
     @Override
     protected String getTableLocation(String tableName)
     {
+        return loadTable(tableName).operations().current().location();
+    }
+
+    private BaseTable loadTable(String tableName)
+    {
         TrinoCatalogFactory catalogFactory = ((IcebergConnector) getQueryRunner().getCoordinator().getConnector("iceberg")).getInjector().getInstance(TrinoCatalogFactory.class);
         TrinoCatalog trinoCatalog = catalogFactory.create(getSession().getIdentity().toConnectorIdentity());
-        BaseTable table = trinoCatalog.loadTable(getSession().toConnectorSession(), new SchemaTableName(getSession().getSchema().orElseThrow(), tableName));
-        return table.operations().current().location();
+        return trinoCatalog.loadTable(getSession().toConnectorSession(), new SchemaTableName(getSession().getSchema().orElseThrow(), tableName));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestingPolarisCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestingPolarisCatalog.java
@@ -21,12 +21,13 @@ import io.airlift.http.client.StatusResponseHandler;
 import io.airlift.http.client.StringResponseHandler.StringResponse;
 import io.airlift.http.client.jetty.JettyHttpClient;
 import io.airlift.json.JsonMapperProvider;
+import io.trino.plugin.base.util.AutoCloseableCloser;
+import io.trino.testing.containers.Minio;
 import org.intellij.lang.annotations.Language;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
@@ -37,11 +38,16 @@ import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
 import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
 import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
 import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static io.trino.testing.containers.Minio.DEFAULT_HOST_NAME;
+import static io.trino.testing.containers.Minio.MINIO_API_PORT;
+import static io.trino.testing.containers.Minio.MINIO_REGION;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 public final class TestingPolarisCatalog
-        implements Closeable
+        implements AutoCloseable
 {
     public static final String WAREHOUSE = "polaris";
     private static final int POLARIS_PORT = 8181;
@@ -52,27 +58,38 @@ public final class TestingPolarisCatalog
     public static final HeaderName POLARIS_REALM_HEADER = HeaderName.of("Polaris-Realm");
     public static final String POLARIS_REALM_NAME = "default-realm";
 
+    private final AutoCloseableCloser closer = AutoCloseableCloser.create();
+    private final Minio minio;
     private final GenericContainer<?> polarisCatalog;
     private final String token;
     private final String warehouseLocation;
 
-    public TestingPolarisCatalog(String warehouseLocation)
+    public TestingPolarisCatalog(String warehouseLocation, String bucketName)
     {
-        this.warehouseLocation = requireNonNull(warehouseLocation, "warehouseLocation is null");
+        requireNonNull(warehouseLocation, "warehouseLocation is null");
+        requireNonNull(bucketName, "bucketName is null");
 
-        // TODO: Use the official docker image https://hub.docker.com/r/apache/polaris
-        polarisCatalog = new GenericContainer<>("ghcr.io/trinodb/testing/polaris-catalog:116");
+        Network network = closer.register(Network.newNetwork());
+        minio = closer.register(Minio.builder().withNetwork(network).build());
+        minio.start();
+        minio.createBucket(bucketName);
+
+        this.warehouseLocation = requireNonNull(warehouseLocation, "warehouseLocation is null");
+        polarisCatalog = closer.register(new GenericContainer<>("apache/polaris:1.5.0"));
         polarisCatalog.addExposedPort(POLARIS_PORT);
-        polarisCatalog.withFileSystemBind(warehouseLocation, warehouseLocation, BindMode.READ_WRITE);
-        polarisCatalog.waitingFor(new LogMessageWaitStrategy().withRegEx(".*Apache Polaris Server.* started.*"));
+        polarisCatalog.withNetwork(network);
+        polarisCatalog.waitingFor(new LogMessageWaitStrategy().withRegEx(".*polaris-server.* started in.*"));
         polarisCatalog.withEnv("POLARIS_BOOTSTRAP_CREDENTIALS", POLARIS_REALM_NAME.concat(",root,s3cr3t"));
         polarisCatalog.withEnv("polaris.realm-context.realms", POLARIS_REALM_NAME);
         polarisCatalog.withEnv("polaris.realm-context.header-name", POLARIS_REALM_HEADER.toString());
         polarisCatalog.withEnv("polaris.realm-context.require-header", "true");
         polarisCatalog.withEnv("polaris.readiness.ignore-severe-issues", "true");
-        polarisCatalog.withEnv("polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"", "[\"FILE\"]");
+        polarisCatalog.withEnv("polaris.features.\"SUPPORTED_CATALOG_STORAGE_TYPES\"", "[\"S3\"]");
         polarisCatalog.withEnv("polaris.features.\"ALLOW_INSECURE_STORAGE_TYPES\"", "true");
         polarisCatalog.withEnv("polaris.features.\"DROP_WITH_PURGE_ENABLED\"", "true");
+        polarisCatalog.withEnv("AWS_ACCESS_KEY_ID", MINIO_ROOT_USER);
+        polarisCatalog.withEnv("AWS_SECRET_ACCESS_KEY", MINIO_ROOT_PASSWORD);
+        polarisCatalog.withEnv("AWS_REGION", MINIO_REGION);
 
         polarisCatalog.start();
 
@@ -101,15 +118,25 @@ public final class TestingPolarisCatalog
 
     private void createCatalog()
     {
-        @Language("JSON")
-        String body = "{" +
-                "\"name\": \"polaris\"," +
-                "\"id\": 1," +
-                "\"type\": \"INTERNAL\"," +
-                "\"readOnly\": false, " +
-                "\"storageConfigInfo\": {\"storageType\": \"FILE\", \"allowedLocations\":[\"" + warehouseLocation + "\"]}, " +
-                "\"properties\": {\"default-base-location\": \"file://" + warehouseLocation + "\"}" +
-                "}";
+        String minioInternalAddress = "http://%s:%s".formatted(DEFAULT_HOST_NAME, MINIO_API_PORT);
+        String body =
+                """
+                {
+                    "catalog": {
+                        "name": "polaris",
+                        "type": "INTERNAL",
+                        "readOnly": false,
+                        "storageConfigInfo": {
+                            "storageType": "S3",
+                            "endpoint": "%s",
+                            "pathStyleAccess": true,
+                            "region": "%s"
+                        },
+                        "properties": {
+                            "default-base-location": "%s"
+                        }
+                    }
+                }""".formatted(minioInternalAddress, MINIO_REGION, warehouseLocation);
         Request request = Request.Builder.preparePost()
                 .setUri(URI.create(restUri() + "/api/management/v1/catalogs"))
                 .setHeader(AUTHORIZATION, "Bearer " + token)
@@ -151,9 +178,15 @@ public final class TestingPolarisCatalog
         return "http://%s:%s".formatted(polarisCatalog.getHost(), polarisCatalog.getMappedPort(POLARIS_PORT));
     }
 
+    public Minio minio()
+    {
+        return minio;
+    }
+
     @Override
     public void close()
+            throws Exception
     {
-        polarisCatalog.close();
+        closer.close();
     }
 }


### PR DESCRIPTION
## Description
This PR reconfigures `TestIcebergPolarisCatalogConnectorSmokeTest` and `IcebergPolarisQueryRunnerMain`  to run with enabled credential vending.
Additionally it changes used Polaris docker image to official one and modifies 


## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
