### PR TITLE
Fix NPE when evaluating Iceberg IN expression with null partition values

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ExpressionConverter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ExpressionConverter.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.base.VerifyException;
+import com.google.common.collect.ImmutableList;
 import com.google.common.math.LongMath;
 import io.airlift.slice.Slice;
 import io.trino.spi.predicate.Domain;
@@ -166,7 +167,15 @@ public final class ExpressionConverter
                 }
             }
             Expression ranges = or(rangeExpressions);
-            Expression values = icebergValues.isEmpty() ? alwaysFalse() : in(columnName, icebergValues);
+            Expression values;
+            if (icebergValues.isEmpty()) {
+                values = alwaysFalse();
+            }
+            else {
+                // Wrap with a notNull guard to prevent NPE in Iceberg's evaluator when manifest
+                // entries have null partition values.
+                values = and(ImmutableList.of(not(isNull(columnName)), in(columnName, icebergValues)));
+            }
             Expression nullExpression = domain.isNullAllowed() ? isNull(columnName) : alwaysFalse();
             return or(nullExpression, or(values, ranges));
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -6405,6 +6405,20 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    void testQueryWithInPredicateOnNullPartitionColumn()
+    {
+        // Regression test for https://github.com/trinodb/trino/issues/30087
+        try (TestTable table = newTrinoTable(
+                "test_in_predicate_null_partition",
+                "(id integer, part varchar) WITH (partitioning = ARRAY['part'])")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (1, 'a'), (2, 'b'), (3, NULL)", 3);
+
+            assertThat(query("SELECT id FROM " + table.getName() + " WHERE part IN ('a', 'b')"))
+                    .matches("VALUES 1, 2");
+        }
+    }
+
+    @Test
     void testPartitionHiddenColumnWithNonPartitionTable()
     {
         try (TestTable table = newTrinoTable("test_non_partition", " AS SELECT 1 id")) {


### PR DESCRIPTION
## Problem

Fixes #30087. After upgrading to Trino 482, queries on Iceberg tables with null partition values sporadically throw:

```
java.lang.NullPointerException: Invalid object: null
    at org.apache.iceberg.util.WrapperSet.contains(WrapperSet.java:72)
    at org.apache.iceberg.util.CharSequenceSet.contains(CharSequenceSet.java:24)
    at org.apache.iceberg.expressions.Evaluator$EvalVisitor.in(Evaluator.java:141)
    ...
    at org.apache.iceberg.ManifestReader.lambda$entries$0(ManifestReader.java:273)
```

## Root Cause

When a partition column has null values, Iceberg's `ManifestReader` evaluates the filter expression against each manifest entry's partition data. When the filter contains an IN predicate on that column and the partition value is null, `CharSequenceSet.contains(null)` throws NPE.

In `ExpressionConverter.toIcebergExpression`, for domains where null is NOT allowed (`isNullAllowed() = false`), the expression generated was:

```
or(alwaysFalse, or(in(col, values), ranges))
```

Iceberg's `visitEvaluator` short-circuits an `OR` only when the **left side is TRUE** (skipping the right), but not when it is false. So the `in(col, values)` sub-expression is always evaluated — even when the partition value is null — causing the NPE.

## Fix

Wrap the `in(col, values)` expression with `and(not(isNull(col)), in(col, values))`. Iceberg's `visitEvaluator` **does** short-circuit `AND` when the left side is false, so null partition values produce false without ever reaching `CharSequenceSet.contains(null)`.

For the `isNullAllowed() = true` case, the existing `or(isNull(col), ...)` structure already short-circuits correctly (if `isNull` returns true, the `in` is never evaluated), so no change is needed there.