### PR TITLE
Convert ResourceUsage to record class

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
@@ -177,9 +177,9 @@ public class InternalResourceGroup
                     hardConcurrencyLimit,
                     succinctBytes(hardPhysicalDataScanLimitBytes),
                     maxQueuedQueries,
-                    succinctBytes(cachedResourceUsage.getMemoryUsageBytes()),
-                    succinctDuration(cachedResourceUsage.getCpuUsageMillis(), MILLISECONDS),
-                    succinctBytes(cachedResourceUsage.getPhysicalInputDataUsageBytes()),
+                    succinctBytes(cachedResourceUsage.memoryUsageBytes()),
+                    succinctDuration(cachedResourceUsage.cpuUsageMillis(), MILLISECONDS),
+                    succinctBytes(cachedResourceUsage.physicalInputDataUsageBytes()),
                     getQueuedQueries(),
                     getRunningQueries(),
                     eligibleSubGroups.size(),
@@ -204,9 +204,9 @@ public class InternalResourceGroup
                     hardConcurrencyLimit,
                     succinctBytes(hardPhysicalDataScanLimitBytes),
                     maxQueuedQueries,
-                    succinctBytes(cachedResourceUsage.getMemoryUsageBytes()),
-                    succinctDuration(cachedResourceUsage.getCpuUsageMillis(), MILLISECONDS),
-                    succinctBytes(cachedResourceUsage.getPhysicalInputDataUsageBytes()),
+                    succinctBytes(cachedResourceUsage.memoryUsageBytes()),
+                    succinctDuration(cachedResourceUsage.cpuUsageMillis(), MILLISECONDS),
+                    succinctBytes(cachedResourceUsage.physicalInputDataUsageBytes()),
                     getQueuedQueries(),
                     getRunningQueries(),
                     eligibleSubGroups.size(),
@@ -305,19 +305,19 @@ public class InternalResourceGroup
     @Managed
     public long getCpuUsageMillis()
     {
-        return getResourceUsageSnapshot().getCpuUsageMillis();
+        return getResourceUsageSnapshot().cpuUsageMillis();
     }
 
     @Managed
     public long getMemoryUsageBytes()
     {
-        return getResourceUsageSnapshot().getMemoryUsageBytes();
+        return getResourceUsageSnapshot().memoryUsageBytes();
     }
 
     @Managed
     public long getPhysicalInputDataUsageBytes()
     {
-        return getResourceUsageSnapshot().getPhysicalInputDataUsageBytes();
+        return getResourceUsageSnapshot().physicalInputDataUsageBytes();
     }
 
     @Managed
@@ -934,12 +934,12 @@ public class InternalResourceGroup
     {
         checkState(Thread.holdsLock(root), "Must hold lock to generate quotas");
         synchronized (root) {
-            long oldCpuUsageMillis = cachedResourceUsage.getCpuUsageMillis();
-            long oldDataScanBytes = cachedResourceUsage.getPhysicalInputDataUsageBytes();
+            long oldCpuUsageMillis = cachedResourceUsage.cpuUsageMillis();
+            long oldDataScanBytes = cachedResourceUsage.physicalInputDataUsageBytes();
 
             long newCpuUsageMillis = computeNewUsage(oldCpuUsageMillis, elapsedSeconds, cpuQuotaGenerationMillisPerSecond);
             long newDataScanBytes = computeNewUsage(oldDataScanBytes, elapsedSeconds, physicalDataScanQuotaGenerationBytesPerSecond);
-            cachedResourceUsage = new ResourceUsage(newCpuUsageMillis, cachedResourceUsage.getMemoryUsageBytes(), newDataScanBytes);
+            cachedResourceUsage = new ResourceUsage(newCpuUsageMillis, cachedResourceUsage.memoryUsageBytes(), newDataScanBytes);
 
             if ((newCpuUsageMillis < hardCpuLimitMillis && oldCpuUsageMillis >= hardCpuLimitMillis) ||
                     (newCpuUsageMillis < softCpuLimitMillis && oldCpuUsageMillis >= softCpuLimitMillis) ||
@@ -1073,9 +1073,9 @@ public class InternalResourceGroup
     {
         checkState(Thread.holdsLock(root), "Must hold lock");
         synchronized (root) {
-            long cpuUsageMillis = cachedResourceUsage.getCpuUsageMillis();
-            long memoryUsageBytes = cachedResourceUsage.getMemoryUsageBytes();
-            long physicalInputDataUsageBytes = cachedResourceUsage.getPhysicalInputDataUsageBytes();
+            long cpuUsageMillis = cachedResourceUsage.cpuUsageMillis();
+            long memoryUsageBytes = cachedResourceUsage.memoryUsageBytes();
+            long physicalInputDataUsageBytes = cachedResourceUsage.physicalInputDataUsageBytes();
             if ((cpuUsageMillis >= hardCpuLimitMillis) || (memoryUsageBytes > softMemoryLimitBytes) || (physicalInputDataUsageBytes >= hardPhysicalDataScanLimitBytes)) {
                 return false;
             }

--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/ResourceUsage.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/ResourceUsage.java
@@ -13,28 +13,12 @@
  */
 package io.trino.execution.resourcegroups;
 
-import com.google.errorprone.annotations.Immutable;
-
-import java.util.Objects;
-
 import static com.google.common.math.LongMath.saturatedAdd;
 import static com.google.common.math.LongMath.saturatedSubtract;
 
-@Immutable
-final class ResourceUsage
+record ResourceUsage(long cpuUsageMillis, long memoryUsageBytes, long physicalInputDataUsageBytes)
 {
     public static final ResourceUsage ZERO = new ResourceUsage(0, 0, 0);
-
-    private final long cpuUsageMillis;
-    private final long memoryUsageBytes;
-    private final long physicalInputDataUsageBytes;
-
-    public ResourceUsage(long cpuUsageMillis, long memoryUsageBytes, long physicalInputDataUsageBytes)
-    {
-        this.cpuUsageMillis = cpuUsageMillis;
-        this.memoryUsageBytes = memoryUsageBytes;
-        this.physicalInputDataUsageBytes = physicalInputDataUsageBytes;
-    }
 
     public ResourceUsage add(ResourceUsage other)
     {
@@ -50,42 +34,5 @@ final class ResourceUsage
         long newMemoryUsageBytes = saturatedSubtract(this.memoryUsageBytes, other.memoryUsageBytes);
         long newPhysicalInputDataUsageBytes = saturatedSubtract(this.physicalInputDataUsageBytes, other.physicalInputDataUsageBytes);
         return new ResourceUsage(newCpuUsageMillis, newMemoryUsageBytes, newPhysicalInputDataUsageBytes);
-    }
-
-    public long getCpuUsageMillis()
-    {
-        return cpuUsageMillis;
-    }
-
-    public long getMemoryUsageBytes()
-    {
-        return memoryUsageBytes;
-    }
-
-    public long getPhysicalInputDataUsageBytes()
-    {
-        return physicalInputDataUsageBytes;
-    }
-
-    @Override
-    public boolean equals(Object other)
-    {
-        if (this == other) {
-            return true;
-        }
-        if ((other == null) || (getClass() != other.getClass())) {
-            return false;
-        }
-
-        ResourceUsage otherUsage = (ResourceUsage) other;
-        return cpuUsageMillis == otherUsage.cpuUsageMillis
-                && memoryUsageBytes == otherUsage.memoryUsageBytes
-                && physicalInputDataUsageBytes == otherUsage.physicalInputDataUsageBytes;
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash(cpuUsageMillis, memoryUsageBytes, physicalInputDataUsageBytes);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
+++ b/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
@@ -1919,7 +1919,7 @@ public class TestResourceGroups
 
     private static void assertExceedsCpuLimit(InternalResourceGroup group, long expectedMillis)
     {
-        long actualMillis = group.getResourceUsageSnapshot().getCpuUsageMillis();
+        long actualMillis = group.getResourceUsageSnapshot().cpuUsageMillis();
         assertThat(actualMillis).isEqualTo(expectedMillis);
         assertThat(actualMillis >= group.getHardCpuLimit().toMillis()).isTrue();
         assertThat(group.getCpuUsageMillis()).isEqualTo(expectedMillis);
@@ -1927,7 +1927,7 @@ public class TestResourceGroups
 
     private static void assertWithinCpuLimit(InternalResourceGroup group, long expectedMillis)
     {
-        long actualMillis = group.getResourceUsageSnapshot().getCpuUsageMillis();
+        long actualMillis = group.getResourceUsageSnapshot().cpuUsageMillis();
         assertThat(actualMillis).isEqualTo(expectedMillis);
         assertThat(actualMillis < group.getHardCpuLimit().toMillis()).isTrue();
         assertThat(group.getCpuUsageMillis()).isEqualTo(expectedMillis);
@@ -1935,7 +1935,7 @@ public class TestResourceGroups
 
     private static void assertExceedsMemoryLimit(InternalResourceGroup group, long expectedBytes)
     {
-        long actualBytes = group.getResourceUsageSnapshot().getMemoryUsageBytes();
+        long actualBytes = group.getResourceUsageSnapshot().memoryUsageBytes();
         assertThat(actualBytes).isEqualTo(expectedBytes);
         assertThat(actualBytes).isGreaterThan(group.getSoftMemoryLimitBytes());
         assertThat(group.getMemoryUsageBytes()).isEqualTo(expectedBytes);
@@ -1943,7 +1943,7 @@ public class TestResourceGroups
 
     private static void assertWithinMemoryLimit(InternalResourceGroup group, long expectedBytes)
     {
-        long actualBytes = group.getResourceUsageSnapshot().getMemoryUsageBytes();
+        long actualBytes = group.getResourceUsageSnapshot().memoryUsageBytes();
         assertThat(actualBytes).isEqualTo(expectedBytes);
         assertThat(actualBytes).isLessThanOrEqualTo(group.getSoftMemoryLimitBytes());
         assertThat(group.getMemoryUsageBytes()).isEqualTo(expectedBytes);
@@ -1951,7 +1951,7 @@ public class TestResourceGroups
 
     private static void assertExceedsPhysicalDataScanLimit(InternalResourceGroup group, long expectedBytes)
     {
-        long actualBytes = group.getResourceUsageSnapshot().getPhysicalInputDataUsageBytes();
+        long actualBytes = group.getResourceUsageSnapshot().physicalInputDataUsageBytes();
         assertThat(actualBytes).isEqualTo(expectedBytes);
         assertThat(actualBytes).isGreaterThan(group.getHardPhysicalDataScanLimitBytes());
         assertThat(group.getPhysicalInputDataUsageBytes()).isEqualTo(expectedBytes);
@@ -1959,7 +1959,7 @@ public class TestResourceGroups
 
     private static void assertWithinPhysicalDataScanLimit(InternalResourceGroup group, long expectedBytes)
     {
-        long actualBytes = group.getResourceUsageSnapshot().getPhysicalInputDataUsageBytes();
+        long actualBytes = group.getResourceUsageSnapshot().physicalInputDataUsageBytes();
         assertThat(actualBytes).isEqualTo(expectedBytes);
         assertThat(actualBytes).isLessThanOrEqualTo(group.getHardPhysicalDataScanLimitBytes());
         assertThat(group.getPhysicalInputDataUsageBytes()).isEqualTo(expectedBytes);


### PR DESCRIPTION
## Description
Simple code cleanup refactor that converts `ResourceUsage` to a record class.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
