### PR TITLE
Fix SpoolingPagePartitioner crash on variable-length rows

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/SpoolingPagePartitioner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SpoolingPagePartitioner.java
@@ -42,7 +42,14 @@ public class SpoolingPagePartitioner
             Page currentPage = queue.removeFirst();
 
             long remainingSize = targetSize - size(currentPartition);
-            verify(remainingSize >= 0, "Current partition size %s is larger than target size %s", size(currentPartition), targetSize);
+            if (remainingSize <= 0) {
+                // averageSizePerPosition in takeFromHead is an estimate; variable-length rows can cause
+                // the first split chunk to overshoot the target, making remainingSize negative here.
+                // Emit the oversized partition and start fresh.
+                partitions.add(ImmutableList.copyOf(currentPartition));
+                currentPartition.clear();
+                remainingSize = targetSize;
+            }
 
             if (currentPage.getSizeInBytes() < remainingSize) {
                 currentPartition.add(currentPage);

--- a/core/trino-main/src/test/java/io/trino/operator/TestSpoolingPagePartitioner.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestSpoolingPagePartitioner.java
@@ -14,7 +14,9 @@
 package io.trino.operator;
 
 import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
 import io.trino.spi.Page;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +26,7 @@ import java.util.function.ToLongFunction;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.SequencePageBuilder.createSequencePage;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TestSpoolingPagePartitioner
@@ -65,6 +68,27 @@ class TestSpoolingPagePartitioner
                 .isEqualTo(3000);
 
         assertPartitionSizes(partitions, maxPartitionSize, expectedPartitions);
+    }
+
+    @Test
+    void testPartitionPagesWithVariableLengthRows()
+    {
+        // First row is very large (1000 chars), remaining 9 rows are tiny (1 char).
+        // averageSizePerPosition ≈ 100 bytes, so when remainingSize=120, takeFromHead
+        // picks 1 position — but that position is 1000 bytes, overshooting the target
+        // by far more than the 10% upper bound. Without the fix this causes
+        // verify(remainingSize >= 0) to fail on the next iteration.
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 10);
+        VARCHAR.writeSlice(blockBuilder, Slices.utf8Slice("a".repeat(1000)));
+        for (int i = 0; i < 9; i++) {
+            VARCHAR.writeSlice(blockBuilder, Slices.utf8Slice("a"));
+        }
+        Page page = new Page(blockBuilder.build());
+
+        List<List<Page>> partitions = SpoolingPagePartitioner.partition(ImmutableList.of(page), 120);
+
+        assertThat(size(partitions)).isEqualTo(page.getSizeInBytes());
+        assertThat(positions(partitions)).isEqualTo(page.getPositionCount());
     }
 
     private void assertPartitionSizes(List<List<Page>> partitions, long maxPartitionSize, int expectedPartitions)


### PR DESCRIPTION
## Description

`SpoolingPagePartitioner` uses `averageSizePerPosition` to estimate how many rows fit in the remaining partition space. For pages with highly variable row sizes (e.g. VARCHAR), the first split chunk from `takeFromHead` can overshoot the target by more than the 10% upper threshold. The partition is not emitted, and on the next iteration `remainingSize` goes negative, triggering a `verify()` failure.

The fix replaces the assertion with a graceful flush: when `remainingSize <= 0`, emit the oversized partition and reset before processing the next page.

## Additional context and related issues

Regression test added: a 10-row VARCHAR page where the first row is 1000 chars and the rest are 1 char each. The average estimate is ~100 bytes/row, so `takeFromHead` picks 1 position for a 120-byte target — but that single position is 1000 bytes, exceeding the target by 8×.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix crash in spooling operator when partitioning pages with highly variable row sizes. ({issue}``)
```