### PR TITLE
OAuth2 token exchange for on-behalf-of api requests

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorContextInstance.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorContextInstance.java
@@ -44,6 +44,7 @@ public class ConnectorContextInstance
     private final BlocksHashFactory blocksHashFactory;
     private final ConnectorExpressionEvaluator evaluator;
     private final ConnectorCacheFactory cacheFactory;
+    private final CredentialProviders credentialProviderManager;
 
     public ConnectorContextInstance(
             OpenTelemetry openTelemetry,
@@ -57,7 +58,8 @@ public class ConnectorContextInstance
             FunctionBundleFactory functionBundleFactory,
             BlocksHashFactory blocksHashFactory,
             ConnectorExpressionEvaluator evaluator,
-            ConnectorCacheFactory cacheFactory)
+            ConnectorCacheFactory cacheFactory,
+            CredentialProviders credentialProviderManager)
     {
         this.openTelemetry = requireNonNull(openTelemetry, "openTelemetry is null");
         this.tracer = requireNonNull(tracer, "tracer is null");
@@ -71,6 +73,7 @@ public class ConnectorContextInstance
         this.blocksHashFactory = requireNonNull(blocksHashFactory, "blocksHashFactory is null");
         this.evaluator = requireNonNull(evaluator, "evaluator is null");
         this.cacheFactory = requireNonNull(cacheFactory, "cacheFactory is null");
+        this.credentialProviderManager = requireNonNull(credentialProviderManager, "credentialProviderManager is null");
     }
 
     @Override
@@ -143,5 +146,11 @@ public class ConnectorContextInstance
     public ConnectorCacheFactory getCacheFactory()
     {
         return cacheFactory;
+    }
+
+    @Override
+    public CredentialProviders getCredentialProviderManager()
+    {
+        return credentialProviderManager;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
@@ -41,6 +41,7 @@ import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorExpressionEvaluator;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.spi.connector.ConnectorName;
+import io.trino.spi.security.CredentialProviders;
 import io.trino.spi.type.TypeManager;
 import io.trino.sql.planner.OptimizerConfig;
 import io.trino.transaction.TransactionManager;
@@ -80,6 +81,7 @@ public class DefaultCatalogFactory
     private final SecretsResolver secretsResolver;
     private final ConnectorExpressionEvaluator evaluator;
     private final CacheManagerRegistry cacheManagerRegistry;
+    private final CredentialProviders credentialProviderManager;
 
     @Inject
     public DefaultCatalogFactory(
@@ -98,7 +100,8 @@ public class DefaultCatalogFactory
             OptimizerConfig optimizerConfig,
             SecretsResolver secretsResolver,
             ConnectorExpressionEvaluator evaluator,
-            CacheManagerRegistry cacheManagerRegistry)
+            CacheManagerRegistry cacheManagerRegistry,
+            CredentialProviders credentialProviderManager)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
@@ -116,6 +119,7 @@ public class DefaultCatalogFactory
         this.secretsResolver = requireNonNull(secretsResolver, "secretsResolver is null");
         this.evaluator = requireNonNull(evaluator, "evaluator is null");
         this.cacheManagerRegistry = requireNonNull(cacheManagerRegistry, "cacheManagerRegistry is null");
+        this.credentialProviderManager = requireNonNull(credentialProviderManager, "credentialProviderManager is null");
     }
 
     @Override
@@ -211,7 +215,8 @@ public class DefaultCatalogFactory
                 new InternalFunctionBundleFactory(),
                 blocksHashFactory,
                 evaluator,
-                cacheManagerRegistry.createConnectorCacheFactory(catalogName));
+                cacheManagerRegistry.createConnectorCacheFactory(catalogName),
+                credentialProviderManager);
 
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(connectorFactory.getClass().getClassLoader())) {
             // TODO: connector factory should take CatalogName

--- a/core/trino-main/src/main/java/io/trino/security/credential/CredentialModule.java
+++ b/core/trino-main/src/main/java/io/trino/security/credential/CredentialModule.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import com.google.inject.Binder;
+import com.google.inject.multibindings.Multibinder;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.spi.security.CredentialProvider;
+import io.trino.spi.security.CredentialProviders;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+
+public class CredentialModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        binder.bind(CredentialProviders.class).to(CredentialProviderManager.class).in(SINGLETON);
+        Multibinder.newSetBinder(binder, CredentialProvider.class);
+
+        httpClientBinder(binder).bindHttpClient("credential-provider", ForCredentialProvider.class);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/security/credential/CredentialProviderManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/credential/CredentialProviderManager.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.Credential;
+import io.trino.spi.security.CredentialProvider;
+import io.trino.spi.security.CredentialProviders;
+import io.trino.spi.security.CredentialRequest;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Singleton
+public class CredentialProviderManager
+        implements CredentialProviders
+{
+    private final Set<CredentialProvider> providers;
+
+    @Inject
+    public CredentialProviderManager(Set<CredentialProvider> providers)
+    {
+        this.providers = providers;
+    }
+
+    @Override
+    public Optional<Credential> getCredential(ConnectorIdentity identity, CredentialRequest request)
+    {
+        for (CredentialProvider provider : providers) {
+            Optional<Credential> result = provider.getCredential(identity, request);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/security/credential/ForCredentialProvider.java
+++ b/core/trino-main/src/main/java/io/trino/security/credential/ForCredentialProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface ForCredentialProvider {}

--- a/core/trino-main/src/main/java/io/trino/server/InternalCommunicationEncryption.java
+++ b/core/trino-main/src/main/java/io/trino/server/InternalCommunicationEncryption.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import com.google.inject.Inject;
+import io.trino.spi.TrinoException;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.util.Objects.requireNonNull;
+import static javax.crypto.Cipher.DECRYPT_MODE;
+import static javax.crypto.Cipher.ENCRYPT_MODE;
+
+public class InternalCommunicationEncryption
+{
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final int IV_LENGTH_BYTE = 12;
+    private static final int AES_KEY_SIZE_BYTE = 32;
+    private static final int TAG_LENGTH_BIT = 128;
+    private final InternalCommunicationConfig config;
+    private SecretKey secretKey;
+
+    @Inject
+    public InternalCommunicationEncryption(InternalCommunicationConfig config)
+    {
+        this.config = requireNonNull(config, "config is null");
+    }
+
+    public boolean isInternalCommunicationEnabled()
+    {
+        return config.getSharedSecret().isPresent();
+    }
+
+    private SecretKey getSecretKey()
+    {
+        if (this.secretKey == null) {
+            try {
+                MessageDigest sha = MessageDigest.getInstance("SHA-512");
+                String sharedSecret = config.getSharedSecret().orElseThrow(() -> new TrinoException(CONFIGURATION_INVALID, "Missing configuration internal-communication.shared-secret"));
+                byte[] secretKey = Base64.getDecoder().decode(sharedSecret);
+                this.secretKey = new SecretKeySpec(Arrays.copyOfRange(sha.digest(secretKey), 0, AES_KEY_SIZE_BYTE), "AES");
+            }
+            catch (NoSuchAlgorithmException e) {
+                throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
+            }
+        }
+        return secretKey;
+    }
+
+    public byte[] encrypt(byte[] plainText)
+    {
+        try {
+            byte[] iv = new byte[IV_LENGTH_BYTE];
+            new SecureRandom().nextBytes(iv);
+
+            GCMParameterSpec spec = new GCMParameterSpec(TAG_LENGTH_BIT, iv);
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(ENCRYPT_MODE, getSecretKey(), spec);
+
+            byte[] cipherText = cipher.doFinal(plainText);
+            ByteBuffer buffer = ByteBuffer.allocate(IV_LENGTH_BYTE + cipherText.length);
+            buffer.put(iv);
+            buffer.put(cipherText);
+            return buffer.array();
+        }
+        catch (Exception e) {
+            throw new TrinoException(CONFIGURATION_INVALID, e);
+        }
+    }
+
+    public byte[] decrypt(byte[] encrypted)
+    {
+        ByteBuffer buffer = ByteBuffer.wrap(encrypted);
+        byte[] iv = new byte[IV_LENGTH_BYTE];
+        buffer.get(iv);
+        byte[] cipherText = new byte[buffer.remaining()];
+        buffer.get(cipherText);
+
+        try {
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            GCMParameterSpec spec = new GCMParameterSpec(TAG_LENGTH_BIT, iv);
+            cipher.init(DECRYPT_MODE, getSecretKey(), spec);
+            return cipher.doFinal(cipherText);
+        }
+        catch (Exception e) {
+            throw new TrinoException(CONFIGURATION_INVALID, e);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/InternalCommunicationModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/InternalCommunicationModule.java
@@ -36,5 +36,6 @@ public class InternalCommunicationModule
             configBinder(binder).bindConfigGlobalDefaults(NodeConfig.class, config -> config.setInternalAddressSource(IP_ENCODED_AS_HOSTNAME));
         }
         binder.bind(InternalAuthenticationManager.class).in(Scopes.SINGLETON);
+        binder.bind(InternalCommunicationEncryption.class).in(Scopes.SINGLETON);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -96,6 +96,7 @@ import io.trino.operator.index.IndexManager;
 import io.trino.operator.scalar.json.JsonExistsFunction;
 import io.trino.operator.scalar.json.JsonQueryFunction;
 import io.trino.operator.scalar.json.JsonValueFunction;
+import io.trino.security.credential.CredentialModule;
 import io.trino.server.PluginManager.PluginsProvider;
 import io.trino.server.SliceSerialization.SliceDeserializer;
 import io.trino.server.SliceSerialization.SliceSerializer;
@@ -476,6 +477,8 @@ public class ServerMainModule
 
         // Dynamic Filtering
         configBinder(binder).bindConfig(DynamicFilterConfig.class);
+
+        install(new CredentialModule());
 
         // dispatcher
         // TODO remove dispatcher from ServerMainModule, and bind dependent components only on coordinators

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
@@ -15,6 +15,7 @@ package io.trino.server.security.oauth2;
 
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
+import io.trino.server.InternalCommunicationEncryption;
 import io.trino.server.security.AbstractBearerAuthenticator;
 import io.trino.server.security.AuthenticationException;
 import io.trino.server.security.UserMapping;
@@ -27,6 +28,7 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 import java.net.URI;
 import java.sql.Date;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -35,6 +37,7 @@ import static io.trino.server.security.UserMapping.createUserMapping;
 import static io.trino.server.security.oauth2.OAuth2TokenExchangeResource.getInitiateUri;
 import static io.trino.server.security.oauth2.OAuth2TokenExchangeResource.getTokenUri;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 public class OAuth2Authenticator
@@ -46,14 +49,18 @@ public class OAuth2Authenticator
     private final UserMapping userMapping;
     private final TokenPairSerializer tokenPairSerializer;
     private final TokenRefresher tokenRefresher;
+    private final InternalCommunicationEncryption internalCommunicationEncryption;
+    private final boolean tokenExchangeAllowed;
 
     @Inject
-    public OAuth2Authenticator(OAuth2Client client, OAuth2Config config, TokenRefresher tokenRefresher, TokenPairSerializer tokenPairSerializer)
+    public OAuth2Authenticator(OAuth2Client client, OAuth2Config config, TokenRefresher tokenRefresher, TokenPairSerializer tokenPairSerializer, InternalCommunicationEncryption internalCommunicationEncryption)
     {
         this.client = requireNonNull(client, "service is null");
         this.principalField = config.getPrincipalField();
         this.tokenRefresher = requireNonNull(tokenRefresher, "tokenRefresher is null");
         this.tokenPairSerializer = requireNonNull(tokenPairSerializer, "tokenPairSerializer is null");
+        this.internalCommunicationEncryption = requireNonNull(internalCommunicationEncryption, "internalCommunicationEncryption is null");
+        this.tokenExchangeAllowed = config.getTokenExchangeAllowed();
         userMapping = createUserMapping(config.getUserMappingPattern(), config.getUserMappingFile());
     }
 
@@ -80,6 +87,11 @@ public class OAuth2Authenticator
         }
         Identity.Builder builder = Identity.forUser(userMapping.mapUser(principal.get()));
         builder.withPrincipal(new BasicPrincipal(principal.get()));
+
+        if (tokenExchangeAllowed) {
+            byte[] encryptedAccessToken = internalCommunicationEncryption.encrypt(tokenPair.accessToken().getBytes(UTF_8));
+            builder.withExtraCredentials(Map.of("oauth_access_token", Base64.getEncoder().encodeToString(encryptedAccessToken)));
+        }
         return Optional.of(builder.build());
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Config.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Config.java
@@ -50,6 +50,8 @@ public class OAuth2Config
     private boolean enableRefreshTokens;
     private boolean enableDiscovery = true;
     private Optional<String> domainHint = Optional.empty();
+    private boolean tokenExchangeAllowed;
+    private long tokenExchangeCacheMaxSize = 1024;
 
     public Optional<String> getStateKey()
     {
@@ -255,6 +257,32 @@ public class OAuth2Config
     public OAuth2Config setDomainHint(String domainHint)
     {
         this.domainHint = Optional.ofNullable(domainHint);
+        return this;
+    }
+
+    public boolean getTokenExchangeAllowed()
+    {
+        return tokenExchangeAllowed;
+    }
+
+    @ConfigDescription("Allow connectors to initiate an oauth2 token exchange")
+    @Config("http-server.authentication.oauth2.token-exchange.allowed")
+    public OAuth2Config setTokenExchangeAllowed(boolean allowed)
+    {
+        this.tokenExchangeAllowed = allowed;
+        return this;
+    }
+
+    public long getTokenExchangeCacheMaxSize()
+    {
+        return tokenExchangeCacheMaxSize;
+    }
+
+    @ConfigDescription("The maximum amount of protobuf descriptors to keep in memory")
+    @Config("http-server.authentication.oauth2.token-exchange.cache.max-size")
+    public OAuth2Config setTokenExchangeCacheMaxSize(long size)
+    {
+        this.tokenExchangeCacheMaxSize = size;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2CredentialProvider.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2CredentialProvider.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.inject.Inject;
+import io.airlift.http.client.FormDataBodyBuilder;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StringResponseHandler;
+import io.airlift.json.JsonCodec;
+import io.trino.cache.EvictableCacheBuilder;
+import io.trino.security.credential.ForCredentialProvider;
+import io.trino.server.InternalCommunicationEncryption;
+import io.trino.spi.TrinoException;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.Credential;
+import io.trino.spi.security.CredentialProvider;
+import io.trino.spi.security.CredentialRequest;
+import io.trino.spi.security.OAuth2Credential;
+import io.trino.spi.security.OAuth2CredentialRequest;
+
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.Optional;
+
+import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public class OAuth2CredentialProvider
+        implements CredentialProvider
+{
+    private static final JsonCodec<TokenExchangeResponse> TOKEN_EXCHANGE_RESPONSE_JSON_CODEC = jsonCodec(TokenExchangeResponse.class);
+    private final LoadingCache<CacheKey, OAuth2Credential> cache;
+
+    @Inject
+    public OAuth2CredentialProvider(@ForCredentialProvider HttpClient httpClient, OAuth2Config config, OAuth2ServerConfigProvider serverConfigProvider, InternalCommunicationEncryption internalCommunicationEncryption)
+    {
+        requireNonNull(config, "config is null");
+        requireNonNull(internalCommunicationEncryption, "internalCommunicationEncryption is null");
+
+        if (internalCommunicationEncryption.isInternalCommunicationEnabled() && config.getTokenExchangeAllowed()) {
+            OAuth2ServerConfigProvider.OAuth2ServerConfig serverConfig = requireNonNull(serverConfigProvider.get(), "serverConfig is null");
+            this.cache = EvictableCacheBuilder.newBuilder()
+                    .maximumSize(config.getTokenExchangeCacheMaxSize())
+                    .build(new CacheLoader<>()
+                    {
+                        @Override
+                        public OAuth2Credential load(CacheKey cacheKey)
+                        {
+                            byte[] accessToken = internalCommunicationEncryption.decrypt(Base64.getDecoder().decode(cacheKey.encryptedAccessToken()));
+                            Request request = preparePost()
+                                    .setUri(serverConfig.tokenUrl())
+                                    .setMethod("POST")
+                                    .setHeader(CONTENT_TYPE, "application/x-www-form-urlencoded")
+                                    .setBodyGenerator(new FormDataBodyBuilder()
+                                            .addField("client_id", requireNonNull(config.getClientId(), "clientId is null"))
+                                            .addField("client_secret", requireNonNull(config.getClientSecret(), "clientSecret is null"))
+                                            .addField("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+                                            .addField("subject_token", new String(accessToken, UTF_8))
+                                            .addField("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
+                                            .addField("scope", cacheKey.scope())
+                                            .addField("audience", cacheKey.audience())
+                                            .build())
+                                    .build();
+
+                            StringResponseHandler.StringResponse response = httpClient.execute(request, createStringResponseHandler());
+                            if (response.getStatusCode() != 200) {
+                                throw new IllegalStateException(serverConfig.tokenUrl() + " returned " + response.getStatusCode() + ": " + response.getBody());
+                            }
+
+                            TokenExchangeResponse exchangeResponse = TOKEN_EXCHANGE_RESPONSE_JSON_CODEC.fromJson(response.getBody());
+                            return new OAuth2Credential(exchangeResponse.accessToken(), Instant.now().plusSeconds(exchangeResponse.expiresIn()).minusSeconds(30));
+                        }
+                    });
+        }
+        else {
+            this.cache = null;
+        }
+    }
+
+    @Override
+    public Optional<Credential> getCredential(ConnectorIdentity identity, CredentialRequest credentialRequest)
+    {
+        if (credentialRequest instanceof OAuth2CredentialRequest request) {
+            if (cache == null) {
+                throw new TrinoException(CONFIGURATION_INVALID, "http-server.authentication.oauth2.token-exchange.allowed should be true and internal-communication.shared-secret should be set to use this feature");
+            }
+
+            try {
+                CacheKey cacheKey = CacheKey.of(identity, request);
+                OAuth2Credential credential = cache.get(cacheKey);
+                if (credential.isValid()) {
+                    return Optional.of(credential);
+                }
+                cache.invalidate(cacheKey);
+                return Optional.of(cache.get(cacheKey));
+            }
+            catch (Exception e) {
+                throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private record CacheKey(String user, String encryptedAccessToken, String audience, String scope)
+    {
+        public static CacheKey of(ConnectorIdentity identity, OAuth2CredentialRequest request)
+        {
+            String encryptedAccessToken = requireNonNull(identity.getExtraCredentials().get("oauth_access_token"), "extra credentials oauth_access_token is null");
+            return new CacheKey(identity.getUser(), encryptedAccessToken, request.audience(), request.scope());
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (!(o instanceof CacheKey cacheKey)) {
+                return false;
+            }
+            return Objects.equals(user, cacheKey.user) && Objects.equals(encryptedAccessToken, cacheKey.encryptedAccessToken) && Objects.equals(scope, cacheKey.scope) && Objects.equals(audience, cacheKey.audience);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(user, encryptedAccessToken, audience, scope);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
@@ -19,12 +19,15 @@ import com.google.inject.Key;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.units.DataSize;
 import io.trino.server.ui.OAuth2WebUiInstalled;
+import io.trino.spi.security.CredentialProvider;
 
 import java.time.Duration;
 
+import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
@@ -71,6 +74,9 @@ public class OAuth2ServiceModule
                 .withConfigDefaults(clientConfig -> clientConfig
                         .setRequestBufferSize(DataSize.of(32, KILOBYTE))
                         .setResponseBufferSize(DataSize.of(32, KILOBYTE)));
+
+        binder.bind(OAuth2CredentialProvider.class).in(SINGLETON);
+        Multibinder.newSetBinder(binder, CredentialProvider.class).addBinding().to(OAuth2CredentialProvider.class);
     }
 
     private void enableRefreshTokens()

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/TokenExchangeResponse.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/TokenExchangeResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record TokenExchangeResponse(String accessToken, long expiresIn)
+{
+    @JsonCreator
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public TokenExchangeResponse(@JsonProperty("access_token") String accessToken, @JsonProperty("expires_in") long expiresIn)
+    {
+        this.accessToken = accessToken;
+        this.expiresIn = expiresIn;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -141,6 +141,7 @@ import io.trino.operator.table.ExcludeColumnsFunction;
 import io.trino.plugin.base.security.AllowAllSystemAccessControl;
 import io.trino.security.AllowAllAccessControl;
 import io.trino.security.GroupProviderManager;
+import io.trino.security.credential.CredentialProviderManager;
 import io.trino.server.PluginManager;
 import io.trino.server.ServerConfig;
 import io.trino.server.SessionPropertyDefaults;
@@ -461,7 +462,8 @@ public class PlanTester
                 optimizerConfig,
                 secretsResolver,
                 evaluator,
-                cacheManagerRegistry));
+                cacheManagerRegistry,
+                new CredentialProviderManager(ImmutableSet.of())));
         this.splitManager = new SplitManager(createSplitManagerProvider(catalogManager), tracer, new QueryManagerConfig());
         this.pageSourceManager = new PageSourceManager(createPageSourceProviderFactory(catalogManager));
         this.pageSinkManager = new PageSinkManager(createPageSinkProvider(catalogManager));

--- a/core/trino-main/src/main/java/io/trino/testing/TestingConnectorContext.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingConnectorContext.java
@@ -22,6 +22,7 @@ import io.trino.operator.GroupByHashPageIndexerFactory;
 import io.trino.operator.NullSafeHashCompiler;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.PagesIndexPageSorter;
+import io.trino.security.credential.CredentialProviderManager;
 import io.trino.spi.BlocksHashFactory;
 import io.trino.spi.NodeManager;
 import io.trino.spi.NodeVersion;
@@ -32,9 +33,12 @@ import io.trino.spi.cache.ConnectorCacheFactory;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.function.FunctionBundleFactory;
+import io.trino.spi.security.CredentialProviders;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeOperators;
 import io.trino.util.EmbedVersion;
+
+import java.util.Set;
 
 import static io.trino.spi.connector.MetadataProvider.NOOP_METADATA_PROVIDER;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
@@ -48,6 +52,7 @@ public final class TestingConnectorContext
     private final PageSorter pageSorter = new PagesIndexPageSorter(new PagesIndex.TestingFactory(false));
     private final FlatHashStrategyCompiler flatHashStrategyCompiler = new FlatHashStrategyCompiler(new TypeOperators(), new NullSafeHashCompiler(new TypeOperators()));
     private final PageIndexerFactory pageIndexerFactory = new GroupByHashPageIndexerFactory(flatHashStrategyCompiler);
+    private final CredentialProviders credentialProviders = new CredentialProviderManager(Set.of());
 
     public TestingConnectorContext()
     {
@@ -123,5 +128,11 @@ public final class TestingConnectorContext
     public ConnectorCacheFactory getCacheFactory()
     {
         return new TestingConnectorCacheFactory();
+    }
+
+    @Override
+    public CredentialProviders getCredentialProviderManager()
+    {
+        return credentialProviders;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2Config.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2Config.java
@@ -51,7 +51,9 @@ public class TestOAuth2Config
                 .setUserMappingFile(null)
                 .setEnableRefreshTokens(false)
                 .setEnableDiscovery(true)
-                .setDomainHint(null));
+                .setDomainHint(null)
+                .setTokenExchangeAllowed(false)
+                .setTokenExchangeCacheMaxSize(1024));
     }
 
     @Test
@@ -75,6 +77,8 @@ public class TestOAuth2Config
                 .put("http-server.authentication.oauth2.refresh-tokens", "true")
                 .put("http-server.authentication.oauth2.oidc.discovery", "false")
                 .put("http-server.authentication.oauth2.domain-hint", "example.com")
+                .put("http-server.authentication.oauth2.token-exchange.allowed", "true")
+                .put("http-server.authentication.oauth2.token-exchange.cache.max-size", "100")
                 .buildOrThrow();
 
         OAuth2Config expected = new OAuth2Config()
@@ -92,7 +96,9 @@ public class TestOAuth2Config
                 .setUserMappingFile(userMappingFile.toFile())
                 .setEnableRefreshTokens(true)
                 .setEnableDiscovery(false)
-                .setDomainHint("example.com");
+                .setDomainHint("example.com")
+                .setTokenExchangeAllowed(true)
+                .setTokenExchangeCacheMaxSize(100);
 
         assertFullMapping(properties, expected);
     }

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2CredentialProvider.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2CredentialProvider.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.StaticBodyGenerator;
+import io.airlift.http.client.testing.TestingHttpClient;
+import io.airlift.http.client.testing.TestingResponse;
+import io.trino.server.InternalCommunicationConfig;
+import io.trino.server.InternalCommunicationEncryption;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.Credential;
+import io.trino.spi.security.OAuth2Credential;
+import io.trino.spi.security.OAuth2CredentialRequest;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
+import static io.airlift.http.client.HttpStatus.OK;
+import static java.net.URLDecoder.decode;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestOAuth2CredentialProvider
+{
+    @Test
+    public void testTokenExchange()
+    {
+        HttpClient httpClient = new TestingHttpClient(request -> {
+            assertThat(request.getMethod()).isEqualTo("POST");
+            assertThat(request.getUri().toASCIIString()).isEqualTo("https://server/realms/master/protocol/openid-connect/token");
+            assertThat(request.getHeader(CONTENT_TYPE)).isEqualTo("application/x-www-form-urlencoded");
+
+            String body = new String(((StaticBodyGenerator) request.getBodyGenerator()).getBody(), UTF_8);
+            Map<String, String> formValues = new HashSet<>(Arrays.asList(body.split("&"))).stream()
+                    .map(keyValue -> keyValue.split("="))
+                    .collect(toMap(keyValue -> decode(keyValue[0], US_ASCII), keyValye -> decode(keyValye[1], US_ASCII)));
+
+            assertThat(formValues).containsEntry("client_id", "trino-client");
+            assertThat(formValues).containsEntry("client_secret", "trino-client-secret");
+            assertThat(formValues).containsEntry("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+            assertThat(formValues).containsEntry("subject_token", "uvwxyz");
+            assertThat(formValues).containsEntry("subject_token_type", "urn:ietf:params:oauth:token-type:access_token");
+            assertThat(formValues).containsEntry("scope", "openid email");
+            assertThat(formValues).containsEntry("audience", "external-client");
+
+            return TestingResponse.mockResponse(OK, JSON_UTF_8,
+                    """
+                    {
+                      "access_token": "abcd",
+                      "expires_in": 60
+                    }
+                    """);
+        });
+
+        OAuth2Config config = new OAuth2Config()
+                .setClientId("trino-client")
+                .setClientSecret("trino-client-secret")
+                .setTokenExchangeAllowed(true);
+
+        OAuth2ServerConfigProvider.OAuth2ServerConfig serverConfig = new OAuth2ServerConfigProvider.OAuth2ServerConfig(
+                Optional.empty(),
+                URI.create("https://server/realms/master/protocol/openid-connect/auth"),
+                URI.create("https://server/realms/master/protocol/openid-connect/token"),
+                URI.create("https://server/realms/master/protocol/openid-connect/jwks.json"),
+                Optional.empty(),
+                Optional.empty());
+        OAuth2ServerConfigProvider serverConfigProvider = () -> serverConfig;
+
+        byte[] sharedSecret = new byte[512];
+        new SecureRandom().nextBytes(sharedSecret);
+        InternalCommunicationConfig internalCommunicationConfig = new InternalCommunicationConfig()
+                .setSharedSecret(Base64.getEncoder().encodeToString(sharedSecret));
+        InternalCommunicationEncryption internalCommunicationEncryption = new InternalCommunicationEncryption(internalCommunicationConfig);
+
+        OAuth2CredentialProvider provider = new OAuth2CredentialProvider(httpClient, config, serverConfigProvider, internalCommunicationEncryption);
+        String audience = "external-client";
+        String scope = "openid email";
+
+        byte[] encryptedToken = internalCommunicationEncryption.encrypt("uvwxyz".getBytes(UTF_8));
+
+        ConnectorIdentity connectorIdentity = ConnectorIdentity.forUser("user1").withExtraCredentials(Map.of("oauth_access_token", Base64.getEncoder().encodeToString(encryptedToken))).build();
+        Credential credential = provider.getCredential(connectorIdentity, new OAuth2CredentialRequest(audience, scope)).get();
+        assertThat(credential).isInstanceOf(OAuth2Credential.class);
+        OAuth2Credential oauth2Credential = (OAuth2Credential) credential;
+        assertThat(oauth2Credential.accessToken()).isEqualTo("abcd");
+        assertThat(oauth2Credential.expiration()).isAfter(Instant.now());
+        assertThat(oauth2Credential.expiration()).isBefore(Instant.now().plusSeconds(40));
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
@@ -24,6 +24,7 @@ import io.trino.spi.Unstable;
 import io.trino.spi.VersionEmbedder;
 import io.trino.spi.cache.ConnectorCacheFactory;
 import io.trino.spi.function.FunctionBundleFactory;
+import io.trino.spi.security.CredentialProviders;
 import io.trino.spi.type.TypeManager;
 
 import java.util.Optional;
@@ -108,5 +109,11 @@ public interface ConnectorContext
     default ConnectorCacheFactory getCacheFactory()
     {
         return _ -> Optional.empty();
+    }
+
+    @Unstable
+    default CredentialProviders getCredentialProviderManager()
+    {
+        throw new UnsupportedOperationException();
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/security/Credential.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/Credential.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security;
+
+public interface Credential
+{
+    boolean isValid();
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/CredentialProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/CredentialProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security;
+
+import java.util.Optional;
+
+public interface CredentialProvider
+{
+    Optional<Credential> getCredential(ConnectorIdentity identity, CredentialRequest request);
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/CredentialProviders.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/CredentialProviders.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security;
+
+import java.util.Optional;
+
+public interface CredentialProviders
+{
+    Optional<Credential> getCredential(ConnectorIdentity identity, CredentialRequest request);
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/CredentialRequest.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/CredentialRequest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security;
+
+public interface CredentialRequest {}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/OAuth2Credential.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/OAuth2Credential.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security;
+
+import java.time.Instant;
+
+public record OAuth2Credential(String accessToken, Instant expiration)
+        implements Credential
+{
+    @Override
+    public boolean isValid()
+    {
+        return expiration().isAfter(Instant.now());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "accessToken with hash " + accessToken.hashCode() + " expires after " + expiration();
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/OAuth2CredentialRequest.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/OAuth2CredentialRequest.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security;
+
+public record OAuth2CredentialRequest(String audience, String scope)
+        implements CredentialRequest {}

--- a/docs/src/main/sphinx/security/oauth2.md
+++ b/docs/src/main/sphinx/security/oauth2.md
@@ -245,6 +245,30 @@ The following configuration properties are available:
     it's generated during startup.
 :::
 
+(trino-oauth2-token-exchange)=
+### Token exchange
+
+OAuth 2.0 *Token Exchange* allows a client to obtain a new access token by 
+submitting an existing credential to an authorization server rather than
+requiring full re-authentication. This protocol enables secure service
+delegation and cross-identity trust, allowing users to move between different
+systems without re-entering their secrets. When allowed, connectors are able to
+obtain a new access token for the connector data source.
+
+:::{list-table} OAuth2 configuration properties for token exchange
+:widths: 40 60
+:header-rows: 1
+
+* - Property
+  - Description
+* - `http-server.authentication.oauth2.token-exchange.allowed`
+  - When enabled, connectors may initiate an oauth2 token exchange to connect
+    to external data sources using the on-behalf-of mechanism. Disabled by 
+    default.
+* - `http-server.authentication.oauth2.token-exchange.cache.max-size`
+  - The maximum of access tokens to cache obtained via token-exchange.
+:::
+
 (trino-oauth2-troubleshooting)=
 ## Troubleshooting
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ConnectorContextModule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ConnectorContextModule.java
@@ -28,6 +28,7 @@ import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorExpressionEvaluator;
 import io.trino.spi.connector.MetadataProvider;
+import io.trino.spi.security.CredentialProviders;
 import io.trino.spi.type.TypeManager;
 
 import static java.util.Objects.requireNonNull;
@@ -61,5 +62,6 @@ public class ConnectorContextModule
         binder.bind(PageIndexerFactory.class).toInstance(context.getPageIndexerFactory());
         binder.bind(BlocksHashFactory.class).toInstance(context.getBlocksHashFactory());
         binder.bind(ConnectorExpressionEvaluator.class).toInstance(context.getExpressionEvaluator());
+        binder.bind(CredentialProviders.class).toInstance(context.getCredentialProviderManager());
     }
 }

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AbstractAiClient.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AbstractAiClient.java
@@ -18,6 +18,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.json.JsonCodec;
 import io.trino.spi.TrinoException;
+import io.trino.spi.security.ConnectorIdentity;
 
 import java.util.List;
 import java.util.Locale;
@@ -62,7 +63,7 @@ public abstract class AbstractAiClient
     }
 
     @Override
-    public String analyzeSentiment(String text)
+    public String analyzeSentiment(ConnectorIdentity identity, String text)
     {
         String prompt =
                 """
@@ -72,12 +73,12 @@ public abstract class AbstractAiClient
                 %s
                 """.formatted(text);
 
-        String response = completion(analyzeSentimentModel, prompt);
+        String response = completion(identity, analyzeSentimentModel, prompt);
         return response.toLowerCase(Locale.ROOT);
     }
 
     @Override
-    public String classify(String text, List<String> labels)
+    public String classify(ConnectorIdentity identity, String text, List<String> labels)
     {
         String prompt =
                 """
@@ -88,7 +89,7 @@ public abstract class AbstractAiClient
                 %s
                 """.formatted(LIST_CODEC.toJson(labels), text);
 
-        String response = completion(classifyModel, prompt);
+        String response = completion(identity, classifyModel, prompt);
         try {
             return STRING_CODEC.fromJson(response);
         }
@@ -98,7 +99,7 @@ public abstract class AbstractAiClient
     }
 
     @Override
-    public Map<String, String> extract(String text, List<String> labels)
+    public Map<String, String> extract(ConnectorIdentity identity, String text, List<String> labels)
     {
         String prompt =
                 """
@@ -112,7 +113,7 @@ public abstract class AbstractAiClient
                 %s
                 """.formatted(LIST_CODEC.toJson(labels), text);
 
-        String response = completion(extractModel, prompt);
+        String response = completion(identity, extractModel, prompt);
         try {
             return filterValues(MAP_CODEC.fromJson(response), Objects::nonNull);
         }
@@ -122,7 +123,7 @@ public abstract class AbstractAiClient
     }
 
     @Override
-    public String fixGrammar(String text)
+    public String fixGrammar(ConnectorIdentity identity, String text)
     {
         String prompt =
                 """
@@ -132,17 +133,17 @@ public abstract class AbstractAiClient
                 %s
                 """.formatted(text);
 
-        return completion(fixGrammarModel, prompt);
+        return completion(identity, fixGrammarModel, prompt);
     }
 
     @Override
-    public String generate(String prompt)
+    public String generate(ConnectorIdentity identity, String prompt)
     {
-        return completion(generateModel, prompt);
+        return completion(identity, generateModel, prompt);
     }
 
     @Override
-    public String mask(String text, List<String> labels)
+    public String mask(ConnectorIdentity identity, String text, List<String> labels)
     {
         String prompt =
                 """
@@ -155,11 +156,11 @@ public abstract class AbstractAiClient
                 %s
                 """.formatted(LIST_CODEC.toJson(labels), text);
 
-        return completion(maskModel, prompt);
+        return completion(identity, maskModel, prompt);
     }
 
     @Override
-    public String translate(String text, String language)
+    public String translate(ConnectorIdentity identity, String text, String language)
     {
         String prompt =
                 """
@@ -171,14 +172,14 @@ public abstract class AbstractAiClient
                 %s
                 """.formatted(STRING_CODEC.toJson(language), text);
 
-        return completion(translateModel, prompt);
+        return completion(identity, translateModel, prompt);
     }
 
-    private String completion(String model, String prompt)
+    private String completion(ConnectorIdentity identity, String model, String prompt)
     {
         try {
-            String key = model + "\0" + prompt;
-            return completionCache.get(key, () -> generateCompletion(model, prompt));
+            String key = identity.getUser() + "\0" + model + "\0" + prompt;
+            return completionCache.get(key, () -> generateCompletion(identity, model, prompt));
         }
         catch (ExecutionException e) {
             throw new UncheckedExecutionException(e);
@@ -191,5 +192,5 @@ public abstract class AbstractAiClient
         }
     }
 
-    protected abstract String generateCompletion(String model, String prompt);
+    protected abstract String generateCompletion(ConnectorIdentity identity, String model, String prompt);
 }

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiClient.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiClient.java
@@ -13,22 +13,24 @@
  */
 package io.trino.plugin.ai.functions;
 
+import io.trino.spi.security.ConnectorIdentity;
+
 import java.util.List;
 import java.util.Map;
 
 public interface AiClient
 {
-    String analyzeSentiment(String text);
+    String analyzeSentiment(ConnectorIdentity identity, String text);
 
-    String classify(String text, List<String> labels);
+    String classify(ConnectorIdentity identity, String text, List<String> labels);
 
-    Map<String, String> extract(String text, List<String> labels);
+    Map<String, String> extract(ConnectorIdentity identity, String text, List<String> labels);
 
-    String fixGrammar(String text);
+    String fixGrammar(ConnectorIdentity identity, String text);
 
-    String generate(String prompt);
+    String generate(ConnectorIdentity identity, String prompt);
 
-    String mask(String text, List<String> labels);
+    String mask(ConnectorIdentity identity, String text, List<String> labels);
 
-    String translate(String text, String language);
+    String translate(ConnectorIdentity identity, String text, String language);
 }

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiFunctions.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiFunctions.java
@@ -18,6 +18,7 @@ import com.google.inject.Inject;
 import io.airlift.slice.Slice;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.SqlMap;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionDependencies;
 import io.trino.spi.function.FunctionId;
@@ -92,13 +93,13 @@ public class AiFunctions
 
     static {
         try {
-            AI_ANALYZE_SENTIMENT = lookup().findVirtual(AiFunctions.class, "aiAnalyzeSentiment", methodType(Slice.class, Slice.class));
-            AI_CLASSIFY = lookup().findVirtual(AiFunctions.class, "aiClassify", methodType(Slice.class, Slice.class, Block.class));
-            AI_EXTRACT = lookup().findVirtual(AiFunctions.class, "aiExtract", methodType(SqlMap.class, MapType.class, Slice.class, Block.class));
-            AI_FIX_GRAMMAR = lookup().findVirtual(AiFunctions.class, "aiFixGrammar", methodType(Slice.class, Slice.class));
-            AI_GEN = lookup().findVirtual(AiFunctions.class, "aiGen", methodType(Slice.class, Slice.class));
-            AI_MASK = lookup().findVirtual(AiFunctions.class, "aiMask", methodType(Slice.class, Slice.class, Block.class));
-            AI_TRANSLATE = lookup().findVirtual(AiFunctions.class, "aiTranslate", methodType(Slice.class, Slice.class, Slice.class));
+            AI_ANALYZE_SENTIMENT = lookup().findVirtual(AiFunctions.class, "aiAnalyzeSentiment", methodType(Slice.class, ConnectorSession.class, Slice.class));
+            AI_CLASSIFY = lookup().findVirtual(AiFunctions.class, "aiClassify", methodType(Slice.class, ConnectorSession.class, Slice.class, Block.class));
+            AI_EXTRACT = lookup().findVirtual(AiFunctions.class, "aiExtract", methodType(SqlMap.class, MapType.class, ConnectorSession.class, Slice.class, Block.class));
+            AI_FIX_GRAMMAR = lookup().findVirtual(AiFunctions.class, "aiFixGrammar", methodType(Slice.class, ConnectorSession.class, Slice.class));
+            AI_GEN = lookup().findVirtual(AiFunctions.class, "aiGen", methodType(Slice.class, ConnectorSession.class, Slice.class));
+            AI_MASK = lookup().findVirtual(AiFunctions.class, "aiMask", methodType(Slice.class, ConnectorSession.class, Slice.class, Block.class));
+            AI_TRANSLATE = lookup().findVirtual(AiFunctions.class, "aiTranslate", methodType(Slice.class, ConnectorSession.class, Slice.class, Slice.class));
         }
         catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
@@ -146,7 +147,7 @@ public class AiFunctions
         InvocationConvention actualConvention = new InvocationConvention(
                 nCopies(boundSignature.getArity(), NEVER_NULL),
                 FAIL_ON_NULL,
-                false,
+                true,
                 false);
 
         handle = ScalarFunctionAdapter.adapt(
@@ -161,39 +162,39 @@ public class AiFunctions
                 .build();
     }
 
-    public Slice aiAnalyzeSentiment(Slice text)
+    public Slice aiAnalyzeSentiment(ConnectorSession session, Slice text)
     {
-        return utf8Slice(client.analyzeSentiment(text.toStringUtf8()));
+        return utf8Slice(client.analyzeSentiment(session.getIdentity(), text.toStringUtf8()));
     }
 
-    public Slice aiClassify(Slice text, Block labels)
+    public Slice aiClassify(ConnectorSession session, Slice text, Block labels)
     {
-        return utf8Slice(client.classify(text.toStringUtf8(), fromSqlArray(labels)));
+        return utf8Slice(client.classify(session.getIdentity(), text.toStringUtf8(), fromSqlArray(labels)));
     }
 
-    public SqlMap aiExtract(MapType mapType, Slice text, Block labels)
+    public SqlMap aiExtract(MapType mapType, ConnectorSession session, Slice text, Block labels)
     {
-        return toSqlMap(mapType, client.extract(text.toStringUtf8(), fromSqlArray(labels)));
+        return toSqlMap(mapType, client.extract(session.getIdentity(), text.toStringUtf8(), fromSqlArray(labels)));
     }
 
-    public Slice aiFixGrammar(Slice text)
+    public Slice aiFixGrammar(ConnectorSession session, Slice text)
     {
-        return utf8Slice(client.fixGrammar(text.toStringUtf8()));
+        return utf8Slice(client.fixGrammar(session.getIdentity(), text.toStringUtf8()));
     }
 
-    public Slice aiGen(Slice prompt)
+    public Slice aiGen(ConnectorSession session, Slice prompt)
     {
-        return utf8Slice(client.generate(prompt.toStringUtf8()));
+        return utf8Slice(client.generate(session.getIdentity(), prompt.toStringUtf8()));
     }
 
-    public Slice aiMask(Slice text, Block labels)
+    public Slice aiMask(ConnectorSession session, Slice text, Block labels)
     {
-        return utf8Slice(client.mask(text.toStringUtf8(), fromSqlArray(labels)));
+        return utf8Slice(client.mask(session.getIdentity(), text.toStringUtf8(), fromSqlArray(labels)));
     }
 
-    public Slice aiTranslate(Slice text, Slice language)
+    public Slice aiTranslate(ConnectorSession session, Slice text, Slice language)
     {
-        return utf8Slice(client.translate(text.toStringUtf8(), language.toStringUtf8()));
+        return utf8Slice(client.translate(session.getIdentity(), text.toStringUtf8(), language.toStringUtf8()));
     }
 
     private static List<String> fromSqlArray(Block block)

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AnthropicClient.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AnthropicClient.java
@@ -24,6 +24,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.spi.TrinoException;
+import io.trino.spi.security.ConnectorIdentity;
 
 import java.net.URI;
 import java.util.List;
@@ -73,7 +74,7 @@ public class AnthropicClient
     }
 
     @Override
-    protected String generateCompletion(String model, String prompt)
+    protected String generateCompletion(ConnectorIdentity identity, String model, String prompt)
     {
         URI uri = uriBuilderFrom(endpoint)
                 .appendPath("/v1/messages")

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/OpenAiClient.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/OpenAiClient.java
@@ -23,9 +23,15 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.spi.TrinoException;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.Credential;
+import io.trino.spi.security.CredentialProviders;
+import io.trino.spi.security.OAuth2Credential;
+import io.trino.spi.security.OAuth2CredentialRequest;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.net.MediaType.JSON_UTF_8;
 import static io.airlift.http.client.HeaderNames.AUTHORIZATION;
@@ -59,23 +65,38 @@ public class OpenAiClient
 
     private final HttpClient httpClient;
     private final Tracer tracer;
-    private final URI endpoint;
-    private final String apiKey;
+    private final OpenAiConfig openAiConfig;
+    private final CredentialProviders credentialProviderManager;
 
     @Inject
-    public OpenAiClient(@ForAiClient HttpClient httpClient, Tracer tracer, OpenAiConfig openAiConfig, AiConfig aiConfig)
+    public OpenAiClient(@ForAiClient HttpClient httpClient, Tracer tracer, OpenAiConfig openAiConfig, AiConfig aiConfig, CredentialProviders credentialProviderManager)
     {
         super(aiConfig);
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.tracer = requireNonNull(tracer, "tracer is null");
-        this.endpoint = openAiConfig.getEndpoint();
-        this.apiKey = openAiConfig.getApiKey();
+        this.openAiConfig = requireNonNull(openAiConfig, "openAiConfig is null");
+        this.credentialProviderManager = requireNonNull(credentialProviderManager, "credentialProviderManager is null");
+    }
+
+    private String getBearerToken(ConnectorIdentity identity)
+    {
+        if (openAiConfig.getApiKey() != null) {
+            return openAiConfig.getApiKey();
+        }
+
+        Optional<Credential> credential = credentialProviderManager.getCredential(identity, new OAuth2CredentialRequest(openAiConfig.getOAuth2Audience(), openAiConfig.getOAuth2Scope()));
+        if (credential.isEmpty()) {
+            throw new TrinoException(AI_ERROR, "No credential received for oauth2 request");
+        }
+        return credential.map(OAuth2Credential.class::cast).get().accessToken();
     }
 
     @Override
-    protected String generateCompletion(String model, String prompt)
+    protected String generateCompletion(ConnectorIdentity identity, String model, String prompt)
     {
-        URI uri = uriBuilderFrom(endpoint)
+        String bearerToken = getBearerToken(identity);
+
+        URI uri = uriBuilderFrom(openAiConfig.getEndpoint())
                 .appendPath("/v1/chat/completions")
                 .build();
 
@@ -84,7 +105,7 @@ public class OpenAiClient
 
         Request request = preparePost()
                 .setUri(uri)
-                .setHeader(AUTHORIZATION, "Bearer " + apiKey)
+                .setHeader(AUTHORIZATION, "Bearer %s".formatted(bearerToken))
                 .setHeader(CONTENT_TYPE, JSON_UTF_8.toString())
                 .setBodyGenerator(jsonBodyGenerator(CHAT_REQUEST_CODEC, body))
                 .build();

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/OpenAiConfig.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/OpenAiConfig.java
@@ -14,7 +14,8 @@
 package io.trino.plugin.ai.functions;
 
 import io.airlift.configuration.Config;
-import jakarta.validation.constraints.NotEmpty;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 
 import java.net.URI;
@@ -23,6 +24,14 @@ public class OpenAiConfig
 {
     private URI endpoint = URI.create("https://api.openai.com");
     private String apiKey;
+    private String oauth2Audience;
+    private String oauth2Scope;
+
+    @AssertTrue(message = "Missing either ai.openai.api-key or (ai.openai.oauth2.audience and ai.openai.oauth2.scope)")
+    public boolean isApiKeyValid()
+    {
+        return apiKey != null || (oauth2Audience != null && oauth2Scope != null);
+    }
 
     @NotNull
     public URI getEndpoint()
@@ -37,16 +46,40 @@ public class OpenAiConfig
         return this;
     }
 
-    @NotEmpty
     public String getApiKey()
     {
         return apiKey;
     }
 
+    @ConfigSecuritySensitive
     @Config("ai.openai.api-key")
     public OpenAiConfig setApiKey(String apiKey)
     {
         this.apiKey = apiKey;
+        return this;
+    }
+
+    public String getOAuth2Audience()
+    {
+        return oauth2Audience;
+    }
+
+    @Config("ai.openai.oauth2.audience")
+    public OpenAiConfig setOAuth2Audience(String oauth2Audience)
+    {
+        this.oauth2Audience = oauth2Audience;
+        return this;
+    }
+
+    public String getOAuth2Scope()
+    {
+        return oauth2Scope;
+    }
+
+    @Config("ai.openai.oauth2.scope")
+    public OpenAiConfig setOAuth2Scope(String oauth2Scope)
+    {
+        this.oauth2Scope = oauth2Scope;
         return this;
     }
 }

--- a/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/TestOpenAiConfig.java
+++ b/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/TestOpenAiConfig.java
@@ -30,7 +30,9 @@ class TestOpenAiConfig
     {
         assertRecordedDefaults(recordDefaults(OpenAiConfig.class)
                 .setEndpoint(URI.create("https://api.openai.com"))
-                .setApiKey(null));
+                .setApiKey(null)
+                .setOAuth2Audience(null)
+                .setOAuth2Scope(null));
     }
 
     @Test
@@ -39,11 +41,15 @@ class TestOpenAiConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("ai.openai.endpoint", "https://api.example.com")
                 .put("ai.openai.api-key", "test-key")
+                .put("ai.openai.oauth2.audience", "audience")
+                .put("ai.openai.oauth2.scope", "scope")
                 .buildOrThrow();
 
         OpenAiConfig expected = new OpenAiConfig()
                 .setEndpoint(URI.create("https://api.example.com"))
-                .setApiKey("test-key");
+                .setApiKey("test-key")
+                .setOAuth2Audience("audience")
+                .setOAuth2Scope("scope");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description
This PR introduces a SPI `CredentialProviders` interface, which can be used by plugins to obtain a credential on behalf of the current user. The first provider is implemented for OAuth2 [token exchange](https://www.keycloak.org/securing-apps/token-exchange).

To prove the example, the `OpenAIClient` has been updated to be able to login into a oauth hardened open api client.

With the following steps, this proof of concept can be run locally.

### /etc/hosts
`127.0.0.1 keycloak.local`

### docker setup
This docker compose runs a keycloak on port 8084 and a oauth secured localai on 8083.
 
docker-compose.yml
```
services:
  postgres:
    image: postgres:16
    container_name: keycloak-postgres
    restart: always
    environment:
      POSTGRES_DB: keycloak
      POSTGRES_USER: keycloak
      POSTGRES_PASSWORD: keycloakpass
    volumes:
      - postgres_data:/var/lib/postgresql/data
    ports:
      - "5432:5432"

  keycloak:
    image: quay.io/keycloak/keycloak:26.6
    command: start-dev
    container_name: keycloak.local
    environment:
      KEYCLOAK_ADMIN: admin
      KEYCLOAK_ADMIN_PASSWORD: admin

      KC_DB: postgres
      KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
      KC_DB_USERNAME: keycloak
      KC_DB_PASSWORD: keycloakpass

      # Required for OIDC redirects
      KC_HOSTNAME: keycloak.local
      KC_HTTP_PORT: 8084

      KC_HTTP_ENABLED: "true"
      KC_HOSTNAME_STRICT: "false"
    ports:
      - "8084:8084"
    depends_on:
      - postgres

  localai:
    # this is the easy setup, but as a query might take too long you might want to set up the gpu backed localai
    image: localai/localai:latest
    container_name: localai
    restart: unless-stopped
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:8080/readyz"]
      interval: 1m
      timeout: 20m
      retries: 5
    ports:
      - "8082:8080"
    environment:
      - DEBUG=true
      - MODELS_PATH=/models
    volumes:
      - ./models:/models

  oauth2-proxy:
    image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3
    container_name: oauth2-proxy
    restart: unless-stopped
    ports:
      - "8083:8083"
    depends_on:
      - localai
      - keycloak

    command:
      - --provider=keycloak-oidc
      - --http-address=0.0.0.0:8083
      - --upstream=http://localai:8080
      - --redirect-url=http://localhost:8083/oauth2/callback
      - --oidc-issuer-url=http://keycloak.local:8084/realms/master
      - --insecure-oidc-skip-issuer-verification=true
      - --client-id=localai-client
      - --client-secret=[ ENTER YOUR LOCALAI CLIENT-SECRET HERE LATER ]
      - --cookie-secret=[ PASTE openssl rand -base64 32 ]
      - --email-domain=*
      - --scope=openid profile email
      - --set-xauthrequest=true
      - --pass-access-token=true
      - --pass-authorization-header=true
      - --reverse-proxy=true
      - --skip-jwt-bearer-tokens=true

    environment:
      OAUTH2_PROXY_COOKIE_SECURE: "false"

volumes:
  postgres_data:
```

Start only the keycloak and postgres:
```
docker compose up keycloak postgres -d
```

### Configure keycloak
Follow these steps to configure a `trino-client` and a `localai-client` in the `master` realm:
```
master realm -> Users ->
Add user
username: yourname
Email, First name, Last name
[x] Email verified
-> Credentials tab
   -> Set password (2x)
      [ ] Temporary


master realm -> Clients
Create client
-> name trino-client
  -> General settings
    -> Client authentication [x]
    -> Standard Token exchange [x]
  -> Login settings
    -> Valid redirect URIs: https://localhost:8443/oauth2/callback
    -> Valid post logout URIs: https://localhost:8443/ui/logout/logout.html

Create client
-> name localai-client
  -> General settings
    -> Client authentication [x]
    -> Standard Token exchange [ ]
  -> Login settings
    -> Valid redirect URIs: http://localhost:8083/oauth2/callback


master realm -> Client scopes
Create scope ->
  -> name: trino-scope
  mappers -> Add mapper -> Configure a new mapper
  -> Type Audience
     -> name trino-audience-mapper
     -> included client audience: trino-client

Create scope ->
  -> name: localai-scope
  mappers -> Add mapper -> Configure a new mapper
  -> Type Audience
     -> name localai-audience-mapper
     -> included client audience: localai-client


master realm -> Clients
 -> trino-client
   -> Client scopes
     -> Add client scope
       -> trino-scope Add->Default
       -> localai-scope Add->Default
   -> Credentials
     -> Copy Client secret to a txt file we'll use later on

master realm -> Clients
 -> localai-client
   -> Client scopes
     -> Add client scope
       -> localai-scope Add->Default
   -> Credentials
     -> Copy Client secret and paste in docker-compose.yml
```

### Set up Trino
build the branch; `mvn clean install -DskipTests`

1. Create a directory in `~/bin/trino` (or anywhere you like)
2. In this directory, create a symlink to your Trino source: `ln -s /home/yourname/IdeaProjects/trino/core/trino-server/target`
3. Create file `start.sh` with content
```
#!/bin/bash
target/trino-server-*-SNAPSHOT/bin/launcher run  -etc-dir "$PWD/data/etc"
```
4. `chmod +x start.sh`
5. Create a file `client.sh` with content
```
#!/bin/bash
java -jar /home/yourname/IdeaProjects/trino/client/trino-cli/target/trino-cli-*-SNAPSHOT-executable.jar --server https://localhost:8443 --external-authentication --insecure
```
6. Run `mkdir data/etc -p`
7. Enter this directory `~/bin/trino/data/etc`
8. Create directory `certs` and enter it
Follow these steps:
```
# Create CA
openssl genrsa -out ca.key 4096

openssl req -x509 -new -nodes \
  -key ca.key \
  -sha256 -days 3650 \
  -out ca.crt \
  -subj "/CN=trino-ca"

# Create Coordinator cert
openssl genrsa -out coordinator.key 4096

openssl req -new \
  -key coordinator.key \
  -out coordinator.csr \
  -subj "/CN=coordinator"

openssl x509 -req \
  -in coordinator.csr \
  -CA ca.crt \
  -CAkey ca.key \
  -CAcreateserial \
  -out coordinator.crt \
  -days 3650 \
  -sha256

# Coordinator keystore
keytool -importcert \
  -trustcacerts \
  -alias coordinator \
  -file coordinator.crt \
  -keystore coordinator.jks \
  -storepass changeit \
  -noprompt
```
10. Go back to `~/bin/trino/data/etc`
11. Create `config.properties` with the following content:
```
coordinator=true
node-scheduler.include-coordinator=true
discovery.uri=https://localhost:8443

# OIDC authentication
http-server.authentication.type=oauth2
http-server.https.enabled=true
http-server.https.port=8443
http-server.https.keystore.path=/home/yourname/bin/trino/data/etc/certs/coordinator.jks
http-server.https.keystore.key=changeit


web-ui.authentication.type=oauth2

# Keycloak (OIDC)
http-server.authentication.oauth2.issuer=http://keycloak.local:8084/realms/master
http-server.authentication.oauth2.client-id=trino-client
http-server.authentication.oauth2.client-secret=[PASTE THE CLIENT-SECRET FROM KEYCLOAK trino-client SETUP HERE]
http-server.authentication.oauth2.scopes=openid,profile,email
http-server.authentication.oauth2.principal-field=preferred_username
#http-server.authentication.oauth2.refresh-tokens=true # TODO support this

http-server.https.enabled=true
http-server.http.enabled=false
http-server.http.port=8086

internal-communication.https.required=true
internal-communication.shared-secret=[RUN openssl rand 512 | base64 -w 0  AND PASTE THE RESULT HERE]
```
13. Create file `node.properties` with the following content:
```
node.environment=production
node.id=ffffffff-ffff-ffff-ffff-ffffffffffff
node.data-dir=/home/yourname/bin/trino/data
```
14. Create file `jvm.properties` with the content as described [here](https://trino.io/docs/current/installation/deployment.html#jvm-config)
15. Create directory `catalog` in `~/bin/trino/data/etc/` and enter it
16. Create file `llm.properties` with the following content:
```
connector.name=ai
ai.provider=openai
ai.model=ornith-1.0-9b
ai.openai.endpoint=http://localhost:8083
ai.openai.oauth2.audience=localai-client
ai.openai.oauth2.scope=openid profile
```
17. Run `docker compose up localai oauth2-proxy -d`
18. Validate that you can access `http://localhost:8083` and that OAuth2 is used to log you into localai. Download a model and test if it works (note: cpu is slow, you want to use a gpu backed localai)
19. Go back to `~/bin/trino/` and run `./start.sh`
20. In a second terminal, run `./client.sh`
21. Run `select 1;`
22. The browser should open a login prompt for the coordinator, login with the user as created in keycloak. If the username is different from the local user, add argument `--user yourusername` to the `client.sh`
23. If the `select 1;` succeeds, you can run `select llm.ai.ai_gen('What is the answer to life, the universe and everything?');`
24. 
<img width="902" height="235" alt="Screenshot from 2026-06-30 01-15-36" src="https://github.com/user-attachments/assets/c3acce64-f680-44cb-afb7-945038115952" />
25. Check the logging in the Trino `start.sh` terminal  


## Things TODO
1. First we should make sure this is the right approach
2. Add exchanged token caching
3. Improve the poor mans json parsing
4. Fix the flow when refresh tokens are enabled
5. Add junit tests


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( x ) Release notes are required, with the following suggested text:

```markdown
## General
* Add `CredentialProviders` interface to SPI to obtain on-behalf-of tokens to use to authenticate connected data sources
```
