### PR TITLE
Improve doc on `internal-communication.shared-secret`

### DIFF
--- a/docs/src/main/sphinx/security/internal-communication.md
+++ b/docs/src/main/sphinx/security/internal-communication.md
@@ -26,7 +26,7 @@ A large random key is recommended, and can be generated with the following Linux
 command:
 
 ```text
-openssl rand 512 | base64
+openssl rand 512 | base64 -w 0
 ```
 
 (verify-secrets)=


### PR DESCRIPTION
## Description
Remove line breaks from `base64 -d` with `-w 0`

## Release notes

( x ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
