### PR TITLE
Expose raw block arrays

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -230,6 +230,102 @@
                                     </old>
                                 </item>
                                 <!-- Backwards incompatible changes since the previous release -->
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method int io.trino.spi.block.ArrayBlock::getOffsetBase()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method io.trino.spi.block.Block io.trino.spi.block.ArrayBlock::getRawElementBlock()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method boolean[] io.trino.spi.block.ArrayBlock::getRawValueIsNull()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method boolean[] io.trino.spi.block.ByteArrayBlock::getRawValueIsNull()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method int io.trino.spi.block.Fixed12Block::getRawOffset()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method boolean[] io.trino.spi.block.Fixed12Block::getRawValueIsNull()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method int[] io.trino.spi.block.Fixed12Block::getRawValues()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method int io.trino.spi.block.Int128ArrayBlock::getRawOffset()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method boolean[] io.trino.spi.block.Int128ArrayBlock::getRawValueIsNull()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method long[] io.trino.spi.block.Int128ArrayBlock::getRawValues()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method boolean[] io.trino.spi.block.IntArrayBlock::getRawValueIsNull()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method boolean[] io.trino.spi.block.LongArrayBlock::getRawValueIsNull()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method long[] io.trino.spi.block.LongArrayBlock::getRawValues()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method int io.trino.spi.block.LongArrayBlock::getRawValuesOffset()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method int io.trino.spi.block.MapBlock::getOffsetBase()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method io.trino.spi.block.Block io.trino.spi.block.MapBlock::getRawKeyBlock()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method boolean[] io.trino.spi.block.MapBlock::getRawMapIsNull()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method io.trino.spi.block.Block io.trino.spi.block.MapBlock::getRawValueBlock()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method boolean[] io.trino.spi.block.ShortArrayBlock::getRawValueIsNull()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method short[] io.trino.spi.block.ShortArrayBlock::getRawValues()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method int io.trino.spi.block.ShortArrayBlock::getRawValuesOffset()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method int io.trino.spi.block.VariableWidthBlock::getRawArrayBase()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method int[] io.trino.spi.block.VariableWidthBlock::getRawOffsets()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityIncreased</code>
+                                    <old>method boolean[] io.trino.spi.block.VariableWidthBlock::getRawValueIsNull()</old>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
@@ -166,23 +166,23 @@ public final class ArrayBlock
         return values.getRegion(start, end - start);
     }
 
-    Block getRawElementBlock()
+    public Block getRawElementBlock()
     {
         return values;
     }
 
-    int[] getOffsets()
+    public int[] getRawOffsets()
     {
         return offsets;
     }
 
     @Nullable
-    boolean[] getRawValueIsNull()
+    public boolean[] getRawValueIsNull()
     {
         return valueIsNull;
     }
 
-    int getOffsetBase()
+    public int getOffsetBase()
     {
         return arrayOffset;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockBuilder.java
@@ -169,7 +169,7 @@ public class ArrayBlockBuilder
         }
 
         int offsetBase = arrayBlock.getOffsetBase();
-        int[] offsets = arrayBlock.getOffsets();
+        int[] offsets = arrayBlock.getRawOffsets();
         int startOffset = offsets[offsetBase + position];
         int length = offsets[offsetBase + position + 1] - startOffset;
 
@@ -200,7 +200,7 @@ public class ArrayBlockBuilder
         ArrayBlock arrayBlock = (ArrayBlock) block;
 
         int rawOffsetBase = arrayBlock.getOffsetBase();
-        int[] rawOffsets = arrayBlock.getOffsets();
+        int[] rawOffsets = arrayBlock.getRawOffsets();
         int startOffset = rawOffsets[rawOffsetBase + offset];
         int endOffset = rawOffsets[rawOffsetBase + offset + length];
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockEncoding.java
@@ -54,7 +54,7 @@ public class ArrayBlockEncoding
         int positionCount = arrayBlock.getPositionCount();
 
         int offsetBase = arrayBlock.getOffsetBase();
-        int[] offsets = arrayBlock.getOffsets();
+        int[] offsets = arrayBlock.getRawOffsets();
 
         int valuesStartOffset = offsets[offsetBase];
         int valuesEndOffset = offsets[offsetBase + positionCount];

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
@@ -248,7 +248,8 @@ public final class ByteArrayBlock
         return Slices.wrappedBuffer(values, arrayOffset, positionCount);
     }
 
-    boolean[] getRawValueIsNull()
+    @Nullable
+    public boolean[] getRawValueIsNull()
     {
         return valueIsNull;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ColumnarArray.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ColumnarArray.java
@@ -38,7 +38,7 @@ public class ColumnarArray
         }
 
         Block elementsBlock = arrayBlock.getRawElementBlock();
-        int[] offsets = arrayBlock.getOffsets();
+        int[] offsets = arrayBlock.getRawOffsets();
         int arrayOffset = arrayBlock.getOffsetBase();
 
         // trim elements to just visible region

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ColumnarMap.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ColumnarMap.java
@@ -39,7 +39,7 @@ public class ColumnarMap
         }
 
         int offsetBase = mapBlock.getOffsetBase();
-        int[] offsets = mapBlock.getOffsets();
+        int[] offsets = mapBlock.getRawOffsets();
 
         // get the keys and values for visible region
         int firstEntryPosition = offsets[offsetBase];

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
@@ -281,18 +281,18 @@ public final class Fixed12Block
         return values[offset + 2];
     }
 
-    int getRawOffset()
+    public int getRawOffset()
     {
         return positionOffset;
     }
 
     @Nullable
-    boolean[] getRawValueIsNull()
+    public boolean[] getRawValueIsNull()
     {
         return valueIsNull;
     }
 
-    int[] getRawValues()
+    public int[] getRawValues()
     {
         return values;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
@@ -243,18 +243,18 @@ public final class Int128ArrayBlock
         return BlockUtil.getNulls(valueIsNull, positionOffset, positionCount);
     }
 
-    int getRawOffset()
+    public int getRawOffset()
     {
         return positionOffset;
     }
 
     @Nullable
-    boolean[] getRawValueIsNull()
+    public boolean[] getRawValueIsNull()
     {
         return valueIsNull;
     }
 
-    long[] getRawValues()
+    public long[] getRawValues()
     {
         return values;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
@@ -225,7 +225,8 @@ public final class IntArrayBlock
         return BlockUtil.getNulls(valueIsNull, arrayOffset, positionCount);
     }
 
-    boolean[] getRawValueIsNull()
+    @Nullable
+    public boolean[] getRawValueIsNull()
     {
         return valueIsNull;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
@@ -225,17 +225,18 @@ public final class LongArrayBlock
         return BlockUtil.getNulls(valueIsNull, arrayOffset, positionCount);
     }
 
-    int getRawValuesOffset()
+    public int getRawValuesOffset()
     {
         return arrayOffset;
     }
 
-    long[] getRawValues()
+    public long[] getRawValues()
     {
         return values;
     }
 
-    boolean[] getRawValueIsNull()
+    @Nullable
+    public boolean[] getRawValueIsNull()
     {
         return valueIsNull;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
@@ -199,18 +199,18 @@ public final class MapBlock
         return valueBlock.getRegion(start, end - start);
     }
 
-    Block getRawKeyBlock()
+    public Block getRawKeyBlock()
     {
         return keyBlock;
     }
 
-    Block getRawValueBlock()
+    public Block getRawValueBlock()
     {
         return valueBlock;
     }
 
     @Nullable
-    boolean[] getRawMapIsNull()
+    public boolean[] getRawMapIsNull()
     {
         return mapIsNull;
     }
@@ -220,12 +220,12 @@ public final class MapBlock
         return hashTables;
     }
 
-    int[] getOffsets()
+    public int[] getRawOffsets()
     {
         return offsets;
     }
 
-    int getOffsetBase()
+    public int getOffsetBase()
     {
         return startOffset;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockBuilder.java
@@ -146,7 +146,7 @@ public class MapBlockBuilder
         }
 
         int offsetBase = mapBlock.getOffsetBase();
-        int[] offsets = mapBlock.getOffsets();
+        int[] offsets = mapBlock.getRawOffsets();
         int startOffset = offsets[offsetBase + position];
         int length = offsets[offsetBase + position + 1] - startOffset;
 

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlockEncoding.java
@@ -61,7 +61,7 @@ public class MapBlockEncoding
         int positionCount = mapBlock.getPositionCount();
 
         int offsetBase = mapBlock.getOffsetBase();
-        int[] offsets = mapBlock.getOffsets();
+        int[] offsets = mapBlock.getRawOffsets();
         Optional<int[]> hashTable = mapBlock.getHashTables().tryGet();
 
         int entriesStartOffset = offsets[offsetBase];

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
@@ -224,17 +224,18 @@ public final class ShortArrayBlock
         return BlockUtil.getNulls(valueIsNull, arrayOffset, positionCount);
     }
 
-    int getRawValuesOffset()
+    public int getRawValuesOffset()
     {
         return arrayOffset;
     }
 
-    short[] getRawValues()
+    public short[] getRawValues()
     {
         return values;
     }
 
-    boolean[] getRawValueIsNull()
+    @Nullable
+    public boolean[] getRawValueIsNull()
     {
         return valueIsNull;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
@@ -279,17 +279,18 @@ public final class VariableWidthBlock
         return new VariableWidthBlock(arrayOffset, positionCount + 1, slice, newOffsets, newValueIsNull);
     }
 
-    int getRawArrayBase()
+    public int getRawArrayBase()
     {
         return arrayOffset;
     }
 
-    int[] getRawOffsets()
+    public int[] getRawOffsets()
     {
         return offsets;
     }
 
-    boolean[] getRawValueIsNull()
+    @Nullable
+    public boolean[] getRawValueIsNull()
     {
         return valueIsNull;
     }


### PR DESCRIPTION
Some blocks expose raw array accessors and other do not.  This changes all blocks to expose the existing raw array and offset accessors.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## SPI
* Consistently expose block raw array accessors. ({issue}`issuenumber`)
```
