### PR TITLE
Improve CLI prompt color on dark terminal background

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/InputReader.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/InputReader.java
@@ -38,7 +38,6 @@ import static org.jline.reader.LineReader.MAIN;
 import static org.jline.reader.LineReader.Option.HISTORY_IGNORE_SPACE;
 import static org.jline.reader.LineReader.Option.HISTORY_TIMESTAMPED;
 import static org.jline.reader.LineReader.SECONDARY_PROMPT_PATTERN;
-import static org.jline.utils.AttributedStyle.BRIGHT;
 import static org.jline.utils.AttributedStyle.DEFAULT;
 
 public class InputReader
@@ -96,7 +95,7 @@ public class InputReader
 
     private static String colored(String value)
     {
-        return new AttributedString(value, DEFAULT.foreground(BRIGHT)).toAnsi();
+        return new AttributedString(value, DEFAULT.bold()).toAnsi();
     }
 
     private static KeyMap<Binding> configureKeyMap(LineReader reader, ClientOptions.EditingMode editingMode)

--- a/client/trino-cli/src/test/java/io/trino/cli/TestPromptColor.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestPromptColor.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.cli;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestPromptColor
+{
+    private static final char ESC = (char) 27;
+    // ESC + "[1m": SGR 1 = bold, applied to the terminal's default foreground.
+    private static final String BOLD = ESC + "[1m";
+    // ESC + "[90m": SGR 90 = "bright black" (dark gray), which has poor contrast on dark backgrounds.
+    private static final String GRAY_FOREGROUND = ESC + "[90m";
+
+    @Test
+    public void testPromptIsBoldAndNotLowContrastGray()
+            throws Exception
+    {
+        String prompt = colored("trino> ");
+
+        assertThat(prompt)
+                .as("CLI prompt should be bold over the terminal's default foreground")
+                .startsWith(BOLD)
+                .contains("trino> ");
+        assertThat(prompt)
+                .as("CLI prompt must not use the dark-gray foreground that is hard to read on dark backgrounds")
+                .doesNotContain(GRAY_FOREGROUND);
+    }
+
+    private static String colored(String value)
+            throws Exception
+    {
+        Method method = InputReader.class.getDeclaredMethod("colored", String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(null, value);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Change the Trino CLI prompt styling from a dark-gray foreground to bold over the
terminal's default foreground color. In InputReader.colored(), the prompt was styled
with DEFAULT.foreground(BRIGHT). In jline 4.0.15, AttributedStyle.BRIGHT == 8, i.e.
ANSI color index 8 ("bright black" / dark gray), emitted as ESC[90m. On a dark
terminal background this has poor contrast and is hard to read. The fix uses
DEFAULT.bold() (emitted as ESC[1m), which preserves the user's configured foreground
color and simply makes the prompt bold, so it stays legible on both dark and light
backgrounds. This also affects the -> continuation prompt, which shares the same helper.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes #6190

The chosen approach - bold over the default foreground rather than picking another
explicit color - is consistent with existing CLI styling (bold keywords in
InputHighlighter, BOLD.foreground(...) in Trino.java) and avoids assuming any
particular background/foreground palette.

Verified against the exact jline version (4.0.15): new AttributedString("trino> ",
DEFAULT.bold()).toAnsi() starts with ESC[1m, contains no ESC[90m, and preserves the
prompt text. A test, TestPromptColor, was added to assert the prompt is bold and does
not use the low-contrast gray escape.

Before: ESC[90mtrino> ESC[0m (dark gray)
After:  ESC[1mtrino> ESC[0m (bold, default foreground)

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## CLI
* Improve the readability of the prompt on terminals with a dark background. ({issue}`6190`)
```
