### PR TITLE
Fix double-rounding in shortDecimalToReal for high-scale short decimals

### DIFF
--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
@@ -1445,6 +1445,24 @@ public class TestDecimalCasts
         assertThat(assertions.expression("cast(a as REAL)")
                 .binding("a", "CAST(-16777217.0 AS DECIMAL(13,1))"))
                 .isEqualTo(-16777217.0f);
+
+        // Unscaled value far below 2^53 but still double-rounds when narrowing to real at scale 14
+        assertThat(assertions.expression("cast(a as REAL)")
+                .binding("a", "DECIMAL '0.00391462049447'"))
+                .isEqualTo(0.0039146203f);
+
+        assertThat(assertions.expression("cast(a as REAL)")
+                .binding("a", "DECIMAL '-0.00391462049447'"))
+                .isEqualTo(-0.0039146203f);
+
+        // Unscaled value above 2^53, where the double divide itself is inexact
+        assertThat(assertions.expression("cast(a as REAL)")
+                .binding("a", "DECIMAL '9600000841482239.99'"))
+                .isEqualTo(9.6e15f);
+
+        assertThat(assertions.expression("cast(a as REAL)")
+                .binding("a", "DECIMAL '-9600000841482239.99'"))
+                .isEqualTo(-9.6e15f);
     }
 
     @Test

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DecimalConversions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DecimalConversions.java
@@ -20,12 +20,19 @@ import java.math.BigInteger;
 
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
+import static io.trino.spi.type.Decimals.MAX_SHORT_PRECISION;
+import static io.trino.spi.type.Decimals.longTenToNth;
 import static io.trino.spi.type.Decimals.overflows;
 import static io.trino.spi.type.Int128Math.compareAbsolute;
 import static io.trino.spi.type.Int128Math.rescale;
+import static java.lang.Double.doubleToRawLongBits;
 import static java.lang.Double.parseDouble;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.parseFloat;
+import static java.lang.Math.abs;
+import static java.lang.Math.fma;
+import static java.lang.Math.nextDown;
+import static java.lang.Math.nextUp;
 import static java.lang.String.format;
 import static java.math.RoundingMode.HALF_UP;
 
@@ -52,6 +59,11 @@ public final class DecimalConversions
     private static final long MAX_EXACT_DOUBLE_LONG = MAX_EXACT_DOUBLE.toLongExact();
     // visible for testing
     static final Int128 MAX_EXACT_FLOAT = Int128.valueOf(1L << 24);
+    // The 29 significand bits a double loses when narrowed to a float: a midpoint sets them to 2^28, and the margin
+    // covers the under 2 ulps a rounded dividend shifts the quotient.
+    private static final long DISCARDED_FLOAT_BITS_MASK = (1L << 29) - 1;
+    private static final long DISCARDED_FLOAT_BITS_MIDPOINT = 1L << 28;
+    private static final long DISCARDED_FLOAT_BITS_MARGIN = 8;
 
     private DecimalConversions() {}
 
@@ -76,11 +88,35 @@ public final class DecimalConversions
 
     public static long shortDecimalToReal(long decimal, long tenToScale)
     {
-        // Divide in double to avoid double-rounding: ((float) decimal) / tenToScale first
-        // rounds the unscaled value to float (losing precision for |decimal| > 2^24),
-        // then divides — the composition can land on a different float than the correctly
-        // rounded mathematical result.
-        return floatToRawIntBits((float) ((double) decimal / tenToScale));
+        if (tenToScale == 1) {
+            return floatToRawIntBits((float) decimal);
+        }
+        // Dividing in double and narrowing to float rounds twice, which can only misround near a float midpoint.
+        double value = (double) decimal / tenToScale;
+        long discardedBits = doubleToRawLongBits(value) & DISCARDED_FLOAT_BITS_MASK;
+        if (abs(discardedBits - DISCARDED_FLOAT_BITS_MIDPOINT) > DISCARDED_FLOAT_BITS_MARGIN) {
+            return floatToRawIntBits((float) value);
+        }
+        if (-MAX_EXACT_DOUBLE_LONG <= decimal && decimal <= MAX_EXACT_DOUBLE_LONG) {
+            // An exact dividend rounds the divide correctly, so only a true midpoint misrounds.
+            if (discardedBits != DISCARDED_FLOAT_BITS_MIDPOINT) {
+                return floatToRawIntBits((float) value);
+            }
+            // Exact operands make the residual's sign exact: zero is a tie, its sign gives the side.
+            double residual = fma(value, tenToScale, -(double) decimal);
+            if (residual == 0) {
+                return floatToRawIntBits((float) value);
+            }
+            if (residual < 0) {
+                return floatToRawIntBits((float) nextUp(value));
+            }
+            return floatToRawIntBits((float) nextDown(value));
+        }
+        int scale = Long.numberOfTrailingZeros(tenToScale);
+        if (scale <= MAX_SHORT_PRECISION && longTenToNth(scale) == tenToScale) {
+            return floatToRawIntBits(BigDecimal.valueOf(decimal, scale).floatValue());
+        }
+        return floatToRawIntBits(BigDecimal.valueOf(decimal).divide(BigDecimal.valueOf(tenToScale)).floatValue());
     }
 
     public static long longDecimalToReal(Int128 decimal, long scale)

--- a/core/trino-spi/src/test/java/io/trino/spi/type/BenchmarkShortDecimalToReal.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/BenchmarkShortDecimalToReal.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.type;
+
+import io.trino.jmh.Benchmarks;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.spi.type.DecimalConversions.shortDecimalToReal;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 20)
+public class BenchmarkShortDecimalToReal
+{
+    @Benchmark
+    public long convert(Data data)
+    {
+        long tenToScale = data.tenToScale;
+        long result = 0;
+        for (long decimal : data.decimals) {
+            result += shortDecimalToReal(decimal, tenToScale);
+        }
+        return result;
+    }
+
+    @State(Scope.Thread)
+    public static class Data
+    {
+        // Enough values to amortize the harness overhead of a sub-nanosecond conversion, while the
+        // array still fits in L1.
+        private static final int COUNT = 1024;
+
+        @Param
+        public Distribution distribution;
+
+        public long[] decimals;
+        public long tenToScale;
+
+        @Setup
+        public void setup()
+        {
+            tenToScale = distribution.tenToScale();
+            decimals = distribution.decimals(COUNT);
+        }
+    }
+
+    public enum Distribution
+    {
+        RANDOM_SCALE_0(0),
+        RANDOM_SCALE_2(2),
+        RANDOM_SCALE_8(8),
+        RANDOM_SCALE_18(18),
+        /**
+         * Quotients that sit exactly on a float midpoint and are exactly representable, so the tie breaks
+         * to even. Exact multiples of a power of one half qualify wherever the float spacing lines up:
+         * scale 1 values ending in .5 between 2^23 and 2^24, all .25 and .75 values an octave below
+         * that, and so on.
+         */
+        MIDPOINT_EXACT_QUOTIENT(1),
+        /**
+         * Quotients on a midpoint that are not exactly representable, resolved from the sign of the
+         * fused multiply-add residual.
+         */
+        MIDPOINT_INEXACT_QUOTIENT(14),
+        /**
+         * The same, but with an unscaled value above 2^53, where the dividend has itself rounded and only
+         * {@link BigDecimal} can settle the direction. About 1 in 2^25 uniformly distributed values.
+         */
+        MIDPOINT_ABOVE_MAX_EXACT(18);
+
+        private final int scale;
+
+        Distribution(int scale)
+        {
+            this.scale = scale;
+        }
+
+        public long tenToScale()
+        {
+            long tenToScale = 1;
+            for (int i = 0; i < scale; i++) {
+                tenToScale *= 10;
+            }
+            return tenToScale;
+        }
+
+        public long[] decimals(int count)
+        {
+            return switch (this) {
+                case RANDOM_SCALE_0, RANDOM_SCALE_2, RANDOM_SCALE_8, RANDOM_SCALE_18 -> randomDecimals(count);
+                case MIDPOINT_EXACT_QUOTIENT -> exactMidpointDecimals(count);
+                // An unscaled value only lands on a midpoint once tenToScale exceeds the quotient's ulp, and the
+                // midpoint is only inexact while it still has a fractional part. Both hold near 70 at scale 14.
+                case MIDPOINT_INEXACT_QUOTIENT -> inexactMidpointDecimals(count, tenToScale(), 70f);
+                case MIDPOINT_ABOVE_MAX_EXACT -> inexactMidpointDecimals(count, tenToScale(), 0.1f);
+            };
+        }
+
+        private static long[] randomDecimals(int count)
+        {
+            Random random = new Random(0);
+            long[] decimals = new long[count];
+            for (int i = 0; i < count; i++) {
+                long decimal = (long) (random.nextDouble() * 1e18);
+                if (random.nextBoolean()) {
+                    decimal = -decimal;
+                }
+                decimals[i] = decimal;
+            }
+            return decimals;
+        }
+
+        private static long[] exactMidpointDecimals(int count)
+        {
+            long[] decimals = new long[count];
+            for (int i = 0; i < count; i++) {
+                decimals[i] = ((1L << 23) + i) * 10 + 5;
+            }
+            return decimals;
+        }
+
+        private static long[] inexactMidpointDecimals(int count, long tenToScale, float from)
+        {
+            long[] decimals = new long[count];
+            float value = from;
+            for (int i = 0; i < count; i++) {
+                value = Math.nextUp(value);
+                double midpoint = ((double) value + (double) Math.nextUp(value)) / 2;
+                decimals[i] = new BigDecimal(midpoint)
+                        .multiply(BigDecimal.valueOf(tenToScale))
+                        .setScale(0, RoundingMode.HALF_UP)
+                        .longValueExact();
+            }
+            return decimals;
+        }
+    }
+
+    static void main()
+            throws RunnerException
+    {
+        Benchmarks.benchmark(BenchmarkShortDecimalToReal.class).run();
+    }
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestDecimalConversions.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestDecimalConversions.java
@@ -25,6 +25,7 @@ import static io.trino.spi.type.DecimalConversions.MAX_EXACT_FLOAT;
 import static io.trino.spi.type.DecimalConversions.longDecimalToDouble;
 import static io.trino.spi.type.DecimalConversions.longDecimalToReal;
 import static io.trino.spi.type.DecimalConversions.shortDecimalToDouble;
+import static io.trino.spi.type.DecimalConversions.shortDecimalToReal;
 import static io.trino.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static java.lang.Math.toIntExact;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,6 +65,25 @@ class TestDecimalConversions
     }
 
     @Test
+    void testShortDecimalToReal()
+    {
+        BigInteger shortDecimalBound = BigInteger.TEN.pow(MAX_SHORT_PRECISION);
+        for (BigInteger unscaledValue : testValues()) {
+            if (unscaledValue.abs().compareTo(shortDecimalBound) >= 0) {
+                // does not fit in a short decimal
+                continue;
+            }
+            long unscaled = unscaledValue.longValueExact();
+            for (int scale = 0; scale <= MAX_SHORT_PRECISION; scale++) {
+                long tenToScale = BigInteger.TEN.pow(scale).longValueExact();
+                assertThat(Float.intBitsToFloat(toIntExact(shortDecimalToReal(unscaled, tenToScale))))
+                        .as("shortDecimalToReal(%s, scale=%d)", unscaled, scale)
+                        .isEqualTo(new BigDecimal(unscaledValue, scale).floatValue());
+            }
+        }
+    }
+
+    @Test
     void testLongDecimalToReal()
     {
         for (BigInteger unscaledValue : testValues()) {
@@ -92,6 +112,28 @@ class TestDecimalConversions
                 values.add(cutoff.add(BigInteger.valueOf(delta)).negate());
             }
         }
+
+        values.add(new BigInteger("9007199791611905"));
+        values.add(new BigInteger("9007199791611905").negate());
+
+        // Well below 2^53 but still double-rounds when narrowing to real at high scale (e.g. scale 14):
+        // (float) ((double) 391462049447 / 1e14) lands one ULP off the correctly rounded float.
+        values.add(new BigInteger("391462049447"));
+        values.add(new BigInteger("391462049447").negate());
+
+        // Above 2^53 near a float midpoint at scale 2, resolved through BigDecimal
+        values.add(new BigInteger("960000084148223999"));
+        values.add(new BigInteger("960000084148223999").negate());
+
+        // Exact float midpoints at scale 1 (8388608.5 and 8388609.5), where the tie resolves down and up to even
+        values.add(new BigInteger("83886085"));
+        values.add(new BigInteger("83886085").negate());
+        values.add(new BigInteger("83886095"));
+        values.add(new BigInteger("83886095").negate());
+
+        // Within the midpoint margin at scale 14 but not a midpoint, so the double divide already rounds correctly
+        values.add(new BigInteger("300315360073"));
+        values.add(new BigInteger("300315360073").negate());
 
         values.add(new BigInteger("12345678901234567890"));
         values.add(new BigInteger("12345678901234567890").negate());


### PR DESCRIPTION
## Description
Currently, `shortDecimalToReal` computed `(float) ((double) decimal / tenToScale)`, which rounds twice and can land on a different float than the correctly rounded result:
```SQL
    SELECT CAST(DECIMAL '9600000841482239.99' AS REAL);  -- was 9.600001E15, correct is 9.6E15
```
`longDecimalToReal` was already correctly rounded, so the same value cast differently depending on its precision.

The Fix: The double divide is kept. Only quotients near a float midpoint divert to `BigDecimal`, since that is where the two roundings can disagree. 

## Additional context and related issues
- https://github.com/trinodb/trino/pull/29378
- Sibling of https://github.com/trinodb/trino/pull/29831

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix incorrect results when casting some short `DECIMAL` values to `REAL`.
```
