### PR TITLE
Update Web UI development instructions

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -260,28 +260,36 @@ the [docs module](../docs).
 
 ## Building the Web UI
 
-The Trino Web UI is composed of several React components and is written in JSX
-and ES6. This source code is compiled and packaged into browser-compatible
-Javascript, which is then checked in to the Trino source code (in the `dist`
-folder). You must have [Node.js](https://nodejs.org/en/download/) and
-[Yarn](https://yarnpkg.com/en/) installed to execute these commands. To update
-this folder after making changes, simply run:
+The Trino Web UI is a React and Vite project located in
+`core/trino-web-ui/src/main/resources/webapp`. You must have
+[Node.js](https://nodejs.org/en/download/) and npm installed to execute these
+commands. Install dependencies with:
 
-    yarn --cwd core/trino-web-ui/src/main/resources/webapp/src install
+    cd core/trino-web-ui/src/main/resources/webapp
+    npm install
 
-If no Javascript dependencies have changed (i.e., no changes to `package.json`),
-it is faster to run:
+For fast local development, run the `WebUiQueryRunner` class. This starts a
+minimal Trino development server configured with the Web UI. Then start the Vite
+development server:
 
-    yarn --cwd core/trino-web-ui/src/main/resources/webapp/src run package
+    npm run dev
 
-To simplify iteration, you can also run in `watch` mode, which automatically
-re-compiles when changes to source files are detected:
+Open `http://localhost:5173/ui` in your browser. The Vite development server
+provides Hot Module Replacement for quick iteration. By default, requests to
+`/ui/auth` and `/ui/api` are proxied to `http://127.0.0.1:8080/`. To use a
+different backend, update `VITE_BASE_URL` in
+`core/trino-web-ui/src/main/resources/webapp/.env.development`.
 
-    yarn --cwd core/trino-web-ui/src/main/resources/webapp/src run watch
+To build the Web UI locally, run:
 
-To iterate quickly, simply re-build the project in IntelliJ after packaging is
-complete. Project resources will be hot-reloaded and changes are reflected on
-browser refresh.
+    npm run build
+
+To run frontend checks, run:
+
+    npm run check
+
+Maven builds package the Web UI automatically, and Maven verification runs the
+frontend checks.
 
 ## Releases
 


### PR DESCRIPTION
## Description

Updates the Web UI development instructions in `DEVELOPMENT.md` for the new default React/Vite Web UI in `core/trino-web-ui/src/main/resources/webapp`.

The section now documents the npm-based workflow for installing dependencies, running the Vite development server, building locally, and running frontend checks.

## Additional context and related issues

The previous instructions described the legacy ui Yarn/Webpack workflow and no longer matched the default Web UI stack.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
