### PR TITLE
Fix XXE vulnerability in SalesforceBasicAuthenticator XML parser

### DIFF
--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/salesforce/SalesforceBasicAuthenticator.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/salesforce/SalesforceBasicAuthenticator.java
@@ -149,6 +149,11 @@ public class SalesforceBasicAuthenticator
         Document xmlResponse;
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalDTD", "");
+            factory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalSchema", "");
             DocumentBuilder builder = factory.newDocumentBuilder();
             xmlResponse = builder.parse(new InputSource(Reader.of(
                     response.getBody())));


### PR DESCRIPTION
## Description

The `DocumentBuilderFactory` in `SalesforceBasicAuthenticator` was
instantiated without any restrictions on DOCTYPE declarations or external
entity resolution. This means the XML parser would process external entities
in any response it receives — if the connection to `login.salesforce.com`
were intercepted or redirected (DNS spoofing, MITM, misconfigured proxy),
a crafted XML response could trigger Blind SSRF or local file read from
the Coordinator node.

Added the standard set of JAXP features to lock down the parser:
- `disallow-doctype-decl` — rejects any response with a DOCTYPE declaration outright
- `external-general-entities` / `external-parameter-entities` — disabled
- `accessExternalDTD` / `accessExternalSchema` — restricted to empty string

Salesforce SOAP responses only ever contain simple element nodes (`sessionId`,
`organizationId`), so these restrictions have zero impact on normal operation.

## Additional context and related issues

Classic OWASP XXE (A05:2021) pattern — using `DocumentBuilderFactory`
without restricting the parser configuration is a well-known footgun in
Java XML handling. The fix is minimal and fully backward-compatible.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.