### PR TITLE
Ship AWS SDK kms on Iceberg REST catalog SigV4 path

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -401,6 +401,12 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>kms</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-security-keyvault-keys</artifactId>
             <scope>test</scope>
@@ -725,12 +731,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-postgresql</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>kms</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Description

Fixes #30163.

Iceberg REST catalogs configured with `iceberg.rest-catalog.security=SIGV4` fail on first query with:

```
java.lang.NoClassDefFoundError: Could not initialize class org.apache.iceberg.aws.AwsProperties
```

The SigV4 signing path loads `org.apache.iceberg.aws.AwsProperties`, whose static initializer (as of Iceberg 1.11.0) references `software.amazon.awssdk.services.kms.model.EncryptionAlgorithmSpec`. The AWS SDK `kms` artifact was declared with `test` scope, so it was excluded from the shipped plugin, making the class fail to initialize.

This changes the `kms` dependency to `runtime` scope so it is packaged with the plugin. Trino's own code does not reference KMS at compile time (only Iceberg does, at class-init), so `runtime` is the appropriate scope.

## Additional context and related issues

See #30163 for the full stack trace and a minimal, credential-free reproduction. Mounting `kms-<version>.jar` into the plugin directory was confirmed to resolve the failure independently of this build change.

## Release notes

```
## Iceberg
* Fix `NoClassDefFoundError` for `org.apache.iceberg.aws.AwsProperties` when using an Iceberg REST catalog with SigV4 signing. ({issue}`30163`)
```
