### PR TITLE
TypeSignatureTranslator cache keys should be case sensitive

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/TypeDescriptorTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/TypeDescriptorTranslator.java
@@ -110,7 +110,7 @@ public final class TypeDescriptorTranslator
     public static TypeDescriptor parseTypeDescriptor(String signature)
     {
         try {
-            return toTypeDescriptor(DATA_TYPE_CACHE.get(signature.toLowerCase(ENGLISH), () -> parseDataType(signature)));
+            return toTypeDescriptor(DATA_TYPE_CACHE.get(signature, () -> parseDataType(signature)));
         }
         catch (Exception e) {
             if (e.getCause() != null) {

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestTypeDescriptorTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestTypeDescriptorTranslator.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.analyzer;
 
+import io.trino.spi.type.TypeDescriptor;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.tree.Identifier;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Comparator;
 import java.util.Locale;
 
+import static io.trino.sql.analyzer.TypeDescriptorTranslator.parseTypeDescriptor;
 import static io.trino.sql.analyzer.TypeDescriptorTranslator.toDataType;
 import static io.trino.sql.analyzer.TypeDescriptorTranslator.toTypeDescriptor;
 import static io.trino.sql.parser.ParserAssert.type;
@@ -98,5 +100,33 @@ public class TestTypeDescriptorTranslator
     public void testComplexTypes()
     {
         assertRoundTrip("ROW(x BIGINT, y DOUBLE PRECISION, z ROW(m array<bigint>,n map<double,varchar>))");
+    }
+
+    @Test
+    public void testParseTypeDescriptorPreservesRowFieldNameCase()
+    {
+        // Regression test for a cache poisoning bug where DATA_TYPE_CACHE was keyed by the lowercased signature
+        // while storing the DataType parsed from the original-cased signature. The first case-variant of a row
+        // signature would then win for every later lookup, returning field names with the wrong casing.
+        // Downstream, NamedTypeSignature.equals is case-sensitive on field names, so function dependency
+        // resolution would miss and throw UndeclaredDependencyException at filter compile time.
+        TypeDescriptor camelCaseFirst = parseTypeDescriptor("row(\"memberId\" integer, \"viewerUrn\" varchar)");
+        TypeDescriptor lowerCaseAfter = parseTypeDescriptor("row(\"memberid\" integer, \"viewerurn\" varchar)");
+
+        assertThat(camelCaseFirst.toString())
+                .isEqualTo("row(\"memberId\" integer,\"viewerUrn\" varchar)");
+        assertThat(lowerCaseAfter.toString())
+                .isEqualTo("row(\"memberid\" integer,\"viewerurn\" varchar)");
+        assertThat(camelCaseFirst).isNotEqualTo(lowerCaseAfter);
+
+        // Reverse order: lowercase first, camelCase second. Both must still preserve their input casing.
+        TypeDescriptor lowerCaseFirst = parseTypeDescriptor("row(\"actorurn\" varchar, \"appname\" varchar)");
+        TypeDescriptor camelCaseAfter = parseTypeDescriptor("row(\"actorUrn\" varchar, \"appName\" varchar)");
+
+        assertThat(lowerCaseFirst.toString())
+                .isEqualTo("row(\"actorurn\" varchar,\"appname\" varchar)");
+        assertThat(camelCaseAfter.toString())
+                .isEqualTo("row(\"actorUrn\" varchar,\"appName\" varchar)");
+        assertThat(lowerCaseFirst).isNotEqualTo(camelCaseAfter);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Previously, when a new entry is added to TypeSignatureTranslator `DATA_TYPE_CACHE` cache, the key would always be set to lower case with the corresponding value unchanged. However, this results in a bug where case sensitive keys that should have different entries in the cache (ex: row(memberId integer) vs row(memberID integer)) getting mapped to the same key value.

Since `NamedTypeSignature.equals` compares field names case-sensitively, the mismatched casing caused `ResolvedFunction.typeDependencies()` to miss bound row types, throwing `UndeclaredDependencyException` at filter compile time.

This PR updates so that `DATA_TYPE_CACHE` cache keys are case sensitive. The max size of the cache is still 4096 with the only side effect being more cache misses.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

