### PR TITLE
Add support for SELECT list EXCLUDE syntax

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -365,9 +365,13 @@ setQuantifier
     ;
 
 selectItem
-    : expression (AS? identifier)?                          #selectSingle
-    | primaryExpression '.' ASTERISK (AS columnAliases)?    #selectAll
-    | ASTERISK                                              #selectAll
+    : expression (AS? identifier)?                                                 #selectSingle
+    | primaryExpression '.' ASTERISK ('(' excludeClause ')')?  (AS columnAliases)? #selectAll
+    | ASTERISK ('(' excludeClause ')')?                                            #selectAll
+    ;
+
+excludeClause
+    : EXCLUDE '(' qualifiedName (',' qualifiedName)* ')'
     ;
 
 relation
@@ -1204,6 +1208,7 @@ END: 'END';
 ERROR: 'ERROR';
 ESCAPE: 'ESCAPE';
 EXCEPT: 'EXCEPT';
+EXCLUDE: 'EXCLUDE';
 EXCLUDING: 'EXCLUDING';
 EXECUTE: 'EXECUTE';
 EXISTS: 'EXISTS';

--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -369,9 +369,13 @@ setQuantifier
     ;
 
 selectItem
-    : expression (AS? identifier)?                          #selectSingle
-    | primaryExpression '.' ASTERISK (AS columnAliases)?    #selectAll
-    | ASTERISK                                              #selectAll
+    : expression (AS? identifier)?                                                 #selectSingle
+    | primaryExpression '.' ASTERISK ('(' excludeClause ')')?  (AS columnAliases)? #selectAll
+    | ASTERISK ('(' excludeClause ')')?                                            #selectAll
+    ;
+
+excludeClause
+    : EXCLUDE '(' qualifiedName (',' qualifiedName)* ')'
     ;
 
 relation
@@ -1208,6 +1212,7 @@ END: 'END';
 ERROR: 'ERROR';
 ESCAPE: 'ESCAPE';
 EXCEPT: 'EXCEPT';
+EXCLUDE: 'EXCLUDE';
 EXCLUDING: 'EXCLUDING';
 EXECUTE: 'EXECUTE';
 EXISTS: 'EXISTS';

--- a/core/trino-grammar/src/test/java/io/trino/grammar/sql/TestSqlKeywords.java
+++ b/core/trino-grammar/src/test/java/io/trino/grammar/sql/TestSqlKeywords.java
@@ -105,6 +105,7 @@ public class TestSqlKeywords
                         "ERROR",
                         "ESCAPE",
                         "EXCEPT",
+                        "EXCLUDE",
                         "EXCLUDING",
                         "EXECUTE",
                         "EXISTS",

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -5292,6 +5292,7 @@ class StatementAnalyzer
                         RelationType relationType = identifierChainBasis.get().getRelationType().orElseThrow();
                         List<Field> requestedFields = relationType.resolveVisibleFieldsWithRelationPrefix(Optional.of(prefix));
                         List<Field> fields = filterInaccessibleFields(requestedFields);
+                        fields = excludeColumns(allColumns, fields);
                         if (fields.isEmpty()) {
                             if (!requestedFields.isEmpty()) {
                                 throw semanticException(TABLE_NOT_FOUND, allColumns, "Relation not found or not allowed");
@@ -5331,6 +5332,7 @@ class StatementAnalyzer
 
                 List<Field> requestedFields = (List<Field>) scope.getRelationType().getVisibleFields();
                 List<Field> fields = filterInaccessibleFields(requestedFields);
+                fields = excludeColumns(allColumns, fields);
                 if (fields.isEmpty()) {
                     if (node.getFrom().isEmpty()) {
                         throw semanticException(COLUMN_NOT_FOUND, allColumns, "SELECT * not allowed in queries without FROM clause");
@@ -5383,6 +5385,29 @@ class StatementAnalyzer
             return fields.stream()
                     .filter(accessibleFields.build()::contains)
                     .collect(toImmutableList());
+        }
+
+        private static List<Field> excludeColumns(AllColumns allColumns, List<Field> fields)
+        {
+            List<QualifiedName> excludeColumns = allColumns.getExcludedColumns();
+            if (excludeColumns.isEmpty()) {
+                return fields;
+            }
+
+            // Validate that all excluded names actually exist in the expanded field list
+            for (QualifiedName excluded : excludeColumns) {
+                boolean found = fields.stream().anyMatch(field -> field.canResolve(excluded));
+                if (!found) {
+                    throw semanticException(COLUMN_NOT_FOUND, allColumns, "Column '%s' not found in SELECT * expansion", excluded);
+                }
+            }
+            List<Field> outputFields = fields.stream()
+                    .filter(field -> excludeColumns.stream().noneMatch(field::canResolve))
+                    .collect(toImmutableList());
+            if (outputFields.isEmpty()) {
+                throw semanticException(COLUMN_NOT_FOUND, allColumns, "SELECT list is empty after excluding all columns");
+            }
+            return outputFields;
         }
 
         private void analyzeAllColumnsFromTable(

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -5370,6 +5370,7 @@ class StatementAnalyzer
                         RelationType relationType = identifierChainBasis.get().getRelationType().orElseThrow();
                         List<Field> requestedFields = relationType.resolveVisibleFieldsWithRelationPrefix(Optional.of(prefix));
                         List<Field> fields = filterInaccessibleFields(requestedFields);
+                        fields = excludeColumns(allColumns, fields);
                         if (fields.isEmpty()) {
                             if (!requestedFields.isEmpty()) {
                                 throw semanticException(TABLE_NOT_FOUND, allColumns, "Relation not found or not allowed");
@@ -5409,6 +5410,7 @@ class StatementAnalyzer
 
                 List<Field> requestedFields = (List<Field>) scope.getRelationType().getVisibleFields();
                 List<Field> fields = filterInaccessibleFields(requestedFields);
+                fields = excludeColumns(allColumns, fields);
                 if (fields.isEmpty()) {
                     if (node.getFrom().isEmpty()) {
                         throw semanticException(COLUMN_NOT_FOUND, allColumns, "SELECT * not allowed in queries without FROM clause");
@@ -5461,6 +5463,29 @@ class StatementAnalyzer
             return fields.stream()
                     .filter(accessibleFields.build()::contains)
                     .collect(toImmutableList());
+        }
+
+        private static List<Field> excludeColumns(AllColumns allColumns, List<Field> fields)
+        {
+            List<QualifiedName> excludeColumns = allColumns.getExcludedColumns();
+            if (excludeColumns.isEmpty()) {
+                return fields;
+            }
+
+            // Validate that all excluded names actually exist in the expanded field list
+            for (QualifiedName excluded : excludeColumns) {
+                boolean found = fields.stream().anyMatch(field -> field.canResolve(excluded));
+                if (!found) {
+                    throw semanticException(COLUMN_NOT_FOUND, allColumns, "Column '%s' not found in SELECT * expansion", excluded);
+                }
+            }
+            List<Field> outputFields = fields.stream()
+                    .filter(field -> excludeColumns.stream().noneMatch(field::canResolve))
+                    .collect(toImmutableList());
+            if (outputFields.isEmpty()) {
+                throw semanticException(COLUMN_NOT_FOUND, allColumns, "SELECT list is empty after excluding all columns");
+            }
+            return outputFields;
         }
 
         private void analyzeAllColumnsFromTable(

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -499,6 +499,30 @@ public class TestAnalyzer
         assertFails("SELECT t.a FROM (SELECT t.* FROM (VALUES 1) t(a))")
                 .hasErrorCode(COLUMN_NOT_FOUND)
                 .hasMessage("line 1:8: Column 't.a' cannot be resolved");
+
+        // EXCLUDE valid usage
+        analyze("SELECT * (EXCLUDE (a)) FROM t1");
+        analyze("SELECT * (EXCLUDE (a, b)) FROM t1");
+        analyze("SELECT t1.* (EXCLUDE (c)) FROM t1");
+        analyze("SELECT t1.* (EXCLUDE (t1.c)) FROM t1");
+
+        // EXCLUDE nonexistent column
+        assertFails("SELECT * (EXCLUDE (nonexistent)) FROM t1")
+                .hasErrorCode(COLUMN_NOT_FOUND)
+                .hasMessage("line 1:8: Column 'nonexistent' not found in SELECT * expansion");
+
+        assertFails("SELECT t1.* (EXCLUDE (nonexistent)) FROM t1")
+                .hasErrorCode(COLUMN_NOT_FOUND)
+                .hasMessage("line 1:8: Column 'nonexistent' not found in SELECT * expansion");
+
+        assertFails("SELECT t1.* (EXCLUDE (u1.c)) FROM t1")
+                .hasErrorCode(COLUMN_NOT_FOUND)
+                .hasMessage("line 1:8: Column 'u1.c' not found in SELECT * expansion");
+
+        // EXCLUDE all columns
+        assertFails("SELECT * (EXCLUDE (a, b, c, d)) FROM t1")
+                .hasErrorCode(COLUMN_NOT_FOUND)
+                .hasMessage("line 1:8: SELECT list is empty after excluding all columns");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSelectAll.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSelectAll.java
@@ -247,4 +247,41 @@ public class TestSelectAll
         assertThat(assertions.query("SELECT * FROM (VALUES 0) t(a), LATERAL (SELECT t2.* from (VALUES 1, 2), LATERAL (SELECT t.*) t2(b))")).failure().hasMessageMatching(UNSUPPORTED_DECORRELATION_MESSAGE);
         assertThat(assertions.query("SELECT * FROM (VALUES 0, 1) t(a), LATERAL (SELECT * from (VALUES 2), LATERAL (SELECT t.*))")).matches("VALUES (0, 2, 0), (1, 2, 1)");
     }
+
+    @Test
+    void testSelectExclude()
+    {
+        // exclude a single column
+        assertThat(assertions.query("SELECT * (EXCLUDE (a)) FROM (VALUES (1, 2, 3)) t(a, b, c)"))
+                .matches("VALUES (2, 3)");
+        assertThat(assertions.query("SELECT * (EXCLUDE (b)) FROM (VALUES (1, 2, 3)) t(a, b, c)"))
+                .matches("VALUES (1, 3)");
+        assertThat(assertions.query("SELECT * (EXCLUDE (c)) FROM (VALUES (1, 2, 3)) t(a, b, c)"))
+                .matches("VALUES (1, 2)");
+
+        assertThat(assertions.query("SELECT c, * (EXCLUDE (c)) FROM (VALUES (1, 2, 3)) t(a, b, c)"))
+                .matches("VALUES (3, 1, 2)");
+        assertThat(assertions.query("SELECT * (EXCLUDE (c)), c FROM (VALUES (1, 2, 3)) t(a, b, c)"))
+                .matches("VALUES (1, 2, 3)");
+        assertThat(assertions.query("SELECT *, * (EXCLUDE (c)) FROM (VALUES (1, 2, 3)) t(a, b, c)"))
+                .matches("VALUES (1, 2, 3, 1, 2)");
+
+        // exclude a duplicate column
+        assertThat(assertions.query("SELECT * (EXCLUDE (c)) FROM (VALUES (1, 2, 3, 4)) t(a, b, c, c)"))
+                .matches("VALUES (1, 2)");
+
+        // exclude multiple columns
+        assertThat(assertions.query("SELECT * (EXCLUDE (a, b)) FROM (VALUES (1, 2, 3)) t(a, b, c)"))
+                .matches("VALUES 3");
+        assertThat(assertions.query("SELECT * (EXCLUDE (b, a)) FROM (VALUES (1, 2, 3)) t(a, b, c)"))
+                .matches("VALUES 3");
+
+        // qualified-asterisk variant
+        assertThat(assertions.query("SELECT t.* (EXCLUDE (a)) FROM (VALUES (1, 2, 3)) t(a, b, c)"))
+                .matches("VALUES (2, 3)");
+
+        // case insensitivity
+        assertThat(assertions.query("SELECT * (EXCLUDE (\"A\")) FROM (VALUES (1, 2, 3)) t(a, b, c)"))
+                .matches("VALUES (2, 3)");
+    }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -748,6 +748,14 @@ public final class ExpressionFormatter
                 builder.append("*");
             }
 
+            if (!node.getExcludedColumns().isEmpty()) {
+                builder.append(" (EXCLUDE (");
+                Joiner.on(", ").appendTo(builder, node.getExcludedColumns().stream()
+                        .map(col -> formatName(col))
+                        .collect(toList()));
+                builder.append("))");
+            }
+
             if (!node.getAliases().isEmpty()) {
                 builder.append(" AS (");
                 Joiner.on(", ").appendTo(builder, node.getAliases().stream()

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -844,6 +844,14 @@ public final class SqlFormatter
                     .append("."));
             builder.append("*");
 
+            if (!node.getExcludedColumns().isEmpty()) {
+                builder.append(" (EXCLUDE (")
+                        .append(Joiner.on(", ").join(node.getExcludedColumns().stream()
+                                .map(SqlFormatter::formatName)
+                                .collect(toImmutableList())))
+                        .append("))");
+            }
+
             if (!node.getAliases().isEmpty()) {
                 builder.append(" AS (")
                         .append(Joiner.on(", ").join(node.getAliases().stream()

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -846,6 +846,14 @@ public final class SqlFormatter
                     .append("."));
             builder.append("*");
 
+            if (!node.getExcludedColumns().isEmpty()) {
+                builder.append(" (EXCLUDE (")
+                        .append(Joiner.on(", ").join(node.getExcludedColumns().stream()
+                                .map(SqlFormatter::formatName)
+                                .collect(toImmutableList())))
+                        .append("))");
+            }
+
             if (!node.getAliases().isEmpty()) {
                 builder.append(" AS (")
                         .append(Joiner.on(", ").join(node.getAliases().stream()

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -1523,10 +1523,18 @@ class AstBuilder
             aliases = visit(context.columnAliases().identifier(), Identifier.class);
         }
 
+        List<QualifiedName> excludedColumns = ImmutableList.of();
+        if (context.excludeClause() != null) {
+            excludedColumns = context.excludeClause().qualifiedName().stream()
+                    .map(this::getQualifiedName)
+                    .collect(toImmutableList());
+        }
+
         return new AllColumns(
                 getLocation(context),
                 visitIfPresent(context.primaryExpression(), Expression.class),
-                aliases);
+                aliases,
+                excludedColumns);
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -1540,10 +1540,18 @@ class AstBuilder
             aliases = visit(context.columnAliases().identifier(), Identifier.class);
         }
 
+        List<QualifiedName> excludedColumns = ImmutableList.of();
+        if (context.excludeClause() != null) {
+            excludedColumns = context.excludeClause().qualifiedName().stream()
+                    .map(this::getQualifiedName)
+                    .collect(toImmutableList());
+        }
+
         return new AllColumns(
                 getLocation(context),
                 visitIfPresent(context.primaryExpression(), Expression.class),
-                aliases);
+                aliases,
+                excludedColumns);
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AllColumns.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AllColumns.java
@@ -27,37 +27,51 @@ public class AllColumns
 {
     private final List<Identifier> aliases;
     private final Optional<Expression> target;
+    private final List<QualifiedName> excludedColumns;
 
     @Deprecated
     public AllColumns()
     {
-        this(Optional.empty(), Optional.empty(), ImmutableList.of());
+        this(Optional.empty(), Optional.empty(), ImmutableList.of(), ImmutableList.of());
     }
 
     @Deprecated
     public AllColumns(Expression target, List<Identifier> aliases)
     {
-        this(Optional.empty(), Optional.of(target), aliases);
+        this(Optional.empty(), Optional.of(target), aliases, ImmutableList.of());
     }
 
     @Deprecated
     public AllColumns(Optional<NodeLocation> location, Optional<Expression> target, List<Identifier> aliases)
     {
+        this(location, target, aliases, ImmutableList.of());
+    }
+
+    @Deprecated
+    public AllColumns(Optional<NodeLocation> location, Optional<Expression> target, List<Identifier> aliases, List<QualifiedName> excludedColumns)
+    {
         super(location);
         this.aliases = ImmutableList.copyOf(requireNonNull(aliases, "aliases is null"));
         this.target = requireNonNull(target, "target is null");
+        this.excludedColumns = ImmutableList.copyOf(excludedColumns);
     }
 
     public AllColumns(NodeLocation location)
     {
-        this(location, Optional.empty(), ImmutableList.of());
+        this(location, Optional.empty(), ImmutableList.of(), ImmutableList.of());
     }
 
     public AllColumns(NodeLocation location, Optional<Expression> target, List<Identifier> aliases)
     {
+        this(location, target, aliases, ImmutableList.of());
+    }
+
+    public AllColumns(NodeLocation location, Optional<Expression> target, List<Identifier> aliases, List<QualifiedName> excludedColumns)
+    {
         super(location);
         this.aliases = ImmutableList.copyOf(aliases);
         this.target = requireNonNull(target, "target is null");
+        this.excludedColumns = ImmutableList.copyOf(excludedColumns);
     }
 
     public List<Identifier> getAliases()
@@ -68,6 +82,11 @@ public class AllColumns
     public Optional<Expression> getTarget()
     {
         return target;
+    }
+
+    public List<QualifiedName> getExcludedColumns()
+    {
+        return excludedColumns;
     }
 
     @Override
@@ -95,13 +114,14 @@ public class AllColumns
 
         AllColumns other = (AllColumns) o;
         return Objects.equals(aliases, other.aliases) &&
-                Objects.equals(target, other.target);
+                Objects.equals(target, other.target) &&
+                Objects.equals(excludedColumns, other.excludedColumns);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(aliases, target);
+        return Objects.hash(aliases, target, excludedColumns);
     }
 
     @Override
@@ -111,6 +131,12 @@ public class AllColumns
 
         target.ifPresent(value -> builder.append(value).append("."));
         builder.append("*");
+
+        if (!excludedColumns.isEmpty()) {
+            builder.append(" (EXCLUDE (");
+            Joiner.on(", ").appendTo(builder, excludedColumns);
+            builder.append("))");
+        }
 
         if (!aliases.isEmpty()) {
             builder.append(" (");
@@ -128,6 +154,8 @@ public class AllColumns
             return false;
         }
 
-        return aliases.equals(((AllColumns) other).aliases);
+        AllColumns otherAllColumns = (AllColumns) other;
+        return aliases.equals(otherAllColumns.aliases) &&
+                excludedColumns.equals(otherAllColumns.excludedColumns);
     }
 }

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -910,6 +910,108 @@ public class TestSqlParser
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty()));
+
+        // EXCLUDE clause on bare *
+        assertThat(statement("SELECT * (EXCLUDE (a, b)) FROM t"))
+                .isEqualTo(new Query(
+                        location(1, 1),
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        new QuerySpecification(
+                                location(1, 1),
+                                new Select(
+                                        location(1, 1),
+                                        false,
+                                        ImmutableList.of(
+                                                new AllColumns(
+                                                        location(1, 8),
+                                                        Optional.empty(),
+                                                        ImmutableList.of(),
+                                                        ImmutableList.of(qualifiedName(location(1, 20), "a"), qualifiedName(location(1, 23), "b"))))),
+                                Optional.of(new Table(location(1, 32), qualifiedName(location(1, 32), "t"))),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()));
+
+        // EXCLUDE clause on qualified *
+        assertThat(statement("SELECT r.* (EXCLUDE (x)) FROM t"))
+                .isEqualTo(new Query(
+                        location(1, 1),
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        new QuerySpecification(
+                                location(1, 1),
+                                new Select(
+                                        location(1, 1),
+                                        false,
+                                        ImmutableList.of(
+                                                new AllColumns(
+                                                        location(1, 8),
+                                                        Optional.of(new Identifier(location(1, 8), "r", false)),
+                                                        ImmutableList.of(),
+                                                        ImmutableList.of(qualifiedName(location(1, 22), "x"))))),
+                                Optional.of(new Table(location(1, 31), qualifiedName(location(1, 31), "t"))),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()));
+
+        // EXCLUDE clause with qualified column name
+        assertThat(statement("SELECT * (EXCLUDE (t.a)) FROM t"))
+                .isEqualTo(new Query(
+                        location(1, 1),
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        new QuerySpecification(
+                                location(1, 1),
+                                new Select(
+                                        location(1, 1),
+                                        false,
+                                        ImmutableList.of(
+                                                new AllColumns(
+                                                        location(1, 8),
+                                                        Optional.empty(),
+                                                        ImmutableList.of(),
+                                                        ImmutableList.of(QualifiedName.of(ImmutableList.of(new Identifier(location(1, 20), "t", false), new Identifier(location(1, 22), "a", false))))))),
+                                Optional.of(new Table(location(1, 31), qualifiedName(location(1, 31), "t"))),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()));
+
+        // EXCLUDE has an empty list
+        assertStatementIsInvalid("SELECT * (EXCLUDE ()) FROM t1")
+                .withMessage("line 1:20: mismatched input ')'. Expecting: <identifier>");
+
+        // EXCLUDE always requires () for column names
+        assertStatementIsInvalid("SELECT * (EXCLUDE x) FROM t1")
+                .withMessage("line 1:19: mismatched input 'x'. Expecting: '('");
+
+        // EXCLUDE can only be used with *
+        assertStatementIsInvalid("SELECT a (EXCLUDE (b)) FROM t1")
+                .withMessage("line 1:11: mismatched input 'EXCLUDE'. Expecting: ')', '*', 'ALL', 'DISTINCT', 'ORDER', <expression>, <identifier>");
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -911,6 +911,108 @@ public class TestSqlParser
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty()));
+
+        // EXCLUDE clause on bare *
+        assertThat(statement("SELECT * (EXCLUDE (a, b)) FROM t"))
+                .isEqualTo(new Query(
+                        location(1, 1),
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        new QuerySpecification(
+                                location(1, 1),
+                                new Select(
+                                        location(1, 1),
+                                        false,
+                                        ImmutableList.of(
+                                                new AllColumns(
+                                                        location(1, 8),
+                                                        Optional.empty(),
+                                                        ImmutableList.of(),
+                                                        ImmutableList.of(qualifiedName(location(1, 20), "a"), qualifiedName(location(1, 23), "b"))))),
+                                Optional.of(new Table(location(1, 32), qualifiedName(location(1, 32), "t"))),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()));
+
+        // EXCLUDE clause on qualified *
+        assertThat(statement("SELECT r.* (EXCLUDE (x)) FROM t"))
+                .isEqualTo(new Query(
+                        location(1, 1),
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        new QuerySpecification(
+                                location(1, 1),
+                                new Select(
+                                        location(1, 1),
+                                        false,
+                                        ImmutableList.of(
+                                                new AllColumns(
+                                                        location(1, 8),
+                                                        Optional.of(new Identifier(location(1, 8), "r", false)),
+                                                        ImmutableList.of(),
+                                                        ImmutableList.of(qualifiedName(location(1, 22), "x"))))),
+                                Optional.of(new Table(location(1, 31), qualifiedName(location(1, 31), "t"))),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()));
+
+        // EXCLUDE clause with qualified column name
+        assertThat(statement("SELECT * (EXCLUDE (t.a)) FROM t"))
+                .isEqualTo(new Query(
+                        location(1, 1),
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        new QuerySpecification(
+                                location(1, 1),
+                                new Select(
+                                        location(1, 1),
+                                        false,
+                                        ImmutableList.of(
+                                                new AllColumns(
+                                                        location(1, 8),
+                                                        Optional.empty(),
+                                                        ImmutableList.of(),
+                                                        ImmutableList.of(QualifiedName.of(ImmutableList.of(new Identifier(location(1, 20), "t", false), new Identifier(location(1, 22), "a", false))))))),
+                                Optional.of(new Table(location(1, 31), qualifiedName(location(1, 31), "t"))),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()));
+
+        // EXCLUDE has an empty list
+        assertStatementIsInvalid("SELECT * (EXCLUDE ()) FROM t1")
+                .withMessage("line 1:20: mismatched input ')'. Expecting: <identifier>");
+
+        // EXCLUDE always requires () for column names
+        assertStatementIsInvalid("SELECT * (EXCLUDE x) FROM t1")
+                .withMessage("line 1:19: mismatched input 'x'. Expecting: '('");
+
+        // EXCLUDE can only be used with *
+        assertStatementIsInvalid("SELECT a (EXCLUDE (b)) FROM t1")
+                .withMessage("line 1:11: mismatched input 'EXCLUDE'. Expecting: ')', '*', 'ALL', 'DISTINCT', 'ORDER', <expression>, <identifier>");
     }
 
     @Test

--- a/docs/src/main/sphinx/language/reserved.md
+++ b/docs/src/main/sphinx/language/reserved.md
@@ -38,6 +38,7 @@ be quoted (using double quotes) in order to be used as an identifier.
 | `END`               | reserved | reserved |
 | `ESCAPE`            | reserved | reserved |
 | `EXCEPT`            | reserved | reserved |
+| `EXCLUDE`           |          |          |
 | `EXISTS`            | reserved | reserved |
 | `EXTRACT`           | reserved | reserved |
 | `FALSE`             | reserved | reserved |

--- a/docs/src/main/sphinx/sql/select.md
+++ b/docs/src/main/sphinx/sql/select.md
@@ -334,6 +334,60 @@ SELECT (ROW(1, true)).*;
 (1 row)
 ```
 
+### Excluding columns
+
+The `EXCLUDE` clause can be used with `*` or `relation.*` to select all
+columns except those listed:
+
+```text
+* (EXCLUDE ( column_name [, ...] ))
+relation.* (EXCLUDE ( column_name [, ...] ))
+```
+
+This avoids enumerating every column when only a few need to be omitted.
+Column names in the `EXCLUDE` list are matched case-insensitively. If
+the same name matches multiple columns (for example, due to a join or an
+aliased relation with duplicate names), all matching columns are excluded.
+
+The following query returns all columns of `t` except `a`:
+
+```sql
+SELECT * (EXCLUDE (a)) FROM (VALUES (1, 2, 3)) t(a, b, c);
+```
+
+```text
+ b | c
+---+---
+ 2 | 3
+(1 row)
+```
+
+Multiple columns can be excluded:
+
+```sql
+SELECT * (EXCLUDE (a, b)) FROM (VALUES (1, 2, 3)) t(a, b, c);
+```
+
+```text
+ c
+---
+ 3
+(1 row)
+```
+
+The qualified-asterisk form also supports `EXCLUDE`:
+
+```sql
+SELECT t.* (EXCLUDE (a)) FROM (VALUES (1, 2, 3)) t(a, b, c);
+```
+
+```text
+ b | c
+---+---
+ 2 | 3
+(1 row)
+```
+
 ## GROUP BY clause
 
 The `GROUP BY` clause divides the output of a `SELECT` statement into


### PR DESCRIPTION
## Description

Add support for `SELECT * EXCLUDE (col, ...)` syntax, which allows excluding specific columns from a wildcard select without listing all remaining columns.

This syntax is now part of the SQL standard (expected to be published next year) according to [this post](https://peter.eisentraut.org/blog/2026/06/30/waiting-for-sql-202y-stockholm-meeting-report) and is already supported by DuckDB, BigQuery, and others. This PR implements `EXCLUDE` only; `REPLACE` and `RENAME` variants are not included.

Example:

```sql
SELECT * (EXCLUDE (comment)) FROM region;

 regionkey |    name
-----------+-------------
         0 | AFRICA
         1 | AMERICA
         2 | ASIA
         3 | EUROPE
         4 | MIDDLE EAST
(5 rows)
```

## Release notes

```markdown
## General
* Add support for `SELECT * EXCLUDE` syntax. ({issue}`30179`)
```
