### PR TITLE
 Fix/remove incorrect ORC CHAR predicate pushdown which silently drops rows

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/TupleDomainOrcPredicate.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/TupleDomainOrcPredicate.java
@@ -46,7 +46,6 @@ import java.util.function.Function;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
-import static io.trino.spi.type.Chars.truncateToLengthAndTrimSpaces;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.DateType.DATE;
@@ -235,7 +234,7 @@ public class TupleDomainOrcPredicate
             return createDomain(type, hasNullValue, columnStatistics.getDecimalStatistics(), value -> Int128.valueOf(rescale(value, decimalType).unscaledValue()));
         }
         else if (type instanceof CharType && columnStatistics.getStringStatistics() != null) {
-            return createDomain(type, hasNullValue, columnStatistics.getStringStatistics(), value -> truncateToLengthAndTrimSpaces(value, type));
+            return Domain.create(ValueSet.all(type), hasNullValue);
         }
         else if (type instanceof VarcharType && columnStatistics.getStringStatistics() != null) {
             return createDomain(type, hasNullValue, columnStatistics.getStringStatistics());

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestOrcCharPredicatePruning.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestOrcCharPredicatePruning.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.orc;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.orc.metadata.OrcColumnId;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.type.CharType;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.orc.OrcReader.MAX_BATCH_SIZE;
+import static io.trino.orc.OrcTester.HIVE_STORAGE_TIME_ZONE;
+import static io.trino.orc.OrcTester.READER_OPTIONS;
+import static io.trino.orc.OrcTester.writeOrcColumnTrino;
+import static io.trino.orc.metadata.CompressionKind.NONE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestOrcCharPredicatePruning
+{
+    private static final CharType CHAR2 = CharType.createCharType(2);
+
+    @Test
+    public void testCharStripeNotPrunedForControlCharValue()
+            throws Exception
+    {
+        List<String> values = ImmutableList.of("z", "z\t", "za");
+
+        try (TempFile tempFile = new TempFile()) {
+            writeOrcColumnTrino(tempFile.getFile(), NONE, CHAR2, values.iterator(), new OrcWriterStats());
+
+            Domain predicate = Domain.singleValue(CHAR2, utf8Slice("z\t"));
+            List<String> read = readWithPredicate(tempFile, predicate);
+            assertThat(read).contains("z\t");
+        }
+    }
+
+    private static List<String> readWithPredicate(TempFile tempFile, Domain domain)
+            throws IOException
+    {
+        TupleDomainOrcPredicate predicate = TupleDomainOrcPredicate.builder()
+                .addColumn(new OrcColumnId(1), domain)
+                .build();
+
+        List<String> result = new ArrayList<>();
+        try (OrcDataSource orcDataSource = new FileOrcDataSource(tempFile.getFile(), READER_OPTIONS)) {
+            OrcReader orcReader = OrcReader.createOrcReader(orcDataSource, READER_OPTIONS)
+                    .orElseThrow(() -> new RuntimeException("File is empty"));
+            try (OrcRecordReader recordReader = orcReader.createRecordReader(
+                    orcReader.getRootColumn().getNestedColumns(),
+                    ImmutableList.of(CHAR2),
+                    false,
+                    predicate,
+                    HIVE_STORAGE_TIME_ZONE,
+                    newSimpleAggregatedMemoryContext(),
+                    MAX_BATCH_SIZE,
+                    RuntimeException::new)) {
+                while (true) {
+                    SourcePage page = recordReader.nextPage();
+                    if (page == null) {
+                        break;
+                    }
+                    Block block = page.getBlock(0);
+                    for (int i = 0; i < block.getPositionCount(); i++) {
+                        result.add(CHAR2.getSlice(block, i).toStringUtf8());
+                    }
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestTupleDomainOrcPredicate.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestTupleDomainOrcPredicate.java
@@ -223,24 +223,24 @@ public class TestTupleDomainOrcPredicate
         assertThat(getDomain(CHAR, 10, stringColumnStats(0L, null, null))).isEqualTo(onlyNull(CHAR));
         assertThat(getDomain(CHAR, 10, stringColumnStats(10L, null, null))).isEqualTo(notNull(CHAR));
 
-        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, "taco      ", "taco      "))).isEqualTo(singleValue(CHAR, utf8Slice("taco")));
-        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, "taco", "taco      "))).isEqualTo(singleValue(CHAR, utf8Slice("taco")));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, "taco      ", "taco      "))).isEqualTo(notNull(CHAR));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, "taco", "taco      "))).isEqualTo(notNull(CHAR));
 
-        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, "apple     ", "taco      "))).isEqualTo(create(ValueSet.ofRanges(range(CHAR, utf8Slice("apple"), true, utf8Slice("taco"), true)), false));
-        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, "apple     ", "taco"))).isEqualTo(create(ValueSet.ofRanges(range(CHAR, utf8Slice("apple"), true, utf8Slice("taco"), true)), false));
-        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, null, "taco      "))).isEqualTo(create(ValueSet.ofRanges(lessThanOrEqual(CHAR, utf8Slice("taco"))), false));
-        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, null, "taco"))).isEqualTo(create(ValueSet.ofRanges(lessThanOrEqual(CHAR, utf8Slice("taco"))), false));
-        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, "apple     ", null))).isEqualTo(create(ValueSet.ofRanges(greaterThanOrEqual(CHAR, utf8Slice("apple"))), false));
-        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, "apple", null))).isEqualTo(create(ValueSet.ofRanges(greaterThanOrEqual(CHAR, utf8Slice("apple"))), false));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, "apple     ", "taco      "))).isEqualTo(notNull(CHAR));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, "apple     ", "taco"))).isEqualTo(notNull(CHAR));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, null, "taco      "))).isEqualTo(notNull(CHAR));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, null, "taco"))).isEqualTo(notNull(CHAR));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, "apple     ", null))).isEqualTo(notNull(CHAR));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, "apple", null))).isEqualTo(notNull(CHAR));
 
-        assertThat(getDomain(CHAR, 10, stringColumnStats(5L, "apple     ", "taco      "))).isEqualTo(create(ValueSet.ofRanges(range(CHAR, utf8Slice("apple"), true, utf8Slice("taco"), true)), true));
-        assertThat(getDomain(CHAR, 10, stringColumnStats(5L, "apple     ", "taco"))).isEqualTo(create(ValueSet.ofRanges(range(CHAR, utf8Slice("apple"), true, utf8Slice("taco"), true)), true));
-        assertThat(getDomain(CHAR, 10, stringColumnStats(5L, null, "taco      "))).isEqualTo(create(ValueSet.ofRanges(lessThanOrEqual(CHAR, utf8Slice("taco"))), true));
-        assertThat(getDomain(CHAR, 10, stringColumnStats(5L, null, "taco"))).isEqualTo(create(ValueSet.ofRanges(lessThanOrEqual(CHAR, utf8Slice("taco"))), true));
-        assertThat(getDomain(CHAR, 10, stringColumnStats(5L, "apple     ", null))).isEqualTo(create(ValueSet.ofRanges(greaterThanOrEqual(CHAR, utf8Slice("apple"))), true));
-        assertThat(getDomain(CHAR, 10, stringColumnStats(5L, "apple", null))).isEqualTo(create(ValueSet.ofRanges(greaterThanOrEqual(CHAR, utf8Slice("apple"))), true));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(5L, "apple     ", "taco      "))).isEqualTo(all(CHAR));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(5L, "apple     ", "taco"))).isEqualTo(all(CHAR));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(5L, null, "taco      "))).isEqualTo(all(CHAR));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(5L, null, "taco"))).isEqualTo(all(CHAR));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(5L, "apple     ", null))).isEqualTo(all(CHAR));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(5L, "apple", null))).isEqualTo(all(CHAR));
 
-        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, "\0 ", " "))).isEqualTo(create(ValueSet.ofRanges(range(CHAR, utf8Slice("\0"), true, utf8Slice(""), true)), false));
+        assertThat(getDomain(CHAR, 10, stringColumnStats(10L, "\0 ", " "))).isEqualTo(notNull(CHAR));
     }
 
     private static ColumnStatistics stringColumnStats(Long numberOfValues, String minimum, String maximum)


### PR DESCRIPTION
## Description
ORC predicate pushdown built a pruning range for CHAR(n) columns from the column's string min/max statistics. Those statistics are ordered by plain binary comparison, but CHAR comparison is space-padded (a shorter value is padded with 0x20). The two orderings disagree for any value containing a byte below 0x20 (e.g. TAB): such a value sorts before its shorter prefix under CHAR semantics but after it in the binary stats. The derived [min, max] range then excludes real values, and the stripe is pruned — silently dropping matching rows.

**Example**: a column with 'z', 'z'+TAB, 'za' has binary stats min="z", max="za". SELECT * FROM t WHERE c = 'z' || chr(9) prunes the stripe and returns no rows.

**Why remove the pruning instead of fixing the bounds**: 
1. Error-prone fix: reconciling ORC's binary-order byte stats with CHAR's space-padded compare needs fragile UTF-8 byte arithmetic — a likely source of the next silent-wrong-result bug.
2. Marginal benefit: Parquet never did CHAR stats pruning either; this just makes them consistent.

We may consider adding it back later if the benefits are more visible.

## Additional context and related issues


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive, Iceberg, Lakehouse
*  Fix incorrect results for queries with a filter on `CHAR` columns in ORC files.
```
