### PR TITLE
Add zstd_compress and zstd_decompress functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
@@ -17,6 +17,10 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Ints;
+import io.airlift.compress.v3.MalformedInputException;
+import io.airlift.compress.v3.zstd.ZstdCompressor;
+import io.airlift.compress.v3.zstd.ZstdDecompressor;
+import io.airlift.compress.v3.zstd.ZstdNativeCompressor;
 import io.airlift.slice.Murmur3Hash128;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -44,6 +48,9 @@ public final class VarbinaryFunctions
             '0', '1', '2', '3', '4', '5', '6', '7',
             '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
     };
+
+    private static final int ZSTD_MIN_COMPRESSION_LEVEL = 1;
+    private static final int ZSTD_MAX_COMPRESSION_LEVEL = 22;
 
     private VarbinaryFunctions() {}
 
@@ -377,6 +384,65 @@ public final class VarbinaryFunctions
         CRC32 crc32 = new CRC32();
         crc32.update(slice.byteArray(), slice.byteArrayOffset(), slice.length());
         return crc32.getValue();
+    }
+
+    @Description("Compresses binary data using Zstandard")
+    @ScalarFunction("zstd_compress")
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice zstdCompress(@SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        return zstdCompress(slice, ZstdCompressor.create());
+    }
+
+    @Description("Compresses binary data using Zstandard at the given compression level (1-22, higher is slower and smaller). Requires the native Zstandard compressor to be available on the current platform")
+    @ScalarFunction("zstd_compress")
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice zstdCompress(@SqlType(StandardTypes.VARBINARY) Slice slice, @SqlType(StandardTypes.BIGINT) long level)
+    {
+        if (level < ZSTD_MIN_COMPRESSION_LEVEL || level > ZSTD_MAX_COMPRESSION_LEVEL) {
+            throw new TrinoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    "zstd compression level must be between %s and %s: %s".formatted(ZSTD_MIN_COMPRESSION_LEVEL, ZSTD_MAX_COMPRESSION_LEVEL, level));
+        }
+        if (!ZstdNativeCompressor.isEnabled()) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "zstd_compress with an explicit level requires the native Zstandard compressor, which is not available on this platform");
+        }
+        return zstdCompress(slice, ZstdCompressor.create((int) level));
+    }
+
+    private static Slice zstdCompress(Slice slice, ZstdCompressor compressor)
+    {
+        byte[] input = slice.byteArray();
+        int inputOffset = slice.byteArrayOffset();
+        int inputLength = slice.length();
+        byte[] output = new byte[compressor.maxCompressedLength(inputLength)];
+        int outputLength = compressor.compress(input, inputOffset, inputLength, output, 0, output.length);
+        return Slices.wrappedBuffer(output, 0, outputLength);
+    }
+
+    @Description("Decompresses Zstandard-compressed binary data")
+    @ScalarFunction("zstd_decompress")
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice zstdDecompress(@SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        ZstdDecompressor decompressor = ZstdDecompressor.create();
+        byte[] input = slice.byteArray();
+        int inputOffset = slice.byteArrayOffset();
+        int inputLength = slice.length();
+        try {
+            long decompressedSize = decompressor.getDecompressedSize(input, inputOffset, inputLength);
+            if (decompressedSize < 0 || decompressedSize > Integer.MAX_VALUE) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "invalid zstd frame: content size is unknown or too large");
+            }
+            byte[] output = new byte[(int) decompressedSize];
+            decompressor.decompress(input, inputOffset, inputLength, output, 0, output.length);
+            return Slices.wrappedBuffer(output);
+        }
+        catch (MalformedInputException | IllegalArgumentException e) {
+            // The pure-Java decompressor throws MalformedInputException; the native
+            // decompressor reports the same class of error as IllegalArgumentException.
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "invalid zstd frame: " + e.getMessage(), e);
+        }
     }
 
     @Description("Suffix starting at given index")

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
@@ -19,13 +19,14 @@ import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Ints;
 import io.airlift.compress.v3.MalformedInputException;
 import io.airlift.compress.v3.zstd.ZstdCompressor;
-import io.airlift.compress.v3.zstd.ZstdDecompressor;
+import io.airlift.compress.v3.zstd.ZstdInputStream;
 import io.airlift.compress.v3.zstd.ZstdNativeCompressor;
 import io.airlift.slice.Murmur3Hash128;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.slice.SpookyHashV2;
 import io.airlift.slice.XxHash64;
+import io.airlift.units.DataSize;
 import io.trino.spi.TrinoException;
 import io.trino.spi.function.Description;
 import io.trino.spi.function.LiteralParameters;
@@ -33,14 +34,18 @@ import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Base64;
 import java.util.HexFormat;
 import java.util.zip.CRC32;
 
 import static io.airlift.slice.Slices.EMPTY_SLICE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.operator.scalar.HmacFunctions.computeHash;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.util.Failures.checkCondition;
+import static java.lang.Math.toIntExact;
 
 public final class VarbinaryFunctions
 {
@@ -51,6 +56,7 @@ public final class VarbinaryFunctions
 
     private static final int ZSTD_MIN_COMPRESSION_LEVEL = 1;
     private static final int ZSTD_MAX_COMPRESSION_LEVEL = 22;
+    private static final int ZSTD_MAX_DECOMPRESSED_SIZE = toIntExact(DataSize.of(4, MEGABYTE).toBytes());
 
     private VarbinaryFunctions() {}
 
@@ -425,22 +431,19 @@ public final class VarbinaryFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice zstdDecompress(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
-        ZstdDecompressor decompressor = ZstdDecompressor.create();
-        byte[] input = slice.byteArray();
-        int inputOffset = slice.byteArrayOffset();
-        int inputLength = slice.length();
-        try {
-            long decompressedSize = decompressor.getDecompressedSize(input, inputOffset, inputLength);
-            if (decompressedSize < 0 || decompressedSize > Integer.MAX_VALUE) {
-                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "invalid zstd frame: content size is unknown or too large");
-            }
-            byte[] output = new byte[(int) decompressedSize];
-            decompressor.decompress(input, inputOffset, inputLength, output, 0, output.length);
+        // Decompress incrementally instead of trusting the size declared in the frame header.
+        // The header is optional, it only describes the first of possibly several concatenated
+        // frames, and it is under the control of whoever produced the input.
+        try (InputStream input = new ZstdInputStream(slice.getInput())) {
+            byte[] output = input.readNBytes(ZSTD_MAX_DECOMPRESSED_SIZE + 1);
+            checkCondition(
+                    output.length <= ZSTD_MAX_DECOMPRESSED_SIZE,
+                    INVALID_FUNCTION_ARGUMENT,
+                    "result of zstd_decompress function must not exceed %s bytes",
+                    ZSTD_MAX_DECOMPRESSED_SIZE);
             return Slices.wrappedBuffer(output);
         }
-        catch (MalformedInputException | IllegalArgumentException e) {
-            // The pure-Java decompressor throws MalformedInputException; the native
-            // decompressor reports the same class of error as IllegalArgumentException.
+        catch (IOException | MalformedInputException | IllegalArgumentException e) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "invalid zstd frame: " + e.getMessage(), e);
         }
     }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestVarbinaryFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestVarbinaryFunctions.java
@@ -816,6 +816,32 @@ public class TestVarbinaryFunctions
     }
 
     @Test
+    public void testZstdCompress()
+    {
+        assertThat(assertions.expression("zstd_decompress(zstd_compress(CAST('hello world' AS VARBINARY)))"))
+                .isEqualTo(sqlVarbinary("hello world"));
+
+        assertThat(assertions.expression("zstd_decompress(zstd_compress(CAST('' AS VARBINARY)))"))
+                .isEqualTo(sqlVarbinary(""));
+
+        assertThat(assertions.expression("zstd_decompress(zstd_compress(CAST('hello world' AS VARBINARY), 19))"))
+                .isEqualTo(sqlVarbinary("hello world"));
+
+        assertTrinoExceptionThrownBy(assertions.expression("zstd_compress(CAST('hello world' AS VARBINARY), 0)")::evaluate)
+                .hasMessage("zstd compression level must be between 1 and 22: 0");
+
+        assertTrinoExceptionThrownBy(assertions.expression("zstd_compress(CAST('hello world' AS VARBINARY), 23)")::evaluate)
+                .hasMessage("zstd compression level must be between 1 and 22: 23");
+    }
+
+    @Test
+    public void testZstdDecompress()
+    {
+        assertTrinoExceptionThrownBy(assertions.expression("zstd_decompress(CAST('not a zstd frame' AS VARBINARY))")::evaluate)
+                .hasMessageStartingWith("invalid zstd frame");
+    }
+
+    @Test
     public void testVarbinarySubstring()
     {
         // TODO

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestVarbinaryFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestVarbinaryFunctions.java
@@ -45,6 +45,15 @@ public class TestVarbinaryFunctions
 {
     private static final byte[] ALL_BYTES;
 
+    /**
+     * A 274 byte Zstandard frame that expands to 8MB of zero bytes, produced by
+     * {@code head -c 8388608 /dev/zero | zstd -19}.
+     */
+    private static final String ZSTD_EXPANSION_BOMB = "KLUv/QRoTAAACAABAPz/ORACAgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIAEAACABAA"
+            + "AgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIA"
+            + "EAACABAAAgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIAEAACABAAAgAQAAIAEAADABAA"
+            + "D9/2YQ==";
+
     static {
         ALL_BYTES = new byte[256];
         for (int i = 0; i < ALL_BYTES.length; i++) {
@@ -837,8 +846,27 @@ public class TestVarbinaryFunctions
     @Test
     public void testZstdDecompress()
     {
+        // "hello world" compressed by the zstd command line tool reading from a pipe. The frame
+        // header of a stream of unknown length does not declare the size of the content.
+        assertThat(assertions.expression("zstd_decompress(from_base64('KLUv/QRYWQAAaGVsbG8gd29ybGRoaR6y'))"))
+                .isEqualTo(sqlVarbinary("hello world"));
+
+        // "hello " and "world" compressed separately and concatenated, which the format allows.
+        // Both frames declare their content size, but the size in the first one covers only the
+        // first one.
+        assertThat(assertions.expression("zstd_decompress(from_base64('KLUv/SQGMQAAaGVsbG8g0jvhqSi1L/0kBSkAAHdvcmxk71HuZg=='))"))
+                .isEqualTo(sqlVarbinary("hello world"));
+
         assertTrinoExceptionThrownBy(assertions.expression("zstd_decompress(CAST('not a zstd frame' AS VARBINARY))")::evaluate)
                 .hasMessageStartingWith("invalid zstd frame");
+
+        // the first half of a valid frame
+        assertTrinoExceptionThrownBy(assertions.expression("zstd_decompress(from_base64('KLUv/QRYWQAAaGVs'))")::evaluate)
+                .hasMessageStartingWith("invalid zstd frame");
+
+        // a 274 byte frame that expands to 8MB of zero bytes
+        assertTrinoExceptionThrownBy(assertions.expression("zstd_decompress(from_base64('%s'))".formatted(ZSTD_EXPANSION_BOMB))::evaluate)
+                .hasMessage("result of zstd_decompress function must not exceed 4194304 bytes");
     }
 
     @Test

--- a/docs/src/main/sphinx/functions/binary.md
+++ b/docs/src/main/sphinx/functions/binary.md
@@ -202,3 +202,27 @@ Computes HMAC with SHA256 of `binary` with the given `key`.
 :::{function} hmac_sha512(binary, key) -> varbinary
 Computes HMAC with SHA512 of `binary` with the given `key`.
 :::
+
+## Compression functions
+
+The compression functions implement the [Zstandard](https://facebook.github.io/zstd/)
+({rfc}`8878`) compression format.
+
+:::{function} zstd_compress(binary) -> varbinary
+Compresses `binary` using Zstandard at the default compression level.
+:::
+
+:::{function} zstd_compress(binary, level) -> varbinary
+:noindex: true
+
+Compresses `binary` using Zstandard at the specified `level`, an integer between `1`
+and `22` where higher values produce smaller output at the cost of more CPU time.
+This overload requires the native Zstandard compressor to be available in the JVM
+running the query; if it is not available, the function fails. Use
+{func}`zstd_compress` without a `level` when the native compressor cannot be assumed
+to be available.
+:::
+
+:::{function} zstd_decompress(binary) -> varbinary
+Decompresses `binary`, which must be data produced by {func}`zstd_compress`.
+:::

--- a/docs/src/main/sphinx/functions/binary.md
+++ b/docs/src/main/sphinx/functions/binary.md
@@ -224,5 +224,8 @@ to be available.
 :::
 
 :::{function} zstd_decompress(binary) -> varbinary
-Decompresses `binary`, which must be data produced by {func}`zstd_compress`.
+Decompresses `binary`, which must be one or more Zstandard frames, and returns the
+original data. Any Zstandard-compressed data can be decompressed, whether or not it
+was produced by {func}`zstd_compress`. The function fails if the decompressed data
+exceeds 4MB.
 :::

--- a/docs/src/main/sphinx/functions/list-by-topic.md
+++ b/docs/src/main/sphinx/functions/list-by-topic.md
@@ -128,6 +128,8 @@ For more details, see {doc}`binary`
 - {func}`to_ieee754_32`
 - {func}`to_ieee754_64`
 - {func}`xxhash64`
+- {func}`zstd_compress`
+- {func}`zstd_decompress`
 
 ## Bitwise
 


### PR DESCRIPTION
## Description

Add `zstd_compress(binary)`, `zstd_compress(binary, level)`, and
`zstd_decompress(binary)` scalar functions.

Trino has no built-in SQL-level compress/decompress functions today —
`VarbinaryFunctions` only has hashing and encoding functions. A common
use case is compressing large bodies (e.g. HTML page content) before
storing them. The main concern isn't just storage size: reading many
large uncompressed VARCHAR body columns into memory during query
execution can blow up memory usage, so keeping them compressed at
rest and decompressing only on demand avoids that.

The implementation is built directly on
`io.airlift.compress.v3.zstd.ZstdCompressor`/`ZstdDecompressor`
(aircompressor), which `trino-main` already depends on and uses
internally for ORC/Parquet compression, exchange buffer compression,
and spooling protocol responses (`ZstdQueryDataEncoder`,
`CompressionCodec`, `OrcZstdDecompressor`). No new dependency is
introduced.

## Additional context and related issues

The `zstd_compress(binary, level)` overload requires the native
(panama-based) Zstandard compressor to be enabled, because
aircompressor's pure-Java fallback compressor only supports the
default compression level and throws for any other value. This is
called out in the function docs. Happy to hear reviewer input on
whether that's an acceptable constraint, or whether the level overload
should be reworked/dropped for the initial version.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Functions
* Add `zstd_compress()` and `zstd_decompress()` functions.
```
