### PR TITLE
Add a check to assertAllMethodsOverridden that the types are different

### DIFF
--- a/testing/trino-testing-services/src/main/java/io/trino/testing/InterfaceTestUtils.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testing/InterfaceTestUtils.java
@@ -43,6 +43,7 @@ public final class InterfaceTestUtils
     public static <I, C extends I> void assertAllMethodsOverridden(Class<I> superType, Class<C> clazz, Set<Method> exclusions)
     {
         checkArgument(superType.isAssignableFrom(clazz), "%s is not supertype of %s", superType, clazz);
+        checkArgument(clazz != superType, "The tested type is the same as the base interface: %s", clazz);
         exclusions = new HashSet<>(exclusions);
         for (Class<?> parent = superType; parent != null; parent = parent.getSuperclass()) {
             for (Method method : parent.getDeclaredMethods()) {

--- a/testing/trino-testing-services/src/test/java/io/trino/testing/TestInterfaceTestUtils.java
+++ b/testing/trino-testing-services/src/test/java/io/trino/testing/TestInterfaceTestUtils.java
@@ -30,6 +30,14 @@ class TestInterfaceTestUtils
                         "[public default void io.trino.testing.TestInterfaceTestUtils$Interface.foo(java.lang.String)]");
     }
 
+    @Test
+    public void testRejectSameType()
+    {
+        assertThatThrownBy(() -> InterfaceTestUtils.assertAllMethodsOverridden(Interface.class, Interface.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The tested type is the same as the base interface: interface io.trino.testing.TestInterfaceTestUtils$Interface");
+    }
+
     private interface Interface
     {
         default void foo(String unused) {}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This is a sanity check that complements the existing check: `superType.isAssignableFrom(clazz)` will pass if `clazz` is exactly the same type as `superType`, which is pointless because it trivially passes all the inheritance checks of this method.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Discovered in the wild (wildly embarrassing).

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
