### PR TITLE
Active queryId metrics

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
@@ -51,17 +51,29 @@ import org.weakref.jmx.Flatten;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.OpenDataException;
+import javax.management.openmbean.OpenType;
+import javax.management.openmbean.SimpleType;
+import javax.management.openmbean.TabularDataSupport;
+import javax.management.openmbean.TabularType;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static com.google.common.base.CaseFormat.UPPER_CAMEL;
+import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.execution.QueryState.FINISHING;
 import static io.trino.execution.QueryState.QUEUED;
 import static io.trino.execution.QueryState.RUNNING;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.QUERY_TEXT_TOO_LARGE;
 import static io.trino.tracing.ScopedSpan.scopedSpan;
 import static io.trino.util.Failures.toFailure;
@@ -74,6 +86,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class DispatchManager
 {
     private static final Logger log = Logger.get(DispatchManager.class);
+    private static final CompositeType ACTIVE_QUERY_COMPOSITE_TYPE;
+    private static final CompositeType ACTIVE_QUERIES_COMPOSITE_TYPE;
+    private static final TabularType ACTIVE_QUERIES_TABULAR_TYPE;
 
     private final QueryIdGenerator queryIdGenerator;
     private final QueryPreparer queryPreparer;
@@ -95,6 +110,33 @@ public class DispatchManager
     private final QueryManagerStats stats = new QueryManagerStats();
     private final QueryMonitor queryMonitor;
     private final ScheduledExecutorService statsUpdaterExecutor;
+
+    static {
+        try {
+            ACTIVE_QUERY_COMPOSITE_TYPE = new CompositeType(
+                    "ActiveQueryCompositeType",
+                    "An active query",
+                    new String[] {"queryId", "status", "active"},
+                    new String[] {"The query id", "Status", "Active"},
+                    new OpenType<?>[] {SimpleType.STRING, SimpleType.STRING, SimpleType.BOOLEAN});
+
+            ACTIVE_QUERIES_TABULAR_TYPE = new TabularType(
+                    "ActiveQueriesTabularType",
+                    "Table of active queries",
+                    ACTIVE_QUERY_COMPOSITE_TYPE,
+                    new String[] {"queryId", "status"});
+
+            ACTIVE_QUERIES_COMPOSITE_TYPE = new CompositeType(
+                    "ActiveQueriesCompositeType",
+                    "All active queries",
+                    new String[] {"query"},
+                    new String[] {"The active query"},
+                    new OpenType<?>[] {ACTIVE_QUERIES_TABULAR_TYPE});
+        }
+        catch (OpenDataException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
 
     @Inject
     public DispatchManager(
@@ -317,6 +359,31 @@ public class DispatchManager
         return queryTracker.getAllQueries().stream()
                 .map(DispatchQuery::getBasicQueryInfo)
                 .collect(toImmutableList());
+    }
+
+    @Managed
+    public CompositeData getActiveQueries()
+    {
+        TabularDataSupport table = new TabularDataSupport(ACTIVE_QUERIES_TABULAR_TYPE);
+        queryTracker.getAllQueries().stream()
+                .filter(query -> !query.isDone())
+                .forEach(query -> {
+                    try {
+                        CompositeData row = new CompositeDataSupport(
+                                ACTIVE_QUERY_COMPOSITE_TYPE,
+                                new String[] {"queryId", "status", "active"},
+                                new Object[] {query.getQueryId(), UPPER_UNDERSCORE.to(UPPER_CAMEL, query.getState().name()), true});
+                        table.put(row);
+                    }
+                    catch (OpenDataException _) {
+                    }
+                });
+        try {
+            return new CompositeDataSupport(ACTIVE_QUERIES_COMPOSITE_TYPE, new String[] {"query"}, new Object[] {table});
+        }
+        catch (OpenDataException e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, e.getMessage());
+        }
     }
 
     @Managed

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -22,6 +22,7 @@ import com.google.common.io.Resources;
 import com.google.inject.Inject;
 import com.google.inject.Key;
 import com.google.inject.Module;
+import io.airlift.http.server.HttpConfig;
 import io.airlift.http.server.HttpServerConfig;
 import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.testing.TestingHttpServer;
@@ -1445,8 +1446,8 @@ public class TestResourceSecurity
             throws IOException
     {
         NodeInfo nodeInfo = new NodeInfo("test");
-        HttpServerConfig config = new HttpServerConfig().setHttpPort(0);
-        HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
+        HttpServerConfig config = new HttpServerConfig();
+        HttpServerInfo httpServerInfo = new HttpServerInfo(config, Optional.of(new HttpConfig().setHttpPort(0)), Optional.empty(), nodeInfo);
 
         return new TestingHttpServer("testing-jwks-server", httpServerInfo, nodeInfo, config, new JwkServlet());
     }

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOidcDiscovery.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOidcDiscovery.java
@@ -16,6 +16,7 @@ package io.trino.server.security.oauth2;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.google.inject.Key;
+import io.airlift.http.server.HttpConfig;
 import io.airlift.http.server.HttpServerConfig;
 import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.testing.TestingHttpServer;
@@ -315,8 +316,8 @@ public class TestOidcDiscovery
                 throws Exception
         {
             NodeInfo nodeInfo = new NodeInfo("test");
-            HttpServerConfig config = new HttpServerConfig().setHttpPort(0);
-            HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
+            HttpServerConfig config = new HttpServerConfig();
+            HttpServerInfo httpServerInfo = new HttpServerInfo(config, Optional.of(new HttpConfig().setHttpPort(0)), Optional.empty(), nodeInfo);
             httpServer = new TestingHttpServer("testing-metadata-server", httpServerInfo, nodeInfo, config, servlet);
             httpServer.start();
         }

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraIdentityProvider.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraIdentityProvider.java
@@ -22,6 +22,7 @@ import com.google.common.io.Resources;
 import com.google.common.net.InetAddresses;
 import com.google.inject.Key;
 import com.nimbusds.oauth2.sdk.GrantType;
+import io.airlift.http.server.HttpConfig;
 import io.airlift.http.server.HttpServerConfig;
 import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.testing.TestingHttpServer;
@@ -60,6 +61,7 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.client.OkHttpUtil.setupInsecureSsl;
@@ -235,8 +237,8 @@ public class TestingHydraIdentityProvider
         NodeInfo nodeInfo = new NodeInfo(new NodeConfig()
                 .setEnvironment("test")
                 .setNodeInternalAddress(InetAddresses.toAddrString(InetAddress.getLocalHost())));
-        HttpServerConfig config = new HttpServerConfig().setHttpPort(0);
-        HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
+        HttpServerConfig config = new HttpServerConfig();
+        HttpServerInfo httpServerInfo = new HttpServerInfo(config, Optional.of(new HttpConfig().setHttpPort(0)), Optional.empty(), nodeInfo);
         return new TestingHttpServer("testing-login-and-consent-server", httpServerInfo, nodeInfo, config, new AcceptAllLoginsAndConsentsServlet());
     }
 

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
@@ -21,6 +21,7 @@ import com.google.common.io.Resources;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.inject.Inject;
 import com.google.inject.Key;
+import io.airlift.http.server.HttpConfig;
 import io.airlift.http.server.HttpServerConfig;
 import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.testing.TestingHttpServer;
@@ -1320,8 +1321,8 @@ public class TestWebUi
             throws IOException
     {
         NodeInfo nodeInfo = new NodeInfo("test");
-        HttpServerConfig config = new HttpServerConfig().setHttpPort(0);
-        HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
+        HttpServerConfig config = new HttpServerConfig();
+        HttpServerInfo httpServerInfo = new HttpServerInfo(config, Optional.of(new HttpConfig().setHttpPort(0)), Optional.empty(), nodeInfo);
 
         return new TestingHttpServer("testing-jwk-server", httpServerInfo, nodeInfo, config, new JwkServlet());
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/AbstractTestIcebergRestCatalogVendedCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/AbstractTestIcebergRestCatalogVendedCredentialsRefresh.java
@@ -15,6 +15,7 @@ package io.trino.plugin.iceberg.catalog.rest;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.http.server.HttpConfig;
 import io.airlift.http.server.HttpServerConfig;
 import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.ServerFeature;
@@ -40,6 +41,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.trino.plugin.iceberg.IcebergTestUtils.getConnectorService;
@@ -75,10 +77,8 @@ abstract class AbstractTestIcebergRestCatalogVendedCredentialsRefresh
         servlet = createServlet(backend);
 
         NodeInfo nodeInfo = new NodeInfo("test");
-        HttpServerConfig config = new HttpServerConfig()
-                .setHttpPort(0)
-                .setHttpEnabled(true);
-        HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
+        HttpServerConfig config = new HttpServerConfig();
+        HttpServerInfo httpServerInfo = new HttpServerInfo(config, Optional.of(new HttpConfig().setHttpPort(0)), Optional.empty(), nodeInfo);
         TestingHttpServer testServer = new TestingHttpServer("rest-catalog", httpServerInfo, nodeInfo, config, servlet, ServerFeature.builder()
                 .withLegacyUriCompliance(true)
                 .build());

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/DelegatingRestSessionCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/DelegatingRestSessionCatalog.java
@@ -13,6 +13,7 @@
  */
 package org.apache.iceberg.rest;
 
+import io.airlift.http.server.HttpConfig;
 import io.airlift.http.server.HttpServerConfig;
 import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.ServerFeature;
@@ -22,6 +23,7 @@ import org.apache.iceberg.catalog.Catalog;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -58,13 +60,10 @@ public class DelegatingRestSessionCatalog
     {
         NodeInfo nodeInfo = new NodeInfo("test");
         HttpServerConfig config = new HttpServerConfig()
-                .setHttpPort(0)
                 .setMinThreads(4)
                 .setMaxThreads(8)
-                .setHttpAcceptorThreads(4)
-                .setHttpAcceptQueueSize(10)
                 .setHttpEnabled(true);
-        HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
+        HttpServerInfo httpServerInfo = new HttpServerInfo(config, Optional.of(new HttpConfig().setHttpPort(0).setHttpAcceptorThreads(4).setAcceptQueueSize(10)), Optional.empty(), nodeInfo);
         RESTCatalogServlet servlet = new RESTCatalogServlet(adapter);
 
         return new TestingHttpServer("rest-catalog", httpServerInfo, nodeInfo, config, servlet, ServerFeature.builder()

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <air.test.jvm.additional-arguments>${air.test.jvm.additional-arguments.default}</air.test.jvm.additional-arguments>
 
         <!-- keep dependency properties sorted -->
-        <dep.airlift.version>436</dep.airlift.version>
+        <dep.airlift.version>437-SNAPSHOT</dep.airlift.version>
         <dep.alluxio.version>2.9.6</dep.alluxio.version>
         <dep.antlr.version>4.13.2</dep.antlr.version>
         <dep.avro.version>1.12.1</dep.avro.version>
@@ -2239,6 +2239,13 @@
                 <groupId>org.sonatype.aether</groupId>
                 <artifactId>aether-api</artifactId>
                 <version>1.13.1</version>
+            </dependency>
+
+            <dependency>
+                <!-- Temporary fix -->
+                <groupId>org.weakref</groupId>
+                <artifactId>jmxutils</artifactId>
+                <version>1.29</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description
In the jmx and openmetrics endpoints, counters are available for the amount of queued, running, finished,.. queries. A running queries = 1 for 10 minutes could mean that 1 query is running, but it could also mean that 10 queries started after each other all taking up one minute. With this PR, a new tabular metric is exposed. Note that this PR depends on https://github.com/airlift/airlift/pull/2031

<img width="720" height="213" alt="Grafana2" src="https://github.com/user-attachments/assets/7aa6332e-a007-4844-9791-ac37c664e0a1" />

This image shows the new tabular metric in Grafana, where the height is the number of concurrent running queries. Each query gets its own color, based on the queryId. Note that in this graph only the running queries are shown.

Example as available in `/metrics`:
```
trino_execution_name_QueryManager_ActiveQueries_query_active{queryId="1234567", state="Queued"} 1.0
trino_execution_name_QueryManager_ActiveQueries_query_active{queryId="987654321", state="Running"} 1.0
trino_execution_name_QueryManager_ActiveQueries_query_active{queryId="71685468", state="Running"} 1.0
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
## General
* Add active queryId metrics
```
