### PR TITLE
Fix repeated SourcePage.selectPositions on loaded blocks

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcRecordReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcRecordReader.java
@@ -578,7 +578,9 @@ public class OrcRecordReader
             for (int i = 0; i < blocks.length; i++) {
                 Block block = blocks[i];
                 if (block != null) {
-                    block = selectedPositions.apply(block);
+                    // loaded blocks already reflect the previous selection, so the incoming
+                    // positions apply to them directly
+                    block = block.getPositions(positions, offset, size);
                     retainedSizeInBytes += block.getRetainedSizeInBytes();
                     blocks[i] = block;
                 }

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestOrcReaderPositions.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestOrcReaderPositions.java
@@ -296,6 +296,31 @@ public class TestOrcReaderPositions
     }
 
     @Test
+    public void testSelectPositionsOnLoadedBlocks()
+            throws Exception
+    {
+        try (TempFile tempFile = new TempFile()) {
+            createSequentialFile(tempFile.getFile(), 1000);
+
+            try (OrcRecordReader reader = createCustomOrcRecordReader(tempFile, OrcPredicate.TRUE, BIGINT, MAX_BATCH_SIZE)) {
+                SourcePage page = reader.nextPage();
+                page.selectPositions(new int[] {1, 3, 5, 7}, 0, 4);
+                Block block = page.getBlock(0);
+                assertThat(block.getPositionCount()).isEqualTo(4);
+                assertThat(BIGINT.getLong(block, 0)).isEqualTo(1);
+                assertThat(BIGINT.getLong(block, 3)).isEqualTo(7);
+
+                // select again with positions relative to the previous selection, on an already loaded block
+                page.selectPositions(new int[] {1, 2}, 0, 2);
+                block = page.getBlock(0);
+                assertThat(block.getPositionCount()).isEqualTo(2);
+                assertThat(BIGINT.getLong(block, 0)).isEqualTo(3);
+                assertThat(BIGINT.getLong(block, 1)).isEqualTo(5);
+            }
+        }
+    }
+
+    @Test
     public void testReadUserMetadata()
             throws Exception
     {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -388,7 +388,9 @@ public class ParquetReader
             for (int i = 0; i < blocks.length; i++) {
                 Block block = blocks[i];
                 if (block != null) {
-                    block = selectedPositions.apply(block);
+                    // loaded blocks already reflect the previous selection, so the incoming
+                    // positions apply to them directly
+                    block = block.getPositions(positions, offset, size);
                     retainedSizeInBytes += block.getRetainedSizeInBytes();
                     blocks[i] = block;
                 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReader.java
@@ -27,8 +27,10 @@ import io.trino.parquet.ParquetReaderOptions;
 import io.trino.parquet.metadata.BlockMetadata;
 import io.trino.parquet.metadata.ParquetMetadata;
 import io.trino.parquet.writer.ParquetWriterOptions;
+import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.SourcePage;
 import io.trino.spi.metrics.Count;
 import io.trino.spi.metrics.Metric;
@@ -159,6 +161,59 @@ public class TestParquetReader
             assertThat(((Count<?>) metrics.get(COLUMN_INDEX_ROWS_FILTERED)).getTotal())
                     .isGreaterThanOrEqualTo(parquetMetadata.getBlocks().get(0).rowCount());
         }
+    }
+
+    @Test
+    public void testSelectPositionsOnLoadedBlocks()
+            throws IOException
+    {
+        List<String> columnNames = ImmutableList.of("columna", "columnb");
+        List<Type> types = ImmutableList.of(BIGINT, BIGINT);
+
+        // columnA has row number values, columnB has row number * 10
+        int rowCount = 100;
+        BlockBuilder columnA = BIGINT.createFixedSizeBlockBuilder(rowCount);
+        BlockBuilder columnB = BIGINT.createFixedSizeBlockBuilder(rowCount);
+        for (int i = 0; i < rowCount; i++) {
+            BIGINT.writeLong(columnA, i);
+            BIGINT.writeLong(columnB, i * 10L);
+        }
+        ParquetDataSource dataSource = new TestingParquetDataSource(
+                writeParquetFile(
+                        ParquetWriterOptions.builder().build(),
+                        types,
+                        columnNames,
+                        ImmutableList.of(new Page(rowCount, columnA.build(), columnB.build()))),
+                ParquetReaderOptions.defaultOptions());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        try (ParquetReader reader = createParquetReader(dataSource, parquetMetadata, newSimpleAggregatedMemoryContext(), types, columnNames)) {
+            // batch sizes grow from 1, skip to a page with at least 8 positions
+            long firstRow = 0;
+            SourcePage page = reader.nextPage();
+            while (page.getPositionCount() < 8) {
+                firstRow += page.getPositionCount();
+                page = reader.nextPage();
+            }
+
+            page.selectPositions(new int[] {1, 3, 5, 7}, 0, 4);
+            assertThat(blockValues(page.getBlock(0))).containsExactly(firstRow + 1, firstRow + 3, firstRow + 5, firstRow + 7);
+
+            // select again with positions relative to the previous selection
+            page.selectPositions(new int[] {1, 2}, 0, 2);
+            assertThat(page.getPositionCount()).isEqualTo(2);
+            // columnA was loaded before the second selection, columnB is loaded after it
+            assertThat(blockValues(page.getBlock(0))).containsExactly(firstRow + 3, firstRow + 5);
+            assertThat(blockValues(page.getBlock(1))).containsExactly((firstRow + 3) * 10, (firstRow + 5) * 10);
+        }
+    }
+
+    private static List<Long> blockValues(Block block)
+    {
+        ImmutableList.Builder<Long> values = ImmutableList.builder();
+        for (int position = 0; position < block.getPositionCount(); position++) {
+            values.add(BIGINT.getLong(block, position));
+        }
+        return values.build();
     }
 
     @Test

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rcfile/RcFilePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rcfile/RcFilePageSource.java
@@ -278,7 +278,9 @@ public class RcFilePageSource
             for (int i = 0; i < blocks.length; i++) {
                 Block block = blocks[i];
                 if (block != null) {
-                    block = selectedPositions.apply(block);
+                    // loaded blocks already reflect the previous selection, so the incoming
+                    // positions apply to them directly
+                    block = block.getPositions(positions, offset, size);
                     retainedSizeInBytes += block.getRetainedSizeInBytes();
                     blocks[i] = block;
                 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/rcfile/TestRcFilePageSource.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/rcfile/TestRcFilePageSource.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.rcfile;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.local.LocalInputFile;
+import io.trino.hive.formats.encodings.binary.BinaryColumnEncodingFactory;
+import io.trino.hive.formats.rcfile.RcFileReader;
+import io.trino.hive.formats.rcfile.RcFileWriter;
+import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.connector.SourcePage;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.metastore.HiveType.HIVE_LONG;
+import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestRcFilePageSource
+{
+    @Test
+    void testSelectPositionsOnLoadedBlocks()
+            throws Exception
+    {
+        File file = File.createTempFile("test-select-positions", ".rc");
+        try {
+            // columnA has row number values, columnB has row number * 10
+            int rowCount = 100;
+            BlockBuilder columnA = BIGINT.createFixedSizeBlockBuilder(rowCount);
+            BlockBuilder columnB = BIGINT.createFixedSizeBlockBuilder(rowCount);
+            for (int i = 0; i < rowCount; i++) {
+                BIGINT.writeLong(columnA, i);
+                BIGINT.writeLong(columnB, i * 10L);
+            }
+            BinaryColumnEncodingFactory encoding = new BinaryColumnEncodingFactory(DateTimeZone.UTC);
+            try (FileOutputStream outputStream = new FileOutputStream(file)) {
+                RcFileWriter writer = new RcFileWriter(
+                        outputStream,
+                        ImmutableList.of(BIGINT, BIGINT),
+                        encoding,
+                        Optional.empty(),
+                        ImmutableMap.of(),
+                        true);
+                writer.write(new Page(rowCount, columnA.build(), columnB.build()));
+                writer.close();
+            }
+
+            RcFileReader reader = new RcFileReader(
+                    new LocalInputFile(file),
+                    encoding,
+                    ImmutableMap.of(0, BIGINT, 1, BIGINT),
+                    0,
+                    file.length());
+            List<HiveColumnHandle> columns = ImmutableList.of(
+                    HiveColumnHandle.createBaseColumn("columna", 0, HIVE_LONG, BIGINT, REGULAR, Optional.empty()),
+                    HiveColumnHandle.createBaseColumn("columnb", 1, HIVE_LONG, BIGINT, REGULAR, Optional.empty()));
+            try (RcFilePageSource pageSource = new RcFilePageSource(reader, columns)) {
+                SourcePage page = pageSource.getNextSourcePage();
+                assertThat(page.getPositionCount()).isEqualTo(rowCount);
+
+                page.selectPositions(new int[] {1, 3, 5, 7}, 0, 4);
+                assertThat(blockValues(page.getBlock(0))).containsExactly(1L, 3L, 5L, 7L);
+
+                // select again with positions relative to the previous selection
+                page.selectPositions(new int[] {1, 2}, 0, 2);
+                assertThat(page.getPositionCount()).isEqualTo(2);
+                // columnA was loaded before the second selection, columnB is loaded after it
+                assertThat(blockValues(page.getBlock(0))).containsExactly(3L, 5L);
+                assertThat(blockValues(page.getBlock(1))).containsExactly(30L, 50L);
+            }
+        }
+        finally {
+            Files.deleteIfExists(file.toPath());
+        }
+    }
+
+    private static List<Long> blockValues(Block block)
+    {
+        ImmutableList.Builder<Long> values = ImmutableList.builder();
+        for (int position = 0; position < block.getPositionCount(); position++) {
+            values.add(BIGINT.getLong(block, position));
+        }
+        return values.build();
+    }
+}


### PR DESCRIPTION
## Description

`SourcePage#selectPositions` takes positions relative to the current page view, but the Parquet, ORC and RCFile source pages narrowed already loaded blocks with positions composed against the original page frame. A second `selectPositions` call after a block was read returned wrong rows or failed with an out of bounds error.

This can occur today when reading a bucket-adapted Hive ACID ORC table with deleted rows: `OrcDeletedRows` selects positions to drop deleted rows after loading the ACID metadata blocks, then `BucketAdapter` selects again on the same page.

## Additional context and related issues

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
