### PR TITLE
Add week and quarter support for date_trunc predicate pushdown

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapDateTruncInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapDateTruncInComparison.java
@@ -286,7 +286,9 @@ public class UnwrapDateTruncInComparison
                 LocalDate date = LocalDate.ofEpochDay((long) rangeStart);
                 LocalDate endExclusive = switch (rangeUnit) {
                     case HOUR, DAY -> throw new UnsupportedOperationException("Unsupported type and unit: %s, %s".formatted(type, rangeUnit));
+                    case WEEK -> date.plusWeeks(1);
                     case MONTH -> date.plusMonths(1);
+                    case QUARTER -> date.plusMonths(3);
                     case YEAR -> date.plusYears(1);
                 };
                 return endExclusive.toEpochDay() - 1;
@@ -301,7 +303,9 @@ public class UnwrapDateTruncInComparison
                     LocalDateTime endExclusive = switch (rangeUnit) {
                         case HOUR -> dateTime.plusHours(1);
                         case DAY -> dateTime.plusDays(1);
+                        case WEEK -> dateTime.plusWeeks(1);
                         case MONTH -> dateTime.plusMonths(1);
+                        case QUARTER -> dateTime.plusMonths(3);
                         case YEAR -> dateTime.plusYears(1);
                     };
                     verify(endExclusive.getNano() == 0, "Unexpected nanos in %s, value not rounded to %s", endExclusive, rangeUnit);
@@ -336,7 +340,9 @@ public class UnwrapDateTruncInComparison
     {
         HOUR,
         DAY,
+        WEEK,
         MONTH,
+        QUARTER,
         YEAR,
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapDateTruncInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapDateTruncInComparison.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.IrExpressions;
+import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.Logical;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.assertions.BasePlanTest;
+import io.trino.type.DateTimes;
+import io.trino.util.DateTimeUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+import static io.trino.sql.ir.ComparisonOperator.EQUAL;
+import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN;
+import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN_OR_EQUAL;
+import static io.trino.sql.ir.ComparisonOperator.LESS_THAN;
+import static io.trino.sql.ir.ComparisonOperator.LESS_THAN_OR_EQUAL;
+import static io.trino.sql.ir.Logical.Operator.AND;
+import static io.trino.sql.ir.Logical.Operator.OR;
+import static io.trino.sql.ir.TestingIr.comparison;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static java.lang.String.format;
+
+public class TestUnwrapDateTruncInComparison
+        extends BasePlanTest
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final ResolvedFunction RANDOM = FUNCTIONS.resolveFunction("random", fromTypes());
+
+    @Test
+    public void testDateSupportedUnitsEqual()
+    {
+        testUnwrap(
+                "date",
+                "date_trunc('week', a) = DATE '2024-01-01'",
+                dateRange("2024-01-01", "2024-01-07"));
+
+        testUnwrap(
+                "date",
+                "date_trunc('month', a) = DATE '2024-04-01'",
+                dateRange("2024-04-01", "2024-04-30"));
+
+        testUnwrap(
+                "date",
+                "date_trunc('quarter', a) = DATE '2024-04-01'",
+                dateRange("2024-04-01", "2024-06-30"));
+
+        testUnwrap(
+                "date",
+                "date_trunc('year', a) = DATE '2024-01-01'",
+                dateRange("2024-01-01", "2024-12-31"));
+
+        testUnwrap(
+                "date",
+                "DATE '2024-04-01' = date_trunc('quarter', a)",
+                dateRange("2024-04-01", "2024-06-30"));
+    }
+
+    @Test
+    public void testTimestampSupportedUnitsEqual()
+    {
+        testUnwrap(
+                "timestamp(3)",
+                "date_trunc('day', a) = TIMESTAMP '2024-01-01 00:00:00.000'",
+                timestampRange("2024-01-01 00:00:00.000", "2024-01-01 23:59:59.999"));
+
+        testUnwrap(
+                "timestamp(3)",
+                "date_trunc('week', a) = TIMESTAMP '2024-01-01 00:00:00.000'",
+                timestampRange("2024-01-01 00:00:00.000", "2024-01-07 23:59:59.999"));
+
+        testUnwrap(
+                "timestamp(3)",
+                "date_trunc('month', a) = TIMESTAMP '2024-04-01 00:00:00.000'",
+                timestampRange("2024-04-01 00:00:00.000", "2024-04-30 23:59:59.999"));
+
+        testUnwrap(
+                "timestamp(3)",
+                "date_trunc('quarter', a) = TIMESTAMP '2024-04-01 00:00:00.000'",
+                timestampRange("2024-04-01 00:00:00.000", "2024-06-30 23:59:59.999"));
+
+        testUnwrap(
+                "timestamp(3)",
+                "date_trunc('year', a) = TIMESTAMP '2024-01-01 00:00:00.000'",
+                timestampRange("2024-01-01 00:00:00.000", "2024-12-31 23:59:59.999"));
+    }
+
+    @Test
+    public void testTimestampWeekAndQuarterComparisons()
+    {
+        testUnwrap(
+                "timestamp(3)",
+                "date_trunc('quarter', a) <= TIMESTAMP '2024-05-15 00:00:00.000'",
+                comparison(LESS_THAN_OR_EQUAL, timestampReference(), timestampConstant("2024-06-30 23:59:59.999")));
+
+        testUnwrap(
+                "timestamp(3)",
+                "date_trunc('week', a) <> TIMESTAMP '2024-01-01 00:00:00.000'",
+                new Logical(OR, ImmutableList.of(
+                        comparison(LESS_THAN, timestampReference(), timestampConstant("2024-01-01 00:00:00.000")),
+                        comparison(LESS_THAN, timestampConstant("2024-01-07 23:59:59.999"), timestampReference()))));
+
+        testUnwrap(
+                "timestamp(3)",
+                "date_trunc('quarter', a) IS NOT DISTINCT FROM TIMESTAMP '2024-04-01 00:00:00.000'",
+                new Logical(AND, ImmutableList.of(
+                        not(new IsNull(timestampReference())),
+                        timestampRange("2024-04-01 00:00:00.000", "2024-06-30 23:59:59.999"))));
+
+        testUnwrap(
+                "timestamp(3)",
+                "date_trunc('week', a) < TIMESTAMP '2024-01-01 00:00:00.000'",
+                comparison(LESS_THAN, timestampReference(), timestampConstant("2024-01-01 00:00:00.000")));
+
+        testUnwrap(
+                "timestamp(9)",
+                "date_trunc('quarter', a) <= TIMESTAMP '2024-05-15 00:00:00.000000000'",
+                comparison(LESS_THAN_OR_EQUAL, timestampReference(9), timestampConstant(9, "2024-06-30 23:59:59.999999999")));
+    }
+
+    @Test
+    public void testDateWeekAndQuarterComparisons()
+    {
+        testUnwrap(
+                "date",
+                "date_trunc('week', a) >= DATE '2024-01-03'",
+                comparison(GREATER_THAN, dateReference(), dateConstant("2024-01-07")));
+
+        testUnwrap(
+                "date",
+                "date_trunc('quarter', a) <= DATE '2024-05-15'",
+                comparison(LESS_THAN_OR_EQUAL, dateReference(), dateConstant("2024-06-30")));
+
+        testUnwrap(
+                "date",
+                "date_trunc('quarter', a) > DATE '2024-04-01'",
+                comparison(GREATER_THAN, dateReference(), dateConstant("2024-06-30")));
+    }
+
+    @Test
+    public void testNonBoundaryEqualityIsFalseIfInputIsNotNull()
+    {
+        testUnwrap("date",
+                "date_trunc('week', a) = DATE '2024-01-03'",
+                new Logical(AND, ImmutableList.of(
+                        new IsNull(dateReference()),
+                        new Constant(BOOLEAN, null))));
+
+        testUnwrap("date",
+                "date_trunc('quarter', a) = DATE '2024-05-15'",
+                new Logical(AND, ImmutableList.of(
+                        new IsNull(dateReference()),
+                        new Constant(BOOLEAN, null))));
+    }
+
+    private void testUnwrap(String inputType, String inputPredicate, Expression expected)
+    {
+        Expression antiOptimization = comparison(EQUAL, new Call(RANDOM, ImmutableList.of()), new Constant(DOUBLE, 42.0));
+        if (expected instanceof Logical logical && logical.operator() == AND) {
+            expected = new Logical(AND, logical.terms().stream()
+                    .flatMap(term -> term instanceof Logical nested && nested.operator() == AND ? nested.terms().stream() : Stream.of(term))
+                    .collect(toImmutableList()));
+        }
+        if (expected instanceof Logical logical && logical.operator() == OR) {
+            expected = new Logical(OR, ImmutableList.<Expression>builder()
+                    .addAll(logical.terms())
+                    .add(antiOptimization)
+                    .build());
+        }
+        else {
+            expected = new Logical(OR, ImmutableList.of(expected, antiOptimization));
+        }
+
+        assertPlan(format("SELECT * FROM (VALUES CAST(NULL AS %s)) t(a) WHERE (%s) OR rand() = 42", inputType, inputPredicate),
+                output(
+                        filter(
+                                expected,
+                                values("a"))));
+    }
+
+    private static Expression dateRange(String startInclusive, String endInclusive)
+    {
+        return new Logical(AND, ImmutableList.of(
+                comparison(GREATER_THAN_OR_EQUAL, dateReference(), dateConstant(startInclusive)),
+                comparison(LESS_THAN_OR_EQUAL, dateReference(), dateConstant(endInclusive))));
+    }
+
+    private static Expression timestampRange(String startInclusive, String endInclusive)
+    {
+        return new Logical(AND, ImmutableList.of(
+                comparison(GREATER_THAN_OR_EQUAL, timestampReference(), timestampConstant(startInclusive)),
+                comparison(LESS_THAN_OR_EQUAL, timestampReference(), timestampConstant(endInclusive))));
+    }
+
+    private static Reference dateReference()
+    {
+        return new Reference(DATE, "a");
+    }
+
+    private static Constant dateConstant(String date)
+    {
+        return new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice(date)));
+    }
+
+    private static Reference timestampReference()
+    {
+        return timestampReference(3);
+    }
+
+    private static Reference timestampReference(int precision)
+    {
+        return new Reference(createTimestampType(precision), "a");
+    }
+
+    private static Constant timestampConstant(String timestamp)
+    {
+        return timestampConstant(3, timestamp);
+    }
+
+    private static Constant timestampConstant(int precision, String timestamp)
+    {
+        return new Constant(createTimestampType(precision), DateTimes.parseTimestamp(precision, timestamp));
+    }
+
+    private static Expression not(Expression value)
+    {
+        return IrExpressions.not(FUNCTIONS.getMetadata(), value);
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/filter/UtcConstraintExtractor.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/filter/UtcConstraintExtractor.java
@@ -66,7 +66,9 @@ import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static java.lang.Math.toIntExact;
 import static java.math.RoundingMode.UNNECESSARY;
+import static java.time.DayOfWeek.MONDAY;
 import static java.time.ZoneOffset.UTC;
+import static java.time.temporal.TemporalAdjusters.previousOrSame;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
@@ -404,9 +406,18 @@ public final class UtcConstraintExtractor
                 periodStart = dateTime.toLocalDate().atStartOfDay().atZone(UTC);
                 nextPeriodStart = periodStart.plusDays(1);
             }
+            case "week" -> {
+                periodStart = dateTime.toLocalDate().with(previousOrSame(MONDAY)).atStartOfDay().atZone(UTC);
+                nextPeriodStart = periodStart.plusWeeks(1);
+            }
             case "month" -> {
                 periodStart = dateTime.toLocalDate().withDayOfMonth(1).atStartOfDay().atZone(UTC);
                 nextPeriodStart = periodStart.plusMonths(1);
+            }
+            case "quarter" -> {
+                int firstMonthOfQuarter = ((dateTime.getMonthValue() - 1) / 3) * 3 + 1;
+                periodStart = dateTime.toLocalDate().withMonth(firstMonthOfQuarter).withDayOfMonth(1).atStartOfDay().atZone(UTC);
+                nextPeriodStart = periodStart.plusMonths(3);
             }
             case "year" -> {
                 periodStart = dateTime.toLocalDate().withMonth(1).withDayOfMonth(1).atStartOfDay().atZone(UTC);

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/filter/TestUtcConstraintExtractor.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/filter/TestUtcConstraintExtractor.java
@@ -437,6 +437,96 @@ public class TestUtcConstraintExtractor
                         columnHandle, Domain.create(ValueSet.ofRanges(Range.range(columnType, startOfDateUtc, true, startOfNextDateUtc, false)), false))));
     }
 
+    @Test
+    public void testExtractDateTruncTimestampTzMillisSupportedUnitComparison()
+    {
+        String timestampTzColumnSymbol = "timestamp_tz_symbol";
+        TimestampWithTimeZoneType columnType = TIMESTAMP_TZ_MILLIS;
+        ColumnHandle columnHandle = new TestingColumnHandle(timestampTzColumnSymbol);
+
+        assertDateTruncTimestampTzMillisDomain(
+                "week",
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 1, 8),
+                columnType,
+                timestampTzColumnSymbol,
+                columnHandle);
+
+        assertDateTruncTimestampTzMillisDomain(
+                "month",
+                LocalDate.of(2024, 4, 1),
+                LocalDate.of(2024, 5, 1),
+                columnType,
+                timestampTzColumnSymbol,
+                columnHandle);
+
+        assertDateTruncTimestampTzMillisDomain(
+                "quarter",
+                LocalDate.of(2024, 4, 1),
+                LocalDate.of(2024, 7, 1),
+                columnType,
+                timestampTzColumnSymbol,
+                columnHandle);
+
+        assertDateTruncTimestampTzMillisDomain(
+                "year",
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2025, 1, 1),
+                columnType,
+                timestampTzColumnSymbol,
+                columnHandle);
+    }
+
+    private static void assertDateTruncTimestampTzMillisDomain(
+            String unit,
+            LocalDate periodStartDate,
+            LocalDate nextPeriodStartDate,
+            TimestampWithTimeZoneType columnType,
+            String timestampTzColumnSymbol,
+            ColumnHandle columnHandle)
+    {
+        ConnectorExpression truncate = new Call(
+                columnType,
+                new FunctionName("date_trunc"),
+                ImmutableList.of(
+                        new Constant(utf8Slice(unit), createVarcharType(17)),
+                        new Variable(timestampTzColumnSymbol, columnType)));
+
+        long periodStartMillis = periodStartDate.atStartOfDay().toEpochSecond(UTC) * MILLISECONDS_PER_SECOND;
+        long nextPeriodStartMillis = nextPeriodStartDate.atStartOfDay().toEpochSecond(UTC) * MILLISECONDS_PER_SECOND;
+        long periodStart = timestampTzMillisFromEpochMillis(periodStartMillis);
+        long nextPeriodStart = timestampTzMillisFromEpochMillis(nextPeriodStartMillis);
+
+        assertThat(extract(
+                constraint(
+                        new Call(BOOLEAN, EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(
+                                truncate,
+                                new Constant(periodStart, columnType))),
+                        Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(columnHandle, domain(Range.range(columnType, periodStart, true, nextPeriodStart, false)))));
+
+        assertThat(extract(
+                constraint(
+                        new Call(BOOLEAN, EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(
+                                truncate,
+                                new Constant(timestampTzMillisFromEpochMillis(periodStartMillis + MILLISECONDS_PER_DAY), columnType))),
+                        Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.none());
+
+        assertThat(extract(constraint(new Call(BOOLEAN, NOT_EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(truncate, new Constant(periodStart, columnType))), Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(columnHandle, domain(Range.lessThan(columnType, periodStart), Range.greaterThanOrEqual(columnType, nextPeriodStart)))));
+        assertThat(extract(constraint(new Call(BOOLEAN, LESS_THAN_OPERATOR_FUNCTION_NAME, ImmutableList.of(truncate, new Constant(periodStart, columnType))), Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(columnHandle, domain(Range.lessThan(columnType, periodStart)))));
+        assertThat(extract(constraint(new Call(BOOLEAN, LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(truncate, new Constant(periodStart, columnType))), Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(columnHandle, domain(Range.lessThan(columnType, nextPeriodStart)))));
+        assertThat(extract(constraint(new Call(BOOLEAN, GREATER_THAN_OPERATOR_FUNCTION_NAME, ImmutableList.of(truncate, new Constant(periodStart, columnType))), Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(columnHandle, domain(Range.greaterThanOrEqual(columnType, nextPeriodStart)))));
+        assertThat(extract(constraint(new Call(BOOLEAN, GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(truncate, new Constant(periodStart, columnType))), Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(columnHandle, domain(Range.greaterThanOrEqual(columnType, periodStart)))));
+        assertThat(extract(constraint(new Call(BOOLEAN, IDENTICAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(truncate, new Constant(periodStart, columnType))), Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(columnHandle, Domain.create(ValueSet.ofRanges(Range.range(columnType, periodStart, true, nextPeriodStart, false)), false))));
+    }
+
     /**
      * Test equivalent of {@code io.trino.sql.planner.iterative.rule.UnwrapDateTruncInComparison} for {@link TimestampWithTimeZoneType}.
      * {@code UnwrapDateTruncInComparison} handles {@link DateType} and {@link TimestampType}, but cannot handle
@@ -520,6 +610,96 @@ public class TestUtcConstraintExtractor
                         Map.of(timestampTzColumnSymbol, columnHandle))))
                 .isEqualTo(TupleDomain.withColumnDomains(Map.of(
                         columnHandle, Domain.create(ValueSet.ofRanges(Range.range(columnType, startOfDateUtc, true, startOfNextDateUtc, false)), false))));
+    }
+
+    @Test
+    public void testExtractDateTruncTimestampTzMicrosSupportedUnitComparison()
+    {
+        String timestampTzColumnSymbol = "timestamp_tz_symbol";
+        TimestampWithTimeZoneType columnType = TIMESTAMP_TZ_MICROS;
+        ColumnHandle columnHandle = new TestingColumnHandle(timestampTzColumnSymbol);
+
+        assertDateTruncTimestampTzMicrosDomain(
+                "week",
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 1, 8),
+                columnType,
+                timestampTzColumnSymbol,
+                columnHandle);
+
+        assertDateTruncTimestampTzMicrosDomain(
+                "month",
+                LocalDate.of(2024, 4, 1),
+                LocalDate.of(2024, 5, 1),
+                columnType,
+                timestampTzColumnSymbol,
+                columnHandle);
+
+        assertDateTruncTimestampTzMicrosDomain(
+                "quarter",
+                LocalDate.of(2024, 4, 1),
+                LocalDate.of(2024, 7, 1),
+                columnType,
+                timestampTzColumnSymbol,
+                columnHandle);
+
+        assertDateTruncTimestampTzMicrosDomain(
+                "year",
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2025, 1, 1),
+                columnType,
+                timestampTzColumnSymbol,
+                columnHandle);
+    }
+
+    private static void assertDateTruncTimestampTzMicrosDomain(
+            String unit,
+            LocalDate periodStartDate,
+            LocalDate nextPeriodStartDate,
+            TimestampWithTimeZoneType columnType,
+            String timestampTzColumnSymbol,
+            ColumnHandle columnHandle)
+    {
+        ConnectorExpression truncate = new Call(
+                columnType,
+                new FunctionName("date_trunc"),
+                ImmutableList.of(
+                        new Constant(utf8Slice(unit), createVarcharType(17)),
+                        new Variable(timestampTzColumnSymbol, columnType)));
+
+        long periodStartMillis = periodStartDate.atStartOfDay().toEpochSecond(UTC) * MILLISECONDS_PER_SECOND;
+        long nextPeriodStartMillis = nextPeriodStartDate.atStartOfDay().toEpochSecond(UTC) * MILLISECONDS_PER_SECOND;
+        LongTimestampWithTimeZone periodStart = timestampTzMicrosFromEpochMillis(periodStartMillis);
+        LongTimestampWithTimeZone nextPeriodStart = timestampTzMicrosFromEpochMillis(nextPeriodStartMillis);
+
+        assertThat(extract(
+                constraint(
+                        new Call(BOOLEAN, EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(
+                                truncate,
+                                new Constant(periodStart, columnType))),
+                        Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(columnHandle, domain(Range.range(columnType, periodStart, true, nextPeriodStart, false)))));
+
+        assertThat(extract(
+                constraint(
+                        new Call(BOOLEAN, EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(
+                                truncate,
+                                new Constant(LongTimestampWithTimeZone.fromEpochMillisAndFraction(periodStartMillis, PICOSECONDS_PER_MICROSECOND, UTC_KEY), columnType))),
+                        Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.none());
+
+        assertThat(extract(constraint(new Call(BOOLEAN, NOT_EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(truncate, new Constant(periodStart, columnType))), Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(columnHandle, domain(Range.lessThan(columnType, periodStart), Range.greaterThanOrEqual(columnType, nextPeriodStart)))));
+        assertThat(extract(constraint(new Call(BOOLEAN, LESS_THAN_OPERATOR_FUNCTION_NAME, ImmutableList.of(truncate, new Constant(periodStart, columnType))), Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(columnHandle, domain(Range.lessThan(columnType, periodStart)))));
+        assertThat(extract(constraint(new Call(BOOLEAN, LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(truncate, new Constant(periodStart, columnType))), Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(columnHandle, domain(Range.lessThan(columnType, nextPeriodStart)))));
+        assertThat(extract(constraint(new Call(BOOLEAN, GREATER_THAN_OPERATOR_FUNCTION_NAME, ImmutableList.of(truncate, new Constant(periodStart, columnType))), Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(columnHandle, domain(Range.greaterThanOrEqual(columnType, nextPeriodStart)))));
+        assertThat(extract(constraint(new Call(BOOLEAN, GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(truncate, new Constant(periodStart, columnType))), Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(columnHandle, domain(Range.greaterThanOrEqual(columnType, periodStart)))));
+        assertThat(extract(constraint(new Call(BOOLEAN, IDENTICAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(truncate, new Constant(periodStart, columnType))), Map.of(timestampTzColumnSymbol, columnHandle))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(columnHandle, Domain.create(ValueSet.ofRanges(Range.range(columnType, periodStart, true, nextPeriodStart, false)), false))));
     }
 
     /**

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -811,7 +811,14 @@ public class TestDeltaLakeConnectorTest
                 .isReplacedWithEmptyValues();
 
         assertThat(query("SELECT * FROM " + tableName + " WHERE date_trunc('week', part) >= TIMESTAMP '2005-09-10 00:00:00.000 +00:00'"))
-                .isNotFullyPushedDown(FilterNode.class);
+                .isFullyPushedDown()
+                .matches("VALUES " +
+                        "(3, TIMESTAMP '2023-11-21 07:19:00.000 UTC')");
+
+        assertThat(query("SELECT * FROM " + tableName + " WHERE date_trunc('quarter', part) = TIMESTAMP '2005-07-01 00:00:00.000 +00:00'"))
+                .isFullyPushedDown()
+                .matches("VALUES " +
+                        "(4, TIMESTAMP '2005-09-10 13:00:00.000 UTC')");
 
         // cast timestamp_tz as DATE optimization
         assertThat(query("SELECT * FROM " + tableName + " WHERE cast(part AS date) >= DATE '2005-09-10'"))

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -2545,7 +2545,11 @@ public abstract class BaseIcebergConnectorTest
         // date_trunc
         assertThat(query("SELECT * FROM test_day_transform_date WHERE date_trunc('day', d) = DATE '2015-01-13'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_date WHERE date_trunc('week', d) = DATE '2015-01-12'"))
+                .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_day_transform_date WHERE date_trunc('month', d) = DATE '2015-01-01'"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_date WHERE date_trunc('quarter', d) = DATE '2015-01-01'"))
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_day_transform_date WHERE date_trunc('year', d) = DATE '2015-01-01'"))
                 .isFullyPushedDown();
@@ -2665,7 +2669,11 @@ public abstract class BaseIcebergConnectorTest
         // date_trunc
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE date_trunc('day', d) = DATE '2015-05-15'"))
                 .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE date_trunc('week', d) = DATE '2015-05-11'"))
+                .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE date_trunc('month', d) = DATE '2015-05-01'"))
+                .isFullyPushedDown();
+        assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE date_trunc('quarter', d) = DATE '2015-04-01'"))
                 .isFullyPushedDown();
         assertThat(query("SELECT * FROM test_day_transform_timestamp WHERE date_trunc('year', d) = DATE '2015-01-01'"))
                 .isFullyPushedDown();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Date predicate reference: https://trino.io/blog/2023/04/11/date-predicates.html

`date_trunc` predicates for `week` and `quarter` were not converted into pruning-friendly ranges, so connectors could keep the original expression as a residual filter and scan more data than necessary. Existing support already handled `day`, `month`, and `year`.

  This PR extends `date_trunc` pruning for `week` and `quarter` by:

  * allowing the planner to unwrap `date_trunc('week', ...)` and `date_trunc('quarter', ...)` comparisons into direct ranges for `DATE` and `TIMESTAMP`
  * extending UTC constraint extraction for `TIMESTAMP WITH TIME ZONE`


For example:
```
EXPLAIN
  SELECT count(*)
  FROM iceberg.pruning_demo.events_day
  WHERE date_trunc('week', ts) = TIMESTAMP '2024-01-01 00:00:00.000000';
```
- Before this PR, the plan result is:
        
```
ScanFilterProject[table = iceberg:pruning_demo.events_day$data@178640355853490787, filterPredicate = (date_trunc(varchar(4) 'week', ts) = timestamp(6) '2024-01-01 00:00:00.000000')] 
  Layout: []                                                                                                                                                                        
  Estimates: {rows: 9 (0B), cpu: 81, memory: 0B, network: 0B}/{rows: ? (0B), cpu: 81, memory: 0B, network: 0B}/{rows: ? (0B), cpu: 0, memory: 0B, network: 0B}                      
  ts := 2:ts:timestamp(6)
```

- After this PR, the predicate can be planned as a direct range constraint on ts:
      
```
TableScan[table = iceberg:pruning_demo.events_day$data@5404647234065700807 constraint on [ts]] 
  Layout: []                                                                                 
  Estimates: {rows: 3 (0B), cpu: 0, memory: 0B, network: 0B}                                 
  2:ts:timestamp(6)                                                                          
      :: [[2024-01-01 00:00:00.000000, 2024-01-07 23:59:59.999999]]
```


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- Fixes #30192


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve query performance for predicates using `date_trunc` with `week` or `quarter`. ({issue}`30192`)
```