### PR TITLE
Allow function bundles to register function instances

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/InternalFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/InternalFunctionBundle.java
@@ -272,9 +272,21 @@ public class InternalFunctionBundle
             return this;
         }
 
+        public InternalFunctionBundleBuilder scalar(Object instance)
+        {
+            functions.addAll(ScalarFromAnnotationsParser.parseFunctionDefinition(instance));
+            return this;
+        }
+
         public InternalFunctionBundleBuilder scalars(Class<?> clazz)
         {
             functions.addAll(ScalarFromAnnotationsParser.parseFunctionDefinitions(clazz));
+            return this;
+        }
+
+        public InternalFunctionBundleBuilder scalars(Object instance)
+        {
+            functions.addAll(ScalarFromAnnotationsParser.parseFunctionDefinitions(instance));
             return this;
         }
 
@@ -299,6 +311,29 @@ public class InternalFunctionBundle
             }
 
             scalars(clazz);
+            return this;
+        }
+
+        public InternalFunctionBundleBuilder functions(Object instance)
+        {
+            requireNonNull(instance, "instance is null");
+            if (instance instanceof Class<?> clazz) {
+                return functions(clazz);
+            }
+            if (instance instanceof SqlFunction sqlFunction) {
+                return function(sqlFunction);
+            }
+            Class<?> clazz = instance.getClass();
+            checkArgument(!WindowFunction.class.isAssignableFrom(clazz), "Window functions do not support instance registration: %s", clazz.getName());
+            checkArgument(!clazz.isAnnotationPresent(AggregationFunction.class), "Aggregation functions do not support instance registration: %s", clazz.getName());
+
+            if (clazz.isAnnotationPresent(ScalarFunction.class) ||
+                    clazz.isAnnotationPresent(ScalarOperator.class)) {
+                scalar(instance);
+                return this;
+            }
+
+            scalars(instance);
             return this;
         }
 

--- a/core/trino-main/src/main/java/io/trino/metadata/InternalFunctionBundleFactory.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/InternalFunctionBundleFactory.java
@@ -38,6 +38,13 @@ public class InternalFunctionBundleFactory
         }
 
         @Override
+        public Builder functions(Object functionInstance)
+        {
+            delegate.functions(functionInstance);
+            return this;
+        }
+
+        @Override
         public FunctionBundle build()
         {
             return delegate.build();

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/ParametricScalarImplementation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/ParametricScalarImplementation.java
@@ -95,6 +95,7 @@ import static io.trino.util.Reflection.constructorMethodHandle;
 import static io.trino.util.Reflection.methodHandle;
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static java.lang.String.format;
+import static java.lang.invoke.MethodHandles.constant;
 import static java.lang.invoke.MethodHandles.permuteArguments;
 import static java.lang.reflect.Modifier.isStatic;
 import static java.util.Objects.requireNonNull;
@@ -479,6 +480,11 @@ public class ParametricScalarImplementation
 
         Parser(Method method, Optional<Constructor<?>> constructor)
         {
+            this(method, constructor, Optional.empty());
+        }
+
+        Parser(Method method, Optional<Constructor<?>> constructor, Optional<Object> instance)
+        {
             Signature.Builder signatureBuilder = Signature.builder();
             boolean nullable = method.getAnnotation(SqlNullable.class) != null;
             checkArgument(nullable || !containsLegacyNullable(method.getAnnotations()), "Method [%s] is annotated with @Nullable but not @SqlNullable", method);
@@ -522,7 +528,7 @@ public class ParametricScalarImplementation
             parseArguments(method, signatureBuilder, dependencies);
 
             List<ImplementationDependency> constructorDependencies = new ArrayList<>();
-            Optional<MethodHandle> constructorMethodHandle = getConstructor(method, constructor, constructorDependencies);
+            Optional<MethodHandle> constructorMethodHandle = getConstructor(method, constructor, instance, constructorDependencies);
 
             this.methodHandle = getMethodHandle(method, dependencies);
 
@@ -682,10 +688,16 @@ public class ParametricScalarImplementation
         }
 
         // Find matching constructor, if this is an instance method, and populate constructorDependencies
-        private Optional<MethodHandle> getConstructor(Method method, Optional<Constructor<?>> optionalConstructor, List<ImplementationDependency> constructorDependencies)
+        private Optional<MethodHandle> getConstructor(Method method, Optional<Constructor<?>> optionalConstructor, Optional<Object> providedInstance, List<ImplementationDependency> constructorDependencies)
         {
             if (isStatic(method.getModifiers())) {
                 return Optional.empty();
+            }
+
+            if (providedInstance.isPresent()) {
+                Object instance = providedInstance.get();
+                checkArgument(method.getDeclaringClass().isInstance(instance), "Method [%s] is an instance method but provided instance is of type [%s]", method, instance.getClass().getName());
+                return Optional.of(constant(Object.class, instance));
             }
 
             checkArgument(optionalConstructor.isPresent(), "Method [%s] is an instance method. It must be in a class annotated with @ScalarFunction or @ScalarOperator, and the class is required to have a public constructor.", method);

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/ScalarFromAnnotationsParser.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/ScalarFromAnnotationsParser.java
@@ -47,7 +47,19 @@ public final class ScalarFromAnnotationsParser
         ImmutableList.Builder<SqlScalarFunction> builder = ImmutableList.builder();
         boolean deprecated = clazz.getAnnotationsByType(Deprecated.class).length > 0;
         for (ScalarHeaderAndMethods scalar : findScalarsInFunctionDefinitionClass(clazz)) {
-            builder.add(parseParametricScalar(scalar, FunctionsParserHelper.findConstructor(clazz), deprecated));
+            builder.add(parseParametricScalar(scalar, FunctionsParserHelper.findConstructor(clazz), Optional.empty(), deprecated));
+        }
+        return builder.build();
+    }
+
+    public static List<SqlScalarFunction> parseFunctionDefinition(Object instance)
+    {
+        requireNonNull(instance, "instance is null");
+        Class<?> clazz = instance.getClass();
+        ImmutableList.Builder<SqlScalarFunction> builder = ImmutableList.builder();
+        boolean deprecated = clazz.getAnnotationsByType(Deprecated.class).length > 0;
+        for (ScalarHeaderAndMethods scalar : findScalarsInFunctionDefinitionClass(clazz)) {
+            builder.add(parseParametricScalar(scalar, Optional.empty(), Optional.of(instance), deprecated));
         }
         return builder.build();
     }
@@ -58,7 +70,19 @@ public final class ScalarFromAnnotationsParser
         for (ScalarHeaderAndMethods methods : findScalarsInFunctionSetClass(clazz)) {
             boolean deprecated = methods.methods().iterator().next().getAnnotationsByType(Deprecated.class).length > 0;
             // Non-static function only makes sense in classes annotated with @ScalarFunction or @ScalarOperator.
-            builder.add(parseParametricScalar(methods, FunctionsParserHelper.findConstructor(clazz), deprecated));
+            builder.add(parseParametricScalar(methods, FunctionsParserHelper.findConstructor(clazz), Optional.empty(), deprecated));
+        }
+        return builder.build();
+    }
+
+    public static List<SqlScalarFunction> parseFunctionDefinitions(Object instance)
+    {
+        requireNonNull(instance, "instance is null");
+        Class<?> clazz = instance.getClass();
+        ImmutableList.Builder<SqlScalarFunction> builder = ImmutableList.builder();
+        for (ScalarHeaderAndMethods methods : findScalarsInFunctionSetClass(clazz)) {
+            boolean deprecated = methods.methods().iterator().next().getAnnotationsByType(Deprecated.class).length > 0;
+            builder.add(parseParametricScalar(methods, Optional.empty(), Optional.of(instance), deprecated));
         }
         return builder.build();
     }
@@ -99,11 +123,11 @@ public final class ScalarFromAnnotationsParser
         return methods;
     }
 
-    private static SqlScalarFunction parseParametricScalar(ScalarHeaderAndMethods scalar, Optional<Constructor<?>> constructor, boolean deprecated)
+    private static SqlScalarFunction parseParametricScalar(ScalarHeaderAndMethods scalar, Optional<Constructor<?>> constructor, Optional<Object> instance, boolean deprecated)
     {
         Map<SpecializedSignature, ParametricScalarImplementation.Builder> signatures = new HashMap<>();
         for (Method method : scalar.methods()) {
-            ParametricScalarImplementation.Parser implementation = new ParametricScalarImplementation.Parser(method, constructor);
+            ParametricScalarImplementation.Parser implementation = new ParametricScalarImplementation.Parser(method, constructor, instance);
             if (!signatures.containsKey(implementation.getSpecializedSignature())) {
                 ParametricScalarImplementation.Builder builder = new ParametricScalarImplementation.Builder(
                         implementation.getSignature(),

--- a/core/trino-main/src/test/java/io/trino/type/TestInstanceFunction.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestInstanceFunction.java
@@ -13,6 +13,7 @@
  */
 package io.trino.type;
 
+import io.airlift.slice.Slice;
 import io.trino.metadata.InternalFunctionBundle;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -43,6 +45,19 @@ public class TestInstanceFunction
         }
     }
 
+    @Test
+    public void testProvidedInstanceFunction()
+    {
+        try (QueryAssertions assertions = new QueryAssertions()) {
+            assertions.addFunctions(InternalFunctionBundle.builder()
+                    .functions(new StatefulFunction("test:"))
+                    .build());
+
+            assertThat(assertions.function("stateful_prefix", "'value'"))
+                    .isEqualTo("test:value");
+        }
+    }
+
     @ScalarFunction("precomputed")
     public static final class PrecomputedFunction
     {
@@ -52,6 +67,23 @@ public class TestInstanceFunction
         public long precomputed()
         {
             return value;
+        }
+    }
+
+    public static final class StatefulFunction
+    {
+        private final String prefix;
+
+        private StatefulFunction(String prefix)
+        {
+            this.prefix = prefix;
+        }
+
+        @ScalarFunction("stateful_prefix")
+        @SqlType(StandardTypes.VARCHAR)
+        public Slice prefix(@SqlType(StandardTypes.VARCHAR) Slice value)
+        {
+            return utf8Slice(prefix + value.toStringUtf8());
         }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/function/FunctionBundleFactory.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/FunctionBundleFactory.java
@@ -24,6 +24,11 @@ public interface FunctionBundleFactory
     {
         Builder functions(Class<?> functionClass);
 
+        default Builder functions(Object functionInstance)
+        {
+            throw new UnsupportedOperationException("Function instance registration is not supported");
+        }
+
         FunctionBundle build();
     }
 }

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiConnector.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiConnector.java
@@ -19,6 +19,7 @@ import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.FunctionBundle;
 import io.trino.spi.function.FunctionProvider;
 import io.trino.spi.transaction.IsolationLevel;
 
@@ -31,14 +32,14 @@ public class AiConnector
 {
     private final LifeCycleManager lifeCycleManager;
     private final ConnectorMetadata metadata;
-    private final FunctionProvider functionProvider;
+    private final FunctionBundle functionBundle;
 
     @Inject
-    public AiConnector(LifeCycleManager lifeCycleManager, ConnectorMetadata metadata, FunctionProvider functionProvider)
+    public AiConnector(LifeCycleManager lifeCycleManager, ConnectorMetadata metadata, FunctionBundle functionBundle)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
-        this.functionProvider = requireNonNull(functionProvider, "functionProvider is null");
+        this.functionBundle = requireNonNull(functionBundle, "functionBundle is null");
     }
 
     @Override
@@ -56,7 +57,7 @@ public class AiConnector
     @Override
     public Optional<FunctionProvider> getFunctionProvider()
     {
-        return Optional.of(functionProvider);
+        return Optional.of(functionBundle.toProvider());
     }
 
     @Override

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiConnectorFactory.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiConnectorFactory.java
@@ -40,7 +40,7 @@ public class AiConnectorFactory
 
         Bootstrap app = new Bootstrap(
                 "io.trino.bootstrap.catalog." + catalogName,
-                new AiModule(),
+                new AiModule(context.getFunctionBundleFactory()),
                 new ConnectorContextModule(catalogName, context));
 
         Injector injector = app

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiFunctions.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiFunctions.java
@@ -13,98 +13,28 @@
  */
 package io.trino.plugin.ai.functions;
 
-import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.airlift.slice.Slice;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.SqlMap;
-import io.trino.spi.function.BoundSignature;
-import io.trino.spi.function.FunctionDependencies;
-import io.trino.spi.function.FunctionId;
-import io.trino.spi.function.FunctionMetadata;
-import io.trino.spi.function.FunctionProvider;
-import io.trino.spi.function.InvocationConvention;
-import io.trino.spi.function.ScalarFunctionAdapter;
-import io.trino.spi.function.ScalarFunctionImplementation;
-import io.trino.spi.function.Signature;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.function.TypeParameter;
 import io.trino.spi.type.MapType;
-import io.trino.spi.type.TypeDescriptor;
+import io.trino.spi.type.StandardTypes;
 
-import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.block.MapValueBuilder.buildMapValue;
-import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
-import static io.trino.spi.type.TypeDescriptor.arrayType;
-import static io.trino.spi.type.TypeDescriptor.mapType;
 import static io.trino.spi.type.VarcharType.VARCHAR;
-import static java.lang.invoke.MethodHandles.lookup;
-import static java.lang.invoke.MethodType.methodType;
-import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 
 public class AiFunctions
-        implements FunctionProvider
 {
-    private static final TypeDescriptor TEXT = VARCHAR.getTypeDescriptor();
-    private static final List<FunctionMetadata> FUNCTIONS = ImmutableList.<FunctionMetadata>builder()
-            .add(function("ai_analyze_sentiment")
-                    .description("Perform sentiment analysis on text")
-                    .signature(signature(TEXT, TEXT))
-                    .build())
-            .add(function("ai_classify")
-                    .description("Classify text with the provided labels")
-                    .signature(signature(TEXT, TEXT, arrayType(TEXT)))
-                    .build())
-            .add(function("ai_extract")
-                    .description("Extract values for the provided labels from text")
-                    .signature(signature(mapType(TEXT, TEXT), TEXT, arrayType(TEXT)))
-                    .build())
-            .add(function("ai_fix_grammar")
-                    .description("Correct grammatical errors in text")
-                    .signature(signature(TEXT, TEXT))
-                    .build())
-            .add(function("ai_gen")
-                    .description("Generate text based on a prompt")
-                    .signature(signature(TEXT, TEXT))
-                    .build())
-            .add(function("ai_mask")
-                    .description("Mask values for the provided labels in text")
-                    .signature(signature(TEXT, TEXT, arrayType(TEXT)))
-                    .build())
-            .add(function("ai_translate")
-                    .description("Translate text to the specified language")
-                    .signature(signature(TEXT, TEXT, TEXT))
-                    .build())
-            .build();
-
-    private static final MethodHandle AI_ANALYZE_SENTIMENT;
-    private static final MethodHandle AI_CLASSIFY;
-    private static final MethodHandle AI_EXTRACT;
-    private static final MethodHandle AI_FIX_GRAMMAR;
-    private static final MethodHandle AI_GEN;
-    private static final MethodHandle AI_MASK;
-    private static final MethodHandle AI_TRANSLATE;
-
-    static {
-        try {
-            AI_ANALYZE_SENTIMENT = lookup().findVirtual(AiFunctions.class, "aiAnalyzeSentiment", methodType(Slice.class, Slice.class));
-            AI_CLASSIFY = lookup().findVirtual(AiFunctions.class, "aiClassify", methodType(Slice.class, Slice.class, Block.class));
-            AI_EXTRACT = lookup().findVirtual(AiFunctions.class, "aiExtract", methodType(SqlMap.class, MapType.class, Slice.class, Block.class));
-            AI_FIX_GRAMMAR = lookup().findVirtual(AiFunctions.class, "aiFixGrammar", methodType(Slice.class, Slice.class));
-            AI_GEN = lookup().findVirtual(AiFunctions.class, "aiGen", methodType(Slice.class, Slice.class));
-            AI_MASK = lookup().findVirtual(AiFunctions.class, "aiMask", methodType(Slice.class, Slice.class, Block.class));
-            AI_TRANSLATE = lookup().findVirtual(AiFunctions.class, "aiTranslate", methodType(Slice.class, Slice.class, Slice.class));
-        }
-        catch (ReflectiveOperationException e) {
-            throw new AssertionError(e);
-        }
-    }
-
     private final AiClient client;
 
     @Inject
@@ -113,85 +43,67 @@ public class AiFunctions
         this.client = requireNonNull(client, "client is null");
     }
 
-    public List<FunctionMetadata> getFunctions()
-    {
-        return FUNCTIONS;
-    }
-
-    @Override
-    public ScalarFunctionImplementation getScalarFunctionImplementation(
-            FunctionId functionId,
-            BoundSignature boundSignature,
-            FunctionDependencies functionDependencies,
-            InvocationConvention invocationConvention)
-    {
-        String name = functionId.toString();
-        MethodHandle handle = switch (name) {
-            case "ai_analyze_sentiment" -> AI_ANALYZE_SENTIMENT;
-            case "ai_classify" -> AI_CLASSIFY;
-            case "ai_extract" -> AI_EXTRACT;
-            case "ai_fix_grammar" -> AI_FIX_GRAMMAR;
-            case "ai_gen" -> AI_GEN;
-            case "ai_mask" -> AI_MASK;
-            case "ai_translate" -> AI_TRANSLATE;
-            default -> throw new IllegalArgumentException("Invalid function ID: " + functionId);
-        };
-
-        handle = handle.bindTo(this);
-
-        if (name.equals("ai_extract")) {
-            handle = handle.bindTo(functionDependencies.getType(mapType(TEXT, TEXT)));
-        }
-
-        InvocationConvention actualConvention = new InvocationConvention(
-                nCopies(boundSignature.getArity(), NEVER_NULL),
-                FAIL_ON_NULL,
-                false,
-                false);
-
-        handle = ScalarFunctionAdapter.adapt(
-                handle,
-                boundSignature.getReturnType(),
-                boundSignature.getArgumentTypes(),
-                actualConvention,
-                invocationConvention);
-
-        return ScalarFunctionImplementation.builder()
-                .methodHandle(handle)
-                .build();
-    }
-
-    public Slice aiAnalyzeSentiment(Slice text)
+    @ScalarFunction(value = "ai_analyze_sentiment", deterministic = false)
+    @Description("Perform sentiment analysis on text")
+    @SqlType(StandardTypes.VARCHAR)
+    public Slice aiAnalyzeSentiment(@SqlType(StandardTypes.VARCHAR) Slice text)
     {
         return utf8Slice(client.analyzeSentiment(text.toStringUtf8()));
     }
 
-    public Slice aiClassify(Slice text, Block labels)
+    @ScalarFunction(value = "ai_classify", deterministic = false)
+    @Description("Classify text with the provided labels")
+    @SqlType(StandardTypes.VARCHAR)
+    public Slice aiClassify(
+            @SqlType(StandardTypes.VARCHAR) Slice text,
+            @SqlType("array(varchar)") Block labels)
     {
         return utf8Slice(client.classify(text.toStringUtf8(), fromSqlArray(labels)));
     }
 
-    public SqlMap aiExtract(MapType mapType, Slice text, Block labels)
+    @ScalarFunction(value = "ai_extract", deterministic = false)
+    @Description("Extract values for the provided labels from text")
+    @SqlType("map(varchar,varchar)")
+    public SqlMap aiExtract(
+            @TypeParameter("map(varchar,varchar)") MapType mapType,
+            @SqlType(StandardTypes.VARCHAR) Slice text,
+            @SqlType("array(varchar)") Block labels)
     {
         return toSqlMap(mapType, client.extract(text.toStringUtf8(), fromSqlArray(labels)));
     }
 
-    public Slice aiFixGrammar(Slice text)
+    @ScalarFunction(value = "ai_fix_grammar", deterministic = false)
+    @Description("Correct grammatical errors in text")
+    @SqlType(StandardTypes.VARCHAR)
+    public Slice aiFixGrammar(@SqlType(StandardTypes.VARCHAR) Slice text)
     {
         return utf8Slice(client.fixGrammar(text.toStringUtf8()));
     }
 
-    public Slice aiGen(Slice prompt)
+    @ScalarFunction(value = "ai_gen", deterministic = false)
+    @Description("Generate text based on a prompt")
+    @SqlType(StandardTypes.VARCHAR)
+    public Slice aiGen(@SqlType(StandardTypes.VARCHAR) Slice prompt)
     {
         return utf8Slice(client.generate(prompt.toStringUtf8()));
     }
 
-    public Slice aiMask(Slice text, Block labels)
+    @ScalarFunction(value = "ai_mask", deterministic = false)
+    @Description("Mask values for the provided labels in text")
+    @SqlType(StandardTypes.VARCHAR)
+    public Slice aiMask(
+            @SqlType(StandardTypes.VARCHAR) Slice text,
+            @SqlType("array(varchar)") Block labels)
     {
         return utf8Slice(client.mask(text.toStringUtf8(), fromSqlArray(labels)));
     }
 
-    public Slice aiTranslate(Slice text, Slice language)
+    @ScalarFunction(value = "ai_translate", deterministic = false)
+    @Description("Translate text to the specified language")
+    @SqlType(StandardTypes.VARCHAR)
+    public Slice aiTranslate(
+            @SqlType(StandardTypes.VARCHAR) Slice text,
+            @SqlType(StandardTypes.VARCHAR) Slice language)
     {
         return utf8Slice(client.translate(text.toStringUtf8(), language.toStringUtf8()));
     }
@@ -217,20 +129,5 @@ public class AiFunctions
                         VARCHAR.writeSlice(valueBuilder, utf8Slice(value));
                     }
                 }));
-    }
-
-    private static FunctionMetadata.Builder function(String name)
-    {
-        return FunctionMetadata.scalarBuilder(name)
-                .functionId(new FunctionId(name))
-                .nondeterministic();
-    }
-
-    private static Signature signature(TypeDescriptor returnType, TypeDescriptor... argumentTypes)
-    {
-        return Signature.builder()
-                .returnType(returnType)
-                .argumentTypes(List.of(argumentTypes))
-                .build();
     }
 }

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiMetadata.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiMetadata.java
@@ -13,11 +13,11 @@
  */
 package io.trino.plugin.ai.functions;
 
-import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionBundle;
 import io.trino.spi.function.FunctionDependencyDeclaration;
 import io.trino.spi.function.FunctionId;
 import io.trino.spi.function.FunctionMetadata;
@@ -26,8 +26,6 @@ import io.trino.spi.function.SchemaFunctionName;
 import java.util.Collection;
 import java.util.List;
 
-import static io.trino.spi.type.TypeDescriptor.mapType;
-import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 
 public class AiMetadata
@@ -35,18 +33,18 @@ public class AiMetadata
 {
     private static final String SCHEMA_NAME = "ai";
 
-    private final List<FunctionMetadata> functions;
+    private final FunctionBundle functionBundle;
 
     @Inject
-    public AiMetadata(List<FunctionMetadata> functions)
+    public AiMetadata(FunctionBundle functionBundle)
     {
-        this.functions = ImmutableList.copyOf(requireNonNull(functions, "functions is null"));
+        this.functionBundle = requireNonNull(functionBundle, "functionBundle is null");
     }
 
     @Override
     public Collection<FunctionMetadata> listFunctions(ConnectorSession session, String schemaName)
     {
-        return schemaName.equals(SCHEMA_NAME) ? functions : List.of();
+        return schemaName.equals(SCHEMA_NAME) ? functionBundle.getFunctions() : List.of();
     }
 
     @Override
@@ -55,7 +53,7 @@ public class AiMetadata
         if (!name.schemaName().equals(SCHEMA_NAME)) {
             return List.of();
         }
-        return functions.stream()
+        return functionBundle.getFunctions().stream()
                 .filter(function -> function.getCanonicalName().equals(name.functionName()))
                 .toList();
     }
@@ -63,7 +61,7 @@ public class AiMetadata
     @Override
     public FunctionMetadata getFunctionMetadata(ConnectorSession session, FunctionId functionId)
     {
-        return functions.stream()
+        return functionBundle.getFunctions().stream()
                 .filter(function -> function.getFunctionId().equals(functionId))
                 .findFirst()
                 .orElseThrow();
@@ -72,8 +70,6 @@ public class AiMetadata
     @Override
     public FunctionDependencyDeclaration getFunctionDependencies(ConnectorSession session, FunctionId functionId, BoundSignature boundSignature)
     {
-        return FunctionDependencyDeclaration.builder()
-                .addType(mapType(VARCHAR.getTypeDescriptor(), VARCHAR.getTypeDescriptor()))
-                .build();
+        return functionBundle.getFunctionDependencies(functionId, boundSignature);
     }
 }

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiModule.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiModule.java
@@ -16,17 +16,25 @@ package io.trino.plugin.ai.functions;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import com.google.inject.Singleton;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorMetadata;
-import io.trino.spi.function.FunctionMetadata;
-import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.FunctionBundle;
+import io.trino.spi.function.FunctionBundleFactory;
 
-import java.util.List;
+import static java.util.Objects.requireNonNull;
 
 public class AiModule
         extends AbstractConfigurationAwareModule
 {
+    private final FunctionBundleFactory functionBundleFactory;
+
+    public AiModule(FunctionBundleFactory functionBundleFactory)
+    {
+        this.functionBundleFactory = requireNonNull(functionBundleFactory, "functionBundleFactory is null");
+    }
+
     @Override
     protected void setup(Binder binder)
     {
@@ -36,7 +44,6 @@ public class AiModule
 
         binder.bind(Connector.class).to(AiConnector.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorMetadata.class).to(AiMetadata.class).in(Scopes.SINGLETON);
-        binder.bind(FunctionProvider.class).to(AiFunctions.class).in(Scopes.SINGLETON);
 
         install(switch (buildConfigObject(AiConfig.class).getProvider()) {
             case ANTHROPIC -> new AnthropicModule();
@@ -45,8 +52,11 @@ public class AiModule
     }
 
     @Provides
-    public static List<FunctionMetadata> getFunctionMetadata(AiFunctions functions)
+    @Singleton
+    public FunctionBundle getFunctionBundle(AiFunctions functions)
     {
-        return functions.getFunctions();
+        return functionBundleFactory.builder()
+                .functions(functions)
+                .build();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Allow `FunctionBundleFactory` to register provided function instances in addition to function classes. 

This adds support for parsing annotated scalar functions from an existing object instance. For instance methods, the scalar implementation now uses the provided instance instead of requiring Trino to construct the function class via a public constructor.

This is used by the AI functions plugin to register `AiFunctions` as a Guice-managed singleton. As a result, AI functions can be implemented with standard scalar annotations while still using the injected `AiClient`.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- Fixes #29180.

The new `FunctionBundleFactory.Builder.functions(Object)` method is a default method so existing external builder implementations are not forced to implement it immediately. Existing registration behavior is preserved for class-based functions and existing `SqlFunction` instances.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## SPI
  * Add support for registering scalar function instances with `FunctionBundleFactory`. ({issue}`29180`)
```

