### PR TITLE
Decode small manifest sets inline in Iceberg table stats

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableStatisticsReader.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableStatisticsReader.java
@@ -90,6 +90,9 @@ public final class TableStatisticsReader
 
     public static final String APACHE_DATASKETCHES_THETA_V1_NDV_PROPERTY = "ndv";
 
+    @VisibleForTesting
+    static final int INLINE_MANIFEST_DECODE_THRESHOLD = 4;
+
     private final TypeManager typeManager;
     private final ExecutorService icebergPlanningExecutor;
 
@@ -178,7 +181,15 @@ public final class TableStatisticsReader
                 .filter(column -> columnIds.contains(column.fieldId()))
                 .collect(toImmutableList());
         IcebergStatistics.Builder icebergStatisticsBuilder = new IcebergStatistics.Builder(columns, typeManager);
-        try (CloseableIterable<DataFile> dataFiles = new ParallelIterable<>(dataFileIterables, icebergPlanningExecutor)) {
+        // Decode small manifest sets inline to avoid bottlenecking small scans on resource contention in the shared planning pool
+        CloseableIterable<DataFile> dataFileSource;
+        if (filteredManifests.size() < INLINE_MANIFEST_DECODE_THRESHOLD) {
+            dataFileSource = CloseableIterable.concat(dataFileIterables);
+        }
+        else {
+            dataFileSource = new ParallelIterable<>(dataFileIterables, icebergPlanningExecutor);
+        }
+        try (CloseableIterable<DataFile> dataFiles = dataFileSource) {
             dataFiles.forEach(dataFile -> {
                 PartitionSpec spec = icebergTable.specs().get(dataFile.specId());
                 if (!partitionDomain.isAll() && !partitionDomain.includesNullableValue(utf8Slice(spec.partitionToPath(dataFile.partition())))) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -1395,6 +1395,42 @@ public class TestIcebergV2
     }
 
     @Test
+    public void testStatsManifestDecoding()
+    {
+        int threshold = TableStatisticsReader.INLINE_MANIFEST_DECODE_THRESHOLD;
+        try (TestTable testTable = newTrinoTable("test_stats_manifest_decoding_", "(a INT)")) {
+            for (int i = 0; i < threshold - 1; i++) {
+                assertUpdate("INSERT INTO " + testTable.getName() + " VALUES (" + i + ")", 1);
+            }
+            assertThat(manifestCount(testTable.getName())).isLessThan(threshold);
+            assertThat(tableRowCountFromStatistics(testTable.getName())).isEqualTo(threshold - 1);
+
+            assertUpdate("INSERT INTO " + testTable.getName() + " VALUES (100)", 1);
+            assertThat(manifestCount(testTable.getName())).isGreaterThanOrEqualTo(threshold);
+            assertThat(tableRowCountFromStatistics(testTable.getName())).isEqualTo(threshold);
+        }
+    }
+
+    private long manifestCount(String tableName)
+    {
+        return (long) computeScalar("SELECT count(*) FROM \"" + tableName + "$manifests\"");
+    }
+
+    private double tableRowCountFromStatistics(String tableName)
+    {
+        OptionalLong snapshotId = OptionalLong.of((long) computeScalar("SELECT snapshot_id FROM \"" + tableName + "$snapshots\" ORDER BY committed_at DESC FETCH FIRST 1 ROW WITH TIES"));
+        TableStatistics statistics = TableStatisticsReader.makeTableStatistics(
+                TESTING_TYPE_MANAGER,
+                loadTable(tableName),
+                snapshotId,
+                TupleDomain.all(),
+                TupleDomain.all(),
+                ImmutableSet.of(),
+                newDirectExecutorService());
+        return statistics.getRowCount().getValue();
+    }
+
+    @Test
     public void testInt96TimestampWithTimeZone()
     {
         assertUpdate("CREATE TABLE hive.tpch.test_timestamptz_base (t timestamp) WITH (format = 'PARQUET')");


### PR DESCRIPTION
## Description

This decodes manifest sets below a small threshold inline on the calling thread instead of going through the shared executor, avoiding that contention for small scans. Larger manifest sets are unaffected and still use `ParallelIterable`.

## Additional context and related issues



## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```