### PR TITLE
Fix maven-compiler-plugin compilerArgs inheritance

### DIFF
--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -562,7 +562,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
                         <!-- Ensure incubator Vector API is on the module path for javac -->
-                        <compilerArgs combine.self="merge">
+                        <compilerArgs combine.children="append">
                             <arg>${extraJavaVectorArgs}</arg>
                         </compilerArgs>
                     </configuration>

--- a/lib/trino-parquet/pom.xml
+++ b/lib/trino-parquet/pom.xml
@@ -241,7 +241,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
-                        <compilerArgs combine.self="merge">
+                        <compilerArgs combine.children="append">
                             <arg>${extraJavaVectorArgs}</arg>
                         </compilerArgs>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -2823,14 +2823,13 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <!--suppress MavenModelInspection -->
-                        <configuration combine.children="merge">
+                        <configuration>
                             <!-- forking not required due to JVM flags in .mvn/jvm.config -->
                             <!-- see https://errorprone.info/docs/installation#maven -->
                             <!-- Do not fail on error-prone's warnings even for modules using air.compiler.fail-warnings -->
                             <!-- TODO silence warnings we choose to ignore and raise important warnings to error and then remove <failOnWarning> -->
                             <failOnWarning>false</failOnWarning>
-                            <compilerArgs>
+                            <compilerArgs combine.children="append">
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>--should-stop=ifError=FLOW</arg>
                                 <arg>-Xplugin:ErrorProne @${air.main.basedir}/.mvn/errorprone.config \


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Use `combine.children="append"` instead of `combine.self="merge"` or anything else. The `<arg>` elements should be stacked together across the POM hierarchy - the "merge" mode would try to combine them into one element instead.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Honestly, I'm stumped why this didn't fail earlier with the `error-prone` profile - I couldn't get it to work locally because when enabled, it lacked the option to enable the Vector API. There may be something fishy in CI around that 🤔

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
