### PR TITLE
Fix date partition projection with sub-day formats

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/DateProjection.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/DateProjection.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
@@ -67,6 +68,8 @@ import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.time.temporal.ChronoUnit.WEEKS;
+import static java.time.temporal.ChronoUnit.YEARS;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
@@ -76,12 +79,8 @@ final class DateProjection
         implements Projection
 {
     private static final ZoneId UTC_TIME_ZONE_ID = ZoneId.of("UTC");
-    // Limited to only DAYS, HOURS, MINUTES, SECONDS as we are not fully sure how everything above day
-    // is implemented in Athena. So we limit it to a subset of interval units which are explicitly clear how to calculate.
-    // The rest will be implemented if this is required as it would require making compatibility tests
-    // for results received from Athena and verifying if we receive identical with Trino.
-    private static final Set<ChronoUnit> DATE_PROJECTION_INTERVAL_UNITS = ImmutableSet.of(DAYS, HOURS, MINUTES, SECONDS);
-    private static final Pattern DATE_RANGE_BOUND_EXPRESSION_PATTERN = Pattern.compile("^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$");
+    private static final Set<ChronoUnit> DATE_PROJECTION_INTERVAL_UNITS = ImmutableSet.of(YEARS, MONTHS, WEEKS, DAYS, HOURS, MINUTES, SECONDS);
+    private static final Pattern DATE_RANGE_BOUND_EXPRESSION_PATTERN = Pattern.compile("^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(YEAR|MONTH|WEEK|DAY|HOUR|MINUTE|SECOND)S?\\s*)?$");
 
     private final String columnName;
     private final String dateFormatPattern;
@@ -121,7 +120,12 @@ final class DateProjection
             throw invalidRangeProperty(columnName, dateFormatPattern, Optional.empty());
         }
 
-        this.dateFormat = DateTimeFormatter.ofPattern(dateFormatPattern, ENGLISH);
+        // Default missing month/day fields so coarse formats such as 'yyyy' or 'yyyy-MM' parse to a complete date.
+        this.dateFormat = new DateTimeFormatterBuilder()
+                .appendPattern(dateFormatPattern)
+                .parseDefaulting(ChronoField.MONTH_OF_YEAR, 1)
+                .parseDefaulting(ChronoField.DAY_OF_MONTH, 1)
+                .toFormatter(ENGLISH);
 
         leftBound = parseDateRangerBound(columnName, range.get(0), dateFormatPattern);
         rightBound = parseDateRangerBound(columnName, range.get(1), dateFormatPattern);
@@ -264,18 +268,21 @@ final class DateProjection
         String datePatternWithoutText = dateFormatPattern.replaceAll("'.*?'", "");
         if (datePatternWithoutText.contains("S") || datePatternWithoutText.contains("s")
                 || datePatternWithoutText.contains("m") || datePatternWithoutText.contains("H")) {
-            // When the provided dates are at single-day or single-month precision.
+            // When the provided dates are at sub-day precision.
             throw new InvalidProjectionException(
                     columnName,
                     format(
-                            "Property: '%s' needs to be set when provided '%s' is less that single-day precision. Interval defaults to 1 day or 1 month, respectively. Otherwise, interval is required",
+                            "Property: '%s' needs to be set when provided '%s' is less than single-day precision. Interval defaults to 1 day, 1 month or 1 year, respectively. Otherwise, interval is required",
                             COLUMN_PROJECTION_INTERVAL_UNIT,
                             COLUMN_PROJECTION_FORMAT));
         }
         if (datePatternWithoutText.contains("d")) {
             return DAYS;
         }
-        return MONTHS;
+        if (datePatternWithoutText.contains("M")) {
+            return MONTHS;
+        }
+        return YEARS;
     }
 
     private Instant parseDateRangerBound(String columnName, String value, String dateFormatPattern)
@@ -290,7 +297,10 @@ final class DateProjection
                 int multiplier = Integer.parseInt(multiplierString);
                 boolean increment = operator.charAt(0) == '+';
                 ChronoUnit unit = ChronoUnit.valueOf(unitString + "S");
-                return Instant.now().plus(increment ? multiplier : -multiplier, unit);
+                // Use a calendar type because Instant.plus does not support estimated units (WEEKS, MONTHS, YEARS).
+                return Instant.now().atZone(UTC_TIME_ZONE_ID)
+                        .plus(increment ? multiplier : -multiplier, unit)
+                        .toInstant();
             }
             if (value.trim().equals("NOW")) {
                 return Instant.now();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
@@ -1773,6 +1773,206 @@ abstract class BaseTestHiveOnDataLake
     }
 
     @Test
+    public void testDatePartitionProjectionOnVarcharColumnWithYearMonthFormat()
+    {
+        String tableName = getRandomTestTableName();
+        String fullyQualifiedTestTableName = getFullyQualifiedTestTableName(tableName);
+
+        computeActual(
+                "CREATE TABLE " + fullyQualifiedTestTableName + " ( " +
+                        "  name varchar(25), " +
+                        "  comment varchar(152), " +
+                        "  nationkey bigint, " +
+                        "  regionkey bigint, " +
+                        "  short_name1 varchar(152) WITH (" +
+                        "    partition_projection_type='enum', " +
+                        "    partition_projection_values=ARRAY['PL1', 'CZ1'] " +
+                        "  ), " +
+                        "  short_name2 varchar WITH (" +
+                        "    partition_projection_type='date', " +
+                        "    partition_projection_format='yyyy-MM', " +
+                        "    partition_projection_range=ARRAY['2022-01', '2022-06']" +
+                        "  )" +
+                        ") WITH ( " +
+                        "  partitioned_by=ARRAY['short_name1', 'short_name2'], " +
+                        "  partition_projection_enabled=true " +
+                        ")");
+
+        assertThat(
+                hiveFlociDataLake
+                        .runOnHive("SHOW TBLPROPERTIES " + getHiveTestTableName(tableName)))
+                .containsPattern("[ |]+projection\\.enabled[ |]+true[ |]+")
+                .containsPattern("[ |]+projection\\.short_name1\\.type[ |]+enum[ |]+")
+                .containsPattern("[ |]+projection\\.short_name1\\.values[ |]+PL1,CZ1[ |]+")
+                .containsPattern("[ |]+projection\\.short_name2\\.type[ |]+date[ |]+")
+                .containsPattern("[ |]+projection\\.short_name2\\.format[ |]+yyyy-MM[ |]+")
+                .containsPattern("[ |]+projection\\.short_name2\\.range[ |]+2022-01,2022-06[ |]+");
+
+        computeActual(createInsertStatement(
+                fullyQualifiedTestTableName,
+                ImmutableList.of(
+                        ImmutableList.of("'POLAND_1'", "'Comment'", "0", "5", "'PL1'", "'2022-01'"),
+                        ImmutableList.of("'POLAND_2'", "'Comment'", "1", "5", "'PL1'", "'2022-03'"),
+                        ImmutableList.of("'CZECH_1'", "'Comment'", "2", "5", "'CZ1'", "'2022-05'"),
+                        ImmutableList.of("'CZECH_2'", "'Comment'", "3", "5", "'CZ1'", "'2022-06'"),
+                        ImmutableList.of("'CZECH_3'", "'Comment'", "4", "5", "'CZ1'", "'2022-09'"))));
+
+        assertQuery(
+                format("SELECT name FROM %s WHERE short_name1='PL1' AND short_name2='2022-03'", fullyQualifiedTestTableName),
+                "VALUES 'POLAND_2'");
+
+        assertQuery(
+                format("SELECT name FROM %s WHERE short_name1='PL1' AND ( short_name2='2022-01' OR short_name2='2022-03' )", fullyQualifiedTestTableName),
+                "VALUES ('POLAND_1'), ('POLAND_2')");
+
+        assertQuery(
+                format("SELECT name FROM %s WHERE short_name2 > '2022-03'", fullyQualifiedTestTableName),
+                "VALUES ('CZECH_1'), ('CZECH_2')");
+
+        assertQuery(
+                format("SELECT name FROM %s WHERE short_name2 >= '2022-03' AND short_name2 <= '2022-06'", fullyQualifiedTestTableName),
+                "VALUES ('POLAND_2'), ('CZECH_1'), ('CZECH_2')");
+
+        assertQuery(
+                format("SELECT name FROM %s WHERE short_name1='PL1'", fullyQualifiedTestTableName),
+                "VALUES ('POLAND_1'), ('POLAND_2')");
+
+        assertQuery(
+                format("SELECT name FROM %s", fullyQualifiedTestTableName),
+                "VALUES ('POLAND_1'), ('POLAND_2'), ('CZECH_1'), ('CZECH_2')");
+    }
+
+    @Test
+    public void testDatePartitionProjectionOnVarcharColumnWithYearFormat()
+    {
+        String tableName = getRandomTestTableName();
+        String fullyQualifiedTestTableName = getFullyQualifiedTestTableName(tableName);
+
+        computeActual(
+                "CREATE TABLE " + fullyQualifiedTestTableName + " ( " +
+                        "  name varchar(25), " +
+                        "  comment varchar(152), " +
+                        "  nationkey bigint, " +
+                        "  regionkey bigint, " +
+                        "  short_name1 varchar(152) WITH (" +
+                        "    partition_projection_type='enum', " +
+                        "    partition_projection_values=ARRAY['PL1', 'CZ1'] " +
+                        "  ), " +
+                        "  short_name2 varchar WITH (" +
+                        "    partition_projection_type='date', " +
+                        "    partition_projection_format='yyyy', " +
+                        "    partition_projection_range=ARRAY['2020', '2024']" +
+                        "  )" +
+                        ") WITH ( " +
+                        "  partitioned_by=ARRAY['short_name1', 'short_name2'], " +
+                        "  partition_projection_enabled=true " +
+                        ")");
+
+        assertThat(
+                hiveFlociDataLake
+                        .runOnHive("SHOW TBLPROPERTIES " + getHiveTestTableName(tableName)))
+                .containsPattern("[ |]+projection\\.enabled[ |]+true[ |]+")
+                .containsPattern("[ |]+projection\\.short_name1\\.type[ |]+enum[ |]+")
+                .containsPattern("[ |]+projection\\.short_name1\\.values[ |]+PL1,CZ1[ |]+")
+                .containsPattern("[ |]+projection\\.short_name2\\.type[ |]+date[ |]+")
+                .containsPattern("[ |]+projection\\.short_name2\\.format[ |]+yyyy[ |]+")
+                .containsPattern("[ |]+projection\\.short_name2\\.range[ |]+2020,2024[ |]+");
+
+        computeActual(createInsertStatement(
+                fullyQualifiedTestTableName,
+                ImmutableList.of(
+                        ImmutableList.of("'POLAND_1'", "'Comment'", "0", "5", "'PL1'", "'2020'"),
+                        ImmutableList.of("'POLAND_2'", "'Comment'", "1", "5", "'PL1'", "'2022'"),
+                        ImmutableList.of("'CZECH_1'", "'Comment'", "2", "5", "'CZ1'", "'2023'"),
+                        ImmutableList.of("'CZECH_2'", "'Comment'", "3", "5", "'CZ1'", "'2024'"),
+                        ImmutableList.of("'CZECH_3'", "'Comment'", "4", "5", "'CZ1'", "'2026'"))));
+
+        assertQuery(
+                format("SELECT name FROM %s WHERE short_name1='PL1' AND short_name2='2022'", fullyQualifiedTestTableName),
+                "VALUES 'POLAND_2'");
+
+        assertQuery(
+                format("SELECT name FROM %s WHERE short_name1='PL1' AND ( short_name2='2020' OR short_name2='2022' )", fullyQualifiedTestTableName),
+                "VALUES ('POLAND_1'), ('POLAND_2')");
+
+        assertQuery(
+                format("SELECT name FROM %s WHERE short_name2 > '2022'", fullyQualifiedTestTableName),
+                "VALUES ('CZECH_1'), ('CZECH_2')");
+
+        assertQuery(
+                format("SELECT name FROM %s WHERE short_name2 >= '2022' AND short_name2 <= '2024'", fullyQualifiedTestTableName),
+                "VALUES ('POLAND_2'), ('CZECH_1'), ('CZECH_2')");
+
+        assertQuery(
+                format("SELECT name FROM %s WHERE short_name1='PL1'", fullyQualifiedTestTableName),
+                "VALUES ('POLAND_1'), ('POLAND_2')");
+
+        assertQuery(
+                format("SELECT name FROM %s", fullyQualifiedTestTableName),
+                "VALUES ('POLAND_1'), ('POLAND_2'), ('CZECH_1'), ('CZECH_2')");
+    }
+
+    @Test
+    public void testDatePartitionProjectionOnVarcharColumnWithWeekInterval()
+    {
+        String tableName = getRandomTestTableName();
+        String fullyQualifiedTestTableName = getFullyQualifiedTestTableName(tableName);
+
+        computeActual(
+                "CREATE TABLE " + fullyQualifiedTestTableName + " ( " +
+                        "  name varchar(25), " +
+                        "  comment varchar(152), " +
+                        "  nationkey bigint, " +
+                        "  regionkey bigint, " +
+                        "  short_name1 varchar(152) WITH (" +
+                        "    partition_projection_type='enum', " +
+                        "    partition_projection_values=ARRAY['PL1', 'CZ1'] " +
+                        "  ), " +
+                        "  short_name2 varchar WITH (" +
+                        "    partition_projection_type='date', " +
+                        "    partition_projection_format='yyyy-MM-dd', " +
+                        "    partition_projection_range=ARRAY['2022-01-01', '2022-01-29'], " +
+                        "    partition_projection_interval=1, " +
+                        "    partition_projection_interval_unit='WEEKS'" +
+                        "  )" +
+                        ") WITH ( " +
+                        "  partitioned_by=ARRAY['short_name1', 'short_name2'], " +
+                        "  partition_projection_enabled=true " +
+                        ")");
+
+        assertThat(
+                hiveFlociDataLake
+                        .runOnHive("SHOW TBLPROPERTIES " + getHiveTestTableName(tableName)))
+                .containsPattern("[ |]+projection\\.enabled[ |]+true[ |]+")
+                .containsPattern("[ |]+projection\\.short_name2\\.type[ |]+date[ |]+")
+                .containsPattern("[ |]+projection\\.short_name2\\.format[ |]+yyyy-MM-dd[ |]+")
+                .containsPattern("[ |]+projection\\.short_name2\\.range[ |]+2022-01-01,2022-01-29[ |]+")
+                .containsPattern("[ |]+projection\\.short_name2\\.interval[ |]+1[ |]+")
+                .containsPattern("[ |]+projection\\.short_name2\\.interval.unit[ |]+weeks[ |]+");
+
+        computeActual(createInsertStatement(
+                fullyQualifiedTestTableName,
+                ImmutableList.of(
+                        ImmutableList.of("'POLAND_1'", "'Comment'", "0", "5", "'PL1'", "'2022-01-01'"),
+                        ImmutableList.of("'POLAND_2'", "'Comment'", "1", "5", "'PL1'", "'2022-01-08'"),
+                        ImmutableList.of("'CZECH_1'", "'Comment'", "2", "5", "'CZ1'", "'2022-01-15'"),
+                        ImmutableList.of("'CZECH_2'", "'Comment'", "3", "5", "'CZ1'", "'2022-01-29'"),
+                        ImmutableList.of("'CZECH_3'", "'Comment'", "4", "5", "'CZ1'", "'2022-01-09'"))));
+
+        assertQuery(
+                format("SELECT name FROM %s WHERE short_name1='PL1' AND short_name2='2022-01-08'", fullyQualifiedTestTableName),
+                "VALUES 'POLAND_2'");
+
+        assertQuery(
+                format("SELECT name FROM %s WHERE short_name2 >= '2022-01-08' AND short_name2 <= '2022-01-29'", fullyQualifiedTestTableName),
+                "VALUES ('POLAND_2'), ('CZECH_1'), ('CZECH_2')");
+
+        assertQuery(
+                format("SELECT name FROM %s", fullyQualifiedTestTableName),
+                "VALUES ('POLAND_1'), ('POLAND_2'), ('CZECH_1'), ('CZECH_2')");
+    }
+
+    @Test
     public void testInjectedPartitionProjectionOnVarcharColumn()
     {
         String tableName = getRandomTestTableName();
@@ -1934,7 +2134,7 @@ abstract class BaseTestHiveOnDataLake
                         "  partition_projection_enabled=true " +
                         ")"))
                 .hasMessage("Column projection for column 'short_name1' failed. Property: 'partition_projection_range' needs to be a list of 2 valid dates formatted as 'yyyy-MM-dd HH' " +
-                        "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential: Text '2001-01-01' could not be parsed at index 10");
+                        "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(YEAR|MONTH|WEEK|DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential: Text '2001-01-01' could not be parsed at index 10");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
                 "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
@@ -1949,7 +2149,7 @@ abstract class BaseTestHiveOnDataLake
                         "  partition_projection_enabled=true " +
                         ")"))
                 .hasMessage("Column projection for column 'short_name1' failed. Property: 'partition_projection_range' needs to be a list of 2 valid dates formatted as 'yyyy-MM-dd' " +
-                        "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential: Text 'NOW*3DAYS' could not be parsed at index 0");
+                        "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(YEAR|MONTH|WEEK|DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential: Text 'NOW*3DAYS' could not be parsed at index 0");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
                 "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
@@ -1964,7 +2164,7 @@ abstract class BaseTestHiveOnDataLake
                         "  partition_projection_enabled=true " +
                         ")"))
                 .hasMessage("Column projection for column 'short_name1' failed. Property: 'partition_projection_range' needs to be a list of 2 valid dates formatted as 'yyyy-MM-dd' " +
-                        "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential");
+                        "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(YEAR|MONTH|WEEK|DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
                 "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
@@ -1980,7 +2180,7 @@ abstract class BaseTestHiveOnDataLake
                         "  partition_projection_enabled=true " +
                         ")"))
                 .hasMessage("Column projection for column 'short_name1' failed. Property: 'partition_projection_interval_unit' value 'Decades' is invalid. " +
-                        "Available options: [Days, Hours, Minutes, Seconds]");
+                        "Available options: [Years, Months, Weeks, Days, Hours, Minutes, Seconds]");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
                 "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
@@ -1995,8 +2195,8 @@ abstract class BaseTestHiveOnDataLake
                         "  partition_projection_enabled=true " +
                         ")"))
                 .hasMessage("Column projection for column 'short_name1' failed. Property: 'partition_projection_interval_unit' " +
-                        "needs to be set when provided 'partition_projection_format' is less that single-day precision. " +
-                        "Interval defaults to 1 day or 1 month, respectively. Otherwise, interval is required");
+                        "needs to be set when provided 'partition_projection_format' is less than single-day precision. " +
+                        "Interval defaults to 1 day, 1 month or 1 year, respectively. Otherwise, interval is required");
 
         assertThatThrownBy(() -> getQueryRunner().execute(
                 "CREATE TABLE " + getFullyQualifiedTestTableName("nation_" + randomNameSuffix()) + " ( " +
@@ -2027,8 +2227,8 @@ abstract class BaseTestHiveOnDataLake
                         "  partition_projection_ignore=true " + // <-- Even if this is set we disallow creating corrupted configuration via Trino
                         ")"))
                 .hasMessage("Column projection for column 'short_name1' failed. Property: 'partition_projection_interval_unit' " +
-                        "needs to be set when provided 'partition_projection_format' is less that single-day precision. " +
-                        "Interval defaults to 1 day or 1 month, respectively. Otherwise, interval is required");
+                        "needs to be set when provided 'partition_projection_format' is less than single-day precision. " +
+                        "Interval defaults to 1 day, 1 month or 1 year, respectively. Otherwise, interval is required");
     }
 
     @Test
@@ -2055,7 +2255,7 @@ abstract class BaseTestHiveOnDataLake
         // Expect invalid Partition Projection properties to fail
         assertThatThrownBy(() -> getQueryRunner().execute("SELECT * FROM " + fullyQualifiedTestTableName))
                 .hasMessage("Column projection for column 'date_time' failed. Property: 'partition_projection_range' needs to be a list of 2 valid dates formatted as 'yyyy-MM-dd HH' " +
-                        "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential: Text '2001-01-01' could not be parsed at index 10");
+                        "or '^\\s*NOW\\s*(([+-])\\s*([0-9]+)\\s*(YEAR|MONTH|WEEK|DAY|HOUR|MINUTE|SECOND)S?\\s*)?$' that are sequential: Text '2001-01-01' could not be parsed at index 10");
 
         // Append kill switch table property to ignore Partition Projection properties
         hiveFlociDataLake.runOnHive(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/projection/TestDateProjectionFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/projection/TestDateProjectionFactory.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static io.trino.plugin.hive.projection.PartitionProjectionProperties.COLUMN_PROJECTION_FORMAT;
+import static io.trino.plugin.hive.projection.PartitionProjectionProperties.COLUMN_PROJECTION_INTERVAL;
+import static io.trino.plugin.hive.projection.PartitionProjectionProperties.COLUMN_PROJECTION_INTERVAL_UNIT;
 import static io.trino.plugin.hive.projection.PartitionProjectionProperties.COLUMN_PROJECTION_RANGE;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DateType.DATE;
@@ -29,6 +31,7 @@ import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_SECONDS;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.time.temporal.ChronoUnit.WEEKS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -62,5 +65,65 @@ class TestDateProjectionFactory
         assertThatThrownBy(() -> new DateProjection("test", VARCHAR, ImmutableMap.of("ignored", ImmutableList.of("2020-01-01", "2020-01-02", "2020-01-03"))))
                 .isInstanceOf(InvalidProjectionException.class)
                 .hasMessage("Column projection for column 'test' failed. Missing required property: 'partition_projection_format'");
+    }
+
+    @Test
+    void testYearFormat()
+    {
+        Projection projection = new DateProjection("test", VARCHAR, ImmutableMap.of(COLUMN_PROJECTION_FORMAT, "yyyy", COLUMN_PROJECTION_RANGE, ImmutableList.of("2020", "2023")));
+        assertThat(projection.getProjectedValues(Optional.empty())).containsExactly("2020", "2021", "2022", "2023");
+        assertThat(projection.getProjectedValues(Optional.of(Domain.singleValue(VARCHAR, Slices.utf8Slice("2021"))))).containsExactly("2021");
+        assertThat(projection.getProjectedValues(Optional.of(Domain.singleValue(VARCHAR, Slices.utf8Slice("2019"))))).isEmpty();
+    }
+
+    @Test
+    void testMonthFormat()
+    {
+        Projection projection = new DateProjection("test", VARCHAR, ImmutableMap.of(COLUMN_PROJECTION_FORMAT, "yyyy-MM", COLUMN_PROJECTION_RANGE, ImmutableList.of("2022-01", "2022-03")));
+        assertThat(projection.getProjectedValues(Optional.empty())).containsExactly("2022-01", "2022-02", "2022-03");
+        assertThat(projection.getProjectedValues(Optional.of(Domain.all(VARCHAR)))).containsExactly("2022-01", "2022-02", "2022-03");
+        assertThat(projection.getProjectedValues(Optional.of(Domain.none(VARCHAR)))).isEmpty();
+        assertThat(projection.getProjectedValues(Optional.of(Domain.singleValue(VARCHAR, Slices.utf8Slice("2022-02"))))).containsExactly("2022-02");
+        assertThat(projection.getProjectedValues(Optional.of(Domain.singleValue(VARCHAR, Slices.utf8Slice("2023-01"))))).isEmpty();
+    }
+
+    @Test
+    void testWeekInterval()
+    {
+        Projection projection = new DateProjection("test", VARCHAR, ImmutableMap.of(
+                COLUMN_PROJECTION_FORMAT, "yyyy-MM-dd",
+                COLUMN_PROJECTION_RANGE, ImmutableList.of("2020-01-01", "2020-01-22"),
+                COLUMN_PROJECTION_INTERVAL, 1,
+                COLUMN_PROJECTION_INTERVAL_UNIT, WEEKS));
+        assertThat(projection.getProjectedValues(Optional.empty())).containsExactly("2020-01-01", "2020-01-08", "2020-01-15", "2020-01-22");
+        assertThat(projection.getProjectedValues(Optional.of(Domain.singleValue(VARCHAR, Slices.utf8Slice("2020-01-08"))))).containsExactly("2020-01-08");
+        assertThat(projection.getProjectedValues(Optional.of(Domain.singleValue(VARCHAR, Slices.utf8Slice("2020-01-09"))))).isEmpty();
+    }
+
+    @Test
+    void testMissingIntervalUnitForSubDayFormat()
+    {
+        assertThatThrownBy(() -> new DateProjection("test", VARCHAR, ImmutableMap.of(
+                COLUMN_PROJECTION_FORMAT, "yyyy-MM-dd HH",
+                COLUMN_PROJECTION_RANGE, ImmutableList.of("2020-01-01 00", "2020-01-02 00"))))
+                .isInstanceOf(InvalidProjectionException.class)
+                .hasMessage("Column projection for column 'test' failed. Property: 'partition_projection_interval_unit' " +
+                        "needs to be set when provided 'partition_projection_format' is less than single-day precision. " +
+                        "Interval defaults to 1 day, 1 month or 1 year, respectively. Otherwise, interval is required");
+    }
+
+    @Test
+    void testNowRelativeRangeWithEstimatedUnits()
+    {
+        // Regression: NOW arithmetic must support estimated units (WEEKS, MONTHS, YEARS) that Instant.plus rejects
+        assertThat(new DateProjection("test", VARCHAR, ImmutableMap.of(
+                COLUMN_PROJECTION_FORMAT, "yyyy-MM",
+                COLUMN_PROJECTION_RANGE, ImmutableList.of("NOW-2MONTHS", "NOW")))
+                .getProjectedValues(Optional.empty())).hasSize(3);
+
+        assertThat(new DateProjection("test", VARCHAR, ImmutableMap.of(
+                COLUMN_PROJECTION_FORMAT, "yyyy",
+                COLUMN_PROJECTION_RANGE, ImmutableList.of("NOW-2YEARS", "NOW")))
+                .getProjectedValues(Optional.empty())).hasSize(3);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->

- fixes #29057

## Description

Date partition projection throws an exception at query planning time whenever the projection format has less
than day precision, e.g. `yyyy-MM` or `yyyy`:

```
java.time.DateTimeException: Unable to obtain LocalDateTime from TemporalAccessor: {Year=2016, MonthOfYear=7},ISO
	at io.trino.plugin.hive.projection.DateProjection.parse(DateProjection.java:316)
```

This is a regression from #25817. That change swapped `SimpleDateFormat` for `java.time.DateTimeFormatter`.
`SimpleDateFormat` was forgiving: parsing `2017-01` with `yyyy-MM` simply filled in the missing day as the 1st.
The new code resolves via `LocalDateTime.from(parsed)`, which is strict, and a `yyyy-MM` pattern only
produces `{Year, MonthOfYear}` and no day, so it throws an exception. It surfaces during planning because
`getProjectedValues()` formats each range bound to the pattern and parses it right back.

The fix restores the old forgiving behavior by filling in the missing calendar/time fields when building
the formatter, so lower-precision patterns resolve to the first instant of the period (month -> 1st day,
midnight). Full-date formats are unaffected because the defaults only apply to fields that weren't parsed.

In addition, this extends the supported `interval.unit` values to `YEARS`, `MONTHS`, and `WEEKS`
(previously only `DAYS`, `HOURS`, `MINUTES`, and `SECONDS` were allowed), matching the
[AWS Athena date projection spec](https://docs.aws.amazon.com/athena/latest/ug/partition-projection-supported-types.html#partition-projection-date-type)
(`MILLIS` is intentionally omitted as impractical for physical partitioning). With this, coarse
formats now generate the correct ranges and pick the right default interval unit: `yyyy` defaults to
`YEARS` and `yyyy-MM` defaults to `MONTHS`, so a range such as `2015-01,NOW` with format `yyyy-MM`
produces `2015-01, 2015-02, 2015-03, ...` instead of iterating by days. The `NOW` relative-range
expression is likewise extended to accept `YEAR`, `MONTH`, and `WEEK` units.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Reproducer:

```sql
CREATE TABLE hive.default.events (
    id BIGINT,
    event_month VARCHAR WITH (
        partition_projection_type          = 'date',
        partition_projection_format        = 'yyyy-MM',
        partition_projection_range         = ARRAY['2017-01', 'NOW'],
        partition_projection_interval      = 1,
        partition_projection_interval_unit = 'DAYS'
    )
)
WITH (
    partition_projection_enabled = true,
    partitioned_by               = ARRAY['event_month'],
    external_location            = 's3://my-bucket/events/'
);

SELECT * FROM hive.default.events;
```

`ARRAY['NOW-3650', 'NOW']` fails the same way.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```
## Hive
* Fix query failure when reading a table that uses date partition projection with a
  format shorter than day precision (for example `yyyy-MM`). ({issue}`25817`)
* Add support for `YEARS`, `MONTHS`, and `WEEKS` date partition projection interval units.
```
