### PR TITLE
Use correct output layout for mixed-distribution UNION ALL

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -1393,7 +1393,9 @@ public class AddExchanges
                             Optional.empty());
 
                     unpartitionedChildren.add(result);
-                    unpartitionedOutputLayouts.add(result.getOutputSymbols());
+                    // Use exchangeOutputLayout, which is positionally aligned with node.getOutputSymbols(),
+                    // rather than the exchange's own output symbols, which the ExchangeNode constructor may reorder.
+                    unpartitionedOutputLayouts.add(exchangeOutputLayout);
                 }
 
                 ImmutableListMultimap.Builder<Symbol, Symbol> mappings = ImmutableListMultimap.builder();


### PR DESCRIPTION
## Description

In `AddExchanges.visitUnion` mixed case (one partitioned child plus at least one single-node
child), the distributed branch is wrapped in a single-source `REMOTE GATHER` `ExchangeNode` and
folded into the set of unpartitioned inputs of a local union. The local union was given the
exchange's own output symbols (`result.getOutputSymbols()`) as its positional output layout.

The symbols positionally aligned with the union output (`node.getOutputSymbols()`) are the
`exchangeOutputLayout` built just above, not the exchange node's reported output symbols — the
latter are produced by the `ExchangeNode` constructor and are not guaranteed to preserve that
order. This changes the local union layout to use `exchangeOutputLayout` directly.

This is a no-op on current `master`, but it removes a fragile assumption that the gathering
exchange's output order matches the union output order.

## Additional context and related issues

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required, with the following suggested text:
