### PR TITLE
Speed up sorting, TopN and sorted merges with sort key prefixes

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/BatchPageSortKeyPrefixFiller.java
+++ b/core/trino-main/src/main/java/io/trino/operator/BatchPageSortKeyPrefixFiller.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.ValueBlock;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Fills sort key prefixes with the type's batch sort key prefix operator when the page's sort
+ * channel is a value block without nulls, falling back to the per-position filler otherwise. The
+ * batch operator produces raw prefixes, which are then adjusted for the layout (descending order
+ * and bit alignment) in a separate pass over the array. Only single-channel layouts are supported,
+ * since the batch operator overwrites the prefix array instead of merging into it.
+ */
+public class BatchPageSortKeyPrefixFiller
+        implements PageSortKeyPrefixFiller
+{
+    private final MethodHandle batchOperator;
+    private final PageSortKeyPrefixFiller fallback;
+    private final int sortChannel;
+    private final boolean descending;
+    private final int extractShift;
+    private final boolean identityLayout;
+
+    public BatchPageSortKeyPrefixFiller(MethodHandle batchOperator, SortKeyPrefixFiller.SortKeyPrefixLayout layout, PageSortKeyPrefixFiller fallback)
+    {
+        this.batchOperator = requireNonNull(batchOperator, "batchOperator is null");
+        this.fallback = requireNonNull(fallback, "fallback is null");
+        if (layout.hasNullBit() || layout.shift() != 0 || layout.valueBase() != 0) {
+            throw new IllegalArgumentException("Batch filling requires a single-channel layout");
+        }
+        this.sortChannel = layout.sortChannel();
+        this.descending = layout.descending();
+        this.extractShift = layout.extractShift();
+        this.identityLayout = !descending && extractShift == 0;
+    }
+
+    @Override
+    public void fill(Page page, long[] prefixes)
+    {
+        Block block = page.getBlock(sortChannel);
+        int positionCount = page.getPositionCount();
+        if (!(block instanceof ValueBlock valueBlock) || block.mayHaveNull()) {
+            fallback.fill(page, prefixes);
+            return;
+        }
+        try {
+            batchOperator.invokeExact(valueBlock, prefixes, positionCount);
+        }
+        catch (Throwable throwable) {
+            throwIfUnchecked(throwable);
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, throwable);
+        }
+        if (!identityLayout) {
+            for (int i = 0; i < positionCount; i++) {
+                long encoded = prefixes[i];
+                if (descending) {
+                    encoded = ~encoded;
+                }
+                prefixes[i] = encoded >>> extractShift;
+            }
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankAccumulator.java
@@ -92,7 +92,7 @@ public class GroupedTopNRankAccumulator
                 + peerGroupLookup.sizeOf();
     }
 
-    public int findFirstPositionToAdd(Page newPage, int groupCount, int[] groupIds, PageWithPositionComparator comparator, RowReferencePageManager pageManager)
+    public int findFirstPositionToAdd(Page newPage, int groupCount, int[] groupIds, PageWithPositionComparator comparator, RowReferencePageManager pageManager, @Nullable long[] prefixes)
     {
         int currentGroups = groupIdToHeapBuffer.getTotalGroups();
         groupIdToHeapBuffer.allocateGroupIfNeeded(groupCount);
@@ -105,6 +105,15 @@ public class GroupedTopNRankAccumulator
             long heapRootNodeIndex = groupIdToHeapBuffer.getHeapRootNodeIndex(groupId);
             if (heapRootNodeIndex == UNKNOWN_INDEX) {
                 return position;
+            }
+            if (prefixes != null) {
+                int prefixComparison = Long.compareUnsigned(prefixes[position], heapNodeBuffer.getPrefix(heapRootNodeIndex));
+                if (prefixComparison != 0) {
+                    if (prefixComparison < 0) {
+                        return position;
+                    }
+                    continue;
+                }
             }
             long rightPageRowId = peekRootRowIdByHeapNodeIndex(heapRootNodeIndex);
             Page rightPage = pageManager.getPage(rightPageRowId);
@@ -124,7 +133,7 @@ public class GroupedTopNRankAccumulator
      *
      * @return true if this row was incorporated, false otherwise
      */
-    public boolean add(int groupId, RowReference rowReference)
+    public boolean add(int groupId, RowReference rowReference, long prefix)
     {
         // Insert to any existing peer groups first (heap nodes contain distinct values)
         long peerHeapNodeIndex = peerGroupLookup.get(groupId, rowReference);
@@ -141,19 +150,23 @@ public class GroupedTopNRankAccumulator
         if (groupIdToHeapBuffer.getHeapValueCount(groupId) < topN) {
             // Always safe to insert if total number of values is still less than topN
             long newPeerGroupIndex = peerGroupBuffer.allocateNewNode(rowReference.allocateRowId(), UNKNOWN_INDEX);
-            heapInsert(groupId, newPeerGroupIndex, 1);
+            heapInsert(groupId, newPeerGroupIndex, 1, prefix);
             return true;
         }
         long heapRootNodeIndex = groupIdToHeapBuffer.getHeapRootNodeIndex(groupId);
-        if (rowReference.compareTo(strategy, peekRootRowIdByHeapNodeIndex(heapRootNodeIndex)) < 0) {
+        int comparison = Long.compareUnsigned(prefix, heapNodeBuffer.getPrefix(heapRootNodeIndex));
+        if (comparison == 0) {
+            comparison = rowReference.compareTo(strategy, peekRootRowIdByHeapNodeIndex(heapRootNodeIndex));
+        }
+        if (comparison < 0) {
             // Given that total number of values >= topN, we can only consider values that are less than the root (otherwise topN would be violated)
             long newPeerGroupIndex = peerGroupBuffer.allocateNewNode(rowReference.allocateRowId(), UNKNOWN_INDEX);
             // Rank will increase by +1 after insertion, so only need to pop if root rank is already == topN.
             if (calculateRootRank(groupId, heapRootNodeIndex) < topN) {
-                heapInsert(groupId, newPeerGroupIndex, 1);
+                heapInsert(groupId, newPeerGroupIndex, 1, prefix);
             }
             else {
-                heapPopAndInsert(groupId, newPeerGroupIndex, 1, rowIdEvictionListener);
+                heapPopAndInsert(groupId, newPeerGroupIndex, 1, prefix, rowIdEvictionListener);
             }
             return true;
         }
@@ -255,6 +268,15 @@ public class GroupedTopNRankAccumulator
         return peerGroupBuffer.getRowId(heapNodeBuffer.getPeerGroupIndex(heapRootNodeIndex));
     }
 
+    private int compare(long leftPrefix, long leftRowId, long rightPrefix, long rightRowId)
+    {
+        int comparison = Long.compareUnsigned(leftPrefix, rightPrefix);
+        if (comparison != 0) {
+            return comparison;
+        }
+        return strategy.compare(leftRowId, rightRowId);
+    }
+
     private long getChildIndex(long heapNodeIndex, HeapTraversal.Child child)
     {
         return child == HeapTraversal.Child.LEFT
@@ -285,6 +307,7 @@ public class GroupedTopNRankAccumulator
         long lastHeapNodeIndex = heapDetachLastInsertionLeaf(groupId);
         long lastPeerGroupIndex = heapNodeBuffer.getPeerGroupIndex(lastHeapNodeIndex);
         long lastPeerGroupCount = heapNodeBuffer.getPeerGroupCount(lastHeapNodeIndex);
+        long lastPrefix = heapNodeBuffer.getPrefix(lastHeapNodeIndex);
 
         if (lastHeapNodeIndex == heapRootNodeIndex) {
             // The root is the last node remaining
@@ -292,7 +315,7 @@ public class GroupedTopNRankAccumulator
         }
         else {
             // Pop the root and insert the last peer group back into the heap to ensure a balanced tree
-            heapPopAndInsert(groupId, lastPeerGroupIndex, lastPeerGroupCount, contextEvictionListener);
+            heapPopAndInsert(groupId, lastPeerGroupIndex, lastPeerGroupCount, lastPrefix, contextEvictionListener);
         }
 
         // peerGroupLookup entry will be updated by definition of inserting the last peer group into a new node
@@ -348,14 +371,14 @@ public class GroupedTopNRankAccumulator
      * Insertions always fill the left child before the right, and fill up an entire heap level before moving to the
      * next level.
      */
-    private void heapInsert(int groupId, long newPeerGroupIndex, long newPeerGroupCount)
+    private void heapInsert(int groupId, long newPeerGroupIndex, long newPeerGroupCount, long newPrefix)
     {
         long newCanonicalRowId = peerGroupBuffer.getRowId(newPeerGroupIndex);
 
         long heapRootNodeIndex = groupIdToHeapBuffer.getHeapRootNodeIndex(groupId);
         if (heapRootNodeIndex == UNKNOWN_INDEX) {
             // Heap is currently empty, so this will be the first node
-            heapRootNodeIndex = heapNodeBuffer.allocateNewNode(newPeerGroupIndex, newPeerGroupCount);
+            heapRootNodeIndex = heapNodeBuffer.allocateNewNode(newPeerGroupIndex, newPeerGroupCount, newPrefix);
             verify(peerGroupLookup.put(groupId, newCanonicalRowId, heapRootNodeIndex) == UNKNOWN_INDEX);
             groupIdToHeapBuffer.setHeapRootNodeIndex(groupId, heapRootNodeIndex);
             groupIdToHeapBuffer.setHeapValueCount(groupId, newPeerGroupCount);
@@ -374,19 +397,22 @@ public class GroupedTopNRankAccumulator
         while (!heapTraversal.isTarget()) {
             long peerGroupIndex = heapNodeBuffer.getPeerGroupIndex(currentHeapNodeIndex);
             long currentCanonicalRowId = peerGroupBuffer.getRowId(peerGroupIndex);
+            long currentPrefix = heapNodeBuffer.getPrefix(currentHeapNodeIndex);
             // We can short-circuit the check if a parent has already been swapped because the new row to insert must
             // be greater than all of it's children.
-            if (swapped || strategy.compare(newCanonicalRowId, currentCanonicalRowId) > 0) {
+            if (swapped || compare(newPrefix, newCanonicalRowId, currentPrefix, currentCanonicalRowId) > 0) {
                 long peerGroupCount = heapNodeBuffer.getPeerGroupCount(currentHeapNodeIndex);
 
                 // Swap the peer groups
                 heapNodeBuffer.setPeerGroupIndex(currentHeapNodeIndex, newPeerGroupIndex);
                 heapNodeBuffer.setPeerGroupCount(currentHeapNodeIndex, newPeerGroupCount);
+                heapNodeBuffer.setPrefix(currentHeapNodeIndex, newPrefix);
                 peerGroupLookup.put(groupId, newCanonicalRowId, currentHeapNodeIndex);
 
                 newPeerGroupIndex = peerGroupIndex;
                 newPeerGroupCount = peerGroupCount;
                 newCanonicalRowId = currentCanonicalRowId;
+                newPrefix = currentPrefix;
                 swapped = true;
             }
 
@@ -398,7 +424,7 @@ public class GroupedTopNRankAccumulator
         verify(previousHeapNodeIndex != UNKNOWN_INDEX && childPosition != null, "heap must have at least one node before starting traversal");
         verify(currentHeapNodeIndex == UNKNOWN_INDEX, "New child shouldn't exist yet");
 
-        long newHeapNodeIndex = heapNodeBuffer.allocateNewNode(newPeerGroupIndex, newPeerGroupCount);
+        long newHeapNodeIndex = heapNodeBuffer.allocateNewNode(newPeerGroupIndex, newPeerGroupCount, newPrefix);
         peerGroupLookup.put(groupId, newCanonicalRowId, newHeapNodeIndex);
 
         //  Link the new child to the parent
@@ -413,7 +439,7 @@ public class GroupedTopNRankAccumulator
      *
      * @param contextEvictionListener optional callback for the root node that gets popped off
      */
-    private void heapPopAndInsert(int groupId, long newPeerGroupIndex, long newPeerGroupCount, @Nullable LongConsumer contextEvictionListener)
+    private void heapPopAndInsert(int groupId, long newPeerGroupIndex, long newPeerGroupCount, long newPrefix, @Nullable LongConsumer contextEvictionListener)
     {
         long heapRootNodeIndex = groupIdToHeapBuffer.getHeapRootNodeIndex(groupId);
         checkState(heapRootNodeIndex != UNKNOWN_INDEX, "popAndInsert() requires at least a root node");
@@ -434,19 +460,22 @@ public class GroupedTopNRankAccumulator
             }
             long maxChildPeerGroupIndex = heapNodeBuffer.getPeerGroupIndex(maxChildNodeIndex);
             long maxChildCanonicalRowId = peerGroupBuffer.getRowId(maxChildPeerGroupIndex);
+            long maxChildPrefix = heapNodeBuffer.getPrefix(maxChildNodeIndex);
 
             long rightChildNodeIndex = heapNodeBuffer.getRightChildHeapIndex(currentNodeIndex);
             if (rightChildNodeIndex != UNKNOWN_INDEX) {
                 long rightChildPeerGroupIndex = heapNodeBuffer.getPeerGroupIndex(rightChildNodeIndex);
                 long rightChildCanonicalRowId = peerGroupBuffer.getRowId(rightChildPeerGroupIndex);
-                if (strategy.compare(rightChildCanonicalRowId, maxChildCanonicalRowId) > 0) {
+                long rightChildPrefix = heapNodeBuffer.getPrefix(rightChildNodeIndex);
+                if (compare(rightChildPrefix, rightChildCanonicalRowId, maxChildPrefix, maxChildCanonicalRowId) > 0) {
                     maxChildNodeIndex = rightChildNodeIndex;
                     maxChildPeerGroupIndex = rightChildPeerGroupIndex;
                     maxChildCanonicalRowId = rightChildCanonicalRowId;
+                    maxChildPrefix = rightChildPrefix;
                 }
             }
 
-            if (strategy.compare(newCanonicalRowId, maxChildCanonicalRowId) >= 0) {
+            if (compare(newPrefix, newCanonicalRowId, maxChildPrefix, maxChildCanonicalRowId) >= 0) {
                 // New row is greater than or equal to both children, so the heap invariant is satisfied by inserting the
                 // new row at this position
                 break;
@@ -455,6 +484,7 @@ public class GroupedTopNRankAccumulator
             // Swap the max child row value into the current node
             heapNodeBuffer.setPeerGroupIndex(currentNodeIndex, maxChildPeerGroupIndex);
             heapNodeBuffer.setPeerGroupCount(currentNodeIndex, heapNodeBuffer.getPeerGroupCount(maxChildNodeIndex));
+            heapNodeBuffer.setPrefix(currentNodeIndex, maxChildPrefix);
             peerGroupLookup.put(groupId, maxChildCanonicalRowId, currentNodeIndex);
 
             // Max child now has an unfilled vacancy, so continue processing with that as the current node
@@ -463,6 +493,7 @@ public class GroupedTopNRankAccumulator
 
         heapNodeBuffer.setPeerGroupIndex(currentNodeIndex, newPeerGroupIndex);
         heapNodeBuffer.setPeerGroupCount(currentNodeIndex, newPeerGroupCount);
+        heapNodeBuffer.setPrefix(currentNodeIndex, newPrefix);
         peerGroupLookup.put(groupId, newCanonicalRowId, currentNodeIndex);
     }
 
@@ -550,12 +581,13 @@ public class GroupedTopNRankAccumulator
         while (peerGroupIndex != UNKNOWN_INDEX);
         verify(actualPeerGroupCount == peerGroupCount, "Recorded peer group count does not match actual");
 
+        long prefix = heapNodeBuffer.getPrefix(heapNodeIndex);
         if (leftChildHeapIndex != UNKNOWN_INDEX) {
-            verify(strategy.compare(rowId, peerGroupBuffer.getRowId(heapNodeBuffer.getPeerGroupIndex(leftChildHeapIndex))) > 0, "Max heap invariant violated");
+            verify(compare(prefix, rowId, heapNodeBuffer.getPrefix(leftChildHeapIndex), peerGroupBuffer.getRowId(heapNodeBuffer.getPeerGroupIndex(leftChildHeapIndex))) > 0, "Max heap invariant violated");
         }
         if (rightChildHeapIndex != UNKNOWN_INDEX) {
             verify(leftChildHeapIndex != UNKNOWN_INDEX, "Left should always be inserted before right");
-            verify(strategy.compare(rowId, peerGroupBuffer.getRowId(heapNodeBuffer.getPeerGroupIndex(rightChildHeapIndex))) > 0, "Max heap invariant violated");
+            verify(compare(prefix, rowId, heapNodeBuffer.getPrefix(rightChildHeapIndex), peerGroupBuffer.getRowId(heapNodeBuffer.getPeerGroupIndex(rightChildHeapIndex))) > 0, "Max heap invariant violated");
         }
 
         IntegrityStats leftIntegrityStats = verifyHeapIntegrity(groupId, leftChildHeapIndex);
@@ -705,15 +737,16 @@ public class GroupedTopNRankAccumulator
     private static final class HeapNodeBuffer
     {
         private static final long INSTANCE_SIZE = instanceSize(HeapNodeBuffer.class);
-        private static final int POSITIONS_PER_ENTRY = 4;
+        private static final int POSITIONS_PER_ENTRY = 5;
         private static final int PEER_GROUP_COUNT_OFFSET = 1;
-        private static final int LEFT_CHILD_HEAP_INDEX_OFFSET = 2;
-        private static final int RIGHT_CHILD_HEAP_INDEX_OFFSET = 3;
+        private static final int PREFIX_OFFSET = 2;
+        private static final int LEFT_CHILD_HEAP_INDEX_OFFSET = 3;
+        private static final int RIGHT_CHILD_HEAP_INDEX_OFFSET = 4;
 
         /*
          *  Memory layout:
-         *  [LONG] peerGroupIndex1, [LONG] peerGroupCount1, [LONG] leftChildNodeIndex1, [LONG] rightChildNodeIndex1,
-         *  [LONG] peerGroupIndex2, [LONG] peerGroupCount2, [LONG] leftChildNodeIndex2, [LONG] rightChildNodeIndex2,
+         *  [LONG] peerGroupIndex1, [LONG] peerGroupCount1, [LONG] prefix1, [LONG] leftChildNodeIndex1, [LONG] rightChildNodeIndex1,
+         *  [LONG] peerGroupIndex2, [LONG] peerGroupCount2, [LONG] prefix2, [LONG] leftChildNodeIndex2, [LONG] rightChildNodeIndex2,
          *  ...
          */
         private final LongBigArray buffer = new LongBigArray();
@@ -727,7 +760,7 @@ public class GroupedTopNRankAccumulator
          *
          * @return index referencing the node
          */
-        public long allocateNewNode(long peerGroupIndex, long peerGroupCount)
+        public long allocateNewNode(long peerGroupIndex, long peerGroupCount, long prefix)
         {
             long newHeapIndex;
             if (!emptySlots.isEmpty()) {
@@ -741,6 +774,7 @@ public class GroupedTopNRankAccumulator
 
             setPeerGroupIndex(newHeapIndex, peerGroupIndex);
             setPeerGroupCount(newHeapIndex, peerGroupCount);
+            setPrefix(newHeapIndex, prefix);
             setLeftChildHeapIndex(newHeapIndex, UNKNOWN_INDEX);
             setRightChildHeapIndex(newHeapIndex, UNKNOWN_INDEX);
 
@@ -775,6 +809,16 @@ public class GroupedTopNRankAccumulator
         public void setPeerGroupCount(long index, long peerGroupCount)
         {
             buffer.set(index * POSITIONS_PER_ENTRY + PEER_GROUP_COUNT_OFFSET, peerGroupCount);
+        }
+
+        public long getPrefix(long index)
+        {
+            return buffer.get(index * POSITIONS_PER_ENTRY + PREFIX_OFFSET);
+        }
+
+        public void setPrefix(long index, long prefix)
+        {
+            buffer.set(index * POSITIONS_PER_ENTRY + PREFIX_OFFSET, prefix);
         }
 
         public void incrementPeerGroupCount(long index)

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankBuilder.java
@@ -23,12 +23,14 @@ import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 import jakarta.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.instanceSize;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.util.Objects.requireNonNull;
 
@@ -48,17 +50,21 @@ public class GroupedTopNRankBuilder
     private GroupByHash groupByHash; // null after output starts
     private final PageWithPositionComparator comparator;
     private final RowReferencePageManager pageManager = new RowReferencePageManager();
+    private final List<PageSortKeyPrefixFiller> prefixFillers;
+    private long[] prefixBuffer = new long[0];
     private final GroupedTopNRankAccumulator groupedTopNRankAccumulator;
 
     public GroupedTopNRankBuilder(
             List<Type> sourceTypes,
             PageWithPositionComparator comparator,
             PageWithPositionEqualsAndHash equalsAndHash,
+            List<PageSortKeyPrefixFiller> prefixFillers,
             int topN,
             boolean produceRanking,
             int[] groupByChannels,
             GroupByHash groupByHash)
     {
+        this.prefixFillers = ImmutableList.copyOf(requireNonNull(prefixFillers, "prefixFillers is null"));
         this.sourceTypes = requireNonNull(sourceTypes, "sourceTypes is null");
         checkArgument(topN > 0, "topN must be > 0");
         this.produceRanking = produceRanking;
@@ -133,12 +139,15 @@ public class GroupedTopNRankBuilder
         return INSTANCE_SIZE
                 + (groupByHash == null ? 0L : groupByHash.getEstimatedSize())
                 + pageManager.sizeOf()
+                + sizeOf(prefixBuffer)
                 + groupedTopNRankAccumulator.sizeOf();
     }
 
     private void processPage(Page newPage, int groupCount, int[] groupIds)
     {
-        int firstPositionToAdd = groupedTopNRankAccumulator.findFirstPositionToAdd(newPage, groupCount, groupIds, comparator, pageManager);
+        long[] prefixes = fillPrefixes(newPage);
+
+        int firstPositionToAdd = groupedTopNRankAccumulator.findFirstPositionToAdd(newPage, groupCount, groupIds, comparator, pageManager, prefixes);
         if (firstPositionToAdd < 0) {
             return;
         }
@@ -147,12 +156,31 @@ public class GroupedTopNRankBuilder
             for (int position = firstPositionToAdd; position < newPage.getPositionCount(); position++) {
                 int groupId = groupIds[position];
                 loadCursor.advance();
-                groupedTopNRankAccumulator.add(groupId, loadCursor);
+                groupedTopNRankAccumulator.add(groupId, loadCursor, prefixes == null ? 0 : prefixes[position]);
             }
             verify(!loadCursor.advance());
         }
 
         pageManager.compactIfNeeded();
+    }
+
+    @Nullable
+    private long[] fillPrefixes(Page newPage)
+    {
+        if (prefixFillers.isEmpty()) {
+            return null;
+        }
+        int positionCount = newPage.getPositionCount();
+        if (prefixBuffer.length < positionCount) {
+            prefixBuffer = new long[positionCount];
+        }
+        else {
+            Arrays.fill(prefixBuffer, 0, positionCount, 0);
+        }
+        for (PageSortKeyPrefixFiller prefixFiller : prefixFillers) {
+            prefixFiller.fill(newPage, prefixBuffer);
+        }
+        return prefixBuffer;
     }
 
     private class ResultIterator

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberAccumulator.java
@@ -26,6 +26,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.instanceSize;
+import static java.lang.Long.compareUnsigned;
 import static java.lang.Math.abs;
 import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
@@ -72,7 +73,7 @@ public class GroupedTopNRowNumberAccumulator
         return INSTANCE_SIZE + groupIdToHeapBuffer.sizeOf() + heapNodeBuffer.sizeOf() + heapTraversal.sizeOf();
     }
 
-    public int findFirstPositionToAdd(Page newPage, int groupCount, int[] groupIds, PageWithPositionComparator comparator, RowReferencePageManager pageManager)
+    public int findFirstPositionToAdd(Page newPage, int groupCount, int[] groupIds, PageWithPositionComparator comparator, RowReferencePageManager pageManager, @Nullable long[] prefixes)
     {
         int currentTotalGroups = groupIdToHeapBuffer.getTotalGroups();
         groupIdToHeapBuffer.allocateGroupIfNeeded(groupCount);
@@ -85,6 +86,15 @@ public class GroupedTopNRowNumberAccumulator
             long heapRootNodeIndex = groupIdToHeapBuffer.getHeapRootNodeIndex(groupId);
             if (heapRootNodeIndex == UNKNOWN_INDEX) {
                 return position;
+            }
+            if (prefixes != null) {
+                int prefixComparison = compareUnsigned(prefixes[position], heapNodeBuffer.getPrefix(heapRootNodeIndex));
+                if (prefixComparison != 0) {
+                    if (prefixComparison < 0) {
+                        return position;
+                    }
+                    continue;
+                }
             }
             long rowId = heapNodeBuffer.getRowId(heapRootNodeIndex);
             Page rightPage = pageManager.getPage(rowId);
@@ -103,17 +113,21 @@ public class GroupedTopNRowNumberAccumulator
      *
      * @return true if this row was incorporated, false otherwise
      */
-    public boolean add(int groupId, RowReference rowReference)
+    public boolean add(int groupId, RowReference rowReference, long prefix)
     {
         groupIdToHeapBuffer.allocateGroupIfNeeded(groupId);
 
         long heapRootNodeIndex = groupIdToHeapBuffer.getHeapRootNodeIndex(groupId);
         if (heapRootNodeIndex == UNKNOWN_INDEX || calculateRootRowNumber(groupId) < topN) {
-            heapInsert(groupId, rowReference.allocateRowId());
+            heapInsert(groupId, rowReference.allocateRowId(), prefix);
             return true;
         }
-        if (rowReference.compareTo(strategy, heapNodeBuffer.getRowId(heapRootNodeIndex)) < 0) {
-            heapPopAndInsert(groupId, rowReference.allocateRowId(), rowIdEvictionListener);
+        int comparison = compareUnsigned(prefix, heapNodeBuffer.getPrefix(heapRootNodeIndex));
+        if (comparison == 0) {
+            comparison = rowReference.compareTo(strategy, heapNodeBuffer.getRowId(heapRootNodeIndex));
+        }
+        if (comparison < 0) {
+            heapPopAndInsert(groupId, rowReference.allocateRowId(), prefix, rowIdEvictionListener);
             return true;
         }
         return false;
@@ -152,6 +166,15 @@ public class GroupedTopNRowNumberAccumulator
         return heapNodeBuffer.getRowId(heapRootNodeIndex);
     }
 
+    private int compare(long leftPrefix, long leftRowId, long rightPrefix, long rightRowId)
+    {
+        int comparison = compareUnsigned(leftPrefix, rightPrefix);
+        if (comparison != 0) {
+            return comparison;
+        }
+        return strategy.compare(leftRowId, rightRowId);
+    }
+
     private long getChildIndex(long heapNodeIndex, HeapTraversal.Child child)
     {
         return child == HeapTraversal.Child.LEFT
@@ -181,6 +204,7 @@ public class GroupedTopNRowNumberAccumulator
 
         long lastNodeIndex = heapDetachLastInsertionLeaf(groupId);
         long lastRowId = heapNodeBuffer.getRowId(lastNodeIndex);
+        long lastPrefix = heapNodeBuffer.getPrefix(lastNodeIndex);
         heapNodeBuffer.deallocate(lastNodeIndex);
 
         if (lastNodeIndex == heapRootNodeIndex) {
@@ -191,7 +215,7 @@ public class GroupedTopNRowNumberAccumulator
         }
         else {
             // Pop the root and insert lastRowId back into the heap to ensure a balanced tree
-            heapPopAndInsert(groupId, lastRowId, contextEvictionListener);
+            heapPopAndInsert(groupId, lastRowId, lastPrefix, contextEvictionListener);
         }
     }
 
@@ -242,12 +266,12 @@ public class GroupedTopNRowNumberAccumulator
      * Insertions always fill the left child before the right, and fill up an entire heap level before moving to the
      * next level.
      */
-    private void heapInsert(int groupId, long newRowId)
+    private void heapInsert(int groupId, long newRowId, long newPrefix)
     {
         long heapRootNodeIndex = groupIdToHeapBuffer.getHeapRootNodeIndex(groupId);
         if (heapRootNodeIndex == UNKNOWN_INDEX) {
             // Heap is currently empty, so this will be the first node
-            heapRootNodeIndex = heapNodeBuffer.allocateNewNode(newRowId);
+            heapRootNodeIndex = heapNodeBuffer.allocateNewNode(newRowId, newPrefix);
 
             groupIdToHeapBuffer.setHeapRootNodeIndex(groupId, heapRootNodeIndex);
             groupIdToHeapBuffer.setHeapSize(groupId, 1);
@@ -261,11 +285,14 @@ public class GroupedTopNRowNumberAccumulator
         heapTraversal.resetWithPathTo(groupIdToHeapBuffer.getHeapSize(groupId) + 1);
         while (!heapTraversal.isTarget()) {
             long currentRowId = heapNodeBuffer.getRowId(currentHeapNodeIndex);
-            if (strategy.compare(newRowId, currentRowId) > 0) {
+            long currentPrefix = heapNodeBuffer.getPrefix(currentHeapNodeIndex);
+            if (compare(newPrefix, newRowId, currentPrefix, currentRowId) > 0) {
                 // Swap the row values
                 heapNodeBuffer.setRowId(currentHeapNodeIndex, newRowId);
+                heapNodeBuffer.setPrefix(currentHeapNodeIndex, newPrefix);
 
                 newRowId = currentRowId;
+                newPrefix = currentPrefix;
             }
 
             previousHeapNodeIndex = currentHeapNodeIndex;
@@ -276,7 +303,7 @@ public class GroupedTopNRowNumberAccumulator
         verify(previousHeapNodeIndex != UNKNOWN_INDEX && childPosition != null, "heap must have at least one node before starting traversal");
         verify(currentHeapNodeIndex == UNKNOWN_INDEX, "New child shouldn't exist yet");
 
-        long newHeapNodeIndex = heapNodeBuffer.allocateNewNode(newRowId);
+        long newHeapNodeIndex = heapNodeBuffer.allocateNewNode(newRowId, newPrefix);
 
         //  Link the new child to the parent
         setChildIndex(previousHeapNodeIndex, childPosition, newHeapNodeIndex);
@@ -292,7 +319,7 @@ public class GroupedTopNRowNumberAccumulator
      *
      * @param contextEvictionListener optional callback for the root node that gets popped off
      */
-    private void heapPopAndInsert(int groupId, long newRowId, @Nullable LongConsumer contextEvictionListener)
+    private void heapPopAndInsert(int groupId, long newRowId, long newPrefix, @Nullable LongConsumer contextEvictionListener)
     {
         long heapRootNodeIndex = groupIdToHeapBuffer.getHeapRootNodeIndex(groupId);
         checkState(heapRootNodeIndex != UNKNOWN_INDEX, "popAndInsert() requires at least a root node");
@@ -309,17 +336,20 @@ public class GroupedTopNRowNumberAccumulator
                 break;
             }
             long maxChildRowId = heapNodeBuffer.getRowId(maxChildNodeIndex);
+            long maxChildPrefix = heapNodeBuffer.getPrefix(maxChildNodeIndex);
 
             long rightChildNodeIndex = heapNodeBuffer.getRightChildHeapIndex(currentNodeIndex);
             if (rightChildNodeIndex != UNKNOWN_INDEX) {
                 long rightRowId = heapNodeBuffer.getRowId(rightChildNodeIndex);
-                if (strategy.compare(rightRowId, maxChildRowId) > 0) {
+                long rightPrefix = heapNodeBuffer.getPrefix(rightChildNodeIndex);
+                if (compare(rightPrefix, rightRowId, maxChildPrefix, maxChildRowId) > 0) {
                     maxChildNodeIndex = rightChildNodeIndex;
                     maxChildRowId = rightRowId;
+                    maxChildPrefix = rightPrefix;
                 }
             }
 
-            if (strategy.compare(newRowId, maxChildRowId) >= 0) {
+            if (compare(newPrefix, newRowId, maxChildPrefix, maxChildRowId) >= 0) {
                 // New row is greater than or equal to both children, so the heap invariant is satisfied by inserting the
                 // new row at this position
                 break;
@@ -327,12 +357,14 @@ public class GroupedTopNRowNumberAccumulator
 
             // Swap the max child row value into the current node
             heapNodeBuffer.setRowId(currentNodeIndex, maxChildRowId);
+            heapNodeBuffer.setPrefix(currentNodeIndex, maxChildPrefix);
 
             // Max child now has an unfilled vacancy, so continue processing with that as the current node
             currentNodeIndex = maxChildNodeIndex;
         }
 
         heapNodeBuffer.setRowId(currentNodeIndex, newRowId);
+        heapNodeBuffer.setPrefix(currentNodeIndex, newPrefix);
 
         if (contextEvictionListener != null) {
             contextEvictionListener.accept(poppedRowId);
@@ -366,12 +398,13 @@ public class GroupedTopNRowNumberAccumulator
         long leftChildHeapIndex = heapNodeBuffer.getLeftChildHeapIndex(heapNodeIndex);
         long rightChildHeapIndex = heapNodeBuffer.getRightChildHeapIndex(heapNodeIndex);
 
+        long prefix = heapNodeBuffer.getPrefix(heapNodeIndex);
         if (leftChildHeapIndex != UNKNOWN_INDEX) {
-            verify(strategy.compare(rowId, heapNodeBuffer.getRowId(leftChildHeapIndex)) >= 0, "Max heap invariant violated");
+            verify(compare(prefix, rowId, heapNodeBuffer.getPrefix(leftChildHeapIndex), heapNodeBuffer.getRowId(leftChildHeapIndex)) >= 0, "Max heap invariant violated");
         }
         if (rightChildHeapIndex != UNKNOWN_INDEX) {
             verify(leftChildHeapIndex != UNKNOWN_INDEX, "Left should always be inserted before right");
-            verify(strategy.compare(rowId, heapNodeBuffer.getRowId(rightChildHeapIndex)) >= 0, "Max heap invariant violated");
+            verify(compare(prefix, rowId, heapNodeBuffer.getPrefix(rightChildHeapIndex), heapNodeBuffer.getRowId(rightChildHeapIndex)) >= 0, "Max heap invariant violated");
         }
 
         IntegrityStats leftIntegrityStats = verifyHeapIntegrity(leftChildHeapIndex);
@@ -492,14 +525,15 @@ public class GroupedTopNRowNumberAccumulator
     private static class HeapNodeBuffer
     {
         private static final long INSTANCE_SIZE = instanceSize(HeapNodeBuffer.class);
-        private static final int POSITIONS_PER_ENTRY = 3;
-        private static final int LEFT_CHILD_HEAP_INDEX_OFFSET = 1;
-        private static final int RIGHT_CHILD_HEAP_INDEX_OFFSET = 2;
+        private static final int POSITIONS_PER_ENTRY = 4;
+        private static final int PREFIX_OFFSET = 1;
+        private static final int LEFT_CHILD_HEAP_INDEX_OFFSET = 2;
+        private static final int RIGHT_CHILD_HEAP_INDEX_OFFSET = 3;
 
         /*
          *  Memory layout:
-         *  [LONG] rowId1, [LONG] leftChildNodeIndex1, [LONG] rightChildNodeIndex1,
-         *  [LONG] rowId2, [LONG] leftChildNodeIndex2, [LONG] rightChildNodeIndex2,
+         *  [LONG] rowId1, [LONG] prefix1, [LONG] leftChildNodeIndex1, [LONG] rightChildNodeIndex1,
+         *  [LONG] rowId2, [LONG] prefix2, [LONG] leftChildNodeIndex2, [LONG] rightChildNodeIndex2,
          *  ...
          */
         private final LongBigArray buffer = new LongBigArray();
@@ -513,7 +547,7 @@ public class GroupedTopNRowNumberAccumulator
          *
          * @return index referencing the node
          */
-        public long allocateNewNode(long rowId)
+        public long allocateNewNode(long rowId, long prefix)
         {
             long newHeapIndex;
             if (!emptySlots.isEmpty()) {
@@ -526,6 +560,7 @@ public class GroupedTopNRowNumberAccumulator
             }
 
             setRowId(newHeapIndex, rowId);
+            setPrefix(newHeapIndex, prefix);
             setLeftChildHeapIndex(newHeapIndex, UNKNOWN_INDEX);
             setRightChildHeapIndex(newHeapIndex, UNKNOWN_INDEX);
 
@@ -550,6 +585,16 @@ public class GroupedTopNRowNumberAccumulator
         public void setRowId(long index, long rowId)
         {
             buffer.set(index * POSITIONS_PER_ENTRY, rowId);
+        }
+
+        public long getPrefix(long index)
+        {
+            return buffer.get(index * POSITIONS_PER_ENTRY + PREFIX_OFFSET);
+        }
+
+        public void setPrefix(long index, long prefix)
+        {
+            buffer.set(index * POSITIONS_PER_ENTRY + PREFIX_OFFSET, prefix);
         }
 
         public long getLeftChildHeapIndex(long index)

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberBuilder.java
@@ -24,12 +24,14 @@ import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 import jakarta.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.instanceSize;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.util.Objects.requireNonNull;
 
@@ -49,15 +51,19 @@ public class GroupedTopNRowNumberBuilder
     private final RowReferencePageManager pageManager = new RowReferencePageManager();
     private final GroupedTopNRowNumberAccumulator groupedTopNRowNumberAccumulator;
     private final PageWithPositionComparator comparator;
+    private final List<PageSortKeyPrefixFiller> prefixFillers;
+    private long[] prefixBuffer = new long[0];
 
     public GroupedTopNRowNumberBuilder(
             List<Type> sourceTypes,
             PageWithPositionComparator comparator,
+            List<PageSortKeyPrefixFiller> prefixFillers,
             int topN,
             boolean produceRowNumber,
             int[] groupByChannels,
             GroupByHash groupByHash)
     {
+        this.prefixFillers = ImmutableList.copyOf(requireNonNull(prefixFillers, "prefixFillers is null"));
         this.sourceTypes = requireNonNull(sourceTypes, "sourceTypes is null");
         checkArgument(topN > 0, "topN must be > 0");
         this.produceRowNumber = produceRowNumber;
@@ -108,12 +114,15 @@ public class GroupedTopNRowNumberBuilder
         return INSTANCE_SIZE
                 + (groupByHash == null ? 0L : groupByHash.getEstimatedSize())
                 + pageManager.sizeOf()
+                + sizeOf(prefixBuffer)
                 + groupedTopNRowNumberAccumulator.sizeOf();
     }
 
     private void processPage(Page newPage, int groupCount, int[] groupIds)
     {
-        int firstPositionToAdd = groupedTopNRowNumberAccumulator.findFirstPositionToAdd(newPage, groupCount, groupIds, comparator, pageManager);
+        long[] prefixes = fillPrefixes(newPage);
+
+        int firstPositionToAdd = groupedTopNRowNumberAccumulator.findFirstPositionToAdd(newPage, groupCount, groupIds, comparator, pageManager, prefixes);
         if (firstPositionToAdd < 0) {
             return;
         }
@@ -122,12 +131,31 @@ public class GroupedTopNRowNumberBuilder
             for (int position = firstPositionToAdd; position < newPage.getPositionCount(); position++) {
                 int groupId = groupIds[position];
                 loadCursor.advance();
-                groupedTopNRowNumberAccumulator.add(groupId, loadCursor);
+                groupedTopNRowNumberAccumulator.add(groupId, loadCursor, prefixes == null ? 0 : prefixes[position]);
             }
             verify(!loadCursor.advance());
         }
 
         pageManager.compactIfNeeded();
+    }
+
+    @Nullable
+    private long[] fillPrefixes(Page newPage)
+    {
+        if (prefixFillers.isEmpty()) {
+            return null;
+        }
+        int positionCount = newPage.getPositionCount();
+        if (prefixBuffer.length < positionCount) {
+            prefixBuffer = new long[positionCount];
+        }
+        else {
+            Arrays.fill(prefixBuffer, 0, positionCount, 0);
+        }
+        for (PageSortKeyPrefixFiller prefixFiller : prefixFillers) {
+            prefixFiller.fill(newPage, prefixBuffer);
+        }
+        return prefixBuffer;
     }
 
     @Nullable

--- a/core/trino-main/src/main/java/io/trino/operator/InterpretedPageSortKeyPrefixFiller.java
+++ b/core/trino-main/src/main/java/io/trino/operator/InterpretedPageSortKeyPrefixFiller.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.util.Objects.requireNonNull;
+
+public class InterpretedPageSortKeyPrefixFiller
+        implements PageSortKeyPrefixFiller
+{
+    private final MethodHandle operator;
+    private final int sortChannel;
+    private final boolean descending;
+    private final long nullSubKey;
+    private final long valueBase;
+    private final int extractShift;
+    private final int shift;
+
+    public InterpretedPageSortKeyPrefixFiller(MethodHandle operator, SortKeyPrefixFiller.SortKeyPrefixLayout layout)
+    {
+        this.operator = requireNonNull(operator, "operator is null");
+        this.sortChannel = layout.sortChannel();
+        this.descending = layout.descending();
+        this.nullSubKey = layout.nullSubKey();
+        this.valueBase = layout.valueBase();
+        this.extractShift = layout.extractShift();
+        this.shift = layout.shift();
+    }
+
+    @Override
+    public void fill(Page page, long[] prefixes)
+    {
+        Block block = page.getBlock(sortChannel);
+        try {
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                long subKey;
+                if (block.isNull(position)) {
+                    subKey = nullSubKey;
+                }
+                else {
+                    long encoded = (long) operator.invokeExact(block, position);
+                    if (descending) {
+                        encoded = ~encoded;
+                    }
+                    subKey = valueBase | (encoded >>> extractShift);
+                }
+                prefixes[position] |= subKey << shift;
+            }
+        }
+        catch (Throwable throwable) {
+            throwIfUnchecked(throwable);
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, throwable);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/InterpretedSortKeyPrefixFiller.java
+++ b/core/trino-main/src/main/java/io/trino/operator/InterpretedSortKeyPrefixFiller.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.trino.operator.SyntheticAddress.decodePosition;
+import static io.trino.operator.SyntheticAddress.decodeSliceIndex;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.util.Objects.requireNonNull;
+
+public class InterpretedSortKeyPrefixFiller
+        implements SortKeyPrefixFiller
+{
+    private final MethodHandle operator;
+    private final int sortChannel;
+    private final boolean descending;
+    private final boolean collideNullsWithValues;
+    private final long nullSubKey;
+    private final long valueBase;
+    private final int extractShift;
+    private final int shift;
+
+    public InterpretedSortKeyPrefixFiller(MethodHandle operator, SortKeyPrefixLayout layout)
+    {
+        this.operator = requireNonNull(operator, "operator is null");
+        this.sortChannel = layout.sortChannel();
+        this.descending = layout.descending();
+        this.collideNullsWithValues = layout.collideNullsWithValues();
+        this.nullSubKey = layout.nullSubKey();
+        this.valueBase = layout.valueBase();
+        this.extractShift = layout.extractShift();
+        this.shift = layout.shift();
+    }
+
+    @Override
+    public boolean fill(PagesIndex pagesIndex, int startPosition, int endPosition, long[] keys, int keysOffset)
+    {
+        LongArrayList valueAddresses = pagesIndex.getValueAddresses();
+        ObjectArrayList<Block> blocks = pagesIndex.getChannel(sortChannel);
+        boolean collidingNulls = false;
+
+        try {
+            for (int position = startPosition; position < endPosition; position++) {
+                long pageAddress = valueAddresses.getLong(position);
+                Block block = blocks.get(decodeSliceIndex(pageAddress));
+                int blockPosition = decodePosition(pageAddress);
+
+                long subKey;
+                if (block.isNull(blockPosition)) {
+                    subKey = nullSubKey;
+                    collidingNulls = collideNullsWithValues;
+                }
+                else {
+                    long encoded = (long) operator.invokeExact(block, blockPosition);
+                    if (descending) {
+                        encoded = ~encoded;
+                    }
+                    subKey = valueBase | (encoded >>> extractShift);
+                }
+                keys[keysOffset + position - startPosition] |= subKey << shift;
+            }
+        }
+        catch (Throwable throwable) {
+            throwIfUnchecked(throwable);
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, throwable);
+        }
+        return collidingNulls;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/MergeHashSort.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MergeHashSort.java
@@ -14,6 +14,7 @@
 package io.trino.operator;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
@@ -53,10 +54,12 @@ public class MergeHashSort
         HashGenerator hashGenerator = new PrecomputedHashGenerator(hashChannel);
         return mergeSortedPages(
                 channels,
-                createHashPageWithPositionComparator(hashGenerator),
+                // the hash prefix is the whole merge key, so equal prefixes are true ties
+                (_, _, _, _) -> 0,
+                ImmutableList.of(hashPrefixFiller(hashGenerator)),
                 IntStream.range(0, allTypes.size()).boxed().collect(toImmutableList()),
                 allTypes,
-                keepSameHashValuesWithinSinglePage(hashGenerator),
+                keepSameHashValuesWithinSinglePage(),
                 true,
                 memoryContext,
                 driverYieldSignal);
@@ -67,10 +70,12 @@ public class MergeHashSort
     {
         return mergeSortedPages(
                 channels,
-                createHashPageWithPositionComparator(hashGenerator),
+                // the hash prefix is the whole merge key, so equal prefixes are true ties
+                (_, _, _, _) -> 0,
+                ImmutableList.of(hashPrefixFiller(hashGenerator)),
                 IntStream.range(0, allTypes.size()).boxed().collect(toImmutableList()),
                 allTypes,
-                keepSameHashValuesWithinSinglePage(hashGenerator),
+                keepSameHashValuesWithinSinglePage(),
                 true,
                 memoryContext,
                 driverYieldSignal);
@@ -82,32 +87,37 @@ public class MergeHashSort
         memoryContext.close();
     }
 
-    private static BiPredicate<PageBuilder, PageWithPosition> keepSameHashValuesWithinSinglePage(HashGenerator hashGenerator)
+    private static BiPredicate<PageBuilder, PageWithPosition> keepSameHashValuesWithinSinglePage()
     {
         return new BiPredicate<>()
         {
-            private long lastHash;
+            private long lastPrefix;
 
             @Override
             public boolean test(PageBuilder pageBuilder, PageWithPosition pageWithPosition)
             {
-                // set the last bit on the hash, so that zero is never produced
-                long hash = hashGenerator.hashPosition(pageWithPosition.getPosition(), pageWithPosition.getPage()) | 1;
-                boolean sameHash = hash == lastHash;
-                lastHash = hash;
+                // set the last bit on the prefix, so that zero is never produced
+                long prefix = pageWithPosition.getPrefix() | 1;
+                boolean samePrefix = prefix == lastPrefix;
+                lastPrefix = prefix;
 
-                return !pageBuilder.isEmpty() && !sameHash && pageBuilder.isFull();
+                return !pageBuilder.isEmpty() && !samePrefix && pageBuilder.isFull();
             }
         };
     }
 
-    private static PageWithPositionComparator createHashPageWithPositionComparator(HashGenerator hashGenerator)
+    /**
+     * The merge key is the 64-bit hash itself, so the sort key prefix is the whole key and fully
+     * decides the merge order: the sign bit is flipped so that the unsigned prefix order matches
+     * the signed hash order, and the hash is computed once per row instead of on every merge
+     * comparison.
+     */
+    private static PageSortKeyPrefixFiller hashPrefixFiller(HashGenerator hashGenerator)
     {
-        return (Page leftPage, int leftPosition, Page rightPage, int rightPosition) -> {
-            long leftHash = hashGenerator.hashPosition(leftPosition, leftPage);
-            long rightHash = hashGenerator.hashPosition(rightPosition, rightPage);
-
-            return Long.compare(leftHash, rightHash);
+        return (page, prefixes) -> {
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                prefixes[position] = hashGenerator.hashPosition(position, page) ^ Long.MIN_VALUE;
+            }
         };
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/MergeOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MergeOperator.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -106,6 +107,7 @@ public class MergeOperator
                     directExchangeClientSupplier,
                     serdeFactory.createDeserializer(effectiveKey.map(Ciphers::deserializeAesEncryptionKey)),
                     orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, sortOrder),
+                    orderingCompiler.compilePageSortKeyPrefixFillers(sortTypes, sortChannels, sortOrder),
                     outputChannels,
                     outputTypes);
         }
@@ -122,6 +124,7 @@ public class MergeOperator
     private final DirectExchangeClientSupplier directExchangeClientSupplier;
     private final PageDeserializer deserializer;
     private final PageWithPositionComparator comparator;
+    private final List<PageSortKeyPrefixFiller> prefixFillers;
     private final List<Integer> outputChannels;
     private final List<Type> outputTypes;
 
@@ -139,6 +142,7 @@ public class MergeOperator
             DirectExchangeClientSupplier directExchangeClientSupplier,
             PageDeserializer deserializer,
             PageWithPositionComparator comparator,
+            List<PageSortKeyPrefixFiller> prefixFillers,
             List<Integer> outputChannels,
             List<Type> outputTypes)
     {
@@ -147,6 +151,7 @@ public class MergeOperator
         this.directExchangeClientSupplier = requireNonNull(directExchangeClientSupplier, "directExchangeClientSupplier is null");
         this.deserializer = requireNonNull(deserializer, "deserializer is null");
         this.comparator = requireNonNull(comparator, "comparator is null");
+        this.prefixFillers = ImmutableList.copyOf(requireNonNull(prefixFillers, "prefixFillers is null"));
         this.outputChannels = requireNonNull(outputChannels, "outputChannels is null");
         this.outputTypes = requireNonNull(outputTypes, "outputTypes is null");
 
@@ -197,6 +202,7 @@ public class MergeOperator
         mergedPages = mergeSortedPages(
                 pageProducers,
                 comparator,
+                prefixFillers,
                 outputChannels,
                 outputTypes,
                 (pageBuilder, _) -> pageBuilder.isFull(),

--- a/core/trino-main/src/main/java/io/trino/operator/OrderByOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OrderByOperator.java
@@ -359,6 +359,7 @@ public class OrderByOperator
         return mergeSortedPages(
                 sortedStreams,
                 orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, sortOrder),
+                orderingCompiler.compilePageSortKeyPrefixFillers(sortTypes, sortChannels, sortOrder),
                 sourceTypes,
                 operatorContext.aggregateUserMemoryContext(),
                 operatorContext.getDriverContext().getYieldSignal());

--- a/core/trino-main/src/main/java/io/trino/operator/OrderByOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OrderByOperator.java
@@ -230,7 +230,7 @@ public class OrderByOperator
                 }
             }
 
-            pageIndex.sort(pagesIndexOrdering);
+            pageIndex.sort(pagesIndexOrdering, localUserMemoryContext);
             Iterator<Page> sortedPagesIndex = pageIndex.getSortedPages();
 
             List<WorkProcessor<Page>> spilledPages = getSpilledPages();
@@ -317,7 +317,7 @@ public class OrderByOperator
                     operatorContext.newAggregateUserMemoryContext()));
         }
 
-        pageIndex.sort(pagesIndexOrdering);
+        pageIndex.sort(pagesIndexOrdering, revocableMemoryContext);
         spillInProgress = asVoid(spiller.get().spill(pageIndex.getSortedPages()));
         finishMemoryRevoke = Optional.of(() -> {
             pageIndex.clear();

--- a/core/trino-main/src/main/java/io/trino/operator/PageSortKeyPrefixFiller.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PageSortKeyPrefixFiller.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.trino.spi.Page;
+
+/**
+ * Fills the bits of one sort channel into the composite sort key prefixes of all positions of a
+ * {@link Page}. Unlike {@link SortKeyPrefixFiller}, prefix ties are never decided by the prefix,
+ * so nulls colliding with extreme values need no special handling.
+ */
+public interface PageSortKeyPrefixFiller
+{
+    void fill(Page page, long[] prefixes);
+}

--- a/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
@@ -22,6 +22,7 @@ import io.airlift.units.DataSize;
 import io.trino.FeaturesConfig;
 import io.trino.Session;
 import io.trino.geospatial.Rectangle;
+import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.SpatialIndexBuilderOperator.SpatialPredicate;
 import io.trino.operator.join.JoinHashSupplier;
 import io.trino.operator.join.LookupSource;
@@ -411,21 +412,27 @@ public class PagesIndex
         return decodePosition(pageAddress);
     }
 
-    public void sort(List<Integer> sortChannels, List<SortOrder> sortOrders)
+    /**
+     * The transient working memory allocated by the sort is accounted in the given memory
+     * context for the duration of the sort. Callers that have no memory context to charge
+     * should pass a context created from a standalone
+     * {@link io.trino.memory.context.AggregatedMemoryContext#newSimpleAggregatedMemoryContext()}.
+     */
+    public void sort(List<Integer> sortChannels, List<SortOrder> sortOrders, LocalMemoryContext memoryContext)
     {
-        sort(createPagesIndexComparator(sortChannels, sortOrders), 0, getPositionCount());
+        sort(createPagesIndexComparator(sortChannels, sortOrders), memoryContext);
     }
 
-    public void sort(PagesIndexOrdering pagesIndexOrdering)
+    public void sort(PagesIndexOrdering pagesIndexOrdering, LocalMemoryContext memoryContext)
     {
-        sort(pagesIndexOrdering, 0, getPositionCount());
+        sort(pagesIndexOrdering, 0, getPositionCount(), memoryContext);
     }
 
-    public void sort(PagesIndexOrdering pagesIndexOrdering, int startPosition, int endPosition)
+    public void sort(PagesIndexOrdering pagesIndexOrdering, int startPosition, int endPosition, LocalMemoryContext memoryContext)
     {
         requireNonNull(pagesIndexOrdering, "pagesIndexOrdering is null");
         modificationCount++;
-        pagesIndexOrdering.sort(this, startPosition, endPosition);
+        pagesIndexOrdering.sort(this, startPosition, endPosition, memoryContext);
     }
 
     public boolean positionIdenticalToPosition(PagesHashStrategy partitionHashStrategy, int leftPosition, int rightPosition)

--- a/core/trino-main/src/main/java/io/trino/operator/PagesIndexOrdering.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesIndexOrdering.java
@@ -13,6 +13,14 @@
  */
 package io.trino.operator;
 
+import io.trino.memory.context.LocalMemoryContext;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import jakarta.annotation.Nullable;
+
+import java.util.List;
+
+import static io.airlift.slice.SizeOf.sizeOfLongArray;
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class PagesIndexOrdering
@@ -20,11 +28,28 @@ public class PagesIndexOrdering
     private static final int SMALL = 7;
     private static final int MEDIUM = 40;
 
-    private final PagesIndexComparator comparator;
+    // below this size the sort key prefix array is not worth building
+    private static final int MIN_SORT_KEY_PREFIX_POSITIONS = 64;
 
-    public PagesIndexOrdering(PagesIndexComparator comparator)
+    // number of leading positions used to estimate the prefix cardinality
+    private static final int CARDINALITY_SAMPLE_POSITIONS = 4096;
+    // abandon the prefixes when fewer than this fraction of the sampled prefixes are distinct
+    private static final double MIN_PREFIX_CARDINALITY_RATIO = 0.1;
+
+    private final PagesIndexComparator comparator;
+    private final List<SortKeyPrefixFiller> sortKeyPrefixFillers;
+    // whether equal prefixes imply that the positions are equal under the comparator: all sort
+    // channels are packed and every field is exact within its bits
+    private final boolean sortKeyPrefixDecidesTies;
+
+    public PagesIndexOrdering(
+            PagesIndexComparator comparator,
+            List<SortKeyPrefixFiller> sortKeyPrefixFillers,
+            boolean sortKeyPrefixDecidesTies)
     {
         this.comparator = requireNonNull(comparator, "comparator is null");
+        this.sortKeyPrefixFillers = List.copyOf(requireNonNull(sortKeyPrefixFillers, "sortKeyPrefixFillers is null"));
+        this.sortKeyPrefixDecidesTies = sortKeyPrefixDecidesTies;
     }
 
     public PagesIndexComparator getComparator()
@@ -32,9 +57,133 @@ public class PagesIndexOrdering
         return comparator;
     }
 
-    public void sort(PagesIndex pagesIndex, int startPosition, int endPosition)
+    /**
+     * Sorts the given range of positions. The transient working memory allocated by the sort
+     * (the sort key prefix array) is accounted in the given memory context for the duration of
+     * the sort.
+     */
+    public void sort(PagesIndex pagesIndex, int startPosition, int endPosition, LocalMemoryContext memoryContext)
     {
-        quickSort(pagesIndex, startPosition, endPosition);
+        long workingMemory = sortWorkingMemory(startPosition, endPosition);
+        if (workingMemory == 0) {
+            sortRange(pagesIndex, startPosition, endPosition);
+            return;
+        }
+        memoryContext.setBytes(memoryContext.getBytes() + workingMemory);
+        try {
+            sortRange(pagesIndex, startPosition, endPosition);
+        }
+        finally {
+            memoryContext.setBytes(memoryContext.getBytes() - workingMemory);
+        }
+    }
+
+    private void sortRange(PagesIndex pagesIndex, int startPosition, int endPosition)
+    {
+        SortKeyPrefixes sortKeyPrefixes = null;
+        if (useSortKeyPrefixes(endPosition - startPosition)) {
+            sortKeyPrefixes = buildSortKeyPrefixes(pagesIndex, startPosition, endPosition);
+        }
+        quickSort(pagesIndex, sortKeyPrefixes, startPosition, endPosition);
+    }
+
+    private long sortWorkingMemory(int startPosition, int endPosition)
+    {
+        int positionCount = endPosition - startPosition;
+        if (useSortKeyPrefixes(positionCount)) {
+            return sizeOfLongArray(positionCount);
+        }
+        return 0;
+    }
+
+    private boolean useSortKeyPrefixes(int positionCount)
+    {
+        return !sortKeyPrefixFillers.isEmpty() && positionCount >= MIN_SORT_KEY_PREFIX_POSITIONS;
+    }
+
+    /**
+     * The leading sort channels of each position, packed into a 64-bit prefix by the types' sort
+     * key prefix operators (see {@link io.trino.spi.function.OperatorType#SORT_KEY_PREFIX_UNORDERED_LAST}),
+     * so most quicksort comparisons are a single primitive comparison instead of indirect block
+     * accesses through the comparator. Descending order inverts the bits of a field. Positions
+     * with equal prefixes are compared with the full comparator, unless the prefix decides ties.
+     */
+    private record SortKeyPrefixes(long[] keys, int offset, boolean decidesTies)
+    {
+        long key(int position)
+        {
+            return keys[position - offset];
+        }
+
+        void swap(int a, int b)
+        {
+            long temp = keys[a - offset];
+            keys[a - offset] = keys[b - offset];
+            keys[b - offset] = temp;
+        }
+    }
+
+    /**
+     * Returns null when the leading sort key values collide too much for the prefixes to pay
+     * off: when the prefix can not decide ties, every colliding comparison costs a wasted key
+     * comparison on top of the full comparison, so low-cardinality prefixes (for example
+     * varchars sharing a long common prefix) would make the sort slower than not using
+     * prefixes at all. Cardinality is estimated from the first positions and the build is
+     * abandoned early, the same way PostgreSQL aborts abbreviated keys.
+     */
+    @Nullable
+    private SortKeyPrefixes buildSortKeyPrefixes(PagesIndex pagesIndex, int startPosition, int endPosition)
+    {
+        long[] keys = new long[endPosition - startPosition];
+
+        int samplePosition = toIntExact(Math.min((long) startPosition + CARDINALITY_SAMPLE_POSITIONS, endPosition));
+        boolean collidingNulls = fillSortKeyPrefixes(pagesIndex, startPosition, samplePosition, keys, 0);
+
+        boolean decidesTies = sortKeyPrefixDecidesTies && !collidingNulls;
+        if (!decidesTies && sampleCardinalityTooLow(keys, samplePosition - startPosition)) {
+            return null;
+        }
+
+        collidingNulls |= fillSortKeyPrefixes(pagesIndex, samplePosition, endPosition, keys, samplePosition - startPosition);
+        decidesTies = sortKeyPrefixDecidesTies && !collidingNulls;
+        return new SortKeyPrefixes(keys, startPosition, decidesTies);
+    }
+
+    private static boolean sampleCardinalityTooLow(long[] keys, int sampleSize)
+    {
+        LongOpenHashSet distinctKeys = new LongOpenHashSet(sampleSize);
+        for (int i = 0; i < sampleSize; i++) {
+            distinctKeys.add(keys[i]);
+        }
+        return distinctKeys.size() < sampleSize * MIN_PREFIX_CARDINALITY_RATIO;
+    }
+
+    private boolean fillSortKeyPrefixes(PagesIndex pagesIndex, int startPosition, int endPosition, long[] keys, int keysOffset)
+    {
+        boolean collidingNulls = false;
+        for (SortKeyPrefixFiller filler : sortKeyPrefixFillers) {
+            collidingNulls |= filler.fill(pagesIndex, startPosition, endPosition, keys, keysOffset);
+        }
+        return collidingNulls;
+    }
+
+    private int compare(PagesIndex pagesIndex, @Nullable SortKeyPrefixes sortKeyPrefixes, int leftPosition, int rightPosition)
+    {
+        if (sortKeyPrefixes != null) {
+            int compare = Long.compareUnsigned(sortKeyPrefixes.key(leftPosition), sortKeyPrefixes.key(rightPosition));
+            if (compare != 0 || sortKeyPrefixes.decidesTies()) {
+                return compare;
+            }
+        }
+        return comparator.compareTo(pagesIndex, leftPosition, rightPosition);
+    }
+
+    private static void swap(PagesIndex pagesIndex, @Nullable SortKeyPrefixes sortKeyPrefixes, int a, int b)
+    {
+        if (sortKeyPrefixes != null) {
+            sortKeyPrefixes.swap(a, b);
+        }
+        pagesIndex.swap(a, b);
     }
 
     /**
@@ -49,14 +198,14 @@ public class PagesIndexOrdering
      */
     // note this code was forked from Fastutils
     @SuppressWarnings("InnerAssignment")
-    private void quickSort(PagesIndex pagesIndex, int from, int to)
+    private void quickSort(PagesIndex pagesIndex, @Nullable SortKeyPrefixes sortKeyPrefixes, int from, int to)
     {
         int len = to - from;
         // Insertion sort on smallest arrays
         if (len < SMALL) {
             for (int i = from; i < to; i++) {
-                for (int j = i; j > from && (comparator.compareTo(pagesIndex, j - 1, j) > 0); j--) {
-                    pagesIndex.swap(j, j - 1);
+                for (int j = i; j > from && (compare(pagesIndex, sortKeyPrefixes, j - 1, j) > 0); j--) {
+                    swap(pagesIndex, sortKeyPrefixes, j, j - 1);
                 }
             }
             return;
@@ -69,13 +218,12 @@ public class PagesIndexOrdering
             int n = to - 1;
             if (len > MEDIUM) { // Big arrays, pseudomedian of 9
                 int s = len / 8;
-                l = median3(pagesIndex, l, l + s, l + 2 * s);
-                m = median3(pagesIndex, m - s, m, m + s);
-                n = median3(pagesIndex, n - 2 * s, n - s, n);
+                l = median3(pagesIndex, sortKeyPrefixes, l, l + s, l + 2 * s);
+                m = median3(pagesIndex, sortKeyPrefixes, m - s, m, m + s);
+                n = median3(pagesIndex, sortKeyPrefixes, n - 2 * s, n - s, n);
             }
-            m = median3(pagesIndex, l, m, n); // Mid-size, med of 3
+            m = median3(pagesIndex, sortKeyPrefixes, l, m, n); // Mid-size, med of 3
         }
-        // int v = x[m];
 
         int a = from;
         int b = a;
@@ -84,7 +232,7 @@ public class PagesIndexOrdering
         int d = c;
         while (true) {
             int comparison;
-            while (b <= c && ((comparison = comparator.compareTo(pagesIndex, b, m)) <= 0)) {
+            while (b <= c && ((comparison = compare(pagesIndex, sortKeyPrefixes, b, m)) <= 0)) {
                 if (comparison == 0) {
                     if (a == m) {
                         m = b; // moving target; DELTA to JDK !!!
@@ -92,11 +240,11 @@ public class PagesIndexOrdering
                     else if (b == m) {
                         m = a; // moving target; DELTA to JDK !!!
                     }
-                    pagesIndex.swap(a++, b);
+                    swap(pagesIndex, sortKeyPrefixes, a++, b);
                 }
                 b++;
             }
-            while (c >= b && ((comparison = comparator.compareTo(pagesIndex, c, m)) >= 0)) {
+            while (c >= b && ((comparison = compare(pagesIndex, sortKeyPrefixes, c, m)) >= 0)) {
                 if (comparison == 0) {
                     if (c == m) {
                         m = d; // moving target; DELTA to JDK !!!
@@ -104,7 +252,7 @@ public class PagesIndexOrdering
                     else if (d == m) {
                         m = c; // moving target; DELTA to JDK !!!
                     }
-                    pagesIndex.swap(c, d--);
+                    swap(pagesIndex, sortKeyPrefixes, c, d--);
                 }
                 c--;
             }
@@ -117,34 +265,34 @@ public class PagesIndexOrdering
             else if (c == m) {
                 m = c; // moving target; DELTA to JDK !!!
             }
-            pagesIndex.swap(b++, c--);
+            swap(pagesIndex, sortKeyPrefixes, b++, c--);
         }
 
         // Swap partition elements back to middle
         int s;
         int n = to;
         s = Math.min(a - from, b - a);
-        vectorSwap(pagesIndex, from, b - s, s);
+        vectorSwap(pagesIndex, sortKeyPrefixes, from, b - s, s);
         s = Math.min(d - c, n - d - 1);
-        vectorSwap(pagesIndex, b, n - s, s);
+        vectorSwap(pagesIndex, sortKeyPrefixes, b, n - s, s);
 
         // Recursively sort non-partition-elements
         if ((s = b - a) > 1) {
-            quickSort(pagesIndex, from, from + s);
+            quickSort(pagesIndex, sortKeyPrefixes, from, from + s);
         }
         if ((s = d - c) > 1) {
-            quickSort(pagesIndex, n - s, n);
+            quickSort(pagesIndex, sortKeyPrefixes, n - s, n);
         }
     }
 
     /**
      * Returns the index of the median of the three positions.
      */
-    private int median3(PagesIndex pagesIndex, int a, int b, int c)
+    private int median3(PagesIndex pagesIndex, @Nullable SortKeyPrefixes sortKeyPrefixes, int a, int b, int c)
     {
-        int ab = comparator.compareTo(pagesIndex, a, b);
-        int ac = comparator.compareTo(pagesIndex, a, c);
-        int bc = comparator.compareTo(pagesIndex, b, c);
+        int ab = compare(pagesIndex, sortKeyPrefixes, a, b);
+        int ac = compare(pagesIndex, sortKeyPrefixes, a, c);
+        int bc = compare(pagesIndex, sortKeyPrefixes, b, c);
         return (ab < 0 ?
                 (bc < 0 ? b : ac < 0 ? c : a) :
                 (bc > 0 ? b : ac > 0 ? c : a));
@@ -153,10 +301,10 @@ public class PagesIndexOrdering
     /**
      * Swaps x[a .. (a+n-1)] with x[b .. (b+n-1)].
      */
-    private static void vectorSwap(PagesIndex pagesIndex, int from, int l, int s)
+    private static void vectorSwap(PagesIndex pagesIndex, @Nullable SortKeyPrefixes sortKeyPrefixes, int from, int l, int s)
     {
         for (int i = 0; i < s; i++, from++, l++) {
-            pagesIndex.swap(from, l);
+            swap(pagesIndex, sortKeyPrefixes, from, l);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/PagesIndexPageSorter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesIndexPageSorter.java
@@ -13,7 +13,9 @@
  */
 package io.trino.operator;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
+import io.trino.memory.context.LocalMemoryContext;
 import io.trino.spi.Page;
 import io.trino.spi.PageSorter;
 import io.trino.spi.connector.SortOrder;
@@ -21,7 +23,9 @@ import io.trino.spi.type.Type;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.LongConsumer;
 
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static java.util.Objects.requireNonNull;
 
 public class PagesIndexPageSorter
@@ -36,12 +40,64 @@ public class PagesIndexPageSorter
     }
 
     @Override
-    public Iterator<Page> sort(List<Type> types, List<Page> pages, List<Integer> sortChannels, List<SortOrder> sortOrders, int expectedPositions)
+    public Iterator<Page> sort(List<Type> types, List<Page> pages, List<Integer> sortChannels, List<SortOrder> sortOrders, int expectedPositions, LongConsumer memoryUsage)
     {
         PagesIndex pagesIndex = pagesIndexFactory.newPagesIndex(types, expectedPositions);
         pages.forEach(pagesIndex::addPage);
-        pagesIndex.sort(sortChannels, sortOrders);
+
+        LocalMemoryContext memoryContext = new MemoryUsageReporter(memoryUsage);
+        memoryContext.setBytes(pagesIndex.getEstimatedSize().toBytes());
+        pagesIndex.sort(sortChannels, sortOrders, memoryContext);
 
         return pagesIndex.getSortedPages();
+    }
+
+    /**
+     * Adapts the SPI memory usage consumer to the memory context the sort accounts its
+     * working memory in.
+     */
+    private static class MemoryUsageReporter
+            implements LocalMemoryContext
+    {
+        private final LongConsumer memoryUsage;
+        private long bytes;
+
+        private MemoryUsageReporter(LongConsumer memoryUsage)
+        {
+            this.memoryUsage = requireNonNull(memoryUsage, "memoryUsage is null");
+        }
+
+        @Override
+        public long getBytes()
+        {
+            return bytes;
+        }
+
+        @Override
+        public ListenableFuture<Void> setBytes(long bytes)
+        {
+            this.bytes = bytes;
+            memoryUsage.accept(bytes);
+            return immediateVoidFuture();
+        }
+
+        @Override
+        public ListenableFuture<Void> addBytes(long delta)
+        {
+            return setBytes(bytes + delta);
+        }
+
+        @Override
+        public boolean trySetBytes(long bytes)
+        {
+            setBytes(bytes);
+            return true;
+        }
+
+        @Override
+        public void close()
+        {
+            setBytes(0);
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/SortKeyPrefixFiller.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SortKeyPrefixFiller.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.trino.spi.connector.SortOrder;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Fills the bits of one sort channel into the composite sort key prefixes of a
+ * {@link PagesIndex} position range.
+ */
+public interface SortKeyPrefixFiller
+{
+    /**
+     * @return whether any null was encoded without a null indicator bit, in which case nulls may
+     *         collide with extreme values and the prefix can not decide ties
+     */
+    boolean fill(PagesIndex pagesIndex, int startPosition, int endPosition, long[] keys, int keysOffset);
+
+    /**
+     * Bit layout of one sort channel within the composite prefix: {@code valueBits} of the sort
+     * key prefix shifted to {@code shift}, preceded by a null indicator bit when
+     * {@code hasNullBit} is set. Fields with a null indicator bit encode nulls exactly; fields
+     * without one (only the sole field of a single-field prefix) let nulls collide with extreme
+     * values, which the sort resolves through the comparator.
+     */
+    record SortKeyPrefixLayout(int sortChannel, SortOrder sortOrder, int valueBits, boolean hasNullBit, int shift)
+    {
+        public SortKeyPrefixLayout
+        {
+            requireNonNull(sortOrder, "sortOrder is null");
+        }
+
+        public boolean descending()
+        {
+            return !sortOrder.isAscending();
+        }
+
+        public boolean collideNullsWithValues()
+        {
+            return !hasNullBit;
+        }
+
+        public int extractShift()
+        {
+            return 64 - valueBits;
+        }
+
+        public long nullSubKey()
+        {
+            if (sortOrder.isNullsFirst()) {
+                return 0;
+            }
+            if (hasNullBit) {
+                // the null indicator is the top bit of the field
+                return 1L << valueBits;
+            }
+            if (valueBits == 64) {
+                return -1;
+            }
+            return (1L << valueBits) - 1;
+        }
+
+        public long valueBase()
+        {
+            if (hasNullBit && sortOrder.isNullsFirst()) {
+                return 1L << valueBits;
+            }
+            return 0;
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/TopNOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNOperator.java
@@ -36,9 +36,10 @@ public class TopNOperator
             PlanNodeId planNodeId,
             List<? extends Type> types,
             int n,
-            PageWithPositionComparator comparator)
+            PageWithPositionComparator comparator,
+            List<PageSortKeyPrefixFiller> prefixFillers)
     {
-        return createAdapterOperatorFactory(new Factory(operatorId, planNodeId, types, n, comparator));
+        return createAdapterOperatorFactory(new Factory(operatorId, planNodeId, types, n, comparator, prefixFillers));
     }
 
     private static class Factory
@@ -49,6 +50,7 @@ public class TopNOperator
         private final List<Type> sourceTypes;
         private final int n;
         private final PageWithPositionComparator comparator;
+        private final List<PageSortKeyPrefixFiller> prefixFillers;
         private boolean closed;
 
         private Factory(
@@ -56,13 +58,15 @@ public class TopNOperator
                 PlanNodeId planNodeId,
                 List<? extends Type> types,
                 int n,
-                PageWithPositionComparator comparator)
+                PageWithPositionComparator comparator,
+                List<PageSortKeyPrefixFiller> prefixFillers)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.sourceTypes = ImmutableList.copyOf(requireNonNull(types, "types is null"));
             this.n = n;
             this.comparator = requireNonNull(comparator, "comparator is null");
+            this.prefixFillers = ImmutableList.copyOf(requireNonNull(prefixFillers, "prefixFillers is null"));
         }
 
         @Override
@@ -76,7 +80,8 @@ public class TopNOperator
                     sourcePages,
                     sourceTypes,
                     n,
-                    comparator);
+                    comparator,
+                    prefixFillers);
         }
 
         @Override
@@ -106,7 +111,7 @@ public class TopNOperator
         @Override
         public Factory duplicate()
         {
-            return new Factory(operatorId, planNodeId, sourceTypes, n, comparator);
+            return new Factory(operatorId, planNodeId, sourceTypes, n, comparator, prefixFillers);
         }
     }
 
@@ -117,7 +122,8 @@ public class TopNOperator
             WorkProcessor<Page> sourcePages,
             List<Type> types,
             int n,
-            PageWithPositionComparator comparator)
+            PageWithPositionComparator comparator,
+            List<PageSortKeyPrefixFiller> prefixFillers)
     {
         if (n == 0) {
             pages = WorkProcessor.of();
@@ -129,7 +135,8 @@ public class TopNOperator
                                     operatorContext.aggregateUserMemoryContext(),
                                     types,
                                     n,
-                                    comparator)));
+                                    comparator,
+                                    prefixFillers)));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/TopNProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNProcessor.java
@@ -40,7 +40,8 @@ public class TopNProcessor
             AggregatedMemoryContext aggregatedMemoryContext,
             List<Type> types,
             int n,
-            PageWithPositionComparator comparator)
+            PageWithPositionComparator comparator,
+            List<PageSortKeyPrefixFiller> prefixFillers)
     {
         requireNonNull(aggregatedMemoryContext, "aggregatedMemoryContext is null");
         checkArgument(n > 0, "n must be > 0, found: %s", n);
@@ -49,6 +50,7 @@ public class TopNProcessor
         topNBuilder = new GroupedTopNRowNumberBuilder(
                 types,
                 comparator,
+                prefixFillers,
                 n,
                 false,
                 new int[0],

--- a/core/trino-main/src/main/java/io/trino/operator/TopNRankingOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNRankingOperator.java
@@ -276,6 +276,7 @@ public class TopNRankingOperator
                     sourceTypes,
                     comparator,
                     equalsAndHash,
+                    prefixFillers,
                     maxRankingPerPartition,
                     generateRanking,
                     groupByChannels,

--- a/core/trino-main/src/main/java/io/trino/operator/TopNRankingOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNRankingOperator.java
@@ -61,6 +61,7 @@ public class TopNRankingOperator
         private boolean closed;
         private final FlatHashStrategyCompiler hashStrategyCompiler;
         private final PageWithPositionComparator comparator;
+        private final List<PageSortKeyPrefixFiller> prefixFillers;
         private final BlockTypeOperators blockTypeOperators;
         private final Optional<DataSize> maxPartialMemory;
 
@@ -79,6 +80,7 @@ public class TopNRankingOperator
                 Optional<DataSize> maxPartialMemory,
                 FlatHashStrategyCompiler hashStrategyCompiler,
                 PageWithPositionComparator comparator,
+                List<PageSortKeyPrefixFiller> prefixFillers,
                 BlockTypeOperators blockTypeOperators)
         {
             this.operatorId = operatorId;
@@ -97,6 +99,7 @@ public class TopNRankingOperator
             this.expectedPositions = expectedPositions;
             this.hashStrategyCompiler = requireNonNull(hashStrategyCompiler, "hashStrategyCompiler is null");
             this.comparator = requireNonNull(comparator, "comparator is null");
+            this.prefixFillers = ImmutableList.copyOf(requireNonNull(prefixFillers, "prefixFillers is null"));
             this.blockTypeOperators = requireNonNull(blockTypeOperators, "blockTypeOperators is null");
             this.maxPartialMemory = requireNonNull(maxPartialMemory, "maxPartialMemory is null");
         }
@@ -120,6 +123,7 @@ public class TopNRankingOperator
                     maxPartialMemory,
                     hashStrategyCompiler,
                     comparator,
+                    prefixFillers,
                     blockTypeOperators);
         }
 
@@ -147,6 +151,7 @@ public class TopNRankingOperator
                     maxPartialMemory,
                     hashStrategyCompiler,
                     comparator,
+                    prefixFillers,
                     blockTypeOperators);
         }
     }
@@ -178,6 +183,7 @@ public class TopNRankingOperator
             Optional<DataSize> maxPartialMemory,
             FlatHashStrategyCompiler hashStrategyCompiler,
             PageWithPositionComparator comparator,
+            List<PageSortKeyPrefixFiller> prefixFillers,
             BlockTypeOperators blockTypeOperators)
     {
         requireNonNull(maxPartialMemory, "maxPartialMemory is null");
@@ -208,6 +214,7 @@ public class TopNRankingOperator
                 maxRankingPerPartition,
                 generateRanking,
                 comparator,
+                prefixFillers,
                 blockTypeOperators,
                 groupByChannels,
                 getGroupByHashSupplier(
@@ -245,6 +252,7 @@ public class TopNRankingOperator
             int maxRankingPerPartition,
             boolean generateRanking,
             PageWithPositionComparator comparator,
+            List<PageSortKeyPrefixFiller> prefixFillers,
             BlockTypeOperators blockTypeOperators,
             int[] groupByChannels,
             Supplier<GroupByHash> groupByHashSupplier)
@@ -253,6 +261,7 @@ public class TopNRankingOperator
             return () -> new GroupedTopNRowNumberBuilder(
                     sourceTypes,
                     comparator,
+                    prefixFillers,
                     maxRankingPerPartition,
                     generateRanking,
                     groupByChannels,

--- a/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
@@ -339,7 +339,8 @@ public class WindowOperator
                     orderChannels,
                     ordering,
                     spillerFactory,
-                    orderingCompiler.compilePageWithPositionComparator(unGroupedOrderTypes, unGroupedOrderChannels, unGroupedOrdering)));
+                    orderingCompiler.compilePageWithPositionComparator(unGroupedOrderTypes, unGroupedOrderChannels, unGroupedOrdering),
+                    orderingCompiler.compilePageSortKeyPrefixFillers(unGroupedOrderTypes, unGroupedOrderChannels, unGroupedOrdering)));
 
             this.outputPages = pageBuffer.pages()
                     .flatTransform(spillablePagesToPagesIndexes.get())
@@ -674,6 +675,7 @@ public class WindowOperator
         final LocalMemoryContext localUserMemoryContext;
         final SpillerFactory spillerFactory;
         final PageWithPositionComparator pageWithPositionComparator;
+        final List<PageSortKeyPrefixFiller> pagePrefixFillers;
 
         boolean spillingWhenConvertingRevocableMemory;
         boolean resetPagesIndex;
@@ -691,8 +693,10 @@ public class WindowOperator
                 List<Integer> orderChannels,
                 List<SortOrder> ordering,
                 SpillerFactory spillerFactory,
-                PageWithPositionComparator pageWithPositionComparator)
+                PageWithPositionComparator pageWithPositionComparator,
+                List<PageSortKeyPrefixFiller> pagePrefixFillers)
         {
+            this.pagePrefixFillers = ImmutableList.copyOf(requireNonNull(pagePrefixFillers, "pagePrefixFillers is null"));
             this.inMemoryPagesIndexWithHashStrategies = inMemoryPagesIndexWithHashStrategies;
             this.mergedPagesIndexWithHashStrategies = mergedPagesIndexWithHashStrategies;
             this.sourceTypes = sourceTypes;
@@ -858,6 +862,7 @@ public class WindowOperator
             WorkProcessor<Page> mergedPages = mergeSortedPages(
                     sortedStreams,
                     pageWithPositionComparator,
+                    pagePrefixFillers,
                     sourceTypes,
                     operatorContext.aggregateUserMemoryContext(),
                     operatorContext.getDriverContext().getYieldSignal());

--- a/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
@@ -570,7 +570,7 @@ public class WindowOperator
 
             // If we have unused input or are finishing, then we have buffered a full group
             if (finishing || pendingInputPosition < pendingInput.getPositionCount()) {
-                sortPagesIndexIfNecessary(pagesIndexWithHashStrategies.pagesIndex, pagesIndexWithHashStrategies.preSortedPartitionHashStrategy, pagesIndexOrdering);
+                sortPagesIndexIfNecessary(pagesIndexWithHashStrategies.pagesIndex, pagesIndexWithHashStrategies.preSortedPartitionHashStrategy, pagesIndexOrdering, memoryContext);
                 resetPagesIndex = true;
                 return TransformationState.ofResult(pagesIndexWithHashStrategies, false);
             }
@@ -787,7 +787,7 @@ public class WindowOperator
                 }
             }
 
-            sortPagesIndexIfNecessary(inMemoryPagesIndexWithHashStrategies.pagesIndex, inMemoryPagesIndexWithHashStrategies.preSortedPartitionHashStrategy, inMemoryPagesIndexOrdering);
+            sortPagesIndexIfNecessary(inMemoryPagesIndexWithHashStrategies.pagesIndex, inMemoryPagesIndexWithHashStrategies.preSortedPartitionHashStrategy, inMemoryPagesIndexOrdering, localUserMemoryContext);
             resetPagesIndex = true;
             return TransformationState.ofResult(unspill(), false);
         }
@@ -813,7 +813,7 @@ public class WindowOperator
             }
 
             verify(inMemoryPagesIndexWithHashStrategies.pagesIndex.getPositionCount() > 0);
-            sortPagesIndexIfNecessary(inMemoryPagesIndexWithHashStrategies.pagesIndex, inMemoryPagesIndexWithHashStrategies.preSortedPartitionHashStrategy, inMemoryPagesIndexOrdering);
+            sortPagesIndexIfNecessary(inMemoryPagesIndexWithHashStrategies.pagesIndex, inMemoryPagesIndexWithHashStrategies.preSortedPartitionHashStrategy, inMemoryPagesIndexOrdering, localRevocableMemoryContext);
             PeekingIterator<Page> sortedPages = peekingIterator(inMemoryPagesIndexWithHashStrategies.pagesIndex.getSortedPages());
             Page anyPage = sortedPages.peek();
             verify(anyPage.getPositionCount() != 0, "PagesIndex.getSortedPages returned an empty page");
@@ -913,13 +913,13 @@ public class WindowOperator
         return startPosition;
     }
 
-    private static void sortPagesIndexIfNecessary(PagesIndex pagesIndex, PagesHashStrategy preSortedPartitionHashStrategy, @Nullable PagesIndexOrdering pagesIndexOrdering)
+    private static void sortPagesIndexIfNecessary(PagesIndex pagesIndex, PagesHashStrategy preSortedPartitionHashStrategy, @Nullable PagesIndexOrdering pagesIndexOrdering, LocalMemoryContext memoryContext)
     {
         if (pagesIndex.getPositionCount() > 1 && pagesIndexOrdering != null) {
             int startPosition = 0;
             while (startPosition < pagesIndex.getPositionCount()) {
                 int endPosition = findGroupEnd(pagesIndex, preSortedPartitionHashStrategy, startPosition);
-                pagesIndex.sort(pagesIndexOrdering, startPosition, endPosition);
+                pagesIndex.sort(pagesIndexOrdering, startPosition, endPosition, memoryContext);
                 startPosition = endPosition;
             }
         }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static java.lang.Long.max;
 import static java.util.Objects.requireNonNull;
@@ -169,7 +170,7 @@ public class OrderedAccumulatorFactory
         public void evaluateFinal(BlockBuilder blockBuilder)
         {
             checkState(pagesIndex != null, "evaluateFinal() already called");
-            pagesIndex.sort(pagesIndexOrdering);
+            pagesIndex.sort(pagesIndexOrdering, newSimpleAggregatedMemoryContext().newLocalMemoryContext(OrderedAccumulator.class.getSimpleName()));
             Iterator<Page> pagesIterator = pagesIndex.getSortedPages();
             AggregationMask mask = AggregationMask.createSelectAll(0);
             pagesIterator.forEachRemaining(arguments -> {
@@ -267,7 +268,7 @@ public class OrderedAccumulatorFactory
         public void prepareFinal()
         {
             checkState(pagesIndex != null, "prepareFinal() already called");
-            pagesIndex.sort(pagesIndexOrdering);
+            pagesIndex.sort(pagesIndexOrdering, newSimpleAggregatedMemoryContext().newLocalMemoryContext(OrderingGroupedAccumulator.class.getSimpleName()));
             Iterator<Page> pagesIterator = pagesIndex.getSortedPages();
             AggregationMask mask = AggregationMask.createSelectAll(0);
             pagesIterator.forEachRemaining(page -> {

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedWindowAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedWindowAccumulator.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static java.util.Objects.requireNonNull;
 
 public class OrderedWindowAccumulator
@@ -134,7 +135,7 @@ public class OrderedWindowAccumulator
                 delegate.output(blockBuilder);
                 return;
             }
-            pagesIndex.sort(pagesIndexOrdering);
+            pagesIndex.sort(pagesIndexOrdering, newSimpleAggregatedMemoryContext().newLocalMemoryContext(OrderedWindowAccumulator.class.getSimpleName()));
             WindowIndex sortedWindowIndex = new PagesWindowIndex(pagesIndex, 0, positionCount);
             delegate.addInput(sortedWindowIndex, 0, positionCount - 1);
             pagesIndexSorted = true;

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalMergeSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalMergeSourceOperator.java
@@ -19,6 +19,7 @@ import io.trino.operator.DriverContext;
 import io.trino.operator.Operator;
 import io.trino.operator.OperatorContext;
 import io.trino.operator.OperatorFactory;
+import io.trino.operator.PageSortKeyPrefixFiller;
 import io.trino.operator.PageWithPositionComparator;
 import io.trino.operator.WorkProcessor;
 import io.trino.spi.Page;
@@ -78,11 +79,12 @@ public class LocalMergeSourceOperator
                     .map(types::get)
                     .collect(toImmutableList());
             PageWithPositionComparator comparator = orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, orderings);
+            List<PageSortKeyPrefixFiller> prefixFillers = orderingCompiler.compilePageSortKeyPrefixFillers(sortTypes, sortChannels, orderings);
             List<LocalExchangeSource> sources = IntStream.range(0, localExchange.getBufferCount())
                     .boxed()
                     .map(_ -> localExchange.getNextSource())
                     .collect(toImmutableList());
-            return new LocalMergeSourceOperator(operatorContext, sources, types, comparator);
+            return new LocalMergeSourceOperator(operatorContext, sources, types, comparator, prefixFillers);
         }
 
         @Override
@@ -102,7 +104,7 @@ public class LocalMergeSourceOperator
     private final List<LocalExchangeSource> sources;
     private final WorkProcessor<Page> mergedPages;
 
-    public LocalMergeSourceOperator(OperatorContext operatorContext, List<LocalExchangeSource> sources, List<Type> types, PageWithPositionComparator comparator)
+    public LocalMergeSourceOperator(OperatorContext operatorContext, List<LocalExchangeSource> sources, List<Type> types, PageWithPositionComparator comparator, List<PageSortKeyPrefixFiller> prefixFillers)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.sources = requireNonNull(sources, "sources is null");
@@ -112,6 +114,7 @@ public class LocalMergeSourceOperator
         mergedPages = mergeSortedPages(
                 pageProducers,
                 requireNonNull(comparator, "comparator is null"),
+                requireNonNull(prefixFillers, "prefixFillers is null"),
                 types,
                 operatorContext.aggregateUserMemoryContext(),
                 operatorContext.getDriverContext().getYieldSignal());

--- a/core/trino-main/src/main/java/io/trino/operator/function/TableFunctionOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/function/TableFunctionOperator.java
@@ -468,7 +468,7 @@ public class TableFunctionOperator
             // sorting serves two purposes:
             // - sort by the remaining partition channels so that the input is fully partitioned,
             // - sort by all the sort channels so that the input is fully sorted
-            sortCurrentGroup(pagesIndex, hashStrategies);
+            sortCurrentGroup(pagesIndex, hashStrategies, memoryContext);
             resetPagesIndex = true;
             return WorkProcessor.TransformationState.ofResult(pagesIndex, false);
         }
@@ -505,7 +505,7 @@ public class TableFunctionOperator
         return startPosition;
     }
 
-    private static void sortCurrentGroup(PagesIndex pagesIndex, HashStrategies hashStrategies)
+    private static void sortCurrentGroup(PagesIndex pagesIndex, HashStrategies hashStrategies, LocalMemoryContext memoryContext)
     {
         if (pagesIndex.getPositionCount() > 1 && hashStrategies.remainingPartitionAndSortOrdering.isPresent()) {
             PagesHashStrategy preSortedStrategy = hashStrategies.preSortedStrategy;
@@ -513,7 +513,7 @@ public class TableFunctionOperator
             int startPosition = 0;
             while (startPosition < pagesIndex.getPositionCount()) {
                 int endPosition = findGroupEnd(pagesIndex, preSortedStrategy, startPosition);
-                pagesIndex.sort(remainingPartitionAndSortOrdering, startPosition, endPosition);
+                pagesIndex.sort(remainingPartitionAndSortOrdering, startPosition, endPosition, memoryContext);
                 startPosition = endPosition;
             }
         }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/OperatorValidator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/OperatorValidator.java
@@ -58,7 +58,7 @@ public final class OperatorValidator
                     default -> {}
                 }
             }
-            case HASH_CODE -> {
+            case HASH_CODE, SORT_KEY_PREFIX_UNORDERED_LAST, SORT_KEY_PREFIX_UNORDERED_FIRST -> {
                 validateOperatorSignature(operatorType, returnType, argumentTypes, 1);
                 checkArgument(returnType.baseName().equals(StandardTypes.BIGINT), "%s operator must return a BIGINT: %s", operatorType, formatSignature(operatorType, returnType, argumentTypes));
             }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/OperatorValidator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/OperatorValidator.java
@@ -62,6 +62,9 @@ public final class OperatorValidator
                 validateOperatorSignature(operatorType, returnType, argumentTypes, 1);
                 checkArgument(returnType.baseName().equals(StandardTypes.BIGINT), "%s operator must return a BIGINT: %s", operatorType, formatSignature(operatorType, returnType, argumentTypes));
             }
+            case SORT_KEY_PREFIX_BATCH_UNORDERED_LAST, SORT_KEY_PREFIX_BATCH_UNORDERED_FIRST -> {
+                throw new IllegalArgumentException(operatorType + " operator can only be used in type operator declarations");
+            }
             case IDENTICAL, XX_HASH_64, INDETERMINATE, READ_VALUE -> {
                 // TODO
             }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/OrderingCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/OrderingCompiler.java
@@ -31,7 +31,9 @@ import io.airlift.bytecode.instruction.LabelNode;
 import io.airlift.log.Logger;
 import io.trino.cache.CacheStatsMBean;
 import io.trino.cache.NonEvictableLoadingCache;
+import io.trino.operator.InterpretedPageSortKeyPrefixFiller;
 import io.trino.operator.InterpretedSortKeyPrefixFiller;
+import io.trino.operator.PageSortKeyPrefixFiller;
 import io.trino.operator.PageWithPositionComparator;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.PagesIndexComparator;
@@ -98,6 +100,12 @@ public class OrderingCompiler
                     .recordStats()
                     .maximumSize(1000),
             CacheLoader.from(key -> internalCompilePageWithPositionComparator(key.getSortTypes(), key.getSortChannels(), key.getSortOrders())));
+
+    private final NonEvictableLoadingCache<PagesIndexComparatorCacheKey, List<PageSortKeyPrefixFiller>> pageSortKeyPrefixFillers = buildNonEvictableCache(
+            CacheBuilder.newBuilder()
+                    .recordStats()
+                    .maximumSize(1000),
+            CacheLoader.from(key -> internalCompilePageSortKeyPrefixFillers(key.getSortTypes(), key.getSortChannels(), key.getSortOrders())));
 
     private final TypeOperators typeOperators;
 
@@ -219,6 +227,114 @@ public class OrderingCompiler
         return new SortKeyPrefixLayoutPlan(
                 ImmutableList.of(layout),
                 typeOperators.isSortKeyPrefixExact(sortType) && sortChannels.size() == 1);
+    }
+
+    /**
+     * Compiles per-channel fillers of composite sort key prefixes for {@link Page} positions,
+     * used by TopN operators to reject most rows with a single primitive comparison. Returns an
+     * empty list when the leading sort channel does not support sort key prefixes.
+     */
+    public List<PageSortKeyPrefixFiller> compilePageSortKeyPrefixFillers(List<Type> sortTypes, List<Integer> sortChannels, List<SortOrder> sortOrders)
+    {
+        requireNonNull(sortTypes, "sortTypes is null");
+        requireNonNull(sortChannels, "sortChannels is null");
+        requireNonNull(sortOrders, "sortOrders is null");
+        checkArgument(sortTypes.size() == sortChannels.size(), "sortTypes and sortChannels must be the same size");
+        checkArgument(sortTypes.size() == sortOrders.size(), "sortTypes and sortOrders must be the same size");
+
+        return pageSortKeyPrefixFillers.getUnchecked(new PagesIndexComparatorCacheKey(sortTypes, sortChannels, sortOrders));
+    }
+
+    private List<PageSortKeyPrefixFiller> internalCompilePageSortKeyPrefixFillers(List<Type> sortTypes, List<Integer> sortChannels, List<SortOrder> sortOrders)
+    {
+        SortKeyPrefixLayoutPlan plan = planSortKeyPrefixLayouts(sortTypes, sortChannels, sortOrders);
+        ImmutableList.Builder<PageSortKeyPrefixFiller> fillers = ImmutableList.builder();
+        for (int i = 0; i < plan.layouts().size(); i++) {
+            fillers.add(pageSortKeyPrefixFiller(sortTypes.get(i), plan.layouts().get(i)));
+        }
+        return fillers.build();
+    }
+
+    private PageSortKeyPrefixFiller pageSortKeyPrefixFiller(Type sortType, SortKeyPrefixLayout layout)
+    {
+        MethodHandle operator = typeOperators.getSortKeyPrefixOperator(sortType, layout.sortOrder(), simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL));
+        try {
+            return compilePageSortKeyPrefixFiller(operator, layout).getConstructor().newInstance();
+        }
+        catch (Throwable e) {
+            log.error(e, "Error compiling page sort key prefix filler for channel %s with order %s", layout.sortChannel(), layout.sortOrder());
+            return new InterpretedPageSortKeyPrefixFiller(operator, layout);
+        }
+    }
+
+    private Class<? extends PageSortKeyPrefixFiller> compilePageSortKeyPrefixFiller(MethodHandle operator, SortKeyPrefixLayout layout)
+    {
+        CallSiteBinder callSiteBinder = new CallSiteBinder();
+
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                makeClassName("PageSortKeyPrefixFiller"),
+                type(Object.class),
+                type(PageSortKeyPrefixFiller.class));
+        classDefinition.declareDefaultConstructor(a(PUBLIC));
+
+        Parameter page = arg("page", Page.class);
+        Parameter prefixes = arg("prefixes", long[].class);
+        MethodDefinition method = classDefinition.declareMethod(a(PUBLIC), "fill", type(void.class), page, prefixes);
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        Variable block = scope.declareVariable(Block.class, "block");
+        body.append(block.set(page.invoke("getBlock", Block.class, constantInt(layout.sortChannel()))));
+        Variable positionCount = scope.declareVariable(int.class, "positionCount");
+        body.append(positionCount.set(page.invoke("getPositionCount", int.class)));
+
+        Variable position = scope.declareVariable(int.class, "position");
+        Variable subKey = scope.declareVariable(long.class, "subKey");
+
+        BytecodeBlock nullCase = new BytecodeBlock()
+                .append(subKey.set(constantLong(layout.nullSubKey())));
+
+        BytecodeExpression encoded = invokeDynamic(
+                BOOTSTRAP_METHOD,
+                ImmutableList.of(callSiteBinder.bind(operator).getBindingId()),
+                "sortKeyPrefix",
+                operator.type(),
+                block,
+                position);
+        if (layout.descending()) {
+            encoded = bitwiseXor(encoded, constantLong(-1));
+        }
+        if (layout.extractShift() != 0) {
+            encoded = shiftRightUnsigned(encoded, constantInt(layout.extractShift()));
+        }
+        if (layout.valueBase() != 0) {
+            encoded = bitwiseOr(constantLong(layout.valueBase()), encoded);
+        }
+        BytecodeBlock valueCase = new BytecodeBlock()
+                .append(subKey.set(encoded));
+
+        BytecodeExpression shiftedSubKey = subKey;
+        if (layout.shift() != 0) {
+            shiftedSubKey = shiftLeft(subKey, constantInt(layout.shift()));
+        }
+
+        BytecodeBlock loopBody = new BytecodeBlock()
+                .append(new IfStatement()
+                        .condition(block.invoke("isNull", boolean.class, position))
+                        .ifTrue(nullCase)
+                        .ifFalse(valueCase))
+                .append(prefixes.setElement(position, bitwiseOr(prefixes.getElement(position), shiftedSubKey)));
+
+        body.append(new ForLoop()
+                .initialize(position.set(constantInt(0)))
+                .condition(lessThan(position, positionCount))
+                .update(position.set(add(position, constantInt(1))))
+                .body(loopBody));
+
+        body.ret();
+
+        return defineClass(classDefinition, PageSortKeyPrefixFiller.class, callSiteBinder.getBindings(), getClass().getClassLoader());
     }
 
     private SortKeyPrefixFiller sortKeyPrefixFiller(Type sortType, SortKeyPrefixLayout layout)

--- a/core/trino-main/src/main/java/io/trino/sql/gen/OrderingCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/OrderingCompiler.java
@@ -31,6 +31,7 @@ import io.airlift.bytecode.instruction.LabelNode;
 import io.airlift.log.Logger;
 import io.trino.cache.CacheStatsMBean;
 import io.trino.cache.NonEvictableLoadingCache;
+import io.trino.operator.BatchPageSortKeyPrefixFiller;
 import io.trino.operator.InterpretedPageSortKeyPrefixFiller;
 import io.trino.operator.InterpretedSortKeyPrefixFiller;
 import io.trino.operator.PageSortKeyPrefixFiller;
@@ -221,9 +222,11 @@ public class OrderingCompiler
             }
         }
 
-        // a single packed channel does not need the null indicator bit
+        // A single packed channel does not need the null indicator bit and keeps the operator's
+        // full top-aligned key: extracting the declared bits would be an order-preserving shift
+        // with no effect on comparisons, only extra work per position.
         Type sortType = sortTypes.getFirst();
-        SortKeyPrefixLayout layout = new SortKeyPrefixLayout(sortChannels.getFirst(), sortOrders.getFirst(), typeOperators.getSortKeyPrefixBits(sortType), false, 0);
+        SortKeyPrefixLayout layout = new SortKeyPrefixLayout(sortChannels.getFirst(), sortOrders.getFirst(), 64, false, 0);
         return new SortKeyPrefixLayoutPlan(
                 ImmutableList.of(layout),
                 typeOperators.isSortKeyPrefixExact(sortType) && sortChannels.size() == 1);
@@ -250,7 +253,16 @@ public class OrderingCompiler
         SortKeyPrefixLayoutPlan plan = planSortKeyPrefixLayouts(sortTypes, sortChannels, sortOrders);
         ImmutableList.Builder<PageSortKeyPrefixFiller> fillers = ImmutableList.builder();
         for (int i = 0; i < plan.layouts().size(); i++) {
-            fillers.add(pageSortKeyPrefixFiller(sortTypes.get(i), plan.layouts().get(i)));
+            PageSortKeyPrefixFiller filler = pageSortKeyPrefixFiller(sortTypes.get(i), plan.layouts().get(i));
+            // the batch operator overwrites the prefix array, so it only applies to single-channel layouts
+            if (plan.layouts().size() == 1) {
+                SortKeyPrefixLayout layout = plan.layouts().get(i);
+                PageSortKeyPrefixFiller fallback = filler;
+                filler = typeOperators.getSortKeyPrefixBatchOperator(sortTypes.get(i), layout.sortOrder())
+                        .<PageSortKeyPrefixFiller>map(batchOperator -> new BatchPageSortKeyPrefixFiller(batchOperator, layout, fallback))
+                        .orElse(filler);
+            }
+            fillers.add(filler);
         }
         return fillers.build();
     }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/OrderingCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/OrderingCompiler.java
@@ -24,17 +24,22 @@ import io.airlift.bytecode.MethodDefinition;
 import io.airlift.bytecode.Parameter;
 import io.airlift.bytecode.Scope;
 import io.airlift.bytecode.Variable;
+import io.airlift.bytecode.control.ForLoop;
+import io.airlift.bytecode.control.IfStatement;
 import io.airlift.bytecode.expression.BytecodeExpression;
 import io.airlift.bytecode.instruction.LabelNode;
 import io.airlift.log.Logger;
 import io.trino.cache.CacheStatsMBean;
 import io.trino.cache.NonEvictableLoadingCache;
+import io.trino.operator.InterpretedSortKeyPrefixFiller;
 import io.trino.operator.PageWithPositionComparator;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.PagesIndexComparator;
 import io.trino.operator.PagesIndexOrdering;
 import io.trino.operator.SimplePageWithPositionComparator;
 import io.trino.operator.SimplePagesIndexComparator;
+import io.trino.operator.SortKeyPrefixFiller;
+import io.trino.operator.SortKeyPrefixFiller.SortKeyPrefixLayout;
 import io.trino.operator.SyntheticAddress;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
@@ -56,11 +61,21 @@ import static io.airlift.bytecode.Access.PUBLIC;
 import static io.airlift.bytecode.Access.a;
 import static io.airlift.bytecode.Parameter.arg;
 import static io.airlift.bytecode.ParameterizedType.type;
+import static io.airlift.bytecode.expression.BytecodeExpressions.add;
+import static io.airlift.bytecode.expression.BytecodeExpressions.bitwiseOr;
+import static io.airlift.bytecode.expression.BytecodeExpressions.bitwiseXor;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantBoolean;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantInt;
+import static io.airlift.bytecode.expression.BytecodeExpressions.constantLong;
 import static io.airlift.bytecode.expression.BytecodeExpressions.invokeDynamic;
 import static io.airlift.bytecode.expression.BytecodeExpressions.invokeStatic;
+import static io.airlift.bytecode.expression.BytecodeExpressions.lessThan;
+import static io.airlift.bytecode.expression.BytecodeExpressions.shiftLeft;
+import static io.airlift.bytecode.expression.BytecodeExpressions.shiftRightUnsigned;
+import static io.airlift.bytecode.expression.BytecodeExpressions.subtract;
 import static io.trino.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.sql.gen.Bootstrap.BOOTSTRAP_METHOD;
@@ -133,8 +148,175 @@ public class OrderingCompiler
             comparator = new SimplePagesIndexComparator(sortTypes, sortChannels, sortOrders, typeOperators);
         }
 
+        SortKeyPrefixPlan sortKeyPrefixPlan = planSortKeyPrefixes(sortTypes, sortChannels, sortOrders);
+
         // we may want to load a separate PagesIndexOrdering for each comparator
-        return new PagesIndexOrdering(comparator);
+        return new PagesIndexOrdering(comparator, sortKeyPrefixPlan.fillers(), sortKeyPrefixPlan.decidesTies());
+    }
+
+    private record SortKeyPrefixPlan(List<SortKeyPrefixFiller> fillers, boolean decidesTies) {}
+
+    /**
+     * Packs the leading sort channels into a single 64-bit sort key prefix. A channel can only be
+     * followed by another packed channel when its prefix is exact within the assigned bits,
+     * otherwise bits of the next channel could contradict the comparator. With multiple packed
+     * channels each field reserves a null indicator bit; a single packed channel uses the whole
+     * budget and relies on nulls colliding with extreme values, which the sort resolves through
+     * the comparator.
+     */
+    private SortKeyPrefixPlan planSortKeyPrefixes(List<Type> sortTypes, List<Integer> sortChannels, List<SortOrder> sortOrders)
+    {
+        SortKeyPrefixLayoutPlan plan = planSortKeyPrefixLayouts(sortTypes, sortChannels, sortOrders);
+        ImmutableList.Builder<SortKeyPrefixFiller> fillers = ImmutableList.builder();
+        for (int i = 0; i < plan.layouts().size(); i++) {
+            fillers.add(sortKeyPrefixFiller(sortTypes.get(i), plan.layouts().get(i)));
+        }
+        return new SortKeyPrefixPlan(fillers.build(), plan.decidesTies());
+    }
+
+    private record SortKeyPrefixLayoutPlan(List<SortKeyPrefixLayout> layouts, boolean decidesTies) {}
+
+    private SortKeyPrefixLayoutPlan planSortKeyPrefixLayouts(List<Type> sortTypes, List<Integer> sortChannels, List<SortOrder> sortOrders)
+    {
+        int candidates = 0;
+        while (candidates < sortTypes.size() && typeOperators.isSortKeyPrefixSupported(sortTypes.get(candidates))) {
+            boolean exact = typeOperators.isSortKeyPrefixExact(sortTypes.get(candidates));
+            candidates++;
+            if (!exact) {
+                break;
+            }
+        }
+        if (candidates == 0) {
+            return new SortKeyPrefixLayoutPlan(ImmutableList.of(), false);
+        }
+
+        if (candidates > 1) {
+            ImmutableList.Builder<SortKeyPrefixLayout> layouts = ImmutableList.builder();
+            int fieldCount = 0;
+            int shift = 64;
+            boolean allExact = true;
+            for (int i = 0; i < candidates && shift > 1; i++) {
+                Type sortType = sortTypes.get(i);
+                int declaredBits = typeOperators.getSortKeyPrefixBits(sortType);
+                int valueBits = Math.min(declaredBits, shift - 1);
+                boolean exact = typeOperators.isSortKeyPrefixExact(sortType) && valueBits == declaredBits;
+                shift -= valueBits + 1;
+                layouts.add(new SortKeyPrefixLayout(sortChannels.get(i), sortOrders.get(i), valueBits, true, shift));
+                fieldCount++;
+                allExact = exact;
+                if (!exact) {
+                    break;
+                }
+            }
+            if (fieldCount > 1) {
+                return new SortKeyPrefixLayoutPlan(layouts.build(), allExact && fieldCount == sortChannels.size());
+            }
+        }
+
+        // a single packed channel does not need the null indicator bit
+        Type sortType = sortTypes.getFirst();
+        SortKeyPrefixLayout layout = new SortKeyPrefixLayout(sortChannels.getFirst(), sortOrders.getFirst(), typeOperators.getSortKeyPrefixBits(sortType), false, 0);
+        return new SortKeyPrefixLayoutPlan(
+                ImmutableList.of(layout),
+                typeOperators.isSortKeyPrefixExact(sortType) && sortChannels.size() == 1);
+    }
+
+    private SortKeyPrefixFiller sortKeyPrefixFiller(Type sortType, SortKeyPrefixLayout layout)
+    {
+        MethodHandle operator = typeOperators.getSortKeyPrefixOperator(sortType, layout.sortOrder(), simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL));
+        try {
+            return compileSortKeyPrefixFiller(operator, layout).getConstructor().newInstance();
+        }
+        catch (Throwable e) {
+            log.error(e, "Error compiling sort key prefix filler for channel %s with order %s", layout.sortChannel(), layout.sortOrder());
+            return new InterpretedSortKeyPrefixFiller(operator, layout);
+        }
+    }
+
+    private Class<? extends SortKeyPrefixFiller> compileSortKeyPrefixFiller(MethodHandle operator, SortKeyPrefixLayout layout)
+    {
+        CallSiteBinder callSiteBinder = new CallSiteBinder();
+
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                makeClassName("SortKeyPrefixFiller"),
+                type(Object.class),
+                type(SortKeyPrefixFiller.class));
+        classDefinition.declareDefaultConstructor(a(PUBLIC));
+
+        Parameter pagesIndex = arg("pagesIndex", PagesIndex.class);
+        Parameter startPosition = arg("startPosition", int.class);
+        Parameter endPosition = arg("endPosition", int.class);
+        Parameter keys = arg("keys", long[].class);
+        Parameter keysOffset = arg("keysOffset", int.class);
+        MethodDefinition method = classDefinition.declareMethod(a(PUBLIC), "fill", type(boolean.class), pagesIndex, startPosition, endPosition, keys, keysOffset);
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        Variable valueAddresses = scope.declareVariable(LongArrayList.class, "valueAddresses");
+        body.append(valueAddresses.set(pagesIndex.invoke("getValueAddresses", LongArrayList.class)));
+        Variable blocks = scope.declareVariable(ObjectArrayList.class, "blocks");
+        body.append(blocks.set(pagesIndex.invoke("getChannel", ObjectArrayList.class, constantInt(layout.sortChannel()))));
+        Variable collidingNulls = scope.declareVariable(boolean.class, "collidingNulls");
+        body.append(collidingNulls.set(constantBoolean(false)));
+
+        Variable position = scope.declareVariable(int.class, "position");
+        Variable pageAddress = scope.declareVariable(long.class, "pageAddress");
+        Variable block = scope.declareVariable(Block.class, "block");
+        Variable blockPosition = scope.declareVariable(int.class, "blockPosition");
+        Variable subKey = scope.declareVariable(long.class, "subKey");
+        Variable keyIndex = scope.declareVariable(int.class, "keyIndex");
+
+        BytecodeBlock nullCase = new BytecodeBlock()
+                .append(subKey.set(constantLong(layout.nullSubKey())));
+        if (layout.collideNullsWithValues()) {
+            nullCase.append(collidingNulls.set(constantBoolean(true)));
+        }
+
+        BytecodeExpression encoded = invokeDynamic(
+                BOOTSTRAP_METHOD,
+                ImmutableList.of(callSiteBinder.bind(operator).getBindingId()),
+                "sortKeyPrefix",
+                operator.type(),
+                block,
+                blockPosition);
+        if (layout.descending()) {
+            encoded = bitwiseXor(encoded, constantLong(-1));
+        }
+        if (layout.extractShift() != 0) {
+            encoded = shiftRightUnsigned(encoded, constantInt(layout.extractShift()));
+        }
+        if (layout.valueBase() != 0) {
+            encoded = bitwiseOr(constantLong(layout.valueBase()), encoded);
+        }
+        BytecodeBlock valueCase = new BytecodeBlock()
+                .append(subKey.set(encoded));
+
+        BytecodeExpression shiftedSubKey = subKey;
+        if (layout.shift() != 0) {
+            shiftedSubKey = shiftLeft(subKey, constantInt(layout.shift()));
+        }
+
+        BytecodeBlock loopBody = new BytecodeBlock()
+                .append(pageAddress.set(valueAddresses.invoke("getLong", long.class, position)))
+                .append(block.set(blocks.invoke("get", Object.class, invokeStatic(SyntheticAddress.class, "decodeSliceIndex", int.class, pageAddress)).cast(Block.class)))
+                .append(blockPosition.set(invokeStatic(SyntheticAddress.class, "decodePosition", int.class, pageAddress)))
+                .append(new IfStatement()
+                        .condition(block.invoke("isNull", boolean.class, blockPosition))
+                        .ifTrue(nullCase)
+                        .ifFalse(valueCase))
+                .append(keyIndex.set(add(keysOffset, subtract(position, startPosition))))
+                .append(keys.setElement(keyIndex, bitwiseOr(keys.getElement(keyIndex), shiftedSubKey)));
+
+        body.append(new ForLoop()
+                .initialize(position.set(startPosition))
+                .condition(lessThan(position, endPosition))
+                .update(position.set(add(position, constantInt(1))))
+                .body(loopBody));
+
+        body.append(collidingNulls.ret());
+
+        return defineClass(classDefinition, SortKeyPrefixFiller.class, callSiteBinder.getBindings(), getClass().getClassLoader());
     }
 
     private Class<? extends PagesIndexComparator> compilePagesIndexComparator(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -1077,6 +1077,7 @@ public class LocalExecutionPlanner
                     maxPartialTopNMemorySize,
                     hashStrategyCompiler,
                     orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, sortOrder),
+                    orderingCompiler.compilePageSortKeyPrefixFillers(sortTypes, sortChannels, sortOrder),
                     blockTypeOperators);
 
             return new PhysicalOperation(operatorFactory, makeLayout(node), source);
@@ -1841,7 +1842,8 @@ public class LocalExecutionPlanner
                     node.getId(),
                     source.getTypes(),
                     (int) node.getCount(),
-                    orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, sortOrders));
+                    orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, sortOrders),
+                    orderingCompiler.compilePageSortKeyPrefixFillers(sortTypes, sortChannels, sortOrders));
 
             return new PhysicalOperation(operator, source.getLayout(), source);
         }

--- a/core/trino-main/src/main/java/io/trino/util/MergeSortedPages.java
+++ b/core/trino-main/src/main/java/io/trino/util/MergeSortedPages.java
@@ -16,6 +16,7 @@ package io.trino.util;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.DriverYieldSignal;
+import io.trino.operator.PageSortKeyPrefixFiller;
 import io.trino.operator.PageWithPositionComparator;
 import io.trino.operator.WorkProcessor;
 import io.trino.operator.WorkProcessor.ProcessState;
@@ -24,7 +25,9 @@ import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
+import jakarta.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiPredicate;
@@ -41,6 +44,7 @@ public final class MergeSortedPages
     public static WorkProcessor<Page> mergeSortedPages(
             List<WorkProcessor<Page>> pageProducers,
             PageWithPositionComparator comparator,
+            List<PageSortKeyPrefixFiller> prefixFillers,
             List<Type> outputTypes,
             AggregatedMemoryContext aggregatedMemoryContext,
             DriverYieldSignal yieldSignal)
@@ -48,6 +52,7 @@ public final class MergeSortedPages
         return mergeSortedPages(
                 pageProducers,
                 comparator,
+                prefixFillers,
                 IntStream.range(0, outputTypes.size()).boxed().collect(toImmutableList()),
                 outputTypes,
                 (pageBuilder, _) -> pageBuilder.isFull(),
@@ -59,6 +64,7 @@ public final class MergeSortedPages
     public static WorkProcessor<Page> mergeSortedPages(
             List<WorkProcessor<Page>> pageProducers,
             PageWithPositionComparator comparator,
+            List<PageSortKeyPrefixFiller> prefixFillers,
             List<Integer> outputChannels,
             List<Type> outputTypes,
             BiPredicate<PageBuilder, PageWithPosition> pageBreakPredicate,
@@ -68,6 +74,7 @@ public final class MergeSortedPages
     {
         requireNonNull(pageProducers, "pageProducers is null");
         requireNonNull(comparator, "comparator is null");
+        requireNonNull(prefixFillers, "prefixFillers is null");
         requireNonNull(outputChannels, "outputChannels is null");
         requireNonNull(outputTypes, "outputTypes is null");
         requireNonNull(pageBreakPredicate, "pageBreakPredicate is null");
@@ -75,14 +82,22 @@ public final class MergeSortedPages
         requireNonNull(yieldSignal, "yieldSignal is null");
 
         List<WorkProcessor<PageWithPosition>> pageWithPositionProducers = pageProducers.stream()
-                .map(pageProducer -> pageWithPositions(pageProducer, aggregatedMemoryContext))
+                .map(pageProducer -> pageWithPositions(pageProducer, aggregatedMemoryContext, prefixFillers))
                 .collect(toImmutableList());
 
-        Comparator<PageWithPosition> pageWithPositionComparator = (firstPageWithPosition, secondPageWithPosition) -> comparator.compareTo(
-                firstPageWithPosition.getPage(),
-                firstPageWithPosition.getPosition(),
-                secondPageWithPosition.getPage(),
-                secondPageWithPosition.getPosition());
+        // the prefixes of both positions are equal when no prefix fillers are given, so the
+        // comparison falls through to the comparator
+        Comparator<PageWithPosition> pageWithPositionComparator = (firstPageWithPosition, secondPageWithPosition) -> {
+            int result = Long.compareUnsigned(firstPageWithPosition.getPrefix(), secondPageWithPosition.getPrefix());
+            if (result != 0) {
+                return result;
+            }
+            return comparator.compareTo(
+                    firstPageWithPosition.getPage(),
+                    firstPageWithPosition.getPosition(),
+                    secondPageWithPosition.getPage(),
+                    secondPageWithPosition.getPosition());
+        };
 
         return buildPage(
                 mergeSorted(pageWithPositionProducers, pageWithPositionComparator),
@@ -143,11 +158,15 @@ public final class MergeSortedPages
                 });
     }
 
-    private static WorkProcessor<PageWithPosition> pageWithPositions(WorkProcessor<Page> pages, AggregatedMemoryContext aggregatedMemoryContext)
+    private static WorkProcessor<PageWithPosition> pageWithPositions(WorkProcessor<Page> pages, AggregatedMemoryContext aggregatedMemoryContext, List<PageSortKeyPrefixFiller> prefixFillers)
     {
+        // pages of a single producer are processed sequentially and the prefix values are copied
+        // into PageWithPosition, so the prefix buffer can be reused across pages
+        PrefixBuffer prefixBuffer = new PrefixBuffer();
         return pages.flatMap(page -> {
             LocalMemoryContext memoryContext = aggregatedMemoryContext.newLocalMemoryContext(MergeSortedPages.class.getSimpleName());
             memoryContext.setBytes(page.getRetainedSizeInBytes());
+            long[] prefixes = prefixBuffer.fill(page, prefixFillers);
 
             return WorkProcessor.create(new WorkProcessor.Process<PageWithPosition>()
             {
@@ -161,21 +180,48 @@ public final class MergeSortedPages
                         return ProcessState.finished();
                     }
 
-                    return ProcessState.ofResult(new PageWithPosition(page, position++));
+                    long prefix = prefixes == null ? 0 : prefixes[position];
+                    return ProcessState.ofResult(new PageWithPosition(page, position++, prefix));
                 }
             });
         });
+    }
+
+    private static class PrefixBuffer
+    {
+        private long[] buffer = new long[0];
+
+        @Nullable
+        long[] fill(Page page, List<PageSortKeyPrefixFiller> prefixFillers)
+        {
+            if (prefixFillers.isEmpty()) {
+                return null;
+            }
+            int positionCount = page.getPositionCount();
+            if (buffer.length < positionCount) {
+                buffer = new long[positionCount];
+            }
+            else {
+                Arrays.fill(buffer, 0, positionCount, 0);
+            }
+            for (PageSortKeyPrefixFiller prefixFiller : prefixFillers) {
+                prefixFiller.fill(page, buffer);
+            }
+            return buffer;
+        }
     }
 
     public static class PageWithPosition
     {
         private final Page page;
         private final int position;
+        private final long prefix;
 
-        private PageWithPosition(Page page, int position)
+        private PageWithPosition(Page page, int position, long prefix)
         {
             this.page = requireNonNull(page, "page is null");
             this.position = position;
+            this.prefix = prefix;
         }
 
         public Page getPage()
@@ -186,6 +232,11 @@ public final class MergeSortedPages
         public int getPosition()
         {
             return position;
+        }
+
+        public long getPrefix()
+        {
+            return prefix;
         }
 
         public void appendTo(PageBuilder pageBuilder, List<Integer> outputChannels)

--- a/core/trino-main/src/test/java/io/trino/BenchmarkPagesIndexPageSorter.java
+++ b/core/trino-main/src/test/java/io/trino/BenchmarkPagesIndexPageSorter.java
@@ -56,7 +56,7 @@ public class BenchmarkPagesIndexPageSorter
     public int runBenchmark(BenchmarkData data)
     {
         PageSorter pageSorter = new PagesIndexPageSorter(new PagesIndex.TestingFactory(false));
-        Iterator<Page> outputPages = pageSorter.sort(data.types, data.pages, data.sortChannels, nCopies(data.sortChannels.size(), ASC_NULLS_FIRST), 10_000);
+        Iterator<Page> outputPages = pageSorter.sort(data.types, data.pages, data.sortChannels, nCopies(data.sortChannels.size(), ASC_NULLS_FIRST), 10_000, _ -> {});
         int totalPositions = 0;
         while (outputPages.hasNext()) {
             Page page = outputPages.next();

--- a/core/trino-main/src/test/java/io/trino/TestPagesIndexPageSorter.java
+++ b/core/trino-main/src/test/java/io/trino/TestPagesIndexPageSorter.java
@@ -148,7 +148,7 @@ public class TestPagesIndexPageSorter
 
     private static void assertSorted(List<Page> inputPages, List<Page> expectedPages, List<Type> types, List<Integer> sortChannels, List<SortOrder> sortOrders, int expectedPositions)
     {
-        List<Page> outputPages = ImmutableList.copyOf(sorter.sort(types, inputPages, sortChannels, sortOrders, expectedPositions));
+        List<Page> outputPages = ImmutableList.copyOf(sorter.sort(types, inputPages, sortChannels, sortOrders, expectedPositions, _ -> {}));
 
         MaterializedResult expected = toMaterializedResult(TEST_SESSION, types, expectedPages);
         MaterializedResult actual = toMaterializedResult(TEST_SESSION, types, outputPages);

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRankBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRankBuilder.java
@@ -105,7 +105,7 @@ public class BenchmarkGroupedTopNRankBuilder
 
         public GroupedTopNBuilder newTopNBuilder()
         {
-            return new GroupedTopNRankBuilder(types, comparator, equalsAndHash, topN, true, new int[0], new CyclingGroupByHash(groupCount));
+            return new GroupedTopNRankBuilder(types, comparator, equalsAndHash, ImmutableList.of(), topN, true, new int[0], new CyclingGroupByHash(groupCount));
         }
 
         public Page getPage()

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupedTopNRowNumberBuilder.java
@@ -93,7 +93,7 @@ public class BenchmarkGroupedTopNRowNumberBuilder
 
         public GroupedTopNRowNumberBuilder newTopNRowNumberBuilder()
         {
-            return new GroupedTopNRowNumberBuilder(types, comparator, topN, false, new int[0], new CyclingGroupByHash(groupCount));
+            return new GroupedTopNRowNumberBuilder(types, comparator, ImmutableList.of(), topN, false, new int[0], new CyclingGroupByHash(groupCount));
         }
 
         public Page getPage()

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkPagesIndexOrdering.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkPagesIndexOrdering.java
@@ -40,6 +40,7 @@ import java.util.stream.IntStream;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.RowPagesBuilder.rowPagesBuilder;
 import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.spi.connector.SortOrder.ASC_NULLS_FIRST;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -115,7 +116,7 @@ public class BenchmarkPagesIndexOrdering
     {
         PagesIndex pagesIndex = new PagesIndex.TestingFactory(true).newPagesIndex(context.types, ROWS_PER_PAGE * NUMBER_OF_PAGES);
         context.pages.forEach(pagesIndex::addPage);
-        pagesIndex.sort(context.sortChannels, context.sortOrders);
+        pagesIndex.sort(context.sortChannels, context.sortOrders, newSimpleAggregatedMemoryContext().newLocalMemoryContext("benchmark"));
         return pagesIndex.getValueAddresses();
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkTopNOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkTopNOperator.java
@@ -104,6 +104,10 @@ public class BenchmarkTopNOperator
                     orderingCompiler.compilePageWithPositionComparator(
                             sortTypes,
                             sortChannels,
+                            ImmutableList.of(DESC_NULLS_LAST, ASC_NULLS_FIRST)),
+                    orderingCompiler.compilePageSortKeyPrefixFillers(
+                            sortTypes,
+                            sortChannels,
                             ImmutableList.of(DESC_NULLS_LAST, ASC_NULLS_FIRST)));
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestBatchPageSortKeyPrefixFiller.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestBatchPageSortKeyPrefixFiller.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.DictionaryBlock;
+import io.trino.spi.block.IntArrayBlock;
+import io.trino.spi.block.LongArrayBlock;
+import io.trino.spi.connector.SortOrder;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import io.trino.sql.gen.OrderingCompiler;
+import org.junit.jupiter.api.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestBatchPageSortKeyPrefixFiller
+{
+    private static final int POSITION_COUNT = 999;
+
+    private final TypeOperators typeOperators = new TypeOperators();
+    private final OrderingCompiler orderingCompiler = new OrderingCompiler(typeOperators);
+
+    @Test
+    public void testLongTypes()
+    {
+        Random random = new Random(42);
+        long[] values = new long[POSITION_COUNT];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = random.nextLong();
+        }
+        values[0] = Long.MIN_VALUE;
+        values[1] = Long.MAX_VALUE;
+        values[2] = 0;
+
+        assertBatchMatchesInterpreted(BIGINT, new LongArrayBlock(POSITION_COUNT, Optional.empty(), values));
+        assertBatchMatchesInterpreted(TIMESTAMP_MILLIS, new LongArrayBlock(POSITION_COUNT, Optional.empty(), values));
+    }
+
+    @Test
+    public void testIntTypes()
+    {
+        Random random = new Random(42);
+        int[] values = new int[POSITION_COUNT];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = random.nextInt();
+        }
+        values[0] = Integer.MIN_VALUE;
+        values[1] = Integer.MAX_VALUE;
+        values[2] = 0;
+
+        assertBatchMatchesInterpreted(INTEGER, new IntArrayBlock(POSITION_COUNT, Optional.empty(), values));
+        assertBatchMatchesInterpreted(DATE, new IntArrayBlock(POSITION_COUNT, Optional.empty(), values));
+    }
+
+    @Test
+    public void testDouble()
+    {
+        Random random = new Random(42);
+        long[] bits = new long[POSITION_COUNT];
+        for (int i = 0; i < bits.length; i++) {
+            bits[i] = Double.doubleToLongBits(random.nextDouble() * 1e9 - 5e8);
+        }
+        bits[0] = Double.doubleToLongBits(Double.NaN);
+        bits[1] = 0x7FF8_0000_0000_0001L; // non-canonical NaN
+        bits[2] = 0xFFF8_0000_0000_0000L; // NaN with sign bit set
+        bits[3] = 0xFFFF_FFFF_FFFF_FFFFL; // NaN with all bits set
+        bits[4] = Double.doubleToLongBits(Double.POSITIVE_INFINITY);
+        bits[5] = Double.doubleToLongBits(Double.NEGATIVE_INFINITY);
+        bits[6] = Double.doubleToLongBits(0.0);
+        bits[7] = Double.doubleToLongBits(-0.0);
+        bits[8] = Double.doubleToLongBits(Double.MIN_VALUE);
+        bits[9] = Double.doubleToLongBits(-Double.MIN_VALUE);
+
+        assertBatchMatchesInterpreted(DOUBLE, new LongArrayBlock(POSITION_COUNT, Optional.empty(), bits));
+    }
+
+    @Test
+    public void testReal()
+    {
+        Random random = new Random(42);
+        int[] bits = new int[POSITION_COUNT];
+        for (int i = 0; i < bits.length; i++) {
+            bits[i] = Float.floatToIntBits(random.nextFloat() * 1e9f - 5e8f);
+        }
+        bits[0] = Float.floatToIntBits(Float.NaN);
+        bits[1] = 0x7F80_0001; // non-canonical NaN
+        bits[2] = 0xFFC0_0000; // NaN with sign bit set
+        bits[3] = 0xFFFF_FFFF; // NaN with all bits set
+        bits[4] = Float.floatToIntBits(Float.POSITIVE_INFINITY);
+        bits[5] = Float.floatToIntBits(Float.NEGATIVE_INFINITY);
+        bits[6] = Float.floatToIntBits(0.0f);
+        bits[7] = Float.floatToIntBits(-0.0f);
+
+        assertBatchMatchesInterpreted(REAL, new IntArrayBlock(POSITION_COUNT, Optional.empty(), bits));
+    }
+
+    @Test
+    public void testFallbackForNullsAndDictionaries()
+    {
+        Random random = new Random(42);
+        long[] values = new long[POSITION_COUNT];
+        boolean[] nulls = new boolean[POSITION_COUNT];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = random.nextLong();
+            nulls[i] = random.nextInt(10) == 0;
+        }
+        Block blockWithNulls = new LongArrayBlock(POSITION_COUNT, Optional.of(nulls), values);
+        assertBatchMatchesInterpreted(BIGINT, blockWithNulls);
+
+        int[] ids = new int[POSITION_COUNT];
+        for (int i = 0; i < ids.length; i++) {
+            ids[i] = random.nextInt(POSITION_COUNT);
+        }
+        Block dictionary = DictionaryBlock.create(POSITION_COUNT, new LongArrayBlock(POSITION_COUNT, Optional.empty(), values), ids);
+        assertBatchMatchesInterpreted(BIGINT, dictionary);
+    }
+
+    private void assertBatchMatchesInterpreted(Type type, Block block)
+    {
+        Page page = new Page(block);
+        for (SortOrder sortOrder : SortOrder.values()) {
+            List<PageSortKeyPrefixFiller> fillers = orderingCompiler.compilePageSortKeyPrefixFillers(
+                    ImmutableList.of(type), ImmutableList.of(0), ImmutableList.of(sortOrder));
+            assertThat(fillers).hasSize(1);
+
+            MethodHandle operator = typeOperators.getSortKeyPrefixOperator(type, sortOrder, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL));
+            SortKeyPrefixFiller.SortKeyPrefixLayout layout = new SortKeyPrefixFiller.SortKeyPrefixLayout(
+                    0, sortOrder, 64, false, 0);
+            PageSortKeyPrefixFiller interpreted = new InterpretedPageSortKeyPrefixFiller(operator, layout);
+
+            long[] actual = new long[POSITION_COUNT];
+            long[] expected = new long[POSITION_COUNT];
+            fillers.getFirst().fill(page, actual);
+            interpreted.fill(page, expected);
+            assertThat(actual).as("type %s, order %s", type, sortOrder).isEqualTo(expected);
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankAccumulator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankAccumulator.java
@@ -65,7 +65,7 @@ public class TestGroupedTopNRankAccumulator
 
         for (int i = 0; i < valueCount; i++) {
             for (int groupId = 0; groupId < groupCount; groupId++) {
-                assertThat(accumulator.add(groupId, toRowReference(rowId))).isTrue();
+                assertThat(accumulator.add(groupId, toRowReference(rowId), 0)).isTrue();
                 accumulator.verifyIntegrity();
 
                 // No evictions because rank does not change for the same input
@@ -116,7 +116,7 @@ public class TestGroupedTopNRankAccumulator
         for (int rowId = 0; rowId < valueCount; rowId++) {
             for (int groupId = 0; groupId < groupCount; groupId++) {
                 // Since rowIds are in increasing order, only the first topN will be accepted
-                assertThat(accumulator.add(groupId, toRowReference(rowId))).isEqualTo(rowId < topN);
+                assertThat(accumulator.add(groupId, toRowReference(rowId), 0)).isEqualTo(rowId < topN);
                 accumulator.verifyIntegrity();
 
                 // No evictions because all results should be rejected at add()
@@ -170,7 +170,7 @@ public class TestGroupedTopNRankAccumulator
         for (long rowId = valueCount - 1; rowId >= 0; rowId--) {
             for (int groupId = 0; groupId < groupCount; groupId++) {
                 // Since rowIds are in decreasing order, new rowIds will always be accepted, potentially evicting older rows
-                assertThat(accumulator.add(groupId, toRowReference(rowId))).isTrue();
+                assertThat(accumulator.add(groupId, toRowReference(rowId), 0)).isTrue();
                 accumulator.verifyIntegrity();
 
                 if (rowId >= topN) {
@@ -215,37 +215,37 @@ public class TestGroupedTopNRankAccumulator
         accumulator.verifyIntegrity();
 
         // Add rowId 0
-        assertThat(accumulator.add(0, toRowReference(0))).isTrue();
+        assertThat(accumulator.add(0, toRowReference(0), 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(evicted).isEmpty();
 
         // Add rowId 1
-        assertThat(accumulator.add(0, toRowReference(1))).isTrue();
+        assertThat(accumulator.add(0, toRowReference(1), 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(evicted).isEmpty();
 
         // Add rowId 0 again, putting rowId 1 at effective rank of 3
-        assertThat(accumulator.add(0, toRowReference(0))).isTrue();
+        assertThat(accumulator.add(0, toRowReference(0), 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(evicted).isEmpty();
 
         // Add rowId 1 again, but rowId 1 should still have an effective rank of 3
-        assertThat(accumulator.add(0, toRowReference(1))).isTrue();
+        assertThat(accumulator.add(0, toRowReference(1), 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(evicted).isEmpty();
 
         // Add rowId 0 again, which should force both values of rowId1 to be evicted
-        assertThat(accumulator.add(0, toRowReference(0))).isTrue();
+        assertThat(accumulator.add(0, toRowReference(0), 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(evicted).isEqualTo(Arrays.asList(1L, 1L));
 
         // Add rowId -1, putting rowId 0 at rank 2
-        assertThat(accumulator.add(0, toRowReference(-1))).isTrue();
+        assertThat(accumulator.add(0, toRowReference(-1), 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(evicted).isEqualTo(Arrays.asList(1L, 1L));
 
         // Add rowId -1 again, putting rowId 0 at rank 3
-        assertThat(accumulator.add(0, toRowReference(-1))).isTrue();
+        assertThat(accumulator.add(0, toRowReference(-1), 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(evicted).isEqualTo(Arrays.asList(1L, 1L));
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankBuilder.java
@@ -59,6 +59,7 @@ public class TestGroupedTopNRankBuilder
                         throw new UnsupportedOperationException();
                     }
                 },
+                ImmutableList.of(),
                 5,
                 false,
                 new int[0],
@@ -83,6 +84,7 @@ public class TestGroupedTopNRankBuilder
                 types,
                 new SimplePageWithPositionComparator(ImmutableList.of(types.get(0)), ImmutableList.of(0), ImmutableList.of(ASC_NULLS_LAST), typeOperators),
                 new SimplePageWithPositionEqualsAndHash(ImmutableList.of(types.get(0)), ImmutableList.of(0), blockTypeOperators),
+                ImmutableList.of(),
                 3,
                 produceRanking,
                 new int[0],
@@ -149,6 +151,7 @@ public class TestGroupedTopNRankBuilder
                 types,
                 new SimplePageWithPositionComparator(ImmutableList.of(types.get(1)), ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), typeOperators),
                 new SimplePageWithPositionEqualsAndHash(ImmutableList.of(types.get(1)), ImmutableList.of(1), blockTypeOperators),
+                ImmutableList.of(),
                 3,
                 produceRanking,
                 new int[] {0},
@@ -230,6 +233,7 @@ public class TestGroupedTopNRankBuilder
                 types,
                 new SimplePageWithPositionComparator(ImmutableList.of(types.get(1)), ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), typeOperators),
                 new SimplePageWithPositionEqualsAndHash(ImmutableList.of(types.get(1)), ImmutableList.of(1), blockTypeOperators),
+                ImmutableList.of(),
                 5,
                 false,
                 new int[] {0},

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRowNumberAccumulator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRowNumberAccumulator.java
@@ -38,21 +38,21 @@ public class TestGroupedTopNRowNumberAccumulator
 
         // Add one row to fill the group
         rowReference.setRowId(0);
-        assertThat(accumulator.add(0, rowReference)).isTrue();
+        assertThat(accumulator.add(0, rowReference, 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(rowReference.isRowIdExtracted()).isTrue();
         assertThat(evicted).isEmpty();
 
         // Add a row which should be ignored because it is not in the topN and group is full
         rowReference.setRowId(1);
-        assertThat(accumulator.add(0, rowReference)).isFalse();
+        assertThat(accumulator.add(0, rowReference, 0)).isFalse();
         accumulator.verifyIntegrity();
         assertThat(rowReference.isRowIdExtracted()).isFalse();
         assertThat(evicted).isEmpty();
 
         // Add a row which should replace the existing buffered row
         rowReference.setRowId(-1);
-        assertThat(accumulator.add(0, rowReference)).isTrue();
+        assertThat(accumulator.add(0, rowReference, 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(rowReference.isRowIdExtracted()).isTrue();
         assertThat(evicted).isEqualTo(Arrays.asList(0L));
@@ -75,35 +75,35 @@ public class TestGroupedTopNRowNumberAccumulator
 
         // Add one row to the group
         rowReference.setRowId(0);
-        assertThat(accumulator.add(0, rowReference)).isTrue();
+        assertThat(accumulator.add(0, rowReference, 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(rowReference.isRowIdExtracted()).isTrue();
         assertThat(evicted).isEmpty();
 
         // Add another row to fill the group
         rowReference.setRowId(1);
-        assertThat(accumulator.add(0, rowReference)).isTrue();
+        assertThat(accumulator.add(0, rowReference, 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(rowReference.isRowIdExtracted()).isTrue();
         assertThat(evicted).isEmpty();
 
         // Add a row which should be ignored because it is not in the topN and group is full
         rowReference.setRowId(2);
-        assertThat(accumulator.add(0, rowReference)).isFalse();
+        assertThat(accumulator.add(0, rowReference, 0)).isFalse();
         accumulator.verifyIntegrity();
         assertThat(rowReference.isRowIdExtracted()).isFalse();
         assertThat(evicted).isEmpty();
 
         // Add a row which should replace the leaf of the heap
         rowReference.setRowId(-2);
-        assertThat(accumulator.add(0, rowReference)).isTrue();
+        assertThat(accumulator.add(0, rowReference, 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(rowReference.isRowIdExtracted()).isTrue();
         assertThat(evicted).isEqualTo(Arrays.asList(1L));
 
         // Add a row which should replace the root of the heap
         rowReference.setRowId(-1);
-        assertThat(accumulator.add(0, rowReference)).isTrue();
+        assertThat(accumulator.add(0, rowReference, 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(rowReference.isRowIdExtracted()).isTrue();
         assertThat(evicted).isEqualTo(Arrays.asList(1L, 0L));
@@ -126,7 +126,7 @@ public class TestGroupedTopNRowNumberAccumulator
         // Add 1 row to partially fill the top N of 2 before draining
         TestingRowReference rowReference = new TestingRowReference();
         rowReference.setRowId(0);
-        assertThat(accumulator.add(0, rowReference)).isTrue();
+        assertThat(accumulator.add(0, rowReference, 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(rowReference.isRowIdExtracted()).isTrue();
         assertThat(evicted).isEmpty();
@@ -148,10 +148,10 @@ public class TestGroupedTopNRowNumberAccumulator
         // Add 2 rows to partially fill the top N of 4 before draining
         TestingRowReference rowReference = new TestingRowReference();
         rowReference.setRowId(0);
-        assertThat(accumulator.add(0, rowReference)).isTrue();
+        assertThat(accumulator.add(0, rowReference, 0)).isTrue();
         accumulator.verifyIntegrity();
         rowReference.setRowId(1);
-        assertThat(accumulator.add(0, rowReference)).isTrue();
+        assertThat(accumulator.add(0, rowReference, 0)).isTrue();
         accumulator.verifyIntegrity();
         assertThat(rowReference.isRowIdExtracted()).isTrue();
         assertThat(evicted).isEmpty();
@@ -179,7 +179,7 @@ public class TestGroupedTopNRowNumberAccumulator
         for (int i = bulkInsertionCount; i < bulkInsertionCount * 2; i++) {
             rowReference.setRowId(i);
             int groupId = i % groupCount;
-            assertThat(accumulator.add(groupId, rowReference)).isTrue();
+            assertThat(accumulator.add(groupId, rowReference, 0)).isTrue();
             accumulator.verifyIntegrity();
             assertThat(rowReference.isRowIdExtracted()).isTrue();
             assertThat(evicted).isEmpty();
@@ -190,7 +190,7 @@ public class TestGroupedTopNRowNumberAccumulator
         for (int i = bulkInsertionCount * 2; i < bulkInsertionCount * 3; i++) {
             rowReference.setRowId(i);
             int groupId = i % groupCount;
-            assertThat(accumulator.add(groupId, rowReference)).isFalse();
+            assertThat(accumulator.add(groupId, rowReference, 0)).isFalse();
             accumulator.verifyIntegrity();
             assertThat(rowReference.isRowIdExtracted()).isFalse();
             assertThat(evicted).isEmpty();
@@ -200,7 +200,7 @@ public class TestGroupedTopNRowNumberAccumulator
         for (int i = bulkInsertionCount - 1; i >= 0; i--) {
             rowReference.setRowId(i);
             int groupId = i % groupCount;
-            assertThat(accumulator.add(groupId, rowReference)).isTrue();
+            assertThat(accumulator.add(groupId, rowReference, 0)).isTrue();
             accumulator.verifyIntegrity();
             assertThat(rowReference.isRowIdExtracted()).isTrue();
         }
@@ -230,7 +230,7 @@ public class TestGroupedTopNRowNumberAccumulator
         TestingRowReference rowReference = new TestingRowReference();
         rowReference.setRowId(0);
         // Adding groupId 1 implies that groupId 0 also exists, but has no data yet.
-        accumulator.add(1, rowReference);
+        accumulator.add(1, rowReference, 0);
         accumulator.verifyIntegrity();
 
         LongBigArray rowIdOutput = new LongBigArray();

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRowNumberBuilder.java
@@ -43,6 +43,7 @@ public class TestGroupedTopNRowNumberBuilder
                 (_, _, _, _) -> {
                     throw new UnsupportedOperationException();
                 },
+                ImmutableList.of(),
                 5,
                 false,
                 new int[0],
@@ -85,6 +86,7 @@ public class TestGroupedTopNRowNumberBuilder
         GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNRowNumberBuilder(
                 types,
                 new SimplePageWithPositionComparator(ImmutableList.of(types.get(1)), ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), TYPE_OPERATORS_CACHE),
+                ImmutableList.of(),
                 2,
                 produceRowNumbers,
                 new int[] {0},
@@ -156,6 +158,7 @@ public class TestGroupedTopNRowNumberBuilder
         GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNRowNumberBuilder(
                 types,
                 new SimplePageWithPositionComparator(ImmutableList.of(types.get(1)), ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), TYPE_OPERATORS_CACHE),
+                ImmutableList.of(),
                 5,
                 produceRowNumbers,
                 new int[0],
@@ -208,6 +211,7 @@ public class TestGroupedTopNRowNumberBuilder
         GroupedTopNBuilder groupedTopNBuilder = new GroupedTopNRowNumberBuilder(
                 types,
                 new SimplePageWithPositionComparator(ImmutableList.of(types.get(1)), ImmutableList.of(1), ImmutableList.of(ASC_NULLS_LAST), TYPE_OPERATORS_CACHE),
+                ImmutableList.of(),
                 5,
                 false,
                 new int[] {0},

--- a/core/trino-main/src/test/java/io/trino/operator/TestPagesIndexOrdering.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestPagesIndexOrdering.java
@@ -1,0 +1,561 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.connector.SortOrder;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Supplier;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_DAY;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
+import static io.trino.spi.type.UuidType.UUID;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.type.IpAddressType.IPADDRESS;
+import static java.lang.Float.floatToRawIntBits;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestPagesIndexOrdering
+{
+    private static final TypeOperators TYPE_OPERATORS = new TypeOperators();
+    private static final int POSITION_COUNT = 4000;
+
+    @Test
+    public void testBigint()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(BIGINT, values(
+                random,
+                ImmutableList.of(Long.MIN_VALUE, Long.MIN_VALUE + 1, -1L, 0L, 1L, Long.MAX_VALUE - 1, Long.MAX_VALUE, 1L << 32, -(1L << 32), 42L, 43L),
+                () -> randomWithTies(random, random::nextLong)));
+    }
+
+    @Test
+    public void testInteger()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(INTEGER, values(
+                random,
+                ImmutableList.of((long) Integer.MIN_VALUE, (long) Integer.MIN_VALUE + 1, -1L, 0L, 1L, (long) Integer.MAX_VALUE),
+                () -> randomWithTies(random, () -> (long) random.nextInt())));
+    }
+
+    @Test
+    public void testSmallint()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(SMALLINT, values(
+                random,
+                ImmutableList.of((long) Short.MIN_VALUE, -1L, 0L, 1L, (long) Short.MAX_VALUE),
+                () -> (long) (short) random.nextInt()));
+    }
+
+    @Test
+    public void testTinyint()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(TINYINT, values(
+                random,
+                ImmutableList.of((long) Byte.MIN_VALUE, -1L, 0L, 1L, (long) Byte.MAX_VALUE),
+                () -> (long) (byte) random.nextInt()));
+    }
+
+    @Test
+    public void testDate()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(DATE, values(
+                random,
+                ImmutableList.of((long) Integer.MIN_VALUE, -1L, 0L, 1L, (long) Integer.MAX_VALUE),
+                () -> randomWithTies(random, () -> (long) random.nextInt())));
+    }
+
+    @Test
+    public void testTime()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(TIME_MICROS, values(
+                random,
+                ImmutableList.of(0L, 1L, PICOSECONDS_PER_DAY - 1),
+                () -> random.nextLong(PICOSECONDS_PER_DAY)));
+    }
+
+    @Test
+    public void testTimestamp()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(TIMESTAMP_MICROS, values(
+                random,
+                ImmutableList.of(Long.MIN_VALUE, -1L, 0L, 1L, Long.MAX_VALUE),
+                () -> randomWithTies(random, random::nextLong)));
+    }
+
+    @Test
+    public void testDouble()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(DOUBLE, values(
+                random,
+                ImmutableList.of(
+                        Double.NaN,
+                        Double.longBitsToDouble(0xFFF8_0000_0000_0001L),
+                        Double.NEGATIVE_INFINITY,
+                        Double.POSITIVE_INFINITY,
+                        -0.0,
+                        0.0,
+                        Double.MIN_VALUE,
+                        -Double.MIN_VALUE,
+                        Double.MAX_VALUE,
+                        -Double.MAX_VALUE,
+                        1.0,
+                        Math.nextUp(1.0),
+                        -1.0,
+                        Math.nextUp(-1.0)),
+                () -> randomWithTies(random, () -> (double) random.nextInt(10), random::nextDouble)));
+    }
+
+    @Test
+    public void testReal()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(REAL, values(
+                random,
+                ImmutableList.of(
+                        realValue(Float.NaN),
+                        // non-canonical NaN bit pattern, as it could appear in stored data
+                        (long) 0xFFC0_0001,
+                        realValue(Float.NEGATIVE_INFINITY),
+                        realValue(Float.POSITIVE_INFINITY),
+                        realValue(-0.0f),
+                        realValue(0.0f),
+                        realValue(Float.MIN_VALUE),
+                        realValue(-Float.MIN_VALUE),
+                        realValue(1.0f),
+                        realValue(Math.nextUp(1.0f)),
+                        realValue(-1.0f)),
+                () -> randomWithTies(random, () -> realValue(random.nextInt(10)), () -> realValue(random.nextFloat() * 1000 - 500))));
+    }
+
+    @Test
+    public void testVarchar()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(VARCHAR, values(
+                random,
+                ImmutableList.of(
+                        Slices.utf8Slice(""),
+                        Slices.utf8Slice("a"),
+                        Slices.utf8Slice("ab"),
+                        Slices.utf8Slice("abc\0"),
+                        Slices.utf8Slice("abc\0a"),
+                        Slices.utf8Slice("abc"),
+                        Slices.utf8Slice("abcdefgh"),
+                        Slices.utf8Slice("abcdefgha"),
+                        Slices.utf8Slice("abcdefghb"),
+                        Slices.utf8Slice("https://example.com/category/aaaa"),
+                        Slices.utf8Slice("https://example.com/category/bbbb"),
+                        Slices.utf8Slice("zażółć gęślą jaźń")),
+                () -> Slices.utf8Slice(randomString(random))));
+    }
+
+    @Test
+    public void testVarbinary()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(VARBINARY, values(
+                random,
+                ImmutableList.of(
+                        Slices.wrappedBuffer(),
+                        Slices.wrappedBuffer((byte) 0x00),
+                        Slices.wrappedBuffer((byte) 0x00, (byte) 0x00),
+                        Slices.wrappedBuffer((byte) 0x7F),
+                        Slices.wrappedBuffer((byte) 0x80),
+                        Slices.wrappedBuffer((byte) 0xFF),
+                        Slices.wrappedBuffer((byte) 0xFF, (byte) 0x00)),
+                () -> {
+                    byte[] bytes = new byte[random.nextInt(12)];
+                    random.nextBytes(bytes);
+                    return Slices.wrappedBuffer(bytes);
+                }));
+    }
+
+    @Test
+    public void testMultipleSortChannels()
+    {
+        // tie-heavy leading channel forces the tie breaker onto the secondary channel
+        Random random = new Random(42);
+        List<Object> leading = values(random, ImmutableList.of(0L, 1L, 2L), () -> (long) random.nextInt(5));
+        List<Object> secondary = values(random, ImmutableList.of(Long.MIN_VALUE, Long.MAX_VALUE), random::nextLong);
+
+        for (SortOrder leadingOrder : SortOrder.values()) {
+            for (SortOrder secondaryOrder : ImmutableList.of(SortOrder.ASC_NULLS_FIRST, SortOrder.DESC_NULLS_LAST)) {
+                assertSortCorrect(
+                        ImmutableList.of(BIGINT, BIGINT),
+                        ImmutableList.of(0, 1),
+                        ImmutableList.of(leadingOrder, secondaryOrder),
+                        buildPages(ImmutableList.of(BIGINT, BIGINT), ImmutableList.of(leading, secondary)));
+            }
+        }
+    }
+
+    @Test
+    public void testCompositePrefixIntegerInteger()
+    {
+        // 32 + 1 null bit each: second channel truncated by 2 bits
+        Random random = new Random(42);
+        List<Object> leading = values(random, ImmutableList.of(0L, 1L), () -> (long) random.nextInt(4));
+        List<Object> secondary = values(random, ImmutableList.of((long) Integer.MIN_VALUE, (long) Integer.MAX_VALUE, -1L, 0L), () -> (long) random.nextInt());
+
+        for (SortOrder leadingOrder : SortOrder.values()) {
+            for (SortOrder secondaryOrder : SortOrder.values()) {
+                assertSortCorrect(
+                        ImmutableList.of(INTEGER, INTEGER),
+                        ImmutableList.of(0, 1),
+                        ImmutableList.of(leadingOrder, secondaryOrder),
+                        buildPages(ImmutableList.of(INTEGER, INTEGER), ImmutableList.of(leading, secondary)));
+            }
+        }
+    }
+
+    @Test
+    public void testCompositePrefixSmallintChannelsDecideTies()
+    {
+        // 17 bits per field: three smallint channels pack exactly, so ties are decided by the prefix
+        Random random = new Random(42);
+        List<Object> first = values(random, ImmutableList.of((long) Short.MIN_VALUE, (long) Short.MAX_VALUE), () -> (long) (short) random.nextInt(8));
+        List<Object> second = values(random, ImmutableList.of(0L), () -> (long) (short) random.nextInt(8));
+        List<Object> third = values(random, ImmutableList.of(0L), () -> (long) (short) random.nextInt());
+
+        assertSortCorrect(
+                ImmutableList.of(SMALLINT, SMALLINT, SMALLINT),
+                ImmutableList.of(0, 1, 2),
+                ImmutableList.of(SortOrder.ASC_NULLS_FIRST, SortOrder.DESC_NULLS_LAST, SortOrder.ASC_NULLS_LAST),
+                buildPages(ImmutableList.of(SMALLINT, SMALLINT, SMALLINT), ImmutableList.of(first, second, third)));
+    }
+
+    @Test
+    public void testCompositePrefixBooleanBigint()
+    {
+        Random random = new Random(42);
+        List<Object> leading = values(random, ImmutableList.of(true, false), random::nextBoolean);
+        List<Object> secondary = values(random, ImmutableList.of(Long.MIN_VALUE, Long.MAX_VALUE, 0L, 1L, -1L), () -> randomWithTies(random, random::nextLong));
+
+        for (SortOrder leadingOrder : SortOrder.values()) {
+            assertSortCorrect(
+                    ImmutableList.of(BOOLEAN, BIGINT),
+                    ImmutableList.of(0, 1),
+                    ImmutableList.of(leadingOrder, SortOrder.ASC_NULLS_LAST),
+                    buildPages(ImmutableList.of(BOOLEAN, BIGINT), ImmutableList.of(leading, secondary)));
+        }
+    }
+
+    @Test
+    public void testCompositePrefixIntegerVarchar()
+    {
+        // varchar is inexact, so it must be the last packed channel
+        Random random = new Random(42);
+        List<Object> leading = values(random, ImmutableList.of(0L, 1L), () -> (long) random.nextInt(4));
+        List<Object> secondary = values(random, ImmutableList.of(Slices.utf8Slice(""), Slices.utf8Slice("a")), () -> Slices.utf8Slice(randomString(random)));
+
+        assertSortCorrect(
+                ImmutableList.of(INTEGER, VARCHAR),
+                ImmutableList.of(0, 1),
+                ImmutableList.of(SortOrder.ASC_NULLS_FIRST, SortOrder.DESC_NULLS_LAST),
+                buildPages(ImmutableList.of(INTEGER, VARCHAR), ImmutableList.of(leading, secondary)));
+    }
+
+    @Test
+    public void testVarcharWithCommonPrefixAndTieBreaker()
+    {
+        // all keys share the first 8 bytes, so every quicksort comparison falls back to the comparator
+        Random random = new Random(42);
+        List<Object> leading = values(random, ImmutableList.of(), () -> Slices.utf8Slice("https://www.example.com/" + randomString(random)));
+        List<Object> secondary = values(random, ImmutableList.of(), random::nextLong);
+
+        assertSortCorrect(
+                ImmutableList.of(VARCHAR, BIGINT),
+                ImmutableList.of(0, 1),
+                ImmutableList.of(SortOrder.ASC_NULLS_FIRST, SortOrder.DESC_NULLS_LAST),
+                buildPages(ImmutableList.of(VARCHAR, BIGINT), ImmutableList.of(leading, secondary)));
+    }
+
+    @Test
+    public void testRangeBelowSortKeyPrefixThreshold()
+    {
+        Random random = new Random(42);
+        List<Object> values = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            values.add(randomWithTies(random, random::nextLong));
+        }
+        values.add(null);
+        for (SortOrder sortOrder : SortOrder.values()) {
+            assertSortCorrect(
+                    ImmutableList.of(BIGINT),
+                    ImmutableList.of(0),
+                    ImmutableList.of(sortOrder),
+                    buildPages(ImmutableList.of(BIGINT), ImmutableList.of(values)));
+        }
+    }
+
+    @Test
+    public void testBoolean()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(BOOLEAN, values(random, ImmutableList.of(true, false), random::nextBoolean));
+    }
+
+    @Test
+    public void testChar()
+    {
+        // char comparison pads the shorter value with spaces, and so must the sort key prefix
+        Random random = new Random(42);
+        assertSortsCorrectly(createCharType(12), values(
+                random,
+                ImmutableList.of(
+                        Slices.utf8Slice(""),
+                        Slices.utf8Slice("a"),
+                        Slices.utf8Slice("ab"),
+                        Slices.utf8Slice("ab\u0001"),
+                        Slices.utf8Slice("ab!"),
+                        Slices.utf8Slice("abz"),
+                        Slices.utf8Slice("abcdefghijkl")),
+                () -> Slices.utf8Slice(randomString(random).stripTrailing())));
+    }
+
+    @Test
+    public void testShortDecimal()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(createDecimalType(15, 2), values(
+                random,
+                ImmutableList.of(-1L, 0L, 1L, 999_999_999_999_999L, -999_999_999_999_999L),
+                () -> randomWithTies(random, random::nextLong)));
+    }
+
+    @Test
+    public void testLongDecimal()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(createDecimalType(38, 2), values(
+                random,
+                ImmutableList.of(
+                        Int128.valueOf(0, 0),
+                        Int128.valueOf(0, 1),
+                        Int128.valueOf(0, -1),
+                        Int128.valueOf(-1, -1),
+                        Int128.valueOf(1, 0),
+                        Int128.valueOf(-1, 0)),
+                () -> Int128.valueOf(random.nextLong() % 1000, random.nextLong())));
+    }
+
+    @Test
+    public void testUuid()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(UUID, values(
+                random,
+                ImmutableList.of(),
+                () -> {
+                    byte[] bytes = new byte[16];
+                    random.nextBytes(bytes);
+                    return Slices.wrappedBuffer(bytes);
+                }));
+    }
+
+    @Test
+    public void testShortTimestampWithTimeZone()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(TIMESTAMP_TZ_MILLIS, values(
+                random,
+                ImmutableList.of(
+                        packDateTimeWithZone(0, UTC_KEY),
+                        // same instant in a different zone must tie with the UTC one
+                        packDateTimeWithZone(0, getTimeZoneKey("Europe/Warsaw")),
+                        packDateTimeWithZone(-1, UTC_KEY),
+                        packDateTimeWithZone(1, UTC_KEY)),
+                () -> packDateTimeWithZone(random.nextLong() % 1_000_000_000_000L, UTC_KEY)));
+    }
+
+    @Test
+    public void testLongTimestamp()
+    {
+        Random random = new Random(42);
+        assertSortsCorrectly(TIMESTAMP_NANOS, values(
+                random,
+                ImmutableList.of(
+                        new LongTimestamp(0, 0),
+                        new LongTimestamp(0, 999_000),
+                        new LongTimestamp(-1, 999_000),
+                        new LongTimestamp(1, 0)),
+                () -> new LongTimestamp(random.nextLong() % 1_000_000_000_000L, random.nextInt(1_000) * 1_000)));
+    }
+
+    @Test
+    public void testUnsupportedTypeUsesComparatorPath()
+    {
+        Random random = new Random(42);
+        List<Object> values = values(random, ImmutableList.of(), () -> {
+            byte[] bytes = new byte[16];
+            random.nextBytes(bytes);
+            return Slices.wrappedBuffer(bytes);
+        });
+        for (SortOrder sortOrder : SortOrder.values()) {
+            assertSortCorrect(
+                    ImmutableList.of(IPADDRESS),
+                    ImmutableList.of(0),
+                    ImmutableList.of(sortOrder),
+                    buildPages(ImmutableList.of(IPADDRESS), ImmutableList.of(values)));
+        }
+    }
+
+    private static void assertSortsCorrectly(Type type, List<Object> values)
+    {
+        for (SortOrder sortOrder : SortOrder.values()) {
+            assertSortCorrect(
+                    ImmutableList.of(type),
+                    ImmutableList.of(0),
+                    ImmutableList.of(sortOrder),
+                    buildPages(ImmutableList.of(type), ImmutableList.of(values)));
+        }
+    }
+
+    private static void assertSortCorrect(List<Type> types, List<Integer> sortChannels, List<SortOrder> sortOrders, List<Page> pages)
+    {
+        PagesIndex pagesIndex = new PagesIndex.TestingFactory(false).newPagesIndex(types, POSITION_COUNT);
+        pages.forEach(pagesIndex::addPage);
+
+        long[] addressesBefore = pagesIndex.getValueAddresses().toLongArray();
+        Arrays.sort(addressesBefore);
+
+        pagesIndex.sort(sortChannels, sortOrders, newSimpleAggregatedMemoryContext().newLocalMemoryContext("test"));
+
+        long[] addressesAfter = pagesIndex.getValueAddresses().toLongArray();
+        Arrays.sort(addressesAfter);
+        assertThat(addressesAfter)
+                .as("sort must permute the positions, not add or drop any")
+                .isEqualTo(addressesBefore);
+
+        List<Type> sortTypes = sortChannels.stream()
+                .map(types::get)
+                .collect(toImmutableList());
+        PagesIndexComparator comparator = new SimplePagesIndexComparator(sortTypes, sortChannels, sortOrders, TYPE_OPERATORS);
+        for (int position = 1; position < pagesIndex.getPositionCount(); position++) {
+            assertThat(comparator.compareTo(pagesIndex, position - 1, position))
+                    .as("positions %s and %s are out of order for %s %s", position - 1, position, sortTypes, sortOrders)
+                    .isLessThanOrEqualTo(0);
+        }
+    }
+
+    private static List<Object> values(Random random, List<Object> edgeValues, Supplier<Object> randomValue)
+    {
+        List<Object> values = new ArrayList<>();
+        // include each edge value twice to create ties
+        values.addAll(edgeValues);
+        values.addAll(edgeValues);
+        while (values.size() < POSITION_COUNT) {
+            if (random.nextInt(10) == 0) {
+                values.add(null);
+            }
+            else {
+                values.add(randomValue.get());
+            }
+        }
+        Collections.shuffle(values, random);
+        return values;
+    }
+
+    private static Object randomWithTies(Random random, Supplier<Object> randomValue)
+    {
+        return randomWithTies(random, () -> (long) random.nextInt(10), randomValue);
+    }
+
+    private static Object randomWithTies(Random random, Supplier<Object> tieValue, Supplier<Object> randomValue)
+    {
+        // mix a small domain into the random values to exercise duplicate handling
+        if (random.nextInt(4) == 0) {
+            return tieValue.get();
+        }
+        return randomValue.get();
+    }
+
+    private static long realValue(float value)
+    {
+        return floatToRawIntBits(value);
+    }
+
+    private static String randomString(Random random)
+    {
+        int length = random.nextInt(16);
+        StringBuilder value = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            value.append((char) ('a' + random.nextInt(26)));
+        }
+        return value.toString();
+    }
+
+    private static List<Page> buildPages(List<Type> types, List<List<Object>> columns)
+    {
+        int positionCount = columns.get(0).size();
+        List<Page> pages = new ArrayList<>();
+        PageBuilder pageBuilder = new PageBuilder(types);
+        for (int position = 0; position < positionCount; position++) {
+            pageBuilder.declarePosition();
+            for (int channel = 0; channel < types.size(); channel++) {
+                writeNativeValue(types.get(channel), pageBuilder.getBlockBuilder(channel), columns.get(channel).get(position));
+            }
+            if (pageBuilder.isFull() || (position > 0 && position % 977 == 0)) {
+                pages.add(pageBuilder.build());
+                pageBuilder.reset();
+            }
+        }
+        if (!pageBuilder.isEmpty()) {
+            pages.add(pageBuilder.build());
+        }
+        return pages;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/TestTopNOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTopNOperator.java
@@ -224,6 +224,7 @@ public class TestTopNOperator
                 new PlanNodeId("test"),
                 types,
                 n,
-                orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, sortOrders));
+                orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, sortOrders),
+                orderingCompiler.compilePageSortKeyPrefixFillers(sortTypes, sortChannels, sortOrders));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/TestTopNRankingOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTopNRankingOperator.java
@@ -113,6 +113,7 @@ public class TestTopNRankingOperator
                 Optional.empty(),
                 hashStrategyCompiler,
                 orderingCompiler.compilePageWithPositionComparator(ImmutableList.of(DOUBLE), Ints.asList(1), ImmutableList.of(SortOrder.ASC_NULLS_LAST)),
+                orderingCompiler.compilePageSortKeyPrefixFillers(ImmutableList.of(DOUBLE), Ints.asList(1), ImmutableList.of(SortOrder.ASC_NULLS_LAST)),
                 blockTypeOperators);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), DOUBLE, VARCHAR, BIGINT)
@@ -166,6 +167,7 @@ public class TestTopNRankingOperator
                     partial ? Optional.of(DataSize.ofBytes(1)) : Optional.empty(),
                     hashStrategyCompiler,
                     orderingCompiler.compilePageWithPositionComparator(ImmutableList.of(DOUBLE), Ints.asList(1), ImmutableList.of(SortOrder.ASC_NULLS_LAST)),
+                    orderingCompiler.compilePageSortKeyPrefixFillers(ImmutableList.of(DOUBLE), Ints.asList(1), ImmutableList.of(SortOrder.ASC_NULLS_LAST)),
                     blockTypeOperators);
 
             MaterializedResult expected;
@@ -231,6 +233,7 @@ public class TestTopNRankingOperator
                     partial ? Optional.of(DataSize.of(1, DataSize.Unit.BYTE)) : Optional.empty(),
                     hashStrategyCompiler,
                     orderingCompiler.compilePageWithPositionComparator(ImmutableList.of(DOUBLE), Ints.asList(1), ImmutableList.of(SortOrder.ASC_NULLS_LAST)),
+                    orderingCompiler.compilePageSortKeyPrefixFillers(ImmutableList.of(DOUBLE), Ints.asList(1), ImmutableList.of(SortOrder.ASC_NULLS_LAST)),
                     blockTypeOperators);
 
             try (TopNRankingOperator operator = (TopNRankingOperator) operatorFactory.createOperator(driverContext)) {
@@ -275,6 +278,7 @@ public class TestTopNRankingOperator
                 Optional.empty(),
                 hashStrategyCompiler,
                 orderingCompiler.compilePageWithPositionComparator(ImmutableList.of(type), Ints.asList(0), ImmutableList.of(SortOrder.ASC_NULLS_LAST)),
+                orderingCompiler.compilePageSortKeyPrefixFillers(ImmutableList.of(type), Ints.asList(0), ImmutableList.of(SortOrder.ASC_NULLS_LAST)),
                 blockTypeOperators);
 
         // get result with yield; pick a relatively small buffer for heaps
@@ -334,6 +338,7 @@ public class TestTopNRankingOperator
                 Optional.empty(),
                 hashStrategyCompiler,
                 orderingCompiler.compilePageWithPositionComparator(ImmutableList.of(DOUBLE), Ints.asList(1), ImmutableList.of(ASC_NULLS_FIRST)),
+                orderingCompiler.compilePageSortKeyPrefixFillers(ImmutableList.of(DOUBLE), Ints.asList(1), ImmutableList.of(ASC_NULLS_FIRST)),
                 blockTypeOperators);
 
         MaterializedResult expected = resultBuilder(driverContext.getSession(), DOUBLE, VARCHAR, BIGINT)

--- a/core/trino-main/src/test/java/io/trino/util/BenchmarkPagesSort.java
+++ b/core/trino-main/src/test/java/io/trino/util/BenchmarkPagesSort.java
@@ -136,6 +136,7 @@ public class BenchmarkPagesSort
                         .map(WorkProcessor::fromIterable)
                         .collect(toImmutableList()),
                 ORDERING_COMPILER.compilePageWithPositionComparator(data.getSortTypes(), data.getSortChannels(), data.getSortOrders()),
+                ORDERING_COMPILER.compilePageSortKeyPrefixFillers(data.getSortTypes(), data.getSortChannels(), data.getSortOrders()),
                 data.getOutputChannels(),
                 data.getTypes(),
                 (pageBuilder, _) -> pageBuilder.isFull(),

--- a/core/trino-main/src/test/java/io/trino/util/BenchmarkPagesSort.java
+++ b/core/trino-main/src/test/java/io/trino/util/BenchmarkPagesSort.java
@@ -15,10 +15,12 @@ package io.trino.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
+import io.airlift.slice.Slices;
 import io.trino.operator.DriverYieldSignal;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.WorkProcessor;
 import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
 import io.trino.spi.block.PageBuilderStatus;
 import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
@@ -38,6 +40,7 @@ import org.openjdk.jmh.runner.RunnerException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -48,6 +51,7 @@ import static io.trino.jmh.Benchmarks.benchmark;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.spi.connector.SortOrder.ASC_NULLS_FIRST;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.util.MergeSortedPages.mergeSortedPages;
 import static java.util.Collections.nCopies;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -74,7 +78,7 @@ public class BenchmarkPagesSort
             pageIndex.addPage(page);
         }
 
-        pageIndex.sort(data.getSortChannels(), data.getSortOrders());
+        pageIndex.sort(data.getSortChannels(), data.getSortOrders(), newSimpleAggregatedMemoryContext().newLocalMemoryContext("benchmark"));
 
         return Streams.stream(pageIndex.getSortedPages()).collect(toImmutableList());
     }
@@ -106,11 +110,22 @@ public class BenchmarkPagesSort
         @Param({"200", "400"})
         private int pagesCount = 200;
 
+        @Param({"SEQUENTIAL_BIGINT", "RANDOM_BIGINT", "RANDOM_VARCHAR", "PREFIXED_VARCHAR"})
+        private DataType dataType = DataType.SEQUENTIAL_BIGINT;
+
         @Setup
         public void setup()
         {
-            super.setup(numSortChannels, totalChannels, 1, pagesCount);
+            super.setup(dataType, numSortChannels, totalChannels, 1, pagesCount);
         }
+    }
+
+    public enum DataType
+    {
+        SEQUENTIAL_BIGINT,
+        RANDOM_BIGINT,
+        RANDOM_VARCHAR,
+        PREFIXED_VARCHAR,
     }
 
     @Benchmark
@@ -190,30 +205,74 @@ public class BenchmarkPagesSort
 
         protected void setup(int numSortChannels, int totalChannels, int numMergeSources, int pagesCount)
         {
-            types = nCopies(totalChannels, BIGINT);
+            setup(DataType.SEQUENTIAL_BIGINT, numSortChannels, totalChannels, numMergeSources, pagesCount);
+        }
+
+        protected void setup(DataType dataType, int numSortChannels, int totalChannels, int numMergeSources, int pagesCount)
+        {
+            Type type = BIGINT;
+            if (dataType == DataType.RANDOM_VARCHAR || dataType == DataType.PREFIXED_VARCHAR) {
+                type = VARCHAR;
+            }
+            types = nCopies(totalChannels, type);
             sortChannels = new ArrayList<>();
             for (int i = 0; i < numSortChannels; i++) {
                 sortChannels.add(i);
             }
-            sortTypes = nCopies(numSortChannels, BIGINT);
+            sortTypes = nCopies(numSortChannels, type);
             sortOrders = nCopies(numSortChannels, ASC_NULLS_FIRST);
             outputChannels = new ArrayList<>();
             for (int i = 0; i < totalChannels; i++) {
                 outputChannels.add(i);
             }
 
-            createPages(totalChannels, pagesCount);
+            createPages(dataType, totalChannels, pagesCount);
             createPageProducers(numMergeSources);
         }
 
-        private void createPages(int totalChannels, int pagesCount)
+        private void createPages(DataType dataType, int totalChannels, int pagesCount)
         {
             int positionCount = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES / (totalChannels * 8);
+            Random random = new Random(42);
             pages = new ArrayList<>(pagesCount);
             for (int numPage = 0; numPage < pagesCount; numPage++) {
-                pages.add(createSequencePage(types, positionCount));
+                pages.add(switch (dataType) {
+                    case SEQUENTIAL_BIGINT -> createSequencePage(types, positionCount);
+                    case RANDOM_BIGINT -> createRandomBigintPage(random, positionCount);
+                    case RANDOM_VARCHAR -> createVarcharPage(random, positionCount, "");
+                    case PREFIXED_VARCHAR -> createVarcharPage(random, positionCount, "https://www.company-name.com/category/");
+                });
             }
             totalPositions = positionCount * pagesCount;
+        }
+
+        private Page createRandomBigintPage(Random random, int positionCount)
+        {
+            PageBuilder pageBuilder = new PageBuilder(positionCount, types);
+            for (int position = 0; position < positionCount; position++) {
+                pageBuilder.declarePosition();
+                for (int channel = 0; channel < types.size(); channel++) {
+                    BIGINT.writeLong(pageBuilder.getBlockBuilder(channel), random.nextLong());
+                }
+            }
+            return pageBuilder.build();
+        }
+
+        private Page createVarcharPage(Random random, int positionCount, String prefix)
+        {
+            PageBuilder pageBuilder = new PageBuilder(positionCount, types);
+            for (int position = 0; position < positionCount; position++) {
+                pageBuilder.declarePosition();
+                for (int channel = 0; channel < types.size(); channel++) {
+                    StringBuilder value = new StringBuilder(prefix);
+                    int length = 8 + random.nextInt(16);
+                    for (int i = 0; i < length; i++) {
+                        value.append((char) ('a' + random.nextInt(26)));
+                    }
+                    VARCHAR.writeSlice(pageBuilder.getBlockBuilder(channel), Slices.utf8Slice(value.toString()));
+                }
+            }
+            return pageBuilder.build();
         }
 
         private void createPageProducers(int numMergeSources)

--- a/core/trino-main/src/test/java/io/trino/util/TestMergeSortedPages.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestMergeSortedPages.java
@@ -23,6 +23,7 @@ import io.trino.spi.Page;
 import io.trino.spi.connector.SortOrder;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
+import io.trino.sql.gen.OrderingCompiler;
 import io.trino.testing.MaterializedResult;
 import org.junit.jupiter.api.Test;
 
@@ -324,6 +325,7 @@ public class TestMergeSortedPages
                         .row(1)
                         .build())),
                 new SimplePageWithPositionComparator(ImmutableList.of(types.get(0)), ImmutableList.of(0), ImmutableList.of(DESC_NULLS_LAST), TYPE_OPERATORS_CACHE),
+                ImmutableList.of(),
                 ImmutableList.of(0),
                 types,
                 (pageBuilder, _) -> pageBuilder.isFull(),
@@ -359,6 +361,7 @@ public class TestMergeSortedPages
         WorkProcessor<Page> mergedPages = MergeSortedPages.mergeSortedPages(
                 ImmutableList.of(WorkProcessor.fromIterable(rowPagesBuilder(type).build())),
                 new SimplePageWithPositionComparator(ImmutableList.of(type), ImmutableList.of(0), ImmutableList.of(DESC_NULLS_LAST), TYPE_OPERATORS_CACHE),
+                ImmutableList.of(),
                 ImmutableList.of(0),
                 ImmutableList.of(type),
                 (pageBuilder, _) -> pageBuilder.isFull(),
@@ -390,6 +393,7 @@ public class TestMergeSortedPages
         WorkProcessor<Page> mergedPages = MergeSortedPages.mergeSortedPages(
                 pageProducers,
                 comparator,
+                new OrderingCompiler(new TypeOperators()).compilePageSortKeyPrefixFillers(sortTypes, sortChannels, sortOrder),
                 types,
                 memoryContext,
                 new DriverYieldSignal());

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -331,6 +331,13 @@
                                     <code>java.method.addedToInterface</code>
                                     <new>method boolean io.trino.spi.spool.SpoolingManager::isRecoverableException(java.io.IOException)</new>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method java.util.Iterator&lt;io.trino.spi.Page&gt; io.trino.spi.PageSorter::sort(java.util.List&lt;io.trino.spi.type.Type&gt;, java.util.List&lt;io.trino.spi.Page&gt;, java.util.List&lt;java.lang.Integer&gt;, java.util.List&lt;io.trino.spi.connector.SortOrder&gt;, int)</old>
+                                    <new>method java.util.Iterator&lt;io.trino.spi.Page&gt; io.trino.spi.PageSorter::sort(java.util.List&lt;io.trino.spi.type.Type&gt;, java.util.List&lt;io.trino.spi.Page&gt;, java.util.List&lt;java.lang.Integer&gt;, java.util.List&lt;io.trino.spi.connector.SortOrder&gt;, int, java.util.function.LongConsumer)</new>
+                                    <justification>Added sort key prefix operators for faster sorting</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/PageSorter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/PageSorter.java
@@ -18,11 +18,16 @@ import io.trino.spi.type.Type;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.LongConsumer;
 
 public interface PageSorter
 {
     /**
+     * Sorts the pages, reporting the memory retained by the sorter — including transient
+     * working memory allocated while sorting — to the given consumer. The consumer receives
+     * the current total in bytes whenever it changes.
+     *
      * @return Iterator of sorted pages.
      */
-    Iterator<Page> sort(List<Type> types, List<Page> pages, List<Integer> sortChannels, List<SortOrder> sortOrders, int expectedPositions);
+    Iterator<Page> sort(List<Type> types, List<Page> pages, List<Integer> sortChannels, List<SortOrder> sortOrders, int expectedPositions, LongConsumer memoryUsage);
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/function/OperatorType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/OperatorType.java
@@ -42,6 +42,18 @@ public enum OperatorType
     XX_HASH_64("XX HASH 64", 1, true),
     INDETERMINATE("INDETERMINATE", 1, true),
     READ_VALUE("READ VALUE", 1, true),
+    /**
+     * Produces a 64-bit key whose unsigned order never contradicts {@link #COMPARISON_UNORDERED_LAST}:
+     * when two keys differ, the values compare in the same order. Equal keys decide nothing unless the
+     * type declares its sort key prefixes to be exact. Unordered values such as NaN map to a key above
+     * all normal keys.
+     */
+    SORT_KEY_PREFIX_UNORDERED_LAST("SORT KEY PREFIX UNORDERED LAST", 1, true),
+    /**
+     * Like {@link #SORT_KEY_PREFIX_UNORDERED_LAST}, but unordered values such as NaN map to a key
+     * below all normal keys, consistent with {@link #COMPARISON_UNORDERED_FIRST}.
+     */
+    SORT_KEY_PREFIX_UNORDERED_FIRST("SORT KEY PREFIX UNORDERED FIRST", 1, true),
     /**/;
 
     private final String operator;

--- a/core/trino-spi/src/main/java/io/trino/spi/function/OperatorType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/OperatorType.java
@@ -54,6 +54,16 @@ public enum OperatorType
      * below all normal keys, consistent with {@link #COMPARISON_UNORDERED_FIRST}.
      */
     SORT_KEY_PREFIX_UNORDERED_FIRST("SORT KEY PREFIX UNORDERED FIRST", 1, true),
+    /**
+     * Batch form of {@link #SORT_KEY_PREFIX_UNORDERED_LAST}: fills an array with the sort key
+     * prefixes of a run of positions of the type's value block in one call. Not available as a
+     * SQL function; only used through type operator declarations.
+     */
+    SORT_KEY_PREFIX_BATCH_UNORDERED_LAST("SORT KEY PREFIX BATCH UNORDERED LAST", 3, true),
+    /**
+     * Batch form of {@link #SORT_KEY_PREFIX_UNORDERED_FIRST}.
+     */
+    SORT_KEY_PREFIX_BATCH_UNORDERED_FIRST("SORT KEY PREFIX BATCH UNORDERED FIRST", 3, true),
     /**/;
 
     private final String operator;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractIntType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractIntType.java
@@ -40,6 +40,8 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_BATCH_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_BATCH_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
 import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
@@ -214,6 +216,27 @@ public abstract class AbstractIntType
     private static long sortKeyPrefix(long value)
     {
         return ((value ^ 0x8000_0000L) & 0xFFFF_FFFFL) << 32;
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_BATCH_UNORDERED_LAST)
+    private static void sortKeyPrefixBatchUnorderedLastOperator(IntArrayBlock block, long[] prefixes, int positionCount)
+    {
+        sortKeyPrefixBatch(block, prefixes, positionCount);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_BATCH_UNORDERED_FIRST)
+    private static void sortKeyPrefixBatchUnorderedFirstOperator(IntArrayBlock block, long[] prefixes, int positionCount)
+    {
+        sortKeyPrefixBatch(block, prefixes, positionCount);
+    }
+
+    private static void sortKeyPrefixBatch(IntArrayBlock block, long[] prefixes, int positionCount)
+    {
+        int[] values = block.getRawValues();
+        int offset = block.getRawValuesOffset();
+        for (int i = 0; i < positionCount; i++) {
+            prefixes[i] = ((long) values[offset + i] << 32) ^ Long.MIN_VALUE;
+        }
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractIntType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractIntType.java
@@ -40,6 +40,8 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
 import static java.lang.String.format;
@@ -49,7 +51,11 @@ public abstract class AbstractIntType
         extends AbstractType
         implements FixedWidthType
 {
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(AbstractIntType.class, lookup(), long.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(long.class)
+            .addOperators(extractOperatorDeclaration(AbstractIntType.class, lookup(), long.class))
+            .sortKeyPrefixExact(true)
+            .sortKeyPrefixBits(32)
+            .build();
     private static final VarHandle INT_HANDLE = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
 
     protected AbstractIntType(TypeDescriptor signature)
@@ -191,6 +197,23 @@ public abstract class AbstractIntType
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash((int) value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(long value)
+    {
+        return ((value ^ 0x8000_0000L) & 0xFFFF_FFFFL) << 32;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractLongType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractLongType.java
@@ -38,6 +38,8 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_BATCH_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_BATCH_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
 import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
@@ -189,6 +191,27 @@ public abstract class AbstractLongType
     private static long sortKeyPrefix(long value)
     {
         return value ^ Long.MIN_VALUE;
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_BATCH_UNORDERED_LAST)
+    private static void sortKeyPrefixBatchUnorderedLastOperator(LongArrayBlock block, long[] prefixes, int positionCount)
+    {
+        sortKeyPrefixBatch(block, prefixes, positionCount);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_BATCH_UNORDERED_FIRST)
+    private static void sortKeyPrefixBatchUnorderedFirstOperator(LongArrayBlock block, long[] prefixes, int positionCount)
+    {
+        sortKeyPrefixBatch(block, prefixes, positionCount);
+    }
+
+    private static void sortKeyPrefixBatch(LongArrayBlock block, long[] prefixes, int positionCount)
+    {
+        long[] values = block.getRawValues();
+        int offset = block.getRawValuesOffset();
+        for (int i = 0; i < positionCount; i++) {
+            prefixes[i] = values[offset + i] ^ Long.MIN_VALUE;
+        }
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractLongType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractLongType.java
@@ -38,6 +38,8 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
 import static java.lang.Long.rotateLeft;
@@ -47,7 +49,10 @@ public abstract class AbstractLongType
         extends AbstractType
         implements FixedWidthType
 {
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(AbstractLongType.class, lookup(), long.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(long.class)
+            .addOperators(extractOperatorDeclaration(AbstractLongType.class, lookup(), long.class))
+            .sortKeyPrefixExact(true)
+            .build();
     private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
     public AbstractLongType(TypeDescriptor signature)
@@ -167,6 +172,23 @@ public abstract class AbstractLongType
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(long value)
+    {
+        return value ^ Long.MIN_VALUE;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractVariableWidthType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractVariableWidthType.java
@@ -38,8 +38,11 @@ import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
+import static java.lang.Long.reverseBytes;
 import static java.lang.Math.min;
 import static java.lang.invoke.MethodHandles.lookup;
 
@@ -57,6 +60,7 @@ public abstract class AbstractVariableWidthType
     protected static final TypeOperatorDeclaration DEFAULT_READ_OPERATORS = extractOperatorDeclaration(DefaultReadOperators.class, lookup(), Slice.class);
     protected static final TypeOperatorDeclaration DEFAULT_COMPARABLE_OPERATORS = extractOperatorDeclaration(DefaultComparableOperators.class, lookup(), Slice.class);
     protected static final TypeOperatorDeclaration DEFAULT_ORDERING_OPERATORS = extractOperatorDeclaration(DefaultOrderingOperators.class, lookup(), Slice.class);
+    protected static final TypeOperatorDeclaration DEFAULT_SORT_KEY_PREFIX_OPERATORS = extractOperatorDeclaration(DefaultSortKeyPrefixOperators.class, lookup(), Slice.class);
 
     protected AbstractVariableWidthType(TypeDescriptor signature, Class<?> javaType)
     {
@@ -440,6 +444,34 @@ public abstract class AbstractVariableWidthType
             int rightLength = rightBlock.getSliceLength(rightPosition);
 
             return left.compareTo(0, left.length(), rightRawSlice, rightRawSliceOffset, rightLength);
+        }
+    }
+
+    private static class DefaultSortKeyPrefixOperators
+    {
+        @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+        private static long sortKeyPrefixUnorderedLastOperator(Slice value)
+        {
+            return sortKeyPrefix(value);
+        }
+
+        @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+        private static long sortKeyPrefixUnorderedFirstOperator(Slice value)
+        {
+            return sortKeyPrefix(value);
+        }
+
+        private static long sortKeyPrefix(Slice value)
+        {
+            int length = value.length();
+            if (length >= Long.BYTES) {
+                return reverseBytes(value.getLong(0));
+            }
+            long key = 0;
+            for (int i = 0; i < length; i++) {
+                key = (key << 8) | (value.getByte(i) & 0xFF);
+            }
+            return key << (8 * (Long.BYTES - length));
         }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/BooleanType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/BooleanType.java
@@ -35,6 +35,8 @@ import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
 import static java.lang.invoke.MethodHandles.lookup;
@@ -44,7 +46,11 @@ public final class BooleanType
         implements FixedWidthType
 {
     public static final String NAME = "boolean";
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(BooleanType.class, lookup(), boolean.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(boolean.class)
+            .addOperators(extractOperatorDeclaration(BooleanType.class, lookup(), boolean.class))
+            .sortKeyPrefixExact(true)
+            .sortKeyPrefixBits(1)
+            .build();
 
     private static final long TRUE_XX_HASH = XxHash64.hash(1);
     private static final long FALSE_XX_HASH = XxHash64.hash(0);
@@ -201,6 +207,23 @@ public final class BooleanType
     private static long xxHash64Operator(boolean value)
     {
         return value ? TRUE_XX_HASH : FALSE_XX_HASH;
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(boolean value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(boolean value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(boolean value)
+    {
+        return value ? Long.MIN_VALUE : 0;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/CharType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/CharType.java
@@ -27,11 +27,14 @@ import java.util.Optional;
 
 import static io.airlift.slice.SliceUtf8.countCodePoints;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.type.Chars.compareChars;
 import static io.trino.spi.type.Chars.padSpaces;
 import static io.trino.spi.type.Slices.sliceRepresentation;
 import static java.lang.Character.MAX_CODE_POINT;
 import static java.lang.Character.MIN_CODE_POINT;
+import static java.lang.Long.reverseBytes;
 import static java.lang.String.format;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.util.Collections.singletonList;
@@ -219,6 +222,35 @@ public final class CharType
     public int hashCode()
     {
         return (length * 31) + getClass().hashCode();
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(Slice value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(Slice value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(Slice value)
+    {
+        int length = value.length();
+        if (length >= Long.BYTES) {
+            return reverseBytes(value.getLong(0));
+        }
+        long key = 0;
+        for (int i = 0; i < length; i++) {
+            key = (key << 8) | (value.getByte(i) & 0xFF);
+        }
+        // char comparison semantics pad the shorter value with spaces
+        for (int i = length; i < Long.BYTES; i++) {
+            key = (key << 8) | ' ';
+        }
+        return key;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DoubleType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DoubleType.java
@@ -28,6 +28,10 @@ import io.trino.spi.function.FlatVariableOffset;
 import io.trino.spi.function.FlatVariableWidth;
 import io.trino.spi.function.IsNull;
 import io.trino.spi.function.ScalarOperator;
+import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
@@ -42,6 +46,8 @@ import static io.trino.spi.function.OperatorType.IDENTICAL;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_BATCH_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_BATCH_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
 import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
@@ -55,6 +61,7 @@ public final class DoubleType
         extends AbstractType
         implements FixedWidthType
 {
+    private static final VectorSpecies<Long> LONG_SPECIES = LongVector.SPECIES_PREFERRED;
     public static final String NAME = "double";
     private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(double.class)
             .addOperators(extractOperatorDeclaration(DoubleType.class, lookup(), double.class))
@@ -261,6 +268,47 @@ public final class DoubleType
             return ~bits;
         }
         return bits ^ Long.MIN_VALUE;
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_BATCH_UNORDERED_LAST)
+    private static void sortKeyPrefixBatchUnorderedLastOperator(LongArrayBlock block, long[] prefixes, int positionCount)
+    {
+        sortKeyPrefixBatch(block, prefixes, positionCount, -1);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_BATCH_UNORDERED_FIRST)
+    private static void sortKeyPrefixBatchUnorderedFirstOperator(LongArrayBlock block, long[] prefixes, int positionCount)
+    {
+        sortKeyPrefixBatch(block, prefixes, positionCount, 0);
+    }
+
+    /**
+     * Vectorized variant of {@link #sortKeyPrefix}: negative values map to {@code ~bits} and
+     * others to {@code bits ^ Long.MIN_VALUE}, expressed branch-free as {@code bits ^ ((bits >> 63)
+     * | Long.MIN_VALUE)}. NaNs (including non-canonical bit patterns) are blended to the flavor's
+     * key, matching the scalar operator's {@code isNaN} check.
+     */
+    private static void sortKeyPrefixBatch(LongArrayBlock block, long[] prefixes, int positionCount, long nanKey)
+    {
+        long[] values = block.getRawValues();
+        int offset = block.getRawValuesOffset();
+        int upperBound = LONG_SPECIES.loopBound(positionCount);
+        int i = 0;
+        for (; i < upperBound; i += LONG_SPECIES.length()) {
+            LongVector bits = LongVector.fromArray(LONG_SPECIES, values, offset + i);
+            LongVector transformed = bits.lanewise(VectorOperators.XOR, bits.lanewise(VectorOperators.ASHR, 63).lanewise(VectorOperators.OR, Long.MIN_VALUE));
+            VectorMask<Long> nan = bits.lanewise(VectorOperators.AND, ~Long.MIN_VALUE).compare(VectorOperators.GT, 0x7FF0_0000_0000_0000L);
+            transformed.blend(nanKey, nan).intoArray(prefixes, i);
+        }
+        for (; i < positionCount; i++) {
+            long bits = values[offset + i];
+            if ((bits & ~Long.MIN_VALUE) > 0x7FF0_0000_0000_0000L) {
+                prefixes[i] = nanKey;
+            }
+            else {
+                prefixes[i] = bits ^ ((bits >> 63) | Long.MIN_VALUE);
+            }
+        }
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DoubleType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DoubleType.java
@@ -42,9 +42,12 @@ import static io.trino.spi.function.OperatorType.IDENTICAL;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
 import static java.lang.Double.doubleToLongBits;
+import static java.lang.Double.isNaN;
 import static java.lang.Double.longBitsToDouble;
 import static java.lang.invoke.MethodHandles.lookup;
 
@@ -53,7 +56,10 @@ public final class DoubleType
         implements FixedWidthType
 {
     public static final String NAME = "double";
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(DoubleType.class, lookup(), double.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(double.class)
+            .addOperators(extractOperatorDeclaration(DoubleType.class, lookup(), double.class))
+            .sortKeyPrefixExact(true)
+            .build();
     private static final VarHandle DOUBLE_HANDLE = MethodHandles.byteArrayViewVarHandle(double[].class, ByteOrder.LITTLE_ENDIAN);
 
     public static final DoubleType DOUBLE = new DoubleType();
@@ -222,10 +228,39 @@ public final class DoubleType
             return leftNull == rightNull;
         }
 
-        if (Double.isNaN(left) && Double.isNaN(right)) {
+        if (isNaN(left) && isNaN(right)) {
             return true;
         }
         return left == right;
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(double value)
+    {
+        if (isNaN(value)) {
+            // above all normal keys; no non-NaN double encodes to this key
+            return -1;
+        }
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(double value)
+    {
+        if (isNaN(value)) {
+            // below all normal keys; no non-NaN double encodes to this key
+            return 0;
+        }
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(double value)
+    {
+        long bits = doubleToLongBits(value);
+        if (bits < 0) {
+            return ~bits;
+        }
+        return bits ^ Long.MIN_VALUE;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)
@@ -238,13 +273,13 @@ public final class DoubleType
     private static long comparisonUnorderedFirstOperator(double left, double right)
     {
         // Double compare puts NaN last, so we must handle NaNs manually
-        if (Double.isNaN(left) && Double.isNaN(right)) {
+        if (isNaN(left) && isNaN(right)) {
             return 0;
         }
-        if (Double.isNaN(left)) {
+        if (isNaN(left)) {
             return -1;
         }
-        if (Double.isNaN(right)) {
+        if (isNaN(right)) {
             return 1;
         }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongDecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongDecimalType.java
@@ -37,6 +37,8 @@ import static io.trino.spi.block.Int128ArrayBlock.INT128_BYTES;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.Decimals.overflows;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
@@ -230,6 +232,23 @@ final class LongDecimalType
     private static long xxHash64(long high, long low)
     {
         return XxHash64.hash(high) ^ XxHash64.hash(low);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(Int128 value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(Int128 value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(Int128 value)
+    {
+        return value.getHigh() ^ Long.MIN_VALUE;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampType.java
@@ -39,6 +39,8 @@ import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.rescale;
@@ -314,6 +316,23 @@ final class LongTimestampType
     private static long xxHash64(long epochMicros, int fraction)
     {
         return XxHash64.hash(epochMicros) ^ XxHash64.hash(fraction);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(LongTimestamp value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(LongTimestamp value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(LongTimestamp value)
+    {
+        return value.getEpochMicros() ^ Long.MIN_VALUE;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZoneType.java
@@ -39,6 +39,8 @@ import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
@@ -324,6 +326,23 @@ final class LongTimestampWithTimeZoneType
     private static long xxHash64(long epochMillis, int picosOfMilli)
     {
         return XxHash64.hash(epochMillis) ^ XxHash64.hash(picosOfMilli);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(LongTimestampWithTimeZone value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(LongTimestampWithTimeZone value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(LongTimestampWithTimeZone value)
+    {
+        return value.getEpochMillis() ^ Long.MIN_VALUE;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
@@ -38,10 +38,13 @@ import static io.trino.spi.function.OperatorType.IDENTICAL;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.Float.intBitsToFloat;
+import static java.lang.Float.isNaN;
 import static java.lang.String.format;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.lang.runtime.ExactConversionsSupport.isLongToIntExact;
@@ -50,7 +53,11 @@ public final class RealType
         extends AbstractIntType
 {
     public static final String NAME = "real";
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(RealType.class, lookup(), long.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(long.class)
+            .addOperators(extractOperatorDeclaration(RealType.class, lookup(), long.class))
+            .sortKeyPrefixExact(true)
+            .sortKeyPrefixBits(32)
+            .build();
     private static final VarHandle INT_HANDLE = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
 
     public static final RealType REAL = new RealType();
@@ -178,10 +185,44 @@ public final class RealType
 
         float leftFloat = intBitsToFloat((int) left);
         float rightFloat = intBitsToFloat((int) right);
-        if (Float.isNaN(leftFloat) && Float.isNaN(rightFloat)) {
+        if (isNaN(leftFloat) && isNaN(rightFloat)) {
             return true;
         }
         return leftFloat == rightFloat;
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(long value)
+    {
+        float floatValue = intBitsToFloat((int) value);
+        if (isNaN(floatValue)) {
+            // above all normal keys; no non-NaN float encodes to this key
+            return -1;
+        }
+        return sortKeyPrefix(floatValue);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(long value)
+    {
+        float floatValue = intBitsToFloat((int) value);
+        if (isNaN(floatValue)) {
+            // below all normal keys; no non-NaN float encodes to this key
+            return 0;
+        }
+        return sortKeyPrefix(floatValue);
+    }
+
+    private static long sortKeyPrefix(float value)
+    {
+        int bits = floatToIntBits(value);
+        if (bits < 0) {
+            bits = ~bits;
+        }
+        else {
+            bits ^= Integer.MIN_VALUE;
+        }
+        return (bits & 0xFFFF_FFFFL) << 32;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)
@@ -196,13 +237,13 @@ public final class RealType
         // Float compare puts NaN last, so we must handle NaNs manually
         float left = intBitsToFloat((int) leftBits);
         float right = intBitsToFloat((int) rightBits);
-        if (Float.isNaN(left) && Float.isNaN(right)) {
+        if (isNaN(left) && isNaN(right)) {
             return 0;
         }
-        if (Float.isNaN(left)) {
+        if (isNaN(left)) {
             return -1;
         }
-        if (Float.isNaN(right)) {
+        if (isNaN(right)) {
             return 1;
         }
         return compare(left, right);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
@@ -17,6 +17,7 @@ import io.airlift.slice.XxHash64;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.IntArrayBlock;
 import io.trino.spi.function.FlatFixed;
 import io.trino.spi.function.FlatFixedOffset;
 import io.trino.spi.function.FlatVariableOffset;
@@ -38,6 +39,8 @@ import static io.trino.spi.function.OperatorType.IDENTICAL;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_BATCH_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_BATCH_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
 import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
@@ -223,6 +226,35 @@ public final class RealType
             bits ^= Integer.MIN_VALUE;
         }
         return (bits & 0xFFFF_FFFFL) << 32;
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_BATCH_UNORDERED_LAST)
+    private static void sortKeyPrefixBatchUnorderedLastOperator(IntArrayBlock block, long[] prefixes, int positionCount)
+    {
+        sortKeyPrefixBatch(block, prefixes, positionCount, -1);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_BATCH_UNORDERED_FIRST)
+    private static void sortKeyPrefixBatchUnorderedFirstOperator(IntArrayBlock block, long[] prefixes, int positionCount)
+    {
+        sortKeyPrefixBatch(block, prefixes, positionCount, 0);
+    }
+
+    private static void sortKeyPrefixBatch(IntArrayBlock block, long[] prefixes, int positionCount, long nanKey)
+    {
+        int[] values = block.getRawValues();
+        int offset = block.getRawValuesOffset();
+        for (int i = 0; i < positionCount; i++) {
+            int bits = values[offset + i];
+            if ((bits & ~Integer.MIN_VALUE) > 0x7F80_0000) {
+                // NaN, including non-canonical bit patterns
+                prefixes[i] = nanKey;
+            }
+            else {
+                int transformed = bits ^ ((bits >> 31) | Integer.MIN_VALUE);
+                prefixes[i] = (transformed & 0xFFFF_FFFFL) << 32;
+            }
+        }
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortDecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortDecimalType.java
@@ -43,6 +43,8 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static io.trino.spi.type.Decimals.longTenToNth;
@@ -54,7 +56,10 @@ import static java.lang.invoke.MethodHandles.lookup;
 final class ShortDecimalType
         extends DecimalType
 {
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(ShortDecimalType.class, lookup(), long.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(long.class)
+            .addOperators(extractOperatorDeclaration(ShortDecimalType.class, lookup(), long.class))
+            .sortKeyPrefixExact(true)
+            .build();
     private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
     private static final ShortDecimalType[][] INSTANCES;
@@ -237,6 +242,23 @@ final class ShortDecimalType
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(long value)
+    {
+        return value ^ Long.MIN_VALUE;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampType.java
@@ -39,6 +39,8 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.Timestamps.rescale;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
@@ -54,7 +56,10 @@ import static java.lang.invoke.MethodHandles.lookup;
 final class ShortTimestampType
         extends TimestampType
 {
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(ShortTimestampType.class, lookup(), long.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(long.class)
+            .addOperators(extractOperatorDeclaration(ShortTimestampType.class, lookup(), long.class))
+            .sortKeyPrefixExact(true)
+            .build();
     private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
     private final Range range;
 
@@ -205,6 +210,23 @@ final class ShortTimestampType
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(long value)
+    {
+        return value ^ Long.MIN_VALUE;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampType.java
@@ -39,6 +39,8 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_BATCH_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_BATCH_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
 import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
@@ -227,6 +229,27 @@ final class ShortTimestampType
     private static long sortKeyPrefix(long value)
     {
         return value ^ Long.MIN_VALUE;
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_BATCH_UNORDERED_LAST)
+    private static void sortKeyPrefixBatchUnorderedLastOperator(LongArrayBlock block, long[] prefixes, int positionCount)
+    {
+        sortKeyPrefixBatch(block, prefixes, positionCount);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_BATCH_UNORDERED_FIRST)
+    private static void sortKeyPrefixBatchUnorderedFirstOperator(LongArrayBlock block, long[] prefixes, int positionCount)
+    {
+        sortKeyPrefixBatch(block, prefixes, positionCount);
+    }
+
+    private static void sortKeyPrefixBatch(LongArrayBlock block, long[] prefixes, int positionCount)
+    {
+        long[] values = block.getRawValues();
+        int offset = block.getRawValuesOffset();
+        for (int i = 0; i < positionCount; i++) {
+            prefixes[i] = values[offset + i] ^ Long.MIN_VALUE;
+        }
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortTimestampWithTimeZoneType.java
@@ -38,6 +38,8 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.DateTimeEncoding.unpackZoneKey;
@@ -53,7 +55,10 @@ import static java.lang.invoke.MethodHandles.lookup;
 final class ShortTimestampWithTimeZoneType
         extends TimestampWithTimeZoneType
 {
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(ShortTimestampWithTimeZoneType.class, lookup(), long.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(long.class)
+            .addOperators(extractOperatorDeclaration(ShortTimestampWithTimeZoneType.class, lookup(), long.class))
+            .sortKeyPrefixExact(true)
+            .build();
     private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
     ShortTimestampWithTimeZoneType(int precision)
@@ -172,6 +177,23 @@ final class ShortTimestampWithTimeZoneType
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash(unpackMillisUtc(value));
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(long value)
+    {
+        return unpackMillisUtc(value) ^ Long.MIN_VALUE;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/SmallintType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SmallintType.java
@@ -43,6 +43,8 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
 import static java.lang.String.format;
@@ -53,7 +55,11 @@ public final class SmallintType
         implements FixedWidthType
 {
     public static final String NAME = "smallint";
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(SmallintType.class, lookup(), long.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(long.class)
+            .addOperators(extractOperatorDeclaration(SmallintType.class, lookup(), long.class))
+            .sortKeyPrefixExact(true)
+            .sortKeyPrefixBits(16)
+            .build();
     private static final VarHandle SHORT_HANDLE = MethodHandles.byteArrayViewVarHandle(short[].class, ByteOrder.LITTLE_ENDIAN);
 
     public static final SmallintType SMALLINT = new SmallintType();
@@ -258,6 +264,23 @@ public final class SmallintType
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash((short) value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(long value)
+    {
+        return ((value ^ 0x8000) & 0xFFFF) << 48;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimeType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimeType.java
@@ -34,6 +34,8 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_DAY;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_SECOND;
@@ -49,7 +51,11 @@ public final class TimeType
         extends AbstractLongType
 {
     public static final String NAME = "time";
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(TimeType.class, lookup(), long.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(long.class)
+            .addOperators(extractOperatorDeclaration(TimeType.class, lookup(), long.class))
+            .sortKeyPrefixExact(true)
+            .sortKeyPrefixBits(57)
+            .build();
     private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
     public static final int MAX_PRECISION = 12;
@@ -175,6 +181,24 @@ public final class TimeType
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(long value)
+    {
+        // picoseconds of day fit in 57 bits
+        return value << 7;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TinyintType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TinyintType.java
@@ -40,6 +40,8 @@ import static io.trino.spi.function.OperatorType.HASH_CODE;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
 import static java.lang.String.format;
@@ -50,7 +52,11 @@ public final class TinyintType
         implements FixedWidthType
 {
     public static final String NAME = "tinyint";
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(TinyintType.class, lookup(), long.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(long.class)
+            .addOperators(extractOperatorDeclaration(TinyintType.class, lookup(), long.class))
+            .sortKeyPrefixExact(true)
+            .sortKeyPrefixBits(8)
+            .build();
 
     public static final TinyintType TINYINT = new TinyintType();
 
@@ -253,6 +259,23 @@ public final class TinyintType
     private static long xxHash64Operator(long value)
     {
         return XxHash64.hash((byte) value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(long value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(long value)
+    {
+        return ((value ^ 0x80) & 0xFF) << 56;
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
@@ -74,6 +74,10 @@ public final class TypeOperatorDeclaration
     private final Collection<OperatorMethodHandle> comparisonUnorderedFirstOperators;
     private final Collection<OperatorMethodHandle> lessThanOperators;
     private final Collection<OperatorMethodHandle> lessThanOrEqualOperators;
+    private final Collection<OperatorMethodHandle> sortKeyPrefixUnorderedLastOperators;
+    private final Collection<OperatorMethodHandle> sortKeyPrefixUnorderedFirstOperators;
+    private final boolean sortKeyPrefixExact;
+    private final int sortKeyPrefixBits;
 
     private TypeOperatorDeclaration(
             Collection<OperatorMethodHandle> readValueOperators,
@@ -85,7 +89,11 @@ public final class TypeOperatorDeclaration
             Collection<OperatorMethodHandle> comparisonUnorderedLastOperators,
             Collection<OperatorMethodHandle> comparisonUnorderedFirstOperators,
             Collection<OperatorMethodHandle> lessThanOperators,
-            Collection<OperatorMethodHandle> lessThanOrEqualOperators)
+            Collection<OperatorMethodHandle> lessThanOrEqualOperators,
+            Collection<OperatorMethodHandle> sortKeyPrefixUnorderedLastOperators,
+            Collection<OperatorMethodHandle> sortKeyPrefixUnorderedFirstOperators,
+            boolean sortKeyPrefixExact,
+            int sortKeyPrefixBits)
     {
         this.readValueOperators = List.copyOf(requireNonNull(readValueOperators, "readValueOperators is null"));
         this.equalOperators = List.copyOf(requireNonNull(equalOperators, "equalOperators is null"));
@@ -97,6 +105,10 @@ public final class TypeOperatorDeclaration
         this.comparisonUnorderedFirstOperators = List.copyOf(requireNonNull(comparisonUnorderedFirstOperators, "comparisonUnorderedFirstOperators is null"));
         this.lessThanOperators = List.copyOf(requireNonNull(lessThanOperators, "lessThanOperators is null"));
         this.lessThanOrEqualOperators = List.copyOf(requireNonNull(lessThanOrEqualOperators, "lessThanOrEqualOperators is null"));
+        this.sortKeyPrefixUnorderedLastOperators = List.copyOf(requireNonNull(sortKeyPrefixUnorderedLastOperators, "sortKeyPrefixUnorderedLastOperators is null"));
+        this.sortKeyPrefixUnorderedFirstOperators = List.copyOf(requireNonNull(sortKeyPrefixUnorderedFirstOperators, "sortKeyPrefixUnorderedFirstOperators is null"));
+        this.sortKeyPrefixExact = sortKeyPrefixExact;
+        this.sortKeyPrefixBits = sortKeyPrefixBits;
     }
 
     public boolean isComparable()
@@ -159,6 +171,36 @@ public final class TypeOperatorDeclaration
         return lessThanOrEqualOperators;
     }
 
+    public Collection<OperatorMethodHandle> getSortKeyPrefixUnorderedLastOperators()
+    {
+        return sortKeyPrefixUnorderedLastOperators;
+    }
+
+    public Collection<OperatorMethodHandle> getSortKeyPrefixUnorderedFirstOperators()
+    {
+        return sortKeyPrefixUnorderedFirstOperators;
+    }
+
+    /**
+     * Whether equal sort key prefixes imply that the values are equal under the corresponding
+     * comparison operator. When false, the sort key prefix is only a prefix and equal keys must be
+     * resolved with a full comparison.
+     */
+    public boolean isSortKeyPrefixExact()
+    {
+        return sortKeyPrefixExact;
+    }
+
+    /**
+     * Number of high bits of the sort key prefix that carry information; the remaining low bits
+     * are always zero. Narrow types declare fewer bits so that multiple sort channels can be
+     * packed into a single 64-bit prefix.
+     */
+    public int getSortKeyPrefixBits()
+    {
+        return sortKeyPrefixBits;
+    }
+
     public static Builder builder(Class<?> typeJavaType)
     {
         return new Builder(typeJavaType);
@@ -185,6 +227,10 @@ public final class TypeOperatorDeclaration
         private final Collection<OperatorMethodHandle> comparisonUnorderedFirstOperators = new ArrayList<>();
         private final Collection<OperatorMethodHandle> lessThanOperators = new ArrayList<>();
         private final Collection<OperatorMethodHandle> lessThanOrEqualOperators = new ArrayList<>();
+        private final Collection<OperatorMethodHandle> sortKeyPrefixUnorderedLastOperators = new ArrayList<>();
+        private final Collection<OperatorMethodHandle> sortKeyPrefixUnorderedFirstOperators = new ArrayList<>();
+        private boolean sortKeyPrefixExact;
+        private int sortKeyPrefixBits = 64;
 
         private Builder(Class<?> typeJavaType)
         {
@@ -204,6 +250,10 @@ public final class TypeOperatorDeclaration
             operatorDeclaration.getComparisonUnorderedFirstOperators().forEach(this::addComparisonUnorderedFirstOperator);
             operatorDeclaration.getLessThanOperators().forEach(this::addLessThanOperator);
             operatorDeclaration.getLessThanOrEqualOperators().forEach(this::addLessThanOrEqualOperator);
+            operatorDeclaration.getSortKeyPrefixUnorderedLastOperators().forEach(this::addSortKeyPrefixUnorderedLastOperator);
+            operatorDeclaration.getSortKeyPrefixUnorderedFirstOperators().forEach(this::addSortKeyPrefixUnorderedFirstOperator);
+            sortKeyPrefixExact |= operatorDeclaration.isSortKeyPrefixExact();
+            sortKeyPrefixBits = Math.min(sortKeyPrefixBits, operatorDeclaration.getSortKeyPrefixBits());
             return this;
         }
 
@@ -367,6 +417,33 @@ public final class TypeOperatorDeclaration
             return this;
         }
 
+        public Builder addSortKeyPrefixUnorderedLastOperator(OperatorMethodHandle sortKeyPrefixOperator)
+        {
+            verifyMethodHandleSignature(1, long.class, sortKeyPrefixOperator);
+            this.sortKeyPrefixUnorderedLastOperators.add(sortKeyPrefixOperator);
+            return this;
+        }
+
+        public Builder addSortKeyPrefixUnorderedFirstOperator(OperatorMethodHandle sortKeyPrefixOperator)
+        {
+            verifyMethodHandleSignature(1, long.class, sortKeyPrefixOperator);
+            this.sortKeyPrefixUnorderedFirstOperators.add(sortKeyPrefixOperator);
+            return this;
+        }
+
+        public Builder sortKeyPrefixExact(boolean sortKeyPrefixExact)
+        {
+            this.sortKeyPrefixExact = sortKeyPrefixExact;
+            return this;
+        }
+
+        public Builder sortKeyPrefixBits(int sortKeyPrefixBits)
+        {
+            checkArgument(sortKeyPrefixBits >= 1 && sortKeyPrefixBits <= 64, "sortKeyPrefixBits must be between 1 and 64, but is %s", sortKeyPrefixBits);
+            this.sortKeyPrefixBits = sortKeyPrefixBits;
+            return this;
+        }
+
         public Builder addOperators(Class<?> operatorsClass, Lookup lookup)
         {
             boolean addedOperator = false;
@@ -375,58 +452,69 @@ public final class TypeOperatorDeclaration
                 if (scalarOperator == null) {
                     continue;
                 }
-                OperatorType operatorType = scalarOperator.value();
-                if (operatorType.neverFails() && scalarOperator.neverFails()) {
-                    throw new IllegalArgumentException("@ScalarOperator(neverFails = true) is redundant for %s operator which is always infallible: %s".formatted(operatorType, method));
-                }
-
-                MethodHandle methodHandle;
-                try {
-                    methodHandle = lookup.unreflect(method);
-                }
-                catch (IllegalAccessException e) {
-                    throw new RuntimeException(e);
-                }
-
-                switch (operatorType) {
-                    case READ_VALUE -> addReadValueOperator(new OperatorMethodHandle(
-                            parseInvocationConvention(operatorType, typeJavaType, method, typeJavaType),
-                            methodHandle));
-                    case EQUAL -> addEqualOperator(new OperatorMethodHandle(
-                            parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle));
-                    case HASH_CODE -> addHashCodeOperator(new OperatorMethodHandle(
-                            parseInvocationConvention(operatorType, typeJavaType, method, long.class),
-                            methodHandle));
-                    case XX_HASH_64 -> addXxHash64Operator(new OperatorMethodHandle(
-                            parseInvocationConvention(operatorType, typeJavaType, method, long.class),
-                            methodHandle));
-                    case IDENTICAL -> addIdenticalOperator(new OperatorMethodHandle(
-                            parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle));
-                    case INDETERMINATE -> addIndeterminateOperator(new OperatorMethodHandle(
-                            parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle));
-                    case COMPARISON_UNORDERED_LAST -> addComparisonUnorderedLastOperator(new OperatorMethodHandle(
-                            parseInvocationConvention(operatorType, typeJavaType, method, long.class),
-                            methodHandle));
-                    case COMPARISON_UNORDERED_FIRST -> addComparisonUnorderedFirstOperator(new OperatorMethodHandle(
-                            parseInvocationConvention(operatorType, typeJavaType, method, long.class),
-                            methodHandle));
-                    case LESS_THAN -> addLessThanOperator(new OperatorMethodHandle(
-                            parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle));
-                    case LESS_THAN_OR_EQUAL -> addLessThanOrEqualOperator(new OperatorMethodHandle(
-                            parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
-                            methodHandle));
-                    default -> throw new IllegalArgumentException(operatorType + " operator is not supported: " + method);
-                }
+                addOperator(method, scalarOperator, lookup);
                 addedOperator = true;
             }
             if (!addedOperator) {
                 throw new IllegalArgumentException(operatorsClass + " does not contain any operators");
             }
             return this;
+        }
+
+        private void addOperator(Method method, ScalarOperator scalarOperator, Lookup lookup)
+        {
+            OperatorType operatorType = scalarOperator.value();
+            if (operatorType.neverFails() && scalarOperator.neverFails()) {
+                throw new IllegalArgumentException("@ScalarOperator(neverFails = true) is redundant for %s operator which is always infallible: %s".formatted(operatorType, method));
+            }
+
+            MethodHandle methodHandle;
+            try {
+                methodHandle = lookup.unreflect(method);
+            }
+            catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+
+            switch (operatorType) {
+                case READ_VALUE -> addReadValueOperator(new OperatorMethodHandle(
+                        parseInvocationConvention(operatorType, typeJavaType, method, typeJavaType),
+                        methodHandle));
+                case EQUAL -> addEqualOperator(new OperatorMethodHandle(
+                        parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
+                        methodHandle));
+                case HASH_CODE -> addHashCodeOperator(new OperatorMethodHandle(
+                        parseInvocationConvention(operatorType, typeJavaType, method, long.class),
+                        methodHandle));
+                case XX_HASH_64 -> addXxHash64Operator(new OperatorMethodHandle(
+                        parseInvocationConvention(operatorType, typeJavaType, method, long.class),
+                        methodHandle));
+                case IDENTICAL -> addIdenticalOperator(new OperatorMethodHandle(
+                        parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
+                        methodHandle));
+                case INDETERMINATE -> addIndeterminateOperator(new OperatorMethodHandle(
+                        parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
+                        methodHandle));
+                case COMPARISON_UNORDERED_LAST -> addComparisonUnorderedLastOperator(new OperatorMethodHandle(
+                        parseInvocationConvention(operatorType, typeJavaType, method, long.class),
+                        methodHandle));
+                case COMPARISON_UNORDERED_FIRST -> addComparisonUnorderedFirstOperator(new OperatorMethodHandle(
+                        parseInvocationConvention(operatorType, typeJavaType, method, long.class),
+                        methodHandle));
+                case LESS_THAN -> addLessThanOperator(new OperatorMethodHandle(
+                        parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
+                        methodHandle));
+                case LESS_THAN_OR_EQUAL -> addLessThanOrEqualOperator(new OperatorMethodHandle(
+                        parseInvocationConvention(operatorType, typeJavaType, method, boolean.class),
+                        methodHandle));
+                case SORT_KEY_PREFIX_UNORDERED_LAST -> addSortKeyPrefixUnorderedLastOperator(new OperatorMethodHandle(
+                        parseInvocationConvention(operatorType, typeJavaType, method, long.class),
+                        methodHandle));
+                case SORT_KEY_PREFIX_UNORDERED_FIRST -> addSortKeyPrefixUnorderedFirstOperator(new OperatorMethodHandle(
+                        parseInvocationConvention(operatorType, typeJavaType, method, long.class),
+                        methodHandle));
+                default -> throw new IllegalArgumentException(operatorType + " operator is not supported: " + method);
+            }
         }
 
         private void verifyMethodHandleSignature(int expectedArgumentCount, Class<?> returnJavaType, OperatorMethodHandle operatorMethodHandle)
@@ -672,6 +760,15 @@ public final class TypeOperatorDeclaration
                     throw new IllegalStateException("Less-than-or-equals operators can not be supplied when comparison operators are not supplied");
                 }
             }
+            if (sortKeyPrefixUnorderedLastOperators.isEmpty() != sortKeyPrefixUnorderedFirstOperators.isEmpty()) {
+                throw new IllegalStateException("Sort key prefix operators must be supplied for both unordered last and unordered first, or neither");
+            }
+            if (sortKeyPrefixExact && sortKeyPrefixUnorderedLastOperators.isEmpty() && sortKeyPrefixUnorderedFirstOperators.isEmpty()) {
+                throw new IllegalStateException("Sort key prefixes can not be declared exact when sort key prefix operators are not supplied");
+            }
+            if (sortKeyPrefixBits != 64 && sortKeyPrefixUnorderedLastOperators.isEmpty() && sortKeyPrefixUnorderedFirstOperators.isEmpty()) {
+                throw new IllegalStateException("Sort key prefix bits can not be declared when sort key prefix operators are not supplied");
+            }
 
             return new TypeOperatorDeclaration(
                     readValueOperators,
@@ -683,7 +780,11 @@ public final class TypeOperatorDeclaration
                     comparisonUnorderedLastOperators,
                     comparisonUnorderedFirstOperators,
                     lessThanOperators,
-                    lessThanOrEqualOperators);
+                    lessThanOrEqualOperators,
+                    sortKeyPrefixUnorderedLastOperators,
+                    sortKeyPrefixUnorderedFirstOperators,
+                    sortKeyPrefixExact,
+                    sortKeyPrefixBits);
         }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
@@ -78,6 +79,8 @@ public final class TypeOperatorDeclaration
     private final Collection<OperatorMethodHandle> sortKeyPrefixUnorderedFirstOperators;
     private final boolean sortKeyPrefixExact;
     private final int sortKeyPrefixBits;
+    private final MethodHandle sortKeyPrefixBatchUnorderedLast;
+    private final MethodHandle sortKeyPrefixBatchUnorderedFirst;
 
     private TypeOperatorDeclaration(
             Collection<OperatorMethodHandle> readValueOperators,
@@ -93,7 +96,9 @@ public final class TypeOperatorDeclaration
             Collection<OperatorMethodHandle> sortKeyPrefixUnorderedLastOperators,
             Collection<OperatorMethodHandle> sortKeyPrefixUnorderedFirstOperators,
             boolean sortKeyPrefixExact,
-            int sortKeyPrefixBits)
+            int sortKeyPrefixBits,
+            MethodHandle sortKeyPrefixBatchUnorderedLast,
+            MethodHandle sortKeyPrefixBatchUnorderedFirst)
     {
         this.readValueOperators = List.copyOf(requireNonNull(readValueOperators, "readValueOperators is null"));
         this.equalOperators = List.copyOf(requireNonNull(equalOperators, "equalOperators is null"));
@@ -109,6 +114,8 @@ public final class TypeOperatorDeclaration
         this.sortKeyPrefixUnorderedFirstOperators = List.copyOf(requireNonNull(sortKeyPrefixUnorderedFirstOperators, "sortKeyPrefixUnorderedFirstOperators is null"));
         this.sortKeyPrefixExact = sortKeyPrefixExact;
         this.sortKeyPrefixBits = sortKeyPrefixBits;
+        this.sortKeyPrefixBatchUnorderedLast = sortKeyPrefixBatchUnorderedLast;
+        this.sortKeyPrefixBatchUnorderedFirst = sortKeyPrefixBatchUnorderedFirst;
     }
 
     public boolean isComparable()
@@ -201,6 +208,21 @@ public final class TypeOperatorDeclaration
         return sortKeyPrefixBits;
     }
 
+    /**
+     * Batch sort key prefix operator with signature {@code (ValueBlock, long[], int)void}: fills
+     * the array with the prefixes of positions {@code [0..positionCount)} of the type's value
+     * block, which must not contain nulls in that range.
+     */
+    public Optional<MethodHandle> getSortKeyPrefixBatchUnorderedLast()
+    {
+        return Optional.ofNullable(sortKeyPrefixBatchUnorderedLast);
+    }
+
+    public Optional<MethodHandle> getSortKeyPrefixBatchUnorderedFirst()
+    {
+        return Optional.ofNullable(sortKeyPrefixBatchUnorderedFirst);
+    }
+
     public static Builder builder(Class<?> typeJavaType)
     {
         return new Builder(typeJavaType);
@@ -231,6 +253,8 @@ public final class TypeOperatorDeclaration
         private final Collection<OperatorMethodHandle> sortKeyPrefixUnorderedFirstOperators = new ArrayList<>();
         private boolean sortKeyPrefixExact;
         private int sortKeyPrefixBits = 64;
+        private MethodHandle sortKeyPrefixBatchUnorderedLast;
+        private MethodHandle sortKeyPrefixBatchUnorderedFirst;
 
         private Builder(Class<?> typeJavaType)
         {
@@ -254,6 +278,8 @@ public final class TypeOperatorDeclaration
             operatorDeclaration.getSortKeyPrefixUnorderedFirstOperators().forEach(this::addSortKeyPrefixUnorderedFirstOperator);
             sortKeyPrefixExact |= operatorDeclaration.isSortKeyPrefixExact();
             sortKeyPrefixBits = Math.min(sortKeyPrefixBits, operatorDeclaration.getSortKeyPrefixBits());
+            operatorDeclaration.getSortKeyPrefixBatchUnorderedLast().ifPresent(operator -> sortKeyPrefixBatchUnorderedLast = operator);
+            operatorDeclaration.getSortKeyPrefixBatchUnorderedFirst().ifPresent(operator -> sortKeyPrefixBatchUnorderedFirst = operator);
             return this;
         }
 
@@ -513,8 +539,24 @@ public final class TypeOperatorDeclaration
                 case SORT_KEY_PREFIX_UNORDERED_FIRST -> addSortKeyPrefixUnorderedFirstOperator(new OperatorMethodHandle(
                         parseInvocationConvention(operatorType, typeJavaType, method, long.class),
                         methodHandle));
+                case SORT_KEY_PREFIX_BATCH_UNORDERED_LAST -> sortKeyPrefixBatchUnorderedLast = adaptSortKeyPrefixBatchOperator(method, methodHandle);
+                case SORT_KEY_PREFIX_BATCH_UNORDERED_FIRST -> sortKeyPrefixBatchUnorderedFirst = adaptSortKeyPrefixBatchOperator(method, methodHandle);
                 default -> throw new IllegalArgumentException(operatorType + " operator is not supported: " + method);
             }
+        }
+
+        private static MethodHandle adaptSortKeyPrefixBatchOperator(Method method, MethodHandle methodHandle)
+        {
+            MethodType methodType = methodHandle.type();
+            if (methodType.returnType() != void.class
+                    || methodType.parameterCount() != 3
+                    || !ValueBlock.class.isAssignableFrom(methodType.parameterType(0))
+                    || methodType.parameterType(1) != long[].class
+                    || methodType.parameterType(2) != int.class) {
+                throw new IllegalArgumentException("Sort key prefix batch operator must have signature (ValueBlock, long[], int)void: " + method);
+            }
+            // the cast of the block argument throws when the block is not the type's value block
+            return methodHandle.asType(methodType(void.class, ValueBlock.class, long[].class, int.class));
         }
 
         private void verifyMethodHandleSignature(int expectedArgumentCount, Class<?> returnJavaType, OperatorMethodHandle operatorMethodHandle)
@@ -769,6 +811,9 @@ public final class TypeOperatorDeclaration
             if (sortKeyPrefixBits != 64 && sortKeyPrefixUnorderedLastOperators.isEmpty() && sortKeyPrefixUnorderedFirstOperators.isEmpty()) {
                 throw new IllegalStateException("Sort key prefix bits can not be declared when sort key prefix operators are not supplied");
             }
+            if ((sortKeyPrefixBatchUnorderedLast != null) && sortKeyPrefixUnorderedLastOperators.isEmpty()) {
+                throw new IllegalStateException("Sort key prefix batch operators can not be supplied when sort key prefix operators are not supplied");
+            }
 
             return new TypeOperatorDeclaration(
                     readValueOperators,
@@ -784,7 +829,9 @@ public final class TypeOperatorDeclaration
                     sortKeyPrefixUnorderedLastOperators,
                     sortKeyPrefixUnorderedFirstOperators,
                     sortKeyPrefixExact,
-                    sortKeyPrefixBits);
+                    sortKeyPrefixBits,
+                    sortKeyPrefixBatchUnorderedLast,
+                    sortKeyPrefixBatchUnorderedFirst);
         }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
@@ -53,6 +53,8 @@ import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -161,6 +163,45 @@ public class TypeOperators
         }
         OperatorType comparisonType = sortOrder.isNullsFirst() ? COMPARISON_UNORDERED_FIRST : COMPARISON_UNORDERED_LAST;
         return getOperatorAdaptor(type, Optional.of(sortOrder), callingConvention, comparisonType).get();
+    }
+
+    /**
+     * Whether the type declares sort key prefix operators (see {@link OperatorType#SORT_KEY_PREFIX_UNORDERED_LAST}).
+     */
+    public boolean isSortKeyPrefixSupported(Type type)
+    {
+        // the declaration guarantees that either both or neither flavor is present
+        return !type.getTypeOperatorDeclaration(this).getSortKeyPrefixUnorderedLastOperators().isEmpty();
+    }
+
+    /**
+     * Whether equal sort key prefixes imply equal values under the type's comparison operator.
+     */
+    public boolean isSortKeyPrefixExact(Type type)
+    {
+        return type.getTypeOperatorDeclaration(this).isSortKeyPrefixExact();
+    }
+
+    /**
+     * Number of high bits of the type's sort key prefix that carry information.
+     */
+    public int getSortKeyPrefixBits(Type type)
+    {
+        return type.getTypeOperatorDeclaration(this).getSortKeyPrefixBits();
+    }
+
+    /**
+     * Returns an operator producing a 64-bit key whose unsigned order never contradicts the
+     * comparison used by {@link #getOrderingOperator} for the given sort order. Null placement
+     * and the descending direction are not part of the key and must be applied by the caller.
+     */
+    public MethodHandle getSortKeyPrefixOperator(Type type, SortOrder sortOrder, InvocationConvention callingConvention)
+    {
+        if (!isSortKeyPrefixSupported(type)) {
+            throw new UnsupportedOperationException(type + " does not declare sort key prefix operators");
+        }
+        OperatorType operatorType = sortOrder.isNullsFirst() ? SORT_KEY_PREFIX_UNORDERED_FIRST : SORT_KEY_PREFIX_UNORDERED_LAST;
+        return getOperatorAdaptor(type, callingConvention, operatorType).get();
     }
 
     public MethodHandle getLessThanOperator(Type type, InvocationConvention callingConvention)
@@ -318,6 +359,8 @@ public class TypeOperators
                     }
                     yield comparisonUnorderedFirstOperators;
                 }
+                case SORT_KEY_PREFIX_UNORDERED_LAST -> typeOperatorDeclaration.getSortKeyPrefixUnorderedLastOperators();
+                case SORT_KEY_PREFIX_UNORDERED_FIRST -> typeOperatorDeclaration.getSortKeyPrefixUnorderedFirstOperators();
                 case LESS_THAN -> {
                     Collection<OperatorMethodHandle> lessThanOperators = typeOperatorDeclaration.getLessThanOperators();
                     if (lessThanOperators.isEmpty()) {
@@ -516,7 +559,7 @@ public class TypeOperators
             return switch (operatorConvention.operatorType()) {
                 case EQUAL, IDENTICAL, LESS_THAN, LESS_THAN_OR_EQUAL, INDETERMINATE -> BOOLEAN;
                 case COMPARISON_UNORDERED_LAST, COMPARISON_UNORDERED_FIRST -> INTEGER;
-                case HASH_CODE, XX_HASH_64 -> BIGINT;
+                case HASH_CODE, XX_HASH_64, SORT_KEY_PREFIX_UNORDERED_LAST, SORT_KEY_PREFIX_UNORDERED_FIRST -> BIGINT;
                 case READ_VALUE -> operatorConvention.type();
                 default -> throw new IllegalArgumentException("Unsupported operator type: " + operatorConvention.operatorType());
             };
@@ -528,7 +571,8 @@ public class TypeOperators
                 case LESS_THAN, LESS_THAN_OR_EQUAL,
                      COMPARISON_UNORDERED_LAST, COMPARISON_UNORDERED_FIRST,
                      EQUAL, IDENTICAL -> List.of(operatorConvention.type(), operatorConvention.type());
-                case READ_VALUE, HASH_CODE, XX_HASH_64, INDETERMINATE -> List.of(operatorConvention.type());
+                case READ_VALUE, HASH_CODE, XX_HASH_64, INDETERMINATE,
+                     SORT_KEY_PREFIX_UNORDERED_LAST, SORT_KEY_PREFIX_UNORDERED_FIRST -> List.of(operatorConvention.type());
                 default -> throw new IllegalArgumentException("Unsupported operator type: " + operatorConvention.operatorType());
             };
         }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
@@ -195,6 +195,22 @@ public class TypeOperators
      * comparison used by {@link #getOrderingOperator} for the given sort order. Null placement
      * and the descending direction are not part of the key and must be applied by the caller.
      */
+    /**
+     * Returns the type's batch sort key prefix operator with signature
+     * {@code (ValueBlock, long[], int)void}, if declared. The operator fills the array with the
+     * prefixes of positions {@code [0..positionCount)} of the type's value block, which must not
+     * contain nulls in that range; it throws when passed a block that is not the type's value
+     * block.
+     */
+    public Optional<MethodHandle> getSortKeyPrefixBatchOperator(Type type, SortOrder sortOrder)
+    {
+        if (!isSortKeyPrefixSupported(type)) {
+            return Optional.empty();
+        }
+        TypeOperatorDeclaration declaration = type.getTypeOperatorDeclaration(this);
+        return sortOrder.isNullsFirst() ? declaration.getSortKeyPrefixBatchUnorderedFirst() : declaration.getSortKeyPrefixBatchUnorderedLast();
+    }
+
     public MethodHandle getSortKeyPrefixOperator(Type type, SortOrder sortOrder, InvocationConvention callingConvention)
     {
         if (!isSortKeyPrefixSupported(type)) {

--- a/core/trino-spi/src/main/java/io/trino/spi/type/UuidType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/UuidType.java
@@ -41,6 +41,8 @@ import static io.trino.spi.block.Int128ArrayBlock.INT128_BYTES;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_FIRST;
+import static io.trino.spi.function.OperatorType.SORT_KEY_PREFIX_UNORDERED_LAST;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
 import static java.lang.Long.reverseBytes;
@@ -288,6 +290,23 @@ public class UuidType
     private static long xxHash64(long low, long high)
     {
         return XxHash64.hash(low) ^ XxHash64.hash(high);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_LAST)
+    private static long sortKeyPrefixUnorderedLastOperator(Slice value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    @ScalarOperator(SORT_KEY_PREFIX_UNORDERED_FIRST)
+    private static long sortKeyPrefixUnorderedFirstOperator(Slice value)
+    {
+        return sortKeyPrefix(value);
+    }
+
+    private static long sortKeyPrefix(Slice value)
+    {
+        return reverseBytes(value.getLong(0));
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/VarbinaryType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/VarbinaryType.java
@@ -28,6 +28,7 @@ public final class VarbinaryType
             .addOperators(DEFAULT_READ_OPERATORS)
             .addOperators(DEFAULT_COMPARABLE_OPERATORS)
             .addOperators(DEFAULT_ORDERING_OPERATORS)
+            .addOperators(DEFAULT_SORT_KEY_PREFIX_OPERATORS)
             .build();
 
     public static final VarbinaryType VARBINARY = new VarbinaryType();

--- a/core/trino-spi/src/main/java/io/trino/spi/type/VarcharType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/VarcharType.java
@@ -39,6 +39,7 @@ public final class VarcharType
             .addOperators(DEFAULT_READ_OPERATORS)
             .addOperators(DEFAULT_COMPARABLE_OPERATORS)
             .addOperators(DEFAULT_ORDERING_OPERATORS)
+            .addOperators(DEFAULT_SORT_KEY_PREFIX_OPERATORS)
             .build();
 
     public static final int UNBOUNDED_LENGTH = Integer.MAX_VALUE;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SortBuffer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SortBuffer.java
@@ -46,6 +46,7 @@ public class SortBuffer
     private final List<Page> pages = new ArrayList<>();
 
     private long usedMemoryBytes;
+    private long sorterMemoryBytes;
     private int rowCount;
 
     public SortBuffer(
@@ -65,7 +66,7 @@ public class SortBuffer
 
     public long getRetainedBytes()
     {
-        return INSTANCE_SIZE + usedMemoryBytes;
+        return INSTANCE_SIZE + usedMemoryBytes + sorterMemoryBytes;
     }
 
     public boolean isEmpty()
@@ -101,11 +102,12 @@ public class SortBuffer
     {
         checkState(!pages.isEmpty(), "page buffer is empty");
 
-        Iterator<Page> sortedPages = pageSorter.sort(types, pages, sortFields, sortOrders, rowCount);
+        Iterator<Page> sortedPages = pageSorter.sort(types, pages, sortFields, sortOrders, rowCount, bytes -> sorterMemoryBytes = bytes);
         sortedPages.forEachRemaining(consumer);
 
         pages.clear();
         rowCount = 0;
         usedMemoryBytes = 0;
+        sorterMemoryBytes = 0;
     }
 }


### PR DESCRIPTION
Encode the leading sort key of each position into a 64-bit prefix whose unsigned order matches the sort order (including null placement and direction), then quicksort on single primitive comparisons, falling back to the full comparator only when prefixes tie. Supported leading types: BIGINT, INTEGER, SMALLINT, TINYINT, DATE, DOUBLE, REAL, short TIMESTAMP, VARCHAR, and VARBINARY.

Speeds up ORDER BY and window sorts on BenchmarkPagesSort by 2.4x for random BIGINT keys and 4.3x for random VARCHAR keys, with no regression when all key prefixes are equal.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
