### PR TITLE
Fix dynamic filtering on Redshift UNLOAD splits

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DynamicFilteringJdbcSplitSource.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DynamicFilteringJdbcSplitSource.java
@@ -101,7 +101,10 @@ public class DynamicFilteringJdbcSplitSource
                 .thenApply(splits -> splits.stream()
                         // attach dynamic filter constraint to JdbcSplit
                         .map(split -> {
-                            JdbcSplit jdbcSplit = (JdbcSplit) split;
+                            // Delegates that want to consume the dynamic filter must produce JdbcSplit or a subclass.
+                            if (!(split instanceof JdbcSplit jdbcSplit)) {
+                                return split;
+                            }
                             // If split was a subclass of JdbcSplit, there would be additional information
                             // that we would need to pass further on.
                             verify(jdbcSplit.getClass() == JdbcSplit.class, "Unexpected split type %s", jdbcSplit);

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcDynamicFilteringSplitManager.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcDynamicFilteringSplitManager.java
@@ -140,4 +140,33 @@ public class TestJdbcDynamicFilteringSplitManager
         assertThat(capturedTableHandle.get()).isNull();
         splitSource.close();
     }
+
+    @Test
+    public void testGetNextBatchPassesThroughNonJdbcSplits()
+            throws Exception
+    {
+        ConnectorSplit nonJdbcSplit = new ConnectorSplit() {};
+        JdbcDynamicFilteringSplitManager manager = new JdbcDynamicFilteringSplitManager(
+                new ConnectorSplitManager()
+                {
+                    @Override
+                    public ConnectorSplitSource getSplits(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorTableHandle table, Set<ColumnHandle> dynamicFilterColumns, Constraint constraint)
+                    {
+                        return new FixedSplitSource(ImmutableList.of(nonJdbcSplit));
+                    }
+                });
+        Set<ColumnHandle> dynamicFilterColumns = ImmutableSet.of(new TestColumnHandle());
+        ConnectorSplitSource splitSource = manager.getSplits(
+                TRANSACTION_HANDLE,
+                SESSION,
+                TABLE_HANDLE,
+                dynamicFilterColumns,
+                alwaysTrue());
+
+        TupleDomain<ColumnHandle> predicate = TupleDomain.withColumnDomains(
+                ImmutableMap.of(JDBC_COLUMN_HANDLE, Domain.singleValue(BIGINT, 42L)));
+        List<ConnectorSplit> batch = splitSource.getNextBatch(100, new DynamicFilterSnapshot(predicate, true)).get();
+        assertThat(batch).containsExactly(nonJdbcSplit);
+        splitSource.close();
+    }
 }

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftUnload.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftUnload.java
@@ -18,6 +18,7 @@ import io.trino.Session;
 import io.trino.operator.OperatorInfo;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
+import io.trino.testing.QueryRunner.MaterializedResultWithPlan;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,7 @@ import java.util.Map;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.onlyElement;
+import static io.trino.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
 import static io.trino.plugin.redshift.RedshiftQueryRunner.IAM_ROLE;
 import static io.trino.plugin.redshift.TestingRedshiftServer.TEST_SCHEMA;
 import static io.trino.testing.TestingNames.randomNameSuffix;
@@ -147,6 +149,36 @@ final class TestRedshiftUnload
                     assertThat(operatorInfo).isNull();
                 },
                 results -> assertThat(results.getRowCount()).isEqualTo(0));
+    }
+
+    @Test
+    void testUnloadWithDynamicFilter()
+    {
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty("redshift", "join_pushdown_enabled", "false")
+                .build();
+
+        // Dynamic filter applied to the UNLOAD (probe) side of a join must not fail when attaching the predicate to the split
+        String query = "SELECT n.name FROM nation n JOIN nation r ON n.nationkey = r.regionkey WHERE r.name = 'ALGERIA'";
+        assertQuery(session, query, "VALUES ('ALGERIA')");
+
+        // The dynamic filter must actually reduce the rows Redshift unloads from the probe side
+        Session dynamicFilteringDisabled = Session.builder(session)
+                .setSystemProperty(ENABLE_DYNAMIC_FILTERING, "false")
+                .build();
+        assertThat(physicalInputPositions(session, query))
+                .isLessThan(physicalInputPositions(dynamicFilteringDisabled, query));
+    }
+
+    private long physicalInputPositions(Session session, String query)
+    {
+        QueryRunner queryRunner = getDistributedQueryRunner();
+        MaterializedResultWithPlan result = queryRunner.executeWithPlan(session, query);
+        return queryRunner.getCoordinator()
+                .getQueryManager()
+                .getFullQueryInfo(result.queryId())
+                .getQueryStats()
+                .getPhysicalInputPositions();
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
On Trino 482, a join between a Redshift catalog with UNLOAD enabled (`redshift.unload-location` set) and any JDBC-based catalog fails with an internal `ClassCastException` when the optimizer builds a dynamic filter for the Redshift table on the probe side of the join: 

 ```
java.lang.ClassCastException: class io.trino.plugin.redshift.RedshiftUnloadSplit
cannot be cast to class io.trino.plugin.jdbc.JdbcSplit                                                                                                   
     at io.trino.plugin.jdbc.DynamicFilteringJdbcSplitSource.lambda$getNextBatch$1(DynamicFilteringJdbcSplitSource.java:104)                              
 ```  

Closes #30209

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
I believe that https://github.com/trinodb/trino/pull/29206 introduced this. I have added a regression test that fails without the changes here.

I first noticed this after enabling the unload feature on Redshift today on 482. I was not previously seeing this issue and had the unload feature enabled (and then disabled for a period of time) on my orgs cluster.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Redshift
* Fix query failure when dynamic filtering is applied to a table read via the UNLOAD path. (`#30209`)
```