### PR TITLE
Index fields by name for faster resolution in RelationType

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/RelationType.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/RelationType.java
@@ -16,6 +16,7 @@ package io.trino.sql.analyzer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ListMultimap;
 import com.google.errorprone.annotations.Immutable;
 import io.trino.sql.tree.QualifiedName;
 
@@ -26,7 +27,9 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableListMultimap.toImmutableListMultimap;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 
 /**
  * TODO: this needs to be merged with RowType at some point (when the type system is unified)
@@ -38,6 +41,7 @@ public class RelationType
     private final List<Field> allFields;
 
     private final Map<Field, Integer> fieldIndexes;
+    private final ListMultimap<String, Field> fieldsByName;
 
     public RelationType(Field... fields)
     {
@@ -58,6 +62,10 @@ public class RelationType
             builder.put(field, index++);
         }
         fieldIndexes = builder.buildOrThrow();
+
+        this.fieldsByName = allFields.stream()
+                .filter(field -> field.getName().isPresent())
+                .collect(toImmutableListMultimap(field -> canonicalize(field.getName().get()), identity()));
     }
 
     /**
@@ -129,9 +137,26 @@ public class RelationType
      */
     public List<Field> resolveFields(QualifiedName name)
     {
-        return allFields.stream()
+        // The index lookup only narrows the candidate set; Field.canResolve remains the authority
+        // on whether a field matches, so resolution semantics are unchanged.
+        return fieldsByName.get(canonicalize(name.getSuffix())).stream()
                 .filter(input -> input.canResolve(name))
                 .collect(toImmutableList());
+    }
+
+    /**
+     * Maps an identifier to the canonical form of its {@link String#equalsIgnoreCase} equivalence class,
+     * so that index lookups agree with the case-insensitive comparison in {@link Field#canResolve}.
+     * {@code String.toLowerCase} would be incorrect here: it uses different character mappings
+     * (e.g. GREEK SMALL LETTER FINAL SIGMA) and can change the string length.
+     */
+    private static String canonicalize(String identifier)
+    {
+        char[] chars = identifier.toCharArray();
+        for (int i = 0; i < chars.length; i++) {
+            chars[i] = Character.toLowerCase(Character.toUpperCase(chars[i]));
+        }
+        return new String(chars);
     }
 
     public boolean canResolve(QualifiedName name)

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestRelationType.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestRelationType.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.analyzer;
+
+import io.trino.sql.tree.QualifiedName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestRelationType
+{
+    @Test
+    public void testResolveFieldsByName()
+    {
+        Field column1 = qualifiedField("t", "c1");
+        Field column2 = qualifiedField("t", "c2");
+        RelationType relationType = new RelationType(column1, column2);
+
+        assertThat(relationType.resolveFields(QualifiedName.of("c1"))).containsExactly(column1);
+        assertThat(relationType.resolveFields(QualifiedName.of("c2"))).containsExactly(column2);
+        assertThat(relationType.resolveFields(QualifiedName.of("c3"))).isEmpty();
+
+        assertThat(relationType.canResolve(QualifiedName.of("c1"))).isTrue();
+        assertThat(relationType.canResolve(QualifiedName.of("c3"))).isFalse();
+    }
+
+    @Test
+    public void testResolveFieldsCaseInsensitively()
+    {
+        Field column = qualifiedField("t", "MixedCase");
+        RelationType relationType = new RelationType(column);
+
+        assertThat(relationType.resolveFields(QualifiedName.of("mixedcase"))).containsExactly(column);
+        assertThat(relationType.resolveFields(QualifiedName.of("MIXEDCASE"))).containsExactly(column);
+        assertThat(relationType.resolveFields(QualifiedName.of("MixedCase"))).containsExactly(column);
+    }
+
+    @Test
+    public void testResolveFieldsMatchesEqualsIgnoreCaseSemantics()
+    {
+        // GREEK SMALL LETTER FINAL SIGMA is a canary for the difference between
+        // String.equalsIgnoreCase and String.toLowerCase based comparisons
+        Field column = qualifiedField("t", "colς");
+        RelationType relationType = new RelationType(column);
+
+        assertThat(relationType.resolveFields(QualifiedName.of("colς"))).containsExactly(column);
+        assertThat(relationType.resolveFields(QualifiedName.of("colσ"))).containsExactly(column);
+        assertThat(relationType.resolveFields(QualifiedName.of("colΣ"))).containsExactly(column);
+    }
+
+    @Test
+    public void testResolveFieldsWithRelationPrefix()
+    {
+        Field column = qualifiedField("t", "c1");
+        RelationType relationType = new RelationType(column);
+
+        assertThat(relationType.resolveFields(QualifiedName.of("t", "c1"))).containsExactly(column);
+        assertThat(relationType.resolveFields(QualifiedName.of("other", "c1"))).isEmpty();
+    }
+
+    @Test
+    public void testResolveFieldsWithDuplicateNames()
+    {
+        Field leftColumn = qualifiedField("left", "c1");
+        Field rightColumn = qualifiedField("right", "c1");
+        RelationType relationType = new RelationType(leftColumn, rightColumn);
+
+        assertThat(relationType.resolveFields(QualifiedName.of("c1"))).containsExactly(leftColumn, rightColumn);
+        assertThat(relationType.resolveFields(QualifiedName.of("left", "c1"))).containsExactly(leftColumn);
+        assertThat(relationType.resolveFields(QualifiedName.of("right", "c1"))).containsExactly(rightColumn);
+    }
+
+    @Test
+    public void testResolveHiddenField()
+    {
+        Field hidden = Field.newQualified(QualifiedName.of("t"), Optional.of("c1"), BIGINT, true, Optional.empty(), Optional.empty(), Optional.empty(), false);
+        RelationType relationType = new RelationType(hidden);
+
+        assertThat(relationType.resolveFields(QualifiedName.of("c1"))).containsExactly(hidden);
+    }
+
+    @Test
+    public void testAnonymousFieldsDoNotResolve()
+    {
+        Field anonymous = Field.newUnqualified(Optional.empty(), BIGINT);
+        RelationType relationType = new RelationType(anonymous);
+
+        assertThat(relationType.resolveFields(QualifiedName.of("c1"))).isEmpty();
+    }
+
+    private static Field qualifiedField(String relation, String name)
+    {
+        return Field.newQualified(QualifiedName.of(relation), Optional.of(name), BIGINT, false, Optional.empty(), Optional.empty(), Optional.empty(), false);
+    }
+}


### PR DESCRIPTION
Resolving an identifier scanned all fields linearly, making analysis of queries with N output columns O(N^2). Build a name-keyed index once per RelationType instead.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
