### PR TITLE
Expose Iceberg metadata tables for materialized views

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -1214,6 +1214,16 @@ the table name:
 SELECT * FROM "test_table$properties";
 ```
 
+The same metadata tables are also available for a materialized view (see
+{ref}`iceberg-materialized-views`) by appending the metadata table name to the
+materialized view name. The query resolves against the materialized view's
+storage table:
+
+```sql
+SELECT * FROM "test_materialized_view$files";
+```
+
+
 ##### `$properties` table
 
 The `$properties` table provides access to general information about Iceberg

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -894,8 +894,11 @@ public class IcebergMetadata
 
         // Only when dealing with an actual system table proceed to retrieve the base table for the system table
         String name = tableNameFrom(tableName.getTableName());
+        SchemaTableName baseName = new SchemaTableName(tableName.getSchemaName(), name);
         try {
-            return Optional.of(catalog.loadTable(session, new SchemaTableName(tableName.getSchemaName(), name)));
+            return getMaterializedView(session, baseName)
+                    .flatMap(_ -> catalog.getMaterializedViewStorageTable(session, baseName))
+                    .or(() -> Optional.of(catalog.loadTable(session, baseName)));
         }
         catch (TableNotFoundException e) {
             return Optional.empty();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -80,6 +80,7 @@ import static io.trino.testing.MaterializedResult.DEFAULT_PRECISION;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.DROP_MATERIALIZED_VIEW;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.REFRESH_MATERIALIZED_VIEW;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.RENAME_MATERIALIZED_VIEW;
+import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
 import static io.trino.testing.TestingAccessControlManager.privilege;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
@@ -1028,6 +1029,47 @@ public abstract class BaseIcebergMaterializedViewTest
             assertUpdate("DROP TABLE " + sourceTableName);
             assertUpdate(format("DROP MATERIALIZED VIEW IF EXISTS iceberg_legacy_mv.%s.%s", schemaName, materializedViewName));
         }
+    }
+
+    @Test
+    public void testMaterializedViewMetadataTables()
+    {
+        assertUpdate("CREATE TABLE base_table1_mv_copy AS SELECT * FROM base_table1", 6L);
+        String mvName = "test_mv_metadata_tables_" + randomNameSuffix();
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " WITH (partitioning = ARRAY['_date']) AS SELECT * FROM base_table1_mv_copy");
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 6);
+
+        // Metadata tables resolve against the materialized view's storage table via the MV name,
+        // mirroring the behavior for regular tables.
+        assertThat((long) computeScalar("SELECT count(*) FROM \"" + mvName + "$files\"")).isEqualTo(3L);
+        assertThat((long) computeScalar("SELECT count(*) FROM \"" + mvName + "$snapshots\"")).isEqualTo(2L);
+        assertThat((long) computeScalar("SELECT count(*) FROM \"" + mvName + "$history\"")).isEqualTo(2L);
+        assertThat((long) computeScalar("SELECT count(*) FROM \"" + mvName + "$partitions\"")).isEqualTo(3L);
+        assertThat(query("SELECT file_path, record_count FROM \"" + mvName + "$files\"")).succeeds();
+        assertThat(query("SELECT * FROM \"" + mvName + "$manifests\"")).succeeds();
+        assertThat(query("SELECT * FROM \"" + mvName + "$refs\"")).succeeds();
+        assertThat(query("SELECT * FROM \"" + mvName + "$properties\"")).succeeds();
+
+        // A second refresh adds a snapshot, visible through the MV's $snapshots table.
+        long snapshotsBefore = (long) computeScalar("SELECT count(*) FROM \"" + mvName + "$snapshots\"");
+        assertUpdate("INSERT INTO base_table1_mv_copy VALUES (6, DATE '2019-09-11')", 1);
+        // implicit RefreshType.INCREMENTAL, only new row is added
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertThat(computeScalar("SELECT count(*) FROM " + mvName)).isEqualTo(7L);
+        assertThat((long) computeScalar("SELECT count(*) FROM \"" + mvName + "$snapshots\"")).isGreaterThan(snapshotsBefore);
+
+        // A metadata-table suffix on a non-existent materialized view still reports the table as missing.
+        assertThat(query("SELECT * FROM \"nonexistent_mv_" + randomNameSuffix() + "$partitions\""))
+                .failure().hasMessageMatching(".* does not exist");
+
+        // Access control is keyed on the suffixed name, exactly as for base-table metadata tables.
+        assertAccessDenied(
+                "SELECT * FROM \"" + mvName + "$partitions\"",
+                "Cannot select from columns .*",
+                privilege(mvName + "$partitions", SELECT_COLUMN));
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        assertUpdate("DROP TABLE base_table1_mv_copy");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Exposes Iceberg connector metadata tables for MV storage table under MV name.
This should allow MV users to make better calls around their MV structure based on available metadata.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Relates to https://github.com/trinodb/trino/issues/21797, as it exposes new lifecycle information around MV storage table

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Add support for querying Iceberg metadata tables (such as `$files`, `$snapshots`, `$partitions`) for a materialized view.
```
