### PR TITLE
Report memory usage from DeltaLakeMergeSink parquet reader

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/MergeWriterOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MergeWriterOperator.java
@@ -18,6 +18,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.Slice;
 import io.trino.Session;
+import io.trino.memory.context.LocalMemoryContext;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;
@@ -79,8 +80,9 @@ public class MergeWriterOperator
         {
             checkState(!closed, "Factory is already closed");
             OperatorContext context = driverContext.addOperatorContext(operatorId, planNodeId, MergeWriterOperator.class.getSimpleName());
-            ConnectorMergeSink mergeSink = pageSinkManager.createMergeSink(session, target.getMergeHandle().orElseThrow(), tableCredentials, PageSinkId.fromTaskId(driverContext.getTaskId()));
-            return new MergeWriterOperator(context, mergeSink, pagePreprocessor);
+            LocalMemoryContext mergeSinkMemoryContext = context.newLocalUserMemoryContext(MergeWriterOperator.class.getSimpleName());
+            ConnectorMergeSink mergeSink = pageSinkManager.createMergeSink(session, target.getMergeHandle().orElseThrow(), tableCredentials, PageSinkId.fromTaskId(driverContext.getTaskId()), mergeSinkMemoryContext::setBytes);
+            return new MergeWriterOperator(context, mergeSink, pagePreprocessor, mergeSinkMemoryContext);
         }
 
         @Override
@@ -104,6 +106,7 @@ public class MergeWriterOperator
     private final OperatorContext operatorContext;
     private State state = State.RUNNING;
     private final ConnectorMergeSink mergeSink;
+    private final LocalMemoryContext mergeSinkMemoryContext;
     private final Function<Page, Page> pagePreprocessor;
     private ListenableFuture<Collection<Slice>> finishFuture;
     private ListenableFuture<Void> blockedFutureView;
@@ -111,11 +114,12 @@ public class MergeWriterOperator
     private long writtenBytes;
     private boolean closed;
 
-    public MergeWriterOperator(OperatorContext operatorContext, ConnectorMergeSink mergeSink, Function<Page, Page> pagePreprocessor)
+    public MergeWriterOperator(OperatorContext operatorContext, ConnectorMergeSink mergeSink, Function<Page, Page> pagePreprocessor, LocalMemoryContext mergeSinkMemoryContext)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.mergeSink = requireNonNull(mergeSink, "mergeSink is null");
         this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
+        this.mergeSinkMemoryContext = requireNonNull(mergeSinkMemoryContext, "mergeSinkMemoryContext is null");
     }
 
     @Override
@@ -233,6 +237,7 @@ public class MergeWriterOperator
             if (finishFuture != null) {
                 finishFuture.cancel(true);
             }
+            mergeSinkMemoryContext.close();
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/split/PageSinkManager.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSinkManager.java
@@ -28,6 +28,7 @@ import io.trino.spi.connector.ConnectorPageSinkId;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableCredentials;
+import io.trino.spi.connector.MemoryContext;
 
 import java.util.Optional;
 
@@ -68,12 +69,12 @@ public class PageSinkManager
     }
 
     @Override
-    public ConnectorMergeSink createMergeSink(Session session, MergeHandle mergeHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId)
+    public ConnectorMergeSink createMergeSink(Session session, MergeHandle mergeHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId, MemoryContext memoryContext)
     {
         // assumes connectorId and catalog are the same
         TableHandle tableHandle = mergeHandle.tableHandle();
         ConnectorSession connectorSession = session.toConnectorSession(tableHandle.catalogHandle());
-        return providerFor(tableHandle.catalogHandle()).createMergeSink(tableHandle.transaction(), connectorSession, mergeHandle.connectorMergeHandle(), tableCredentials, pageSinkId);
+        return providerFor(tableHandle.catalogHandle()).createMergeSink(tableHandle.transaction(), connectorSession, mergeHandle.connectorMergeHandle(), tableCredentials, pageSinkId, memoryContext);
     }
 
     private ConnectorPageSinkProvider providerFor(CatalogHandle catalogHandle)

--- a/core/trino-main/src/main/java/io/trino/split/PageSinkProvider.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSinkProvider.java
@@ -22,6 +22,7 @@ import io.trino.spi.connector.ConnectorMergeSink;
 import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.connector.ConnectorPageSinkId;
 import io.trino.spi.connector.ConnectorTableCredentials;
+import io.trino.spi.connector.MemoryContext;
 
 import java.util.Optional;
 
@@ -42,5 +43,5 @@ public interface PageSinkProvider
     /*
      * Used to write the result of SQL MERGE to an existing table
      */
-    ConnectorMergeSink createMergeSink(Session session, MergeHandle mergeHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId);
+    ConnectorMergeSink createMergeSink(Session session, MergeHandle mergeHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId, MemoryContext memoryContext);
 }

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -72,6 +72,7 @@ import io.trino.spi.connector.JoinApplicationResult;
 import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.MaterializedViewFreshness;
+import io.trino.spi.connector.MemoryContext;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RecordPageSource;
 import io.trino.spi.connector.RelationColumnsMetadata;
@@ -1085,7 +1086,8 @@ public class MockConnector
                 ConnectorSession session,
                 ConnectorMergeTableHandle mergeHandle,
                 Optional<ConnectorTableCredentials> tableCredentials,
-                ConnectorPageSinkId pageSinkId)
+                ConnectorPageSinkId pageSinkId,
+                MemoryContext memoryContext)
         {
             return new MockPageSink();
         }

--- a/core/trino-main/src/test/java/io/trino/operator/TestMergeWriterOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestMergeWriterOperator.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import io.airlift.slice.Slice;
+import io.trino.connector.CatalogServiceProvider;
+import io.trino.metadata.MergeHandle;
+import io.trino.operator.MergeWriterOperator.MergeWriterOperatorFactory;
+import io.trino.spi.Page;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.connector.ConnectorInsertTableHandle;
+import io.trino.spi.connector.ConnectorMergeSink;
+import io.trino.spi.connector.ConnectorMergeTableHandle;
+import io.trino.spi.connector.ConnectorOutputTableHandle;
+import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.connector.ConnectorPageSinkId;
+import io.trino.spi.connector.ConnectorPageSinkProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableCredentials;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.MemoryContext;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.split.PageSinkManager;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.TableWriterNode.MergeParadigmAndTypes;
+import io.trino.sql.planner.plan.TableWriterNode.MergeTarget;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.spi.connector.RowChangeParadigm.DELETE_ROW_AND_INSERT_ROW;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
+import static io.trino.testing.TestingHandles.TEST_TABLE_HANDLE;
+import static io.trino.testing.TestingTaskContext.createTaskContext;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Execution(ExecutionMode.CONCURRENT)
+public class TestMergeWriterOperator
+{
+    private static final long FINISH_MEMORY_USAGE = 12345;
+
+    private ExecutorService executor;
+    private ScheduledExecutorService scheduledExecutor;
+
+    @BeforeAll
+    public void setUp()
+    {
+        executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed(getClass().getSimpleName() + "-scheduledExecutor-%s"));
+    }
+
+    @AfterAll
+    public void tearDown()
+    {
+        executor.shutdownNow();
+        scheduledExecutor.shutdownNow();
+    }
+
+    @Test
+    public void testMergeSinkMemoryUsageIsReported()
+            throws Exception
+    {
+        MemoryReportingMergeSinkProvider mergeSinkProvider = new MemoryReportingMergeSinkProvider();
+        PageSinkManager pageSinkManager = new PageSinkManager(CatalogServiceProvider.singleton(TEST_CATALOG_HANDLE, mergeSinkProvider));
+        MergeWriterOperatorFactory factory = new MergeWriterOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                pageSinkManager,
+                mergeTarget(),
+                Optional.empty(),
+                TEST_SESSION,
+                Function.identity());
+
+        DriverContext driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
+                .addPipelineContext(0, true, true, false)
+                .addDriverContext();
+        Operator operator = factory.createOperator(driverContext);
+        OperatorContext operatorContext = operator.getOperatorContext();
+
+        assertThat(operatorContext.getOperatorMemoryContext().getUserMemory()).isEqualTo(0);
+
+        // memory reported by the merge sink while storing pages must be reflected in the operator memory context
+        operator.addInput(createMergePage(42));
+        long reportedMemory = mergeSinkProvider.sink().reportedMemory();
+        assertThat(reportedMemory).isGreaterThan(0);
+        assertThat(operatorContext.getOperatorMemoryContext().getUserMemory()).isEqualTo(reportedMemory);
+
+        // memory reported from within ConnectorMergeSink.finish() must also be reflected
+        operator.finish();
+        assertThat(operatorContext.getOperatorMemoryContext().getUserMemory()).isEqualTo(FINISH_MEMORY_USAGE);
+        assertThat(operator.getOutput()).isNotNull();
+        assertThat(operator.isFinished()).isTrue();
+
+        // closing the operator releases the memory
+        operator.close();
+        assertThat(operatorContext.getOperatorMemoryContext().getUserMemory()).isEqualTo(0);
+    }
+
+    @Test
+    public void testMergeSinkMemoryUsageIsReleasedOnAbort()
+            throws Exception
+    {
+        MemoryReportingMergeSinkProvider mergeSinkProvider = new MemoryReportingMergeSinkProvider();
+        PageSinkManager pageSinkManager = new PageSinkManager(CatalogServiceProvider.singleton(TEST_CATALOG_HANDLE, mergeSinkProvider));
+        MergeWriterOperatorFactory factory = new MergeWriterOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                pageSinkManager,
+                mergeTarget(),
+                Optional.empty(),
+                TEST_SESSION,
+                Function.identity());
+
+        DriverContext driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
+                .addPipelineContext(0, true, true, false)
+                .addDriverContext();
+        Operator operator = factory.createOperator(driverContext);
+        OperatorContext operatorContext = operator.getOperatorContext();
+
+        // simulate query cancellation: close operator without calling finish, then assert that the memory is released
+        operator.addInput(createMergePage(42));
+        assertThat(mergeSinkProvider.sink().reportedMemory()).isGreaterThan(0);
+        assertThat(operatorContext.getOperatorMemoryContext().getUserMemory()).isGreaterThan(0);
+
+        operator.close();
+        assertThat(operatorContext.getOperatorMemoryContext().getUserMemory()).isEqualTo(0);
+    }
+
+    private static MergeTarget mergeTarget()
+    {
+        ConnectorMergeTableHandle mergeTableHandle = new ConnectorMergeTableHandle()
+        {
+            @Override
+            public ConnectorTableHandle getTableHandle()
+            {
+                return TEST_TABLE_HANDLE.connectorHandle();
+            }
+        };
+        return new MergeTarget(
+                TEST_TABLE_HANDLE,
+                Optional.of(new MergeHandle(TEST_TABLE_HANDLE, mergeTableHandle)),
+                new SchemaTableName("testSchema", "testTable"),
+                new MergeParadigmAndTypes(Optional.of(DELETE_ROW_AND_INSERT_ROW), ImmutableList.of(BIGINT), ImmutableList.of("column"), BIGINT),
+                ImmutableList.of(),
+                ImmutableMultimap.of());
+    }
+
+    private static Page createMergePage(long value)
+    {
+        BlockBuilder dataColumn = BIGINT.createFixedSizeBlockBuilder(1);
+        BIGINT.writeLong(dataColumn, value);
+        BlockBuilder insertFromUpdateColumn = TINYINT.createFixedSizeBlockBuilder(1);
+        TINYINT.writeLong(insertFromUpdateColumn, 0);
+        return new Page(dataColumn.build(), insertFromUpdateColumn.build());
+    }
+
+    private static class MemoryReportingMergeSinkProvider
+            implements ConnectorPageSinkProvider
+    {
+        private MemoryReportingMergeSink sink;
+
+        public MemoryReportingMergeSink sink()
+        {
+            return requireNonNull(sink, "merge sink not created yet");
+        }
+
+        @Override
+        public ConnectorPageSink createPageSink(
+                ConnectorTransactionHandle transactionHandle,
+                ConnectorSession session,
+                ConnectorOutputTableHandle outputTableHandle,
+                Optional<ConnectorTableCredentials> tableCredentials,
+                ConnectorPageSinkId pageSinkId)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ConnectorPageSink createPageSink(
+                ConnectorTransactionHandle transactionHandle,
+                ConnectorSession session,
+                ConnectorInsertTableHandle insertTableHandle,
+                Optional<ConnectorTableCredentials> tableCredentials,
+                ConnectorPageSinkId pageSinkId)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ConnectorMergeSink createMergeSink(
+                ConnectorTransactionHandle transactionHandle,
+                ConnectorSession session,
+                ConnectorMergeTableHandle mergeHandle,
+                Optional<ConnectorTableCredentials> tableCredentials,
+                ConnectorPageSinkId pageSinkId,
+                MemoryContext memoryContext)
+        {
+            sink = new MemoryReportingMergeSink(memoryContext);
+            return sink;
+        }
+    }
+
+    private static class MemoryReportingMergeSink
+            implements ConnectorMergeSink
+    {
+        private final MemoryContext memoryContext;
+        private long reportedMemory;
+
+        public MemoryReportingMergeSink(MemoryContext memoryContext)
+        {
+            this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");
+        }
+
+        public long reportedMemory()
+        {
+            return reportedMemory;
+        }
+
+        @Override
+        public void storeMergedRows(Page page)
+        {
+            reportedMemory += page.getRetainedSizeInBytes();
+            memoryContext.setBytes(reportedMemory);
+        }
+
+        @Override
+        public CompletableFuture<Collection<Slice>> finish()
+        {
+            // simulates memory used while producing the merge result, e.g. by a file reader
+            memoryContext.setBytes(FINISH_MEMORY_USAGE);
+            return completedFuture(ImmutableList.of());
+        }
+    }
+}

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -571,6 +571,11 @@
                                     <annotation>@com.fasterxml.jackson.annotation.JsonProperty</annotation>
                                     <justification>getName() is deprecated and replaced by getPrincipalName() which preserves the original case of USER principal names. The @JsonProperty annotation is moved to getPrincipalName() so that JSON serialization reflects the stored name verbatim.</justification>
                                 </item>
+                                <item>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method io.trino.spi.connector.ConnectorMergeSink io.trino.spi.connector.ConnectorPageSinkProvider::createMergeSink(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorMergeTableHandle, java.util.Optional&lt;io.trino.spi.connector.ConnectorTableCredentials&gt;, io.trino.spi.connector.ConnectorPageSinkId)</old>
+                                    <new>method io.trino.spi.connector.ConnectorMergeSink io.trino.spi.connector.ConnectorPageSinkProvider::createMergeSink(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorMergeTableHandle, java.util.Optional&lt;io.trino.spi.connector.ConnectorTableCredentials&gt;, io.trino.spi.connector.ConnectorPageSinkId, io.trino.spi.connector.MemoryContext)</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSinkProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSinkProvider.java
@@ -83,6 +83,7 @@ public interface ConnectorPageSinkProvider
      * @param mergeHandle the handle identifying the merge operation
      * @param tableCredentials credentials for accessing the table data
      * @param pageSinkId unique identifier for this page sink instance
+     * @param memoryContext memory context for reporting memory usage of the merge sink
      * @return a merge sink for executing the MERGE operation
      */
     default ConnectorMergeSink createMergeSink(
@@ -90,7 +91,8 @@ public interface ConnectorPageSinkProvider
             ConnectorSession session,
             ConnectorMergeTableHandle mergeHandle,
             Optional<ConnectorTableCredentials> tableCredentials,
-            ConnectorPageSinkId pageSinkId)
+            ConnectorPageSinkId pageSinkId,
+            MemoryContext memoryContext)
     {
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support SQL MERGE operations");
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSinkProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSinkProvider.java
@@ -26,6 +26,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.MemoryContext;
 
 import java.util.Optional;
 
@@ -89,10 +90,11 @@ public final class ClassLoaderSafeConnectorPageSinkProvider
             ConnectorSession session,
             ConnectorMergeTableHandle mergeHandle,
             Optional<ConnectorTableCredentials> tableCredentials,
-            ConnectorPageSinkId pageSinkId)
+            ConnectorPageSinkId pageSinkId,
+            MemoryContext memoryContext)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return new ClassLoaderSafeConnectorMergeSink(delegate.createMergeSink(transactionHandle, session, mergeHandle, tableCredentials, pageSinkId), classLoader);
+            return new ClassLoaderSafeConnectorMergeSink(delegate.createMergeSink(transactionHandle, session, mergeHandle, tableCredentials, pageSinkId, memoryContext), classLoader);
         }
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSinkProvider.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSinkProvider.java
@@ -25,6 +25,7 @@ import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.MemoryContext;
 
 import java.util.Optional;
 
@@ -73,7 +74,8 @@ public class JdbcPageSinkProvider
             ConnectorSession session,
             ConnectorMergeTableHandle mergeHandle,
             Optional<ConnectorTableCredentials> tableCredentials,
-            ConnectorPageSinkId pageSinkId)
+            ConnectorPageSinkId pageSinkId,
+            MemoryContext memoryContext)
     {
         return new JdbcMergeSink(session, mergeHandle, jdbcClient, pageSinkId, queryModifier, queryBuilder);
     }

--- a/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHolePageSinkProvider.java
+++ b/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHolePageSinkProvider.java
@@ -24,6 +24,7 @@ import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.MemoryContext;
 
 import java.util.Optional;
 
@@ -69,7 +70,8 @@ public class BlackHolePageSinkProvider
             ConnectorSession session,
             ConnectorMergeTableHandle mergeHandle,
             Optional<ConnectorTableCredentials> tableCredentials,
-            ConnectorPageSinkId pageSinkId)
+            ConnectorPageSinkId pageSinkId,
+            MemoryContext memoryContext)
     {
         return new BlackHoleMergeSink();
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -136,6 +136,7 @@ public class DeltaLakeMergeSink
     private final int randomPrefixLength;
     private final Optional<String> shallowCloneSourceTableLocation;
     private final boolean useDeltaLengthByteArrayEncoding;
+    private final MemoryContext memoryContext;
     private long writtenBytes;
 
     @Nullable
@@ -164,7 +165,8 @@ public class DeltaLakeMergeSink
             Map<String, DeletionVectorEntry> deletionVectors,
             int randomPrefixLength,
             Optional<String> shallowCloneSourceTableLocation,
-            boolean useDeltaLengthByteArrayEncoding)
+            boolean useDeltaLengthByteArrayEncoding,
+            MemoryContext memoryContext)
     {
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
         this.session = requireNonNull(session, "session is null");
@@ -195,6 +197,7 @@ public class DeltaLakeMergeSink
         this.randomPrefixLength = randomPrefixLength;
         this.shallowCloneSourceTableLocation = requireNonNull(shallowCloneSourceTableLocation, "shallowCloneSourceTableLocation is null");
         this.useDeltaLengthByteArrayEncoding = useDeltaLengthByteArrayEncoding;
+        this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");
 
         dataColumnsIndices = new int[tableColumnCount];
         dataAndRowIdColumnsIndices = new int[tableColumnCount + 1];
@@ -712,8 +715,7 @@ public class DeltaLakeMergeSink
                 Optional.empty(),
                 domainCompactionThreshold,
                 OptionalLong.of(fileSize),
-                // TODO (https://github.com/trinodb/trino/issues/29956) report memory usage
-                MemoryContext.NO_LIMIT);
+                memoryContext);
     }
 
     private String getReferencedPath(String basePath, String sourcePath)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSinkProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSinkProvider.java
@@ -237,7 +237,8 @@ public class DeltaLakePageSinkProvider
                 merge.deletionVectors(),
                 getRandomPrefixLength(tableHandle.metadataEntry()),
                 merge.shallowCloneSourceTableLocation(),
-                useDeltaLengthByteArrayEncoding);
+                useDeltaLengthByteArrayEncoding,
+                memoryContext);
     }
 
     private DeltaLakeCdfPageSink createCdfPageSink(

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSinkProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSinkProvider.java
@@ -38,6 +38,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.MemoryContext;
 import io.trino.spi.type.TypeManager;
 import org.joda.time.DateTimeZone;
 
@@ -204,7 +205,8 @@ public class DeltaLakePageSinkProvider
             ConnectorSession session,
             ConnectorMergeTableHandle mergeHandle,
             Optional<ConnectorTableCredentials> tableCredentials,
-            ConnectorPageSinkId pageSinkId)
+            ConnectorPageSinkId pageSinkId,
+            MemoryContext memoryContext)
     {
         DeltaLakeMergeTableHandle merge = (DeltaLakeMergeTableHandle) mergeHandle;
         DeltaLakeInsertTableHandle tableHandle = merge.insertTableHandle();

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMergeSinkMemoryReporting.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMergeSinkMemoryReporting.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import io.trino.operator.OperatorStats;
+import io.trino.spi.QueryId;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.QueryRunner.MaterializedResultWithPlan;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers memory reporting from {@link DeltaLakeMergeSink}'s parquet reader, used when a DELETE rewrites a file.
+ */
+public class TestDeltaLakeMergeSinkMemoryReporting
+        extends AbstractTestQueryFramework
+{
+    private Path catalogDir;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        catalogDir = Files.createTempDirectory("catalog-dir");
+        closeAfterClass(() -> deleteRecursively(catalogDir, ALLOW_INSECURE));
+
+        return DeltaLakeQueryRunner.builder()
+                .addDeltaProperty("fs.hadoop.enabled", "true")
+                .addDeltaProperty("hive.metastore.catalog.dir", catalogDir.toUri().toString())
+                .addDeltaProperty("delta.enable-non-concurrent-writes", "true")
+                .build();
+    }
+
+    @Test
+    public void testDeleteRewritingFileReportsMergeWriterMemoryUsage()
+    {
+        String tableName = "test_delete_rewrite_memory_" + randomNameSuffix();
+        // both rows share the same partition value and land in one file; deleting only one forces a rewrite
+        assertUpdate(
+                "CREATE TABLE " + tableName + " (id, part, value) WITH (partitioned_by = ARRAY['part']) " +
+                        "AS VALUES (1, 'p', 'a'), (2, 'p', 'b')",
+                2);
+
+        MaterializedResultWithPlan result = getDistributedQueryRunner().executeWithPlan(getSession(), "DELETE FROM " + tableName + " WHERE id = 1");
+        assertThat(getMergeWriterOperatorStats(result.queryId()).getPeakUserMemoryReservation().toBytes())
+                .isGreaterThan(0);
+
+        assertQuery("SELECT * FROM " + tableName, "VALUES (2, 'p', 'b')");
+    }
+
+    private OperatorStats getMergeWriterOperatorStats(QueryId queryId)
+    {
+        return getDistributedQueryRunner().getCoordinator()
+                .getQueryManager()
+                .getFullQueryInfo(queryId)
+                .getQueryStats()
+                .getOperatorSummaries()
+                .stream()
+                .filter(summary -> summary.getOperatorType().equals("MergeWriterOperator"))
+                .collect(onlyElement());
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
@@ -37,6 +37,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.MemoryContext;
 import io.trino.spi.type.TypeManager;
 
 import java.util.List;
@@ -141,7 +142,8 @@ public class HivePageSinkProvider
             ConnectorSession session,
             ConnectorMergeTableHandle mergeHandle,
             Optional<ConnectorTableCredentials> tableCredentials,
-            ConnectorPageSinkId pageSinkId)
+            ConnectorPageSinkId pageSinkId,
+            MemoryContext memoryContext)
     {
         HiveMergeTableHandle hiveMergeHandle = (HiveMergeTableHandle) mergeHandle;
         HiveInsertTableHandle insertHandle = hiveMergeHandle.getInsertHandle();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -32,6 +32,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.MemoryContext;
 import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.PartitionSpec;
@@ -183,7 +184,7 @@ public class IcebergPageSinkProvider
     }
 
     @Override
-    public ConnectorMergeSink createMergeSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorMergeTableHandle mergeHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId)
+    public ConnectorMergeSink createMergeSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorMergeTableHandle mergeHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId, MemoryContext memoryContext)
     {
         verify(tableCredentials.isPresent(), "tableCredentials is empty");
         IcebergMergeTableHandle merge = (IcebergMergeTableHandle) mergeHandle;

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehousePageSinkProvider.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehousePageSinkProvider.java
@@ -39,6 +39,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.MemoryContext;
 
 import java.util.Optional;
 
@@ -81,9 +82,9 @@ public class LakehousePageSinkProvider
     }
 
     @Override
-    public ConnectorMergeSink createMergeSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorMergeTableHandle mergeHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId)
+    public ConnectorMergeSink createMergeSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorMergeTableHandle mergeHandle, Optional<ConnectorTableCredentials> tableCredentials, ConnectorPageSinkId pageSinkId, MemoryContext memoryContext)
     {
-        return forHandle(mergeHandle).createMergeSink(transactionHandle, session, mergeHandle, tableCredentials, pageSinkId);
+        return forHandle(mergeHandle).createMergeSink(transactionHandle, session, mergeHandle, tableCredentials, pageSinkId, memoryContext);
     }
 
     private ConnectorPageSinkProvider forHandle(ConnectorOutputTableHandle handle)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
- Fixes #29956.

`DeltaLakeMergeSink` reads back the affected parquet files during `finish()` (CDF processing and file rewrites), but the parquet page sources were created with `MemoryContext.NO_LIMIT`, so the reader's memory was invisible to the engine.

All of that reading happens synchronously inside `ConnectorMergeSink.finish()`, so poll-based reporting (a `getMemoryUsage()` method on the sink) cannot observe it. The memory is allocated and released entirely between two polls. This PR extends the push-based reporting from #29948 to merge sinks:

* `ConnectorPageSinkProvider.createMergeSink` takes a `MemoryContext` parameter. The overload without it is removed, and all in-tree implementors are migrated.
* `MergeWriterOperator` creates a `LocalMemoryContext` and passes `::setBytes` through `PageSinkManager` at sink creation, mirroring `TableScanOperator`'s handling of `ConnectorPageSource`.
* `DeltaLakeMergeSink` uses the supplied context for its parquet page sources, replacing the `MemoryContext.NO_LIMIT` TODO.

`TestMergeWriterOperator` verifies that memory reported from `storeMergedRows()` and `finish()` reaches the operator's memory context, and that it is released both on normal close and on the abort path. `TestDeltaLakeMergeSinkMemoryReporting` asserts non-zero peak memory on `MergeWriterOperator` for a `DELETE` that rewrites a file.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- The same parameter gives `IcebergMergeSink` a path to fix #29957.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake
* Improve memory tracking for `MERGE`, `UPDATE`, and `DELETE` queries. ({issue}`29956`)

## SPI
* {{breaking}} Add a `MemoryContext` parameter to `ConnectorPageSinkProvider.createMergeSink` and remove the overload without it. ({issue}`29956`)
```
