### PR TITLE
Coarsen page source memory usage reporting

### DIFF
--- a/lib/trino-memory-context/src/main/java/io/trino/memory/context/MemoryContextReservationHandler.java
+++ b/lib/trino-memory-context/src/main/java/io/trino/memory/context/MemoryContextReservationHandler.java
@@ -23,10 +23,20 @@ final class MemoryContextReservationHandler
         implements MemoryReservationHandler
 {
     private static final ListenableFuture<Void> NOT_BLOCKED = immediateVoidFuture();
+    // Propagating every page-sized fluctuation to the operator memory context walks the
+    // whole context tree from inside the reader's decode loop. Following the strategy of
+    // CoarseGrainLocalMemoryContext, round usage up to this granule and report only when
+    // the rounded value changes, preferring over-counting over under-counting.
+    private static final long REPORT_GRANULARITY = 1 << 20;
+    private static final long GRANULARITY_MASK = ~(REPORT_GRANULARITY - 1);
+
     private final MemoryContext memoryContext;
 
     @GuardedBy("this")
     private long memoryUsage;
+
+    @GuardedBy("this")
+    private long reportedUsage;
 
     public MemoryContextReservationHandler(MemoryContext memoryContext)
     {
@@ -39,10 +49,20 @@ final class MemoryContextReservationHandler
         if (delta != 0) {
             synchronized (this) {
                 memoryUsage += delta;
-                memoryContext.setBytes(memoryUsage);
+                long roundedUsage = roundUpToGranularity(memoryUsage);
+                if (roundedUsage != reportedUsage) {
+                    memoryContext.setBytes(roundedUsage);
+                    reportedUsage = roundedUsage;
+                }
             }
         }
         return NOT_BLOCKED;
+    }
+
+    private static long roundUpToGranularity(long bytes)
+    {
+        long masked = bytes & GRANULARITY_MASK;
+        return masked == bytes ? masked : masked + REPORT_GRANULARITY;
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -139,6 +139,9 @@ public class TestOrcPageSourceMemoryTracking
     private static final Configuration CONFIGURATION = new Configuration(false);
     private static final int NUM_ROWS = 50000;
     private static final int STRIPE_ROWS = 20000;
+    // Page source memory usage is reported rounded up to this granule,
+    // keep in sync with MemoryContextReservationHandler.REPORT_GRANULARITY
+    private static final long MEMORY_REPORT_GRANULARITY = 1 << 20;
     private static final TestingFunctionResolution FUNCTION_RESOLUTION = new TestingFunctionResolution();
     private static final ExpressionCompiler EXPRESSION_COMPILER = FUNCTION_RESOLUTION.getExpressionCompiler();
     private static final ConnectorSession UNCACHED_SESSION = HiveTestUtils.getHiveSession(new HiveConfig(), new OrcReaderConfig().setTinyStripeThreshold(DataSize.of(0, BYTE)));
@@ -203,7 +206,7 @@ public class TestOrcPageSourceMemoryTracking
 
         if (useCache) {
             // file is fully cached
-            assertThat(memoryContext.currentBytes).isBetween(testPreparer.getFileSize(), testPreparer.getFileSize() + 200);
+            assertThat(memoryContext.currentBytes).isEqualTo(MEMORY_REPORT_GRANULARITY);
         }
         else {
             assertThat(memoryContext.currentBytes).isEqualTo(0);
@@ -219,10 +222,10 @@ public class TestOrcPageSourceMemoryTracking
             if (memoryUsage == -1) {
                 // Memory usage before data loading
                 if (useCache) {
-                    assertThat(memoryContext.currentBytes).isBetween(testPreparer.getFileSize(), testPreparer.getFileSize() + 2000);
+                    assertThat(memoryContext.currentBytes).isEqualTo(MEMORY_REPORT_GRANULARITY);
                 }
                 else {
-                    assertThat(memoryContext.currentBytes).isBetween(0L, 1000L);
+                    assertThat(memoryContext.currentBytes).isIn(0L, MEMORY_REPORT_GRANULARITY);
                 }
 
                 // trigger data loading
@@ -230,10 +233,10 @@ public class TestOrcPageSourceMemoryTracking
 
                 memoryUsage = memoryContext.currentBytes;
                 if (useCache) {
-                    assertThat(memoryContext.currentBytes).isBetween(testPreparer.getFileSize() + 270_000, testPreparer.getFileSize() + 280_000);
+                    assertThat(memoryContext.currentBytes).isEqualTo(MEMORY_REPORT_GRANULARITY);
                 }
                 else {
-                    assertThat(memoryUsage).isBetween(460_000L, 469_999L);
+                    assertThat(memoryUsage).isEqualTo(MEMORY_REPORT_GRANULARITY);
                 }
             }
 
@@ -253,10 +256,10 @@ public class TestOrcPageSourceMemoryTracking
             if (memoryUsage == -1) {
                 // Memory usage before data loading
                 if (useCache) {
-                    assertThat(memoryContext.currentBytes).isBetween(testPreparer.getFileSize(), testPreparer.getFileSize() + 2000);
+                    assertThat(memoryContext.currentBytes).isEqualTo(MEMORY_REPORT_GRANULARITY);
                 }
                 else {
-                    assertThat(memoryContext.currentBytes).isBetween(0L, 1000L);
+                    assertThat(memoryContext.currentBytes).isIn(0L, MEMORY_REPORT_GRANULARITY);
                 }
 
                 // trigger data loading
@@ -264,10 +267,10 @@ public class TestOrcPageSourceMemoryTracking
 
                 memoryUsage = memoryContext.currentBytes;
                 if (useCache) {
-                    assertThat(memoryContext.currentBytes).isBetween(testPreparer.getFileSize() + 270_000, testPreparer.getFileSize() + 280_000);
+                    assertThat(memoryContext.currentBytes).isEqualTo(MEMORY_REPORT_GRANULARITY);
                 }
                 else {
-                    assertThat(memoryUsage).isBetween(460_000L, 469_999L);
+                    assertThat(memoryUsage).isEqualTo(MEMORY_REPORT_GRANULARITY);
                 }
             }
 
@@ -287,10 +290,10 @@ public class TestOrcPageSourceMemoryTracking
             if (memoryUsage == -1) {
                 // Memory usage before lazy-loading the block
                 if (useCache) {
-                    assertThat(memoryContext.currentBytes).isBetween(testPreparer.getFileSize(), testPreparer.getFileSize() + 2000);
+                    assertThat(memoryContext.currentBytes).isEqualTo(MEMORY_REPORT_GRANULARITY);
                 }
                 else {
-                    assertThat(memoryContext.currentBytes).isBetween(0L, 1000L);
+                    assertThat(memoryContext.currentBytes).isIn(0L, MEMORY_REPORT_GRANULARITY);
                 }
 
                 // trigger data loading
@@ -298,10 +301,10 @@ public class TestOrcPageSourceMemoryTracking
 
                 memoryUsage = memoryContext.currentBytes;
                 if (useCache) {
-                    assertThat(memoryContext.currentBytes).isBetween(testPreparer.getFileSize() + 260_000, testPreparer.getFileSize() + 270_000);
+                    assertThat(memoryContext.currentBytes).isEqualTo(MEMORY_REPORT_GRANULARITY);
                 }
                 else {
-                    assertThat(memoryUsage).isBetween(360_000L, 369_999L);
+                    assertThat(memoryUsage).isEqualTo(MEMORY_REPORT_GRANULARITY);
                 }
             }
 
@@ -317,7 +320,7 @@ public class TestOrcPageSourceMemoryTracking
         assertThat(pageSource.isFinished()).isTrue();
         if (useCache) {
             // file is fully cached
-            assertThat(memoryContext.currentBytes).isBetween(testPreparer.getFileSize(), testPreparer.getFileSize() + 200);
+            assertThat(memoryContext.currentBytes).isEqualTo(MEMORY_REPORT_GRANULARITY);
         }
         else {
             assertThat(memoryContext.currentBytes).isEqualTo(0);
@@ -418,7 +421,7 @@ public class TestOrcPageSourceMemoryTracking
                 assertThat(page).isNotNull();
                 if (memoryUsage == -1) {
                     memoryUsage = driverContext.getMemoryUsage();
-                    assertThat(memoryUsage).isBetween(460000L, 469999L);
+                    assertThat(memoryUsage).isEqualTo(MEMORY_REPORT_GRANULARITY);
                 }
                 else {
                     assertThat(driverContext.getMemoryUsage()).isEqualTo(memoryUsage);
@@ -433,7 +436,7 @@ public class TestOrcPageSourceMemoryTracking
                 assertThat(page).isNotNull();
                 if (memoryUsage == -1) {
                     memoryUsage = driverContext.getMemoryUsage();
-                    assertThat(memoryUsage).isBetween(460000L, 469999L);
+                    assertThat(memoryUsage).isEqualTo(MEMORY_REPORT_GRANULARITY);
                 }
                 else {
                     assertThat(driverContext.getMemoryUsage()).isEqualTo(memoryUsage);
@@ -448,7 +451,7 @@ public class TestOrcPageSourceMemoryTracking
                 assertThat(page).isNotNull();
                 if (memoryUsage == -1) {
                     memoryUsage = driverContext.getMemoryUsage();
-                    assertThat(memoryUsage).isBetween(360000L, 369999L);
+                    assertThat(memoryUsage).isEqualTo(MEMORY_REPORT_GRANULARITY);
                 }
                 else {
                     assertThat(driverContext.getMemoryUsage()).isEqualTo(memoryUsage);
@@ -482,7 +485,7 @@ public class TestOrcPageSourceMemoryTracking
 
                 // memory usage varies depending on stripe alignment
                 long memoryUsage = driverContext.getMemoryUsage();
-                assertThat(memoryUsage < 1000 || (memoryUsage > 150_000 && memoryUsage < 630_000))
+                assertThat(memoryUsage < 1000 || memoryUsage == MEMORY_REPORT_GRANULARITY)
                         .describedAs(format("Memory usage (%s) outside of bounds", memoryUsage))
                         .isTrue();
 


### PR DESCRIPTION
Report page source memory to the operator memory context only when usage moved by at least 1MB since the last report. Live per-page reporting from inside the parquet decode loop cost ~5% CPU on scan-heavy queries such as TPC-DS q64 on Iceberg.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
