### PR TITLE
Upgraded ignite-core to 2.18.0 to resolve CVE-2025-48977

### DIFF
--- a/plugin/trino-ignite/pom.xml
+++ b/plugin/trino-ignite/pom.xml
@@ -64,7 +64,25 @@
         <dependency>
             <groupId>org.apache.ignite</groupId>
             <artifactId>ignite-core</artifactId>
-            <version>2.17.0</version>
+            <version>2.18.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.ignite</groupId>
+                    <artifactId>ignite-binary-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.ignite</groupId>
+                    <artifactId>ignite-binary-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.ignite</groupId>
+                    <artifactId>ignite-commons</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.ignite</groupId>
+                    <artifactId>ignite-grid-unsafe</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-all/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-all/jvm.config
@@ -1,5 +1,6 @@
 -server
 --add-opens=java.base/java.nio=ALL-UNNAMED
+--add-opens=java.base/java.util=ALL-UNNAMED
 -Xmx2G
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-ignite/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/trino-product-tests/conf/environment/multinode-ignite/jvm.config
@@ -1,5 +1,6 @@
 -server
 --add-opens=java.base/java.nio=ALL-UNNAMED
+--add-opens=java.base/java.util=ALL-UNNAMED
 -Xmx2G
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent


### PR DESCRIPTION
## Description

Bumps `ignite-core` from 2.17.0 to 2.18.0 to resolve CVE-2025-48977, a high-severity
(CVSS 8.5) path traversal vulnerability in the Apache Ignite REST API. The vulnerability
allows an authenticated user to read arbitrary files on the server via a crafted `cmd=log`
request. All versions 2.0.0–2.17.0 are affected; 2.18.0 is the recommended fix.

In 2.18.0, Apache Ignite refactored `ignite-core` by extracting classes into separate
sub-modules (`ignite-commons`, `ignite-binary-api`, `ignite-binary-impl`,
`ignite-grid-unsafe`). These are pulled in as transitive dependencies but their classes
are still bundled in `ignite-core` itself, causing duplicate-class failures. The four
sub-modules are excluded to resolve this.

## Additional context and related issues

- CVE: [CVE-2025-48977](https://www.cve.org/CVERecord?id=CVE-2025-48977)
- Apache Ignite 2.18.0 release: https://ignite.apache.org/blog/

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
