### PR TITLE
Limit uncorrelated EXISTS subquery to single row

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -65,6 +65,7 @@ import io.trino.sql.planner.iterative.rule.ImplementOffset;
 import io.trino.sql.planner.iterative.rule.ImplementTableFunctionSource;
 import io.trino.sql.planner.iterative.rule.InlineProjectIntoFilter;
 import io.trino.sql.planner.iterative.rule.InlineProjections;
+import io.trino.sql.planner.iterative.rule.LimitBoolOrAggregationSource;
 import io.trino.sql.planner.iterative.rule.MergeExcept;
 import io.trino.sql.planner.iterative.rule.MergeFilters;
 import io.trino.sql.planner.iterative.rule.MergeIntersect;
@@ -609,6 +610,7 @@ public class PlanOptimizers
                                 .add(new InlineProjections())
                                 .addAll(new PushFilterThroughCountAggregation(plannerContext).rules()) // must run after PredicatePushDown and after TransformFilteringSemiJoinToInnerJoin
                                 .addAll(new PushFilterThroughBoolOrAggregation(plannerContext).rules())
+                                .add(new LimitBoolOrAggregationSource()) // must run after CheckSubqueryNodesAreRewritten
                                 .build()));
 
         // Perform redirection before CBO rules to ensure stats from destination connector are used

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/LimitBoolOrAggregationSource.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/LimitBoolOrAggregationSource.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.spi.function.CatalogSchemaFunctionName;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.AggregationNode;
+import io.trino.sql.planner.plan.AggregationNode.Aggregation;
+import io.trino.sql.planner.plan.LimitNode;
+import io.trino.sql.planner.plan.ProjectNode;
+
+import java.util.List;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
+import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.planner.optimizations.QueryCardinalityUtil.isAtMostScalar;
+import static io.trino.sql.planner.plan.AggregationNode.Step.SINGLE;
+import static io.trino.sql.planner.plan.Patterns.aggregation;
+import static io.trino.sql.planner.plan.Patterns.project;
+import static io.trino.sql.planner.plan.Patterns.source;
+
+/// Limit the source of a global `bool_or` aggregation over a constant `true`
+/// argument to a single row.
+///
+/// The result of `bool_or` over rows that are all `true` depends only on whether
+/// the source produces any row, so a single arbitrary row is sufficient. This shape
+/// is produced by [TransformExistsApplyToCorrelatedJoin] for uncorrelated EXISTS
+/// subqueries, where the inserted limit prevents a full scan of the subquery source.
+///
+/// Transforms:
+/// ```
+/// - aggregation
+///   global grouping
+///   bool <- bool_or(s)
+///     - project (s := true)
+///       - source
+/// ```
+/// into:
+/// ```
+/// - aggregation
+///   global grouping
+///   bool <- bool_or(s)
+///     - project (s := true)
+///       - limit (1)
+///         - source
+/// ```
+///
+/// The rule must run after subquery planning is complete (see `CheckSubqueryNodesAreRewritten`),
+/// when the aggregation source can no longer contain correlated references. Inserting the limit
+/// earlier could prevent decorrelation of EXISTS subqueries correlated with an outer query.
+public class LimitBoolOrAggregationSource
+        implements Rule<AggregationNode>
+{
+    private static final CatalogSchemaFunctionName BOOL_OR = builtinFunctionName("bool_or");
+
+    private static final Capture<ProjectNode> PROJECT = newCapture();
+
+    private static final Pattern<AggregationNode> PATTERN = aggregation()
+            .matching(LimitBoolOrAggregationSource::isGlobalBoolOr)
+            .with(source().matching(project().capturedAs(PROJECT)));
+
+    @Override
+    public Pattern<AggregationNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(AggregationNode node, Captures captures, Context context)
+    {
+        ProjectNode projectNode = captures.get(PROJECT);
+
+        Aggregation aggregation = getOnlyElement(node.getAggregations().values());
+        Symbol argument = Symbol.from(aggregation.getArguments().getFirst());
+        if (!TRUE.equals(projectNode.getAssignments().get(argument))) {
+            return Result.empty();
+        }
+
+        if (isAtMostScalar(projectNode.getSource(), context.getLookup())) {
+            return Result.empty();
+        }
+
+        LimitNode limit = new LimitNode(
+                context.getIdAllocator().getNextId(),
+                projectNode.getSource(),
+                1L,
+                false);
+        return Result.ofPlanNode(node.replaceChildren(ImmutableList.of(projectNode.replaceChildren(ImmutableList.of(limit)))));
+    }
+
+    private static boolean isGlobalBoolOr(AggregationNode node)
+    {
+        if (!node.hasSingleGlobalAggregation() || node.getStep() != SINGLE) {
+            return false;
+        }
+
+        if (node.getAggregations().size() != 1) {
+            return false;
+        }
+
+        Aggregation aggregation = getOnlyElement(node.getAggregations().values());
+        if (aggregation.isDistinct() ||
+                aggregation.getFilter().isPresent() ||
+                aggregation.getMask().isPresent() ||
+                aggregation.getOrderingScheme().isPresent()) {
+            return false;
+        }
+
+        if (!aggregation.getResolvedFunction().name().equals(BOOL_OR)) {
+            return false;
+        }
+
+        List<Expression> arguments = aggregation.getArguments();
+        return arguments.size() == 1 && arguments.getFirst() instanceof Reference;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -806,7 +806,24 @@ public class TestLogicalPlanner
                 anyTree(
                         node(AggregationNode.class,
                                 project(ImmutableMap.of("subquerytrue", expression(TRUE)),
-                                        tableScan("orders")))));
+                                        limit(1, anyTree(tableScan("orders")))))));
+    }
+
+    @Test
+    public void testUncorrelatedExistsSubqueryLimitedToSingleRow()
+    {
+        // Uncorrelated EXISTS only checks whether the subquery produces any row,
+        // so the subquery source is limited to a single row instead of being fully scanned.
+        assertPlan(
+                "SELECT regionkey FROM region WHERE EXISTS (SELECT 1 FROM nation)",
+                anyTree(
+                        join(INNER, builder -> builder
+                                .left(tableScan("region"))
+                                .right(
+                                        anyTree(
+                                                node(AggregationNode.class,
+                                                        project(ImmutableMap.of("subquerytrue", expression(TRUE)),
+                                                                limit(1, anyTree(tableScan("nation"))))))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestLimitBoolOrAggregationSource.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestLimitBoolOrAggregationSource.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import io.trino.sql.planner.plan.Assignments;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.sql.ir.Booleans.FALSE;
+import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregationFunction;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.limit;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestLimitBoolOrAggregationSource
+        extends BaseRuleTest
+{
+    @Test
+    public void testAddLimit()
+    {
+        tester().assertThat(new LimitBoolOrAggregationSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a", BIGINT);
+                    Symbol subqueryTrue = p.symbol("subquerytrue", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.aggregation(builder -> builder
+                            .globalGrouping()
+                            .addAggregation(aggrBool, PlanBuilder.aggregation("bool_or", ImmutableList.of(subqueryTrue.toSymbolReference())), ImmutableList.of(BOOLEAN))
+                            .source(p.project(
+                                    Assignments.of(subqueryTrue, TRUE),
+                                    p.values(2, a))));
+                })
+                .matches(
+                        aggregation(
+                                ImmutableMap.of("aggrbool", aggregationFunction("bool_or", ImmutableList.of("subquerytrue"))),
+                                project(
+                                        ImmutableMap.of("subquerytrue", expression(TRUE)),
+                                        limit(1, values("a")))));
+    }
+
+    @Test
+    public void testDoesNotFireOnGroupedAggregation()
+    {
+        tester().assertThat(new LimitBoolOrAggregationSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a", BIGINT);
+                    Symbol subqueryTrue = p.symbol("subquerytrue", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.aggregation(builder -> builder
+                            .singleGroupingSet(a)
+                            .addAggregation(aggrBool, PlanBuilder.aggregation("bool_or", ImmutableList.of(subqueryTrue.toSymbolReference())), ImmutableList.of(BOOLEAN))
+                            .source(p.project(
+                                    Assignments.builder()
+                                            .putIdentity(a)
+                                            .put(subqueryTrue, TRUE)
+                                            .build(),
+                                    p.values(2, a))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireOnOtherAggregationFunction()
+    {
+        tester().assertThat(new LimitBoolOrAggregationSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a", BIGINT);
+                    Symbol subqueryTrue = p.symbol("subquerytrue", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.aggregation(builder -> builder
+                            .globalGrouping()
+                            .addAggregation(aggrBool, PlanBuilder.aggregation("bool_and", ImmutableList.of(subqueryTrue.toSymbolReference())), ImmutableList.of(BOOLEAN))
+                            .source(p.project(
+                                    Assignments.of(subqueryTrue, TRUE),
+                                    p.values(2, a))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireOnMultipleAggregations()
+    {
+        tester().assertThat(new LimitBoolOrAggregationSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a", BIGINT);
+                    Symbol subqueryTrue = p.symbol("subquerytrue", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    Symbol count = p.symbol("count", BIGINT);
+                    return p.aggregation(builder -> builder
+                            .globalGrouping()
+                            .addAggregation(aggrBool, PlanBuilder.aggregation("bool_or", ImmutableList.of(subqueryTrue.toSymbolReference())), ImmutableList.of(BOOLEAN))
+                            .addAggregation(count, PlanBuilder.aggregation("count", ImmutableList.of()), ImmutableList.of())
+                            .source(p.project(
+                                    Assignments.of(subqueryTrue, TRUE),
+                                    p.values(2, a))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireOnMaskedAggregation()
+    {
+        tester().assertThat(new LimitBoolOrAggregationSource())
+                .on(p -> {
+                    Symbol mask = p.symbol("mask", BOOLEAN);
+                    Symbol subqueryTrue = p.symbol("subquerytrue", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.aggregation(builder -> builder
+                            .globalGrouping()
+                            .addAggregation(aggrBool, PlanBuilder.aggregation("bool_or", ImmutableList.of(subqueryTrue.toSymbolReference())), ImmutableList.of(BOOLEAN), mask)
+                            .source(p.project(
+                                    Assignments.builder()
+                                            .putIdentity(mask)
+                                            .put(subqueryTrue, TRUE)
+                                            .build(),
+                                    p.values(2, mask))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWhenArgumentNotConstantTrue()
+    {
+        tester().assertThat(new LimitBoolOrAggregationSource())
+                .on(p -> {
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol subqueryTrue = p.symbol("subquerytrue", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.aggregation(builder -> builder
+                            .globalGrouping()
+                            .addAggregation(aggrBool, PlanBuilder.aggregation("bool_or", ImmutableList.of(subqueryTrue.toSymbolReference())), ImmutableList.of(BOOLEAN))
+                            .source(p.project(
+                                    Assignments.of(subqueryTrue, bool.toSymbolReference()),
+                                    p.values(2, bool))));
+                })
+                .doesNotFire();
+
+        tester().assertThat(new LimitBoolOrAggregationSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a", BIGINT);
+                    Symbol subqueryTrue = p.symbol("subquerytrue", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.aggregation(builder -> builder
+                            .globalGrouping()
+                            .addAggregation(aggrBool, PlanBuilder.aggregation("bool_or", ImmutableList.of(subqueryTrue.toSymbolReference())), ImmutableList.of(BOOLEAN))
+                            .source(p.project(
+                                    Assignments.of(subqueryTrue, FALSE),
+                                    p.values(2, a))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWithoutProject()
+    {
+        tester().assertThat(new LimitBoolOrAggregationSource())
+                .on(p -> {
+                    Symbol bool = p.symbol("bool", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.aggregation(builder -> builder
+                            .globalGrouping()
+                            .addAggregation(aggrBool, PlanBuilder.aggregation("bool_or", ImmutableList.of(bool.toSymbolReference())), ImmutableList.of(BOOLEAN))
+                            .source(p.values(2, bool)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWhenSourceProducesAtMostSingleRow()
+    {
+        tester().assertThat(new LimitBoolOrAggregationSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a", BIGINT);
+                    Symbol subqueryTrue = p.symbol("subquerytrue", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.aggregation(builder -> builder
+                            .globalGrouping()
+                            .addAggregation(aggrBool, PlanBuilder.aggregation("bool_or", ImmutableList.of(subqueryTrue.toSymbolReference())), ImmutableList.of(BOOLEAN))
+                            .source(p.project(
+                                    Assignments.of(subqueryTrue, TRUE),
+                                    p.limit(1, p.values(2, a)))));
+                })
+                .doesNotFire();
+
+        tester().assertThat(new LimitBoolOrAggregationSource())
+                .on(p -> {
+                    Symbol a = p.symbol("a", BIGINT);
+                    Symbol subqueryTrue = p.symbol("subquerytrue", BOOLEAN);
+                    Symbol aggrBool = p.symbol("aggrbool", BOOLEAN);
+                    return p.aggregation(builder -> builder
+                            .globalGrouping()
+                            .addAggregation(aggrBool, PlanBuilder.aggregation("bool_or", ImmutableList.of(subqueryTrue.toSymbolReference())), ImmutableList.of(BOOLEAN))
+                            .source(p.project(
+                                    Assignments.of(subqueryTrue, TRUE),
+                                    p.values(1, a))));
+                })
+                .doesNotFire();
+    }
+}


### PR DESCRIPTION
## Description
Uncorrelated `EXISTS` subqueries are planned as a global `bool_or(true)` aggregation over the entire subquery, so a query like

```sql
SELECT a FROM table_1 WHERE EXISTS (SELECT 1 FROM table_2)
```

fully scans `table_2` even though producing a single row is enough to decide the result. The current workaround is to write `EXISTS (SELECT 1 FROM table_2 LIMIT 1)` manually.

`TransformExistsApplyToCorrelatedJoin` intentionally skips the efficient `Limit(1)` rewrite when the correlation list is empty, because an empty correlation list can also mean the subquery is correlated with symbols from a further outer scope, and the limit would prevent decorrelation in that case (see the TODO in that rule).

This change adds a new rule, `LimitBoolOrAggregationSource`, which inserts `Limit(1)` below a global `bool_or` aggregation over a constant `true` argument. The result of `bool_or` over rows that are all `true` depends only on whether the source produces any row, so a single arbitrary row is sufficient. The rule runs after `CheckSubqueryNodesAreRewritten`, when the plan can no longer contain correlated references, so it cannot interfere with decorrelation, and the further-outer-scope case keeps its current behavior.

Plan for `SELECT regionkey FROM region WHERE EXISTS (SELECT 1 FROM nation)` after this change:

```
CrossJoin
├─ TableScan[region]
└─ FilterProject[COALESCE(aggrbool, false)]
   └─ Aggregate[aggrbool := bool_or(subquerytrue)]
      └─ Project[subquerytrue := true]
         └─ Limit[count = 1]          <== inserted by the new rule
            └─ TableScan[nation]
```

Grouped `bool_or` aggregations produced by decorrelated correlated `EXISTS` subqueries are not affected, since limiting the source across groups would be incorrect.

## Additional context and related issues
The explicit rewrite of uncorrelated `EXISTS` to the aggregation form was introduced in #2007, together with the TODO explaining that the empty correlation list is ambiguous. This change does not resolve that ambiguity; it recovers the single-row behavior at a point in optimization where correlation is already guaranteed to be resolved.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve performance of uncorrelated `EXISTS` subqueries. ({issue}`30224`)
```
