### PR TITLE
Fix case-insensitive namespace resolution in REST catalog

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -1086,18 +1086,42 @@ public class TrinoRestCatalog
 
     private Namespace findRemoteNamespace(ConnectorSession session, Namespace trinoNamespace)
     {
-        List<Namespace> matchingRemoteNamespaces = listNamespaces(session, Namespace.empty()).stream()
-                .filter(ns -> toTrinoNamespace(ns).equals(trinoNamespace))
-                .collect(toImmutableList());
-        if (matchingRemoteNamespaces.size() > 1) {
-            throw new TrinoException(NOT_SUPPORTED, "Duplicate namespace names are not supported with Iceberg REST catalog: " + matchingRemoteNamespaces);
-        }
-        return matchingRemoteNamespaces.isEmpty() ? trinoNamespace : matchingRemoteNamespaces.getFirst();
+        // Convert session ONCE at the entry point to prevent OAuth token spam
+        // during recursive resolution.
+        SessionContext context = convert(session);
+
+        return resolveNamespaceHierarchically(context, trinoNamespace)
+                .orElse(trinoNamespace);
     }
 
-    private List<Namespace> listNamespaces(ConnectorSession session, Namespace parentNamespace)
+    private Optional<Namespace> resolveNamespaceHierarchically(SessionContext context, Namespace requestedNamespace)
     {
-        return listNamespaces(convert(session), parentNamespace);
+        // 1. OPTIMISTIC CHECK (Case-Sensitive API Fast-Path)
+        if (requestedNamespace.isEmpty() || restSessionCatalog.namespaceExists(context, requestedNamespace)) {
+            return Optional.of(requestedNamespace);
+        }
+
+        // 2. CASE-INSENSITIVE SEARCH
+        // Recursive Step: Resolve the parent path's true casing first
+        String[] parentLevels = Arrays.copyOf(requestedNamespace.levels(), requestedNamespace.length() - 1);
+        Namespace preservedCaseParentPath = Namespace.of(parentLevels);
+        Optional<Namespace> resolvedParent = resolveNamespaceHierarchically(context, preservedCaseParentPath);
+
+        return resolvedParent.flatMap(namespace -> findChildCaseInsensitive(context, namespace, toTrinoNamespace(requestedNamespace)));
+    }
+
+    private Optional<Namespace> findChildCaseInsensitive(SessionContext context, Namespace parent, Namespace trinoTargetNamespace)
+    {
+        List<Namespace> children = restSessionCatalog.listNamespaces(context, parent);
+
+        List<Namespace> matches = children.stream()
+                .filter(child -> toTrinoNamespace(child).equals(trinoTargetNamespace))
+                .collect(toImmutableList());
+        if (matches.size() > 1) {
+            throw new TrinoException(NOT_SUPPORTED, "Duplicate namespace names are not supported with Iceberg REST catalog: " + matches);
+        }
+
+        return matches.stream().findFirst();
     }
 
     private List<Namespace> listNamespaceIfExists(SessionContext sessionContext, Namespace namespace)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -272,6 +273,112 @@ public class TestTrinoRestCatalog
                 .cause()
                 .isInstanceOf(RESTException.class)
                 .hasMessage("catalog failure");
+    }
+
+    @Test
+    public void testSchemaExistsExactMatchAvoidsListing()
+    {
+        AtomicInteger listNamespacesCalls = new AtomicInteger(0);
+
+        RESTSessionCatalog restSessionCatalog = new RESTSessionCatalog()
+        {
+            @Override
+            public boolean namespaceExists(SessionContext context, Namespace namespace)
+            {
+                // Simulate that the exact path exists on the remote catalog
+                return namespace.equals(Namespace.of("My_Db", "My_Schema"));
+            }
+
+            @Override
+            public List<Namespace> listNamespaces(SessionContext context, Namespace namespace)
+            {
+                listNamespacesCalls.incrementAndGet();
+                return List.of();
+            }
+        };
+
+        // caseInsensitiveNameMatching = true
+        TrinoCatalog catalog = createTrinoRestCatalog(false, restSessionCatalog, true, false);
+
+        boolean exists = catalog.namespaceExists(SESSION, "My_Db.My_Schema");
+
+        assertThat(exists).isTrue();
+        // PROOF: listNamespaces was never called because optimistic check succeeded
+        assertThat(listNamespacesCalls.get()).isEqualTo(0);
+    }
+
+    @Test
+    public void testNamespaceExistsCaseInsensitiveParentLookup()
+    {
+        // Use Maps to record the exact requested path and its call frequency
+        Map<String, Integer> namespaceExistsCalls = new ConcurrentHashMap<>();
+        Map<String, Integer> listNamespacesCalls = new ConcurrentHashMap<>();
+
+        // The absolute truth of the case-sensitive remote catalog
+        Namespace trueRoot = Namespace.of("My_Db");
+        Namespace trueParent = Namespace.of("My_Db", "My_Schema");
+        Namespace trueChild = Namespace.of("My_Db", "My_Schema", "My_Subschema");
+
+        RESTSessionCatalog restSessionCatalog = new RESTSessionCatalog()
+        {
+            @Override
+            public boolean namespaceExists(SessionContext context, Namespace namespace)
+            {
+                // Record the exact string payload that Trino requested
+                String path = String.join(".", namespace.levels());
+                namespaceExistsCalls.merge(path.toLowerCase(ENGLISH), 1, Integer::sum);
+
+                // Strict Case-Sensitive Server logic
+                return namespace.equals(trueRoot) ||
+                        namespace.equals(trueParent) ||
+                        namespace.equals(trueChild);
+            }
+
+            @Override
+            public List<Namespace> listNamespaces(SessionContext context, Namespace namespace)
+            {
+                // Record the exact string payload requested for listing
+                String path = String.join(".", namespace.levels());
+                listNamespacesCalls.merge(path.toLowerCase(ENGLISH), 1, Integer::sum);
+
+                if (namespace.isEmpty()) {
+                    return List.of(trueRoot);
+                }
+                if (namespace.equals(trueRoot)) {
+                    return List.of(trueParent);
+                }
+                if (namespace.equals(trueParent)) {
+                    return List.of(trueChild);
+                }
+                return List.of();
+            }
+        };
+
+        TrinoCatalog catalog = createTrinoRestCatalog(false, restSessionCatalog, true, true);
+
+        // Input completely mangled casing.
+        boolean exists = catalog.namespaceExists(SESSION, "mY_Db.my_SCHema.my_SUBschEma");
+
+        // 1. Resolution must succeed
+        assertThat(exists).isTrue();
+
+        // 2. ASSERT EXACT LISTING TRAVERSAL
+        // Because optimistic checks failed, it had to walk the tree using the true casing at each step.
+        assertThat(listNamespacesCalls)
+                .as("Must list the root, then the verified DB, then the verified schema")
+                .hasSize(3)
+                .containsEntry("", 1)                  // Listed Root
+                .containsEntry("my_db", 1)             // Listed Database
+                .containsEntry("my_db.my_schema", 1);  // Listed Schema
+
+        // 3. ASSERT EXACT EXISTENCE CHECKS (Translation + Execution phases)
+        assertThat(namespaceExistsCalls)
+                .as("Must attempt optimistic translation lookups, then one final execution check")
+                .hasSize(3)
+                // PHASE 1: TRANSLATION (The Optimistic failures)
+                .containsEntry("my_db.my_schema.my_subschema", 2)
+                .containsEntry("my_db.my_schema", 1)
+                .containsEntry("my_db", 1);
     }
 
     private static class NamespaceDeletedDuringRecursiveListingCatalog


### PR DESCRIPTION
Fixing bad performance issue where hierarchical namespaces keep querying all schemas to find proper one.
Fall back to a hierarchical listNamespaces walk if the optimistic exact-match namespaceExists check fails due to case mismatch.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(*) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Improve performance of case-insensitive schema resolution in the Iceberg REST catalog by resolving paths hierarchically, avoiding recursive listings of all namespaces in the catalog.
```
