### PR TITLE
Add new IR optimizer/planner rules

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
@@ -56,6 +56,7 @@ import io.trino.sql.ir.optimizer.rule.FlattenLogical;
 import io.trino.sql.ir.optimizer.rule.FlattenNestedCase;
 import io.trino.sql.ir.optimizer.rule.InlineTrivialLet;
 import io.trino.sql.ir.optimizer.rule.MergeCaseClauses;
+import io.trino.sql.ir.optimizer.rule.RemoveAbsorbedLogicalTerms;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantCaseClauses;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantCoalesceArguments;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantInItems;
@@ -128,6 +129,7 @@ public class IrExpressionOptimizer
                 new EvaluateLogical(),
                 new FlattenLogical(),
                 new RemoveRedundantLogicalTerms(),
+                new RemoveAbsorbedLogicalTerms(context),
                 new DistributeComparisonOverMatch(context),
                 new DistributeComparisonOverCase(context),
                 new SimplifyRedundantCase(context),

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
@@ -53,6 +53,7 @@ import io.trino.sql.ir.optimizer.rule.EvaluateReference;
 import io.trino.sql.ir.optimizer.rule.EvaluateRow;
 import io.trino.sql.ir.optimizer.rule.FlattenCoalesce;
 import io.trino.sql.ir.optimizer.rule.FlattenLogical;
+import io.trino.sql.ir.optimizer.rule.FlattenNestedCase;
 import io.trino.sql.ir.optimizer.rule.InlineTrivialLet;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantCaseClauses;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantCoalesceArguments;
@@ -111,6 +112,7 @@ public class IrExpressionOptimizer
                 new EvaluateCallWithNullInput(),
                 new RemoveRedundantMatchClauses(context),
                 new RemoveRedundantCaseClauses(),
+                new FlattenNestedCase(),
                 new RemoveRedundantTry(context),
                 new RemoveRedundantInItems(context),
                 new SimplifyContinuousInValues(context),

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
@@ -55,6 +55,7 @@ import io.trino.sql.ir.optimizer.rule.FlattenCoalesce;
 import io.trino.sql.ir.optimizer.rule.FlattenLogical;
 import io.trino.sql.ir.optimizer.rule.FlattenNestedCase;
 import io.trino.sql.ir.optimizer.rule.InlineTrivialLet;
+import io.trino.sql.ir.optimizer.rule.MergeCaseClauses;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantCaseClauses;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantCoalesceArguments;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantInItems;
@@ -113,6 +114,7 @@ public class IrExpressionOptimizer
                 new RemoveRedundantMatchClauses(context),
                 new RemoveRedundantCaseClauses(),
                 new FlattenNestedCase(),
+                new MergeCaseClauses(context),
                 new RemoveRedundantTry(context),
                 new RemoveRedundantInItems(context),
                 new SimplifyContinuousInValues(context),

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
@@ -73,6 +73,7 @@ import io.trino.sql.ir.optimizer.rule.SimplifyRedundantCast;
 import io.trino.sql.ir.optimizer.rule.SimplifyRedundantTryCast;
 import io.trino.sql.ir.optimizer.rule.SimplifyStackedArithmeticNegation;
 import io.trino.sql.ir.optimizer.rule.SimplifyStackedNot;
+import io.trino.sql.ir.optimizer.rule.SpecializeCaseToMatch;
 import io.trino.sql.ir.optimizer.rule.SpecializeCastWithJsonParse;
 import io.trino.sql.ir.optimizer.rule.SpecializeTransformWithJsonParse;
 import io.trino.sql.planner.Symbol;
@@ -137,6 +138,9 @@ public class IrExpressionOptimizer
                 new DistributeComparisonOverMatch(context),
                 new DistributeComparisonOverCase(context),
                 new SimplifyRedundantCase(context),
+                // must run after SimplifyRedundantCase: constant boolean results are better
+                // expressed as plain logic than as a Match
+                new SpecializeCaseToMatch(context),
                 new SpecializeCastWithJsonParse(context),
                 new SpecializeTransformWithJsonParse(context)));
     }

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
@@ -37,6 +37,8 @@ import io.trino.sql.ir.Row;
 import io.trino.sql.ir.WhenClause;
 import io.trino.sql.ir.optimizer.rule.DistributeComparisonOverCase;
 import io.trino.sql.ir.optimizer.rule.DistributeComparisonOverMatch;
+import io.trino.sql.ir.optimizer.rule.DistributeIsNullOverCase;
+import io.trino.sql.ir.optimizer.rule.DistributeIsNullOverMatch;
 import io.trino.sql.ir.optimizer.rule.EvaluateArray;
 import io.trino.sql.ir.optimizer.rule.EvaluateBind;
 import io.trino.sql.ir.optimizer.rule.EvaluateCall;
@@ -137,6 +139,8 @@ public class IrExpressionOptimizer
                 new RemoveAbsorbedLogicalTerms(context),
                 new DistributeComparisonOverMatch(context),
                 new DistributeComparisonOverCase(context),
+                new DistributeIsNullOverMatch(),
+                new DistributeIsNullOverCase(),
                 new SimplifyRedundantCase(context),
                 // must run after SimplifyRedundantCase: constant boolean results are better
                 // expressed as plain logic than as a Match

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
@@ -54,8 +54,10 @@ import io.trino.sql.ir.optimizer.rule.EvaluateRow;
 import io.trino.sql.ir.optimizer.rule.FlattenCoalesce;
 import io.trino.sql.ir.optimizer.rule.FlattenLogical;
 import io.trino.sql.ir.optimizer.rule.FlattenNestedCase;
+import io.trino.sql.ir.optimizer.rule.FlattenNestedMatch;
 import io.trino.sql.ir.optimizer.rule.InlineTrivialLet;
 import io.trino.sql.ir.optimizer.rule.MergeCaseClauses;
+import io.trino.sql.ir.optimizer.rule.MergeMatchClauses;
 import io.trino.sql.ir.optimizer.rule.RemoveAbsorbedLogicalTerms;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantCaseClauses;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantCoalesceArguments;
@@ -113,6 +115,8 @@ public class IrExpressionOptimizer
                 new EvaluateIn(context),
                 new EvaluateCallWithNullInput(),
                 new RemoveRedundantMatchClauses(context),
+                new FlattenNestedMatch(),
+                new MergeMatchClauses(context),
                 new RemoveRedundantCaseClauses(),
                 new FlattenNestedCase(),
                 new MergeCaseClauses(context),

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
@@ -74,6 +74,7 @@ import io.trino.sql.ir.optimizer.rule.SimplifyRedundantCase;
 import io.trino.sql.ir.optimizer.rule.SimplifyRedundantCast;
 import io.trino.sql.ir.optimizer.rule.SimplifyRedundantTryCast;
 import io.trino.sql.ir.optimizer.rule.SimplifyStackedArithmeticNegation;
+import io.trino.sql.ir.optimizer.rule.SimplifyStackedCast;
 import io.trino.sql.ir.optimizer.rule.SimplifyStackedNot;
 import io.trino.sql.ir.optimizer.rule.SpecializeCaseToMatch;
 import io.trino.sql.ir.optimizer.rule.SpecializeCastWithJsonParse;
@@ -127,6 +128,7 @@ public class IrExpressionOptimizer
                 new RemoveRedundantInItems(context),
                 new SimplifyContinuousInValues(context),
                 new SimplifyRedundantCast(),
+                new SimplifyStackedCast(context),
                 new SimplifyRedundantTryCast(context),
                 new SimplifyCharLength(context),
                 new SimplifyStackedNot(),

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
@@ -54,6 +54,7 @@ import io.trino.sql.ir.optimizer.rule.EvaluateMatch;
 import io.trino.sql.ir.optimizer.rule.EvaluateReference;
 import io.trino.sql.ir.optimizer.rule.EvaluateRow;
 import io.trino.sql.ir.optimizer.rule.FlattenCoalesce;
+import io.trino.sql.ir.optimizer.rule.FlattenConcat;
 import io.trino.sql.ir.optimizer.rule.FlattenLogical;
 import io.trino.sql.ir.optimizer.rule.FlattenNestedCase;
 import io.trino.sql.ir.optimizer.rule.FlattenNestedMatch;
@@ -134,6 +135,7 @@ public class IrExpressionOptimizer
                 new SimplifyStackedNot(),
                 new SimplifyStackedArithmeticNegation(),
                 new FlattenCoalesce(),
+                new FlattenConcat(context),
                 new RemoveRedundantCoalesceArguments(context),
                 new EvaluateLogical(),
                 new FlattenLogical(),

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/DistributeIsNullOverCase.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/DistributeIsNullOverCase.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer.rule;
+
+import io.trino.Session;
+import io.trino.sql.ir.Case;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.WhenClause;
+import io.trino.sql.ir.optimizer.IrOptimizerRule;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.sql.ir.IrExpressions.matchNullIf;
+
+/// Transforms:
+/// ```
+/// $is_null(Case([When(c1, r1), When(c2, r2), ...], d))
+/// ```
+/// into:
+/// ```
+/// Case([When(c1, $is_null(r1)), When(c2, $is_null(r2)), ...], $is_null(d))
+/// ```
+/// so that the per-branch nullability can be evaluated further (e.g., constant branches fold
+/// to true or false).
+public class DistributeIsNullOverCase
+        implements IrOptimizerRule
+{
+    @Override
+    public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
+    {
+        if (!(expression instanceof IsNull(Case caseTerm))) {
+            return Optional.empty();
+        }
+
+        // Leave a desugared NULLIF intact so it stays recognizable for connector pushdown.
+        if (matchNullIf(caseTerm) != null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new Case(
+                caseTerm.whenClauses().stream()
+                        .map(clause -> new WhenClause(clause.getOperand(), new IsNull(clause.getResult())))
+                        .toList(),
+                new IsNull(caseTerm.defaultValue())));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/DistributeIsNullOverMatch.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/DistributeIsNullOverMatch.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer.rule;
+
+import io.trino.Session;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.Match;
+import io.trino.sql.ir.MatchClause;
+import io.trino.sql.ir.optimizer.IrOptimizerRule;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+
+import java.util.Map;
+import java.util.Optional;
+
+/// Transforms:
+/// ```
+/// $is_null(Match(x, [When(p1, r1), When(p2, r2), ...], d))
+/// ```
+/// into:
+/// ```
+/// Match(x, [When(p1, $is_null(r1)), When(p2, $is_null(r2)), ...], $is_null(d))
+/// ```
+/// so that the per-clause nullability can be evaluated further (e.g., constant results fold
+/// to true or false).
+public class DistributeIsNullOverMatch
+        implements IrOptimizerRule
+{
+    @Override
+    public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
+    {
+        if (!(expression instanceof IsNull(Match match))) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new Match(
+                match.operand(),
+                match.clauses().stream()
+                        .map(clause -> new MatchClause(clause.predicate(), new IsNull(clause.result())))
+                        .toList(),
+                new IsNull(match.defaultValue())));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/EvaluateIsNull.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/EvaluateIsNull.java
@@ -15,8 +15,12 @@ package io.trino.sql.ir.optimizer.rule;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.spi.function.FunctionNullability;
+import io.trino.spi.type.FunctionType;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.IrExpressions.Comparison;
@@ -26,9 +30,11 @@ import io.trino.sql.ir.optimizer.IrOptimizerRule;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
 import static io.trino.sql.ir.Booleans.FALSE;
 import static io.trino.sql.ir.Booleans.TRUE;
@@ -36,6 +42,8 @@ import static io.trino.sql.ir.ComparisonOperator.IDENTICAL;
 import static io.trino.sql.ir.IrExpressions.matchComparison;
 import static io.trino.sql.ir.IrExpressions.mayBeNull;
 import static io.trino.sql.ir.IrExpressions.mayFail;
+import static io.trino.sql.ir.IrUtils.and;
+import static io.trino.sql.ir.IrUtils.or;
 import static io.trino.sql.ir.Logical.Operator.OR;
 import static io.trino.type.BooleanOperators.NOT_FUNCTION_NAME;
 import static java.util.Objects.requireNonNull;
@@ -48,6 +56,8 @@ import static java.util.Objects.requireNonNull;
  *     <li>{@code $is_null(1::bigint) -> false}
  *     <li>{@code $is_null($is_null(...) -> false}
  *     <li>{@code $is_null(Cast(x, t)) -> $is_null(x)}
+ *     <li>{@code $is_null(Coalesce(a, b)) -> And($is_null(a), $is_null(b))}
+ *     <li>{@code $is_null($add(a, b)) -> Or($is_null(a), $is_null(b))} for strict functions that cannot fail
  *     <li>...
  * </ul>
  */
@@ -64,11 +74,9 @@ public class EvaluateIsNull
     @Override
     public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
     {
-        if (!(expression instanceof IsNull isNull)) {
+        if (!(expression instanceof IsNull(Expression value))) {
             return Optional.empty();
         }
-
-        Expression value = isNull.value();
 
         if (value instanceof Constant inner) {
             return Optional.of(inner.value() == null ? TRUE : FALSE);
@@ -80,14 +88,38 @@ public class EvaluateIsNull
                     new IsNull(comparison.right()))));
         }
 
-        if (value instanceof Call inner && inner.function().name().equals(builtinFunctionName(NOT_FUNCTION_NAME))) {
-            return Optional.of(new IsNull(inner.arguments().getFirst()));
+        if (value instanceof Call(ResolvedFunction function, List<Expression> arguments) && function.name().equals(builtinFunctionName(NOT_FUNCTION_NAME))) {
+            return Optional.of(new IsNull(arguments.getFirst()));
         }
 
         if (!mayBeNull(plannerContext, value) && !mayFail(plannerContext, value)) {
             return Optional.of(FALSE);
         }
 
+        if (value instanceof Coalesce(List<Expression> operands)) {
+            // null if and only if all operands are null. The conjunction preserves laziness:
+            // both forms evaluate an operand only when all preceding operands are null.
+            return Optional.of(and(operands.stream()
+                    .map(IsNull::new)
+                    .collect(toImmutableList())));
+        }
+
+        if (value instanceof Call call &&
+                returnsNullIfAndOnlyIfAnyArgumentIsNull(call.function().functionNullability()) &&
+                call.arguments().stream().noneMatch(argument -> argument.type() instanceof FunctionType) &&
+                !mayFail(plannerContext, call)) {
+            // The function must not fail, since it is no longer evaluated.
+            return Optional.of(or(call.arguments().stream()
+                    .map(IsNull::new)
+                    .collect(toImmutableList())));
+        }
+
         return Optional.empty();
+    }
+
+    private static boolean returnsNullIfAndOnlyIfAnyArgumentIsNull(FunctionNullability nullability)
+    {
+        return !nullability.isReturnNullable() &&
+                nullability.getArgumentNullable().stream().noneMatch(nullable -> nullable);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/FlattenConcat.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/FlattenConcat.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.spi.function.CatalogSchemaFunctionName;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.optimizer.IrOptimizerRule;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
+import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+
+/// Flatten nested calls to the variadic `concat` function into a single call. E.g.,
+/// - `concat(concat(a, b), c) -> concat(a, b, c)`
+///
+/// The `||` operator parses into nested two-argument `concat` calls, so `a || b || c` evaluates
+/// through an intermediate copy. A single variadic call produces the same value without
+/// materializing intermediate results: `concat` is strict, deterministic, preserves argument
+/// order, and its failure behavior does not depend on association (the accumulated length
+/// exceeds the limit for some nesting if and only if the total length does).
+///
+/// Only the uniform variants (all argument types equal to the result type: `varchar`,
+/// `varbinary`, and `array` concatenation) participate. The `element || array` form has a
+/// different signature and cannot be merged into a variadic call.
+public class FlattenConcat
+        implements IrOptimizerRule
+{
+    private static final CatalogSchemaFunctionName CONCAT_NAME = builtinFunctionName("concat");
+
+    private final Metadata metadata;
+
+    public FlattenConcat(PlannerContext context)
+    {
+        metadata = context.getMetadata();
+    }
+
+    @Override
+    public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
+    {
+        if (!(expression instanceof Call(ResolvedFunction function, List<Expression> arguments)) || !isUniformConcat(function)) {
+            return Optional.empty();
+        }
+
+        if (arguments.stream().noneMatch(FlattenConcat::isUniformConcatCall)) {
+            return Optional.empty();
+        }
+
+        ImmutableList.Builder<Expression> flattened = ImmutableList.builder();
+        for (Expression argument : arguments) {
+            if (argument instanceof Call(ResolvedFunction innerFunction, List<Expression> innerArguments) && isUniformConcat(innerFunction)) {
+                flattened.addAll(innerArguments);
+            }
+            else {
+                flattened.add(argument);
+            }
+        }
+
+        List<Expression> newArguments = flattened.build();
+        return Optional.of(new Call(
+                metadata.resolveBuiltinFunction("concat", fromTypes(newArguments.stream()
+                        .map(Expression::type)
+                        .collect(toImmutableList()))),
+                newArguments));
+    }
+
+    private static boolean isUniformConcatCall(Expression expression)
+    {
+        return expression instanceof Call call && isUniformConcat(call.function());
+    }
+
+    private static boolean isUniformConcat(ResolvedFunction function)
+    {
+        return function.name().equals(CONCAT_NAME) &&
+                function.signature().getArgumentTypes().stream()
+                        .allMatch(type -> type.equals(function.signature().getReturnType()));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/FlattenNestedCase.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/FlattenNestedCase.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.sql.ir.Case;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.WhenClause;
+import io.trino.sql.ir.optimizer.IrOptimizerRule;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.sql.ir.IrUtils.and;
+
+/// Flatten Case expressions nested inside another Case. E.g.,
+/// - `Case([When(a, r1)], Case([When(b, r2)], d)) -> Case([When(a, r1), When(b, r2)], d)`
+/// - `Case([When(a, Case([When(b, r)], d))], d) -> Case([When(And(a, b), r)], d)`
+///
+/// The second pattern applies only to the last clause: for an earlier clause the original
+/// expression produces the shared default when `a` is true and `b` is not, whereas
+/// the flattened form would fall through to the remaining clauses.
+public class FlattenNestedCase
+        implements IrOptimizerRule
+{
+    @Override
+    public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
+    {
+        if (!(expression instanceof Case(List<WhenClause> whenClauses, Expression defaultValue))) {
+            return Optional.empty();
+        }
+
+        boolean changed = false;
+        List<WhenClause> clauses = whenClauses;
+
+        WhenClause lastClause = clauses.getLast();
+        if (lastClause.getResult() instanceof Case(List<WhenClause> innerClauses, Expression innerDefault) &&
+                innerClauses.size() == 1 &&
+                innerDefault.equals(defaultValue)) {
+            WhenClause innerClause = innerClauses.getFirst();
+            clauses = ImmutableList.<WhenClause>builderWithExpectedSize(clauses.size())
+                    .addAll(clauses.subList(0, clauses.size() - 1))
+                    .add(new WhenClause(and(lastClause.getOperand(), innerClause.getOperand()), innerClause.getResult()))
+                    .build();
+            changed = true;
+        }
+
+        if (defaultValue instanceof Case(List<WhenClause> innerClauses, Expression innerDefault)) {
+            clauses = ImmutableList.<WhenClause>builderWithExpectedSize(clauses.size() + innerClauses.size())
+                    .addAll(clauses)
+                    .addAll(innerClauses)
+                    .build();
+            defaultValue = innerDefault;
+            changed = true;
+        }
+
+        if (!changed) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new Case(clauses, defaultValue));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/FlattenNestedMatch.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/FlattenNestedMatch.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Match;
+import io.trino.sql.ir.MatchClause;
+import io.trino.sql.ir.optimizer.IrOptimizerRule;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
+
+/// Flatten a Match nested in the default clause of another Match over the same operand. E.g.,
+/// - `Match(x, [When(p1, r1)], Match(x, [When(p2, r2)], d)) -> Match(x, [When(p1, r1), When(p2, r2)], d)`
+///
+/// The operand must be deterministic: the original expression evaluates it a second time when
+/// no outer clause matches, and the rewrite is valid only when both evaluations are guaranteed
+/// to produce the same value.
+public class FlattenNestedMatch
+        implements IrOptimizerRule
+{
+    @Override
+    public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
+    {
+        if (!(expression instanceof Match(Expression operand, List<MatchClause> clauses, Expression defaultValue))) {
+            return Optional.empty();
+        }
+
+        if (!(defaultValue instanceof Match(Expression innerOperand, List<MatchClause> innerClauses, Expression innerDefault))) {
+            return Optional.empty();
+        }
+
+        if (!operand.equals(innerOperand) || !isDeterministic(operand)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new Match(
+                operand,
+                ImmutableList.<MatchClause>builderWithExpectedSize(clauses.size() + innerClauses.size())
+                        .addAll(clauses)
+                        .addAll(innerClauses)
+                        .build(),
+                innerDefault));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/MergeCaseClauses.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/MergeCaseClauses.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Case;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.WhenClause;
+import io.trino.sql.ir.optimizer.IrOptimizerRule;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.sql.ir.IrExpressions.mayFail;
+import static io.trino.sql.ir.IrUtils.or;
+import static java.util.Objects.requireNonNull;
+
+/// Merge Case clauses that produce the same result. E.g.,
+/// - `Case([When(a, r1), When(b, r1), When(c, r2)], d) -> Case([When(Or(a, b), r1), When(c, r2)], d)`
+/// - `Case([When(a, r), When(b, d)], d) -> Case([When(a, r)], d)`
+/// - `Case([When(a, d)], d) -> d`
+///
+/// Only adjacent clauses are merged: merging a clause past one with a different result would
+/// change which clause wins when both operands are true. Trailing clauses whose result equals
+/// the default are dropped only when their operands cannot fail — the operand's value no longer
+/// affects the output, but skipping it would also skip its error.
+public class MergeCaseClauses
+        implements IrOptimizerRule
+{
+    private final PlannerContext plannerContext;
+
+    public MergeCaseClauses(PlannerContext plannerContext)
+    {
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+    }
+
+    @Override
+    public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
+    {
+        if (!(expression instanceof Case(List<WhenClause> whenClauses, Expression defaultValue))) {
+            return Optional.empty();
+        }
+
+        boolean changed = false;
+
+        List<WhenClause> clauses = new ArrayList<>(whenClauses);
+        while (!clauses.isEmpty() &&
+                clauses.getLast().getResult().equals(defaultValue) &&
+                !mayFail(plannerContext, clauses.getLast().getOperand())) {
+            clauses.removeLast();
+            changed = true;
+        }
+
+        if (clauses.isEmpty()) {
+            return Optional.of(defaultValue);
+        }
+
+        ImmutableList.Builder<WhenClause> merged = ImmutableList.builderWithExpectedSize(clauses.size());
+        int index = 0;
+        while (index < clauses.size()) {
+            WhenClause clause = clauses.get(index);
+            int start = index;
+            index++;
+            while (index < clauses.size() && clauses.get(index).getResult().equals(clause.getResult())) {
+                index++;
+            }
+
+            if (index - start == 1) {
+                merged.add(clause);
+            }
+            else {
+                List<Expression> operands = clauses.subList(start, index).stream()
+                        .map(WhenClause::getOperand)
+                        .collect(toImmutableList());
+                merged.add(new WhenClause(or(operands), clause.getResult()));
+                changed = true;
+            }
+        }
+
+        if (!changed) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new Case(merged.build(), defaultValue));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/MergeMatchClauses.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/MergeMatchClauses.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.ExpressionRewriter;
+import io.trino.sql.ir.ExpressionTreeRewriter;
+import io.trino.sql.ir.Lambda;
+import io.trino.sql.ir.Match;
+import io.trino.sql.ir.MatchClause;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.optimizer.IrOptimizerRule;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.sql.ir.IrExpressions.mayFail;
+import static io.trino.sql.ir.IrUtils.or;
+import static java.util.Objects.requireNonNull;
+
+/// Merge Match clauses that produce the same result. E.g.,
+/// - `Match(x, [When(p1, r1), When(p2, r1), When(p3, r2)], d) -> Match(x, [When(Or(p1, p2), r1), When(p3, r2)], d)`
+/// - `Match(x, [When(p1, r), When(p2, d)], d) -> Match(x, [When(p1, r)], d)`
+/// - `Match(x, [When(p, d)], d) -> d`
+///
+/// Only adjacent clauses are merged: merging a clause past one with a different result would
+/// change which clause wins when both predicates match. Trailing clauses whose result equals
+/// the default are dropped only when their predicates cannot fail — the predicate's value no
+/// longer affects the output, but skipping it would also skip its error. Removing the last
+/// clause additionally requires the operand to not fail, since it is no longer evaluated.
+/// Clauses with capture-desugared (Bind-wrapped) predicates are left as-is.
+public class MergeMatchClauses
+        implements IrOptimizerRule
+{
+    private final PlannerContext plannerContext;
+
+    public MergeMatchClauses(PlannerContext plannerContext)
+    {
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+    }
+
+    @Override
+    public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
+    {
+        if (!(expression instanceof Match(Expression operand, List<MatchClause> matchClauses, Expression defaultValue))) {
+            return Optional.empty();
+        }
+
+        boolean changed = false;
+
+        List<MatchClause> clauses = new ArrayList<>(matchClauses);
+        while (!clauses.isEmpty()) {
+            MatchClause last = clauses.getLast();
+            if (!last.result().equals(defaultValue) ||
+                    last.bind() != null ||
+                    mayFail(plannerContext, last.lambda().body())) {
+                break;
+            }
+            if (clauses.size() == 1 && mayFail(plannerContext, operand)) {
+                break;
+            }
+            clauses.removeLast();
+            changed = true;
+        }
+
+        if (clauses.isEmpty()) {
+            return Optional.of(defaultValue);
+        }
+
+        ImmutableList.Builder<MatchClause> merged = ImmutableList.builderWithExpectedSize(clauses.size());
+        int index = 0;
+        while (index < clauses.size()) {
+            MatchClause clause = clauses.get(index);
+            int start = index;
+            do {
+                index++;
+            }
+            while (index < clauses.size() &&
+            clause.bind() == null &&
+            clauses.get(index).bind() == null &&
+            clauses.get(index).result().equals(clause.result()));
+
+            if (index - start == 1) {
+                merged.add(clause);
+            }
+            else {
+                merged.add(new MatchClause(mergePredicates(clauses.subList(start, index)), clause.result()));
+                changed = true;
+            }
+        }
+
+        if (!changed) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new Match(operand, merged.build(), defaultValue));
+    }
+
+    private static Lambda mergePredicates(List<MatchClause> clauses)
+    {
+        Lambda first = clauses.getFirst().lambda();
+        Symbol parameter = getOnlyElement(first.arguments());
+
+        List<Expression> disjuncts = new ArrayList<>();
+        disjuncts.add(first.body());
+        for (MatchClause clause : clauses.subList(1, clauses.size())) {
+            Lambda lambda = clause.lambda();
+            disjuncts.add(replaceParameter(lambda.body(), getOnlyElement(lambda.arguments()), parameter));
+        }
+
+        return new Lambda(first.arguments(), or(disjuncts));
+    }
+
+    private static Expression replaceParameter(Expression body, Symbol from, Symbol to)
+    {
+        if (from.equals(to)) {
+            return body;
+        }
+
+        return ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<>()
+        {
+            @Override
+            public Expression rewriteReference(Reference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                if (node.name().equals(from.name())) {
+                    return to.toSymbolReference();
+                }
+                return node;
+            }
+        }, body);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/RemoveAbsorbedLogicalTerms.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/RemoveAbsorbedLogicalTerms.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.trino.Session;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Logical;
+import io.trino.sql.ir.optimizer.IrOptimizerRule;
+import io.trino.sql.planner.DeterminismEvaluator;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.trino.sql.ir.IrExpressions.mayFail;
+import static io.trino.sql.ir.Logical.Operator.AND;
+import static io.trino.sql.ir.Logical.Operator.OR;
+import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
+import static java.util.Objects.requireNonNull;
+
+/// Apply the absorption laws of boolean algebra, which hold in three-valued logic. E.g.,
+/// - `Or(a, And(a, b)) -> a`
+/// - `And(a, Or(a, b)) -> a`
+/// - `Or(And(a, b), And(a, b, c)) -> And(a, b)`
+///
+/// In general, a term is absorbed when the sub-terms of another term are a subset of its own
+/// sub-terms. The shared sub-terms must be deterministic — otherwise the two occurrences may
+/// evaluate to different values — and the absorbed extra sub-terms must not fail, since
+/// dropping them also drops their error.
+public class RemoveAbsorbedLogicalTerms
+        implements IrOptimizerRule
+{
+    private final PlannerContext plannerContext;
+
+    public RemoveAbsorbedLogicalTerms(PlannerContext plannerContext)
+    {
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+    }
+
+    @Override
+    public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
+    {
+        if (!(expression instanceof Logical(Logical.Operator operator, List<Expression> terms))) {
+            return Optional.empty();
+        }
+
+        Logical.Operator innerOperator = operator == AND ? OR : AND;
+
+        List<Set<Expression>> subTerms = terms.stream()
+                .map(term -> subTerms(term, innerOperator))
+                .toList();
+
+        boolean[] absorbed = new boolean[terms.size()];
+        for (int i = 0; i < terms.size(); i++) {
+            if (!(terms.get(i) instanceof Logical inner) || inner.operator() != innerOperator) {
+                // a term without sub-terms can only be absorbed by an equal term, which
+                // RemoveRedundantLogicalTerms already handles
+                continue;
+            }
+            for (int j = 0; j < terms.size(); j++) {
+                if (j != i && absorbs(subTerms.get(j), subTerms.get(i), j < i)) {
+                    absorbed[i] = true;
+                    break;
+                }
+            }
+        }
+
+        ImmutableList.Builder<Expression> remaining = ImmutableList.builderWithExpectedSize(terms.size());
+        for (int i = 0; i < terms.size(); i++) {
+            if (!absorbed[i]) {
+                remaining.add(terms.get(i));
+            }
+        }
+
+        List<Expression> newTerms = remaining.build();
+        if (newTerms.size() == terms.size()) {
+            return Optional.empty();
+        }
+
+        if (newTerms.size() == 1) {
+            return Optional.of(newTerms.getFirst());
+        }
+
+        return Optional.of(new Logical(operator, newTerms));
+    }
+
+    private boolean absorbs(Set<Expression> absorber, Set<Expression> term, boolean firstWinsTie)
+    {
+        if (!term.containsAll(absorber)) {
+            return false;
+        }
+
+        if (absorber.size() == term.size() && !firstWinsTie) {
+            // terms with equal sub-term sets absorb each other; keep the first one
+            return false;
+        }
+
+        return absorber.stream()
+                .allMatch(DeterminismEvaluator::isDeterministic) && Sets.difference(term, absorber).stream().
+        noneMatch(extra -> mayFail(plannerContext, extra));
+    }
+
+    private static Set<Expression> subTerms(Expression term, Logical.Operator operator)
+    {
+        if (term instanceof Logical(Logical.Operator innerOperator, List<Expression> terms) && innerOperator == operator) {
+            return ImmutableSet.copyOf(terms);
+        }
+        return ImmutableSet.of(term);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyStackedCast.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyStackedCast.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer.rule;
+
+import io.trino.Session;
+import io.trino.metadata.OperatorNotFoundException;
+import io.trino.spi.type.Type;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Cast;
+import io.trino.sql.ir.Cast.Kind;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.optimizer.IrOptimizerRule;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.sql.ir.Cast.Kind.REINTERPRET;
+import static java.util.Objects.requireNonNull;
+
+/// Collapse stacked casts when the inner cast is a type-only coercion. E.g.,
+/// - `Cast(Cast(x::varchar(5), varchar(20)), bigint) -> Cast(x, bigint)`
+///
+/// A type-only coercion does not change the value, so casting the original value directly to
+/// the target type produces the same result.
+public class SimplifyStackedCast
+        implements IrOptimizerRule
+{
+    private final PlannerContext plannerContext;
+
+    public SimplifyStackedCast(PlannerContext plannerContext)
+    {
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+    }
+
+    @Override
+    public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
+    {
+        if (!(expression instanceof Cast(Cast(Expression inner, Type _, Kind innerKind), Type targetType, Kind targetKind))) {
+            return Optional.empty();
+        }
+
+        // A REINTERPRET inner cast preserves the physical representation, so `inner` and the intermediate value
+        // share a representation. Casting `inner` straight to the target therefore yields the same result and,
+        // by the same reasoning, the same kind as the outer cast (validated by TypeValidator).
+        if (innerKind != REINTERPRET) {
+            return Optional.empty();
+        }
+
+        try {
+            plannerContext.getMetadata().getCoercion(inner.type(), targetType);
+        }
+        catch (OperatorNotFoundException e) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new Cast(inner, targetType, targetKind));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SpecializeCaseToMatch.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SpecializeCaseToMatch.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.metadata.Metadata;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Case;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.IrExpressions.Comparison;
+import io.trino.sql.ir.Match;
+import io.trino.sql.ir.MatchClause;
+import io.trino.sql.ir.WhenClause;
+import io.trino.sql.ir.optimizer.IrOptimizerRule;
+import io.trino.sql.planner.DeterminismEvaluator;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+import io.trino.sql.planner.iterative.rule.LambdaCaptureDesugaringRewriter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.sql.ir.IrExpressions.equalityClause;
+import static io.trino.sql.ir.IrExpressions.matchComparison;
+import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
+
+/// Convert a searched Case whose clauses all compare the same expression for equality into a
+/// Match over that expression. E.g.,
+/// - `Case([When(x = 1, r1), When(2 = x, r2)], d) -> Match(x, [When(= 1, r1), When(= 2, r2)], d)`
+///
+/// Match evaluates the shared operand once instead of per clause, and the equality-shaped
+/// clauses become visible to the Match rules (deduplication, merging, flattening). The operand
+/// must be deterministic, since its per-clause evaluations collapse into one, and non-constant,
+/// since a constant has no repeated evaluation to save. Single-clause expressions are left
+/// alone for the same reason. Clause values that reference symbols get their captures lifted
+/// into an explicit Bind, matching the post-desugaring lambda form the engine expects.
+public class SpecializeCaseToMatch
+        implements IrOptimizerRule
+{
+    private final Metadata metadata;
+
+    public SpecializeCaseToMatch(PlannerContext context)
+    {
+        metadata = context.getMetadata();
+    }
+
+    @Override
+    public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
+    {
+        if (!(expression instanceof Case(List<WhenClause> whenClauses, Expression defaultValue))) {
+            return Optional.empty();
+        }
+
+        if (whenClauses.size() < 2) {
+            return Optional.empty();
+        }
+
+        List<Comparison.Equal> equalities = new ArrayList<>();
+        for (WhenClause clause : whenClauses) {
+            if (!(matchComparison(clause.getOperand()) instanceof Comparison.Equal equality)) {
+                return Optional.empty();
+            }
+            equalities.add(equality);
+        }
+
+        List<Expression> candidates = new ArrayList<>();
+        candidates.add(equalities.getFirst().left());
+        candidates.add(equalities.getFirst().right());
+        for (Comparison.Equal equality : equalities) {
+            candidates.removeIf(candidate -> !candidate.equals(equality.left()) && !candidate.equals(equality.right()));
+            if (candidates.isEmpty()) {
+                return Optional.empty();
+            }
+        }
+
+        // A constant operand offers no repeated evaluation to save, so don't consider it.
+        Optional<Expression> commonOperand = candidates.stream()
+                .filter(candidate -> !(candidate instanceof Constant))
+                .filter(DeterminismEvaluator::isDeterministic)
+                .findFirst();
+        if (commonOperand.isEmpty()) {
+            return Optional.empty();
+        }
+        Expression operand = commonOperand.get();
+
+        Symbol parameter = symbolAllocator.newSymbol("match", operand.type());
+        ImmutableList.Builder<MatchClause> clauses = ImmutableList.builderWithExpectedSize(whenClauses.size());
+        for (int i = 0; i < whenClauses.size(); i++) {
+            Comparison.Equal equality = equalities.get(i);
+            Expression value = equality.left().equals(operand) ? equality.right() : equality.left();
+            MatchClause clause = equalityClause(metadata, parameter, value, whenClauses.get(i).getResult());
+            // This rule runs after DesugarLambdaExpressions, when lambdas must no longer reference
+            // outer-scope symbols directly; a value containing references needs its captures lifted
+            // into an explicit Bind.
+            clauses.add(new MatchClause(
+                    LambdaCaptureDesugaringRewriter.rewrite(clause.predicate(), symbolAllocator),
+                    clause.result()));
+        }
+
+        return Optional.of(new Match(operand, clauses.build(), defaultValue));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyFilterPredicate.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyFilterPredicate.java
@@ -21,6 +21,7 @@ import io.trino.sql.ir.Case;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.IrExpressions;
+import io.trino.sql.ir.IrExpressions.Comparison;
 import io.trino.sql.ir.IsNull;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Match;
@@ -36,9 +37,13 @@ import java.util.Optional;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.sql.ir.Booleans.FALSE;
 import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.ir.ComparisonOperator.IDENTICAL;
+import static io.trino.sql.ir.IrExpressions.comparison;
+import static io.trino.sql.ir.IrExpressions.matchComparison;
 import static io.trino.sql.ir.IrExpressions.not;
 import static io.trino.sql.ir.IrUtils.combineConjuncts;
 import static io.trino.sql.ir.IrUtils.extractConjuncts;
+import static io.trino.sql.ir.IrUtils.or;
 import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
 import static io.trino.sql.planner.plan.Patterns.filter;
 
@@ -81,6 +86,7 @@ public class SimplifyFilterPredicate
                     switch (conjunct) {
                         case Case expression -> simplify(expression);
                         case Match expression -> simplify(expression);
+                        case Logical expression when expression.operator() == Logical.Operator.OR -> simplifyNullSafeEquality(expression);
                         case null, default -> Optional.empty();
                     };
 
@@ -222,6 +228,56 @@ public class SimplifyFilterPredicate
             return Optional.of(FALSE);
         }
         return Optional.empty();
+    }
+
+    /**
+     * Replace the null-safe equality pattern {@code a = b OR (a IS NULL AND b IS NULL)} among the
+     * terms of a disjunction with {@code a IS NOT DISTINCT FROM b}, exposing it to equi-join
+     * extraction and domain translation. The two forms differ when exactly one side is null
+     * (null vs false), which is equivalent in filter context.
+     */
+    private Optional<Expression> simplifyNullSafeEquality(Logical disjunction)
+    {
+        List<Expression> terms = new ArrayList<>(disjunction.terms());
+        boolean changed = false;
+
+        for (int i = 0; i < terms.size(); i++) {
+            if (!(matchComparison(terms.get(i)) instanceof Comparison.Equal(Expression left, Expression right)) ||
+                    !isDeterministic(left) ||
+                    !isDeterministic(right)) {
+                continue;
+            }
+            for (int j = 0; j < terms.size(); j++) {
+                if (j != i && isNullPair(terms.get(j), left, right)) {
+                    terms.set(i, comparison(metadata, IDENTICAL, left, right));
+                    terms.remove(j);
+                    if (j < i) {
+                        i--;
+                    }
+                    changed = true;
+                    break;
+                }
+            }
+        }
+
+        if (!changed) {
+            return Optional.empty();
+        }
+
+        return Optional.of(or(terms));
+    }
+
+    private static boolean isNullPair(Expression expression, Expression left, Expression right)
+    {
+        if (!(expression instanceof Logical(Logical.Operator operator, List<Expression> terms)) ||
+                operator != Logical.Operator.AND ||
+                terms.size() != 2) {
+            return false;
+        }
+        if (!(terms.get(0) instanceof IsNull(Expression first)) || !(terms.get(1) instanceof IsNull(Expression second))) {
+            return false;
+        }
+        return (first.equals(left) && second.equals(right)) || (first.equals(right) && second.equals(left));
     }
 
     private static boolean isNotTrue(Expression expression)

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestDistributeIsNullOverCase.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestDistributeIsNullOverCase.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.ir.Case;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.WhenClause;
+import io.trino.sql.ir.optimizer.rule.DistributeIsNullOverCase;
+import io.trino.sql.planner.SymbolAllocator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.ir.TestingIr.nullIf;
+import static io.trino.testing.TestingSession.testSession;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDistributeIsNullOverCase
+{
+    @Test
+    void testDistribute()
+    {
+        assertThat(optimize(
+                new IsNull(new Case(
+                        ImmutableList.of(
+                                new WhenClause(new Reference(BOOLEAN, "a"), new Reference(VARCHAR, "r1")),
+                                new WhenClause(new Reference(BOOLEAN, "b"), new Constant(VARCHAR, null))),
+                        new Reference(VARCHAR, "d")))))
+                .isEqualTo(Optional.of(new Case(
+                        ImmutableList.of(
+                                new WhenClause(new Reference(BOOLEAN, "a"), new IsNull(new Reference(VARCHAR, "r1"))),
+                                new WhenClause(new Reference(BOOLEAN, "b"), new IsNull(new Constant(VARCHAR, null)))),
+                        new IsNull(new Reference(VARCHAR, "d")))));
+    }
+
+    @Test
+    void testDoesNotFire()
+    {
+        assertThat(optimize(new IsNull(nullIf(new SymbolAllocator(), new Reference(BIGINT, "x"), new Constant(BIGINT, 1L)))))
+                .describedAs("desugared NULLIF is preserved for connector pushdown")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(new IsNull(new Reference(VARCHAR, "a"))))
+                .describedAs("not a case expression")
+                .isEqualTo(Optional.empty());
+    }
+
+    private Optional<Expression> optimize(Expression expression)
+    {
+        return new DistributeIsNullOverCase().apply(expression, testSession(), new SymbolAllocator(), ImmutableMap.of());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestDistributeIsNullOverMatch.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestDistributeIsNullOverMatch.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.IrExpressions;
+import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.Match;
+import io.trino.sql.ir.MatchClause;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.optimizer.rule.DistributeIsNullOverMatch;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.testing.TestingSession.testSession;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDistributeIsNullOverMatch
+{
+    @Test
+    void testDistribute()
+    {
+        assertThat(optimize(
+                new IsNull(new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(
+                                equalityClause(new Constant(BIGINT, 1L), new Reference(VARCHAR, "r1")),
+                                equalityClause(new Constant(BIGINT, 2L), new Constant(VARCHAR, null))),
+                        new Reference(VARCHAR, "d")))))
+                .isEqualTo(Optional.of(new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(
+                                equalityClause(new Constant(BIGINT, 1L), new IsNull(new Reference(VARCHAR, "r1"))),
+                                equalityClause(new Constant(BIGINT, 2L), new IsNull(new Constant(VARCHAR, null)))),
+                        new IsNull(new Reference(VARCHAR, "d")))));
+    }
+
+    @Test
+    void testDoesNotFire()
+    {
+        assertThat(optimize(new IsNull(new Reference(VARCHAR, "a"))))
+                .describedAs("not a match expression")
+                .isEqualTo(Optional.empty());
+    }
+
+    private Optional<Expression> optimize(Expression expression)
+    {
+        return new DistributeIsNullOverMatch().apply(expression, testSession(), new SymbolAllocator(), ImmutableMap.of());
+    }
+
+    private static MatchClause equalityClause(Expression value, Expression result)
+    {
+        return IrExpressions.equalityClause(PLANNER_CONTEXT.getMetadata(), new Symbol(value.type(), "operand"), value, result);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestEvaluateIsNull.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestEvaluateIsNull.java
@@ -15,7 +15,10 @@ package io.trino.sql.ir.optimizer;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
 import io.trino.sql.ir.Array;
+import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.Constant;
@@ -30,14 +33,18 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static io.trino.spi.function.OperatorType.ADD;
+import static io.trino.spi.function.OperatorType.NEGATION;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.ir.Booleans.FALSE;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.ComparisonOperator.EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.IDENTICAL;
 import static io.trino.sql.ir.IrExpressions.not;
+import static io.trino.sql.ir.Logical.Operator.AND;
 import static io.trino.sql.ir.Logical.Operator.OR;
 import static io.trino.sql.ir.TestingIr.comparison;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
@@ -46,6 +53,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestEvaluateIsNull
 {
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final ResolvedFunction ADD_DOUBLE = FUNCTIONS.resolveOperator(ADD, ImmutableList.of(DOUBLE, DOUBLE));
+    private static final ResolvedFunction ADD_BIGINT = FUNCTIONS.resolveOperator(ADD, ImmutableList.of(BIGINT, BIGINT));
+    private static final ResolvedFunction NEGATION_DOUBLE = FUNCTIONS.resolveOperator(NEGATION, ImmutableList.of(DOUBLE));
+
     @Test
     void test()
     {
@@ -83,6 +95,22 @@ public class TestEvaluateIsNull
         assertThat(optimize(new IsNull(new Coalesce(new Constant(BIGINT, null), new Reference(BIGINT, "a"), new Constant(BIGINT, 1L)))))
                 .describedAs("coalesce is not nullable when any operand is not nullable")
                 .isEqualTo(Optional.of(FALSE));
+
+        assertThat(optimize(new IsNull(new Coalesce(new Reference(BIGINT, "a"), new Reference(BIGINT, "b")))))
+                .describedAs("coalesce is null when all operands are null")
+                .isEqualTo(Optional.of(new Logical(AND, ImmutableList.of(new IsNull(new Reference(BIGINT, "a")), new IsNull(new Reference(BIGINT, "b"))))));
+
+        assertThat(optimize(new IsNull(new Call(ADD_DOUBLE, ImmutableList.of(new Reference(DOUBLE, "a"), new Reference(DOUBLE, "b"))))))
+                .describedAs("strict function that cannot fail")
+                .isEqualTo(Optional.of(new Logical(OR, ImmutableList.of(new IsNull(new Reference(DOUBLE, "a")), new IsNull(new Reference(DOUBLE, "b"))))));
+
+        assertThat(optimize(new IsNull(new Call(NEGATION_DOUBLE, ImmutableList.of(new Reference(DOUBLE, "a"))))))
+                .describedAs("single-argument strict function")
+                .isEqualTo(Optional.of(new IsNull(new Reference(DOUBLE, "a"))));
+
+        assertThat(optimize(new IsNull(new Call(ADD_BIGINT, ImmutableList.of(new Reference(BIGINT, "a"), new Reference(BIGINT, "b"))))))
+                .describedAs("bigint addition may fail on overflow")
+                .isEqualTo(Optional.empty());
     }
 
     private Optional<Expression> optimize(Expression expression)

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestFlattenConcat.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestFlattenConcat.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.spi.type.ArrayType;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.optimizer.rule.FlattenConcat;
+import io.trino.sql.planner.SymbolAllocator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+import static io.trino.sql.ir.optimizer.IrExpressionOptimizer.newOptimizer;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.testing.TestingSession.testSession;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestFlattenConcat
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final ArrayType BIGINT_ARRAY = new ArrayType(BIGINT);
+
+    private static final ResolvedFunction CONCAT_2 = FUNCTIONS.resolveFunction("concat", fromTypes(VARCHAR, VARCHAR));
+    private static final ResolvedFunction CONCAT_3 = FUNCTIONS.resolveFunction("concat", fromTypes(VARCHAR, VARCHAR, VARCHAR));
+    private static final ResolvedFunction CONCAT_4 = FUNCTIONS.resolveFunction("concat", fromTypes(VARCHAR, VARCHAR, VARCHAR, VARCHAR));
+    private static final ResolvedFunction VARBINARY_CONCAT = FUNCTIONS.resolveFunction("concat", fromTypes(VARBINARY, VARBINARY));
+    private static final ResolvedFunction VARBINARY_CONCAT_3 = FUNCTIONS.resolveFunction("concat", fromTypes(VARBINARY, VARBINARY, VARBINARY));
+    private static final ResolvedFunction ARRAY_CONCAT = FUNCTIONS.resolveFunction("concat", fromTypes(BIGINT_ARRAY, BIGINT_ARRAY));
+    private static final ResolvedFunction ARRAY_CONCAT_3 = FUNCTIONS.resolveFunction("concat", fromTypes(BIGINT_ARRAY, BIGINT_ARRAY, BIGINT_ARRAY));
+    private static final ResolvedFunction ELEMENT_ARRAY_CONCAT = FUNCTIONS.resolveFunction("concat", fromTypes(BIGINT, BIGINT_ARRAY));
+
+    @Test
+    void testFlatten()
+    {
+        Reference a = new Reference(VARCHAR, "a");
+        Reference b = new Reference(VARCHAR, "b");
+        Reference c = new Reference(VARCHAR, "c");
+        Reference d = new Reference(VARCHAR, "d");
+
+        assertThat(optimize(
+                new Call(CONCAT_2, ImmutableList.of(new Call(CONCAT_2, ImmutableList.of(a, b)), c))))
+                .describedAs("left-nested")
+                .isEqualTo(Optional.of(new Call(CONCAT_3, ImmutableList.of(a, b, c))));
+
+        assertThat(optimize(
+                new Call(CONCAT_2, ImmutableList.of(a, new Call(CONCAT_2, ImmutableList.of(b, c))))))
+                .describedAs("right-nested")
+                .isEqualTo(Optional.of(new Call(CONCAT_3, ImmutableList.of(a, b, c))));
+
+        assertThat(optimize(
+                new Call(CONCAT_2, ImmutableList.of(
+                        new Call(CONCAT_2, ImmutableList.of(a, b)),
+                        new Call(CONCAT_2, ImmutableList.of(c, d))))))
+                .describedAs("nested on both sides")
+                .isEqualTo(Optional.of(new Call(CONCAT_4, ImmutableList.of(a, b, c, d))));
+    }
+
+    @Test
+    void testVarbinary()
+    {
+        Reference a = new Reference(VARBINARY, "a");
+        Reference b = new Reference(VARBINARY, "b");
+        Reference c = new Reference(VARBINARY, "c");
+
+        assertThat(optimize(
+                new Call(VARBINARY_CONCAT, ImmutableList.of(new Call(VARBINARY_CONCAT, ImmutableList.of(a, b)), c))))
+                .isEqualTo(Optional.of(new Call(VARBINARY_CONCAT_3, ImmutableList.of(a, b, c))));
+    }
+
+    @Test
+    void testArray()
+    {
+        Reference a = new Reference(BIGINT_ARRAY, "a");
+        Reference b = new Reference(BIGINT_ARRAY, "b");
+        Reference c = new Reference(BIGINT_ARRAY, "c");
+
+        assertThat(optimize(
+                new Call(ARRAY_CONCAT, ImmutableList.of(new Call(ARRAY_CONCAT, ImmutableList.of(a, b)), c))))
+                .isEqualTo(Optional.of(new Call(ARRAY_CONCAT_3, ImmutableList.of(a, b, c))));
+    }
+
+    @Test
+    void testDoesNotFire()
+    {
+        assertThat(optimize(
+                new Call(CONCAT_2, ImmutableList.of(new Reference(VARCHAR, "a"), new Reference(VARCHAR, "b")))))
+                .describedAs("no nested concat")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new Call(ARRAY_CONCAT, ImmutableList.of(
+                        new Call(ELEMENT_ARRAY_CONCAT, ImmutableList.of(new Reference(BIGINT, "e"), new Reference(BIGINT_ARRAY, "a"))),
+                        new Reference(BIGINT_ARRAY, "b")))))
+                .describedAs("element || array child has a non-uniform signature")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new Call(ELEMENT_ARRAY_CONCAT, ImmutableList.of(
+                        new Reference(BIGINT, "e"),
+                        new Call(ARRAY_CONCAT, ImmutableList.of(new Reference(BIGINT_ARRAY, "a"), new Reference(BIGINT_ARRAY, "b")))))))
+                .describedAs("element || array parent has a non-uniform signature")
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void testFlattensFullyWithOptimizer()
+    {
+        Reference a = new Reference(VARCHAR, "a");
+        Reference b = new Reference(VARCHAR, "b");
+        Reference c = new Reference(VARCHAR, "c");
+        Reference d = new Reference(VARCHAR, "d");
+
+        // a || b || c || d parses as concat(concat(concat(a, b), c), d)
+        assertThat(newOptimizer(PLANNER_CONTEXT).process(
+                new Call(CONCAT_2, ImmutableList.of(
+                        new Call(CONCAT_2, ImmutableList.of(new Call(CONCAT_2, ImmutableList.of(a, b)), c)),
+                        d)),
+                testSession(),
+                new SymbolAllocator(),
+                ImmutableMap.of()))
+                .isEqualTo(Optional.of(new Call(CONCAT_4, ImmutableList.of(a, b, c, d))));
+    }
+
+    private Optional<Expression> optimize(Expression expression)
+    {
+        return new FlattenConcat(PLANNER_CONTEXT).apply(expression, testSession(), new SymbolAllocator(), ImmutableMap.of());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestFlattenNestedCase.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestFlattenNestedCase.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.ir.Case;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.WhenClause;
+import io.trino.sql.ir.optimizer.rule.FlattenNestedCase;
+import io.trino.sql.planner.SymbolAllocator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.ir.IrExpressions.ifExpression;
+import static io.trino.sql.ir.IrUtils.and;
+import static io.trino.sql.ir.optimizer.IrExpressionOptimizer.newOptimizer;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.testing.TestingSession.testSession;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestFlattenNestedCase
+{
+    private static final Expression A = new Reference(BOOLEAN, "a");
+    private static final Expression B = new Reference(BOOLEAN, "b");
+    private static final Expression C = new Reference(BOOLEAN, "c");
+    private static final Expression R1 = new Reference(VARCHAR, "r1");
+    private static final Expression R2 = new Reference(VARCHAR, "r2");
+    private static final Expression DEFAULT = new Reference(VARCHAR, "d");
+
+    @Test
+    void testCaseInDefault()
+    {
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(new WhenClause(A, R1)),
+                        new Case(
+                                ImmutableList.of(new WhenClause(B, R2)),
+                                DEFAULT))))
+                .isEqualTo(Optional.of(new Case(
+                        ImmutableList.of(
+                                new WhenClause(A, R1),
+                                new WhenClause(B, R2)),
+                        DEFAULT)));
+    }
+
+    @Test
+    void testCaseInLastClause()
+    {
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(new WhenClause(A, new Case(ImmutableList.of(new WhenClause(B, R1)), DEFAULT))),
+                        DEFAULT)))
+                .describedAs("nested IF with shared default")
+                .isEqualTo(Optional.of(new Case(
+                        ImmutableList.of(new WhenClause(and(A, B), R1)),
+                        DEFAULT)));
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(A, R1),
+                                new WhenClause(B, new Case(ImmutableList.of(new WhenClause(C, R2)), DEFAULT))),
+                        DEFAULT)))
+                .describedAs("nested case in last clause of multi-clause case")
+                .isEqualTo(Optional.of(new Case(
+                        ImmutableList.of(
+                                new WhenClause(A, R1),
+                                new WhenClause(and(B, C), R2)),
+                        DEFAULT)));
+    }
+
+    @Test
+    void testBothPatterns()
+    {
+        Expression sharedDefault = new Case(ImmutableList.of(new WhenClause(C, R2)), DEFAULT);
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(new WhenClause(A, new Case(ImmutableList.of(new WhenClause(B, R1)), sharedDefault))),
+                        sharedDefault)))
+                .isEqualTo(Optional.of(new Case(
+                        ImmutableList.of(
+                                new WhenClause(and(A, B), R1),
+                                new WhenClause(C, R2)),
+                        DEFAULT)));
+    }
+
+    @Test
+    void testDoesNotFire()
+    {
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(A, new Case(ImmutableList.of(new WhenClause(B, R1)), DEFAULT)),
+                                new WhenClause(C, R2)),
+                        DEFAULT)))
+                .describedAs("nested case in non-last clause")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(new WhenClause(A, new Case(ImmutableList.of(new WhenClause(B, R1)), R2))),
+                        DEFAULT)))
+                .describedAs("nested case with different default")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(new WhenClause(A, new Case(
+                                ImmutableList.of(
+                                        new WhenClause(B, R1),
+                                        new WhenClause(C, R2)),
+                                DEFAULT))),
+                        DEFAULT)))
+                .describedAs("nested case with multiple clauses")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(new WhenClause(A, R1)),
+                        DEFAULT)))
+                .describedAs("no nested case")
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void testChainedIfFlattensFully()
+    {
+        assertThat(newOptimizer(PLANNER_CONTEXT).process(
+                ifExpression(A, ifExpression(B, ifExpression(C, R1, DEFAULT), DEFAULT), DEFAULT),
+                testSession(),
+                new SymbolAllocator(),
+                ImmutableMap.of()))
+                .isEqualTo(Optional.of(new Case(
+                        ImmutableList.of(new WhenClause(and(A, B, C), R1)),
+                        DEFAULT)));
+    }
+
+    private Optional<Expression> optimize(Expression expression)
+    {
+        return new FlattenNestedCase().apply(expression, testSession(), new SymbolAllocator(), ImmutableMap.of());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestFlattenNestedMatch.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestFlattenNestedMatch.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.IrExpressions;
+import io.trino.sql.ir.Match;
+import io.trino.sql.ir.MatchClause;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.optimizer.rule.FlattenNestedMatch;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.testing.TestingSession.testSession;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestFlattenNestedMatch
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final ResolvedFunction RANDOM = FUNCTIONS.resolveFunction("random", ImmutableList.of());
+
+    @Test
+    void testFlatten()
+    {
+        assertThat(optimize(
+                new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(equalityClause(new Reference(BIGINT, "a"), new Reference(VARCHAR, "r1"))),
+                        new Match(
+                                new Reference(BIGINT, "x"),
+                                ImmutableList.of(equalityClause(new Reference(BIGINT, "b"), new Reference(VARCHAR, "r2"))),
+                                new Reference(VARCHAR, "d")))))
+                .isEqualTo(Optional.of(new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(
+                                equalityClause(new Reference(BIGINT, "a"), new Reference(VARCHAR, "r1")),
+                                equalityClause(new Reference(BIGINT, "b"), new Reference(VARCHAR, "r2"))),
+                        new Reference(VARCHAR, "d"))));
+    }
+
+    @Test
+    void testDoesNotFire()
+    {
+        assertThat(optimize(
+                new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(equalityClause(new Reference(BIGINT, "a"), new Reference(VARCHAR, "r1"))),
+                        new Match(
+                                new Reference(BIGINT, "y"),
+                                ImmutableList.of(equalityClause(new Reference(BIGINT, "b"), new Reference(VARCHAR, "r2"))),
+                                new Reference(VARCHAR, "d")))))
+                .describedAs("different operands")
+                .isEqualTo(Optional.empty());
+
+        Expression random = new Call(RANDOM, ImmutableList.of());
+        assertThat(optimize(
+                new Match(
+                        random,
+                        ImmutableList.of(equalityClause(new Reference(DOUBLE, "a"), new Reference(VARCHAR, "r1"))),
+                        new Match(
+                                random,
+                                ImmutableList.of(equalityClause(new Reference(DOUBLE, "b"), new Reference(VARCHAR, "r2"))),
+                                new Reference(VARCHAR, "d")))))
+                .describedAs("non-deterministic operand: the two evaluations may differ")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(equalityClause(new Reference(BIGINT, "a"), new Reference(VARCHAR, "r1"))),
+                        new Reference(VARCHAR, "d"))))
+                .describedAs("no nested match")
+                .isEqualTo(Optional.empty());
+    }
+
+    private Optional<Expression> optimize(Expression expression)
+    {
+        return new FlattenNestedMatch().apply(expression, testSession(), new SymbolAllocator(), ImmutableMap.of());
+    }
+
+    private static MatchClause equalityClause(Expression value, Expression result)
+    {
+        return IrExpressions.equalityClause(PLANNER_CONTEXT.getMetadata(), new Symbol(value.type(), "operand"), value, result);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestMergeCaseClauses.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestMergeCaseClauses.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Case;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.WhenClause;
+import io.trino.sql.ir.optimizer.rule.MergeCaseClauses;
+import io.trino.sql.planner.SymbolAllocator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.function.OperatorType.DIVIDE;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.ir.ComparisonOperator.EQUAL;
+import static io.trino.sql.ir.IrExpressions.ifExpression;
+import static io.trino.sql.ir.IrUtils.or;
+import static io.trino.sql.ir.TestingIr.comparison;
+import static io.trino.sql.ir.optimizer.IrExpressionOptimizer.newOptimizer;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.testing.TestingSession.testSession;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMergeCaseClauses
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final ResolvedFunction RANDOM = FUNCTIONS.resolveFunction("random", ImmutableList.of());
+    private static final ResolvedFunction DIVIDE_BIGINT = FUNCTIONS.resolveOperator(DIVIDE, ImmutableList.of(BIGINT, BIGINT));
+
+    private static final Expression A = new Reference(BOOLEAN, "a");
+    private static final Expression B = new Reference(BOOLEAN, "b");
+    private static final Expression C = new Reference(BOOLEAN, "c");
+    private static final Expression R1 = new Reference(VARCHAR, "r1");
+    private static final Expression R2 = new Reference(VARCHAR, "r2");
+    private static final Expression DEFAULT = new Reference(VARCHAR, "d");
+
+    @Test
+    void testMergeAdjacentClauses()
+    {
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(A, R1),
+                                new WhenClause(B, R1),
+                                new WhenClause(C, R2)),
+                        DEFAULT)))
+                .isEqualTo(Optional.of(new Case(
+                        ImmutableList.of(
+                                new WhenClause(or(A, B), R1),
+                                new WhenClause(C, R2)),
+                        DEFAULT)));
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(A, R1),
+                                new WhenClause(B, R1),
+                                new WhenClause(C, R1)),
+                        DEFAULT)))
+                .describedAs("run of three clauses")
+                .isEqualTo(Optional.of(new Case(
+                        ImmutableList.of(new WhenClause(or(A, B, C), R1)),
+                        DEFAULT)));
+
+        Expression randomResult = new Call(RANDOM, ImmutableList.of());
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(A, new Call(RANDOM, ImmutableList.of())),
+                                new WhenClause(B, new Call(RANDOM, ImmutableList.of()))),
+                        new Constant(DOUBLE, 0.0))))
+                .describedAs("non-deterministic results: only one copy is evaluated per row, before and after")
+                .isEqualTo(Optional.of(new Case(
+                        ImmutableList.of(new WhenClause(or(A, B), randomResult)),
+                        new Constant(DOUBLE, 0.0))));
+    }
+
+    @Test
+    void testDropTrailingClauses()
+    {
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(A, R1),
+                                new WhenClause(B, DEFAULT)),
+                        DEFAULT)))
+                .isEqualTo(Optional.of(new Case(
+                        ImmutableList.of(new WhenClause(A, R1)),
+                        DEFAULT)));
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(new WhenClause(A, DEFAULT)),
+                        DEFAULT)))
+                .describedAs("all clauses produce the default")
+                .isEqualTo(Optional.of(DEFAULT));
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(A, R1),
+                                new WhenClause(B, R1),
+                                new WhenClause(C, DEFAULT)),
+                        DEFAULT)))
+                .describedAs("drop trailing clause, then merge")
+                .isEqualTo(Optional.of(new Case(
+                        ImmutableList.of(new WhenClause(or(A, B), R1)),
+                        DEFAULT)));
+    }
+
+    @Test
+    void testDoesNotFire()
+    {
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(A, R1),
+                                new WhenClause(B, R2),
+                                new WhenClause(C, R1)),
+                        DEFAULT)))
+                .describedAs("non-adjacent clauses with the same result")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(A, DEFAULT),
+                                new WhenClause(B, R1)),
+                        DEFAULT)))
+                .describedAs("non-trailing clause producing the default")
+                .isEqualTo(Optional.empty());
+
+        Expression failingOperand = comparison(
+                EQUAL,
+                new Call(DIVIDE_BIGINT, ImmutableList.of(new Reference(BIGINT, "x"), new Constant(BIGINT, 0L))),
+                new Constant(BIGINT, 1L));
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(new WhenClause(failingOperand, DEFAULT)),
+                        DEFAULT)))
+                .describedAs("trailing clause with failing operand")
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void testComposesWithFlattenNestedCase()
+    {
+        assertThat(newOptimizer(PLANNER_CONTEXT).process(
+                ifExpression(A, R1, ifExpression(B, R1, DEFAULT)),
+                testSession(),
+                new SymbolAllocator(),
+                ImmutableMap.of()))
+                .isEqualTo(Optional.of(new Case(
+                        ImmutableList.of(new WhenClause(or(A, B), R1)),
+                        DEFAULT)));
+    }
+
+    private Optional<Expression> optimize(Expression expression)
+    {
+        return new MergeCaseClauses(PLANNER_CONTEXT).apply(expression, testSession(), new SymbolAllocator(), ImmutableMap.of());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestMergeMatchClauses.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestMergeMatchClauses.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.IrExpressions;
+import io.trino.sql.ir.Lambda;
+import io.trino.sql.ir.Match;
+import io.trino.sql.ir.MatchClause;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.optimizer.rule.MergeMatchClauses;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.function.OperatorType.DIVIDE;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.ir.ComparisonOperator.EQUAL;
+import static io.trino.sql.ir.IrUtils.or;
+import static io.trino.sql.ir.TestingIr.comparison;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.testing.TestingSession.testSession;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMergeMatchClauses
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final ResolvedFunction DIVIDE_BIGINT = FUNCTIONS.resolveOperator(DIVIDE, ImmutableList.of(BIGINT, BIGINT));
+
+    private static final Symbol PARAMETER = new Symbol(BIGINT, "operand");
+
+    @Test
+    void testMergeAdjacentClauses()
+    {
+        assertThat(optimize(
+                new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(
+                                equalityClause(new Reference(BIGINT, "a"), new Reference(VARCHAR, "r1")),
+                                equalityClause(new Reference(BIGINT, "b"), new Reference(VARCHAR, "r1")),
+                                equalityClause(new Reference(BIGINT, "c"), new Reference(VARCHAR, "r2"))),
+                        new Reference(VARCHAR, "d"))))
+                .isEqualTo(Optional.of(new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(
+                                mergedEqualityClause(new Reference(VARCHAR, "r1"), new Reference(BIGINT, "a"), new Reference(BIGINT, "b")),
+                                equalityClause(new Reference(BIGINT, "c"), new Reference(VARCHAR, "r2"))),
+                        new Reference(VARCHAR, "d"))));
+
+        assertThat(optimize(
+                new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(
+                                equalityClause(new Reference(BIGINT, "a"), new Reference(VARCHAR, "r1")),
+                                equalityClause(new Reference(BIGINT, "b"), new Reference(VARCHAR, "r1")),
+                                equalityClause(new Reference(BIGINT, "c"), new Reference(VARCHAR, "r1"))),
+                        new Reference(VARCHAR, "d"))))
+                .describedAs("run of three clauses")
+                .isEqualTo(Optional.of(new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(
+                                mergedEqualityClause(new Reference(VARCHAR, "r1"), new Reference(BIGINT, "a"), new Reference(BIGINT, "b"), new Reference(BIGINT, "c"))),
+                        new Reference(VARCHAR, "d"))));
+
+        MatchClause differentParameter = new MatchClause(
+                new Lambda(
+                        ImmutableList.of(new Symbol(BIGINT, "q")),
+                        comparison(EQUAL, new Reference(BIGINT, "q"), new Reference(BIGINT, "b"))),
+                new Reference(VARCHAR, "r1"));
+        assertThat(optimize(
+                new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(
+                                equalityClause(new Reference(BIGINT, "a"), new Reference(VARCHAR, "r1")),
+                                differentParameter),
+                        new Reference(VARCHAR, "d"))))
+                .describedAs("lambda parameters are unified when merging")
+                .isEqualTo(Optional.of(new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(
+                                mergedEqualityClause(new Reference(VARCHAR, "r1"), new Reference(BIGINT, "a"), new Reference(BIGINT, "b"))),
+                        new Reference(VARCHAR, "d"))));
+    }
+
+    @Test
+    void testDropTrailingClauses()
+    {
+        assertThat(optimize(
+                new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(
+                                equalityClause(new Reference(BIGINT, "a"), new Reference(VARCHAR, "r1")),
+                                equalityClause(new Reference(BIGINT, "b"), new Reference(VARCHAR, "d"))),
+                        new Reference(VARCHAR, "d"))))
+                .isEqualTo(Optional.of(new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(equalityClause(new Reference(BIGINT, "a"), new Reference(VARCHAR, "r1"))),
+                        new Reference(VARCHAR, "d"))));
+
+        assertThat(optimize(
+                new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(equalityClause(new Reference(BIGINT, "a"), new Reference(VARCHAR, "d"))),
+                        new Reference(VARCHAR, "d"))))
+                .describedAs("all clauses produce the default")
+                .isEqualTo(Optional.of(new Reference(VARCHAR, "d")));
+    }
+
+    @Test
+    void testDoesNotFire()
+    {
+        assertThat(optimize(
+                new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(
+                                equalityClause(new Reference(BIGINT, "a"), new Reference(VARCHAR, "r1")),
+                                equalityClause(new Reference(BIGINT, "b"), new Reference(VARCHAR, "r2")),
+                                equalityClause(new Reference(BIGINT, "c"), new Reference(VARCHAR, "r1"))),
+                        new Reference(VARCHAR, "d"))))
+                .describedAs("non-adjacent clauses with the same result")
+                .isEqualTo(Optional.empty());
+
+        Expression failing = comparison(
+                EQUAL,
+                new Call(DIVIDE_BIGINT, ImmutableList.of(new Reference(BIGINT, "y"), new Constant(BIGINT, 0L))),
+                new Constant(BIGINT, 1L));
+        assertThat(optimize(
+                new Match(
+                        new Reference(BIGINT, "x"),
+                        ImmutableList.of(
+                                equalityClause(new Reference(BIGINT, "a"), new Reference(VARCHAR, "r1")),
+                                new MatchClause(
+                                        new Lambda(ImmutableList.of(PARAMETER), failing),
+                                        new Reference(VARCHAR, "d"))),
+                        new Reference(VARCHAR, "d"))))
+                .describedAs("trailing clause with failing predicate")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new Match(
+                        new Call(DIVIDE_BIGINT, ImmutableList.of(new Reference(BIGINT, "y"), new Constant(BIGINT, 0L))),
+                        ImmutableList.of(equalityClause(new Reference(BIGINT, "a"), new Reference(VARCHAR, "d"))),
+                        new Reference(VARCHAR, "d"))))
+                .describedAs("dropping the last clause would skip the failing operand")
+                .isEqualTo(Optional.empty());
+    }
+
+    private Optional<Expression> optimize(Expression expression)
+    {
+        return new MergeMatchClauses(PLANNER_CONTEXT).apply(expression, testSession(), new SymbolAllocator(), ImmutableMap.of());
+    }
+
+    private static MatchClause equalityClause(Expression value, Expression result)
+    {
+        return IrExpressions.equalityClause(PLANNER_CONTEXT.getMetadata(), new Symbol(value.type(), "operand"), value, result);
+    }
+
+    private static MatchClause mergedEqualityClause(Expression result, Expression... values)
+    {
+        ImmutableList.Builder<Expression> disjuncts = ImmutableList.builder();
+        for (Expression value : values) {
+            disjuncts.add(IrExpressions.equalityClause(PLANNER_CONTEXT.getMetadata(), PARAMETER, value, result).lambda().body());
+        }
+        return new MatchClause(new Lambda(ImmutableList.of(PARAMETER), or(disjuncts.build())), result);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestRemoveAbsorbedLogicalTerms.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestRemoveAbsorbedLogicalTerms.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.optimizer.rule.RemoveAbsorbedLogicalTerms;
+import io.trino.sql.planner.SymbolAllocator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.function.OperatorType.DIVIDE;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.sql.ir.ComparisonOperator.EQUAL;
+import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN_OR_EQUAL;
+import static io.trino.sql.ir.IrUtils.and;
+import static io.trino.sql.ir.IrUtils.or;
+import static io.trino.sql.ir.TestingIr.comparison;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.testing.TestingSession.testSession;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestRemoveAbsorbedLogicalTerms
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final ResolvedFunction RANDOM = FUNCTIONS.resolveFunction("random", ImmutableList.of());
+    private static final ResolvedFunction DIVIDE_BIGINT = FUNCTIONS.resolveOperator(DIVIDE, ImmutableList.of(BIGINT, BIGINT));
+
+    private static final Expression A = new Reference(BOOLEAN, "a");
+    private static final Expression B = new Reference(BOOLEAN, "b");
+    private static final Expression C = new Reference(BOOLEAN, "c");
+    private static final Expression D = new Reference(BOOLEAN, "d");
+
+    @Test
+    void testAbsorption()
+    {
+        assertThat(optimize(or(A, and(A, B))))
+                .isEqualTo(Optional.of(A));
+
+        assertThat(optimize(and(A, or(A, B))))
+                .isEqualTo(Optional.of(A));
+
+        assertThat(optimize(or(A, and(A, B), C)))
+                .isEqualTo(Optional.of(or(A, C)));
+
+        assertThat(optimize(and(A, or(A, B), or(C, D))))
+                .isEqualTo(Optional.of(and(A, or(C, D))));
+
+        assertThat(optimize(or(and(A, B), and(A, B, C))))
+                .describedAs("sub-terms of one term are a subset of the other's")
+                .isEqualTo(Optional.of(and(A, B)));
+
+        assertThat(optimize(or(and(A, B), and(B, A))))
+                .describedAs("terms with equal sub-term sets: keep the first")
+                .isEqualTo(Optional.of(and(A, B)));
+
+        assertThat(optimize(or(and(A, B, C), and(B, A), A)))
+                .describedAs("chained absorption")
+                .isEqualTo(Optional.of(A));
+    }
+
+    @Test
+    void testDoesNotFire()
+    {
+        assertThat(optimize(or(and(A, B), and(A, C))))
+                .describedAs("neither sub-term set contains the other")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(and(A, and(A, B))))
+                .describedAs("nested term with the same operator")
+                .isEqualTo(Optional.empty());
+
+        Expression nonDeterministic = comparison(
+                GREATER_THAN_OR_EQUAL,
+                new Call(RANDOM, ImmutableList.of()),
+                new Constant(DOUBLE, 0.5));
+        assertThat(optimize(or(nonDeterministic, and(nonDeterministic, B))))
+                .describedAs("non-deterministic shared term: the two occurrences may differ")
+                .isEqualTo(Optional.empty());
+
+        Expression failing = comparison(
+                EQUAL,
+                new Call(DIVIDE_BIGINT, ImmutableList.of(new Reference(BIGINT, "x"), new Constant(BIGINT, 0L))),
+                new Constant(BIGINT, 1L));
+        assertThat(optimize(or(A, and(A, failing))))
+                .describedAs("absorbed extra term that may fail")
+                .isEqualTo(Optional.empty());
+    }
+
+    private Optional<Expression> optimize(Expression expression)
+    {
+        return new RemoveAbsorbedLogicalTerms(PLANNER_CONTEXT).apply(expression, testSession(), new SymbolAllocator(), ImmutableMap.of());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestSimplifyStackedCast.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestSimplifyStackedCast.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.ir.Cast;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.optimizer.rule.SimplifyStackedCast;
+import io.trino.sql.planner.SymbolAllocator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.sql.ir.Cast.Kind.CONVERT;
+import static io.trino.sql.ir.Cast.Kind.REINTERPRET;
+import static io.trino.sql.ir.optimizer.IrExpressionOptimizer.newOptimizer;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.testing.TestingSession.testSession;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSimplifyStackedCast
+{
+    @Test
+    void testCollapse()
+    {
+        assertThat(optimize(
+                new Cast(new Cast(new Reference(createVarcharType(5), "x"), createVarcharType(20), REINTERPRET), createVarcharType(10))))
+                .isEqualTo(Optional.of(new Cast(new Reference(createVarcharType(5), "x"), createVarcharType(10))));
+
+        assertThat(optimize(
+                new Cast(new Cast(new Reference(createVarcharType(5), "x"), createVarcharType(20), REINTERPRET), BIGINT)))
+                .describedAs("cast to a different type family")
+                .isEqualTo(Optional.of(new Cast(new Reference(createVarcharType(5), "x"), BIGINT)));
+
+        assertThat(optimize(
+                new Cast(new Cast(new Reference(createDecimalType(10, 2), "x"), createDecimalType(12, 2), REINTERPRET), createDecimalType(14, 2))))
+                .describedAs("widening decimal chain")
+                .isEqualTo(Optional.of(new Cast(new Reference(createDecimalType(10, 2), "x"), createDecimalType(14, 2))));
+    }
+
+    @Test
+    void testDoesNotFire()
+    {
+        assertThat(optimize(
+                new Cast(new Cast(new Reference(createVarcharType(20), "x"), createVarcharType(5)), createVarcharType(10))))
+                .describedAs("narrowing inner cast may truncate or fail")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new Cast(new Cast(new Reference(BIGINT, "x"), DOUBLE), createVarcharType(20))))
+                .describedAs("inner cast changes the value representation")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new Cast(new Cast(new Reference(createVarcharType(5), "x"), createVarcharType(20), CONVERT), createVarcharType(10))))
+                .describedAs("type-only-shaped inner cast tagged CONVERT is not a reinterpretation")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(new Cast(new Reference(createVarcharType(5), "x"), createVarcharType(10))))
+                .describedAs("single cast")
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void testCollapsesFullyWithRedundantCast()
+    {
+        assertThat(newOptimizer(PLANNER_CONTEXT).process(
+                new Cast(new Cast(new Reference(createVarcharType(5), "x"), createVarcharType(20), REINTERPRET), createVarcharType(5)),
+                testSession(),
+                new SymbolAllocator(),
+                ImmutableMap.of()))
+                .isEqualTo(Optional.of(new Reference(createVarcharType(5), "x")));
+    }
+
+    private Optional<Expression> optimize(Expression expression)
+    {
+        return new SimplifyStackedCast(PLANNER_CONTEXT).apply(expression, testSession(), new SymbolAllocator(), ImmutableMap.of());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestSpecializeCaseToMatch.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestSpecializeCaseToMatch.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.sql.ir.Bind;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Case;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.IrExpressions;
+import io.trino.sql.ir.Lambda;
+import io.trino.sql.ir.Match;
+import io.trino.sql.ir.MatchClause;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.WhenClause;
+import io.trino.sql.ir.optimizer.rule.SpecializeCaseToMatch;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.ir.ComparisonOperator.EQUAL;
+import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN;
+import static io.trino.sql.ir.TestingIr.comparison;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.testing.TestingSession.testSession;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSpecializeCaseToMatch
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final ResolvedFunction RANDOM = FUNCTIONS.resolveFunction("random", ImmutableList.of());
+
+    private static final Expression X = new Reference(BIGINT, "x");
+    private static final Expression R1 = new Reference(VARCHAR, "r1");
+    private static final Expression R2 = new Reference(VARCHAR, "r2");
+    private static final Expression DEFAULT = new Reference(VARCHAR, "d");
+
+    @Test
+    void testSpecialize()
+    {
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(comparison(EQUAL, X, new Constant(BIGINT, 1L)), R1),
+                                new WhenClause(comparison(EQUAL, X, new Constant(BIGINT, 2L)), R2)),
+                        DEFAULT)))
+                .isEqualTo(Optional.of(new Match(
+                        X,
+                        ImmutableList.of(
+                                equalityClause(new Constant(BIGINT, 1L), R1),
+                                equalityClause(new Constant(BIGINT, 2L), R2)),
+                        DEFAULT)));
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(comparison(EQUAL, new Constant(BIGINT, 1L), X), R1),
+                                new WhenClause(comparison(EQUAL, X, new Constant(BIGINT, 2L)), R2)),
+                        DEFAULT)))
+                .describedAs("operand on either side of the equality")
+                .isEqualTo(Optional.of(new Match(
+                        X,
+                        ImmutableList.of(
+                                equalityClause(new Constant(BIGINT, 1L), R1),
+                                equalityClause(new Constant(BIGINT, 2L), R2)),
+                        DEFAULT)));
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(comparison(EQUAL, X, new Reference(BIGINT, "a")), R1),
+                                new WhenClause(comparison(EQUAL, X, new Reference(BIGINT, "b")), R2)),
+                        DEFAULT)))
+                .describedAs("non-constant values are lifted into Bind captures")
+                .isEqualTo(Optional.of(new Match(
+                        X,
+                        ImmutableList.of(
+                                captureClause(new Reference(BIGINT, "a"), R1),
+                                captureClause(new Reference(BIGINT, "b"), R2)),
+                        DEFAULT)));
+    }
+
+    @Test
+    void testDoesNotFire()
+    {
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(new WhenClause(comparison(EQUAL, X, new Constant(BIGINT, 1L)), R1)),
+                        DEFAULT)))
+                .describedAs("single clause")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(comparison(EQUAL, X, new Constant(BIGINT, 1L)), R1),
+                                new WhenClause(comparison(EQUAL, new Reference(BIGINT, "y"), new Constant(BIGINT, 2L)), R2)),
+                        DEFAULT)))
+                .describedAs("no common operand")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(comparison(EQUAL, X, new Constant(BIGINT, 0L)), R1),
+                                new WhenClause(comparison(EQUAL, new Reference(BIGINT, "y"), new Constant(BIGINT, 0L)), R2)),
+                        DEFAULT)))
+                .describedAs("constant common operand")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(comparison(EQUAL, X, new Constant(BIGINT, 1L)), R1),
+                                new WhenClause(comparison(GREATER_THAN, X, new Constant(BIGINT, 2L)), R2)),
+                        DEFAULT)))
+                .describedAs("non-equality condition")
+                .isEqualTo(Optional.empty());
+
+        Expression random = new Call(RANDOM, ImmutableList.of());
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(comparison(EQUAL, random, new Constant(DOUBLE, 1.0)), R1),
+                                new WhenClause(comparison(EQUAL, random, new Constant(DOUBLE, 2.0)), R2)),
+                        DEFAULT)))
+                .describedAs("non-deterministic common operand")
+                .isEqualTo(Optional.empty());
+
+        assertThat(optimize(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(new Reference(BOOLEAN, "a"), R1),
+                                new WhenClause(comparison(EQUAL, X, new Constant(BIGINT, 2L)), R2)),
+                        DEFAULT)))
+                .describedAs("non-comparison condition")
+                .isEqualTo(Optional.empty());
+    }
+
+    private Optional<Expression> optimize(Expression expression)
+    {
+        return new SpecializeCaseToMatch(PLANNER_CONTEXT).apply(expression, testSession(), new SymbolAllocator(), ImmutableMap.of());
+    }
+
+    private static MatchClause equalityClause(Expression value, Expression result)
+    {
+        return IrExpressions.equalityClause(PLANNER_CONTEXT.getMetadata(), new Symbol(BIGINT, "match"), value, result);
+    }
+
+    private static MatchClause captureClause(Reference value, Expression result)
+    {
+        MatchClause plain = equalityClause(value, result);
+        return new MatchClause(
+                new Bind(
+                        ImmutableList.of(value),
+                        new Lambda(
+                                ImmutableList.of(new Symbol(value.type(), value.name()), new Symbol(BIGINT, "match")),
+                                plain.lambda().body())),
+                result);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapCastInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapCastInComparison.java
@@ -835,7 +835,7 @@ public class TestUnwrapCastInComparison
         testUnwrap("timestamp(3)", "date(a) <= NULL", new Constant(BOOLEAN, null));
         testUnwrap("timestamp(3)", "date(a) > NULL", new Constant(BOOLEAN, null));
         testUnwrap("timestamp(3)", "date(a) >= NULL", new Constant(BOOLEAN, null));
-        testUnwrap("timestamp(3)", "date(a) IS DISTINCT FROM NULL", not(new IsNull(new Cast(new Reference(createTimestampType(3), "a"), DATE))));
+        testUnwrap("timestamp(3)", "date(a) IS DISTINCT FROM NULL", not(new IsNull(new Reference(createTimestampType(3), "a"))));
 
         // non-optimized expression on the right
         testUnwrap("timestamp(3)", "date(a) = DATE '1981-06-22' + INTERVAL '2' DAY", new Logical(AND, ImmutableList.of(comparison(GREATER_THAN_OR_EQUAL, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1981-06-24 00:00:00.000"))), comparison(LESS_THAN, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1981-06-25 00:00:00.000"))))));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapYearInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapYearInComparison.java
@@ -70,8 +70,6 @@ public class TestUnwrapYearInComparison
 {
     private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
     private static final ResolvedFunction RANDOM = FUNCTIONS.resolveFunction("random", fromTypes());
-    private static final ResolvedFunction YEAR_DATE = FUNCTIONS.resolveFunction("year", fromTypes(DATE));
-    private static final ResolvedFunction YEAR_TIMESTAMP_3 = FUNCTIONS.resolveFunction("year", fromTypes(createTimestampType(3)));
 
     @Test
     public void testEquals()
@@ -286,8 +284,8 @@ public class TestUnwrapYearInComparison
     @Test
     public void testNaN()
     {
-        testUnwrap("date", "year(a) = nan()", new Logical(AND, ImmutableList.of(new IsNull(new Call(YEAR_DATE, ImmutableList.of(new Reference(DATE, "a")))), new Constant(BOOLEAN, null))));
-        testUnwrap("timestamp", "year(a) = nan()", new Logical(AND, ImmutableList.of(new IsNull(new Call(YEAR_TIMESTAMP_3, ImmutableList.of(new Reference(createTimestampType(3), "a")))), new Constant(BOOLEAN, null))));
+        testUnwrap("date", "year(a) = nan()", new Logical(AND, ImmutableList.of(new IsNull(new Reference(DATE, "a")), new Constant(BOOLEAN, null))));
+        testUnwrap("timestamp", "year(a) = nan()", new Logical(AND, ImmutableList.of(new IsNull(new Reference(createTimestampType(3), "a")), new Constant(BOOLEAN, null))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -177,9 +177,10 @@ public class TestSimplifyExpressions
         assertSimplifies(
                 new Logical(OR, ImmutableList.of(new Logical(AND, ImmutableList.of(new Logical(OR, ImmutableList.of(new Reference(BOOLEAN, "X"), new Reference(BOOLEAN, "V"))), new Reference(BOOLEAN, "Z"))), new Logical(AND, ImmutableList.of(new Logical(OR, ImmutableList.of(new Reference(BOOLEAN, "X"), new Reference(BOOLEAN, "V"))), new Reference(BOOLEAN, "V"))))),
                 new Logical(AND, ImmutableList.of(new Logical(OR, ImmutableList.of(new Reference(BOOLEAN, "X"), new Reference(BOOLEAN, "V"))), new Logical(OR, ImmutableList.of(new Reference(BOOLEAN, "Z"), new Reference(BOOLEAN, "V"))))));
+        // after common predicate extraction, X absorbs the residual disjunction (Z OR V OR X)
         assertSimplifies(
                 new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "X"), new Logical(OR, ImmutableList.of(new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "Y"), new Reference(BOOLEAN, "Z"))), new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "Y"), new Reference(BOOLEAN, "V"))), new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "Y"), new Reference(BOOLEAN, "X"))))))),
-                new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "X"), new Reference(BOOLEAN, "Y"), new Logical(OR, ImmutableList.of(new Reference(BOOLEAN, "Z"), new Reference(BOOLEAN, "V"), new Reference(BOOLEAN, "X"))))));
+                new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "X"), new Reference(BOOLEAN, "Y"))));
         assertSimplifies(
                 new Logical(OR, ImmutableList.of(new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "A"), new Reference(BOOLEAN, "B"), new Reference(BOOLEAN, "C"), new Reference(BOOLEAN, "D"))), new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "A"), new Reference(BOOLEAN, "B"), new Reference(BOOLEAN, "E"))), new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "A"), new Reference(BOOLEAN, "F"))))),
                 new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "A"), new Logical(OR, ImmutableList.of(new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "B"), new Reference(BOOLEAN, "C"), new Reference(BOOLEAN, "D"))), new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "B"), new Reference(BOOLEAN, "E"))), new Reference(BOOLEAN, "F"))))));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyFilterPredicate.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyFilterPredicate.java
@@ -33,6 +33,7 @@ import io.trino.sql.planner.SymbolAllocator;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import org.junit.jupiter.api.Test;
 
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -41,6 +42,7 @@ import static io.trino.sql.ir.Booleans.NULL_BOOLEAN;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.ComparisonOperator.EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN;
+import static io.trino.sql.ir.ComparisonOperator.IDENTICAL;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN;
 import static io.trino.sql.ir.IrExpressions.ifExpression;
 import static io.trino.sql.ir.Logical.Operator.AND;
@@ -56,6 +58,7 @@ public class TestSimplifyFilterPredicate
 {
     private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
     private static final ResolvedFunction ADD_INTEGER = FUNCTIONS.resolveOperator(OperatorType.ADD, ImmutableList.of(INTEGER, INTEGER));
+    private static final ResolvedFunction RANDOM = FUNCTIONS.resolveFunction("random", ImmutableList.of());
 
     @Test
     public void testSimplifyIfExpression()
@@ -488,6 +491,76 @@ public class TestSimplifyFilterPredicate
                         filter(
                                 FALSE,
                                 values("a", "b")));
+    }
+
+    @Test
+    public void testNullSafeEquality()
+    {
+        // a = b OR (a IS NULL AND b IS NULL) -> a IS NOT DISTINCT FROM b
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+                .on(p -> p.filter(
+                        new Logical(OR, ImmutableList.of(
+                                comparison(EQUAL, new Reference(BIGINT, "a"), new Reference(BIGINT, "b")),
+                                new Logical(AND, ImmutableList.of(new IsNull(new Reference(BIGINT, "a")), new IsNull(new Reference(BIGINT, "b")))))),
+                        p.values(p.symbol("a"), p.symbol("b"))))
+                .matches(
+                        filter(
+                                comparison(IDENTICAL, new Reference(BIGINT, "a"), new Reference(BIGINT, "b")),
+                                values("a", "b")));
+
+        // the null conjunction can precede the equality, and its terms can be in either order
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+                .on(p -> p.filter(
+                        new Logical(OR, ImmutableList.of(
+                                new Logical(AND, ImmutableList.of(new IsNull(new Reference(BIGINT, "b")), new IsNull(new Reference(BIGINT, "a")))),
+                                comparison(EQUAL, new Reference(BIGINT, "a"), new Reference(BIGINT, "b")))),
+                        p.values(p.symbol("a"), p.symbol("b"))))
+                .matches(
+                        filter(
+                                comparison(IDENTICAL, new Reference(BIGINT, "a"), new Reference(BIGINT, "b")),
+                                values("a", "b")));
+
+        // unrelated disjunction terms are preserved
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+                .on(p -> p.filter(
+                        new Logical(OR, ImmutableList.of(
+                                new Reference(BOOLEAN, "c"),
+                                comparison(EQUAL, new Reference(BIGINT, "a"), new Reference(BIGINT, "b")),
+                                new Logical(AND, ImmutableList.of(new IsNull(new Reference(BIGINT, "a")), new IsNull(new Reference(BIGINT, "b")))))),
+                        p.values(p.symbol("a"), p.symbol("b"), p.symbol("c", BOOLEAN))))
+                .matches(
+                        filter(
+                                new Logical(OR, ImmutableList.of(
+                                        new Reference(BOOLEAN, "c"),
+                                        comparison(IDENTICAL, new Reference(BIGINT, "a"), new Reference(BIGINT, "b")))),
+                                values("a", "b", "c")));
+
+        // the null conjunction must test exactly the compared expressions
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+                .on(p -> p.filter(
+                        new Logical(OR, ImmutableList.of(
+                                comparison(EQUAL, new Reference(BIGINT, "a"), new Reference(BIGINT, "b")),
+                                new Logical(AND, ImmutableList.of(new IsNull(new Reference(BIGINT, "a")), new IsNull(new Reference(BIGINT, "c")))))),
+                        p.values(p.symbol("a"), p.symbol("b"), p.symbol("c"))))
+                .doesNotFire();
+
+        // a conjunction with additional terms is not the null-safe equality pattern
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+                .on(p -> p.filter(
+                        new Logical(OR, ImmutableList.of(
+                                comparison(EQUAL, new Reference(BIGINT, "a"), new Reference(BIGINT, "b")),
+                                new Logical(AND, ImmutableList.of(new IsNull(new Reference(BIGINT, "a")), new IsNull(new Reference(BIGINT, "b")), new Reference(BOOLEAN, "c"))))),
+                        p.values(p.symbol("a"), p.symbol("b"), p.symbol("c", BOOLEAN))))
+                .doesNotFire();
+
+        // non-deterministic sides may evaluate to different values in the two occurrences
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+                .on(p -> p.filter(
+                        new Logical(OR, ImmutableList.of(
+                                comparison(EQUAL, new Call(RANDOM, ImmutableList.of()), new Reference(DOUBLE, "a")),
+                                new Logical(AND, ImmutableList.of(new IsNull(new Call(RANDOM, ImmutableList.of())), new IsNull(new Reference(DOUBLE, "a")))))),
+                        p.values(p.symbol("a", DOUBLE))))
+                .doesNotFire();
     }
 
     private static Expression not(Expression expression)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This PR adds nine always-on IR optimizer rules and one planner-rule extension, each in a separate commit with dedicated tests. All rewrites preserve exact expression semantics under three-valued logic — evaluation order, null propagation, and failure behavior — with mayFail/determinism guards wherever an evaluation is dropped or merged.

  CASE and MATCH restructuring

  - Flatten nested CASE (FlattenNestedCase): merges a CASE nested in the default clause into its parent, and collapses IF(x, IF(y, v, d), d) chains into a single CASE with conjoined conditions.
  - Merge CASE clauses (MergeCaseClauses): combines adjacent WHEN clauses with identical results into one clause with OR-ed conditions; drops trailing clauses whose result equals the default when their conditions cannot fail.
  - Flatten and merge MATCH clauses (FlattenNestedMatch, MergeMatchClauses): the MATCH (simple CASE) analogues of the two rules above, operating over a common deterministic operand.
  - Searched CASE → MATCH (SpecializeCaseToMatch): when every WHEN clause is an equality over the same deterministic expression, rewrites to a MATCH that evaluates the shared operand once instead of per clause, exposing the clauses to MATCH deduplication and merging.

  Logical and IS NULL simplification

  - Absorption laws (RemoveAbsorbedLogicalTerms): a OR (a AND b) → a, a AND (a OR b) → a, generalized to n-ary terms; the identity holds in Kleene logic, so no null guards are needed.
  - IS NULL decomposition (EvaluateIsNull): x IS NULL over COALESCE becomes a conjunction of IS NULL predicates (preserving laziness), and over a call to a function that returns null iff an argument is null becomes a disjunction over its arguments (guarded by never-fails).
  - Distribute IS NULL over CASE/MATCH (DistributeIsNullOverCase, DistributeIsNullOverMatch): pushes IS NULL into branches so per-branch nullability folds to constants; desugared NULLIF shapes are left intact for connector pushdown.

  Casts and concatenation

  - Collapse stacked casts (SimplifyStackedCast): CAST(CAST(x AS intermediate) AS target) → CAST(x AS target) when the inner cast is a type-only coercion. Composes with SimplifyRedundantCast to remove round-trip casts entirely.
  - Flatten concat (FlattenConcat): a || b || c parses as nested two-argument concat calls, each materializing an intermediate copy; chains of the uniform variadic variants (varchar, varbinary, array) are flattened into a single call. Failure behavior is association-independent, so the rewrite is exact.

  Planner rule

  - Null-safe equality recognition (SimplifyFilterPredicate): rewrites a = b OR (a IS NULL AND b IS NULL) in filter disjunctions to a IS NOT DISTINCT FROM b. The forms differ only in null-vs-false when exactly one side is null, which is equivalent in filter context — hence a planner rule rather than an IR rule. The IS NOT DISTINCT FROM form is recognized by
  equi-join extraction and domain translation, so hand-written null-safe join predicates can become hash joins instead of filtered cross joins.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## General
* Improve performance of queries containing nested or redundant `CASE` expressions, `IS NULL` predicates over conditional expressions, chained casts, chained `||` concatenations, and null-safe equality predicates written as `a = b OR (a IS NULL AND b IS NULL)`({issue}`issuenumber`)
```
