### PR TITLE
Fix CoarseGrainMemoryContext#addBytes

### DIFF
--- a/lib/trino-memory-context/src/main/java/io/trino/memory/context/CoarseGrainLocalMemoryContext.java
+++ b/lib/trino-memory-context/src/main/java/io/trino/memory/context/CoarseGrainLocalMemoryContext.java
@@ -38,6 +38,8 @@ public class CoarseGrainLocalMemoryContext
     private final long mask;
     @GuardedBy("this")
     private long currentBytes;
+    @GuardedBy("this")
+    private long exactBytes;
 
     public CoarseGrainLocalMemoryContext(LocalMemoryContext delegate)
     {
@@ -59,9 +61,16 @@ public class CoarseGrainLocalMemoryContext
         return currentBytes;
     }
 
+    @VisibleForTesting
+    synchronized long getExactBytes()
+    {
+        return exactBytes;
+    }
+
     @Override
     public synchronized ListenableFuture<Void> setBytes(long bytes)
     {
+        exactBytes = bytes;
         long roundedUpBytes = roundUpToNearest(bytes);
         if (roundedUpBytes != currentBytes) {
             currentBytes = roundedUpBytes;
@@ -73,21 +82,25 @@ public class CoarseGrainLocalMemoryContext
     @Override
     public synchronized ListenableFuture<Void> addBytes(long delta)
     {
-        return setBytes(addExact(currentBytes, delta));
+        return setBytes(addExact(exactBytes, delta));
     }
 
     @Override
     public synchronized boolean trySetBytes(long bytes)
     {
         long roundedUpBytes = roundUpToNearest(bytes);
-        if (roundedUpBytes != currentBytes) {
+        if (roundedUpBytes == currentBytes) {
+            exactBytes = bytes;
+            return true;
+        }
+        else {
             if (delegate.trySetBytes(roundedUpBytes)) {
                 currentBytes = roundedUpBytes;
+                exactBytes = bytes;
                 return true;
             }
             return false;
         }
-        return true;
     }
 
     @Override
@@ -95,6 +108,7 @@ public class CoarseGrainLocalMemoryContext
     {
         delegate.close();
         currentBytes = 0;
+        exactBytes = 0;
     }
 
     @VisibleForTesting

--- a/lib/trino-memory-context/src/test/java/io/trino/memory/context/TestMemoryContexts.java
+++ b/lib/trino-memory-context/src/test/java/io/trino/memory/context/TestMemoryContexts.java
@@ -193,19 +193,35 @@ public class TestMemoryContexts
 
         // test trySetBytes()
         coarseGrainContext.setBytes(0);
+        assertThat(coarseGrainContext.getExactBytes()).isEqualTo(0);
         assertThat(coarseGrainContext.trySetBytes(1)).isEqualTo(true);
+        assertThat(coarseGrainContext.getExactBytes()).isEqualTo(1);
         assertThat(coarseGrainContext.getBytes()).isEqualTo(granularity);
         assertThat(delegate.getBytes()).isEqualTo(granularity);
 
+        // test addBytes
+        coarseGrainContext.setBytes(0);
+        coarseGrainContext.addBytes(5);
+        coarseGrainContext.addBytes(10);
+        assertThat(coarseGrainContext.getExactBytes()).isEqualTo(15);
+        assertThat(coarseGrainContext.getBytes()).isEqualTo(granularity);
+
         // new bytes = previously set bytes(rounded-up)
         assertThat(coarseGrainContext.trySetBytes(2)).isEqualTo(true);
+        assertThat(coarseGrainContext.getExactBytes()).isEqualTo(2);
         assertThat(coarseGrainContext.getBytes()).isEqualTo(granularity);
         assertThat(delegate.getBytes()).isEqualTo(granularity);
 
         // something underlying delegate cannot set
         assertThat(coarseGrainContext.trySetBytes(guaranteedMemory * 3)).isEqualTo(false);
+        assertThat(coarseGrainContext.getExactBytes()).isEqualTo(2); // from last successful value
         assertThat(coarseGrainContext.getBytes()).isEqualTo(granularity);
         assertThat(delegate.getBytes()).isEqualTo(granularity);
+
+        coarseGrainContext.close();
+        assertThat(coarseGrainContext.getExactBytes()).isEqualTo(0);
+        assertThat(coarseGrainContext.getBytes()).isEqualTo(0);
+        assertThat(delegate.getBytes()).isEqualTo(0);
     }
 
     private static void assertCoarseGrainContextValues(
@@ -215,6 +231,7 @@ public class TestMemoryContexts
             long expectedValue)
     {
         assertThat(coarseGrainContext.setBytes(valueToSet)).isEqualTo(NOT_BLOCKED);
+        assertThat(coarseGrainContext.getExactBytes()).isEqualTo(valueToSet);
 
         assertThat(coarseGrainContext.roundUpToNearest(valueToSet)).isEqualTo(expectedValue);
         assertThat(coarseGrainContext.getBytes()).isEqualTo(expectedValue);


### PR DESCRIPTION
## Description
Previously, addBytes always added the incremental delta in bytes to the rounded-up value which could result in reported memory values diverging from the actual memory usage significantly. This doesn't appear to have been an issue in practice since `CoarseGrainLocalMemoryContext` was never used in a context that would use the `addBytes` method.

This behavioral regression was introduced by https://github.com/trinodb/trino/pull/26225


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
