### PR TITLE
Do not fold Match clauses that reference unbound symbols

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/EvaluateMatch.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/EvaluateMatch.java
@@ -25,6 +25,7 @@ import io.trino.sql.ir.optimizer.IrExpressionEvaluator;
 import io.trino.sql.ir.optimizer.IrOptimizerRule;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
+import io.trino.sql.planner.SymbolsExtractor;
 
 import java.util.HashMap;
 import java.util.List;
@@ -83,6 +84,15 @@ public class EvaluateMatch
                 clauseBindings.put(arguments.get(i).name(), ((Constant) bind.values().get(i)).value());
             }
             clauseBindings.put(arguments.getLast().name(), constantOperand.value());
+
+            // The evaluator silently resolves unbound references to null, so a body referencing
+            // symbols beyond the lambda arguments cannot be folded soundly. Bail and leave the
+            // Match for per-row evaluation.
+            boolean hasFreeReferences = SymbolsExtractor.extractAll(lambda.body()).stream()
+                    .anyMatch(symbol -> !clauseBindings.containsKey(symbol.name()));
+            if (hasFreeReferences) {
+                return Optional.empty();
+            }
 
             Object result;
             try {

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestEvaluateMatch.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestEvaluateMatch.java
@@ -88,6 +88,21 @@ public class TestEvaluateMatch
                         new Reference(VARCHAR, "b"))))
                 .describedAs("non-constant capture")
                 .isEqualTo(Optional.empty());
+
+        // A clause whose lambda body references an outer symbol directly (no Bind) must not be
+        // evaluated: the evaluator would silently resolve the free reference to null.
+        MatchClause clauseWithFreeReference = new MatchClause(
+                new Lambda(
+                        ImmutableList.of(parameter),
+                        comparison(EQUAL, new Reference(BIGINT, parameter.name()), new Reference(BIGINT, "x"))),
+                new Reference(VARCHAR, "a"));
+        assertThat(optimize(
+                new Match(
+                        new Constant(BIGINT, 1L),
+                        ImmutableList.of(clauseWithFreeReference),
+                        new Reference(VARCHAR, "b"))))
+                .describedAs("free reference in predicate body")
+                .isEqualTo(Optional.empty());
     }
 
     @Test


### PR DESCRIPTION
The IR evaluator silently resolves unbound references to null, so evaluating a clause predicate whose body references symbols beyond the lambda arguments folds the Match to a wrong result. Bail and leave the Match for per-row evaluation.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
