### PR TITLE
Add router plugin for prefix-based catalog redirection

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
@@ -118,7 +118,7 @@ public class CommentTask
 
     private void commentOnView(Comment statement, Session session)
     {
-        QualifiedObjectName viewName = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName viewName = metadata.getWriteRedirectedTableName(session, createQualifiedObjectName(session, statement, statement.getName()));
         if (!metadata.isView(session, viewName)) {
             String additionalInformation;
             if (metadata.getMaterializedView(session, viewName).isPresent()) {

--- a/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
@@ -135,7 +135,12 @@ public class CreateTableTask
         checkArgument(!statement.getElements().isEmpty(), "no columns for table");
 
         Map<NodeRef<Parameter>, Expression> parameterLookup = bindParameters(statement, parameters);
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
+        // Resolve write redirection before anything else: the existence check, access control and
+        // above all the table properties must be evaluated against the target catalog, since a
+        // pure-redirection catalog registers no table properties of its own.
+        QualifiedObjectName tableName = plannerContext.getMetadata().getWriteRedirectedTableName(
+                session,
+                createQualifiedObjectName(session, statement, statement.getName()));
         Optional<TableHandle> tableHandle;
         try {
             tableHandle = plannerContext.getMetadata().getTableHandle(session, tableName);

--- a/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
@@ -91,7 +91,8 @@ public class CreateViewTask
         Map<NodeRef<Parameter>, Expression> parameterLookup = bindParameters(statement, parameters);
 
         Session session = stateMachine.getSession();
-        QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName originalName = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName name = metadata.getWriteRedirectedTableName(session, originalName);
 
         accessControl.checkCanCreateView(session.toSecurityContext(), name);
 
@@ -136,10 +137,18 @@ public class CreateViewTask
                 parameterLookup,
                 true);
 
+        // When the view name was redirected, record the target catalog/schema as the defaults for
+        // resolving unqualified names in the view body. Storing the redirecting catalog would make
+        // the view resolvable only through it, and break reads against the catalog it actually
+        // lives in.
+        boolean redirected = !name.equals(originalName);
+        Optional<String> definitionCatalog = redirected ? Optional.of(name.catalogName()) : session.getCatalog();
+        Optional<String> definitionSchema = redirected ? Optional.of(name.schemaName()) : session.getSchema();
+
         ViewDefinition definition = new ViewDefinition(
                 sql,
-                session.getCatalog(),
-                session.getSchema(),
+                definitionCatalog,
+                definitionSchema,
                 columns,
                 statement.getComment(),
                 owner,

--- a/core/trino-main/src/main/java/io/trino/execution/DropViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropViewTask.java
@@ -58,7 +58,7 @@ public class DropViewTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
+        QualifiedObjectName name = metadata.getWriteRedirectedTableName(session, createQualifiedObjectName(session, statement, statement.getName()));
 
         if (metadata.isMaterializedView(session, name)) {
             throw semanticException(

--- a/core/trino-main/src/main/java/io/trino/execution/RefreshViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RefreshViewTask.java
@@ -86,7 +86,7 @@ public class RefreshViewTask
     {
         Metadata metadata = plannerContext.getMetadata();
         Session session = stateMachine.getSession();
-        QualifiedObjectName viewName = createQualifiedObjectName(session, refreshView, refreshView.getName());
+        QualifiedObjectName viewName = metadata.getWriteRedirectedTableName(session, createQualifiedObjectName(session, refreshView, refreshView.getName()));
 
         ViewDefinition viewDefinition = metadata.getView(session, viewName)
                 .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, refreshView, "View '%s' not found", viewName));

--- a/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
@@ -95,7 +95,9 @@ public class RenameTableTask
 
         TableHandle tableHandle = redirectionAwareTableHandle.tableHandle().get();
         QualifiedObjectName source = redirectionAwareTableHandle.redirectedTableName().orElse(tableName);
-        QualifiedObjectName target = createTargetQualifiedObjectName(source, statement.getTarget());
+        // Resolve the target through write redirection too, so an explicitly qualified three-part
+        // target naming the redirecting catalog lands in the same target catalog as the source.
+        QualifiedObjectName target = metadata.getWriteRedirectedTableName(session, createTargetQualifiedObjectName(source, statement.getTarget()));
         if (metadata.getCatalogHandle(session, target.catalogName()).isEmpty()) {
             throw semanticException(CATALOG_NOT_FOUND, statement, "Target catalog '%s' not found", target.catalogName());
         }

--- a/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
@@ -63,7 +63,7 @@ public class RenameViewTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName viewName = createQualifiedObjectName(session, statement, statement.getSource());
+        QualifiedObjectName viewName = metadata.getWriteRedirectedTableName(session, createQualifiedObjectName(session, statement, statement.getSource()));
         if (metadata.isMaterializedView(session, viewName)) {
             throw semanticException(
                     TABLE_NOT_FOUND,
@@ -86,7 +86,7 @@ public class RenameViewTask
             throw semanticException(TABLE_NOT_FOUND, statement, "View '%s' does not exist", viewName);
         }
 
-        QualifiedObjectName target = createTargetQualifiedObjectName(viewName, statement.getTarget());
+        QualifiedObjectName target = metadata.getWriteRedirectedTableName(session, createTargetQualifiedObjectName(viewName, statement.getTarget()));
         if (metadata.getCatalogHandle(session, target.catalogName()).isEmpty()) {
             throw semanticException(CATALOG_NOT_FOUND, statement, "Target catalog '%s' not found", target.catalogName());
         }

--- a/core/trino-main/src/main/java/io/trino/execution/SetPropertiesTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetPropertiesTask.java
@@ -106,8 +106,10 @@ public class SetPropertiesTask
         return immediateVoidFuture();
     }
 
-    private void setTableProperties(SetProperties statement, QualifiedObjectName tableName, Session session, Map<String, Optional<Object>> properties)
+    private void setTableProperties(SetProperties statement, QualifiedObjectName originalTableName, Session session, Map<String, Optional<Object>> properties)
     {
+        QualifiedObjectName tableName = plannerContext.getMetadata().getWriteRedirectedTableName(session, originalTableName);
+
         if (plannerContext.getMetadata().isMaterializedView(session, tableName)) {
             throw semanticException(NOT_SUPPORTED, statement, "Cannot set properties to a materialized view in ALTER TABLE");
         }

--- a/core/trino-main/src/main/java/io/trino/execution/TruncateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TruncateTableTask.java
@@ -60,7 +60,8 @@ public class TruncateTableTask
             WarningCollector warningCollector)
     {
         Session session = stateMachine.getSession();
-        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName());
+        QualifiedObjectName originalTableName = createQualifiedObjectName(session, statement, statement.getTableName());
+        QualifiedObjectName tableName = metadata.getWriteRedirectedTableName(session, originalTableName);
 
         if (metadata.isMaterializedView(session, tableName)) {
             throw semanticException(NOT_SUPPORTED, statement, "Cannot truncate a materialized view");

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -909,6 +909,13 @@ public interface Metadata
     RedirectionAwareView getRedirectionAwareView(Session session, QualifiedObjectName viewName);
 
     /**
+     * Resolve the redirection target for a write operation (table or view DDL), by name only.
+     * Returns {@code tableName} unchanged when the catalog does not redirect writes. The target is
+     * not required to exist, so this is also usable for CREATE.
+     */
+    QualifiedObjectName getWriteRedirectedTableName(Session session, QualifiedObjectName tableName);
+
+    /**
      * Returns a table handle for the specified table name with a specified version
      */
     Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion);

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -451,6 +451,15 @@ public final class MetadataManager
             CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle();
             ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
 
+            // If the connector would redirect this table, resolve the system table in the target catalog.
+            // Without this, system tables (e.g. $manifests) on prefix-schema tables are served by the
+            // source connector instead of the redirected catalog.
+            Optional<QualifiedObjectName> redirectedName = metadata.redirectTable(session.toConnectorSession(catalogHandle), tableName.asSchemaTableName())
+                    .map(name -> convertFromSchemaTableName(name.getCatalogName()).apply(name.getSchemaTableName()));
+            if (redirectedName.isPresent()) {
+                return getSystemTable(session, redirectedName.get());
+            }
+
             return metadata.getSystemTable(session.toConnectorSession(catalogHandle), tableName.asSchemaTableName());
         }
         return Optional.empty();
@@ -1685,16 +1694,49 @@ public final class MetadataManager
             return Optional.empty();
         }
 
-        Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, viewName.catalogName());
-        if (catalog.isPresent()) {
-            CatalogMetadata catalogMetadata = catalog.get();
-            CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle(session, viewName, Optional.empty(), Optional.empty());
-            ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
+        QualifiedObjectName name = viewName;
+        Set<QualifiedObjectName> visitedNames = new LinkedHashSet<>();
+        visitedNames.add(name);
 
-            ConnectorSession connectorSession = session.toConnectorSession(catalogHandle);
-            return metadata.getView(connectorSession, viewName.asSchemaTableName());
+        for (int count = 0; count < MAX_TABLE_REDIRECTIONS; count++) {
+            Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, name.catalogName());
+            if (catalog.isEmpty()) {
+                return Optional.empty();
+            }
+            CatalogMetadata catalogMetadata = catalog.get();
+
+            CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle(session, name, Optional.empty(), Optional.empty());
+            ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
+            Optional<ConnectorViewDefinition> view = metadata.getView(session.toConnectorSession(catalogHandle), name.asSchemaTableName());
+            if (view.isPresent()) {
+                return view;
+            }
+
+            // The view was not found directly. A pure-redirection connector (e.g. the router/virtual
+            // catalog that redirects a prefixed schema to the catalog where the relation actually
+            // resides) serves the view only on the redirect target and returns null from getTableHandle
+            // for it. Follow the redirect and retry getView() on the target, mirroring how
+            // getRedirectedTableName() follows redirects for tables.
+            CatalogHandle redirectHandle = catalogMetadata.getCatalogHandle();
+            ConnectorMetadata redirectMetadata = catalogMetadata.getMetadataFor(session, redirectHandle);
+            Optional<QualifiedObjectName> redirectedName = redirectMetadata.redirectTable(session.toConnectorSession(redirectHandle), name.asSchemaTableName())
+                    .map(target -> convertFromSchemaTableName(target.getCatalogName()).apply(target.getSchemaTableName()));
+            if (redirectedName.isEmpty()) {
+                return Optional.empty();
+            }
+
+            name = redirectedName.get();
+
+            // Check for loop in redirection
+            if (!visitedNames.add(name)) {
+                throw new TrinoException(TABLE_REDIRECTION_ERROR,
+                        format("Table redirections form a loop: %s",
+                                Streams.concat(visitedNames.stream(), Stream.of(name))
+                                        .map(QualifiedObjectName::toString)
+                                        .collect(Collectors.joining(" -> "))));
+            }
         }
-        return Optional.empty();
+        throw new TrinoException(TABLE_REDIRECTION_ERROR, format("Table redirected too many times (%d): %s", MAX_TABLE_REDIRECTIONS, visitedNames));
     }
 
     @Override
@@ -1909,31 +1951,65 @@ public final class MetadataManager
             return Optional.empty();
         }
 
-        Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, viewName.catalogName());
-        if (catalog.isPresent()) {
-            CatalogMetadata catalogMetadata = catalog.get();
-            CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle(session, viewName, Optional.empty(), Optional.empty());
-            ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
+        QualifiedObjectName name = viewName;
+        Set<QualifiedObjectName> visitedNames = new LinkedHashSet<>();
+        visitedNames.add(name);
 
-            ConnectorSession connectorSession = session.toConnectorSession(catalogHandle);
-            return metadata.getMaterializedView(connectorSession, viewName.asSchemaTableName());
+        for (int count = 0; count < MAX_TABLE_REDIRECTIONS; count++) {
+            Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, name.catalogName());
+            if (catalog.isEmpty()) {
+                return Optional.empty();
+            }
+            CatalogMetadata catalogMetadata = catalog.get();
+
+            CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle(session, name, Optional.empty(), Optional.empty());
+            ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
+            Optional<ConnectorMaterializedViewDefinition> materializedView = metadata.getMaterializedView(session.toConnectorSession(catalogHandle), name.asSchemaTableName());
+            if (materializedView.isPresent()) {
+                return materializedView;
+            }
+
+            // The materialized view was not found directly. A pure-redirection connector (e.g. the router/virtual
+            // catalog that redirects a prefixed schema to the catalog where the relation actually resides) serves the
+            // materialized view only on the redirect target. Follow the redirect and retry getMaterializedView() on the
+            // target, mirroring how getViewInternal() and getRedirectedTableName() follow redirects.
+            CatalogHandle redirectHandle = catalogMetadata.getCatalogHandle();
+            ConnectorMetadata redirectMetadata = catalogMetadata.getMetadataFor(session, redirectHandle);
+            Optional<QualifiedObjectName> redirectedName = redirectMetadata.redirectTable(session.toConnectorSession(redirectHandle), name.asSchemaTableName())
+                    .map(target -> convertFromSchemaTableName(target.getCatalogName()).apply(target.getSchemaTableName()));
+            if (redirectedName.isEmpty()) {
+                return Optional.empty();
+            }
+
+            name = redirectedName.get();
+
+            // Check for loop in redirection
+            if (!visitedNames.add(name)) {
+                throw new TrinoException(TABLE_REDIRECTION_ERROR,
+                        format("Table redirections form a loop: %s",
+                                Streams.concat(visitedNames.stream(), Stream.of(name))
+                                        .map(QualifiedObjectName::toString)
+                                        .collect(Collectors.joining(" -> "))));
+            }
         }
-        return Optional.empty();
+        throw new TrinoException(TABLE_REDIRECTION_ERROR, format("Table redirected too many times (%d): %s", MAX_TABLE_REDIRECTIONS, visitedNames));
     }
 
     @Override
     public Map<String, Object> getMaterializedViewProperties(Session session, QualifiedObjectName viewName, MaterializedViewDefinition materializedViewDefinition)
     {
-        Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, viewName.catalogName());
+        // Follow redirects so properties are read from the catalog where the materialized view actually resides.
+        QualifiedObjectName resolvedName = getRedirectedTableName(session, viewName);
+        Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, resolvedName.catalogName());
         if (catalog.isPresent()) {
             CatalogMetadata catalogMetadata = catalog.get();
-            CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle(session, viewName, Optional.empty(), Optional.empty());
+            CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle(session, resolvedName, Optional.empty(), Optional.empty());
             ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
 
             ConnectorSession connectorSession = session.toConnectorSession(catalogHandle);
             return ImmutableMap.copyOf(metadata.getMaterializedViewProperties(
                     connectorSession,
-                    viewName.asSchemaTableName(),
+                    resolvedName.asSchemaTableName(),
                     materializedViewDefinition.toConnectorMaterializedViewDefinition()));
         }
         return ImmutableMap.of();
@@ -1942,14 +2018,18 @@ public final class MetadataManager
     @Override
     public MaterializedViewFreshness getMaterializedViewFreshness(Session session, QualifiedObjectName viewName, boolean considerGracePeriod)
     {
-        Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, viewName.catalogName());
+        // A materialized view may be reached through a redirect (e.g. the router/virtual catalog). Resolve to the
+        // catalog where it actually resides before asking for freshness, otherwise the source connector (which has
+        // no materialized view there) throws "getMaterializedView() is implemented without getMaterializedViewFreshness()".
+        QualifiedObjectName resolvedName = getRedirectedTableName(session, viewName);
+        Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, resolvedName.catalogName());
         if (catalog.isPresent()) {
             CatalogMetadata catalogMetadata = catalog.get();
-            CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle(session, viewName, Optional.empty(), Optional.empty());
+            CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle(session, resolvedName, Optional.empty(), Optional.empty());
             ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
 
             ConnectorSession connectorSession = session.toConnectorSession(catalogHandle);
-            return metadata.getMaterializedViewFreshness(connectorSession, viewName.asSchemaTableName(), considerGracePeriod);
+            return metadata.getMaterializedViewFreshness(connectorSession, resolvedName.asSchemaTableName(), considerGracePeriod);
         }
         return new MaterializedViewFreshness(STALE, Optional.empty());
     }
@@ -2009,7 +2089,18 @@ public final class MetadataManager
         return metadata.applyTableScanRedirect(connectorSession, tableHandle.connectorHandle());
     }
 
-    private QualifiedObjectName getRedirectedTableName(Session session, QualifiedObjectName originalTableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
+    @Override
+    public QualifiedObjectName getWriteRedirectedTableName(Session session, QualifiedObjectName tableName)
+    {
+        return getRedirectedTableName(session, tableName, true);
+    }
+
+    private QualifiedObjectName getRedirectedTableName(Session session, QualifiedObjectName originalTableName)
+    {
+        return getRedirectedTableName(session, originalTableName, false);
+    }
+
+    private QualifiedObjectName getRedirectedTableName(Session session, QualifiedObjectName originalTableName, boolean forWrite)
     {
         requireNonNull(session, "session is null");
         requireNonNull(originalTableName, "originalTableName is null");
@@ -2030,10 +2121,18 @@ public final class MetadataManager
             }
 
             CatalogMetadata catalogMetadata = catalog.get();
-            CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle(session, tableName, toConnectorVersion(startVersion), toConnectorVersion(endVersion));
+            // Always consult the main catalog connector for redirect decisions, bypassing
+            // the system table routing in getCatalogHandle(session, table, ...). This ensures
+            // that system tables (e.g. $manifests, $partitions) on prefix-schema tables are
+            // redirected to the target catalog where the table actually resides.
+            CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle();
             ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
 
-            Optional<QualifiedObjectName> redirectedTableName = metadata.redirectTable(session.toConnectorSession(catalogHandle), tableName.asSchemaTableName())
+            ConnectorSession connectorSession = session.toConnectorSession(catalogHandle);
+            SchemaTableName schemaTableName = tableName.asSchemaTableName();
+            Optional<QualifiedObjectName> redirectedTableName = (forWrite
+                    ? metadata.redirectTableForWrite(connectorSession, schemaTableName)
+                    : metadata.redirectTable(connectorSession, schemaTableName))
                     .map(name -> convertFromSchemaTableName(name.getCatalogName()).apply(name.getSchemaTableName()));
 
             if (redirectedTableName.isEmpty()) {
@@ -2063,7 +2162,7 @@ public final class MetadataManager
     @Override
     public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
     {
-        QualifiedObjectName targetTableName = getRedirectedTableName(session, tableName, startVersion, endVersion);
+        QualifiedObjectName targetTableName = getRedirectedTableName(session, tableName);
         if (targetTableName.equals(tableName)) {
             return noRedirection(getTableHandle(session, tableName, startVersion, endVersion));
         }
@@ -2078,15 +2177,15 @@ public final class MetadataManager
             throw new TrinoException(TABLE_REDIRECTION_ERROR, format("Table '%s' redirected to '%s', but the target catalog '%s' does not exist", tableName, targetTableName, targetTableName.catalogName()));
         }
         if (!schemaExists(session, new CatalogSchemaName(targetTableName.catalogName(), targetTableName.schemaName()))) {
-            throw new TrinoException(TABLE_REDIRECTION_ERROR, format("Table '%s' redirected to '%s', but the target schema '%s' does not exist", tableName, targetTableName, targetTableName.schemaName()));
+            throw new TrinoException(SCHEMA_NOT_FOUND, format("Schema '%s' does not exist", targetTableName.schemaName()));
         }
-        throw new TrinoException(TABLE_REDIRECTION_ERROR, format("Table '%s' redirected to '%s', but the target table '%s' does not exist", tableName, targetTableName, targetTableName));
+        throw new TrinoException(TABLE_NOT_FOUND, format("Table '%s' does not exist", tableName));
     }
 
     @Override
     public RedirectionAwareView getRedirectionAwareView(Session session, QualifiedObjectName viewName)
     {
-        QualifiedObjectName targetViewName = getRedirectedTableName(session, viewName, Optional.empty(), Optional.empty());
+        QualifiedObjectName targetViewName = getRedirectedTableName(session, viewName);
         Optional<ViewDefinition> view = getView(session, targetViewName);
 
         if (targetViewName.equals(viewName)) {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -935,7 +935,10 @@ class StatementAnalyzer
         protected Scope visitCreateTableAsSelect(CreateTableAsSelect node, Optional<Scope> scope)
         {
             // turn this into a query that has a new table writer node on top.
-            QualifiedObjectName targetTable = createQualifiedObjectName(session, node, node.getName());
+            // Resolve write redirection first so the existence check, table properties and access
+            // control all apply to the target catalog, and so the resolved name is what lands in
+            // analysis.setCreate() for the planner.
+            QualifiedObjectName targetTable = metadata.getWriteRedirectedTableName(session, createQualifiedObjectName(session, node, node.getName()));
 
             Optional<TableHandle> targetTableHandle = metadata.getTableHandle(session, targetTable);
             if (targetTableHandle.isPresent() && node.getSaveMode() != REPLACE) {

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -1488,6 +1488,15 @@ public class TracingConnectorMetadata
     }
 
     @Override
+    public Optional<CatalogSchemaTableName> redirectTableForWrite(ConnectorSession session, SchemaTableName tableName)
+    {
+        Span span = startSpan("redirectTableForWrite", tableName);
+        try (var _ = scopedSpan(span)) {
+            return delegate.redirectTableForWrite(session, tableName);
+        }
+    }
+
+    @Override
     public OptionalInt getMaxWriterTasks(ConnectorSession session)
     {
         Span span = startSpan("getMaxWriterTasks");

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -1666,6 +1666,15 @@ public class TracingMetadata
     }
 
     @Override
+    public QualifiedObjectName getWriteRedirectedTableName(Session session, QualifiedObjectName tableName)
+    {
+        Span span = startSpan("getWriteRedirectedTableName", tableName);
+        try (var _ = scopedSpan(span)) {
+            return delegate.getWriteRedirectedTableName(session, tableName);
+        }
+    }
+
+    @Override
     public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
     {
         Span span = startSpan("getTableHandle", tableName);

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -1111,6 +1111,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public QualifiedObjectName getWriteRedirectedTableName(Session session, QualifiedObjectName tableName)
+    {
+        return tableName;
+    }
+
+    @Override
     public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
     {
         if (startVersion.isEmpty() || endVersion.isEmpty()) {

--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -272,6 +272,12 @@
         </artifact>
     </artifactSet>
 
+    <artifactSet to="plugin/router">
+        <artifact id="${project.groupId}:trino-router:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
     <artifactSet to="plugin/singlestore">
         <artifact id="${project.groupId}:trino-singlestore:zip:${project.version}">
             <unpack />

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1834,6 +1834,19 @@ public interface ConnectorMetadata
         return Optional.empty();
     }
 
+    /**
+     * Redirects a table for write operations (table and view DDL) which may or may not be in the
+     * same catalog. Unlike {@link #redirectTable}, the target is not required to already exist, so
+     * this is also consulted for CREATE TABLE, CREATE TABLE AS SELECT and CREATE VIEW.
+     * <p>
+     * Defaults to no redirection so that connectors implementing only {@link #redirectTable} keep
+     * their current write behaviour.
+     */
+    default Optional<CatalogSchemaTableName> redirectTableForWrite(ConnectorSession session, SchemaTableName tableName)
+    {
+        return Optional.empty();
+    }
+
     default OptionalInt getMaxWriterTasks(ConnectorSession session)
     {
         return OptionalInt.empty();

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -1327,6 +1327,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public Optional<CatalogSchemaTableName> redirectTableForWrite(ConnectorSession session, SchemaTableName tableName)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.redirectTableForWrite(session, tableName);
+        }
+    }
+
+    @Override
     public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName, Optional<ConnectorTableVersion> startVersion, Optional<ConnectorTableVersion> endVersion)
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -137,10 +137,12 @@ import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.StandardErrorCode.PERMISSION_DENIED;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.UNSUPPORTED_TABLE_TYPE;
 import static io.trino.spi.connector.SchemaTableName.schemaTableName;
 import static io.trino.spi.security.PrincipalType.USER;
+import static java.lang.String.format;
 import static java.util.Map.entry;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newFixedThreadPool;
@@ -480,6 +482,13 @@ public class GlueHiveMetastore
         }
         catch (EntityNotFoundException e) {
             return Optional.empty();
+        }
+        catch (AccessDeniedException e) {
+            // Glue/Lake Formation returns AccessDenied when the caller lacks permission (e.g. LF Describe).
+            // Surface it as a permission error instead of converting it to TableNotFoundException: the
+            // latter is misleading (especially for CREATE TABLE, where the table not yet existing is
+            // expected) and masks the real cause, which is the missing Lake Formation permission.
+            throw new TrinoException(PERMISSION_DENIED, format("Cannot access table '%s.%s' in Glue catalog: insufficient Lake Formation permissions", databaseName, tableName), e);
         }
         catch (SdkException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewDefinition.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewDefinition.java
@@ -62,6 +62,7 @@ public record IcebergMaterializedViewDefinition(
 
     public static IcebergMaterializedViewDefinition decodeMaterializedViewData(String data)
     {
+        checkCondition(data != null, HIVE_INVALID_VIEW_DATA, "Materialized View data is null");
         checkCondition(data.startsWith(MATERIALIZED_VIEW_PREFIX), HIVE_INVALID_VIEW_DATA, "Materialized View data missing prefix: %s", data);
         checkCondition(data.endsWith(MATERIALIZED_VIEW_SUFFIX), HIVE_INVALID_VIEW_DATA, "Materialized View data missing suffix: %s", data);
         data = data.substring(MATERIALIZED_VIEW_PREFIX.length());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -1339,13 +1339,13 @@ public class TrinoGlueCatalog
             String storageSchema = Optional.ofNullable(materializedViewParameters.get(STORAGE_SCHEMA))
                     .orElse(viewName.getSchemaName());
             storageTableName = new SchemaTableName(storageSchema, storageTable);
-
-            if (table.viewOriginalText() == null) {
-                throw new TrinoException(ICEBERG_BAD_DATA, "Materialized view did not have original text " + viewName);
-            }
         }
         else {
             storageTableName = new SchemaTableName(viewName.getSchemaName(), tableNameWithType(viewName.getTableName(), MATERIALIZED_VIEW_STORAGE));
+        }
+
+        if (table.viewOriginalText() == null) {
+            throw new TrinoException(ICEBERG_BAD_DATA, "Materialized view did not have original text " + viewName);
         }
 
         return getMaterializedViewDefinition(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedViewDefinition.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedViewDefinition.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.TrinoException;
+import io.trino.spi.type.TypeId;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.decodeMaterializedViewData;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.encodeMaterializedViewData;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestIcebergMaterializedViewDefinition
+{
+    @Test
+    public void testRoundTrip()
+    {
+        List<IcebergMaterializedViewDefinition.Column> columns = ImmutableList.of(
+                new IcebergMaterializedViewDefinition.Column("a", TypeId.of("integer"), Optional.empty()));
+        IcebergMaterializedViewDefinition definition = new IcebergMaterializedViewDefinition(
+                "SELECT a FROM base",
+                Optional.of("iceberg"),
+                Optional.of("schema"),
+                columns,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.of());
+
+        assertThat(decodeMaterializedViewData(encodeMaterializedViewData(definition))).isEqualTo(definition);
+    }
+
+    @Test
+    public void testDecodeNullData()
+    {
+        // Regression for EGANP-6330: a materialized view whose ViewOriginalText is null in the
+        // metastore must surface a clean TrinoException, not an unguarded NullPointerException
+        // (which escaped to the user as GENERIC_INTERNAL_ERROR).
+        assertThatThrownBy(() -> decodeMaterializedViewData(null))
+                .isInstanceOf(TrinoException.class)
+                .hasMessageContaining("Materialized View data is null");
+    }
+
+    @Test
+    public void testDecodeMissingPrefix()
+    {
+        assertThatThrownBy(() -> decodeMaterializedViewData("not a materialized view"))
+                .isInstanceOf(TrinoException.class)
+                .hasMessageContaining("missing prefix");
+    }
+}

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseMetadata.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseMetadata.java
@@ -692,6 +692,18 @@ public class LakehouseMetadata
             return icebergMetadata.getView(session, viewName);
         }
 
+        // EXPERIMENT (EGANP-6330): proposed fix to short-circuit materialized-view headers before the Hive
+        // view path. Iceberg materialized views are VIRTUAL_VIEW entries with a "/* Presto Materialized View: */"
+        // header; return empty here so getMaterializedView() (iceberg) owns them. Isolated commit — revert if it
+        // doesn't change the observed failures (which originate in the iceberg getMaterializedView path).
+        String viewOriginalText = hiveMetadata.getMetastore()
+                .getTable(viewName.getSchemaName(), viewName.getTableName())
+                .flatMap(Table::getViewOriginalText)
+                .orElse("");
+        if (viewOriginalText.startsWith("/* Presto Materialized View:")
+                || viewOriginalText.startsWith("/* Trino Materialized View:")) {
+            return Optional.empty();
+        }
         return hiveMetadata.getView(session, viewName);
     }
 

--- a/plugin/trino-router/pom.xml
+++ b/plugin/trino-router/pom.xml
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>484-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-router</artifactId>
+    <packaging>trino-plugin</packaging>
+    <name>${project.artifactId}</name>
+    <description>Trino - Router connector (virtual catalog with schema-based redirection)</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>classes</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>glue</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-client-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sdk-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-hdfs</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-iceberg</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredResourcePatterns>
+                        <ignoredResourcePattern>iceberg-build.properties</ignoredResourcePattern>
+                    </ignoredResourcePatterns>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugin/trino-router/src/main/java/io/trino/plugin/router/RouterConfig.java
+++ b/plugin/trino-router/src/main/java/io/trino/plugin/router/RouterConfig.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.router;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+public class RouterConfig
+{
+    private Map<String, String> schemaPrefixRules = ImmutableMap.of();
+    private Map<String, String> schemaPrefixGlueCatalogIds = ImmutableMap.of();
+    private Map<String, List<String>> schemaPrefixMappedSchemas = ImmutableMap.of();
+    private Optional<String> defaultCatalogTarget = Optional.empty();
+    private Optional<String> defaultCatalogId = Optional.empty();
+    private List<String> defaultMappedSchemas = ImmutableList.of();
+    private boolean writesEnabled;
+    private Optional<String> glueRegion = Optional.empty();
+    private Optional<String> glueIamRole = Optional.empty();
+    private Optional<String> glueExternalId = Optional.empty();
+    private Optional<String> glueAwsAccessKey = Optional.empty();
+    private Optional<String> glueAwsSecretKey = Optional.empty();
+    private boolean glueUseWebIdentityTokenCredentialsProvider;
+    private boolean gluePinClientToCurrentRegion;
+
+    public Map<String, String> getSchemaPrefixRules()
+    {
+        return schemaPrefixRules;
+    }
+
+    @Config("router.schema-prefix-rules")
+    @ConfigDescription("Comma-separated list of prefix=catalog pairs; schemas matching a prefix are redirected with the prefix stripped (e.g. 'prod_=catalog_prod,staging_=catalog_staging')")
+    public RouterConfig setSchemaPrefixRules(List<String> rules)
+    {
+        this.schemaPrefixRules = parseRules(rules, "router.schema-prefix-rules");
+        return this;
+    }
+
+    public Map<String, String> getSchemaPrefixGlueCatalogIds()
+    {
+        return schemaPrefixGlueCatalogIds;
+    }
+
+    @Config("router.schema-prefix-glue-catalog-ids")
+    @ConfigDescription("Comma-separated list of prefix=glue-catalog-id pairs specifying which Glue catalog (AWS account ID) to query for each prefix; omitting a prefix uses the default account (e.g. 'prod_=111122223333,staging_=444455556666')")
+    public RouterConfig setSchemaPrefixGlueCatalogIds(List<String> rules)
+    {
+        this.schemaPrefixGlueCatalogIds = parseRules(rules, "router.schema-prefix-glue-catalog-ids");
+        return this;
+    }
+
+    public Map<String, List<String>> getSchemaPrefixMappedSchemas()
+    {
+        return schemaPrefixMappedSchemas;
+    }
+
+    @Config("router.schema-prefix-mapped-schemas")
+    @ConfigDescription("Comma-separated list of prefix=regex entries restricting which schemas are exposed per prefix; omitting a prefix allows all schemas (e.g. 'prod_=sales.*,prod_=marketing,staging_=stg_.*')")
+    public RouterConfig setSchemaPrefixMappedSchemas(List<String> entries)
+    {
+        Map<String, ImmutableList.Builder<String>> builders = new LinkedHashMap<>();
+        for (String entry : entries) {
+            String[] parts = entry.split("=", 2);
+            if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+                throw new IllegalArgumentException("Invalid router.schema-prefix-mapped-schemas entry, expected 'prefix=regex': " + entry);
+            }
+            try {
+                Pattern.compile(parts[1]);
+            }
+            catch (PatternSyntaxException e) {
+                throw new IllegalArgumentException("Invalid regex in router.schema-prefix-mapped-schemas: " + parts[1], e);
+            }
+            builders.computeIfAbsent(parts[0], _ -> ImmutableList.builder()).add(parts[1]);
+        }
+        this.schemaPrefixMappedSchemas = builders.entrySet().stream()
+                .collect(toImmutableMap(Map.Entry::getKey, e -> e.getValue().build()));
+        return this;
+    }
+
+    public Optional<String> getDefaultCatalogTarget()
+    {
+        return defaultCatalogTarget;
+    }
+
+    @Config("router.default.catalog-target")
+    @ConfigDescription("Trino catalog to redirect unprefixed Glue schemas to; enables local Glue schema listing when set")
+    public RouterConfig setDefaultCatalogTarget(String defaultCatalogTarget)
+    {
+        this.defaultCatalogTarget = Optional.ofNullable(defaultCatalogTarget);
+        return this;
+    }
+
+    public Optional<String> getDefaultCatalogId()
+    {
+        return defaultCatalogId;
+    }
+
+    @Config("router.default.catalog-id")
+    @ConfigDescription("Glue catalog ID (AWS account ID) for unprefixed schema listing; omit to use the default account")
+    public RouterConfig setDefaultCatalogId(String defaultCatalogId)
+    {
+        this.defaultCatalogId = Optional.ofNullable(defaultCatalogId);
+        return this;
+    }
+
+    public List<String> getDefaultMappedSchemas()
+    {
+        return defaultMappedSchemas;
+    }
+
+    @Config("router.default.mapped-schemas")
+    @ConfigDescription("Comma-separated list of Java regexes restricting which unprefixed schemas are exposed; empty allows all (e.g. 'sales.*,marketing')")
+    public RouterConfig setDefaultMappedSchemas(List<String> patterns)
+    {
+        for (String pattern : patterns) {
+            try {
+                Pattern.compile(pattern);
+            }
+            catch (PatternSyntaxException e) {
+                throw new IllegalArgumentException("Invalid regex in router.default.mapped-schemas: " + pattern, e);
+            }
+        }
+        this.defaultMappedSchemas = ImmutableList.copyOf(patterns);
+        return this;
+    }
+
+    public boolean isWritesEnabled()
+    {
+        return writesEnabled;
+    }
+
+    @Config("router.writes-enabled")
+    @ConfigDescription("Redirect write operations (CREATE TABLE, CREATE TABLE AS SELECT, TRUNCATE, ALTER TABLE SET PROPERTIES, three-part RENAME TO, and view DDL) to the target catalog; when false these statements fail as unsupported")
+    public RouterConfig setWritesEnabled(boolean writesEnabled)
+    {
+        this.writesEnabled = writesEnabled;
+        return this;
+    }
+
+    public Optional<String> getGlueRegion()
+    {
+        return glueRegion;
+    }
+
+    @Config("router.glue.region")
+    @ConfigDescription("AWS region for the Glue Data Catalog used to enumerate prefix-mapped schemas")
+    public RouterConfig setGlueRegion(String glueRegion)
+    {
+        this.glueRegion = Optional.ofNullable(glueRegion);
+        return this;
+    }
+
+    public Optional<String> getGlueIamRole()
+    {
+        return glueIamRole;
+    }
+
+    @Config("router.glue.iam-role")
+    @ConfigDescription("ARN of an IAM role to assume when connecting to Glue")
+    public RouterConfig setGlueIamRole(String glueIamRole)
+    {
+        this.glueIamRole = Optional.ofNullable(glueIamRole);
+        return this;
+    }
+
+    public Optional<String> getGlueExternalId()
+    {
+        return glueExternalId;
+    }
+
+    @Config("router.glue.external-id")
+    @ConfigDescription("External ID for the IAM role trust policy when connecting to Glue")
+    public RouterConfig setGlueExternalId(String glueExternalId)
+    {
+        this.glueExternalId = Optional.ofNullable(glueExternalId);
+        return this;
+    }
+
+    public Optional<String> getGlueAwsAccessKey()
+    {
+        return glueAwsAccessKey;
+    }
+
+    @Config("router.glue.aws-access-key")
+    @ConfigDescription("AWS access key for Glue")
+    public RouterConfig setGlueAwsAccessKey(String glueAwsAccessKey)
+    {
+        this.glueAwsAccessKey = Optional.ofNullable(glueAwsAccessKey);
+        return this;
+    }
+
+    public Optional<String> getGlueAwsSecretKey()
+    {
+        return glueAwsSecretKey;
+    }
+
+    @Config("router.glue.aws-secret-key")
+    @ConfigDescription("AWS secret key for Glue")
+    @ConfigSecuritySensitive
+    public RouterConfig setGlueAwsSecretKey(String glueAwsSecretKey)
+    {
+        this.glueAwsSecretKey = Optional.ofNullable(glueAwsSecretKey);
+        return this;
+    }
+
+    public boolean isGlueUseWebIdentityTokenCredentialsProvider()
+    {
+        return glueUseWebIdentityTokenCredentialsProvider;
+    }
+
+    @Config("router.glue.use-web-identity-token-credentials-provider")
+    @ConfigDescription("Use the WebIdentityTokenCredentialsProvider for Glue authentication")
+    public RouterConfig setGlueUseWebIdentityTokenCredentialsProvider(boolean glueUseWebIdentityTokenCredentialsProvider)
+    {
+        this.glueUseWebIdentityTokenCredentialsProvider = glueUseWebIdentityTokenCredentialsProvider;
+        return this;
+    }
+
+    public boolean isGluePinClientToCurrentRegion()
+    {
+        return gluePinClientToCurrentRegion;
+    }
+
+    @Config("router.glue.pin-client-to-current-region")
+    @ConfigDescription("Pin the Glue client to the current EC2 region")
+    public RouterConfig setGluePinClientToCurrentRegion(boolean gluePinClientToCurrentRegion)
+    {
+        this.gluePinClientToCurrentRegion = gluePinClientToCurrentRegion;
+        return this;
+    }
+
+    private static Map<String, String> parseRules(List<String> rules, String configName)
+    {
+        return rules.stream()
+                .map(rule -> rule.split("=", 2))
+                .peek(parts -> {
+                    if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+                        throw new IllegalArgumentException("Invalid " + configName + " entry, expected 'key=catalog': " + String.join("=", parts));
+                    }
+                })
+                .collect(toImmutableMap(parts -> parts[0], parts -> parts[1]));
+    }
+}

--- a/plugin/trino-router/src/main/java/io/trino/plugin/router/RouterConnector.java
+++ b/plugin/trino-router/src/main/java/io/trino/plugin/router/RouterConnector.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.router;
+
+import com.google.inject.Inject;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.transaction.IsolationLevel;
+
+import static io.trino.spi.transaction.IsolationLevel.READ_COMMITTED;
+import static io.trino.spi.transaction.IsolationLevel.checkConnectorSupports;
+import static java.util.Objects.requireNonNull;
+
+public class RouterConnector
+        implements Connector
+{
+    private final LifeCycleManager lifeCycleManager;
+    private final RouterMetadata metadata;
+
+    @Inject
+    public RouterConnector(LifeCycleManager lifeCycleManager, RouterMetadata metadata)
+    {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
+    {
+        checkConnectorSupports(READ_COMMITTED, isolationLevel);
+        return RouterTransactionHandle.INSTANCE;
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transactionHandle)
+    {
+        return metadata;
+    }
+
+    @Override
+    public void shutdown()
+    {
+        lifeCycleManager.stop();
+    }
+}

--- a/plugin/trino-router/src/main/java/io/trino/plugin/router/RouterConnectorFactory.java
+++ b/plugin/trino-router/src/main/java/io/trino/plugin/router/RouterConnectorFactory.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.router;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.log.Logger;
+import io.trino.plugin.base.ConnectorContextModule;
+import io.trino.plugin.base.jmx.MBeanServerModule;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.GlueClientBuilder;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.auth.StsWebIdentityTokenFileCredentialsProvider;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class RouterConnectorFactory
+        implements ConnectorFactory
+{
+    private static final Logger log = Logger.get(RouterConnectorFactory.class);
+
+    @Override
+    public String getName()
+    {
+        return "router";
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+    {
+        log.info("Creating router connector for catalog '%s'", catalogName);
+        // No checkStrictSpiVersionMatch: that guard is intended only for plugins distributed with Trino.
+        // trino-router is an EG-internal plugin deployed as a standalone ZIP across OS Trino and Starburst
+        // (e.g. 476-e.7), whose SPI version strings never match exactly. The SPI surface used here is stable
+        // across these versions, so a single artifact is binary-compatible without the exact-version check.
+        Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.catalog." + catalogName,
+                new MBeanServerModule(),
+                new ConnectorContextModule(catalogName, context),
+                new RouterModule());
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .disableSystemProperties()
+                .setRequiredConfigurationProperties(config)
+                .initialize();
+
+        return injector.getInstance(RouterConnector.class);
+    }
+
+    private static class RouterModule
+            extends AbstractModule
+    {
+        @Override
+        protected void configure()
+        {
+            configBinder(binder()).bindConfig(RouterConfig.class);
+            bind(RouterConnector.class).in(Scopes.SINGLETON);
+            bind(RouterMetadata.class).in(Scopes.SINGLETON);
+        }
+
+        @Provides
+        @Singleton
+        public GlueClient provideGlueClient(RouterConfig routerConfig)
+        {
+            GlueClientBuilder glue = GlueClient.builder();
+
+            Optional<StaticCredentialsProvider> staticCredentials = Optional.empty();
+            if (routerConfig.getGlueAwsAccessKey().isPresent() && routerConfig.getGlueAwsSecretKey().isPresent()) {
+                staticCredentials = Optional.of(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(routerConfig.getGlueAwsAccessKey().get(), routerConfig.getGlueAwsSecretKey().get())));
+            }
+
+            if (routerConfig.isGlueUseWebIdentityTokenCredentialsProvider()) {
+                log.info("Router Glue auth: web identity token credentials provider (configured region=%s)", routerConfig.getGlueRegion().orElse("<default>"));
+                StsClientBuilder sts = StsClient.builder();
+                staticCredentials.ifPresent(sts::credentialsProvider);
+                routerConfig.getGlueRegion().ifPresent(r -> sts.region(Region.of(r)));
+                glue.credentialsProvider(StsWebIdentityTokenFileCredentialsProvider.builder()
+                        .stsClient(sts.build())
+                        .asyncCredentialUpdateEnabled(true)
+                        .build());
+            }
+            else if (routerConfig.getGlueIamRole().isPresent()) {
+                log.info("Router Glue auth: assume IAM role %s (externalId set=%s, configured region=%s)",
+                        routerConfig.getGlueIamRole().get(),
+                        routerConfig.getGlueExternalId().isPresent(),
+                        routerConfig.getGlueRegion().orElse("<default>"));
+                StsClientBuilder sts = StsClient.builder();
+                staticCredentials.ifPresent(sts::credentialsProvider);
+                routerConfig.getGlueRegion().ifPresent(r -> sts.region(Region.of(r)));
+                glue.credentialsProvider(StsAssumeRoleCredentialsProvider.builder()
+                        .refreshRequest(request -> request
+                                .roleArn(routerConfig.getGlueIamRole().get())
+                                .roleSessionName("trino-router-session")
+                                .externalId(routerConfig.getGlueExternalId().orElse(null)))
+                        .stsClient(sts.build())
+                        .asyncCredentialUpdateEnabled(true)
+                        .build());
+            }
+            else {
+                log.info("Router Glue auth: %s credentials (configured region=%s)",
+                        staticCredentials.isPresent() ? "static" : "default provider chain",
+                        routerConfig.getGlueRegion().orElse("<default>"));
+                staticCredentials.ifPresent(glue::credentialsProvider);
+            }
+
+            if (routerConfig.getGlueRegion().isPresent()) {
+                glue.region(Region.of(routerConfig.getGlueRegion().get()));
+            }
+            else if (routerConfig.isGluePinClientToCurrentRegion()) {
+                Region resolvedRegion = DefaultAwsRegionProviderChain.builder().build().getRegion();
+                log.info("Router Glue client pinned to current region %s", resolvedRegion);
+                glue.region(resolvedRegion);
+            }
+
+            glue.httpClientBuilder(ApacheHttpClient.builder());
+
+            return glue.build();
+        }
+    }
+}

--- a/plugin/trino-router/src/main/java/io/trino/plugin/router/RouterMetadata.java
+++ b/plugin/trino-router/src/main/java/io/trino/plugin/router/RouterMetadata.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.router;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableVersion;
+import io.trino.spi.connector.RelationColumnsMetadata;
+import io.trino.spi.connector.SchemaTableName;
+import jakarta.annotation.Nullable;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.GetDatabasesRequest;
+import software.amazon.awssdk.services.glue.model.GetDatabasesResponse;
+import software.amazon.awssdk.services.glue.model.GetTablesRequest;
+import software.amazon.awssdk.services.glue.model.GetTablesResponse;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+public class RouterMetadata
+        implements ConnectorMetadata
+{
+    private static final Logger log = Logger.get(RouterMetadata.class);
+
+    private final Map<String, String> schemaPrefixRules;
+    private final Map<String, String> schemaPrefixGlueCatalogIds;
+    private final Map<String, List<Pattern>> schemaPrefixMappedSchemas;
+    private final Optional<String> defaultCatalogTarget;
+    private final Optional<String> defaultCatalogId;
+    private final List<Pattern> defaultMappedSchemas;
+    private final boolean writesEnabled;
+    private final GlueClient glueClient;
+
+    @Inject
+    public RouterMetadata(RouterConfig config, GlueClient glueClient)
+    {
+        requireNonNull(config, "config is null");
+        this.schemaPrefixRules = config.getSchemaPrefixRules();
+        this.schemaPrefixGlueCatalogIds = config.getSchemaPrefixGlueCatalogIds();
+        this.schemaPrefixMappedSchemas = config.getSchemaPrefixMappedSchemas().entrySet().stream()
+                .collect(toImmutableMap(
+                        Map.Entry::getKey,
+                        e -> e.getValue().stream().map(Pattern::compile).collect(toImmutableList())));
+        this.defaultCatalogTarget = config.getDefaultCatalogTarget();
+        this.defaultCatalogId = config.getDefaultCatalogId();
+        this.defaultMappedSchemas = config.getDefaultMappedSchemas().stream()
+                .map(Pattern::compile)
+                .collect(toImmutableList());
+        this.writesEnabled = config.isWritesEnabled();
+        this.glueClient = requireNonNull(glueClient, "glueClient is null");
+
+        log.info("Router catalog initialized: schemaPrefixRules=%s, schemaPrefixGlueCatalogIds=%s, schemaPrefixMappedSchemas=%s, defaultCatalogTarget=%s, defaultCatalogId=%s, defaultMappedSchemas=%s, writesEnabled=%s",
+                schemaPrefixRules,
+                schemaPrefixGlueCatalogIds,
+                schemaPrefixMappedSchemas,
+                defaultCatalogTarget,
+                defaultCatalogId,
+                defaultMappedSchemas,
+                writesEnabled);
+    }
+
+    private boolean schemaMatchesLocalFilter(String schemaName)
+    {
+        if (defaultMappedSchemas.isEmpty()) {
+            return true;
+        }
+        return defaultMappedSchemas.stream().anyMatch(p -> p.matcher(schemaName).matches());
+    }
+
+    private boolean schemaMatchesFilter(String prefix, String targetSchema)
+    {
+        List<Pattern> patterns = schemaPrefixMappedSchemas.get(prefix);
+        if (patterns == null || patterns.isEmpty()) {
+            return true;
+        }
+        return patterns.stream().anyMatch(p -> p.matcher(targetSchema).matches());
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        log.debug("listSchemaNames: enumerating %s prefix rule(s); defaultCatalogTarget=%s", schemaPrefixRules.size(), defaultCatalogTarget);
+        ImmutableList.Builder<String> schemas = ImmutableList.builder();
+
+        for (Map.Entry<String, String> rule : schemaPrefixRules.entrySet()) {
+            String prefix = rule.getKey();
+            String glueCatalogId = schemaPrefixGlueCatalogIds.get(prefix);
+            Consumer<GetDatabasesRequest.Builder> glueRequest = r -> {
+                if (glueCatalogId != null) {
+                    r.catalogId(glueCatalogId);
+                }
+            };
+            List<String> glueSchemas;
+            try {
+                glueSchemas = glueClient.getDatabasesPaginator(glueRequest).stream()
+                        .map(GetDatabasesResponse::databaseList)
+                        .flatMap(List::stream)
+                        .map(db -> db.name())
+                        .filter(dbName -> schemaMatchesFilter(prefix, dbName))
+                        .map(dbName -> prefix + dbName)
+                        .toList();
+            }
+            catch (RuntimeException e) {
+                log.error(e, "listSchemaNames: Glue getDatabases failed for prefix '%s' (glueCatalogId=%s)", prefix, glueCatalogId);
+                throw e;
+            }
+            log.debug("listSchemaNames: prefix '%s' (glueCatalogId=%s) returned %s schema(s)", prefix, glueCatalogId, glueSchemas.size());
+            schemas.addAll(glueSchemas);
+        }
+
+        if (defaultCatalogTarget.isPresent()) {
+            String catalogId = defaultCatalogId.orElse(null);
+            Consumer<GetDatabasesRequest.Builder> localRequest = r -> {
+                if (catalogId != null) {
+                    r.catalogId(catalogId);
+                }
+            };
+            List<String> localSchemas;
+            try {
+                localSchemas = glueClient.getDatabasesPaginator(localRequest).stream()
+                        .map(GetDatabasesResponse::databaseList)
+                        .flatMap(List::stream)
+                        .map(db -> db.name())
+                        .filter(this::schemaMatchesLocalFilter)
+                        .toList();
+            }
+            catch (RuntimeException e) {
+                log.error(e, "listSchemaNames: Glue getDatabases failed for default catalog target '%s' (glueCatalogId=%s)", defaultCatalogTarget.get(), catalogId);
+                throw e;
+            }
+            log.debug("listSchemaNames: default catalog target '%s' (glueCatalogId=%s) returned %s unprefixed schema(s)", defaultCatalogTarget.get(), catalogId, localSchemas.size());
+            schemas.addAll(localSchemas);
+        }
+
+        List<String> result = schemas.build();
+        log.debug("listSchemaNames: returning %s schema(s) total", result.size());
+        return result;
+    }
+
+    @Override
+    public boolean schemaExists(ConnectorSession session, String schemaName)
+    {
+        for (String prefix : schemaPrefixRules.keySet()) {
+            if (schemaName.startsWith(prefix) && schemaName.length() > prefix.length()) {
+                String targetSchema = schemaName.substring(prefix.length());
+                if (schemaMatchesFilter(prefix, targetSchema)) {
+                    log.debug("schemaExists: '%s' matched prefix '%s' -> true", schemaName, prefix);
+                    return true;
+                }
+            }
+        }
+        if (defaultCatalogTarget.isPresent() && schemaMatchesLocalFilter(schemaName)) {
+            log.debug("schemaExists: '%s' matched default catalog target '%s' -> true", schemaName, defaultCatalogTarget.get());
+            return true;
+        }
+        log.debug("schemaExists: '%s' matched no prefix rule or default target -> false", schemaName);
+        return false;
+    }
+
+    @Nullable
+    @Override
+    public ConnectorTableHandle getTableHandle(
+            ConnectorSession session,
+            SchemaTableName tableName,
+            Optional<ConnectorTableVersion> startVersion,
+            Optional<ConnectorTableVersion> endVersion)
+    {
+        return null;
+    }
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+    {
+        if (schemaName.isEmpty()) {
+            // Enumerating every schema would require one Glue GetTables call per schema
+            // (hundreds), which is prohibitively expensive. Table enumeration is only
+            // supported when scoped to a schema (e.g. SHOW TABLES IN <schema>).
+            log.debug("listTables: called with no schema; skipping full enumeration");
+            return ImmutableList.of();
+        }
+        String schema = schemaName.get();
+
+        for (Map.Entry<String, String> rule : schemaPrefixRules.entrySet()) {
+            String prefix = rule.getKey();
+            if (schema.startsWith(prefix) && schema.length() > prefix.length()) {
+                String targetSchema = schema.substring(prefix.length());
+                if (!schemaMatchesFilter(prefix, targetSchema)) {
+                    log.debug("listTables: schema '%s' filtered out for prefix '%s'", schema, prefix);
+                    return ImmutableList.of();
+                }
+                return listGlueTables(schema, targetSchema, schemaPrefixGlueCatalogIds.get(prefix));
+            }
+        }
+
+        if (defaultCatalogTarget.isPresent() && schemaMatchesLocalFilter(schema)) {
+            return listGlueTables(schema, schema, defaultCatalogId.orElse(null));
+        }
+
+        log.debug("listTables: schema '%s' matched no prefix rule or default target", schema);
+        return ImmutableList.of();
+    }
+
+    private List<SchemaTableName> listGlueTables(String routerSchema, String targetDatabase, @Nullable String glueCatalogId)
+    {
+        Consumer<GetTablesRequest.Builder> request = r -> {
+            r.databaseName(targetDatabase);
+            if (glueCatalogId != null) {
+                r.catalogId(glueCatalogId);
+            }
+        };
+        List<SchemaTableName> tables;
+        try {
+            tables = glueClient.getTablesPaginator(request).stream()
+                    .map(GetTablesResponse::tableList)
+                    .flatMap(List::stream)
+                    .map(table -> new SchemaTableName(routerSchema, table.name()))
+                    .toList();
+        }
+        catch (RuntimeException e) {
+            log.error(e, "listTables: Glue getTables failed for schema '%s' (database '%s', glueCatalogId=%s)", routerSchema, targetDatabase, glueCatalogId);
+            throw e;
+        }
+        log.debug("listTables: schema '%s' (database '%s', glueCatalogId=%s) returned %s table(s)", routerSchema, targetDatabase, glueCatalogId, tables.size());
+        return tables;
+    }
+
+    @Override
+    public Optional<CatalogSchemaTableName> redirectTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        requireNonNull(session, "session is null");
+        requireNonNull(tableName, "tableName is null");
+        String schemaName = tableName.getSchemaName();
+
+        // Never redirect the engine-provided metadata schemas. Trino implements
+        // SHOW SCHEMAS/TABLES by reading <catalog>.information_schema; if redirectTable
+        // sends those to the default catalog, the query returns the default catalog's
+        // metadata and the router's own enumeration (listSchemaNames) is bypassed.
+        if (schemaName.equals("information_schema") || schemaName.equals("system")) {
+            log.debug("redirectTable: %s is a metadata schema; not redirecting", tableName);
+            return Optional.empty();
+        }
+
+        for (Map.Entry<String, String> rule : schemaPrefixRules.entrySet()) {
+            String prefix = rule.getKey();
+            String targetCatalog = rule.getValue();
+            if (schemaName.startsWith(prefix)) {
+                String targetSchema = schemaName.substring(prefix.length());
+                if (targetSchema.isEmpty() || !schemaMatchesFilter(prefix, targetSchema)) {
+                    log.debug("redirectTable: %s matched prefix '%s' but target schema '%s' is empty or filtered out; trying next rule", tableName, prefix, targetSchema);
+                    continue;
+                }
+                CatalogSchemaTableName target = new CatalogSchemaTableName(targetCatalog, targetSchema, tableName.getTableName());
+                log.debug("redirectTable: %s redirected via prefix '%s' to %s", tableName, prefix, target);
+                return Optional.of(target);
+            }
+        }
+
+        if (defaultCatalogTarget.isPresent() && schemaMatchesLocalFilter(schemaName)) {
+            CatalogSchemaTableName target = new CatalogSchemaTableName(defaultCatalogTarget.get(), schemaName, tableName.getTableName());
+            log.debug("redirectTable: %s redirected via default catalog target to %s", tableName, target);
+            return Optional.of(target);
+        }
+
+        log.debug("redirectTable: %s matched no prefix rule or default target; no redirection applied", tableName);
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<CatalogSchemaTableName> redirectTableForWrite(ConnectorSession session, SchemaTableName tableName)
+    {
+        if (!writesEnabled) {
+            log.debug("redirectTableForWrite: %s not redirected; router.writes-enabled is false", tableName);
+            return Optional.empty();
+        }
+        return redirectTable(session, tableName);
+    }
+
+    @Override
+    public Iterator<RelationColumnsMetadata> streamRelationColumns(
+            ConnectorSession session,
+            Optional<String> schemaName,
+            UnaryOperator<Set<SchemaTableName>> relationFilter)
+    {
+        // The router owns no local tables; all access is via redirectTable().
+        return ImmutableList.<RelationColumnsMetadata>of().iterator();
+    }
+}

--- a/plugin/trino-router/src/main/java/io/trino/plugin/router/RouterPlugin.java
+++ b/plugin/trino-router/src/main/java/io/trino/plugin/router/RouterPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.router;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.ConnectorFactory;
+
+public class RouterPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableList.of(new RouterConnectorFactory());
+    }
+}

--- a/plugin/trino-router/src/main/java/io/trino/plugin/router/RouterTransactionHandle.java
+++ b/plugin/trino-router/src/main/java/io/trino/plugin/router/RouterTransactionHandle.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.router;
+
+import io.trino.spi.connector.ConnectorTransactionHandle;
+
+public enum RouterTransactionHandle
+        implements ConnectorTransactionHandle
+{
+    INSTANCE
+}

--- a/plugin/trino-router/src/test/java/io/trino/plugin/router/TestRouterConfig.java
+++ b/plugin/trino-router/src/test/java/io/trino/plugin/router/TestRouterConfig.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.router;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestRouterConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(RouterConfig.class)
+                .setSchemaPrefixRules(List.of())
+                .setSchemaPrefixGlueCatalogIds(List.of())
+                .setSchemaPrefixMappedSchemas(List.of())
+                .setDefaultCatalogTarget(null)
+                .setDefaultCatalogId(null)
+                .setDefaultMappedSchemas(List.of())
+                .setWritesEnabled(false)
+                .setGlueRegion(null)
+                .setGlueIamRole(null)
+                .setGlueExternalId(null)
+                .setGlueAwsAccessKey(null)
+                .setGlueAwsSecretKey(null)
+                .setGlueUseWebIdentityTokenCredentialsProvider(false)
+                .setGluePinClientToCurrentRegion(false));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("router.schema-prefix-rules", "prod_=catalog_prod,staging_=catalog_staging")
+                .put("router.schema-prefix-glue-catalog-ids", "prod_=111122223333,staging_=444455556666")
+                .put("router.schema-prefix-mapped-schemas", "prod_=sales.*,prod_=marketing,staging_=stg_.*")
+                .put("router.default.catalog-target", "catalog_default")
+                .put("router.default.catalog-id", "999900001111")
+                .put("router.default.mapped-schemas", "sales.*,marketing")
+                .put("router.writes-enabled", "true")
+                .put("router.glue.region", "us-east-1")
+                .put("router.glue.iam-role", "arn:aws:iam::123456789012:role/GlueRole")
+                .put("router.glue.external-id", "my-external-id")
+                .put("router.glue.aws-access-key", "AKIAIOSFODNN7EXAMPLE")
+                .put("router.glue.aws-secret-key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+                .put("router.glue.use-web-identity-token-credentials-provider", "true")
+                .put("router.glue.pin-client-to-current-region", "true")
+                .buildOrThrow();
+
+        RouterConfig expected = new RouterConfig()
+                .setSchemaPrefixRules(List.of("prod_=catalog_prod", "staging_=catalog_staging"))
+                .setSchemaPrefixGlueCatalogIds(List.of("prod_=111122223333", "staging_=444455556666"))
+                .setSchemaPrefixMappedSchemas(List.of("prod_=sales.*", "prod_=marketing", "staging_=stg_.*"))
+                .setDefaultCatalogTarget("catalog_default")
+                .setDefaultCatalogId("999900001111")
+                .setDefaultMappedSchemas(List.of("sales.*", "marketing"))
+                .setWritesEnabled(true)
+                .setGlueRegion("us-east-1")
+                .setGlueIamRole("arn:aws:iam::123456789012:role/GlueRole")
+                .setGlueExternalId("my-external-id")
+                .setGlueAwsAccessKey("AKIAIOSFODNN7EXAMPLE")
+                .setGlueAwsSecretKey("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+                .setGlueUseWebIdentityTokenCredentialsProvider(true)
+                .setGluePinClientToCurrentRegion(true);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-router/src/test/java/io/trino/plugin/router/TestRouterMetadata.java
+++ b/plugin/trino-router/src/test/java/io/trino/plugin/router/TestRouterMetadata.java
@@ -1,0 +1,473 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.router;
+
+import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.SchemaTableName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.Database;
+import software.amazon.awssdk.services.glue.model.GetDatabasesRequest;
+import software.amazon.awssdk.services.glue.model.GetDatabasesResponse;
+import software.amazon.awssdk.services.glue.model.GetTablesRequest;
+import software.amazon.awssdk.services.glue.model.GetTablesResponse;
+import software.amazon.awssdk.services.glue.model.Table;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestRouterMetadata
+{
+    @Test
+    public void testRedirectPrefixMatch()
+    {
+        RouterMetadata metadata = metadataWithPrefix("prod_", "catalog_prod");
+
+        Optional<CatalogSchemaTableName> result = metadata.redirectTable(SESSION, new SchemaTableName("prod_sales", "orders"));
+
+        assertThat(result).contains(new CatalogSchemaTableName("catalog_prod", "sales", "orders"));
+    }
+
+    @Test
+    public void testRedirectNoMatch()
+    {
+        RouterMetadata metadata = metadataWithPrefix("prod_", "catalog_prod");
+
+        Optional<CatalogSchemaTableName> result = metadata.redirectTable(SESSION, new SchemaTableName("unknown_schema", "t"));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testPrefixMatchWithOnlyPrefix()
+    {
+        RouterMetadata metadata = metadataWithPrefix("prod_", "catalog_prod");
+
+        // Schema name IS the prefix with nothing after it — no valid target schema, skip rule
+        Optional<CatalogSchemaTableName> result = metadata.redirectTable(SESSION, new SchemaTableName("prod_", "t"));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testSchemaExistsPrefixRule()
+    {
+        RouterMetadata metadata = metadataWithPrefix("prod_", "catalog_prod");
+
+        assertThat(metadata.schemaExists(SESSION, "prod_sales")).isTrue();
+        assertThat(metadata.schemaExists(SESSION, "prod_")).isFalse();
+        assertThat(metadata.schemaExists(SESSION, "other_sales")).isFalse();
+    }
+
+    @Test
+    public void testGetTableHandleAlwaysNull()
+    {
+        RouterMetadata metadata = metadataWithPrefix("prod_", "catalog_prod");
+
+        assertThat(metadata.getTableHandle(SESSION, new SchemaTableName("prod_sales", "t"), Optional.empty(), Optional.empty()))
+                .isNull();
+    }
+
+    @Test
+    public void testListSchemaNamesIncludesPrefixMappedGlueDatabases()
+    {
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig().setSchemaPrefixRules(List.of("prod_=catalog_prod")),
+                stubbedGlueClient(List.of("sales", "marketing")));
+
+        List<String> schemas = metadata.listSchemaNames(SESSION);
+
+        assertThat(schemas).containsExactlyInAnyOrder("prod_sales", "prod_marketing");
+    }
+
+    @Test
+    public void testListSchemaNamesQueriesPerPrefixGlueCatalogId()
+    {
+        // Each prefix hits a different Glue catalog; the stub returns different databases per catalog ID.
+        GlueClient glueClient = catalogAwareGlueClient(Map.of(
+                "111122223333", List.of("sales", "marketing"),
+                "444455556666", List.of("reports")));
+
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig()
+                        .setSchemaPrefixRules(List.of("prod_=catalog_prod", "staging_=catalog_staging"))
+                        .setSchemaPrefixGlueCatalogIds(List.of("prod_=111122223333", "staging_=444455556666")),
+                glueClient);
+
+        List<String> schemas = metadata.listSchemaNames(SESSION);
+
+        assertThat(schemas).containsExactlyInAnyOrder("prod_sales", "prod_marketing", "staging_reports");
+    }
+
+    @Test
+    public void testListSchemaNamesUsesDefaultGlueCatalogWhenIdAbsent()
+    {
+        // Prefix has no catalog ID configured — request must have no catalogId set (null).
+        GlueClient glueClient = catalogAwareGlueClient(Map.of("", List.of("db1")));
+
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig().setSchemaPrefixRules(List.of("prod_=catalog_prod")),
+                glueClient);
+
+        List<String> schemas = metadata.listSchemaNames(SESSION);
+
+        assertThat(schemas).containsExactlyInAnyOrder("prod_db1");
+    }
+
+    @Test
+    public void testMappedSchemasFiltersListSchemaNames()
+    {
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig()
+                        .setSchemaPrefixRules(List.of("prod_=catalog_prod"))
+                        .setSchemaPrefixMappedSchemas(List.of("prod_=sales.*")),
+                stubbedGlueClient(List.of("sales", "sales_eu", "marketing")));
+
+        List<String> schemas = metadata.listSchemaNames(SESSION);
+
+        assertThat(schemas).containsExactlyInAnyOrder("prod_sales", "prod_sales_eu");
+    }
+
+    @Test
+    public void testMappedSchemasFiltersRedirect()
+    {
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig()
+                        .setSchemaPrefixRules(List.of("prod_=catalog_prod"))
+                        .setSchemaPrefixMappedSchemas(List.of("prod_=sales.*")),
+                stubbedGlueClient(List.of()));
+
+        assertThat(metadata.redirectTable(SESSION, new SchemaTableName("prod_sales", "t")))
+                .contains(new CatalogSchemaTableName("catalog_prod", "sales", "t"));
+        assertThat(metadata.redirectTable(SESSION, new SchemaTableName("prod_marketing", "t")))
+                .isEmpty();
+    }
+
+    @Test
+    public void testMappedSchemasFiltersSchemaExists()
+    {
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig()
+                        .setSchemaPrefixRules(List.of("prod_=catalog_prod"))
+                        .setSchemaPrefixMappedSchemas(List.of("prod_=sales.*")),
+                stubbedGlueClient(List.of()));
+
+        assertThat(metadata.schemaExists(SESSION, "prod_sales")).isTrue();
+        assertThat(metadata.schemaExists(SESSION, "prod_marketing")).isFalse();
+    }
+
+    @Test
+    public void testMappedSchemasMultiplePatternsPerPrefix()
+    {
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig()
+                        .setSchemaPrefixRules(List.of("prod_=catalog_prod"))
+                        .setSchemaPrefixMappedSchemas(List.of("prod_=sales", "prod_=marketing")),
+                stubbedGlueClient(List.of()));
+
+        assertThat(metadata.redirectTable(SESSION, new SchemaTableName("prod_sales", "t")))
+                .contains(new CatalogSchemaTableName("catalog_prod", "sales", "t"));
+        assertThat(metadata.redirectTable(SESSION, new SchemaTableName("prod_marketing", "t")))
+                .contains(new CatalogSchemaTableName("catalog_prod", "marketing", "t"));
+        assertThat(metadata.redirectTable(SESSION, new SchemaTableName("prod_other", "t")))
+                .isEmpty();
+    }
+
+    @Test
+    public void testMappedSchemasAbsentPrefixAllowsAll()
+    {
+        // prod_ has a filter; staging_ has none — all staging schemas should pass
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig()
+                        .setSchemaPrefixRules(List.of("prod_=catalog_prod", "staging_=catalog_staging"))
+                        .setSchemaPrefixMappedSchemas(List.of("prod_=sales")),
+                stubbedGlueClient(List.of()));
+
+        assertThat(metadata.redirectTable(SESSION, new SchemaTableName("staging_anything", "t")))
+                .contains(new CatalogSchemaTableName("catalog_staging", "anything", "t"));
+        assertThat(metadata.redirectTable(SESSION, new SchemaTableName("prod_other", "t")))
+                .isEmpty();
+    }
+
+    @Test
+    public void testLocalGlueCatalogListsSchemas()
+    {
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig().setDefaultCatalogTarget("catalog_default"),
+                stubbedGlueClient(List.of("sales", "marketing")));
+
+        assertThat(metadata.listSchemaNames(SESSION)).containsExactlyInAnyOrder("sales", "marketing");
+    }
+
+    @Test
+    public void testLocalGlueCatalogRedirectsTable()
+    {
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig().setDefaultCatalogTarget("catalog_default"),
+                stubbedGlueClient(List.of()));
+
+        assertThat(metadata.redirectTable(SESSION, new SchemaTableName("sales", "orders")))
+                .contains(new CatalogSchemaTableName("catalog_default", "sales", "orders"));
+    }
+
+    @Test
+    public void testLocalGlueCatalogMappedSchemasFilter()
+    {
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig()
+                        .setDefaultCatalogTarget("catalog_default")
+                        .setDefaultMappedSchemas(List.of("sales.*")),
+                stubbedGlueClient(List.of("sales", "sales_eu", "marketing")));
+
+        assertThat(metadata.listSchemaNames(SESSION)).containsExactlyInAnyOrder("sales", "sales_eu");
+        assertThat(metadata.redirectTable(SESSION, new SchemaTableName("sales", "t")))
+                .contains(new CatalogSchemaTableName("catalog_default", "sales", "t"));
+        assertThat(metadata.redirectTable(SESSION, new SchemaTableName("marketing", "t"))).isEmpty();
+    }
+
+    @Test
+    public void testLocalGlueCatalogSchemaExists()
+    {
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig()
+                        .setDefaultCatalogTarget("catalog_default")
+                        .setDefaultMappedSchemas(List.of("sales.*")),
+                stubbedGlueClient(List.of()));
+
+        assertThat(metadata.schemaExists(SESSION, "sales")).isTrue();
+        assertThat(metadata.schemaExists(SESSION, "sales_eu")).isTrue();
+        assertThat(metadata.schemaExists(SESSION, "marketing")).isFalse();
+    }
+
+    @Test
+    public void testPrefixRuleTakesPrecedenceOverLocalGlue()
+    {
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig()
+                        .setSchemaPrefixRules(List.of("prod_=catalog_prod"))
+                        .setDefaultCatalogTarget("catalog_default"),
+                stubbedGlueClient(List.of()));
+
+        // prod_sales matches the prefix rule — must NOT be redirected via local Glue
+        assertThat(metadata.redirectTable(SESSION, new SchemaTableName("prod_sales", "t")))
+                .contains(new CatalogSchemaTableName("catalog_prod", "sales", "t"));
+        // sales has no prefix match — falls through to local Glue
+        assertThat(metadata.redirectTable(SESSION, new SchemaTableName("sales", "t")))
+                .contains(new CatalogSchemaTableName("catalog_default", "sales", "t"));
+    }
+
+    @Test
+    public void testLocalGlueCatalogUsesConfiguredCatalogId()
+    {
+        GlueClient glueClient = catalogAwareGlueClient(Map.of("999900001111", List.of("sales")));
+
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig()
+                        .setDefaultCatalogTarget("catalog_default")
+                        .setDefaultCatalogId("999900001111"),
+                glueClient);
+
+        assertThat(metadata.listSchemaNames(SESSION)).containsExactlyInAnyOrder("sales");
+    }
+
+    @Test
+    public void testListTablesWithoutSchemaReturnsEmpty()
+    {
+        // Enumerating every schema would require one Glue GetTables call per schema (hundreds);
+        // listTables() intentionally refuses full enumeration and returns nothing rather than a
+        // partial/expensive result.
+        RouterMetadata metadata = metadataWithPrefix("prod_", "catalog_prod");
+
+        assertThat(metadata.listTables(SESSION, Optional.empty())).isEmpty();
+    }
+
+    @Test
+    public void testListTablesWithPrefixRule()
+    {
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig().setSchemaPrefixRules(List.of("prod_=catalog_prod")),
+                stubbedGlueClientWithTables(Map.of("sales", List.of("orders", "customers"))));
+
+        assertThat(metadata.listTables(SESSION, Optional.of("prod_sales")))
+                .containsExactlyInAnyOrder(
+                        new SchemaTableName("prod_sales", "orders"),
+                        new SchemaTableName("prod_sales", "customers"));
+    }
+
+    @Test
+    public void testListTablesFallsThroughToDefaultCatalog()
+    {
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig().setDefaultCatalogTarget("catalog_default"),
+                stubbedGlueClientWithTables(Map.of("sales", List.of("orders"))));
+
+        assertThat(metadata.listTables(SESSION, Optional.of("sales")))
+                .containsExactly(new SchemaTableName("sales", "orders"));
+    }
+
+    @Test
+    public void testListTablesReturnsEmptyWhenSchemaMatchesNoRuleOrDefault()
+    {
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig().setSchemaPrefixRules(List.of("prod_=catalog_prod")),
+                stubbedGlueClientWithTables(Map.of("sales", List.of("orders"))));
+
+        assertThat(metadata.listTables(SESSION, Optional.of("unrelated_schema"))).isEmpty();
+    }
+
+    @Test
+    public void testListTablesFilteredOutByMappedSchemas()
+    {
+        RouterMetadata metadata = new RouterMetadata(
+                new RouterConfig()
+                        .setSchemaPrefixRules(List.of("prod_=catalog_prod"))
+                        .setSchemaPrefixMappedSchemas(List.of("prod_=marketing.*")),
+                stubbedGlueClientWithTables(Map.of("sales", List.of("orders"))));
+
+        // "sales" doesn't match the "marketing.*" filter for prefix "prod_", so the whole schema
+        // is filtered out before any Glue getTables call would be made.
+        assertThat(metadata.listTables(SESSION, Optional.of("prod_sales"))).isEmpty();
+    }
+
+    @Test
+    public void testWriteRedirectDisabledByDefault()
+    {
+        RouterMetadata metadata = metadataWithPrefix("prod_", "catalog_prod");
+
+        // Reads still redirect...
+        assertThat(metadata.redirectTable(SESSION, new SchemaTableName("prod_sales", "orders")))
+                .contains(new CatalogSchemaTableName("catalog_prod", "sales", "orders"));
+        // ...but writes do not, so CREATE TABLE and view DDL fail exactly as before the flag existed.
+        assertThat(metadata.redirectTableForWrite(SESSION, new SchemaTableName("prod_sales", "orders")))
+                .isEmpty();
+    }
+
+    @Test
+    public void testWriteRedirectWhenEnabled()
+    {
+        RouterMetadata metadata = metadataWithPrefix("prod_", "catalog_prod", true);
+
+        assertThat(metadata.redirectTableForWrite(SESSION, new SchemaTableName("prod_sales", "orders")))
+                .contains(new CatalogSchemaTableName("catalog_prod", "sales", "orders"));
+    }
+
+    @Test
+    public void testWriteRedirectHonoursNonMatchingSchema()
+    {
+        RouterMetadata metadata = metadataWithPrefix("prod_", "catalog_prod", true);
+
+        // Enabling writes must not widen which schemas redirect.
+        assertThat(metadata.redirectTableForWrite(SESSION, new SchemaTableName("unknown_schema", "t")))
+                .isEmpty();
+        assertThat(metadata.redirectTableForWrite(SESSION, new SchemaTableName("information_schema", "tables")))
+                .isEmpty();
+    }
+
+    private static RouterMetadata metadataWithPrefix(String prefix, String catalog)
+    {
+        return metadataWithPrefix(prefix, catalog, false);
+    }
+
+    private static RouterMetadata metadataWithPrefix(String prefix, String catalog, boolean writesEnabled)
+    {
+        return new RouterMetadata(
+                new RouterConfig()
+                        .setSchemaPrefixRules(List.of(prefix + "=" + catalog))
+                        .setWritesEnabled(writesEnabled),
+                stubbedGlueClient(List.of()));
+    }
+
+    // Returns databases keyed by catalog ID; use empty string key for the no-catalog-id case.
+    private static GlueClient catalogAwareGlueClient(Map<String, List<String>> dbsByCatalogId)
+    {
+        return new GlueClient()
+        {
+            @Override
+            public String serviceName()
+            {
+                return "glue";
+            }
+
+            @Override
+            public void close() {}
+
+            @Override
+            public GetDatabasesResponse getDatabases(GetDatabasesRequest request)
+            {
+                String key = request.catalogId() != null ? request.catalogId() : "";
+                List<String> names = dbsByCatalogId.getOrDefault(key, List.of());
+                List<Database> databases = names.stream()
+                        .map(name -> Database.builder().name(name).build())
+                        .toList();
+                return GetDatabasesResponse.builder().databaseList(databases).build();
+            }
+        };
+    }
+
+    // Returns tables keyed by database name; getDatabases() is unused by these tests.
+    private static GlueClient stubbedGlueClientWithTables(Map<String, List<String>> tablesByDatabase)
+    {
+        return new GlueClient()
+        {
+            @Override
+            public String serviceName()
+            {
+                return "glue";
+            }
+
+            @Override
+            public void close() {}
+
+            @Override
+            public GetTablesResponse getTables(GetTablesRequest request)
+            {
+                List<String> names = tablesByDatabase.getOrDefault(request.databaseName(), List.of());
+                List<Table> tables = names.stream()
+                        .map(name -> Table.builder().name(name).build())
+                        .toList();
+                return GetTablesResponse.builder().tableList(tables).build();
+            }
+        };
+    }
+
+    private static GlueClient stubbedGlueClient(List<String> databaseNames)
+    {
+        List<Database> databases = databaseNames.stream()
+                .map(name -> Database.builder().name(name).build())
+                .toList();
+        GetDatabasesResponse response = GetDatabasesResponse.builder().databaseList(databases).build();
+
+        return new GlueClient()
+        {
+            @Override
+            public String serviceName()
+            {
+                return "glue";
+            }
+
+            @Override
+            public void close() {}
+
+            @Override
+            public GetDatabasesResponse getDatabases(GetDatabasesRequest request)
+            {
+                return response;
+            }
+        };
+    }
+}

--- a/plugin/trino-router/src/test/java/io/trino/plugin/router/TestRouterQueries.java
+++ b/plugin/trino-router/src/test/java/io/trino/plugin/router/TestRouterQueries.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.router;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.iceberg.IcebergPlugin;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.io.File;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+/**
+ * End-to-end coverage for the {@code router} connector: exercises real SQL statements through
+ * {@code router.<prefix><schema>.<table>} and confirms they land on the physical target catalog
+ * resolved by {@link RouterMetadata#redirectTable}. {@link TestRouterMetadata} covers the redirect
+ * logic itself against a stubbed Glue client; this class proves the engine actually honors (or, for
+ * object-creation statements, does not yet honor) that redirect.
+ *
+ * <p>Trino only consults {@code redirectTable()} when resolving a table/view/materialized view that
+ * already exists (see {@code MetadataManager.getRedirectedTableName}/{@code getViewInternal}/
+ * {@code getMaterializedViewInternal}). Statements that create a brand-new object bind directly to
+ * the catalog named in the SQL, so {@code CREATE TABLE}/{@code CREATE VIEW}/
+ * {@code CREATE MATERIALIZED VIEW} through {@code router.*} fail today with {@code NOT_SUPPORTED},
+ * since {@link RouterMetadata} implements no creation methods. Both behaviors are asserted below so
+ * a future change to either is a deliberate, reviewed diff rather than a silent regression.
+ */
+@Execution(SAME_THREAD) // shares one target catalog/schema across tests
+public class TestRouterQueries
+        extends AbstractTestQueryFramework
+{
+    private static final String ROUTER_CATALOG = "router";
+    private static final String TARGET_CATALOG = "target";
+    private static final String PREFIX = "redirect_";
+    private static final String TARGET_SCHEMA = "sales";
+
+    private static String routerTable(String table)
+    {
+        return "%s.%s%s.%s".formatted(ROUTER_CATALOG, PREFIX, TARGET_SCHEMA, table);
+    }
+
+    private static String targetTable(String table)
+    {
+        return "%s.%s.%s".formatted(TARGET_CATALOG, TARGET_SCHEMA, table);
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(
+                        testSessionBuilder().setCatalog(TARGET_CATALOG).setSchema(TARGET_SCHEMA).build())
+                .build();
+
+        File dataDirectory = queryRunner.getCoordinator().getBaseDataDir().resolve(getClass().getSimpleName()).toFile();
+        verify(dataDirectory.mkdirs());
+
+        queryRunner.installPlugin(new IcebergPlugin());
+        queryRunner.createCatalog(
+                TARGET_CATALOG,
+                "iceberg",
+                ImmutableMap.of(
+                        "iceberg.catalog.type", "TESTING_FILE_METASTORE",
+                        "hive.metastore.catalog.dir", dataDirectory.getPath(),
+                        "fs.hadoop.enabled", "true"));
+
+        // No Glue call is made by any statement below: they all resolve through redirectTable(),
+        // which is pure schema-prefix string matching. router.glue.region is set only so building
+        // the (otherwise unused) GlueClient doesn't fail trying to resolve a default region.
+        queryRunner.installPlugin(new RouterPlugin());
+        queryRunner.createCatalog(
+                ROUTER_CATALOG,
+                "router",
+                ImmutableMap.of(
+                        "router.schema-prefix-rules", PREFIX + "=" + TARGET_CATALOG,
+                        "router.glue.region", "us-east-1"));
+
+        queryRunner.execute("CREATE SCHEMA " + TARGET_CATALOG + "." + TARGET_SCHEMA);
+
+        return queryRunner;
+    }
+
+    @Test
+    public void testInsertSelectThroughRedirect()
+    {
+        String table = "orders_" + randomNameSuffix();
+        getQueryRunner().execute("CREATE TABLE " + targetTable(table) + " (id INT, total DOUBLE)");
+
+        getQueryRunner().execute("INSERT INTO " + routerTable(table) + " VALUES (1, 10.5), (2, 20.0)");
+
+        assertThat(getQueryRunner().execute("TABLE " + routerTable(table)))
+                .containsAll(getQueryRunner().execute("TABLE " + targetTable(table)));
+    }
+
+    @Test
+    public void testUpdateThroughRedirect()
+    {
+        String table = "orders_" + randomNameSuffix();
+        getQueryRunner().execute("CREATE TABLE " + targetTable(table) + " (id INT, total DOUBLE)");
+        getQueryRunner().execute("INSERT INTO " + targetTable(table) + " VALUES (1, 10.5), (2, 20.0)");
+
+        getQueryRunner().execute("UPDATE " + routerTable(table) + " SET total = 99.9 WHERE id = 1");
+
+        assertThat(getQueryRunner().execute("SELECT total FROM " + targetTable(table) + " WHERE id = 1").getOnlyValue())
+                .isEqualTo(99.9);
+    }
+
+    @Test
+    public void testDeleteThroughRedirect()
+    {
+        String table = "orders_" + randomNameSuffix();
+        getQueryRunner().execute("CREATE TABLE " + targetTable(table) + " (id INT)");
+        getQueryRunner().execute("INSERT INTO " + targetTable(table) + " VALUES (1), (2), (3)");
+
+        getQueryRunner().execute("DELETE FROM " + routerTable(table) + " WHERE id = 2");
+
+        assertThat(getQueryRunner().execute("SELECT id FROM " + targetTable(table)).getOnlyColumnAsSet())
+                .containsExactlyInAnyOrder(1, 3);
+    }
+
+    @Test
+    public void testAlterTableAddColumnThroughRedirect()
+    {
+        String table = "orders_" + randomNameSuffix();
+        getQueryRunner().execute("CREATE TABLE " + targetTable(table) + " (id INT)");
+
+        getQueryRunner().execute("ALTER TABLE " + routerTable(table) + " ADD COLUMN total DOUBLE");
+
+        assertThat(getQueryRunner().execute("SELECT column_name FROM " + TARGET_CATALOG + ".information_schema.columns WHERE table_schema = '" + TARGET_SCHEMA + "' AND table_name = '" + table + "'")
+                .getOnlyColumnAsSet())
+                .contains("total");
+    }
+
+    @Test
+    public void testAlterTableExecuteOptimizeThroughRedirect()
+    {
+        String table = "orders_" + randomNameSuffix();
+        getQueryRunner().execute("CREATE TABLE " + targetTable(table) + " (id INT)");
+        getQueryRunner().execute("INSERT INTO " + targetTable(table) + " VALUES (1)");
+        getQueryRunner().execute("INSERT INTO " + targetTable(table) + " VALUES (2)");
+
+        // Table procedure invocation through the redirected name must not fail; the physical
+        // effect (file compaction) is already covered by Iceberg's own optimize tests, this only
+        // proves the procedure call resolves against the redirect target.
+        getQueryRunner().execute("ALTER TABLE " + routerTable(table) + " EXECUTE optimize");
+
+        assertThat(getQueryRunner().execute("SELECT id FROM " + targetTable(table)).getOnlyColumnAsSet())
+                .containsExactlyInAnyOrder(1, 2);
+    }
+
+    @Test
+    public void testDropTableThroughRedirect()
+    {
+        String table = "orders_" + randomNameSuffix();
+        getQueryRunner().execute("CREATE TABLE " + targetTable(table) + " (id INT)");
+
+        getQueryRunner().execute("DROP TABLE " + routerTable(table));
+
+        assertThat(getQueryRunner().tableExists(getSession(), targetTable(table))).isFalse();
+    }
+
+    @Test
+    public void testCreateTableThroughRedirectIsNotSupported()
+    {
+        // CREATE TABLE has no existing object to redirect from, so it binds directly to the
+        // router catalog's own ConnectorMetadata, which implements no creation methods.
+        assertThatThrownByRouter(
+                "CREATE TABLE " + routerTable("orders_" + randomNameSuffix()) + " (id INT)",
+                "This connector does not support creating tables");
+    }
+
+    @Test
+    public void testSelectViewThroughRedirect()
+    {
+        String table = "orders_" + randomNameSuffix();
+        String view = "orders_view_" + randomNameSuffix();
+        getQueryRunner().execute("CREATE TABLE " + targetTable(table) + " (id INT)");
+        getQueryRunner().execute("INSERT INTO " + targetTable(table) + " VALUES (1), (2)");
+        // Created directly on the target: CREATE VIEW binds by catalog name, same as CREATE TABLE.
+        getQueryRunner().execute("CREATE VIEW " + targetTable(view) + " AS SELECT * FROM " + targetTable(table));
+
+        // But reading it through the router-qualified name must follow the redirect (this is what
+        // the "follow catalog redirects for views and materialized views" fix added).
+        assertThat(getQueryRunner().execute("SELECT id FROM " + routerTable(view)).getOnlyColumnAsSet())
+                .containsExactlyInAnyOrder(1, 2);
+    }
+
+    @Test
+    public void testCreateViewThroughRedirectIsNotSupported()
+    {
+        assertThatThrownByRouter(
+                "CREATE VIEW " + routerTable("orders_view_" + randomNameSuffix()) + " AS SELECT 1 x",
+                "This connector does not support creating views");
+    }
+
+    @Test
+    public void testDropViewThroughRedirectIsNotSupported()
+    {
+        String view = "orders_view_" + randomNameSuffix();
+        getQueryRunner().execute("CREATE VIEW " + targetTable(view) + " AS SELECT 1 x");
+
+        // Unlike SELECT, DropViewTask resolves the view directly against the named catalog
+        // (metadata.getView on "router" itself, unredirected) before ever calling dropView(), so
+        // this fails one step earlier than CREATE VIEW's NOT_SUPPORTED: the router simply reports
+        // no such view, since RouterMetadata never claims ownership of the redirected object.
+        assertThatThrownByRouter("DROP VIEW " + routerTable(view), "does not exist");
+
+        getQueryRunner().execute("DROP VIEW " + targetTable(view));
+    }
+
+    @Test
+    public void testSelectMaterializedViewThroughRedirectFailsOnStorageTableResolution()
+    {
+        String table = "orders_" + randomNameSuffix();
+        String mv = "orders_mv_" + randomNameSuffix();
+        getQueryRunner().execute("CREATE TABLE " + targetTable(table) + " (id INT)");
+        getQueryRunner().execute("INSERT INTO " + targetTable(table) + " VALUES (1), (2)");
+        getQueryRunner().execute("CREATE MATERIALIZED VIEW " + targetTable(mv) + " AS SELECT * FROM " + targetTable(table));
+        getQueryRunner().execute("REFRESH MATERIALIZED VIEW " + targetTable(mv));
+
+        // Verified gap, not a spec: getMaterializedView() itself follows the redirect fine (it finds
+        // the MV on "target"), but once it's found fresh, StatementAnalyzer re-qualifies the MV's
+        // storage table using the ORIGINAL router-qualified name (catalog "router", schema
+        // "redirect_sales") instead of the redirected one, so checkStorageTableNotRedirected() looks
+        // for a table that only exists under the router's own (non-existent, prefix-rule-only)
+        // "redirect_sales" schema and fails. Selecting a materialized view through a redirected
+        // schema does not work today -- this pins that down so a future fix is a deliberate, tested
+        // diff rather than a silent behavior change.
+        assertThatThrownByRouter("SELECT id FROM " + routerTable(mv), "does not exist");
+    }
+
+    @Test
+    public void testCreateMaterializedViewThroughRedirectIsNotSupported()
+    {
+        assertThatThrownByRouter(
+                "CREATE MATERIALIZED VIEW " + routerTable("orders_mv_" + randomNameSuffix()) + " AS SELECT 1 x",
+                "This connector does not support creating materialized views");
+    }
+
+    @Test
+    public void testMetadataTableThroughRedirect()
+    {
+        String table = "orders_" + randomNameSuffix();
+        getQueryRunner().execute("CREATE TABLE " + targetTable(table) + " (id INT)");
+        getQueryRunner().execute("INSERT INTO " + targetTable(table) + " VALUES (1)");
+        getQueryRunner().execute("INSERT INTO " + targetTable(table) + " VALUES (2)");
+
+        // Iceberg's "$snapshots" metadata table, reached through the router's redirected schema,
+        // must see the same snapshot history as querying the physical target catalog directly.
+        assertThat(getQueryRunner().execute("SELECT snapshot_id FROM " + ROUTER_CATALOG + "." + PREFIX + TARGET_SCHEMA + ".\"" + table + "$snapshots\"").getOnlyColumnAsSet())
+                .isEqualTo(getQueryRunner().execute("SELECT snapshot_id FROM " + TARGET_CATALOG + "." + TARGET_SCHEMA + ".\"" + table + "$snapshots\"").getOnlyColumnAsSet());
+    }
+
+    private void assertThatThrownByRouter(String sql, String expectedMessageContains)
+    {
+        assertThatThrownBy(() -> getQueryRunner().execute(sql))
+                .hasMessageContaining(expectedMessageContains);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
         <module>plugin/trino-redis</module>
         <module>plugin/trino-redshift</module>
         <module>plugin/trino-resource-group-managers</module>
+        <module>plugin/trino-router</module>
         <module>plugin/trino-session-property-managers</module>
         <module>plugin/trino-singlestore</module>
         <module>plugin/trino-snowflake</module>


### PR DESCRIPTION
## Problem Statement

Organizations migrating from a single, centralized Hive Metastore (HMS) — often federated across multiple underlying metastores via a proxy layer such as WaggleDance — to AWS Glue Data Catalog face a schema-naming discontinuity that blocks incremental migration.

**Legacy model:** Under a federated HMS setup, the target metastore/account is encoded as a prefix concatenated into a single flat schema name (e.g., prod_analytics_sales, where prod_analytics identifies the underlying metastore and sales is the actual schema). Consumers — BI tools, dbt models, notebooks, and scheduled jobs — reference tables using this flat prod_analytics_sales.table two-part name.

**New model:** Once the federation layer is removed in favor of Glue, the former prefix becomes a first-class Glue catalog. The same table is now addressed with three parts: prod_analytics.sales.table (catalog = prod_analytics, schema = sales, table = table). The underlying data is unchanged — only the namespace shape changes.

**Gap:** Trino already supports catalog redirection for Iceberg, Delta Lake, and Hudi tables (hive.iceberg-catalog-name, etc.), but that redirection is:

table-format-specific (only fires for those formats), and
metastore-dependent (it requires a Hive metastore lookup to discover the table before redirecting).
There is no general-purpose mechanism to redirect a query from one catalog to another based purely on a schema-name prefix convention, independent of table format, and without requiring a metastore round-trip.

**Impact:** Without this, every consumer of a two-part flat schema name must be rewritten to the new three-part Glue name before the underlying metastore can be decommissioned. For a large table/schema footprint, this becomes a slow, multi-quarter coordination effort across many independent teams and tools, and it becomes the critical path gating the rest of the migration.

**Desired behavior:** Transparent, prefix-based schema redirection — a client continues to query the legacy flat schema name against a stable, user-facing catalog, and the engine silently routes the query to the correct underlying Glue-backed catalog based on the schema-name prefix, with no metastore round-trip and no client-side SQL changes required.

## Changes

- **Add router virtual catalog connector plugin** — new `plugin/trino-router`
  module. It owns no tables of its own; `listSchemaNames`, `listTables`, and
  `redirectTable` enumerate prefix-mapped schemas via Glue and redirect every
  table under a matching schema prefix to the configured target catalog
  (with support for a default catalog target, per-prefix catalog IDs, and
  local schema listing). Bundled into the server distribution.
- **Enable redirect resolution for system tables** — system tables
  (`$manifests`, `$partitions`, `$snapshots`, etc.) on redirected tables now
  resolve against the target catalog instead of failing on the source
  connector.
- **Fix router table/schema redirection, SHOW SCHEMAS/TABLES, permission
  errors** — correct `TABLE_REDIRECTION_ERROR`/`TABLE_NOT_FOUND` handling,
  SPI-version portability across engine versions, `SHOW TABLES` via Glue
  `GetTables`, and `information_schema`/`system` exclusion from redirects
  (so the engine's own metadata-schema queries aren't redirected away).
- **Surface Glue/Lake Formation AccessDenied as PERMISSION_DENIED** — an
  access-denied response from Glue/Lake Formation on `getTable` now surfaces
  as a clear permission error instead of a misleading
  `TableNotFoundException`.
- **Follow catalog redirects for views and materialized views** — the
  engine's view and materialized-view resolution never consulted
  `redirectTable()`, unlike regular table lookups. Views and materialized
  views on redirected tables now resolve correctly instead of failing with
  `TABLE_NOT_FOUND`; also fixes a null materialized-view-text NPE.

- **Redirect write operations for pure-redirection catalogs** — table
  redirection was only consulted for reads and a subset of DDL, so
  `CREATE TABLE`, `CREATE TABLE AS SELECT`, `TRUNCATE`,
  `ALTER TABLE ... SET PROPERTIES`, a fully-qualified `RENAME TO` target, and
  all view DDL failed on a catalog that owns no tables of its own. Adds
  `ConnectorMetadata.redirectTableForWrite()`, defaulting to no redirection, and
  resolves names through a new `Metadata.getWriteRedirectedTableName()` that
  reuses the existing redirection loop (cycle detection, redirection limit).
  In the router this is gated by `router.writes-enabled` (default `false`).
- **Fix `trino-router` parent version** — the module pinned parent
  `482-SNAPSHOT` while the root pom is `483-SNAPSHOT`, so building it resolved
  `trino-spi` and other siblings from a different release than the one being
  built.

## Notes on the write-redirection design

**Why a separate SPI method rather than reusing `redirectTable()`.**
`getRedirectionAwareTableHandle()` requires the redirect target to resolve to an
existing table, so it cannot serve `CREATE`, where the target does not exist
yet. A separate method also defaults to doing nothing, which is the property
that matters most for review: connectors implementing only `redirectTable()`
keep their exact current write behaviour, so the Hive connector's Iceberg,
Delta Lake and Hudi redirection is unaffected regardless of configuration.
That holds structurally, not as a consequence of how any catalog is set up.

**What is deliberately unchanged.** Reads continue through `redirectTable()`.
`INSERT`, `UPDATE`, `DELETE`, `MERGE`, `DROP TABLE`, column DDL and
`COMMENT ON TABLE` already resolve through redirection today and are untouched.

**Ordering.** Resolution happens before table-property validation and access
control, because a pure-redirection catalog registers no table properties of its
own and both checks must apply to the target catalog.

**View definitions.** `CreateViewTask` records the resolved target catalog and
schema in the stored view definition when the name was redirected, so a view
created through a redirecting catalog remains resolvable when queried directly
against the catalog it actually lives in. Gated on the name having changed, so
behaviour is identical when nothing redirects.

## Out of scope

- `CREATE`/`DROP`/`RENAME SCHEMA` — there is no schema-redirection mechanism in
  the SPI; this would need a further addition.
- Materialized view DDL — an MV's storage table is recorded as a fully-qualified
  catalog-schema-table name, so a single `REFRESH` spans two catalogs;
  `delegateMaterializedViewRefreshToConnector()` and `refreshMaterializedView()`
  resolve the catalog from the statement name; and the storage-table redirection
  guard is asserted in three separate places. MV *reads* are unaffected.
- Rewriting fully-qualified references written inside a stored view body.
- Writing into a branch of a redirected table, which the engine rejects.

## Testing

- `plugin/trino-router`: 43 tests pass, including new cases asserting that reads
  still redirect while writes do not when `router.writes-enabled` is unset, and
  that enabling writes does not widen which schemas redirect
  (`information_schema`/`system` stay excluded).
- `core/trino-main`: 71 tests pass across every DDL task touched —
  `TestCreateTableTask`, `TestCreateViewTask`, `TestDropViewTask`,
  `TestRenameViewTask`, `TestRefreshViewTask`, `TestRenameTableTask`,
  `TestCommentTask`, `TestSetPropertiesTask` — all with no redirecting catalog
  present, covering the no-op path for existing connectors.
