### PR TITLE
Represent type-only coercions explicitly on the IR Cast node

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ConstantEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ConstantEvaluator.java
@@ -20,7 +20,6 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.security.AccessControl;
 import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
-import io.trino.sql.ir.Cast;
 import io.trino.sql.planner.SymbolAllocator;
 import io.trino.sql.planner.TranslationMap;
 import io.trino.sql.tree.Expression;
@@ -34,6 +33,7 @@ import java.util.Optional;
 import static io.trino.spi.StandardErrorCode.EXPRESSION_NOT_CONSTANT;
 import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static io.trino.sql.ir.IrExpressions.cast;
 
 public final class ConstantEvaluator
 {
@@ -70,7 +70,7 @@ public final class ConstantEvaluator
         }
 
         if (!actualType.equals(expectedType)) {
-            rewritten = new Cast(rewritten, expectedType);
+            rewritten = cast(plannerContext.getTypeManager(), rewritten, expectedType);
         }
 
         return plannerContext.getExpressionEvaluator().evaluate(rewritten, session, ImmutableMap.of());

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -291,6 +291,7 @@ import static io.trino.sql.analyzer.SemanticExceptions.missingAttributeException
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
 import static io.trino.sql.analyzer.TypeDescriptorTranslator.toTypeDescriptor;
+import static io.trino.sql.ir.IrExpressions.cast;
 import static io.trino.sql.tree.DereferenceExpression.isQualifiedAllFieldsReference;
 import static io.trino.sql.tree.FrameBound.Type.CURRENT_ROW;
 import static io.trino.sql.tree.FrameBound.Type.FOLLOWING;
@@ -4736,7 +4737,7 @@ public class ExpressionAnalyzer
         }
 
         plannerContext.getExpressionEvaluator().evaluate(
-                new io.trino.sql.ir.Cast(new Constant(literalType, value), type),
+                cast(plannerContext.getTypeManager(), new Constant(literalType, value), type),
                 session,
                 ImmutableMap.of());
     }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/ExpressionBytecodeCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/ExpressionBytecodeCompiler.java
@@ -49,7 +49,6 @@ import io.trino.sql.ir.Match;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.ir.Row;
 import io.trino.sql.ir.WhenClause;
-import io.trino.type.TypeCoercion;
 
 import java.util.List;
 import java.util.Map;
@@ -65,6 +64,7 @@ import static io.airlift.bytecode.instruction.Constant.loadLong;
 import static io.airlift.bytecode.instruction.Constant.loadString;
 import static io.trino.sql.gen.BytecodeUtils.loadConstant;
 import static io.trino.sql.gen.LambdaBytecodeGenerator.generateLambda;
+import static io.trino.sql.ir.Cast.Kind.REINTERPRET;
 import static java.util.Objects.requireNonNull;
 
 public class ExpressionBytecodeCompiler
@@ -75,7 +75,6 @@ public class ExpressionBytecodeCompiler
     private final BiFunction<Reference, Scope, BytecodeNode> referenceCompiler;
     private final FunctionManager functionManager;
     private final Metadata metadata;
-    private final TypeCoercion typeCoercion;
     private final Map<Lambda, CompiledLambda> compiledLambdaMap;
     private final List<Parameter> contextArguments;  // arguments that need to be propagated to generated methods
 
@@ -96,7 +95,6 @@ public class ExpressionBytecodeCompiler
         this.referenceCompiler = requireNonNull(referenceCompiler, "referenceCompiler is null");
         this.functionManager = requireNonNull(functionManager, "functionManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
-        this.typeCoercion = new TypeCoercion(requireNonNull(typeManager, "typeManager is null")::getType);
         this.compiledLambdaMap = requireNonNull(compiledLambdaMap, "compiledLambdaMap is null");
         this.contextArguments = ImmutableList.copyOf(requireNonNull(contextArguments, "contextArguments is null"));
     }
@@ -235,10 +233,11 @@ public class ExpressionBytecodeCompiler
             Type returnType = node.type();
             Type sourceType = node.expression().type();
 
-            // Type-only coercions (e.g., varchar(10) to varchar(20)) don't change the runtime
-            // value — the Java type is the same. Simply compile the inner expression and use
-            // the result directly, without generating a coercion function call.
-            if (typeCoercion.isTypeOnlyCoercion(sourceType, returnType)) {
+            // A REINTERPRET cast (e.g., varchar(10) to varchar(20)) doesn't change the runtime value —
+            // the physical representation is the same. Compile the inner expression and use the result
+            // directly, without generating a coercion function call. The kind is classified where the
+            // cast is created (see Cast.Kind), so we don't re-derive it here.
+            if (node.kind() == REINTERPRET) {
                 return generatorContext.generate(node.expression());
             }
 

--- a/core/trino-main/src/main/java/io/trino/sql/ir/Cast.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/Cast.java
@@ -13,6 +13,8 @@
  */
 package io.trino.sql.ir;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.type.Type;
@@ -21,14 +23,39 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
+/// A cast of an expression to a target type. [#kind] distinguishes a value-changing [Kind#CONVERT]
+/// from a representation-preserving [Kind#REINTERPRET].
 @JsonSerialize
-public record Cast(Expression expression, Type type)
+public record Cast(Expression expression, Type type, Kind kind)
         implements Expression
 {
-    public Cast
+    /// Distinguishes how a [Cast] relates its source and target types.
+    public enum Kind
     {
-        requireNonNull(expression, "expression is null");
-        requireNonNull(type, "type is null");
+        /// The source and target have different physical representations, so the cast changes the
+        /// value's encoding at runtime via a coercion function and may fail.
+        CONVERT,
+
+        /// The source and target share the same physical representation, so the cast is a runtime
+        /// no-op. Corresponds to `TypeCoercion.isTypeOnlyCoercion(source, target)`.
+        REINTERPRET,
+    }
+
+    @JsonCreator
+    public Cast(
+            @JsonProperty("expression") Expression expression,
+            @JsonProperty("type") Type type,
+            @JsonProperty("kind") Kind kind)
+    {
+        this.expression = requireNonNull(expression, "expression is null");
+        this.type = requireNonNull(type, "type is null");
+        this.kind = requireNonNull(kind, "kind is null");
+    }
+
+    /// Creates a [Kind#CONVERT] cast (the common case).
+    public Cast(Expression expression, Type type)
+    {
+        this(expression, type, Kind.CONVERT);
     }
 
     @Override
@@ -52,6 +79,6 @@ public record Cast(Expression expression, Type type)
     @Override
     public String toString()
     {
-        return "Cast(%s, %s)".formatted(expression, type);
+        return "Cast(%s, %s%s)".formatted(expression, type, kind == Kind.REINTERPRET ? ", reinterpret" : "");
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionTreeRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/ExpressionTreeRewriter.java
@@ -390,7 +390,7 @@ public final class ExpressionTreeRewriter<C>
             Expression expression = rewrite(node.expression(), context.get());
 
             if (node.expression() != expression) {
-                return new Cast(expression, node.type());
+                return new Cast(expression, node.type(), node.kind());
             }
 
             return node;

--- a/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
@@ -30,6 +30,7 @@ import io.trino.spi.type.SmallintType;
 import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.TrinoNumber;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
@@ -54,6 +55,8 @@ import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.DynamicFilters.isDynamicFilterFunction;
 import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+import static io.trino.sql.ir.Cast.Kind.CONVERT;
+import static io.trino.sql.ir.Cast.Kind.REINTERPRET;
 import static io.trino.sql.ir.ComparisonOperator.EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN_OR_EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN_OR_EQUAL;
@@ -64,6 +67,16 @@ import static io.trino.type.BooleanOperators.NOT_FUNCTION_NAME;
 public final class IrExpressions
 {
     private IrExpressions() {}
+
+    /// Creates a cast that coerces `expression` to `type`, classifying its [Cast.Kind]:
+    /// [Cast.Kind#REINTERPRET] when the coercion is a no-op on the physical representation,
+    /// [Cast.Kind#CONVERT] otherwise. Birth sites should build coercion casts through this method so
+    /// the classification stays consistent with the plan type validator.
+    public static Cast cast(TypeManager typeManager, Expression expression, Type type)
+    {
+        boolean typeOnly = new TypeCoercion(typeManager::getType).isTypeOnlyCoercion(expression.type(), type);
+        return new Cast(expression, type, typeOnly ? REINTERPRET : CONVERT);
+    }
 
     public static Constant constantNull(Type type)
     {
@@ -268,21 +281,21 @@ public final class IrExpressions
     /// Lower a NULLIF to `if(first = second) then null else first`, wrapping `first` in a [Let]
     /// when it is non-trivial so the operand is evaluated exactly once. Defaults the comparison
     /// type to `first.type()` — see the overload below for the mixed-type case.
-    public static Expression nullIf(Metadata metadata, SymbolAllocator allocator, Expression first, Expression second)
+    public static Expression nullIf(Metadata metadata, TypeManager typeManager, SymbolAllocator allocator, Expression first, Expression second)
     {
-        return nullIf(metadata, allocator, first, second, first.type());
+        return nullIf(metadata, typeManager, allocator, first, second, first.type());
     }
 
-    /// Same as [#nullIf(Metadata,SymbolAllocator,Expression,Expression)] but performs the equality at
+    /// Same as [#nullIf(Metadata,TypeManager,SymbolAllocator,Expression,Expression)] but performs the equality at
     /// `comparisonType`, casting `first` and `second` as needed. The returned value keeps
     /// `first`'s type, matching SQL `NULLIF` semantics; the cast is applied only for the
     /// comparison.
-    public static Expression nullIf(Metadata metadata, SymbolAllocator allocator, Expression first, Expression second, Type comparisonType)
+    public static Expression nullIf(Metadata metadata, TypeManager typeManager, SymbolAllocator allocator, Expression first, Expression second, Type comparisonType)
     {
-        Expression secondForComparison = second.type().equals(comparisonType) ? second : new Cast(second, comparisonType);
+        Expression secondForComparison = second.type().equals(comparisonType) ? second : cast(typeManager, second, comparisonType);
         // Inline trivial values directly so the result stays a plain Case expression.
         if (first instanceof Reference || first instanceof Constant) {
-            Expression firstForComparison = first.type().equals(comparisonType) ? first : new Cast(first, comparisonType);
+            Expression firstForComparison = first.type().equals(comparisonType) ? first : cast(typeManager, first, comparisonType);
             return ifExpression(
                     comparison(metadata, EQUAL, firstForComparison, secondForComparison),
                     constantNull(first.type()),
@@ -290,7 +303,7 @@ public final class IrExpressions
         }
         Symbol bound = allocator.newSymbol("nullif", first.type());
         Reference reference = new Reference(first.type(), bound.name());
-        Expression referenceForComparison = first.type().equals(comparisonType) ? reference : new Cast(reference, comparisonType);
+        Expression referenceForComparison = first.type().equals(comparisonType) ? reference : cast(typeManager, reference, comparisonType);
         return new Let(bound, first, ifExpression(
                 comparison(metadata, EQUAL, referenceForComparison, secondForComparison),
                 constantNull(first.type()),

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
@@ -184,7 +184,7 @@ public class IrExpressionOptimizer
     {
         return switch (expression) {
             case Reference _, Constant _ -> Optional.empty();
-            case Cast cast -> process(cast.expression(), session, symbolAllocator, bindings).map(value -> new Cast(value, cast.type()));
+            case Cast cast -> process(cast.expression(), session, symbolAllocator, bindings).map(value -> new Cast(value, cast.type(), cast.kind()));
             case IsNull isNull -> process(isNull.value(), session, symbolAllocator, bindings).map(value -> new IsNull(value));
             case Logical logical -> process(logical.terms(), session, symbolAllocator, bindings).map(arguments -> new Logical(logical.operator(), arguments));
             case Call call -> process(call.arguments(), session, symbolAllocator, bindings).map(arguments -> new Call(call.function(), arguments));

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/EvaluateCast.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/EvaluateCast.java
@@ -49,7 +49,7 @@ public class EvaluateCast
     @Override
     public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
     {
-        if (expression instanceof Cast(Constant constant, Type type)) {
+        if (expression instanceof Cast(Constant constant, Type type, _)) {
             try {
                 return Optional.of(new Constant(
                         type,

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyRedundantCast.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyRedundantCast.java
@@ -36,7 +36,7 @@ public class SimplifyRedundantCast
     @Override
     public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
     {
-        if (expression instanceof Cast(Expression value, Type type) && type.equals(value.type())) {
+        if (expression instanceof Cast(Expression value, Type type, _) && type.equals(value.type())) {
             return Optional.of(value);
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyRedundantTryCast.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyRedundantTryCast.java
@@ -17,6 +17,7 @@ import io.trino.Session;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Cast;
@@ -30,6 +31,7 @@ import java.util.Optional;
 
 import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
 import static io.trino.operator.scalar.TryCastFunction.TRY_CAST_FUNCTION_NAME;
+import static io.trino.sql.ir.IrExpressions.cast;
 
 /// Replace a `$try_cast` with a plain [Cast] when the underlying coercion can never fail. E.g,
 ///
@@ -43,10 +45,12 @@ public class SimplifyRedundantTryCast
         implements IrOptimizerRule
 {
     private final Metadata metadata;
+    private final TypeManager typeManager;
 
     public SimplifyRedundantTryCast(PlannerContext context)
     {
         this.metadata = context.getMetadata();
+        this.typeManager = context.getTypeManager();
     }
 
     @Override
@@ -63,6 +67,6 @@ public class SimplifyRedundantTryCast
             return Optional.empty();
         }
 
-        return Optional.of(new Cast(value, targetType));
+        return Optional.of(cast(typeManager, value, targetType));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SpecializeCastWithJsonParse.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SpecializeCastWithJsonParse.java
@@ -54,7 +54,7 @@ public class SpecializeCastWithJsonParse
     @Override
     public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
     {
-        if (expression instanceof Cast(Call call, Type type) &&
+        if (expression instanceof Cast(Call call, Type type, _) &&
                 call.function().name().equals(builtinFunctionName("json_parse"))) {
             Expression string = call.arguments().getFirst();
             return switch (type) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
@@ -116,6 +116,7 @@ import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.DynamicFilters.isDynamicFilterFunction;
 import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+import static io.trino.sql.ir.IrExpressions.cast;
 import static io.trino.sql.ir.IrExpressions.comparison;
 import static io.trino.sql.ir.IrExpressions.matchBetween;
 import static io.trino.sql.ir.IrExpressions.matchComparison;
@@ -423,7 +424,7 @@ public final class ConnectorExpressionTranslator
                 if ((formalType == JONI_REGEXP || formalType instanceof Re2JRegexpType || formalType instanceof JsonPathType)
                         && argumentType instanceof VarcharType) {
                     // These types are not used in connector expressions, so require special handling when translating back to expressions.
-                    expression = new Cast(expression, formalType);
+                    expression = cast(plannerContext.getTypeManager(), expression, formalType);
                 }
                 else if (!argumentType.equals(formalType)) {
                     // There are no implicit coercions in connector expressions except for engine types that are not exposed in connector expressions.
@@ -468,7 +469,7 @@ public final class ConnectorExpressionTranslator
             Optional<Expression> translatedExpression = translate(expression, lambdaArguments);
 
             if (translatedExpression.isPresent()) {
-                return Optional.of(new Cast(translatedExpression.get(), type));
+                return Optional.of(cast(plannerContext.getTypeManager(), translatedExpression.get(), type));
             }
 
             return Optional.empty();
@@ -492,7 +493,7 @@ public final class ConnectorExpressionTranslator
             Optional<Expression> firstExpression = translate(first, lambdaArguments);
             Optional<Expression> secondExpression = translate(second, lambdaArguments);
             if (firstExpression.isPresent() && secondExpression.isPresent()) {
-                return Optional.of(IrExpressions.nullIf(plannerContext.getMetadata(), symbolAllocator, firstExpression.get(), secondExpression.get()));
+                return Optional.of(IrExpressions.nullIf(plannerContext.getMetadata(), plannerContext.getTypeManager(), symbolAllocator, firstExpression.get(), secondExpression.get()));
             }
 
             return Optional.empty();
@@ -636,13 +637,13 @@ public final class ConnectorExpressionTranslator
             return Optional.of(translatedExpressions.build());
         }
 
-        private static Expression castIfNecessary(Expression expression, Type type)
+        private Expression castIfNecessary(Expression expression, Type type)
         {
             if (expression.type().equals(type)) {
                 return expression;
             }
 
-            return new Cast(expression, type);
+            return cast(plannerContext.getTypeManager(), expression, type);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -60,6 +60,7 @@ import io.trino.spi.type.FunctionType;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.VarcharType;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.analyzer.Analysis;
@@ -161,6 +162,7 @@ import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN_OR_EQUAL;
+import static io.trino.sql.ir.IrExpressions.cast;
 import static io.trino.sql.ir.IrExpressions.comparison;
 import static io.trino.sql.ir.IrExpressions.ifExpression;
 import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED;
@@ -551,7 +553,7 @@ public class LogicalPlanner
                 if (column.getDefaultValue().isPresent()) {
                     io.trino.sql.tree.Expression defaultExpression = defaultColumnValues.get(columnHandle);
                     expression = planBuilder.rewrite(defaultExpression);
-                    expression = noTruncationCast(metadata, symbolAllocator, expression, expression.type(), tableType);
+                    expression = noTruncationCast(metadata, plannerContext.getTypeManager(), symbolAllocator, expression, expression.type(), tableType);
                 }
                 else {
                     expression = new Constant(column.getType(), null);
@@ -645,7 +647,7 @@ public class LogicalPlanner
         if (queryType.equals(tableType)) {
             return fieldMapping.toSymbolReference();
         }
-        return noTruncationCast(metadata, symbolAllocator, fieldMapping.toSymbolReference(), queryType, tableType);
+        return noTruncationCast(metadata, plannerContext.getTypeManager(), symbolAllocator, fieldMapping.toSymbolReference(), queryType, tableType);
     }
 
     private Expression createNullNotAllowedFailExpression(String columnName, Type type)
@@ -829,22 +831,22 @@ public class LogicalPlanner
      * length. The check recurses through {@code array}, {@code map} and {@code row} so that character types nested
      * inside structural types are guarded the same way as top-level character columns.
      */
-    public static Expression noTruncationCast(Metadata metadata, SymbolAllocator symbolAllocator, Expression expression, Type fromType, Type toType)
+    public static Expression noTruncationCast(Metadata metadata, TypeManager typeManager, SymbolAllocator symbolAllocator, Expression expression, Type fromType, Type toType)
     {
         if (fromType.equals(toType) || fromType instanceof UnknownType || !containsBoundedCharacterType(toType)) {
             // Nothing can be silently truncated, so an ordinary cast suffices.
-            return new Cast(expression, toType);
+            return cast(typeManager, expression, toType);
         }
 
         if (toType instanceof CharType || toType instanceof VarcharType) {
-            return characterNoTruncationCast(metadata, expression, fromType, toType);
+            return characterNoTruncationCast(metadata, typeManager, expression, fromType, toType);
         }
 
         if (fromType instanceof ArrayType fromArray && toType instanceof ArrayType toArray) {
             Type fromElement = fromArray.getElementType();
             Type toElement = toArray.getElementType();
             Symbol element = symbolAllocator.newSymbol("element", fromElement);
-            Expression body = noTruncationCast(metadata, symbolAllocator, element.toSymbolReference(), fromElement, toElement);
+            Expression body = noTruncationCast(metadata, typeManager, symbolAllocator, element.toSymbolReference(), fromElement, toElement);
             // transform(array, element -> guarded cast of element)
             return BuiltinFunctionCallBuilder.resolve(metadata)
                     .setName("transform")
@@ -859,7 +861,7 @@ public class LogicalPlanner
                 MapType currentType = (MapType) result.type();
                 Symbol key = symbolAllocator.newSymbol("key", currentType.getKeyType());
                 Symbol value = symbolAllocator.newSymbol("value", currentType.getValueType());
-                Expression body = noTruncationCast(metadata, symbolAllocator, value.toSymbolReference(), currentType.getValueType(), toMap.getValueType());
+                Expression body = noTruncationCast(metadata, typeManager, symbolAllocator, value.toSymbolReference(), currentType.getValueType(), toMap.getValueType());
                 result = BuiltinFunctionCallBuilder.resolve(metadata)
                         .setName("transform_values")
                         .addArgument(currentType, result)
@@ -870,7 +872,7 @@ public class LogicalPlanner
                 MapType currentType = (MapType) result.type();
                 Symbol key = symbolAllocator.newSymbol("key", currentType.getKeyType());
                 Symbol value = symbolAllocator.newSymbol("value", currentType.getValueType());
-                Expression body = noTruncationCast(metadata, symbolAllocator, key.toSymbolReference(), currentType.getKeyType(), toMap.getKeyType());
+                Expression body = noTruncationCast(metadata, typeManager, symbolAllocator, key.toSymbolReference(), currentType.getKeyType(), toMap.getKeyType());
                 result = BuiltinFunctionCallBuilder.resolve(metadata)
                         .setName("transform_keys")
                         .addArgument(currentType, result)
@@ -885,21 +887,21 @@ public class LogicalPlanner
             List<Type> toFields = toRow.getTypeParameters();
             ImmutableList.Builder<Expression> items = ImmutableList.builderWithExpectedSize(fromFields.size());
             for (int i = 0; i < fromFields.size(); i++) {
-                items.add(noTruncationCast(metadata, symbolAllocator, new FieldReference(expression, i), fromFields.get(i), toFields.get(i)));
+                items.add(noTruncationCast(metadata, typeManager, symbolAllocator, new FieldReference(expression, i), fromFields.get(i), toFields.get(i)));
             }
             // Rebuild the row field by field, but keep a null row null rather than turning it into a row of nulls.
             return ifExpression(new IsNull(expression), new Constant(toType, null), new Row(items.build(), toType));
         }
 
-        return new Cast(expression, toType);
+        return cast(typeManager, expression, toType);
     }
 
-    private static Expression characterNoTruncationCast(Metadata metadata, Expression expression, Type fromType, Type toType)
+    private static Expression characterNoTruncationCast(Metadata metadata, TypeManager typeManager, Expression expression, Type fromType, Type toType)
     {
         int targetLength;
         if (toType instanceof VarcharType varcharType) {
             if (varcharType.isUnbounded()) {
-                return new Cast(expression, toType);
+                return cast(typeManager, expression, toType);
             }
             targetLength = varcharType.getBoundedLength();
         }
@@ -919,9 +921,9 @@ public class LogicalPlanner
                         new Coalesce(
                                 new Call(
                                         spaceTrimmedLength,
-                                        ImmutableList.of(new Cast(expression, VARCHAR))),
+                                        ImmutableList.of(cast(typeManager, expression, VARCHAR))),
                                 new Constant(BIGINT, 0L))),
-                new Cast(expression, toType),
+                cast(typeManager, expression, toType),
                 new Cast(
                         failFunction(metadata, INVALID_CAST_ARGUMENT, format(
                                 "Cannot truncate non-space characters when casting from %s to %s on INSERT",

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -373,7 +373,7 @@ public class PlanOptimizers
         Set<Rule<?>> simplifyOptimizerRules = ImmutableSet.<Rule<?>>builder()
                 .addAll(new SimplifyExpressions(plannerContext).rules())
                 .addAll(new UnwrapRowSubscript(plannerContext).rules())
-                .addAll(new PushCastIntoRow().rules())
+                .addAll(new PushCastIntoRow(plannerContext).rules())
                 .addAll(new UnwrapCastInComparison(plannerContext).rules())
                 .addAll(new UnwrapDateTruncInComparison(plannerContext).rules())
                 .addAll(new UnwrapYearInComparison(plannerContext).rules())
@@ -421,7 +421,7 @@ public class PlanOptimizers
                                 .addAll(projectionPushdownRules)
                                 .addAll(simplifyOptimizerRules)
                                 .addAll(new UnwrapRowSubscript(plannerContext).rules())
-                                .addAll(new PushCastIntoRow().rules())
+                                .addAll(new PushCastIntoRow(plannerContext).rules())
                                 .add(new OptimizeRowPattern())
                                 .addAll(ImmutableSet.of(
                                         new ImplementTableFunctionSource(metadata),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -33,6 +33,7 @@ import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
 import io.trino.sql.NodeUtils;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.analyzer.Analysis;
@@ -154,6 +155,7 @@ import static io.trino.sql.NodeUtils.getSortItemsFromOrderBy;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN_OR_EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN_OR_EQUAL;
+import static io.trino.sql.ir.IrExpressions.cast;
 import static io.trino.sql.ir.IrExpressions.comparison;
 import static io.trino.sql.ir.IrExpressions.ifExpression;
 import static io.trino.sql.ir.IrExpressions.not;
@@ -293,7 +295,7 @@ class QueryPlanner
             coercedRecursionStep = pruneInvisibleFields(recursionStepPlan, idAllocator);
         }
         else {
-            coercedRecursionStep = coerce(recursionStepPlan, types, symbolAllocator, idAllocator);
+            coercedRecursionStep = coerce(plannerContext.getTypeManager(), recursionStepPlan, types, symbolAllocator, idAllocator);
         }
 
         NodeAndMappings replacementSpot = new NodeAndMappings(anchorPlan.getRoot(), anchorPlan.getFieldMappings());
@@ -660,7 +662,7 @@ class QueryPlanner
                 // This column is updated...
                 io.trino.sql.tree.Expression original = orderedColumnValues.get(index);
                 subPlanBuilder = subqueryPlanner.handleSubqueries(subPlanBuilder, original, analysis.getSubqueries(node));
-                Expression rewritten = coerceIfNecessary(analysis, original, subPlanBuilder.rewrite(original));
+                Expression rewritten = coerceIfNecessary(plannerContext, analysis, original, subPlanBuilder.rewrite(original));
 
                 // If the updated column is non-null, check that the value is not null
                 if (mergeAnalysis.getNonNullableColumnHandles().contains(dataColumnHandle)) {
@@ -743,7 +745,7 @@ class QueryPlanner
 
             Expression predicate = ifExpression(
                     // When predicate evaluates to UNKNOWN (e.g. NULL > 100), it should not violate the check constraint.
-                    new Coalesce(coerceIfNecessary(analysis, constraint, symbol), TRUE),
+                    new Coalesce(coerceIfNecessary(plannerContext, analysis, constraint, symbol), TRUE),
                     TRUE,
                     new Cast(failFunction(plannerContext.getMetadata(), CONSTRAINT_VIOLATION, "Check constraint violation: " + constraint), BOOLEAN));
 
@@ -830,7 +832,7 @@ class QueryPlanner
                     io.trino.sql.tree.Expression setExpression = mergeCase.getSetExpressions().get(index);
                     subPlan = subqueryPlanner.handleSubqueries(subPlan, setExpression, analysis.getSubqueries(merge));
                     Expression rewritten = subPlan.rewrite(setExpression);
-                    rewritten = coerceIfNecessary(analysis, setExpression, rewritten);
+                    rewritten = coerceIfNecessary(plannerContext, analysis, setExpression, rewritten);
                     if (nonNullableColumnHandles.contains(dataColumnHandle)) {
                         ColumnSchema columnSchema = dataColumnSchemas.get(fieldNumber);
                         String columnName = columnSchema.getName();
@@ -846,7 +848,7 @@ class QueryPlanner
                         if (defaultColumnValues.containsKey(dataColumnHandle)) {
                             io.trino.sql.tree.Expression defaultExpression = defaultColumnValues.get(dataColumnHandle);
                             expression = subPlan.rewrite(defaultExpression);
-                            expression = noTruncationCast(metadata, symbolAllocator, expression, expression.type(), columnSchema.getType());
+                            expression = noTruncationCast(metadata, plannerContext.getTypeManager(), symbolAllocator, expression, expression.type(), columnSchema.getType());
                         }
                         if (nonNullableColumnHandles.contains(dataColumnHandle)) {
                             String columnName = columnSchema.getName();
@@ -878,7 +880,7 @@ class QueryPlanner
             if (casePredicate.isPresent()) {
                 condition = and(
                         condition,
-                        coerceIfNecessary(analysis, casePredicate.get(), subPlan.rewrite(casePredicate.get())));
+                        coerceIfNecessary(plannerContext, analysis, casePredicate.get(), subPlan.rewrite(casePredicate.get())));
             }
 
             whenClauses.add(new WhenClause(condition, new Row(rowBuilder.build())));
@@ -1152,7 +1154,7 @@ class QueryPlanner
 
         subPlan = subqueryPlanner.handleSubqueries(subPlan, predicate, analysis.getSubqueries(node));
 
-        return subPlan.withNewRoot(new FilterNode(idAllocator.getNextId(), subPlan.getRoot(), coerceIfNecessary(analysis, predicate, subPlan.rewrite(predicate))));
+        return subPlan.withNewRoot(new FilterNode(idAllocator.getNextId(), subPlan.getRoot(), coerceIfNecessary(plannerContext, analysis, predicate, subPlan.rewrite(predicate))));
     }
 
     private PlanBuilder aggregate(PlanBuilder subPlan, QuerySpecification node)
@@ -1197,7 +1199,7 @@ class QueryPlanner
         //    avg(v)
         // Needs to be rewritten as
         //    avg(CAST(v AS double))
-        PlanAndMappings coercions = coerce(subPlan, inputs, analysis, idAllocator, symbolAllocator);
+        PlanAndMappings coercions = coerce(plannerContext.getTypeManager(), subPlan, inputs, analysis, idAllocator, symbolAllocator);
         subPlan = coercions.getSubPlan();
 
         GroupingSetsPlan groupingSets = planGroupingSets(subPlan, node, groupingSetAnalysis);
@@ -1521,7 +1523,7 @@ class QueryPlanner
             //    avg(v) OVER (ORDER BY v)
             // Needs to be rewritten as
             //    avg(CAST(v AS double)) OVER (ORDER BY v)
-            PlanAndMappings coercions = coerce(subPlan, inputs, analysis, idAllocator, symbolAllocator);
+            PlanAndMappings coercions = coerce(plannerContext.getTypeManager(), subPlan, inputs, analysis, idAllocator, symbolAllocator);
             subPlan = coercions.getSubPlan();
 
             // For frame of type RANGE, append casts and functions necessary for frame bound calculations
@@ -1623,7 +1625,7 @@ class QueryPlanner
                 sortKeyCoercedForFrameBoundCalculation = alreadyCoerced;
             }
             else {
-                Expression cast = new Cast(coercions.get(sortKey).toSymbolReference(), expectedType);
+                Expression cast = cast(plannerContext.getTypeManager(), coercions.get(sortKey).toSymbolReference(), expectedType);
                 sortKeyCoercedForFrameBoundCalculation = symbolAllocator.newSymbol(cast);
                 sortKeyCoercions.put(expectedType, sortKeyCoercedForFrameBoundCalculation);
                 subPlan = subPlan.withNewRoot(new ProjectNode(
@@ -1663,7 +1665,7 @@ class QueryPlanner
                 sortKeyCoercedForFrameBoundComparison = Optional.of(alreadyCoerced);
             }
             else {
-                Expression cast = new Cast(coercions.get(sortKey).toSymbolReference(), expectedType);
+                Expression cast = cast(plannerContext.getTypeManager(), coercions.get(sortKey).toSymbolReference(), expectedType);
                 Symbol castSymbol = symbolAllocator.newSymbol(cast);
                 sortKeyCoercions.put(expectedType, castSymbol);
                 subPlan = subPlan.withNewRoot(new ProjectNode(
@@ -1712,7 +1714,7 @@ class QueryPlanner
             int actualPrecision = decimalType.getPrecision();
 
             if (actualPrecision < MAX_BIGINT_PRECISION) {
-                offsetToBigint = new Cast(offsetSymbol.toSymbolReference(), BIGINT);
+                offsetToBigint = cast(plannerContext.getTypeManager(), offsetSymbol.toSymbolReference(), BIGINT);
             }
             else if (actualPrecision > MAX_BIGINT_PRECISION) {
                 // If the offset value exceeds max bigint, it implies that the frame bound falls beyond the partition bound.
@@ -1723,12 +1725,12 @@ class QueryPlanner
             else {
                 offsetToBigint = ifExpression(
                         comparison(plannerContext.getMetadata(), LESS_THAN_OR_EQUAL, offsetSymbol.toSymbolReference(), new Constant(decimalType, Int128.valueOf(Long.MAX_VALUE))),
-                        new Cast(offsetSymbol.toSymbolReference(), BIGINT),
+                        cast(plannerContext.getTypeManager(), offsetSymbol.toSymbolReference(), BIGINT),
                         new Constant(BIGINT, Long.MAX_VALUE));
             }
         }
         else {
-            offsetToBigint = new Cast(offsetSymbol.toSymbolReference(), BIGINT);
+            offsetToBigint = cast(plannerContext.getTypeManager(), offsetSymbol.toSymbolReference(), BIGINT);
         }
 
         Symbol coercedOffsetSymbol = symbolAllocator.newSymbol(offsetToBigint);
@@ -2098,7 +2100,7 @@ class QueryPlanner
      *
      * @return the new subplan and a mapping of each expression to the symbol representing the coercion or an existing symbol if a coercion wasn't needed
      */
-    public static PlanAndMappings coerce(PlanBuilder subPlan, List<io.trino.sql.tree.Expression> expressions, Analysis analysis, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
+    public static PlanAndMappings coerce(TypeManager typeManager, PlanBuilder subPlan, List<io.trino.sql.tree.Expression> expressions, Analysis analysis, PlanNodeIdAllocator idAllocator, SymbolAllocator symbolAllocator)
     {
         Assignments.Builder assignments = Assignments.builder();
         assignments.putIdentities(subPlan.getRoot().getOutputSymbols());
@@ -2112,7 +2114,7 @@ class QueryPlanner
                 if (coercion != null) {
                     Symbol symbol = symbolAllocator.newSymbol("expr", coercion);
 
-                    assignments.put(symbol, new Cast(subPlan.rewrite(expression), coercion));
+                    assignments.put(symbol, cast(typeManager, subPlan.rewrite(expression), coercion));
 
                     mappings.put(NodeRef.of(expression), symbol);
                 }
@@ -2131,17 +2133,17 @@ class QueryPlanner
         return new PlanAndMappings(subPlan, mappings);
     }
 
-    public static Expression coerceIfNecessary(Analysis analysis, io.trino.sql.tree.Expression original, Expression rewritten)
+    public static Expression coerceIfNecessary(PlannerContext plannerContext, Analysis analysis, io.trino.sql.tree.Expression original, Expression rewritten)
     {
         Type coercion = analysis.getCoercion(original);
         if (coercion == null) {
             return rewritten;
         }
 
-        return new Cast(rewritten, coercion);
+        return cast(plannerContext.getTypeManager(), rewritten, coercion);
     }
 
-    public static NodeAndMappings coerce(RelationPlan plan, List<Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
+    public static NodeAndMappings coerce(TypeManager typeManager, RelationPlan plan, List<Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
     {
         List<Symbol> visibleFields = visibleFields(plan);
         checkArgument(visibleFields.size() == types.size());
@@ -2154,7 +2156,7 @@ class QueryPlanner
 
             if (!input.type().equals(type)) {
                 Symbol coerced = symbolAllocator.newSymbol(input.name(), type);
-                assignments.put(coerced, new Cast(input.toSymbolReference(), type));
+                assignments.put(coerced, cast(typeManager, input.toSymbolReference(), type));
                 mappings.add(coerced);
             }
             else {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -192,6 +192,7 @@ import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN_OR_EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN_OR_EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.NOT_EQUAL;
+import static io.trino.sql.ir.IrExpressions.cast;
 import static io.trino.sql.ir.IrExpressions.comparison;
 import static io.trino.sql.ir.IrExpressions.ifExpression;
 import static io.trino.sql.planner.LogicalPlanner.failFunction;
@@ -320,7 +321,7 @@ class RelationPlanner
                     .map(Field::getType)
                     .collect(toImmutableList());
 
-            NodeAndMappings coerced = coerce(subPlan, types, symbolAllocator, idAllocator);
+            NodeAndMappings coerced = coerce(plannerContext.getTypeManager(), subPlan, types, symbolAllocator, idAllocator);
 
             plan = new RelationPlan(coerced.getNode(), scope, coerced.getFields(), outerContext);
         }
@@ -353,7 +354,7 @@ class RelationPlanner
                         .map(Field::getType)
                         .collect(toImmutableList());
                 // apply required coercion and prune invisible fields from child outputs
-                NodeAndMappings coerced = coerce(plan, types, symbolAllocator, idAllocator);
+                NodeAndMappings coerced = coerce(plannerContext.getTypeManager(), plan, types, symbolAllocator, idAllocator);
                 plan = new RelationPlan(coerced.getNode(), scope, coerced.getFields(), outerContext);
             }
         }
@@ -388,7 +389,7 @@ class RelationPlanner
         for (io.trino.sql.tree.Expression filter : filters) {
             planBuilder = subqueryPlanner.handleSubqueries(planBuilder, filter, analysis.getSubqueries(filter));
 
-            Expression predicate = coerceIfNecessary(analysis, filter, planBuilder.rewrite(filter));
+            Expression predicate = coerceIfNecessary(plannerContext, analysis, filter, planBuilder.rewrite(filter));
             predicate = predicateTransformation.apply(predicate);
             planBuilder = planBuilder.withNewRoot(new FilterNode(
                     idAllocator.getNextId(),
@@ -413,7 +414,7 @@ class RelationPlanner
 
             Expression predicate = ifExpression(
                     // When predicate evaluates to UNKNOWN (e.g. NULL > 100), it should not violate the check constraint.
-                    new Coalesce(coerceIfNecessary(analysis, constraint, planBuilder.rewrite(constraint)), Booleans.TRUE),
+                    new Coalesce(coerceIfNecessary(plannerContext, analysis, constraint, planBuilder.rewrite(constraint)), Booleans.TRUE),
                     Booleans.TRUE,
                     new Cast(failFunction(plannerContext.getMetadata(), CONSTRAINT_VIOLATION, "Check constraint violation: " + constraint), BOOLEAN));
 
@@ -453,7 +454,7 @@ class RelationPlanner
             if (mask != null) {
                 planBuilder = subqueryPlanner.handleSubqueries(planBuilder, mask, analysis.getSubqueries(mask));
                 symbol = symbolAllocator.newSymbol(symbol);
-                projection = coerceIfNecessary(analysis, mask, planBuilder.rewrite(mask));
+                projection = coerceIfNecessary(plannerContext, analysis, mask, planBuilder.rewrite(mask));
             }
 
             assignments.put(symbol, projection);
@@ -516,7 +517,7 @@ class RelationPlanner
                 // if there are partitioning columns, they might have to be coerced for copartitioning
                 if (tableArgument.getPartitionBy().isPresent() && !tableArgument.getPartitionBy().get().isEmpty()) {
                     List<io.trino.sql.tree.Expression> partitioningColumns = tableArgument.getPartitionBy().get();
-                    PlanAndMappings copartitionCoercions = coerce(sourcePlanBuilder, partitioningColumns, analysis, idAllocator, symbolAllocator);
+                    PlanAndMappings copartitionCoercions = coerce(plannerContext.getTypeManager(), sourcePlanBuilder, partitioningColumns, analysis, idAllocator, symbolAllocator);
                     sourcePlanBuilder = copartitionCoercions.getSubPlan();
                     partitionBy = partitioningColumns.stream()
                             .map(copartitionCoercions::get)
@@ -804,7 +805,7 @@ class RelationPlanner
                             new AggregatedSetDescriptor(labels, descriptor.mode() == RUNNING),
                             descriptor.arguments().stream()
                                     .filter(argument -> !DereferenceExpression.isQualifiedAllFieldsReference(argument))
-                                    .map(argument -> coerceIfNecessary(analysis, argument, argumentTranslation.rewrite(argument)))
+                                    .map(argument -> coerceIfNecessary(plannerContext, analysis, argument, argumentTranslation.rewrite(argument)))
                                     .toList(),
                             classifierSymbol,
                             matchNumberSymbol);
@@ -995,9 +996,9 @@ class RelationPlanner
             leftPlanBuilder = leftPlanBuilder.appendProjections(leftComparisonExpressions, symbolAllocator, idAllocator);
             rightPlanBuilder = rightPlanBuilder.appendProjections(rightComparisonExpressions, symbolAllocator, idAllocator);
 
-            PlanAndMappings leftCoercions = coerce(leftPlanBuilder, leftComparisonExpressions, analysis, idAllocator, symbolAllocator);
+            PlanAndMappings leftCoercions = coerce(plannerContext.getTypeManager(), leftPlanBuilder, leftComparisonExpressions, analysis, idAllocator, symbolAllocator);
             leftPlanBuilder = leftCoercions.getSubPlan();
-            PlanAndMappings rightCoercions = coerce(rightPlanBuilder, rightComparisonExpressions, analysis, idAllocator, symbolAllocator);
+            PlanAndMappings rightCoercions = coerce(plannerContext.getTypeManager(), rightPlanBuilder, rightComparisonExpressions, analysis, idAllocator, symbolAllocator);
             rightPlanBuilder = rightCoercions.getSubPlan();
 
             for (int i = 0; i < leftComparisonExpressions.size(); i++) {
@@ -1067,7 +1068,7 @@ class RelationPlanner
                     rightPlanBuilder.getRoot().getOutputSymbols(),
                     false,
                     Optional.of(IrUtils.and(complexJoinExpressions.stream()
-                            .map(e -> coerceIfNecessary(analysis, e, translationMap.rewrite(e)))
+                            .map(e -> coerceIfNecessary(plannerContext, analysis, e, translationMap.rewrite(e)))
                             .collect(Collectors.toList()))),
                     Optional.empty(),
                     Optional.empty(),
@@ -1081,7 +1082,7 @@ class RelationPlanner
             rootPlanBuilder = subqueryPlanner.handleSubqueries(rootPlanBuilder, complexJoinExpressions, subqueries);
 
             for (io.trino.sql.tree.Expression expression : complexJoinExpressions) {
-                postInnerJoinConditions.add(coerceIfNecessary(analysis, expression, rootPlanBuilder.rewrite(expression)));
+                postInnerJoinConditions.add(coerceIfNecessary(plannerContext, analysis, expression, rootPlanBuilder.rewrite(expression)));
             }
             root = rootPlanBuilder.getRoot();
 
@@ -1155,13 +1156,13 @@ class RelationPlanner
             // compute the coercion for the field on the left to the common supertype of left & right
             Symbol leftOutput = symbolAllocator.newSymbol(identifier.getValue(), type);
             int leftField = joinAnalysis.getLeftJoinFields().get(i);
-            leftCoercions.put(leftOutput, new Cast(left.getSymbol(leftField).toSymbolReference(), type));
+            leftCoercions.put(leftOutput, cast(plannerContext.getTypeManager(), left.getSymbol(leftField).toSymbolReference(), type));
             leftJoinColumns.put(identifier, leftOutput);
 
             // compute the coercion for the field on the right to the common supertype of left & right
             Symbol rightOutput = symbolAllocator.newSymbol(identifier.getValue(), type);
             int rightField = joinAnalysis.getRightJoinFields().get(i);
-            rightCoercions.put(rightOutput, new Cast(right.getSymbol(rightField).toSymbolReference(), type));
+            rightCoercions.put(rightOutput, cast(plannerContext.getTypeManager(), right.getSymbol(rightField).toSymbolReference(), type));
             rightJoinColumns.put(identifier, rightOutput);
 
             clauses.add(new JoinNode.EquiJoinClause(leftOutput, rightOutput));
@@ -1331,7 +1332,7 @@ class RelationPlanner
                 rightPlanBuilder.getRoot().getOutputSymbols(),
                 false,
                 Optional.of(IrUtils.and(predicates.stream()
-                        .map(expression -> coerceIfNecessary(analysis, expression, candidateTranslations.rewrite(expression)))
+                        .map(expression -> coerceIfNecessary(plannerContext, analysis, expression, candidateTranslations.rewrite(expression)))
                         .collect(toImmutableList()))),
                 Optional.empty(),
                 Optional.empty(),
@@ -1400,7 +1401,7 @@ class RelationPlanner
             }
 
             io.trino.sql.tree.Expression filterExpression = (io.trino.sql.tree.Expression) getOnlyElement(criteria.getNodes());
-            rewrittenFilterCondition = coerceIfNecessary(analysis, filterExpression, translationMap.rewrite(filterExpression));
+            rewrittenFilterCondition = coerceIfNecessary(plannerContext, analysis, filterExpression, translationMap.rewrite(filterExpression));
         }
 
         PlanBuilder planBuilder = subqueryPlanner.appendCorrelatedJoin(
@@ -1501,7 +1502,7 @@ class RelationPlanner
         // apply coercions
         // coercions might be necessary for the context item and path parameters before the input functions are applied
         // also, the default expressions in value columns (DEFAULT ... ON EMPTY / ON ERROR) might need a coercion to match the required output type
-        PlanAndMappings coerced = coerce(planBuilder, inputExpressions, analysis, idAllocator, symbolAllocator);
+        PlanAndMappings coerced = coerce(plannerContext.getTypeManager(), planBuilder, inputExpressions, analysis, idAllocator, symbolAllocator);
         planBuilder = coerced.getSubPlan();
 
         // apply the input function to the input expression
@@ -1537,7 +1538,7 @@ class RelationPlanner
         Map<NodeRef<io.trino.sql.tree.Expression>, Expression> rewrittenDefaultExpressions = new HashMap<>();
         ImmutableList.Builder<Symbol> defaultSymbolsBuilder = ImmutableList.builder();
         for (io.trino.sql.tree.Expression defaultExpression : defaultExpressions) {
-            Expression rewritten = coerceIfNecessary(analysis, defaultExpression, planBuilder.rewrite(defaultExpression));
+            Expression rewritten = coerceIfNecessary(plannerContext, analysis, defaultExpression, planBuilder.rewrite(defaultExpression));
             rewrittenDefaultExpressions.put(NodeRef.of(defaultExpression), rewritten);
             defaultSymbolsBuilder.addAll(SymbolsExtractor.extractUnique(rewritten));
         }
@@ -1646,7 +1647,7 @@ class RelationPlanner
                 Type expectedType = jsonTableRelationType.getFieldByIndex(i).getType();
                 Type resultType = outputFunction.signature().getReturnType();
                 if (!resultType.equals(expectedType)) {
-                    result = new Cast(result, expectedType);
+                    result = cast(plannerContext.getTypeManager(), result, expectedType);
                 }
 
                 Symbol output = symbolAllocator.newSymbol(result);
@@ -1911,7 +1912,7 @@ class RelationPlanner
 
         ImmutableList.Builder<Expression> rows = ImmutableList.builder();
         for (io.trino.sql.tree.Expression row : node.getRows()) {
-            Expression rewritten = coerceIfNecessary(analysis, row, translationMap.rewrite(row));
+            Expression rewritten = coerceIfNecessary(plannerContext, analysis, row, translationMap.rewrite(row));
             if (!(analysis.getType(row) instanceof RowType)) {
                 rewritten = new Row(ImmutableList.of(rewritten));
             }
@@ -2041,7 +2042,7 @@ class RelationPlanner
             }
             else {
                 // apply required coercion and prune invisible fields from child outputs
-                planAndMappings = coerce(plan, types, symbolAllocator, idAllocator);
+                planAndMappings = coerce(plannerContext.getTypeManager(), plan, types, symbolAllocator, idAllocator);
             }
             for (int i = 0; i < outputFields.getAllFields().size(); i++) {
                 symbolMapping.put(outputs.get(i), planAndMappings.getFields().get(i));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SubqueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SubqueryPlanner.java
@@ -27,7 +27,6 @@ import io.trino.sql.analyzer.Analysis.OperandAndPredicate;
 import io.trino.sql.analyzer.Field;
 import io.trino.sql.analyzer.RelationType;
 import io.trino.sql.analyzer.Scope;
-import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.ComparisonOperator;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
@@ -73,6 +72,7 @@ import static com.google.common.collect.Streams.stream;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.ir.IrExpressions.cast;
 import static io.trino.sql.ir.IrExpressions.comparison;
 import static io.trino.sql.ir.IrExpressions.not;
 import static io.trino.sql.planner.PlanBuilder.newPlanBuilder;
@@ -312,7 +312,7 @@ class SubqueryPlanner
                 }
             }
 
-            Expression expression = new Cast(new Row(fields.build()), type);
+            Expression expression = cast(plannerContext.getTypeManager(), new Row(fields.build()), type);
 
             root = new ProjectNode(idAllocator.getNextId(), root, Assignments.of(column, expression));
         }
@@ -555,7 +555,7 @@ class SubqueryPlanner
                 }
                 else {
                     Symbol castSymbol = symbolAllocator.newSymbol("cast", targetType);
-                    assignments.put(castSymbol, new Cast(original.toSymbolReference(), targetType));
+                    assignments.put(castSymbol, cast(plannerContext.getTypeManager(), original.toSymbolReference(), targetType));
                     coerced.add(castSymbol);
                 }
             }
@@ -813,7 +813,7 @@ class SubqueryPlanner
                 new ProjectNode(
                         idAllocator.getNextId(),
                         relationPlan.getRoot(),
-                        Assignments.of(column, new Cast(new Row(fields.build()), type))));
+                        Assignments.of(column, cast(plannerContext.getTypeManager(), new Row(fields.build()), type))));
 
         return coerceIfNecessary(subqueryPlan, column, subquery, coercion);
     }
@@ -827,7 +827,7 @@ class SubqueryPlanner
 
             Assignments assignments = Assignments.builder()
                     .putIdentities(subPlan.getRoot().getOutputSymbols())
-                    .put(coerced, new Cast(symbol.toSymbolReference(), coercion.get()))
+                    .put(coerced, cast(plannerContext.getTypeManager(), symbol.toSymbolReference(), coercion.get()))
                     .build();
 
             subPlan = subPlan.withNewRoot(new ProjectNode(idAllocator.getNextId(), subPlan.getRoot(), assignments));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -176,6 +176,7 @@ import static io.trino.sql.ir.ComparisonOperator.LESS_THAN;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN_OR_EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.NOT_EQUAL;
 import static io.trino.sql.ir.IrExpressions.between;
+import static io.trino.sql.ir.IrExpressions.cast;
 import static io.trino.sql.ir.IrExpressions.comparison;
 import static io.trino.sql.ir.IrExpressions.equalityClause;
 import static io.trino.sql.ir.IrExpressions.ifExpression;
@@ -444,14 +445,14 @@ public class TranslationMap
 
         // Don't add a coercion for the top-level expression. That depends on the context
         // the expression is used and it's the responsibility of the caller.
-        return isRoot ? result : QueryPlanner.coerceIfNecessary(analysis, expr, result);
+        return isRoot ? result : QueryPlanner.coerceIfNecessary(plannerContext, analysis, expr, result);
     }
 
     private io.trino.sql.ir.Expression translate(NullIfExpression expression)
     {
         io.trino.sql.ir.Expression first = translateExpression(expression.getFirst());
         io.trino.sql.ir.Expression second = translateExpression(expression.getSecond());
-        return nullIf(plannerContext.getMetadata(), symbolAllocator, first, second, analysis.getNullIfComparisonType(expression));
+        return nullIf(plannerContext.getMetadata(), plannerContext.getTypeManager(), symbolAllocator, first, second, analysis.getNullIfComparisonType(expression));
     }
 
     private io.trino.sql.ir.Expression translate(ArithmeticUnaryExpression expression)
@@ -788,7 +789,7 @@ public class TranslationMap
                     ImmutableList.of(translateExpression(expression.getExpression())));
         }
 
-        return new io.trino.sql.ir.Cast(
+        return cast(plannerContext.getTypeManager(),
                 translateExpression(expression.getExpression()),
                 analysis.getType(expression));
     }
@@ -1120,7 +1121,7 @@ public class TranslationMap
         return switch (valueType) {
             case TimeType type -> BuiltinFunctionCallBuilder.resolve(plannerContext.getMetadata())
                     .setName(AT_TIMEZONE_FUNCTION_NAME)
-                    .addArgument(createTimeWithTimeZoneType(type.getPrecision()), new io.trino.sql.ir.Cast(value, createTimeWithTimeZoneType(type.getPrecision())))
+                    .addArgument(createTimeWithTimeZoneType(type.getPrecision()), cast(plannerContext.getTypeManager(), value, createTimeWithTimeZoneType(type.getPrecision())))
                     .addArgument(timeZoneType, timeZone)
                     .build();
             case TimeWithTimeZoneType _ -> BuiltinFunctionCallBuilder.resolve(plannerContext.getMetadata())
@@ -1130,7 +1131,7 @@ public class TranslationMap
                     .build();
             case TimestampType type -> BuiltinFunctionCallBuilder.resolve(plannerContext.getMetadata())
                     .setName("at_timezone")
-                    .addArgument(createTimestampWithTimeZoneType(type.getPrecision()), new io.trino.sql.ir.Cast(value, createTimestampWithTimeZoneType(type.getPrecision())))
+                    .addArgument(createTimestampWithTimeZoneType(type.getPrecision()), cast(plannerContext.getTypeManager(), value, createTimestampWithTimeZoneType(type.getPrecision())))
                     .addArgument(timeZoneType, timeZone)
                     .build();
             case TimestampWithTimeZoneType _ -> BuiltinFunctionCallBuilder.resolve(plannerContext.getMetadata())
@@ -1153,7 +1154,7 @@ public class TranslationMap
 
         return BuiltinFunctionCallBuilder.resolve(plannerContext.getMetadata())
                 .setName(FORMAT_FUNCTION_NAME)
-                .addArgument(VARCHAR, new io.trino.sql.ir.Cast(arguments.get(0), VARCHAR))
+                .addArgument(VARCHAR, cast(plannerContext.getTypeManager(), arguments.get(0), VARCHAR))
                 .addArgument(RowType.anonymous(argumentTypes.subList(1, arguments.size())), new io.trino.sql.ir.Row(arguments.subList(1, arguments.size())))
                 .build();
     }
@@ -1178,14 +1179,14 @@ public class TranslationMap
         if (escape.isPresent()) {
             patternCall = BuiltinFunctionCallBuilder.resolve(plannerContext.getMetadata())
                     .setName(LIKE_PATTERN_FUNCTION_NAME)
-                    .addArgument(VARCHAR, new io.trino.sql.ir.Cast(pattern, VARCHAR))
-                    .addArgument(VARCHAR, new io.trino.sql.ir.Cast(escape.get(), VARCHAR))
+                    .addArgument(VARCHAR, cast(plannerContext.getTypeManager(), pattern, VARCHAR))
+                    .addArgument(VARCHAR, cast(plannerContext.getTypeManager(), escape.get(), VARCHAR))
                     .build();
         }
         else {
             patternCall = BuiltinFunctionCallBuilder.resolve(plannerContext.getMetadata())
                     .setName(LIKE_PATTERN_FUNCTION_NAME)
-                    .addArgument(VARCHAR, new io.trino.sql.ir.Cast(pattern, VARCHAR))
+                    .addArgument(VARCHAR, cast(plannerContext.getTypeManager(), pattern, VARCHAR))
                     .build();
         }
 
@@ -1244,8 +1245,8 @@ public class TranslationMap
         return new Call(
                 operator,
                 ImmutableList.of(
-                        new io.trino.sql.ir.Cast(translateExpression(node.getBase()), operator.signature().getArgumentType(0)),
-                        new io.trino.sql.ir.Cast(translateExpression(node.getIndex()), operator.signature().getArgumentType(1))));
+                        cast(plannerContext.getTypeManager(), translateExpression(node.getBase()), operator.signature().getArgumentType(0)),
+                        cast(plannerContext.getTypeManager(), translateExpression(node.getIndex()), operator.signature().getArgumentType(1))));
     }
 
     private io.trino.sql.ir.Expression translate(LambdaExpression node)
@@ -1398,7 +1399,7 @@ public class TranslationMap
 
         Type resultType = outputFunction.signature().getReturnType();
         if (!resultType.equals(returnedType)) {
-            result = new io.trino.sql.ir.Cast(result, returnedType);
+            result = cast(plannerContext.getTypeManager(), result, returnedType);
         }
 
         return result;
@@ -1465,7 +1466,7 @@ public class TranslationMap
 
         Type resultType = outputFunction.signature().getReturnType();
         if (!resultType.equals(returnedType)) {
-            result = new io.trino.sql.ir.Cast(result, returnedType);
+            result = cast(plannerContext.getTypeManager(), result, returnedType);
         }
 
         return result;
@@ -1521,7 +1522,7 @@ public class TranslationMap
 
         Type resultType = outputFunction.signature().getReturnType();
         if (!resultType.equals(returnedType)) {
-            result = new io.trino.sql.ir.Cast(result, returnedType);
+            result = cast(plannerContext.getTypeManager(), result, returnedType);
         }
 
         return result;
@@ -1584,7 +1585,7 @@ public class TranslationMap
                     parameters.add(rewrittenParameter);
                 }
             }
-            parametersRow = new io.trino.sql.ir.Cast(new io.trino.sql.ir.Row(parameters.build()), parameterRowType);
+            parametersRow = cast(plannerContext.getTypeManager(), new io.trino.sql.ir.Row(parameters.build()), parameterRowType);
             parametersOrder = pathParameters.stream()
                     .map(parameter -> parameter.getName().getCanonicalValue())
                     .collect(toImmutableList());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyTableScanRedirection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyTableScanRedirection.java
@@ -50,6 +50,7 @@ import static io.trino.spi.StandardErrorCode.COLUMN_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
+import static io.trino.sql.ir.IrExpressions.cast;
 import static io.trino.sql.planner.plan.Patterns.tableScan;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -269,6 +270,6 @@ public class ApplyTableScanRedirection
                     sourceType));
         }
 
-        return new Cast(destinationSymbol.toSymbolReference(), sourceType);
+        return cast(plannerContext.getTypeManager(), destinationSymbol.toSymbolReference(), sourceType);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PreAggregateCaseAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PreAggregateCaseAggregations.java
@@ -63,6 +63,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+import static io.trino.sql.ir.IrExpressions.cast;
 import static io.trino.sql.ir.IrExpressions.ifExpression;
 import static io.trino.sql.ir.IrExpressions.mayFail;
 import static io.trino.sql.ir.IrUtils.or;
@@ -299,7 +300,7 @@ public class PreAggregateCaseAggregations
                             Type preProjectionType = getType(preProjection);
                             Type aggregationInputType = getOnlyElement(key.getFunction().signature().getArgumentTypes());
                             if (!preProjectionType.equals(aggregationInputType)) {
-                                preProjection = new Cast(preProjection, aggregationInputType);
+                                preProjection = cast(plannerContext.getTypeManager(), preProjection, aggregationInputType);
                             }
 
                             // Wrap the preProjection with IF to retain the conditional nature on the CASE aggregation(s) during pre-aggregation
@@ -416,7 +417,7 @@ public class PreAggregateCaseAggregations
                     name,
                     caseExpression.whenClauses().get(0).getOperand(),
                     caseExpression.whenClauses().get(0).getResult(),
-                    new Cast(caseExpression.defaultValue(), aggregationType)));
+                    cast(plannerContext.getTypeManager(), caseExpression.defaultValue(), aggregationType)));
         }
 
         return Optional.empty();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushCastIntoRow.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushCastIntoRow.java
@@ -16,12 +16,16 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.ExpressionTreeRewriter;
 import io.trino.sql.ir.Row;
 
 import java.util.List;
+
+import static io.trino.sql.ir.IrExpressions.cast;
 
 /**
  * Transforms expressions of the form
@@ -43,14 +47,21 @@ import java.util.List;
 public class PushCastIntoRow
         extends ExpressionRewriteRuleSet
 {
-    public PushCastIntoRow()
+    public PushCastIntoRow(PlannerContext plannerContext)
     {
-        super((expression, _) -> ExpressionTreeRewriter.rewriteWith(new Rewriter(), expression, null));
+        super((expression, _) -> ExpressionTreeRewriter.rewriteWith(new Rewriter(plannerContext.getTypeManager()), expression, null));
     }
 
     private static class Rewriter
             extends io.trino.sql.ir.ExpressionRewriter<Void>
     {
+        private final TypeManager typeManager;
+
+        public Rewriter(TypeManager typeManager)
+        {
+            this.typeManager = typeManager;
+        }
+
         @Override
         public Expression rewriteCast(Cast node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
         {
@@ -65,7 +76,7 @@ public class PushCastIntoRow
                     Expression fieldValue = expressions.get(i);
                     Type fieldType = castToType.getFields().get(i).getType();
                     if (!fieldValue.type().equals(fieldType)) {
-                        fieldValue = new Cast(fieldValue, fieldType);
+                        fieldValue = cast(typeManager, fieldValue, fieldType);
                     }
                     items.add(fieldValue);
                 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapRowSubscript.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapRowSubscript.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.metadata.Metadata;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Cast;
@@ -31,6 +32,7 @@ import java.util.Deque;
 
 import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
 import static io.trino.operator.scalar.TryCastFunction.TRY_CAST_FUNCTION_NAME;
+import static io.trino.sql.ir.IrExpressions.cast;
 
 /**
  * Transforms expressions of the form
@@ -47,17 +49,19 @@ public class UnwrapRowSubscript
 {
     public UnwrapRowSubscript(PlannerContext context)
     {
-        super((expression, _) -> ExpressionTreeRewriter.rewriteWith(new Rewriter(context.getMetadata()), expression));
+        super((expression, _) -> ExpressionTreeRewriter.rewriteWith(new Rewriter(context.getMetadata(), context.getTypeManager()), expression));
     }
 
     private static class Rewriter
             extends io.trino.sql.ir.ExpressionRewriter<Void>
     {
         private final Metadata metadata;
+        private final TypeManager typeManager;
 
-        public Rewriter(Metadata metadata)
+        public Rewriter(Metadata metadata, TypeManager typeManager)
         {
             this.metadata = metadata;
+            this.typeManager = typeManager;
         }
 
         @Override
@@ -98,7 +102,7 @@ public class UnwrapRowSubscript
                             new Call(
                                     metadata.getCoercion(builtinFunctionName(TRY_CAST_FUNCTION_NAME), result.type(), coercion.getType()),
                                     ImmutableList.of(result)) :
-                            new Cast(result, coercion.getType());
+                            cast(typeManager, result, coercion.getType());
                 }
 
                 return result;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/TypeValidator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/TypeValidator.java
@@ -14,6 +14,8 @@
 package io.trino.sql.planner.sanity;
 
 import com.google.common.collect.ListMultimap;
+import com.google.common.graph.SuccessorsFunction;
+import com.google.common.graph.Traverser;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.spi.function.BoundSignature;
@@ -21,8 +23,10 @@ import io.trino.spi.type.FunctionType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.ExpressionExtractor;
 import io.trino.sql.planner.SimplePlanVisitor;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.plan.AggregationNode;
@@ -31,6 +35,7 @@ import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.planner.plan.UnionNode;
 import io.trino.sql.planner.plan.WindowNode;
+import io.trino.type.TypeCoercion;
 import io.trino.type.UnknownType;
 
 import java.util.List;
@@ -38,6 +43,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.sql.ir.Cast.Kind.CONVERT;
+import static io.trino.sql.ir.Cast.Kind.REINTERPRET;
 
 /**
  * Ensures that all the expressions and FunctionCalls matches their output symbols
@@ -53,6 +60,16 @@ public final class TypeValidator
             WarningCollector warningCollector)
     {
         plan.accept(new Visitor(), null);
+
+        TypeCoercion typeCoercion = new TypeCoercion(plannerContext.getTypeManager()::getType);
+        for (Expression expression : ExpressionExtractor.extractExpressions(plan)) {
+            for (Expression node : Traverser.forTree((SuccessorsFunction<Expression>) Expression::children).depthFirstPreOrder(expression)) {
+                if (node instanceof Cast cast) {
+                    Cast.Kind expected = typeCoercion.isTypeOnlyCoercion(cast.expression().type(), cast.type()) ? REINTERPRET : CONVERT;
+                    checkArgument(cast.kind() == expected, "Cast from %s to %s must have kind %s but was %s", cast.expression().type(), cast.type(), expected, cast.kind());
+                }
+            }
+        }
     }
 
     private static class Visitor

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutinePlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutinePlanner.java
@@ -19,13 +19,13 @@ import io.trino.Session;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.analyzer.Analysis;
 import io.trino.sql.analyzer.Field;
 import io.trino.sql.analyzer.RelationId;
 import io.trino.sql.analyzer.RelationType;
 import io.trino.sql.analyzer.Scope;
-import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.ExpressionRewriter;
 import io.trino.sql.ir.ExpressionTreeRewriter;
 import io.trino.sql.ir.Reference;
@@ -79,6 +79,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.sql.ir.IrExpressions.call;
+import static io.trino.sql.ir.IrExpressions.cast;
 import static io.trino.sql.ir.IrExpressions.constantNull;
 import static io.trino.sql.planner.LogicalPlanner.buildLambdaDeclarationToSymbolMap;
 import static java.util.Locale.ENGLISH;
@@ -318,7 +319,7 @@ public final class SqlRoutinePlanner
 
             // Apply casts, desugar expression, and perform other rewrites
             TranslationMap translationMap = new TranslationMap(Optional.empty(), scope, analysis, nodeRefSymbolMap, fieldSymbols, session, plannerContext, symbolAllocator);
-            io.trino.sql.ir.Expression translated = coerceIfNecessary(analysis, expression, translationMap.rewrite(expression));
+            io.trino.sql.ir.Expression translated = coerceIfNecessary(plannerContext.getTypeManager(), analysis, expression, translationMap.rewrite(expression));
 
             // desugar the lambda captures
             io.trino.sql.ir.Expression lambdaCaptureDesugared = LambdaCaptureDesugaringRewriter.rewrite(translated, symbolAllocator);
@@ -350,13 +351,13 @@ public final class SqlRoutinePlanner
             }, optimized);
         }
 
-        public static io.trino.sql.ir.Expression coerceIfNecessary(Analysis analysis, Expression original, io.trino.sql.ir.Expression rewritten)
+        public static io.trino.sql.ir.Expression coerceIfNecessary(TypeManager typeManager, Analysis analysis, Expression original, io.trino.sql.ir.Expression rewritten)
         {
             Type coercion = analysis.getCoercion(original);
             if (coercion == null) {
                 return rewritten;
             }
-            return new Cast(rewritten, coercion);
+            return cast(typeManager, rewritten, coercion);
         }
 
         private List<IrStatement> statements(List<ControlStatement> statements, Context context)

--- a/core/trino-main/src/test/java/io/trino/sql/ir/TestingIr.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/TestingIr.java
@@ -45,11 +45,11 @@ public final class TestingIr
     /// resolving the equality operator against the shared testing planner context.
     public static Expression nullIf(SymbolAllocator allocator, Expression first, Expression second)
     {
-        return IrExpressions.nullIf(PLANNER_CONTEXT.getMetadata(), allocator, first, second);
+        return IrExpressions.nullIf(PLANNER_CONTEXT.getMetadata(), PLANNER_CONTEXT.getTypeManager(), allocator, first, second);
     }
 
     public static Expression nullIf(SymbolAllocator allocator, Expression first, Expression second, Type comparisonType)
     {
-        return IrExpressions.nullIf(PLANNER_CONTEXT.getMetadata(), allocator, first, second, comparisonType);
+        return IrExpressions.nullIf(PLANNER_CONTEXT.getMetadata(), PLANNER_CONTEXT.getTypeManager(), allocator, first, second, comparisonType);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
@@ -101,6 +101,7 @@ import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+import static io.trino.sql.ir.Cast.Kind.REINTERPRET;
 import static io.trino.sql.ir.IrExpressions.not;
 import static io.trino.sql.ir.TestingIr.between;
 import static io.trino.sql.ir.TestingIr.comparison;
@@ -459,7 +460,7 @@ public class TestConnectorExpressionTranslator
     public void testTranslateCast()
     {
         assertTranslationRoundTrips(
-                new Cast(new Reference(VARCHAR, "varchar_symbol_1"), VARCHAR_TYPE),
+                new Cast(new Reference(VARCHAR, "varchar_symbol_1"), VARCHAR_TYPE, REINTERPRET),
                 new io.trino.spi.expression.Call(
                         VARCHAR_TYPE,
                         CAST_FUNCTION_NAME,
@@ -497,7 +498,7 @@ public class TestConnectorExpressionTranslator
                                     .addArgument(LIKE_PATTERN,
                                             BuiltinFunctionCallBuilder.resolve(PLANNER_CONTEXT.getMetadata())
                                                     .setName(LikeFunctions.LIKE_PATTERN_FUNCTION_NAME)
-                                                    .addArgument(VARCHAR, new Cast(new Constant(createVarcharType(pattern.length()), utf8Slice(pattern)), VARCHAR))
+                                                    .addArgument(VARCHAR, new Cast(new Constant(createVarcharType(pattern.length()), utf8Slice(pattern)), VARCHAR, REINTERPRET))
                                                     .build())
                                     .build());
 
@@ -526,8 +527,8 @@ public class TestConnectorExpressionTranslator
                                     .addArgument(LIKE_PATTERN,
                                             BuiltinFunctionCallBuilder.resolve(PLANNER_CONTEXT.getMetadata())
                                                     .setName(LikeFunctions.LIKE_PATTERN_FUNCTION_NAME)
-                                                    .addArgument(VARCHAR, new Cast(new Constant(createVarcharType(9), utf8Slice(pattern)), VARCHAR))
-                                                    .addArgument(VARCHAR, new Cast(new Constant(createVarcharType(1), utf8Slice(escape)), VARCHAR))
+                                                    .addArgument(VARCHAR, new Cast(new Constant(createVarcharType(9), utf8Slice(pattern)), VARCHAR, REINTERPRET))
+                                                    .addArgument(VARCHAR, new Cast(new Constant(createVarcharType(1), utf8Slice(escape)), VARCHAR, REINTERPRET))
                                                     .build())
                                     .build());
                 });

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDynamicFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDynamicFilter.java
@@ -45,6 +45,7 @@ import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
 import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.ir.Cast.Kind.REINTERPRET;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN_OR_EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.IDENTICAL;
@@ -295,7 +296,7 @@ public class TestDynamicFilter
     {
         assertPlan("SELECT o.comment, l.comment FROM lineitem l, orders o WHERE o.comment < l.comment",
                 anyTree(filter(
-                        comparison(GREATER_THAN, new Cast(new Reference(VARCHAR, "L_COMMENT"), createVarcharType(79)), new Reference(createVarcharType(79), "O_COMMENT")),
+                        comparison(GREATER_THAN, new Cast(new Reference(VARCHAR, "L_COMMENT"), createVarcharType(79), REINTERPRET), new Reference(createVarcharType(79), "O_COMMENT")),
                         join(INNER, builder -> builder
                                 .addDynamicFilter("DF", "O_COMMENT")
                                 .left(
@@ -314,7 +315,7 @@ public class TestDynamicFilter
 
     private Expression typeOnlyCast(String symbol, Type asDataType)
     {
-        return new Cast(new Symbol(UNKNOWN, symbol).toSymbolReference(), asDataType);
+        return new Cast(new Symbol(UNKNOWN, symbol).toSymbolReference(), asDataType, REINTERPRET);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushCastIntoRow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushCastIntoRow.java
@@ -73,7 +73,7 @@ public class TestPushCastIntoRow
 
     private void test(Expression original, Expression unwrapped)
     {
-        tester().assertThat(new PushCastIntoRow().projectExpressionRewrite())
+        tester().assertThat(new PushCastIntoRow(tester().getPlannerContext()).projectExpressionRewrite())
                 .on(p -> p.project(
                         Assignments.builder()
                                 .put(p.symbol("output", original.type()), original)

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
@@ -422,6 +422,7 @@ public class TestPostgreSqlClient
                         translateToConnectorExpression(
                                 nullIf(
                                         FUNCTIONS.getMetadata(),
+                                        FUNCTIONS.getPlannerContext().getTypeManager(),
                                         new SymbolAllocator(),
                                         new Reference(VARCHAR, "a_varchar_symbol"),
                                         new Reference(VARCHAR, "b_varchar_symbol"))),


### PR DESCRIPTION
## Description

A cast whose source and target share the same physical representation — e.g. `varchar(5)` → `varchar(20)`, a same-scale/same-subtype decimal widening, or a row cast that only drops field names — is a runtime no-op. Today every consumer re-derives that by calling `TypeCoercion.isTypeOnlyCoercion`.

This marks it on the node instead. `Cast` carries a `Cast.Kind`:

- `REINTERPRET` — source and target share a physical representation; the cast is a runtime no-op with no coercion function to invoke.
- `CONVERT` — the value's encoding changes via a coercion function.

The kind is classified once, where the cast is created, and read thereafter. Analogous to LLVM `bitcast`, Clang `CK_NoOp`, and GIMPLE `NOP_EXPR`.

- The 2-arg `Cast` constructor defaults to `CONVERT`, so value-changing cast sites are unchanged.
- `IrExpressions.cast(typeManager, expression, type)` is the single classifier (`REINTERPRET` iff `isTypeOnlyCoercion`); coercion cast sites across the planner, analyzer, routine planner, and optimizer rules build their casts through it.
- `ExpressionBytecodeCompiler` reads `Cast.kind()` and skips the coercion function for a `REINTERPRET` cast, instead of computing `isTypeOnlyCoercion` itself.
- `TypeValidator` enforces the invariant on final plans: a `Cast` is `REINTERPRET` iff its coercion is type-only, so a mis-classified birth site fails loudly rather than silently mis-generating code.

## Additional context and related issues

No behavior change: this moves the type-only classification from consumer-side re-derivation to an explicitly-carried, validated property of the node. Pure rewriters (`ExpressionTreeRewriter`, `IrExpressionOptimizer`) preserve the existing kind; error casts (`fail(...)`), `→ date`, `→ KdbTree`, and `→ JoniRegexp`/`JsonPath` casts are never type-only and remain `CONVERT`.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
