### PR TITLE
Fail fast: Validate aggregation input parameters are not boxed primitive types to avoid latent runtime exception

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ParametricAggregationImplementation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ParametricAggregationImplementation.java
@@ -15,6 +15,7 @@ package io.trino.operator.aggregation;
 
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Primitives;
 import io.trino.operator.ParametricImplementation;
 import io.trino.operator.aggregation.AggregationFromAnnotationsParser.AccumulatorStateDetails;
 import io.trino.operator.aggregation.AggregationFunctionAdapter.AggregationParameterKind;
@@ -342,6 +343,14 @@ public class ParametricAggregationImplementation
                 else if (baseTypeAnnotation instanceof SqlType) {
                     boolean isParameterBlock = isParameterBlock(annotations[i]);
                     boolean isParameterNullable = isParameterNullable(annotations[i]);
+                    if (!isParameterBlock && !isParameterNullable) {
+                        Class<?> parameterType = method.getParameterTypes()[i];
+                        checkArgument(
+                                parameterType == Void.class || !Primitives.isWrapperType(parameterType),
+                                "%s contains an input parameter with boxed primitive type %s; a non-nullable aggregation input parameter must use the corresponding primitive type",
+                                methodName,
+                                parameterType.getSimpleName());
+                    }
                     builder.add(getInputParameterKind(isParameterNullable, isParameterBlock, methodName));
                 }
                 else if (baseTypeAnnotation instanceof BlockIndex) {

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestAggregationValidation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestAggregationValidation.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation;
+
+import io.trino.operator.aggregation.state.NullableLongState;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AggregationFunction;
+import io.trino.spi.function.AggregationState;
+import io.trino.spi.function.CombineFunction;
+import io.trino.spi.function.InputFunction;
+import io.trino.spi.function.OutputFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.operator.aggregation.AggregationFromAnnotationsParser.parseFunctionDefinitions;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestAggregationValidation
+{
+    @Test
+    public void testBoxedInputParameterRejected()
+    {
+        assertThatThrownBy(() -> parseFunctionDefinitions(BoxedInputParameter.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageMatching(".*contains an input parameter with boxed primitive type Long; " +
+                        "a non-nullable aggregation input parameter must use the corresponding primitive type");
+    }
+
+    @Test
+    public void testPrimitiveInputParameterAccepted()
+    {
+        // The equivalent function with a primitive input parameter parses cleanly.
+        parseFunctionDefinitions(PrimitiveInputParameter.class);
+    }
+
+    @AggregationFunction("boxed_input_parameter")
+    protected static final class BoxedInputParameter
+    {
+        private BoxedInputParameter() {}
+
+        @InputFunction
+        public static void input(@AggregationState NullableLongState state, @SqlType(StandardTypes.BIGINT) Long value)
+        {
+            // noop, only for annotation validation
+        }
+
+        @CombineFunction
+        public static void combine(@AggregationState NullableLongState state, @AggregationState NullableLongState other)
+        {
+            // noop, only for annotation validation
+        }
+
+        @OutputFunction(StandardTypes.BIGINT)
+        public static void output(@AggregationState NullableLongState state, BlockBuilder out)
+        {
+            // noop, only for annotation validation
+        }
+    }
+
+    @AggregationFunction("primitive_input_parameter")
+    protected static final class PrimitiveInputParameter
+    {
+        private PrimitiveInputParameter() {}
+
+        @InputFunction
+        public static void input(@AggregationState NullableLongState state, @SqlType(StandardTypes.BIGINT) long value)
+        {
+            // noop, only for annotation validation
+        }
+
+        @CombineFunction
+        public static void combine(@AggregationState NullableLongState state, @AggregationState NullableLongState other)
+        {
+            // noop, only for annotation validation
+        }
+
+        @OutputFunction(StandardTypes.BIGINT)
+        public static void output(@AggregationState NullableLongState state, BlockBuilder out)
+        {
+            // noop, only for annotation validation
+        }
+    }
+}


### PR DESCRIPTION
## Description
A by-value aggregation input (`@SqlType`, non-nullable, non-block) is bound to a primitive value getter, so declaring it as a boxed wrapper (`Integer`, `Long`, …) fails at query time with an opaque method-handle error instead of at registration. This shipped once already — `theta_sketch_union` (#29725).

The scalar framework already rejects this (`ParametricScalarImplementation` / `TestScalarValidation`); this adds the same check for aggregations so it could fail fast rather than throwing an exception at query time. `Void` and object-backed types (`Slice`, `Block`, …) are unaffected.

**Not covered**: wrong-width primitives (e.g. `@SqlType(INTEGER) int`) — needs the resolved `Type`, only available at specialization. Possible follow-up if people think it's really helpful since it seems a bigger change.


## Additional context and related issues
The error case which should have been captured by this check: #29725


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

