### PR TITLE
Add block projection APIs

### DIFF
--- a/core/trino-main/src/test/java/io/trino/block/TestArrayBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestArrayBlock.java
@@ -33,6 +33,7 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestArrayBlock
         extends AbstractTestBlock
@@ -182,6 +183,42 @@ public class TestArrayBlock
         testNotCompactBlock(fromElementBlock(valueIsNull.length - 1, Optional.of(valueIsValid), offsets, compactValueBlock));
         // underlying value block is not compact
         testNotCompactBlock(fromElementBlock(valueIsNull.length, Optional.of(valueIsValid), offsets, inCompactValueBlock));
+    }
+
+    @Test
+    public void testCreateProjectionFromVisibleElements()
+    {
+        long[] valueIsValid = {0b1101};
+        int[] offsets = {0, 2, 2, 5, 6};
+        ArrayBlock block = fromElementBlock(
+                4,
+                Optional.of(valueIsValid),
+                offsets,
+                new ByteArrayBlock(6, Optional.empty(), new byte[] {1, 2, 3, 4, 5, 6}));
+
+        Block zeroAlignedProjectedElements = new ByteArrayBlock(6, Optional.empty(), new byte[] {11, 12, 13, 14, 15, 16});
+        ArrayBlock zeroAlignedProjection = block.createProjection(zeroAlignedProjectedElements);
+        assertThat(zeroAlignedProjection.getOffsetBase()).isEqualTo(0);
+        assertThat(zeroAlignedProjection.getRawOffsets()).isSameAs(offsets);
+        assertThat(zeroAlignedProjection.getRawValueIsValid()).isSameAs(valueIsValid);
+        assertThat(zeroAlignedProjection.getRawElementBlock()).isSameAs(zeroAlignedProjectedElements);
+        assertPositionValue(zeroAlignedProjection, 2, new Byte[] {13, 14, 15});
+
+        ArrayBlock region = block.getRegion(1, 2);
+        Block projectedElements = new ByteArrayBlock(3, Optional.empty(), new byte[] {21, 22, 23});
+        ArrayBlock projection = region.createProjection(projectedElements);
+
+        assertThat(projection.getPositionCount()).isEqualTo(2);
+        assertThat(projection.getOffsetBase()).isEqualTo(0);
+        assertThat(projection.getRawOffsets()).containsExactly(0, 0, 3);
+        assertThat(projection.getRawValueIsValid()).containsExactly(0b10);
+        assertThat(projection.getRawElementBlock()).isSameAs(projectedElements);
+        assertThat(projection.isNull(0)).isTrue();
+        assertPositionValue(projection, 1, new Byte[] {21, 22, 23});
+
+        assertThatThrownBy(() -> region.createProjection(new ByteArrayBlock(4, Optional.empty(), new byte[4])))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("newVisibleElements must have the same position count as getElementsBlock(); expected 3 but got 4");
     }
 
     private static BlockBuilder createBlockBuilderWithValues(long[][][] expectedValues)

--- a/core/trino-main/src/test/java/io/trino/block/TestRowBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestRowBlock.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.ByteArrayBlock;
+import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.block.RowBlock;
 import io.trino.spi.block.RowBlockBuilder;
 import io.trino.spi.block.SqlRow;
@@ -38,6 +39,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestRowBlock
         extends AbstractTestBlock
@@ -111,6 +113,51 @@ public class TestRowBlock
                 new ByteArrayBlock(6, Optional.of(rowValidity), createExpectedValue(6).getBytes()),
                 new ByteArrayBlock(6, Optional.of(rowValidity), createExpectedValue(6).getBytes()),
         }));
+    }
+
+    @Test
+    public void testCreateProjectionFromVisibleFields()
+    {
+        long[] valueIsValid = {0b1101};
+        RowBlock block = fromNotNullSuppressedFieldBlocks(
+                4,
+                Optional.of(valueIsValid),
+                new Block[] {
+                        new LongArrayBlock(4, Optional.of(valueIsValid), new long[] {1, 0, 3, 4}),
+                        new LongArrayBlock(4, Optional.of(valueIsValid), new long[] {10, 0, 30, 40}),
+                });
+
+        Block[] zeroAlignedProjectedFields = {
+                new LongArrayBlock(4, Optional.empty(), new long[] {101, 102, 103, 104}),
+        };
+        RowBlock zeroAlignedProjection = block.createProjection(zeroAlignedProjectedFields);
+        assertThat(zeroAlignedProjection.getOffsetBase()).isEqualTo(0);
+        assertThat(zeroAlignedProjection.getRawValueIsValid()).isSameAs(valueIsValid);
+        assertThat(zeroAlignedProjection.getRawFieldBlocks()).containsExactly(zeroAlignedProjectedFields);
+        SqlRow zeroAlignedRow = zeroAlignedProjection.getRow(2);
+        assertThat(zeroAlignedRow.getFieldCount()).isEqualTo(1);
+        assertThat(BIGINT.getLong(zeroAlignedRow.getRawFieldBlock(0), zeroAlignedRow.getRawIndex())).isEqualTo(103);
+
+        RowBlock region = block.getRegion(1, 2);
+        Block[] projectedFields = {
+                new LongArrayBlock(2, Optional.empty(), new long[] {201, 203}),
+        };
+        RowBlock projection = region.createProjection(projectedFields);
+
+        assertThat(projection.getPositionCount()).isEqualTo(2);
+        assertThat(projection.getOffsetBase()).isEqualTo(0);
+        assertThat(projection.getRawValueIsValid()).containsExactly(0b10);
+        assertThat(projection.getRawFieldBlocks()).containsExactly(projectedFields);
+        assertThat(projection.isNull(0)).isTrue();
+        SqlRow row = projection.getRow(1);
+        assertThat(row.getFieldCount()).isEqualTo(1);
+        assertThat(BIGINT.getLong(row.getRawFieldBlock(0), row.getRawIndex())).isEqualTo(203);
+
+        assertThatThrownBy(() -> region.createProjection(new Block[] {
+                new LongArrayBlock(3, Optional.empty(), new long[3]),
+        }))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("newVisibleFieldBlocks must have the same position count as this block; expected 2 but field 0 has 3");
     }
 
     @Test

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
@@ -191,6 +191,33 @@ public final class ArrayBlock
         return arrayOffset;
     }
 
+    /**
+     * Creates a projection by replacing the visible elements for this array block.
+     * The replacement elements must correspond to {@link #getElementsBlock()}, not {@link #getRawElementBlock()}.
+     * If this block is zero-aligned, the existing offsets and validity bitmap are reused.
+     * Otherwise, the visible offsets and validity bits are normalized and the returned block has an offset base of zero.
+     */
+    public ArrayBlock createProjection(Block newVisibleElements)
+    {
+        requireNonNull(newVisibleElements, "newVisibleElements is null");
+
+        int visibleElementCount = offsets[arrayOffset + positionCount] - offsets[arrayOffset];
+        if (newVisibleElements.getPositionCount() != visibleElementCount) {
+            throw new IllegalArgumentException(format("newVisibleElements must have the same position count as getElementsBlock(); expected %s but got %s", visibleElementCount, newVisibleElements.getPositionCount()));
+        }
+
+        if (arrayOffset == 0 && offsets[0] == 0) {
+            return new ArrayBlock(0, positionCount, valueIsValid, offsets, newVisibleElements);
+        }
+
+        int[] newOffsets = new int[positionCount + 1];
+        for (int i = 1; i <= positionCount; i++) {
+            newOffsets[i] = offsets[arrayOffset + i] - offsets[arrayOffset];
+        }
+        long[] newValueIsValid = compactBitmap(valueIsValid, arrayOffset, positionCount);
+        return new ArrayBlock(0, positionCount, newValueIsValid, newOffsets, newVisibleElements);
+    }
+
     @Override
     public boolean mayHaveNull()
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -163,6 +163,35 @@ public final class RowBlock
         return startOffset;
     }
 
+    /**
+     * Creates a projection by replacing the visible field blocks for this row block.
+     * The replacement fields must correspond to {@link #getFieldBlocks()}, not {@link #getRawFieldBlocks()}.
+     * The replacement field count may differ from this block's field count.
+     * If this block is zero-aligned, the existing validity bitmap is reused.
+     * Otherwise, the visible validity bits are normalized and the returned block has an offset base of zero.
+     */
+    public RowBlock createProjection(Block[] newVisibleFieldBlocks)
+    {
+        requireNonNull(newVisibleFieldBlocks, "newVisibleFieldBlocks is null");
+
+        for (int i = 0; i < newVisibleFieldBlocks.length; i++) {
+            Block fieldBlock = newVisibleFieldBlocks[i];
+            if (fieldBlock == null) {
+                throw new NullPointerException(format("newVisibleFieldBlocks[%s] is null", i));
+            }
+            if (fieldBlock.getPositionCount() != positionCount) {
+                throw new IllegalArgumentException(format("newVisibleFieldBlocks must have the same position count as this block; expected %s but field %s has %s", positionCount, i, fieldBlock.getPositionCount()));
+            }
+        }
+
+        if (startOffset == 0) {
+            return new RowBlock(0, positionCount, valueIsValid, newVisibleFieldBlocks);
+        }
+
+        long[] newValueIsValid = compactBitmap(valueIsValid, startOffset, positionCount);
+        return new RowBlock(0, positionCount, newValueIsValid, newVisibleFieldBlocks);
+    }
+
     @Override
     public boolean mayHaveNull()
     {


### PR DESCRIPTION
Structural rewrites can replace ArrayBlock and RowBlock children after coercing or pruning visible child blocks. Using public constructors repeats validation for offsets and row nulls already proved valid by the original block.

Add projection APIs that accept replacements in the visible coordinate space returned by getElementsBlock() and getFieldBlocks(). Zero-aligned blocks reuse their structural arrays, while sliced blocks normalize offsets or nulls to an offset-zero result.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
