### PR TITLE
Add domain_hint support for OAuth2 SSO account filtering

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/NimbusOAuth2Client.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/NimbusOAuth2Client.java
@@ -96,6 +96,7 @@ public class NimbusOAuth2Client
     private final Set<String> accessTokenAudiences;
     private final Duration maxClockSkew;
     private final Optional<String> jwtType;
+    private final Optional<String> domainHint;
     private final NimbusHttpClient httpClient;
     private final OAuth2ServerConfigProvider serverConfigurationProvider;
     private volatile boolean loaded;
@@ -117,6 +118,7 @@ public class NimbusOAuth2Client
         principalField = oauthConfig.getPrincipalField();
         maxClockSkew = oauthConfig.getMaxClockSkew();
         jwtType = oauthConfig.getJwtType();
+        domainHint = oauthConfig.getDomainHint();
 
         accessTokenAudiences = new HashSet<>(oauthConfig.getAdditionalAudiences());
         accessTokenAudiences.add(clientId.getValue());
@@ -221,15 +223,16 @@ public class NimbusOAuth2Client
         @Override
         public Request createAuthorizationRequest(String state, URI callbackUri)
         {
-            return new Request(
-                    new AuthorizationRequest.Builder(CODE, clientId)
-                            .redirectionURI(callbackUri)
-                            .scope(scope)
-                            .endpointURI(authUrl)
-                            .state(new State(state))
-                            .build()
-                            .toURI(),
-                    Optional.empty());
+            AuthorizationRequest.Builder builder = new AuthorizationRequest.Builder(CODE, clientId)
+                    .redirectionURI(callbackUri)
+                    .scope(scope)
+                    .endpointURI(authUrl)
+                    .state(new State(state));
+            domainHint.ifPresent(hint -> {
+                builder.customParameter("domain_hint", hint);
+                builder.customParameter("prompt", "select_account");
+            });
+            return new Request(builder.build().toURI(), Optional.empty());
         }
 
         @Override
@@ -290,14 +293,15 @@ public class NimbusOAuth2Client
         public Request createAuthorizationRequest(String state, URI callbackUri)
         {
             String nonce = new Nonce().getValue();
-            return new Request(
-                    new AuthenticationRequest.Builder(CODE, scope, clientId, callbackUri)
-                            .endpointURI(authUrl)
-                            .state(new State(state))
-                            .nonce(new Nonce(hashNonce(nonce)))
-                            .build()
-                            .toURI(),
-                    Optional.of(nonce));
+            AuthenticationRequest.Builder builder = new AuthenticationRequest.Builder(CODE, scope, clientId, callbackUri)
+                    .endpointURI(authUrl)
+                    .state(new State(state))
+                    .nonce(new Nonce(hashNonce(nonce)));
+            domainHint.ifPresent(hint -> {
+                builder.customParameter("domain_hint", hint);
+                builder.customParameter("prompt", "select_account");
+            });
+            return new Request(builder.build().toURI(), Optional.of(nonce));
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Config.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Config.java
@@ -49,6 +49,7 @@ public class OAuth2Config
     private Optional<File> userMappingFile = Optional.empty();
     private boolean enableRefreshTokens;
     private boolean enableDiscovery = true;
+    private Optional<String> domainHint = Optional.empty();
 
     public Optional<String> getStateKey()
     {
@@ -241,6 +242,19 @@ public class OAuth2Config
     public OAuth2Config setEnableDiscovery(boolean enableDiscovery)
     {
         this.enableDiscovery = enableDiscovery;
+        return this;
+    }
+
+    public Optional<String> getDomainHint()
+    {
+        return domainHint;
+    }
+
+    @Config("http-server.authentication.oauth2.domain-hint")
+    @ConfigDescription("Domain hint to restrict SSO account selection to a specific domain (e.g. for Azure AD)")
+    public OAuth2Config setDomainHint(String domainHint)
+    {
+        this.domainHint = Optional.ofNullable(domainHint);
         return this;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2Config.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2Config.java
@@ -50,7 +50,8 @@ public class TestOAuth2Config
                 .setUserMappingPattern(null)
                 .setUserMappingFile(null)
                 .setEnableRefreshTokens(false)
-                .setEnableDiscovery(true));
+                .setEnableDiscovery(true)
+                .setDomainHint(null));
     }
 
     @Test
@@ -73,6 +74,7 @@ public class TestOAuth2Config
                 .put("http-server.authentication.oauth2.user-mapping.file", userMappingFile.toString())
                 .put("http-server.authentication.oauth2.refresh-tokens", "true")
                 .put("http-server.authentication.oauth2.oidc.discovery", "false")
+                .put("http-server.authentication.oauth2.domain-hint", "example.com")
                 .buildOrThrow();
 
         OAuth2Config expected = new OAuth2Config()
@@ -89,7 +91,8 @@ public class TestOAuth2Config
                 .setUserMappingPattern("(.*)@something")
                 .setUserMappingFile(userMappingFile.toFile())
                 .setEnableRefreshTokens(true)
-                .setEnableDiscovery(false);
+                .setEnableDiscovery(false)
+                .setDomainHint("example.com");
 
         assertFullMapping(properties, expected);
     }

--- a/docs/src/main/sphinx/security/oauth2.md
+++ b/docs/src/main/sphinx/security/oauth2.md
@@ -106,6 +106,11 @@ The following configuration properties are available:
     order to begin the OAuth 2.0 authorization process. Providing this value
     while OIDC discovery is enabled overrides the value from the OpenID provider
     metadata document.
+* - `http-server.authentication.oauth2.domain-hint`
+  - Domain hint to restrict SSO account selection to a specific domain. When
+    set, it is included in the authorization URL as a `domain_hint` parameter
+    together with `prompt=select_account`, which some IdPs (for example Azure
+    AD) use to filter the account picker shown to users during login.
 * - `http-server.authentication.oauth2.token-url`
   - The URL of the endpoint on the authorization server which Trino uses to
     obtain an access token. Providing this value while OIDC discovery is enabled


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
- Adds a configurable `http-server.authentication.oauth2.domain-hint` property to restrict which accounts are shown during SSO login
- When set, appends `domain_hint` and `prompt=select_account` to the OAuth2 authorization URL
- `prompt=select_account` redirects to the federated IdP while `domain_hint` filters the account picker to only show accounts from the specified domain
- Documents the new property in the OAuth2 security docs

## Testing Done
- Verified `TestOAuth2Config` passes with the new config property
- Compiled `core/trino-main` and ran `checkstyle:check` successfully

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( x ) Release notes are required, with the following suggested text:

```markdown
## Section
* Adds a configurable http-server.authentication.oauth2.domain-hint property to restrict which accounts are shown during SSO login . ({30272}`[30272](https://github.com/trinodb/trino/issues/30272)`)
```
