### PR TITLE
Optimize case-insensitive table and view resolution in REST catalog

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -1003,9 +1003,18 @@ public class TrinoRestCatalog
     private TableIdentifier findRemoteTable(ConnectorSession session, TableIdentifier tableIdentifier)
     {
         Namespace remoteNamespace = toRemoteNamespace(session, tableIdentifier.namespace());
+        SessionContext context = convert(session);
+        TableIdentifier exactIdentifier = TableIdentifier.of(remoteNamespace, tableIdentifier.name());
+
+        // 1. OPTIMISTIC CHECK (Case-Sensitive Fast-Path)
+        if (restSessionCatalog.tableExists(context, exactIdentifier)) {
+            return exactIdentifier;
+        }
+
+        // 2. CASE-INSENSITIVE FALLBACK: scan listing
         List<TableIdentifier> tableIdentifiers;
         try {
-            tableIdentifiers = restSessionCatalog.listTables(convert(session), remoteNamespace);
+            tableIdentifiers = restSessionCatalog.listTables(context, remoteNamespace);
         }
         catch (RESTException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to list tables", e);
@@ -1020,7 +1029,7 @@ public class TrinoRestCatalog
                 matchingTable = identifier;
             }
         }
-        return matchingTable == null ? TableIdentifier.of(remoteNamespace, tableIdentifier.name()) : matchingTable;
+        return matchingTable == null ? exactIdentifier : matchingTable;
     }
 
     private TableIdentifier toRemoteView(ConnectorSession session, SchemaTableName schemaViewName, boolean getCached)
@@ -1036,6 +1045,15 @@ public class TrinoRestCatalog
         }
 
         Namespace remoteNamespace = toRemoteNamespace(session, tableIdentifier.namespace());
+        SessionContext context = convert(session);
+        TableIdentifier exactIdentifier = TableIdentifier.of(remoteNamespace, tableIdentifier.name());
+
+        // 1. OPTIMISTIC CHECK (Case-Sensitive Fast-Path)
+        if (restSessionCatalog.viewExists(context, exactIdentifier)) {
+            return exactIdentifier;
+        }
+
+        // 2. CASE-INSENSITIVE FALLBACK: scan listing
         List<TableIdentifier> tableIdentifiers;
         try {
             tableIdentifiers = restSessionCatalog.listViews(convert(session), remoteNamespace);
@@ -1053,7 +1071,7 @@ public class TrinoRestCatalog
                 matchingView = identifier;
             }
         }
-        return matchingView == null ? TableIdentifier.of(remoteNamespace, tableIdentifier.name()) : matchingView;
+        return matchingView == null ? exactIdentifier : matchingView;
     }
 
     private TableIdentifier toRemoteObject(TableIdentifier tableIdentifier, Supplier<TableIdentifier> remoteObjectProvider, boolean getCached)


### PR DESCRIPTION
Previously, resolving a case-insensitive table or view name always called listTables()/listViews() to scan the entire namespace contents, even when the table name casing matched the remote catalog exactly.

Add an optimistic case-sensitive fast-path check using tableExists()/viewExists() before falling back to a full namespace listing scan. This mirrors the hierarchical namespace resolution fix applied to namespace lookups.

For the common case where Trino's lowercased identifiers match the remote catalog casing exactly, this reduces resolution cost from one full listing REST request to a single lightweight HEAD request with no namespace scanning.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(*) Release notes are required, with the following suggested text:

```markdown
## Section
* Adds optimistic table/viewExists call before doing expensive remote full list.
```
