### PR TITLE
Fix task creation on nodes without assigned buckets

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/BucketNodeMap.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/BucketNodeMap.java
@@ -20,6 +20,7 @@ import io.trino.node.InternalNode;
 import java.util.List;
 import java.util.function.ToIntFunction;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public final class BucketNodeMap
@@ -51,6 +52,11 @@ public final class BucketNodeMap
     public InternalNode getAssignedNode(Split split)
     {
         return getAssignedNode(getBucket(split));
+    }
+
+    public List<InternalNode> getDistinctNodes()
+    {
+        return bucketToNode.stream().distinct().collect(toImmutableList());
     }
 
     public ToIntFunction<Split> getSplitToBucketFunction()

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
@@ -79,7 +79,6 @@ import io.trino.tracing.TrinoAttributes;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -1168,8 +1167,7 @@ public class PipelinedQueryScheduler
             if (fragment.getRemoteSourceNodes().stream().allMatch(node -> node.getExchangeType() == REPLICATE)) {
                 // no remote source
                 bucketNodeMap = nodePartitioningManager.getBucketNodeMap(session, partitioningHandle, partitionCount);
-                stageNodeList = new ArrayList<>(nodeScheduler.createNodeSelector(session).allNodes());
-                Collections.shuffle(stageNodeList);
+                stageNodeList = bucketNodeMap.getDistinctNodes();
             }
             else {
                 // remote source requires nodePartitionMap

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestStageScheduler.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestStageScheduler.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.connector.MockConnectorColumnHandle;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorPlugin;
+import io.trino.connector.MockConnectorTableHandle;
+import io.trino.spi.connector.BucketFunction;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorBucketNodeMap;
+import io.trino.spi.connector.ConnectorNodePartitioningProvider;
+import io.trino.spi.connector.ConnectorPartitioningHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorTablePartitioning;
+import io.trino.spi.connector.ConnectorTableProperties;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.Type;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.QueryRunner.MaterializedResultWithPlan;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.ToIntFunction;
+
+import static io.trino.SystemSessionProperties.MAX_HASH_PARTITION_COUNT;
+import static io.trino.SystemSessionProperties.MIN_HASH_PARTITION_COUNT;
+import static io.trino.SystemSessionProperties.TABLE_SCAN_NODE_PARTITIONING_MIN_BUCKET_TO_TASK_RATIO;
+import static io.trino.spi.connector.ConnectorBucketNodeMap.createBucketNodeMap;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestStageScheduler
+        extends AbstractTestQueryFramework
+{
+    private static final String MOCK_CATALOG = "mock";
+    private static final String TABLE_NAME = "test_table";
+    private static final SchemaTableName SCHEMA_TABLE_NAME = new SchemaTableName("default", TABLE_NAME);
+    private static final ConnectorPartitioningHandle PARTITIONING_HANDLE = new TestPartitionHandle();
+    private static final ColumnHandle KEY_COLUMN_HANDLE = new MockConnectorColumnHandle("key", BIGINT);
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        QueryRunner queryRunner = DistributedQueryRunner.builder(
+                        testSessionBuilder()
+                                .setCatalog(MOCK_CATALOG)
+                                .setSchema("default")
+                                .build())
+                .setWorkerCount(2)
+                .build();
+
+        queryRunner.installPlugin(
+                new MockConnectorPlugin(
+                        MockConnectorFactory.builder()
+                                .withGetColumns(_ -> ImmutableList.of(
+                                        new ColumnMetadata("key", BIGINT),
+                                        new ColumnMetadata("value", BIGINT)))
+                                .withGetTableProperties((_, tableHandle) -> {
+                                    String tableName = ((MockConnectorTableHandle) tableHandle).getTableName().getTableName();
+                                    if (tableName.equals(TABLE_NAME)) {
+                                        return new ConnectorTableProperties(
+                                                TupleDomain.all(),
+                                                Optional.of(new ConnectorTablePartitioning(PARTITIONING_HANDLE, ImmutableList.of(KEY_COLUMN_HANDLE), true)),
+                                                Optional.empty(),
+                                                ImmutableList.of());
+                                    }
+                                    return new ConnectorTableProperties();
+                                })
+                                .withPartitionProvider(new TestPartitioningProvider())
+                                .withData(schemaTableName -> {
+                                    if (schemaTableName.equals(SCHEMA_TABLE_NAME)) {
+                                        ImmutableList.Builder<List<?>> rows = ImmutableList.builder();
+                                        for (int i = 0; i < 25; i++) {
+                                            rows.add(ImmutableList.of((long) (i % 5), (long) i));
+                                        }
+                                        return rows.build();
+                                    }
+                                    return ImmutableList.of();
+                                })
+                                .build()));
+        queryRunner.createCatalog(MOCK_CATALOG, "mock", ImmutableMap.of());
+        return queryRunner;
+    }
+
+    @Test
+    void testTaskCountMatchesPartitionCount()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(MAX_HASH_PARTITION_COUNT, "1")
+                .setSystemProperty(MIN_HASH_PARTITION_COUNT, "1")
+                .setSystemProperty(TABLE_SCAN_NODE_PARTITIONING_MIN_BUCKET_TO_TASK_RATIO, "0")
+                .build();
+
+        DistributedQueryRunner queryRunner = getDistributedQueryRunner();
+
+        MaterializedResultWithPlan result = queryRunner.executeWithPlan(session, "SELECT count(*) FROM mock.default.test_table GROUP BY key");
+
+        assertThat(result.result().getMaterializedRows())
+                .hasSize(5)
+                .allMatch(row -> (long) row.getField(0) == 5);
+
+        QueryInfo queryInfo = queryRunner.getCoordinator()
+                .getQueryManager()
+                .getFullQueryInfo(result.queryId());
+        List<StageInfo> stages = StagesInfo.getAllStages(queryInfo.getStages());
+        StageInfo partitionedStage = stages.stream()
+                .filter(stage -> stage.plan() != null && stage.plan().getPartitioning().getConnectorHandle() instanceof TestPartitionHandle)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No stage with connector partitioning found"));
+
+        assertThat(partitionedStage.tasks()).hasSize(1);
+    }
+
+    public record TestPartitionHandle()
+            implements ConnectorPartitioningHandle {}
+
+    private static class TestPartitioningProvider
+            implements ConnectorNodePartitioningProvider
+    {
+        @Override
+        public Optional<ConnectorBucketNodeMap> getBucketNodeMapping(
+                ConnectorTransactionHandle transactionHandle,
+                ConnectorSession session,
+                ConnectorPartitioningHandle partitioningHandle)
+        {
+            if (partitioningHandle.equals(PARTITIONING_HANDLE)) {
+                return Optional.of(createBucketNodeMap(1));
+            }
+            throw new IllegalArgumentException("Unknown partitioning handle: " + partitioningHandle);
+        }
+
+        @Override
+        public ToIntFunction<ConnectorSplit> getSplitBucketFunction(
+                ConnectorTransactionHandle transactionHandle,
+                ConnectorSession session,
+                ConnectorPartitioningHandle partitioningHandle,
+                int bucketCount)
+        {
+            return _ -> 0;
+        }
+
+        @Override
+        public BucketFunction getBucketFunction(
+                ConnectorTransactionHandle transactionHandle,
+                ConnectorSession session,
+                ConnectorPartitioningHandle partitioningHandle,
+                List<Type> partitionChannelTypes,
+                int bucketCount)
+        {
+            return (_, _) -> 0;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

`PipelinedQueryScheduler` created tasks on all cluster nodes regardless of the bucket-to-node mapping. When partition count was lower than the number of nodes, some tasks had no buckets assigned and never received any splits. These empty tasks wasted resources.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
