### PR TITLE
Fix large row constructors in compiled filters

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
@@ -29,6 +29,7 @@ import io.airlift.bytecode.Scope;
 import io.airlift.bytecode.Variable;
 import io.airlift.bytecode.control.ForLoop;
 import io.airlift.bytecode.control.IfStatement;
+import io.airlift.bytecode.expression.BytecodeExpression;
 import io.trino.cache.CacheStatsMBean;
 import io.trino.cache.NonEvictableCache;
 import io.trino.metadata.FunctionManager;
@@ -582,7 +583,7 @@ public class PageFunctionCompiler
                 classDefinition,
                 callSiteBinder,
                 cachedInstanceBinder,
-                fieldReferenceCompiler(compactLayout, callSiteBinder),
+                fieldReferenceCompiler(compactLayout, callSiteBinder, scope),
                 functionManager,
                 metadata,
                 typeManager,
@@ -638,15 +639,19 @@ public class PageFunctionCompiler
         };
     }
 
-    private static BiFunction<Reference, Scope, BytecodeNode> fieldReferenceCompiler(Map<Symbol, Integer> compactLayout, CallSiteBinder callSiteBinder)
+    private static BiFunction<Reference, Scope, BytecodeNode> fieldReferenceCompiler(Map<Symbol, Integer> compactLayout, CallSiteBinder callSiteBinder, Scope filterScope)
     {
         return (reference, scope) -> {
             int field = compactLayout.get(Symbol.from(reference));
+            // Scope identity distinguishes the filter method from generated helpers, which cannot access block variables.
+            BytecodeExpression block = scope == filterScope
+                    ? scope.getVariable("block_" + field)
+                    : scope.getVariable("page").invoke("getBlock", Block.class, constantInt(field));
             return generateInputReference(
                     callSiteBinder,
                     scope,
                     reference.type(),
-                    scope.getVariable("block_" + field),
+                    block,
                     scope.getVariable("position"));
         };
     }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/RowConstructorCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/RowConstructorCodeGenerator.java
@@ -54,7 +54,7 @@ public class RowConstructorCodeGenerator
     private final RowType rowType;
     private final List<Expression> arguments;
     // Arbitrary value chosen to balance the code size vs performance trade off. Not perf tested.
-    private static final int MEGAMORPHIC_FIELD_COUNT = 64;
+    static final int MEGAMORPHIC_FIELD_COUNT = 64;
 
     // number of fields to initialize in a single method for large rows
     private static final int LARGE_ROW_BATCH_SIZE = 100;

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestPageFunctionCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestPageFunctionCompiler.java
@@ -86,6 +86,7 @@ import static io.trino.spi.function.OperatorType.ADD;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+import static io.trino.sql.gen.RowConstructorCodeGenerator.MEGAMORPHIC_FIELD_COUNT;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN;
 import static io.trino.sql.ir.IrExpressions.call;
 import static io.trino.sql.ir.TestingIr.comparison;
@@ -287,6 +288,23 @@ public class TestPageFunctionCompiler
         Page page = createLongBlockPage(0);
         Block result = project(projection, page, SelectedPositions.positionsRange(0, page.getPositionCount()));
         assertThat(hiddenType.getObjectValue(result, 0)).isEqualTo(42);
+    }
+
+    @Test
+    void testFilterWithLargeInputBackedRow()
+    {
+        int fieldCount = MEGAMORPHIC_FIELD_COUNT + 1;
+        Reference input = new Reference(BIGINT, "$col_0");
+        Row row = new Row(nCopies(fieldCount, input), RowType.anonymous(nCopies(fieldCount, BIGINT)));
+        Expression filter = comparison(GREATER_THAN, new FieldReference(row, fieldCount - 1), new Constant(BIGINT, 2L));
+
+        PageFilter compiled = FUNCTION_RESOLUTION.getPageFunctionCompiler()
+                .compileFilter(filter, ImmutableMap.of(new Symbol(BIGINT, "$col_0"), 0), Optional.empty())
+                .get();
+
+        Page page = createLongBlockPage(0, 1, 2, 3, 4);
+        SourcePage inputPage = compiled.getInputChannels().getInputChannels(SourcePage.create(page));
+        assertThat(compiled.filter(SESSION, inputPage).size()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
## Description

Fix compilation of filters that construct rows with more than 64 input-backed fields.

`RowConstructorCodeGenerator` evaluates fields of large rows in generated helper methods. These helpers have a different bytecode scope and cannot access the `block_N` local variables declared by `PageFunctionCompiler` in the parent filter method.

The change reads input blocks from the `Page` in generated helper scopes while retaining local-variable access in the filter scope. A regression test covers the first row size above `MEGAMORPHIC_FIELD_COUNT`.

## Additional context and related issues

### Reproduction

Trino 482 fails to compile the following query when `node_id` is repeated 65 times in the row constructor:

```sql
SELECT node_id
FROM system.runtime.nodes
WHERE json_format(CAST(ROW(node_id, node_id, /* 61 more */, node_id, node_id) AS JSON)) <> ''
```

Using `system.runtime.nodes` keeps `node_id` as an input reference. A `VALUES` query can be constant-folded before bytecode generation.

The following standalone reproducer generates the complete query:

```java
package reproducer;

import io.trino.testing.StandaloneQueryRunner;

import static io.trino.testing.TestingSession.testSession;
import static java.util.Collections.nCopies;

public final class TrinoLargeRowConstructorReproducer
{
    private static final int FIELD_COUNT = 65;

    private TrinoLargeRowConstructorReproducer() {}

    public static void main(String[] args)
    {
        String rowArguments = String.join(", ", nCopies(FIELD_COUNT, "node_id"));
        String sql = "SELECT node_id FROM system.runtime.nodes " +
                "WHERE json_format(CAST(ROW(" + rowArguments + ") AS JSON)) <> ''";

        try (StandaloneQueryRunner queryRunner = new StandaloneQueryRunner(testSession())) {
            queryRunner.execute(queryRunner.getDefaultSession(), sql);
        }
    }
}
```

Changing `FIELD_COUNT` from `65` to `64` makes the query succeed.

### Root cause

`RowConstructorCodeGenerator` generates rows with at most 64 fields inline. For larger rows, it moves field evaluation into a `partialRowConstructor...` helper method.

`PageFunctionCompiler` declares input blocks as `block_N` local variables in the parent `filter` method. The helper method has a separate scope and does not receive or redeclare those variables. Compiling its first input reference therefore fails with:

```text
java.lang.IllegalArgumentException: Variable 'block_0' not defined
    at io.airlift.bytecode.Scope.getVariable(Scope.java:112)
    at io.trino.sql.gen.PageFunctionCompiler.lambda$fieldReferenceCompiler$0(PageFunctionCompiler.java:649)
    at io.trino.sql.gen.RowConstructorCodeGenerator.generatePartialRowConstructor(RowConstructorCodeGenerator.java:183)
```

No class file is generated because the exception occurs while constructing the bytecode model.

### Verification

The regression test was run against the latest master sources with only the `PageFunctionCompiler` fix removed. `testFilterWithLargeInputBackedRow` failed during filter compilation, confirming that the issue is still present on master. Restoring the fix made all 12 `TestPageFunctionCompiler` tests pass. AirStyle and Checkstyle also pass.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix query failures for filters containing row constructors with more than 64 fields that reference input columns. ({issue}`issuenumber`)
```
