### PR TITLE
Convert SDO_GEOMETRY and SDO_POINT_TYPE cols to WKT format

### DIFF
--- a/plugin/trino-oracle/pom.xml
+++ b/plugin/trino-oracle/pom.xml
@@ -108,6 +108,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.oracle.database.nls</groupId>
             <artifactId>orai18n</artifactId>
             <scope>runtime</scope>
@@ -172,6 +178,12 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-exchange-filesystem</artifactId>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-geospatial</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -71,11 +71,17 @@ import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeDescriptor;
+import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.VarcharType;
 import oracle.jdbc.OraclePreparedStatement;
 import oracle.jdbc.OracleTypes;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 
 import java.math.RoundingMode;
 import java.sql.Connection;
@@ -233,6 +239,8 @@ public class OracleClient
             .buildOrThrow();
 
     private final boolean synonymsEnabled;
+    private final SpatialColumnMapping spatialColumnMapping;
+    private final Type geometryType;
     private final ConnectorExpressionRewriter<ParameterizedExpression> connectorExpressionRewriter;
     private final ProjectFunctionRewriter<JdbcExpression, ParameterizedExpression> projectFunctionRewriter;
     private final AggregateFunctionRewriter<JdbcExpression, ?> aggregateFunctionRewriter;
@@ -244,12 +252,19 @@ public class OracleClient
             OracleConfig oracleConfig,
             ConnectionFactory connectionFactory,
             QueryBuilder queryBuilder,
+            TypeManager typeManager,
             IdentifierMapping identifierMapping,
             RemoteQueryModifier queryModifier)
     {
         super("\"", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(), identifierMapping, queryModifier, true);
 
         this.synonymsEnabled = oracleConfig.isSynonymsEnabled();
+        this.spatialColumnMapping = oracleConfig.getSpatialColumnMapping();
+        // Only resolve the GEOMETRY type when the user has opted into native geometry mapping;
+        // otherwise deployments without the geospatial types registered would fail to start.
+        this.geometryType = spatialColumnMapping == SpatialColumnMapping.GEOMETRY
+                ? typeManager.getType(new TypeDescriptor(StandardTypes.GEOMETRY))
+                : null;
 
         this.connectorExpressionRewriter = JdbcConnectorExpressionRewriterBuilder.newBuilder()
                 .addStandardRules(this::quoted)
@@ -531,6 +546,19 @@ public class OracleClient
                     FULL_PUSHDOWN));
         }
 
+        // Oracle Spatial UDTs are OPAQUE and cannot be read through JDBC without oracle.xdb.XMLType
+        // (not on the plugin classpath). OracleQueryBuilder wraps these columns in
+        // MDSYS.SDO_UTIL.TO_WKTGEOMETRY(...) at query time, so the driver only ever sees a CLOB.
+        // Depending on oracle.spatial-column-mapping the value is surfaced as unbounded VARCHAR (WKT)
+        // or as Trino's native GEOMETRY (WKT parsed inside the connector, equivalent to
+        // ST_GeometryFromText applied to the VARCHAR path).
+        if (jdbcTypeName.equalsIgnoreCase("SDO_GEOMETRY") || jdbcTypeName.equalsIgnoreCase("SDO_POINT_TYPE")) {
+            if (spatialColumnMapping == SpatialColumnMapping.GEOMETRY) {
+                return Optional.of(oracleSpatialGeometryColumnMapping(geometryType, jdbcTypeName));
+            }
+            return Optional.of(oracleSpatialColumnMapping(jdbcTypeName));
+        }
+
         Optional<ColumnMapping> columnMapping = switch (typeHandle.jdbcType()) {
             case Types.SMALLINT -> Optional.of(ColumnMapping.longMapping(
                     SMALLINT,
@@ -649,6 +677,39 @@ public class OracleClient
             return mapToUnboundedVarchar(typeHandle);
         }
         return Optional.empty();
+    }
+
+    private static ColumnMapping oracleSpatialColumnMapping(String remoteTypeName)
+    {
+        return ColumnMapping.sliceMapping(
+                createUnboundedVarcharType(),
+                (resultSet, columnIndex) -> utf8Slice(resultSet.getString(columnIndex)),
+                (_, _, _) -> {
+                    throw new TrinoException(NOT_SUPPORTED, "Writing " + remoteTypeName + " is not supported");
+                },
+                DISABLE_PUSHDOWN);
+    }
+
+    private static ColumnMapping oracleSpatialGeometryColumnMapping(Type geometryType, String remoteTypeName)
+    {
+        return ColumnMapping.objectMapping(
+                geometryType,
+                ObjectReadFunction.of(Geometry.class, (resultSet, columnIndex) -> {
+                    String wkt = resultSet.getString(columnIndex);
+                    if (wkt == null) {
+                        return null;
+                    }
+                    try {
+                        return new WKTReader().read(wkt);
+                    }
+                    catch (ParseException e) {
+                        throw new TrinoException(JDBC_ERROR, "Failed to parse WKT geometry from Oracle column: " + wkt, e);
+                    }
+                }),
+                ObjectWriteFunction.of(Geometry.class, (_, _, _) -> {
+                    throw new TrinoException(NOT_SUPPORTED, "Writing " + remoteTypeName + " is not supported");
+                }),
+                DISABLE_PUSHDOWN);
     }
 
     private static ColumnMapping oracleTimestampColumnMapping(TimestampType timestampType)

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClientModule.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClientModule.java
@@ -30,6 +30,7 @@ import io.trino.plugin.jdbc.ForJdbcClient;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcMetadataConfig;
 import io.trino.plugin.jdbc.MaxDomainCompactionThreshold;
+import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RetryStrategy;
 import io.trino.plugin.jdbc.TimestampTimeZoneDomain;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
@@ -56,6 +57,7 @@ public class OracleClientModule
     public void configure(Binder binder)
     {
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(OracleClient.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, QueryBuilder.class).setBinding().to(OracleQueryBuilder.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, TimestampTimeZoneDomain.class).setBinding().toInstance(TimestampTimeZoneDomain.ANY);
         bindSessionPropertiesProvider(binder, OracleSessionProperties.class);
         configBinder(binder).bindConfig(OracleConfig.class);

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleConfig.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleConfig.java
@@ -41,6 +41,7 @@ public class OracleConfig
     private Duration inactiveConnectionTimeout = new Duration(20, MINUTES);
     private Duration connectionPoolWaitDuration = new Duration(3, SECONDS);
     private Integer fetchSize;
+    private SpatialColumnMapping spatialColumnMapping = SpatialColumnMapping.VARCHAR;
 
     public boolean isSynonymsEnabled()
     {
@@ -179,5 +180,19 @@ public class OracleConfig
     public boolean isPoolSizedProperly()
     {
         return getConnectionPoolMaxSize() >= getConnectionPoolMinSize();
+    }
+
+    @NotNull
+    public SpatialColumnMapping getSpatialColumnMapping()
+    {
+        return spatialColumnMapping;
+    }
+
+    @Config("oracle.spatial-column-mapping")
+    @ConfigDescription("How MDSYS.SDO_GEOMETRY and MDSYS.SDO_POINT_TYPE columns are surfaced: VARCHAR (WKT text) or GEOMETRY (Trino native geometry, equivalent to ST_GeometryFromText applied to the WKT)")
+    public OracleConfig setSpatialColumnMapping(SpatialColumnMapping spatialColumnMapping)
+    {
+        this.spatialColumnMapping = spatialColumnMapping;
+        return this;
     }
 }

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleQueryBuilder.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleQueryBuilder.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.oracle;
+
+import com.google.inject.Inject;
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.QueryParameter;
+import io.trino.plugin.jdbc.expression.ParameterizedExpression;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static java.lang.String.format;
+
+/**
+ * Wraps Oracle Spatial columns in the SELECT projection so their values can be materialized
+ * through JDBC without needing the {@code oracle.xdb.XMLType} class. The Oracle JDBC driver's
+ * default OPAQUE handler tries to load {@code oracle.xdb.XMLType} to represent SDO_GEOMETRY /
+ * SDO_POINT_TYPE values; the {@code xdb} module is not on the Trino classpath, so any read of
+ * a raw SDO column fails with {@code NoClassDefFoundError: oracle/xdb/XMLType}. Converting the
+ * value to text server-side via {@code MDSYS.SDO_UTIL.TO_WKTGEOMETRY} sidesteps that path
+ * entirely — the driver just sees a CLOB.
+ */
+public class OracleQueryBuilder
+        extends DefaultQueryBuilder
+{
+    @Inject
+    public OracleQueryBuilder(RemoteQueryModifier queryModifier)
+    {
+        super(queryModifier);
+    }
+
+    @Override
+    protected String getProjection(JdbcClient client, List<JdbcColumnHandle> columns, Map<String, ParameterizedExpression> columnExpressions, Consumer<QueryParameter> accumulator)
+    {
+        if (columns.isEmpty()) {
+            return "1 x";
+        }
+        List<String> projections = new ArrayList<>();
+        for (JdbcColumnHandle jdbcColumnHandle : columns) {
+            String columnAlias = client.quoted(jdbcColumnHandle.getColumnName());
+            ParameterizedExpression expression = columnExpressions.get(jdbcColumnHandle.getColumnName());
+            if (expression != null) {
+                projections.add(format("%s AS %s", expression.expression(), columnAlias));
+                expression.parameters().forEach(accumulator);
+                continue;
+            }
+            String remoteTypeName = jdbcColumnHandle.getJdbcTypeHandle().jdbcTypeName().orElse("");
+            String wrapped = wrapSpatialColumn(columnAlias, remoteTypeName);
+            if (wrapped != null) {
+                projections.add(format("%s AS %s", wrapped, columnAlias));
+            }
+            else {
+                projections.add(columnAlias);
+            }
+        }
+        return String.join(", ", projections);
+    }
+
+    /**
+     * Returns a server-side expression that converts the raw SDO column to a WKT string,
+     * or {@code null} if the column is not a spatial UDT and needs no wrapping.
+     */
+    private static String wrapSpatialColumn(String quotedColumn, String remoteTypeName)
+    {
+        if (remoteTypeName.equalsIgnoreCase("SDO_GEOMETRY")) {
+            return "MDSYS.SDO_UTIL.TO_WKTGEOMETRY(" + quotedColumn + ")";
+        }
+        if (remoteTypeName.equalsIgnoreCase("SDO_POINT_TYPE")) {
+            // SDO_UTIL only operates on SDO_GEOMETRY, so promote the point to a 2001 (2-D point)
+            // geometry first. Guard the NULL case explicitly — the SDO_GEOMETRY constructor
+            // materializes a non-NULL geometry even from a NULL point, and we want NULL in, NULL out.
+            return "CASE WHEN " + quotedColumn + " IS NULL THEN NULL "
+                    + "ELSE MDSYS.SDO_UTIL.TO_WKTGEOMETRY(MDSYS.SDO_GEOMETRY(2001, NULL, " + quotedColumn + ", NULL, NULL)) "
+                    + "END";
+        }
+        return null;
+    }
+}

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/SpatialColumnMapping.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/SpatialColumnMapping.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.oracle;
+
+/**
+ * How MDSYS.SDO_GEOMETRY and MDSYS.SDO_POINT_TYPE columns are surfaced to Trino.
+ * <ul>
+ *     <li>{@link #VARCHAR} — unbounded VARCHAR containing the WKT text produced by
+ *         {@code MDSYS.SDO_UTIL.TO_WKTGEOMETRY}. Default; matches the initial fix for
+ *         trinodb/trino#30020.</li>
+ *     <li>{@link #GEOMETRY} — Trino's native GEOMETRY type. WKT is parsed inside the
+ *         connector, equivalent to {@code ST_GeometryFromText(...)} on the VARCHAR path.
+ *         Requires the geospatial types to be registered on the coordinator.</li>
+ * </ul>
+ */
+public enum SpatialColumnMapping
+{
+    VARCHAR,
+    GEOMETRY,
+}

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/OracleQueryRunner.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/OracleQueryRunner.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.log.Logger;
+import io.trino.plugin.geospatial.GeoPlugin;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -83,6 +84,10 @@ public final class OracleQueryRunner
         {
             DistributedQueryRunner queryRunner = super.build();
             try {
+                // Install GeoPlugin early so oracle.spatial-column-mapping=GEOMETRY (which resolves
+                // the GEOMETRY type at OracleClient construction) can find it.
+                queryRunner.installPlugin(new GeoPlugin());
+
                 queryRunner.installPlugin(new TpchPlugin());
                 queryRunner.createCatalog("tpch", "tpch");
 

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleClient.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleClient.java
@@ -49,6 +49,7 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestOracleClient
@@ -60,6 +61,7 @@ public class TestOracleClient
                 throw new UnsupportedOperationException();
             },
             new DefaultQueryBuilder(RemoteQueryModifier.NONE),
+            TESTING_TYPE_MANAGER,
             new DefaultIdentifierMapping(),
             RemoteQueryModifier.NONE);
 

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConfig.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConfig.java
@@ -44,7 +44,8 @@ public class TestOracleConfig
                 .setConnectionPoolMaxSize(30)
                 .setInactiveConnectionTimeout(new Duration(20, MINUTES))
                 .setConnectionPoolWaitDuration(new Duration(3, SECONDS))
-                .setFetchSize(null));
+                .setFetchSize(null)
+                .setSpatialColumnMapping(SpatialColumnMapping.VARCHAR));
     }
 
     @Test
@@ -61,6 +62,7 @@ public class TestOracleConfig
                 .put("oracle.connection-pool.inactive-timeout", "30s")
                 .put("oracle.connection-pool.wait-duration", "10s")
                 .put("oracle.fetch-size", "2000")
+                .put("oracle.spatial-column-mapping", "GEOMETRY")
                 .buildOrThrow();
 
         OracleConfig expected = new OracleConfig()
@@ -73,7 +75,8 @@ public class TestOracleConfig
                 .setConnectionPoolMaxSize(20)
                 .setInactiveConnectionTimeout(new Duration(30, SECONDS))
                 .setConnectionPoolWaitDuration(new Duration(10, SECONDS))
-                .setFetchSize(2000);
+                .setFetchSize(2000)
+                .setSpatialColumnMapping(SpatialColumnMapping.GEOMETRY);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleSdoGeometry.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleSdoGeometry.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.oracle;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.testing.Closeables;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedRow;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.math.BigDecimal;
+
+import static io.trino.plugin.oracle.TestingOracleServer.TEST_SCHEMA;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+/**
+ * Reproduces trinodb/trino#30020: MDSYS.SDO_GEOMETRY columns fail to surface through the
+ * Trino Oracle connector. Currently, the connector drops SDO_GEOMETRY columns (Optional.empty
+ * from toColumnMapping), and enabling unsupported-type-handling=CONVERT_TO_VARCHAR raises an
+ * INTERNAL_ERROR whose message is "oracle/xdb/XMLType" — the JVM class name from a
+ * NoClassDefFoundError inside the Oracle JDBC driver's OPAQUE handler.
+ *
+ * <p>This test asserts the post-fix behavior: an SDO_GEOMETRY column materializes as a
+ * VARCHAR containing the geometry's WKT representation (via server-side SDO_UTIL.TO_WKTGEOMETRY).
+ * Until the plugin change lands, this test is expected to fail — either because the geom
+ * column is not resolvable, or because reading it raises the XMLType error.
+ *
+ * <p>Uses the full (non-slim) gvenzl/oracle-free image via {@link TestingOracleSpatialServer};
+ * Oracle Spatial (which provides MDSYS.SDO_GEOMETRY) is stripped from the slim variant.
+ */
+@TestInstance(PER_CLASS)
+public class TestOracleSdoGeometry
+        extends AbstractTestQueryFramework
+{
+    private TestingOracleSpatialServer oracleServer;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        oracleServer = new TestingOracleSpatialServer();
+        return OracleQueryRunner.builder(oracleServer)
+                .addConnectorProperties(ImmutableMap.<String, String>builder()
+                        .put("oracle.connection-pool.enabled", "false")
+                        .buildOrThrow())
+                .build();
+    }
+
+    @AfterAll
+    public final void destroy()
+            throws Exception
+    {
+        Closeables.closeAll(oracleServer);
+        oracleServer = null;
+    }
+
+    @Test
+    public void testSelectSdoGeometryAsWkt()
+    {
+        String tableName = "test_sdo_geom_" + randomNameSuffix();
+        String qualifiedName = TEST_SCHEMA + "." + tableName;
+        oracleServer.execute(format("CREATE TABLE %s (id NUMBER(10), geom MDSYS.SDO_GEOMETRY)", qualifiedName));
+        try {
+            // 2D point (1.0, 2.0). SDO_GTYPE=2001 (2-dimensional point).
+            oracleServer.execute(format(
+                    "INSERT INTO %s (id, geom) VALUES (1, MDSYS.SDO_GEOMETRY(2001, NULL, MDSYS.SDO_POINT_TYPE(1.0, 2.0, NULL), NULL, NULL))",
+                    qualifiedName));
+
+            MaterializedResult result = computeActual(format("SELECT id, geom FROM %s", tableName));
+            assertThat(result.getRowCount()).isEqualTo(1);
+
+            MaterializedRow row = result.getMaterializedRows().getFirst();
+            assertThat(row.getField(0)).isEqualTo(new BigDecimal("1"));
+            assertThat((String) row.getField(1))
+                    .as("SDO_GEOMETRY column should be surfaced as WKT once the plugin fix is applied")
+                    .isNotNull()
+                    .containsIgnoringCase("POINT")
+                    .contains("1")
+                    .contains("2");
+        }
+        finally {
+            oracleServer.execute("DROP TABLE " + qualifiedName);
+        }
+    }
+
+    /**
+     * Verifies the {@code oracle.spatial-column-mapping=GEOMETRY} config path: the connector
+     * parses the server-side WKT and hands Trino a native GEOMETRY column, so spatial functions
+     * like {@code ST_AsText} apply directly (no {@code ST_GeometryFromText(varchar)} wrapping).
+     * Uses a locally-scoped QueryRunner because the config property is bound at connector
+     * construction time — it can't be flipped per query on the class-level runner.
+     */
+    @Test
+    public void testSelectSdoGeometryAsNativeType()
+            throws Exception
+    {
+        String tableName = "test_sdo_geom_native_" + randomNameSuffix();
+        String qualifiedName = TEST_SCHEMA + "." + tableName;
+        oracleServer.execute(format("CREATE TABLE %s (id NUMBER(10), geom MDSYS.SDO_GEOMETRY)", qualifiedName));
+        try (QueryRunner nativeRunner = OracleQueryRunner.builder(oracleServer)
+                .addConnectorProperties(ImmutableMap.<String, String>builder()
+                        .put("oracle.connection-pool.enabled", "false")
+                        .put("oracle.spatial-column-mapping", "GEOMETRY")
+                        .buildOrThrow())
+                .build()) {
+            oracleServer.execute(format(
+                    "INSERT INTO %s (id, geom) VALUES (1, MDSYS.SDO_GEOMETRY(2001, NULL, MDSYS.SDO_POINT_TYPE(1.0, 2.0, NULL), NULL, NULL))",
+                    qualifiedName));
+
+            // ST_AsText only compiles against a GEOMETRY column; success here proves the column
+            // is truly native geometry, not a VARCHAR that happens to hold WKT.
+            MaterializedResult result = nativeRunner.execute(
+                    nativeRunner.getDefaultSession(),
+                    format("SELECT id, ST_AsText(geom) FROM %s", tableName));
+            assertThat(result.getRowCount()).isEqualTo(1);
+            MaterializedRow row = result.getMaterializedRows().getFirst();
+            assertThat(row.getField(0)).isEqualTo(new BigDecimal("1"));
+            assertThat((String) row.getField(1))
+                    .as("ST_AsText should round-trip the geometry")
+                    .isEqualTo("POINT (1 2)");
+        }
+        finally {
+            oracleServer.execute("DROP TABLE " + qualifiedName);
+        }
+    }
+}

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
@@ -64,16 +64,16 @@ public class TestingOracleServer
     public static final String TEST_SCHEMA = TEST_USER; // schema and user is the same thing in Oracle
     public static final String TEST_PASS = "trino_test_password";
 
-    private OracleContainer container;
+    protected OracleContainer container;
 
-    private Closeable cleanup = () -> {};
+    protected Closeable cleanup = () -> {};
 
     public TestingOracleServer()
     {
         Failsafe.with(CONTAINER_RETRY_POLICY).run(this::createContainer);
     }
 
-    private void createContainer()
+    protected void createContainer()
     {
         OracleContainer container = new OracleContainer("gvenzl/oracle-free:23.9-slim")
                 .withCopyFileToContainer(MountableFile.forClasspathResource("init.sql"), "/container-entrypoint-initdb.d/01-init.sql")
@@ -92,7 +92,7 @@ public class TestingOracleServer
         }
     }
 
-    private Path createConfigureScript()
+    protected Path createConfigureScript()
     {
         try {
             File tempFile = File.createTempFile("init-", ".sql");

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleSpatialServer.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleSpatialServer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.oracle;
+
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.oracle.OracleContainer;
+import org.testcontainers.utility.MountableFile;
+
+import java.time.Duration;
+
+import static io.trino.testing.containers.TestContainers.startOrReuse;
+
+/**
+ * Variant of {@link TestingOracleServer} that runs the non-slim gvenzl/oracle-free image.
+ * The slim image strips Oracle Spatial; the non-slim image ships MDSYS.SDO_GEOMETRY and SDO_UTIL,
+ * which are required to reproduce and test the geometry-column mapping issue from trinodb/trino#30020.
+ * The non-slim image is larger and slower to start.
+ */
+public class TestingOracleSpatialServer
+        extends TestingOracleServer
+{
+    @Override
+    protected void createContainer()
+    {
+        OracleContainer container = new OracleContainer("gvenzl/oracle-free:23.9")
+                .withCopyFileToContainer(MountableFile.forClasspathResource("init.sql"), "/container-entrypoint-initdb.d/01-init.sql")
+                .withCopyFileToContainer(MountableFile.forClasspathResource("restart.sh"), "/container-entrypoint-initdb.d/02-restart.sh")
+                .withCopyFileToContainer(MountableFile.forHostPath(createConfigureScript()), "/container-entrypoint-initdb.d/03-create-users.sql")
+                .waitingFor(Wait.forLogMessage(".*DATABASE IS READY TO USE!.*\\s", 1).withStartupTimeout(Duration.ofMinutes(10)))
+                .withStartupTimeoutSeconds(600);
+        try {
+            this.cleanup = startOrReuse(container);
+            this.container = container;
+        }
+        catch (Throwable e) {
+            try (container) {
+                throw e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
* Fixes #30020

Injects MDSYS.SDO_UTIL.TO_WKTGEOMETRY calls in Oracle queries for SDO_GEOMETRY or SDO_POINT_TYPE columns to avoid unsupported data types from reaching the JDBC connector, thereby enabling these columns to be read in Trino.

Also adds oracle.spatial-column-mapping, an opt-in config option that autoconverts MDSYS.SDO_GEOMETRY and MDSYS.SDO_POINT_TYPE columns into Trino's native GEOMETRY type instead of unbounded VARCHAR (WKT) (which is the default behavior).

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Adds support for Oracle's SDO_GEOMETRY type, with optional auto-conversion to Trino's native GEOMETRY object. ({issue}`30020`)
```
