### PR TITLE
Bind duplicated operand via Let when unwrapping timestamp-to-date comparisons

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/IrExpressions.java
@@ -42,6 +42,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
 import static io.trino.metadata.GlobalFunctionCatalog.isBuiltinFunctionName;
@@ -217,21 +218,26 @@ public final class IrExpressions
         }
     }
 
+    /// Builds an expression that references `value` more than once while evaluating it exactly once. A
+    /// trivial `value` (a reference or constant) is passed to `body` directly, keeping the result free of
+    /// a wrapping [Let]; any other `value` is bound to a fresh symbol (named with `namePrefix`) and `body`
+    /// receives a reference to that symbol, so the operand is evaluated a single time.
+    public static Expression bindIfNecessary(SymbolAllocator allocator, String namePrefix, Expression value, Function<Expression, Expression> body)
+    {
+        if (value instanceof Reference || value instanceof Constant) {
+            return body.apply(value);
+        }
+        Symbol bound = allocator.newSymbol(namePrefix, value.type());
+        return new Let(bound, value, body.apply(bound.toSymbolReference()));
+    }
+
     /// Lower a BETWEEN to `value >= min AND value <= max`, wrapping `value` in a [Let] when it is
     /// non-trivial so the operand is evaluated exactly once.
     public static Expression between(Metadata metadata, SymbolAllocator allocator, Expression value, Expression min, Expression max)
     {
-        // Inline trivial values directly so the result stays a plain AND of comparisons.
-        if (value instanceof Reference || value instanceof Constant) {
-            return new Logical(AND, ImmutableList.of(
-                    comparison(metadata, GREATER_THAN_OR_EQUAL, value, min),
-                    comparison(metadata, LESS_THAN_OR_EQUAL, value, max)));
-        }
-        Symbol bound = allocator.newSymbol("between", value.type());
-        Reference reference = new Reference(value.type(), bound.name());
-        return new Let(bound, value, new Logical(AND, ImmutableList.of(
-                comparison(metadata, GREATER_THAN_OR_EQUAL, reference, min),
-                comparison(metadata, LESS_THAN_OR_EQUAL, reference, max))));
+        return bindIfNecessary(allocator, "between", value, operand -> new Logical(AND, ImmutableList.of(
+                comparison(metadata, GREATER_THAN_OR_EQUAL, operand, min),
+                comparison(metadata, LESS_THAN_OR_EQUAL, operand, max))));
     }
 
     /// Recognize a BETWEEN-shape as produced by [#between]. `between` builds `min <= value AND
@@ -293,21 +299,13 @@ public final class IrExpressions
     public static Expression nullIf(Metadata metadata, TypeManager typeManager, SymbolAllocator allocator, Expression first, Expression second, Type comparisonType)
     {
         Expression secondForComparison = second.type().equals(comparisonType) ? second : cast(typeManager, second, comparisonType);
-        // Inline trivial values directly so the result stays a plain Case expression.
-        if (first instanceof Reference || first instanceof Constant) {
-            Expression firstForComparison = first.type().equals(comparisonType) ? first : cast(typeManager, first, comparisonType);
+        return bindIfNecessary(allocator, "nullif", first, operand -> {
+            Expression operandForComparison = first.type().equals(comparisonType) ? operand : cast(typeManager, operand, comparisonType);
             return ifExpression(
-                    comparison(metadata, EQUAL, firstForComparison, secondForComparison),
+                    comparison(metadata, EQUAL, operandForComparison, secondForComparison),
                     constantNull(first.type()),
-                    first);
-        }
-        Symbol bound = allocator.newSymbol("nullif", first.type());
-        Reference reference = new Reference(first.type(), bound.name());
-        Expression referenceForComparison = first.type().equals(comparisonType) ? reference : cast(typeManager, reference, comparisonType);
-        return new Let(bound, first, ifExpression(
-                comparison(metadata, EQUAL, referenceForComparison, secondForComparison),
-                constantNull(first.type()),
-                reference));
+                    operand);
+        });
     }
 
     /// Recognize a NULLIF-shape as produced by [#nullIf] in either the trivial-value form

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyContinuousInValues.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/SimplifyContinuousInValues.java
@@ -30,9 +30,7 @@ import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.In;
 import io.trino.sql.ir.IsNull;
-import io.trino.sql.ir.Let;
 import io.trino.sql.ir.Logical;
-import io.trino.sql.ir.Reference;
 import io.trino.sql.ir.optimizer.IrOptimizerRule;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
@@ -44,6 +42,7 @@ import java.util.Optional;
 
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN_OR_EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN_OR_EQUAL;
+import static io.trino.sql.ir.IrExpressions.bindIfNecessary;
 import static io.trino.sql.ir.IrExpressions.comparison;
 import static io.trino.sql.ir.IrUtils.or;
 import static io.trino.sql.ir.Logical.Operator.AND;
@@ -106,17 +105,15 @@ public class SimplifyContinuousInValues
             return Optional.empty();
         }
 
-        // Trivial values can be duplicated freely; non-trivial values are bound once via Let so
-        // the operand is evaluated exactly once across the IS NULL check and both comparisons.
-        if (value instanceof Reference || value instanceof Constant) {
-            Expression rangeFilter = rangeFilter(value, valueType, min, max);
-            return Optional.of(nullMatch ? or(new IsNull(value), rangeFilter) : rangeFilter);
-        }
-        Symbol bound = symbolAllocator.newSymbol("range", value.type());
-        Reference reference = new Reference(value.type(), bound.name());
-        Expression rangeFilter = rangeFilter(reference, valueType, min, max);
-        Expression body = nullMatch ? or(new IsNull(reference), rangeFilter) : rangeFilter;
-        return Optional.of(new Let(bound, value, body));
+        // Bind a non-trivial value once so it is evaluated exactly once across the IS NULL check and both
+        // comparisons; trivial values are used inline.
+        long lowerBound = min;
+        long upperBound = max;
+        boolean includesNull = nullMatch;
+        return Optional.of(bindIfNecessary(symbolAllocator, "range", value, operand -> {
+            Expression rangeFilter = rangeFilter(operand, valueType, lowerBound, upperBound);
+            return includesNull ? or(new IsNull(operand), rangeFilter) : rangeFilter;
+        }));
     }
 
     private Expression rangeFilter(Expression value, Type valueType, long min, long max)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
@@ -42,6 +42,7 @@ import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.ExpressionTreeRewriter;
 import io.trino.sql.ir.IrExpressions.Comparison;
 import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.Reference;
 import io.trino.sql.ir.optimizer.IrExpressionOptimizer;
 import io.trino.sql.planner.SymbolAllocator;
 import io.trino.type.TypeCoercion;
@@ -52,6 +53,7 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.time.zone.ZoneOffsetTransition;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SliceUtf8.countCodePoints;
@@ -78,6 +80,7 @@ import static io.trino.sql.ir.ComparisonOperator.IDENTICAL;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN_OR_EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.NOT_EQUAL;
+import static io.trino.sql.ir.IrExpressions.bindIfNecessary;
 import static io.trino.sql.ir.IrExpressions.comparison;
 import static io.trino.sql.ir.IrExpressions.matchComparison;
 import static io.trino.sql.ir.IrExpressions.not;
@@ -430,24 +433,40 @@ public class UnwrapCastInComparison
             Expression nextDateTimestamp = new Constant(sourceType, coerce(date + 1, targetToSource));
 
             return switch (operator) {
-                case EQUAL -> Optional.of(
-                        and(
-                                comparison(plannerContext.getMetadata(), GREATER_THAN_OR_EQUAL, timestampExpression, dateTimestamp),
-                                comparison(plannerContext.getMetadata(), LESS_THAN, timestampExpression, nextDateTimestamp)));
-                case NOT_EQUAL -> Optional.of(
-                        or(
-                                comparison(plannerContext.getMetadata(), LESS_THAN, timestampExpression, dateTimestamp),
-                                comparison(plannerContext.getMetadata(), GREATER_THAN_OR_EQUAL, timestampExpression, nextDateTimestamp)));
+                case EQUAL -> Optional.of(bindSourceIfNecessary(timestampExpression, operand ->
+                        and(comparison(plannerContext.getMetadata(), GREATER_THAN_OR_EQUAL, operand, dateTimestamp),
+                                comparison(plannerContext.getMetadata(), LESS_THAN, operand, nextDateTimestamp))));
+                case NOT_EQUAL -> Optional.of(bindSourceIfNecessary(timestampExpression, operand ->
+                        or(comparison(plannerContext.getMetadata(), LESS_THAN, operand, dateTimestamp),
+                                comparison(plannerContext.getMetadata(), GREATER_THAN_OR_EQUAL, operand, nextDateTimestamp))));
                 case LESS_THAN -> Optional.of(comparison(plannerContext.getMetadata(), LESS_THAN, timestampExpression, dateTimestamp));
                 case LESS_THAN_OR_EQUAL -> Optional.of(comparison(plannerContext.getMetadata(), LESS_THAN, timestampExpression, nextDateTimestamp));
                 case GREATER_THAN -> Optional.of(comparison(plannerContext.getMetadata(), GREATER_THAN_OR_EQUAL, timestampExpression, nextDateTimestamp));
                 case GREATER_THAN_OR_EQUAL -> Optional.of(comparison(plannerContext.getMetadata(), GREATER_THAN_OR_EQUAL, timestampExpression, dateTimestamp));
-                case IDENTICAL -> Optional.of(
-                        and(
-                                not(plannerContext.getMetadata(), new IsNull(timestampExpression)),
-                                comparison(plannerContext.getMetadata(), GREATER_THAN_OR_EQUAL, timestampExpression, dateTimestamp),
-                                comparison(plannerContext.getMetadata(), LESS_THAN, timestampExpression, nextDateTimestamp)));
+                case IDENTICAL -> Optional.of(bindSourceIfNecessary(timestampExpression, operand ->
+                        and(not(plannerContext.getMetadata(), new IsNull(operand)),
+                                comparison(plannerContext.getMetadata(), GREATER_THAN_OR_EQUAL, operand, dateTimestamp),
+                                comparison(plannerContext.getMetadata(), LESS_THAN, operand, nextDateTimestamp))));
             };
+        }
+
+        private Expression bindSourceIfNecessary(Expression source, Function<Expression, Expression> body)
+        {
+            // A cast over a reference or constant is cheap and deterministic, and must stay inline so a later
+            // unwrap pass can reach the underlying column and push the predicate into the scan; bind anything
+            // else once so a non-trivial source is evaluated a single time.
+            if (isCastOverTrivial(source)) {
+                return body.apply(source);
+            }
+            return bindIfNecessary(symbolAllocator, "operand", source, body);
+        }
+
+        private static boolean isCastOverTrivial(Expression value)
+        {
+            return value instanceof Cast cast
+                    && (cast.expression() instanceof Reference
+                    || cast.expression() instanceof Constant
+                    || isCastOverTrivial(cast.expression()));
         }
 
         private boolean hasInjectiveImplicitCoercion(Type source, Type target, Object value)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapCastInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapCastInComparison.java
@@ -14,6 +14,8 @@
 package io.trino.sql.planner;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.graph.SuccessorsFunction;
+import com.google.common.graph.Traverser;
 import io.airlift.slice.Slices;
 import io.trino.Session;
 import io.trino.metadata.ResolvedFunction;
@@ -21,10 +23,12 @@ import io.trino.metadata.TestingFunctionResolution;
 import io.trino.spi.type.TimeZoneKey;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Cast;
+import io.trino.sql.ir.ComparisonOperator;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.IrExpressions;
 import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.Let;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.assertions.BasePlanTest;
@@ -32,6 +36,9 @@ import io.trino.type.DateTimes;
 import io.trino.util.DateTimeUtils;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
+import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.SystemSessionProperties.PUSH_FILTER_INTO_VALUES_MAX_ROW_COUNT;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -61,10 +68,12 @@ import static io.trino.sql.ir.TestingIr.comparison;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.iterative.rule.UnwrapCastInComparison.unwrapCasts;
 import static io.trino.type.Reals.toReal;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUnwrapCastInComparison
         extends BasePlanTest
@@ -850,6 +859,113 @@ public class TestUnwrapCastInComparison
                 output(
                         filter(comparison(EQUAL, new Call(RANDOM, ImmutableList.of()), new Constant(DOUBLE, 42.0)),
                                 values("a"))));
+    }
+
+    @Test
+    public void testTimestampToDateBindsNonTrivialOperandOnce()
+    {
+        // Unwrapping CAST(f(a) AS date) <op> DATE '...' into a range references the operand more than once
+        // (twice for EQUAL/NOT_EQUAL, three times for IDENTICAL). A non-trivial operand must be bound via
+        // Let so it is evaluated once: this is required for correctness when it is non-deterministic (each
+        // occurrence would otherwise evaluate independently, so the range would no longer denote a single
+        // value) and avoids re-evaluating an expensive one.
+
+        // A deterministic but non-trivial operand.
+        ResolvedFunction dateTrunc = FUNCTIONS.resolveFunction("date_trunc", fromTypes(createVarcharType(4), createTimestampType(6)));
+        Expression deterministic = new Call(dateTrunc, ImmutableList.of(
+                new Constant(createVarcharType(4), Slices.utf8Slice("hour")),
+                new Reference(createTimestampType(6), "a")));
+
+        // A non-deterministic operand of the same timestamp type (this is the case the binding exists for).
+        ResolvedFunction fromUnixtime = FUNCTIONS.resolveFunction("from_unixtime", fromTypes(DOUBLE));
+        Expression nonDeterministic = new Cast(
+                new Call(fromUnixtime, ImmutableList.of(new Call(RANDOM, ImmutableList.of()))),
+                createTimestampType(6));
+
+        for (ComparisonOperator operator : asList(EQUAL, NOT_EQUAL, IDENTICAL)) {
+            assertBoundOnce(operator, deterministic);
+            assertBoundOnce(operator, nonDeterministic);
+        }
+    }
+
+    private static void assertBoundOnce(ComparisonOperator operator, Expression operand)
+    {
+        Expression unwrapped = unwrapCasts(
+                TEST_SESSION,
+                FUNCTIONS.getPlannerContext(),
+                new SymbolAllocator(),
+                comparison(operator, new Cast(operand, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2021-06-01"))));
+
+        // Exactly one Let binds the operand (wherever the operator places it in the tree; NOT_EQUAL, for
+        // instance, wraps the range in a NOT) and the operand is evaluated a single time: it appears only as
+        // that bound value, never in the body.
+        List<Let> bindings = letsBinding(unwrapped, operand);
+        assertThat(bindings).as("operator %s", operator).hasSize(1);
+        assertThat(occurrences(bindings.getFirst().body(), operand)).as("operator %s body", operator).isEqualTo(0);
+        assertThat(occurrences(unwrapped, operand)).as("operator %s total", operator).isEqualTo(1);
+    }
+
+    private static List<Let> letsBinding(Expression tree, Expression operand)
+    {
+        ImmutableList.Builder<Let> bindings = ImmutableList.builder();
+        for (Expression node : Traverser.forTree((SuccessorsFunction<Expression>) Expression::children).depthFirstPreOrder(tree)) {
+            if (node instanceof Let let && let.value().equals(operand)) {
+                bindings.add(let);
+            }
+        }
+        return bindings.build();
+    }
+
+    @Test
+    public void testTimestampToDateKeepsTrivialOperandInline()
+    {
+        // A column reference is cheap and deterministic, so it is duplicated directly rather than bound via
+        // Let. Keeping the bare column comparisons preserves range-based pruning.
+        Reference operand = new Reference(createTimestampType(6), "a");
+
+        for (ComparisonOperator operator : asList(EQUAL, NOT_EQUAL, IDENTICAL)) {
+            Expression unwrapped = unwrapCasts(
+                    TEST_SESSION,
+                    FUNCTIONS.getPlannerContext(),
+                    new SymbolAllocator(),
+                    comparison(operator, new Cast(operand, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2021-06-01"))));
+
+            assertThat(unwrapped).as("operator %s", operator).isNotInstanceOf(Let.class);
+            // The reference stays inline in each comparison rather than being bound once.
+            assertThat(occurrences(unwrapped, operand)).as("operator %s", operator).isGreaterThanOrEqualTo(2);
+        }
+    }
+
+    @Test
+    public void testTimestampToDateKeepsCastOfReferenceInline()
+    {
+        // The cast source may itself be a cast over a column (a date column coerced to timestamp). A cast
+        // chain over a reference is cheap and deterministic, so it stays inline rather than bound. Keeping
+        // the inner cast visible lets a later unwrap pass collapse the predicate onto the column and push it
+        // into the scan (e.g. Iceberg partition pruning); binding it in a Let would block that.
+        Expression operand = new Cast(new Reference(DATE, "a"), createTimestampType(6));
+
+        for (ComparisonOperator operator : asList(EQUAL, NOT_EQUAL, IDENTICAL)) {
+            Expression unwrapped = unwrapCasts(
+                    TEST_SESSION,
+                    FUNCTIONS.getPlannerContext(),
+                    new SymbolAllocator(),
+                    comparison(operator, new Cast(operand, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2021-06-01"))));
+
+            assertThat(unwrapped).as("operator %s", operator).isNotInstanceOf(Let.class);
+            assertThat(occurrences(unwrapped, operand)).as("operator %s", operator).isGreaterThanOrEqualTo(2);
+        }
+    }
+
+    private static int occurrences(Expression tree, Expression target)
+    {
+        int count = 0;
+        for (Expression node : Traverser.forTree((SuccessorsFunction<Expression>) Expression::children).depthFirstPreOrder(tree)) {
+            if (node.equals(target)) {
+                count++;
+            }
+        }
+        return count;
     }
 
     private void testUnwrap(String inputType, String inputPredicate, Expression expectedPredicate)


### PR DESCRIPTION
## Description

`UnwrapCastInComparison` rewrites `CAST(s AS date) <op> DATE '…'` into a half-open range over the cast source `s`. For `=`, `<>`, and `IS NOT DISTINCT FROM`, that range references `s` two or three times. When `s` is non-deterministic, each occurrence is evaluated independently, so the range no longer denotes a single value and the predicate's meaning changes; when `s` is merely expensive, it is recomputed.

Following the approach already used in `SimplifyContinuousInValues`, trivial operands (column references and constants) are still duplicated inline, so the resulting column comparisons remain available for range-based pruning. Any other operand is bound once via a `Let` node and evaluated a single time. `DomainTranslator` inlines a `Let`-bound source symbolically, so pruning is unaffected.

## Additional context and related issues

The same duplication is addressed by #14648 (for the `BETWEEN` rewrite) with an `isDeterministic` bail-out; this change instead binds the source once, which also avoids recomputing deterministic-but-expensive sources and keeps the rewrite available in all cases.

## Release notes

(x) Release notes are required, with the following suggested text:

```
# General
* Fix potential incorrect results when comparing a non-deterministic expression cast to `date` against a `date` literal, such as `CAST(f() AS date) = DATE '2020-01-01'`.
```
