### PR TITLE
Extract conjunct common to all CASE branches out of the CASE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
@@ -51,6 +51,7 @@ import io.trino.sql.ir.optimizer.rule.EvaluateLogical;
 import io.trino.sql.ir.optimizer.rule.EvaluateMatch;
 import io.trino.sql.ir.optimizer.rule.EvaluateReference;
 import io.trino.sql.ir.optimizer.rule.EvaluateRow;
+import io.trino.sql.ir.optimizer.rule.ExtractCommonConjunctFromCase;
 import io.trino.sql.ir.optimizer.rule.FlattenCoalesce;
 import io.trino.sql.ir.optimizer.rule.FlattenLogical;
 import io.trino.sql.ir.optimizer.rule.InlineTrivialLet;
@@ -127,6 +128,7 @@ public class IrExpressionOptimizer
                 new DistributeComparisonOverMatch(context),
                 new DistributeComparisonOverCase(context),
                 new SimplifyRedundantCase(context),
+                new ExtractCommonConjunctFromCase(context),
                 new SpecializeCastWithJsonParse(context),
                 new SpecializeTransformWithJsonParse(context)));
     }

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/ExtractCommonConjunctFromCase.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/ExtractCommonConjunctFromCase.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.trino.Session;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Case;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.WhenClause;
+import io.trino.sql.ir.optimizer.IrOptimizerRule;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.ir.IrExpressions.mayFail;
+import static io.trino.sql.ir.IrUtils.combineConjuncts;
+import static io.trino.sql.ir.IrUtils.extractConjuncts;
+import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toCollection;
+
+/// Extract a conjunct common to every branch of a boolean Case out to a top-level conjunction. E.g.,
+/// - `Case(When(c, And(X, A)), .., And(X, B)) -> And(X, Case(When(c, A), .., B))`
+///
+/// Exposes a conjunct common to every branch for predicate pushdown (for example, an equality
+/// buried in an IF becomes a hash-join key). A conjunct that may fail is left in place: within a
+/// branch a sibling conjunct may short-circuit before it, so hoisting it could surface a failure
+/// that the original expression avoids.
+public class ExtractCommonConjunctFromCase
+        implements IrOptimizerRule
+{
+    private final PlannerContext context;
+
+    public ExtractCommonConjunctFromCase(PlannerContext context)
+    {
+        this.context = requireNonNull(context, "context is null");
+    }
+
+    @Override
+    public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
+    {
+        if (!(expression instanceof Case caseTerm) || !BOOLEAN.equals(caseTerm.type())) {
+            return Optional.empty();
+        }
+
+        List<Expression> results = branchResults(caseTerm);
+        Set<Expression> common = commonConjuncts(results);
+        if (common.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Case reduced = new Case(
+                caseTerm.whenClauses().stream()
+                        .map(clause -> new WhenClause(clause.getOperand(), removeConjuncts(clause.getResult(), common)))
+                        .collect(toImmutableList()),
+                removeConjuncts(caseTerm.defaultValue(), common));
+
+        return Optional.of(combineConjuncts(ImmutableList.<Expression>builderWithExpectedSize(common.size() + 1)
+                .addAll(common)
+                .add(reduced)
+                .build()));
+    }
+
+    private static List<Expression> branchResults(Case caseTerm)
+    {
+        return ImmutableList.<Expression>builder()
+                .addAll(caseTerm.whenClauses().stream().map(WhenClause::getResult).collect(toImmutableList()))
+                .add(caseTerm.defaultValue())
+                .build();
+    }
+
+    private Set<Expression> commonConjuncts(List<Expression> results)
+    {
+        // Deterministic, non-failing, non-trivial conjuncts present in every branch, keyed by structural equality.
+        Set<Expression> common = extractConjuncts(results.getFirst()).stream()
+                .filter(conjunct -> !conjunct.equals(TRUE) && isDeterministic(conjunct) && !mayFail(context, conjunct))
+                .collect(toCollection(LinkedHashSet::new));
+
+        for (int branch = 1; branch < results.size() && !common.isEmpty(); branch++) {
+            common.retainAll(extractConjuncts(results.get(branch)));
+        }
+
+        return common;
+    }
+
+    private static Expression removeConjuncts(Expression expression, Set<Expression> removed)
+    {
+        return combineConjuncts(Sets.difference(ImmutableSet.copyOf(extractConjuncts(expression)), removed));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestExtractCommonConjunctFromCase.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestExtractCommonConjunctFromCase.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Case;
+import io.trino.sql.ir.Cast;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Logical;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.WhenClause;
+import io.trino.sql.ir.optimizer.rule.ExtractCommonConjunctFromCase;
+import io.trino.sql.planner.SymbolAllocator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.ir.ComparisonOperator.EQUAL;
+import static io.trino.sql.ir.Logical.Operator.AND;
+import static io.trino.sql.ir.TestingIr.comparison;
+import static io.trino.testing.TestingSession.testSession;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestExtractCommonConjunctFromCase
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final PlannerContext PLANNER_CONTEXT = FUNCTIONS.getPlannerContext();
+    private static final ResolvedFunction RANDOM = FUNCTIONS.resolveFunction("random", ImmutableList.of());
+    private static final Expression SHARED = comparison(EQUAL, new Reference(BIGINT, "a"), new Reference(BIGINT, "b"));
+    private static final Expression OTHER = comparison(EQUAL, new Reference(BIGINT, "c"), new Reference(BIGINT, "d"));
+    private static final Expression THIRD = comparison(EQUAL, new Reference(BIGINT, "e"), new Reference(BIGINT, "f"));
+    private static final Expression NON_DETERMINISTIC = comparison(EQUAL, new Call(RANDOM, ImmutableList.of()), new Constant(DOUBLE, 0.5));
+    private static final Expression MAY_FAIL = comparison(EQUAL, new Cast(new Reference(VARCHAR, "s"), BIGINT), new Constant(BIGINT, 1L));
+    private static final Reference CONDITION = new Reference(BOOLEAN, "condition");
+    private static final Reference CONDITION2 = new Reference(BOOLEAN, "condition2");
+
+    @Test
+    void extractsConjunctSharedByEveryBranch()
+    {
+        assertThat(optimize(new Case(
+                ImmutableList.of(new WhenClause(CONDITION, SHARED)),
+                Logical.and(OTHER, SHARED))))
+                .isEqualTo(Optional.of(new Logical(AND, ImmutableList.of(
+                        SHARED,
+                        new Case(
+                                ImmutableList.of(new WhenClause(CONDITION, TRUE)),
+                                OTHER)))));
+    }
+
+    @Test
+    void extractsConjunctSharedAcrossMultipleWhenClauses()
+    {
+        assertThat(optimize(new Case(
+                ImmutableList.of(
+                        new WhenClause(CONDITION, Logical.and(SHARED, OTHER)),
+                        new WhenClause(CONDITION2, Logical.and(SHARED, THIRD))),
+                SHARED)))
+                .isEqualTo(Optional.of(new Logical(AND, ImmutableList.of(
+                        SHARED,
+                        new Case(
+                                ImmutableList.of(
+                                        new WhenClause(CONDITION, OTHER),
+                                        new WhenClause(CONDITION2, THIRD)),
+                                TRUE)))));
+    }
+
+    @Test
+    void doesNotFireWhenNoConjunctIsCommonToAllBranches()
+    {
+        assertThat(optimize(new Case(
+                ImmutableList.of(new WhenClause(CONDITION, SHARED)),
+                OTHER)))
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void doesNotExtractNonDeterministicConjunct()
+    {
+        assertThat(optimize(new Case(
+                ImmutableList.of(new WhenClause(CONDITION, Logical.and(NON_DETERMINISTIC, OTHER))),
+                Logical.and(NON_DETERMINISTIC, SHARED))))
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void doesNotExtractConjunctThatMayFail()
+    {
+        assertThat(optimize(new Case(
+                ImmutableList.of(new WhenClause(CONDITION, Logical.and(OTHER, MAY_FAIL))),
+                Logical.and(SHARED, MAY_FAIL))))
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void doesNotExtractTrueConjunct()
+    {
+        assertThat(optimize(new Case(
+                ImmutableList.of(new WhenClause(CONDITION, Logical.and(TRUE, OTHER))),
+                Logical.and(TRUE, SHARED))))
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void doesNotFireOnNonBooleanCase()
+    {
+        assertThat(optimize(new Case(
+                ImmutableList.of(new WhenClause(CONDITION, new Reference(BIGINT, "x"))),
+                new Reference(BIGINT, "y"))))
+                .isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void doesNotFireOnCaseWithImplicitElse()
+    {
+        assertThat(optimize(new Case(
+                ImmutableList.of(new WhenClause(CONDITION, Logical.and(SHARED, OTHER))),
+                new Constant(BOOLEAN, null))))
+                .isEqualTo(Optional.empty());
+    }
+
+    private Optional<Expression> optimize(Expression expression)
+    {
+        return new ExtractCommonConjunctFromCase(PLANNER_CONTEXT).apply(expression, testSession(), new SymbolAllocator(), ImmutableMap.of());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestExtractCommonConjunctFromCase.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestExtractCommonConjunctFromCase.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.ir.Case;
+import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.WhenClause;
+import io.trino.sql.planner.assertions.BasePlanTest;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.ir.ComparisonOperator.EQUAL;
+import static io.trino.sql.ir.TestingIr.comparison;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.plan.JoinType.INNER;
+
+/**
+ * An equality shared by every branch of an IF join predicate is extracted to a top-level conjunct by
+ * {@link io.trino.sql.ir.optimizer.rule.ExtractCommonConjunctFromCase} and recognized as a hash-join key.
+ */
+final class TestExtractCommonConjunctFromCase
+        extends BasePlanTest
+{
+    @Test
+    void conditionalEqualityPlansAsHashJoin()
+    {
+        // Equality o.custkey = lookup.join_key appears in both IF branches, so it is extracted to a hash-join key.
+        assertPlan(
+                """
+                SELECT o.orderkey FROM orders o
+                JOIN (VALUES (BIGINT '1', CAST(NULL AS bigint)), (BIGINT '2', BIGINT '7')) lookup(join_key, optional_key)
+                ON IF(lookup.optional_key IS NULL, o.custkey = lookup.join_key, lookup.optional_key = o.orderkey AND o.custkey = lookup.join_key)
+                """,
+                anyTree(join(INNER, builder -> builder
+                        .equiCriteria("CUSTKEY", "JOIN_KEY")
+                        .filter(new Case(
+                                ImmutableList.of(new WhenClause(new IsNull(new Reference(BIGINT, "OPTIONAL_KEY")), TRUE)),
+                                comparison(EQUAL, new Reference(BIGINT, "OPTIONAL_KEY"), new Reference(BIGINT, "ORDERKEY"))))
+                        .left(anyTree(tableScan("orders", ImmutableMap.of("CUSTKEY", "custkey", "ORDERKEY", "orderkey"))))
+                        .right(values("JOIN_KEY", "OPTIONAL_KEY")))));
+    }
+}


### PR DESCRIPTION
## Description

Add an IR optimizer rule `ExtractCommonConjunctFromCase` that pulls a conjunct shared by every branch of a boolean `Case` up to a top-level conjunction:

    Case(When(c, And(X, A)), .., And(X, B))  ->  And(X, Case(When(c, A), .., B))

The rewrite is exact under three-valued logic: whichever branch the conditions select, the value is `X AND A_selected` either way. Because `X` must appear in every branch (including the default) for the rule to fire, it is evaluated exactly once in both forms. Only deterministic conjuncts are extracted, and the trivial `TRUE` conjunct is ignored. The full shared set is extracted in one pass, so the rule does not re-fire on its own output.

The point is to expose an equality buried in an `IF`/`CASE` predicate as a plain conjunct that predicate pushdown can use. For example a join on

    ON IF(lookup.optional_key IS NULL,
          o.custkey = lookup.join_key,
          lookup.optional_key = o.orderkey AND o.custkey = lookup.join_key)

now surfaces `o.custkey = lookup.join_key` as an equi-join key and plans as a hash join instead of a cross join with a filter.

## Additional context and related issues

The rule is registered in `IrExpressionOptimizer`. Covered by `io.trino.sql.ir.optimizer.TestExtractCommonConjunctFromCase` (extract, no common conjunct, non-boolean `Case`) and by `io.trino.sql.planner.TestExtractCommonConjunctFromCase#conditionalEqualityPlansAsHashJoin`, which asserts the hash-join plan for the query above.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve performance of joins whose condition places an equality inside an `IF` or `CASE`, such as `IF(k IS NULL, a = b, a = b AND c = d)`, by extracting the shared equality as a hash-join key. ({issue}`30288`)
```
