### PR TITLE
Search flat hash control bytes with the Vector API

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/ControlMatcher.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ControlMatcher.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+/**
+ * Searches the control bytes of a flat hash table {@link #vectorLength()} slots at a time.
+ * <p>
+ * A control byte is either zero, meaning the slot is empty, or the seven low bits of the hash
+ * with the high bit set. The table stores {@link #vectorLength()} extra control bytes mirroring
+ * the first slots, so a vector can always be read at any slot without wrapping.
+ */
+sealed interface ControlMatcher
+        permits ScalarControlMatcher, VectorControlMatcher
+{
+    /**
+     * The fastest matcher for the hardware this server runs on. This must not be a field of this
+     * interface, as initializing an implementation initializes this interface first, which would
+     * then observe the implementation as half initialized.
+     */
+    static ControlMatcher preferred()
+    {
+        return VectorControlMatcher.isSupported() ? new VectorControlMatcher() : new ScalarControlMatcher();
+    }
+
+    /**
+     * Number of consecutive control slots inspected by a single {@link #match} call.
+     * Always a power of two.
+     */
+    int vectorLength();
+
+    /**
+     * Finds the slots matching {@code hashPrefix} within the {@link #vectorLength()} slots starting
+     * at {@code position}. The result is an opaque match set which must be inspected with
+     * {@link #firstSlot(long)} and {@link #clearFirstSlot(long)}, and is zero when there is no match.
+     * <p>
+     * A match set never misses a matching slot, but when matching a hash prefix, it may contain
+     * occupied slots that do not actually match, so the caller must compare the values of the
+     * matched slots anyway. Matching the empty control byte is exact, as an empty slot is never
+     * reported as occupied and vice versa.
+     */
+    long match(byte[] control, int position, byte hashPrefix);
+
+    /**
+     * Slot offset, relative to the start of the vector, of the first match in the match set.
+     * The match set must not be empty.
+     */
+    int firstSlot(long matches);
+
+    /**
+     * Removes the first match from the match set.
+     */
+    default long clearFirstSlot(long matches)
+    {
+        return matches & (matches - 1);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/FlatHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatHash.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.trino.spi.BlocksHash;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
@@ -58,12 +59,14 @@ public final class FlatHash
     private static final int RECORDS_PER_GROUP = 1 << RECORDS_PER_GROUP_SHIFT;
     private static final int RECORDS_PER_GROUP_MASK = RECORDS_PER_GROUP - 1;
 
-    private static final int VECTOR_LENGTH = Long.BYTES;
+    private static final byte EMPTY_CONTROL = 0;
     private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, LITTLE_ENDIAN);
 
     private final FlatHashStrategy flatHashStrategy;
     private final AppendOnlyVariableWidthData variableWidthData;
     private final UpdateMemory checkMemoryReservation;
+    private final ControlMatcher controlMatcher;
+    private final int vectorLength;
 
     private final boolean cacheHashValue;
     private final int fixedRecordSize;
@@ -83,8 +86,16 @@ public final class FlatHash
 
     public FlatHash(FlatHashStrategy flatHashStrategy, boolean cacheHashValue, int expectedSize, UpdateMemory checkMemoryReservation)
     {
+        this(flatHashStrategy, cacheHashValue, expectedSize, checkMemoryReservation, ControlMatcher.preferred());
+    }
+
+    @VisibleForTesting
+    FlatHash(FlatHashStrategy flatHashStrategy, boolean cacheHashValue, int expectedSize, UpdateMemory checkMemoryReservation, ControlMatcher controlMatcher)
+    {
         this.flatHashStrategy = requireNonNull(flatHashStrategy, "flatHashStrategy is null");
         this.checkMemoryReservation = requireNonNull(checkMemoryReservation, "checkMemoryReservation is null");
+        this.controlMatcher = requireNonNull(controlMatcher, "controlMatcher is null");
+        this.vectorLength = controlMatcher.vectorLength();
         boolean hasVariableData = flatHashStrategy.isAnyVariableWidth();
         this.variableWidthData = hasVariableData ? new AppendOnlyVariableWidthData() : null;
         this.cacheHashValue = cacheHashValue;
@@ -97,12 +108,12 @@ public final class FlatHash
         this.fixedValueOffset = variableWidthOffset + (hasVariableData ? AppendOnlyVariableWidthData.POINTER_SIZE : 0);
         this.fixedRecordSize = fixedValueOffset + flatHashStrategy.getTotalFlatFixedLength();
 
-        this.capacity = max(VECTOR_LENGTH, computeCapacity(expectedSize, DEFAULT_LOAD_FACTOR));
+        this.capacity = max(vectorLength, computeCapacity(expectedSize, DEFAULT_LOAD_FACTOR));
         this.mask = capacity - 1;
         this.maxFill = calculateMaxFill(capacity);
 
         int groupsRequired = recordGroupsRequiredForCapacity(capacity);
-        this.control = new byte[capacity + VECTOR_LENGTH];
+        this.control = new byte[capacity + vectorLength];
         this.groupIdsByHash = new int[capacity];
         Arrays.fill(groupIdsByHash, -1);
         this.fixedSizeRecords = new byte[groupsRequired][];
@@ -112,6 +123,8 @@ public final class FlatHash
     {
         this.flatHashStrategy = other.flatHashStrategy;
         this.checkMemoryReservation = other.checkMemoryReservation;
+        this.controlMatcher = other.controlMatcher;
+        this.vectorLength = other.vectorLength;
         this.variableWidthData = other.variableWidthData == null ? null : new AppendOnlyVariableWidthData(other.variableWidthData);
         this.cacheHashValue = other.cacheHashValue;
         this.fixedRecordSize = other.fixedRecordSize;
@@ -280,49 +293,44 @@ public final class FlatHash
         int bucket = bucket((int) (hash >> 7));
 
         int step = 1;
-        long repeated = repeat(hashPrefix);
-
         while (true) {
-            final long controlVector = (long) LONG_HANDLE.get(control, bucket);
-
-            int matchIndex = matchInVector(blocks, position, hash, bucket, repeated, controlVector);
+            int matchIndex = matchInVector(blocks, position, hash, bucket, hashPrefix);
             if (matchIndex >= 0) {
                 return matchIndex;
             }
 
-            int emptyIndex = findEmptyInVector(controlVector, bucket);
+            int emptyIndex = findEmptyInVector(bucket);
             if (emptyIndex >= 0) {
                 return -emptyIndex - 1;
             }
 
             bucket = bucket(bucket + step);
-            step += VECTOR_LENGTH;
+            step += vectorLength;
         }
     }
 
-    private int matchInVector(Block[] blocks, int position, long hash, int vectorStartBucket, long repeated, long controlVector)
+    private int matchInVector(Block[] blocks, int position, long hash, int vectorStartBucket, byte hashPrefix)
     {
-        long controlMatches = match(controlVector, repeated);
+        long controlMatches = controlMatcher.match(control, vectorStartBucket, hashPrefix);
         while (controlMatches != 0) {
-            int index = bucket(vectorStartBucket + (Long.numberOfTrailingZeros(controlMatches) >>> 3));
+            int index = bucket(vectorStartBucket + controlMatcher.firstSlot(controlMatches));
             int groupId = groupIdsByHash[index];
             if (valueIdentical(groupId, blocks, position, hash)) {
                 return index;
             }
 
-            controlMatches = controlMatches & (controlMatches - 1);
+            controlMatches = controlMatcher.clearFirstSlot(controlMatches);
         }
         return -1;
     }
 
-    private int findEmptyInVector(long vector, int vectorStartBucket)
+    private int findEmptyInVector(int vectorStartBucket)
     {
-        long controlMatches = match(vector, 0x00_00_00_00_00_00_00_00L);
+        long controlMatches = controlMatcher.match(control, vectorStartBucket, EMPTY_CONTROL);
         if (controlMatches == 0) {
             return -1;
         }
-        int slot = Long.numberOfTrailingZeros(controlMatches) >>> 3;
-        return bucket(vectorStartBucket + slot);
+        return bucket(vectorStartBucket + controlMatcher.firstSlot(controlMatches));
     }
 
     private int addNewGroup(int index, Block[] blocks, int position, long hash)
@@ -369,7 +377,7 @@ public final class FlatHash
     private void setControl(int index, byte hashPrefix)
     {
         control[index] = hashPrefix;
-        if (index < VECTOR_LENGTH) {
+        if (index < vectorLength) {
             control[index + capacity] = hashPrefix;
         }
     }
@@ -407,7 +415,7 @@ public final class FlatHash
         fixedSizeRecords = Arrays.copyOf(fixedSizeRecords, recordGroupsRequiredForCapacity(capacity));
 
         // Construct the new hash table
-        control = new byte[capacity + VECTOR_LENGTH];
+        control = new byte[capacity + vectorLength];
         groupIdsByHash = new int[capacity];
         Arrays.fill(groupIdsByHash, -1);
 
@@ -420,9 +428,8 @@ public final class FlatHash
             // getIndex is not used here because values in a rehash are always distinct
             int step = 1;
             while (true) {
-                final long controlVector = (long) LONG_HANDLE.get(control, bucket);
                 // values are already distinct, so just find the first empty slot
-                int emptyIndex = findEmptyInVector(controlVector, bucket);
+                int emptyIndex = findEmptyInVector(bucket);
                 if (emptyIndex >= 0) {
                     setControl(emptyIndex, hashPrefix);
                     if (groupIdsByHash[emptyIndex] != -1) {
@@ -432,7 +439,7 @@ public final class FlatHash
                     break;
                 }
                 bucket = bucket(bucket + step);
-                step += VECTOR_LENGTH;
+                step += vectorLength;
             }
         }
 
@@ -498,18 +505,6 @@ public final class FlatHash
             throw new TrinoException(GENERIC_INSUFFICIENT_RESOURCES, "Size of hash table cannot exceed 1 billion entries");
         }
         return toIntExact(newCapacityLong);
-    }
-
-    private static long repeat(byte value)
-    {
-        return ((value & 0xFF) * 0x01_01_01_01_01_01_01_01L);
-    }
-
-    private static long match(long vector, long repeatedValue)
-    {
-        // HD 6-1
-        long comparison = vector ^ repeatedValue;
-        return (comparison - 0x01_01_01_01_01_01_01_01L) & ~comparison & 0x80_80_80_80_80_80_80_80L;
     }
 
     private static int recordGroupsRequiredForCapacity(int capacity)

--- a/core/trino-main/src/main/java/io/trino/operator/ScalarControlMatcher.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ScalarControlMatcher.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+
+/**
+ * Matches eight control slots at a time using SWAR arithmetic on a single long.
+ * The match set holds {@code 0x80} in the byte of every matching slot.
+ * <p>
+ * A borrow out of a matching byte can turn the byte above it into a spurious match, which is why
+ * {@link ControlMatcher#match} only promises a superset of the matching occupied slots. An empty
+ * slot is never reported spuriously, because a borrow cannot clear the high bit that every occupied
+ * control byte carries.
+ */
+final class ScalarControlMatcher
+        implements ControlMatcher
+{
+    private static final int VECTOR_LENGTH = Long.BYTES;
+    private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, LITTLE_ENDIAN);
+
+    @Override
+    public int vectorLength()
+    {
+        return VECTOR_LENGTH;
+    }
+
+    @Override
+    public long match(byte[] control, int position, byte hashPrefix)
+    {
+        long vector = (long) LONG_HANDLE.get(control, position);
+        long repeated = (hashPrefix & 0xFFL) * 0x01_01_01_01_01_01_01_01L;
+        // HD 6-1
+        long comparison = vector ^ repeated;
+        return (comparison - 0x01_01_01_01_01_01_01_01L) & ~comparison & 0x80_80_80_80_80_80_80_80L;
+    }
+
+    @Override
+    public int firstSlot(long matches)
+    {
+        return Long.numberOfTrailingZeros(matches) >>> 3;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/VectorControlMatcher.java
+++ b/core/trino-main/src/main/java/io/trino/operator/VectorControlMatcher.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.base.StandardSystemProperty;
+import jdk.incubator.vector.ByteVector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorShape;
+import jdk.incubator.vector.VectorSpecies;
+
+import static java.util.Locale.ENGLISH;
+
+/**
+ * Matches thirty two control slots at a time with a single vector comparison, four times as many as
+ * the scalar matcher. The match set holds one bit per matching slot.
+ * <p>
+ * The comparison lowers to {@code pcmpeqb} plus {@code pmovmskb} on x86, and to {@code cmeq} plus a
+ * mask reduction on ARM. The species has to be a constant of the class using it, otherwise the JVM
+ * cannot compile the comparison into a vector instruction at all, so the width cannot be chosen at
+ * runtime: hardware that has no 256 bit vector register uses the scalar matcher instead of a
+ * narrower vector.
+ */
+final class VectorControlMatcher
+        implements ControlMatcher
+{
+    private static final VectorSpecies<Byte> SPECIES = ByteVector.SPECIES_256;
+
+    public static boolean isSupported()
+    {
+        // A vector wider than the hardware register is emulated by the JVM, which is slower than the scalar code
+        if (VectorShape.preferredShape().vectorBitSize() < SPECIES.vectorBitSize()) {
+            return false;
+        }
+        String arch = StandardSystemProperty.OS_ARCH.value();
+        arch = arch == null ? "" : arch.toLowerCase(ENGLISH);
+        // A byte comparison is a single instruction on x86 (AVX2) and on ARM (SVE), but may be emulated elsewhere
+        return arch.contains("x86") || arch.contains("amd64") || arch.contains("aarch64") || arch.contains("arm");
+    }
+
+    @Override
+    public int vectorLength()
+    {
+        return SPECIES.length();
+    }
+
+    @Override
+    public long match(byte[] control, int position, byte hashPrefix)
+    {
+        return ByteVector.fromArray(SPECIES, control, position)
+                .compare(VectorOperators.EQ, hashPrefix)
+                .toLong();
+    }
+
+    @Override
+    public int firstSlot(long matches)
+    {
+        return Long.numberOfTrailingZeros(matches);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkFlatHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkFlatHash.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.operator.FlatHashStrategyCompiler.compileFlatHashStrategy;
+import static io.trino.operator.UpdateMemory.NOOP;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+
+/**
+ * Measures the control byte matching of {@link FlatHash}, comparing the scalar and the vectorized
+ * {@link ControlMatcher} implementations. Each JMH fork only loads the matcher under test, so the
+ * calls into it are monomorphic, exactly as they are in a server that only ever loads the matcher
+ * selected for its hardware.
+ * <p>
+ * The vector matcher is only meaningful to measure on hardware with a 256 bit vector register, which
+ * is the only hardware a server selects it on. Elsewhere, such as on a CPU with 128 bit NEON registers
+ * only, the JVM emulates the comparison and the result says nothing about the matcher.
+ */
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkFlatHash
+{
+    private static final int POSITIONS = 1_000_000;
+    private static final int EXPECTED_SIZE = 10_000;
+
+    /**
+     * Fills the hash table from empty, which is dominated by inserts and rehashes.
+     */
+    @Benchmark
+    @OperationsPerInvocation(POSITIONS)
+    public Object putIfAbsent(BenchmarkData data)
+    {
+        FlatHash flatHash = data.createFlatHash();
+        Block[] blocks = data.getBlocks();
+        for (int position = 0; position < POSITIONS; position++) {
+            flatHash.putIfAbsent(blocks, position);
+        }
+        return flatHash;
+    }
+
+    /**
+     * Probes a table filled to its maximum load factor, where the probe sequences are the longest.
+     */
+    @Benchmark
+    @OperationsPerInvocation(POSITIONS)
+    public long getIfPresent(BenchmarkData data)
+    {
+        FlatHash flatHash = data.getFilledFlatHash();
+        Block[] blocks = data.getBlocks();
+        long result = 0;
+        for (int position = 0; position < POSITIONS; position++) {
+            result += flatHash.getIfPresent(blocks, position);
+        }
+        return result;
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"SCALAR", "VECTOR"})
+        private String matcher = "SCALAR";
+
+        @Param({"BIGINT", "VARCHAR"})
+        private String dataType = "BIGINT";
+
+        @Param({"1", "5"})
+        private int channelCount = 1;
+
+        @Param({"8000", "3000000"})
+        private int groupCount = 3_000_000;
+
+        @Param({"true", "false"})
+        private boolean cacheHashValue;
+
+        private FlatHashStrategy flatHashStrategy;
+        private Block[] blocks;
+        private FlatHash filledFlatHash;
+
+        @Setup
+        public void setup()
+        {
+            if (matcher.equals("VECTOR") && !VectorControlMatcher.isSupported()) {
+                System.out.println("WARNING: this hardware has no 256 bit vector register, so the vector matcher is emulated by the JVM " +
+                        "and is far slower than it is on the hardware it would actually be selected for. The numbers below are meaningless.");
+            }
+
+            List<Type> types = switch (dataType) {
+                case "BIGINT" -> Collections.<Type>nCopies(channelCount, BIGINT);
+                case "VARCHAR" -> Collections.<Type>nCopies(channelCount, VARCHAR);
+                default -> throw new UnsupportedOperationException("Unsupported dataType: " + dataType);
+            };
+            flatHashStrategy = compileFlatHashStrategy(types, new TypeOperators());
+            blocks = createBlocks(types);
+
+            filledFlatHash = createFlatHash();
+            for (int position = 0; position < POSITIONS; position++) {
+                filledFlatHash.putIfAbsent(blocks, position);
+            }
+        }
+
+        public FlatHash createFlatHash()
+        {
+            ControlMatcher controlMatcher = switch (matcher) {
+                case "SCALAR" -> new ScalarControlMatcher();
+                case "VECTOR" -> new VectorControlMatcher();
+                default -> throw new UnsupportedOperationException("Unsupported matcher: " + matcher);
+            };
+            return new FlatHash(flatHashStrategy, cacheHashValue, EXPECTED_SIZE, NOOP, controlMatcher);
+        }
+
+        public FlatHash getFilledFlatHash()
+        {
+            return filledFlatHash;
+        }
+
+        public Block[] getBlocks()
+        {
+            return blocks;
+        }
+
+        private Block[] createBlocks(List<Type> types)
+        {
+            PageBuilder pageBuilder = new PageBuilder(POSITIONS, types);
+            for (int position = 0; position < POSITIONS; position++) {
+                int value = ThreadLocalRandom.current().nextInt(groupCount);
+                pageBuilder.declarePosition();
+                for (int channel = 0; channel < channelCount; channel++) {
+                    switch (dataType) {
+                        case "BIGINT" -> BIGINT.writeLong(pageBuilder.getBlockBuilder(channel), value);
+                        case "VARCHAR" -> VARCHAR.writeSlice(pageBuilder.getBlockBuilder(channel), varcharValue(value));
+                        default -> throw new UnsupportedOperationException("Unsupported dataType: " + dataType);
+                    }
+                }
+            }
+            Page page = pageBuilder.build();
+            Block[] blocks = new Block[channelCount];
+            for (int channel = 0; channel < channelCount; channel++) {
+                blocks[channel] = page.getBlock(channel);
+            }
+            return blocks;
+        }
+
+        private static Slice varcharValue(int value)
+        {
+            return Slices.wrappedHeapBuffer(ByteBuffer.allocate(4).putInt(value).flip());
+        }
+    }
+
+    static void main()
+            throws RunnerException
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkFlatHash().putIfAbsent(data);
+        new BenchmarkFlatHash().getIfPresent(data);
+
+        benchmark(BenchmarkFlatHash.class)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgs("-Xmx8g"))
+                .run();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/TestControlMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestControlMatcher.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestControlMatcher
+{
+    private static final byte EMPTY = 0;
+
+    private static List<ControlMatcher> matchers()
+    {
+        return ImmutableList.of(new ScalarControlMatcher(), new VectorControlMatcher());
+    }
+
+    @ParameterizedTest
+    @MethodSource("matchers")
+    void testVectorLength(ControlMatcher matcher)
+    {
+        int vectorLength = matcher.vectorLength();
+        assertThat(vectorLength).isGreaterThanOrEqualTo(Long.BYTES);
+        assertThat(Integer.bitCount(vectorLength)).isEqualTo(1);
+        // the match set must fit into a long
+        assertThat(vectorLength).isLessThanOrEqualTo(Long.SIZE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("matchers")
+    void testMatchesEveryPrefixInEverySlot(ControlMatcher matcher)
+    {
+        int vectorLength = matcher.vectorLength();
+        byte[] control = new byte[vectorLength];
+        for (int prefix = 0; prefix < 128; prefix++) {
+            byte hashPrefix = (byte) (prefix | 0x80);
+            for (int slot = 0; slot < vectorLength; slot++) {
+                control[slot] = hashPrefix;
+                assertThat(matchedSlots(matcher, control, hashPrefix, 0)).containsExactly(slot);
+                control[slot] = EMPTY;
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("matchers")
+    void testMatchesAgainstRandomControl(ControlMatcher matcher)
+    {
+        int vectorLength = matcher.vectorLength();
+        Random random = new Random(0);
+        // like a hash table of the given capacity, the control array repeats its first vectorLength slots at the end
+        int capacity = 1024;
+        byte[] control = new byte[capacity + vectorLength];
+        for (int slot = 0; slot < capacity; slot++) {
+            // leave a quarter of the slots empty, and use few distinct prefixes so that a single vector contains multiple matches
+            control[slot] = random.nextInt(4) == 0 ? EMPTY : (byte) (random.nextInt(4) | 0x80);
+        }
+        System.arraycopy(control, 0, control, capacity, vectorLength);
+
+        for (int start = 0; start < capacity; start++) {
+            int position = start;
+            for (int prefix = 0; prefix < 4; prefix++) {
+                byte hashPrefix = (byte) (prefix | 0x80);
+                List<Integer> matched = matchedSlots(matcher, control, hashPrefix, position);
+                // a match set contains every matching slot, and only occupied slots
+                assertThat(matched).containsAll(expectedSlots(control, position, vectorLength, hashPrefix));
+                assertThat(matched).allMatch(slot -> control[position + slot] != EMPTY);
+            }
+            // matching the empty control byte must be exact, as inserts rely on it to find a free slot
+            assertThat(matchedSlots(matcher, control, EMPTY, position))
+                    .isEqualTo(expectedSlots(control, position, vectorLength, EMPTY));
+        }
+    }
+
+    private static List<Integer> matchedSlots(ControlMatcher matcher, byte[] control, byte hashPrefix, int position)
+    {
+        ImmutableList.Builder<Integer> slots = ImmutableList.builder();
+        long matches = matcher.match(control, position, hashPrefix);
+        while (matches != 0) {
+            slots.add(matcher.firstSlot(matches));
+            matches = matcher.clearFirstSlot(matches);
+        }
+        return slots.build();
+    }
+
+    private static List<Integer> expectedSlots(byte[] control, int position, int vectorLength, byte hashPrefix)
+    {
+        return IntStream.range(0, vectorLength)
+                .filter(slot -> control[position + slot] == hashPrefix)
+                .boxed()
+                .collect(toImmutableList());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/TestFlatHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestFlatHash.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.operator.FlatHashStrategyCompiler.compileFlatHashStrategy;
+import static io.trino.operator.UpdateMemory.NOOP;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestFlatHash
+{
+    private static final List<Type> TYPES = ImmutableList.of(BIGINT, VARCHAR);
+    private static final FlatHashStrategy FLAT_HASH_STRATEGY = compileFlatHashStrategy(TYPES, new TypeOperators());
+
+    private static final int DISTINCT_VALUES = 20_000;
+    private static final int POSITIONS = DISTINCT_VALUES * 3;
+
+    private static List<ControlMatcher> matchers()
+    {
+        return ImmutableList.of(new ScalarControlMatcher(), new VectorControlMatcher());
+    }
+
+    /**
+     * The vectorized and the scalar matcher must build the exact same hash table, including the group id assignment,
+     * which is only determined by the insertion order.
+     */
+    @ParameterizedTest
+    @MethodSource("matchers")
+    void testAgreesWithReferenceMapping(ControlMatcher matcher)
+    {
+        Block[] blocks = createBlocks();
+        FlatHash flatHash = new FlatHash(FLAT_HASH_STRATEGY, true, 16, NOOP, matcher);
+
+        for (int position = 0; position < POSITIONS; position++) {
+            assertThat(flatHash.putIfAbsent(blocks, position)).isEqualTo(expectedGroupId(position));
+        }
+        assertThat(flatHash.size()).isEqualTo(DISTINCT_VALUES);
+
+        for (int position = 0; position < POSITIONS; position++) {
+            assertThat(flatHash.getIfPresent(blocks, position)).isEqualTo(expectedGroupId(position));
+        }
+
+        Block[] missingBlocks = createBlocks(DISTINCT_VALUES);
+        for (int position = 0; position < POSITIONS; position++) {
+            assertThat(flatHash.getIfPresent(missingBlocks, position)).isEqualTo(-1);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("matchers")
+    void testAppendTo(ControlMatcher matcher)
+    {
+        Block[] blocks = createBlocks();
+        FlatHash flatHash = new FlatHash(FLAT_HASH_STRATEGY, false, 16, NOOP, matcher);
+        for (int position = 0; position < POSITIONS; position++) {
+            flatHash.putIfAbsent(blocks, position);
+        }
+
+        PageBuilder pageBuilder = new PageBuilder(flatHash.size(), TYPES);
+        BlockBuilder[] blockBuilders = new BlockBuilder[] {pageBuilder.getBlockBuilder(0), pageBuilder.getBlockBuilder(1)};
+        for (int groupId = 0; groupId < flatHash.size(); groupId++) {
+            pageBuilder.declarePosition();
+            flatHash.appendTo(groupId, blockBuilders);
+        }
+
+        Page page = pageBuilder.build();
+        Block bigintValues = page.getBlock(0);
+        Block varcharValues = page.getBlock(1);
+        for (int value = 0; value < DISTINCT_VALUES; value++) {
+            // group ids are assigned in the order the values were first seen, which is the natural order of the values
+            assertThat(BIGINT.getLong(bigintValues, value)).isEqualTo(value);
+            assertThat(VARCHAR.getSlice(varcharValues, value)).isEqualTo(varcharValue(value));
+        }
+    }
+
+    private static int expectedGroupId(int position)
+    {
+        return position % DISTINCT_VALUES;
+    }
+
+    private static Block[] createBlocks()
+    {
+        return createBlocks(0);
+    }
+
+    private static Block[] createBlocks(int offset)
+    {
+        PageBuilder pageBuilder = new PageBuilder(POSITIONS, TYPES);
+        for (int position = 0; position < POSITIONS; position++) {
+            int value = offset + expectedGroupId(position);
+            pageBuilder.declarePosition();
+            BIGINT.writeLong(pageBuilder.getBlockBuilder(0), value);
+            VARCHAR.writeSlice(pageBuilder.getBlockBuilder(1), varcharValue(value));
+        }
+        Page page = pageBuilder.build();
+        return new Block[] {page.getBlock(0), page.getBlock(1)};
+    }
+
+    private static Slice varcharValue(int value)
+    {
+        return utf8Slice("value " + value);
+    }
+}


### PR DESCRIPTION
FlatHash searched the control bytes eight slots at a time, with SWAR arithmetic on a long. A ControlMatcher now abstracts that search, so that a single 256 bit vector comparison can search thirty two slots at a time, which shortens the probe of a table kept at a 15/16 load factor.

A vector species has to be a constant of the class that uses it for the JVM to compile the comparison into a vector instruction, so the width cannot be chosen at runtime. Hardware without a 256 bit vector register therefore keeps using the scalar matcher, rather than a narrower vector.

BenchmarkFlatHash measures both matchers, and TestFlatHash asserts that they build the same table, down to the group id assignment.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
