### PR TITLE
Generate encryption keys with SecureRandom

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/encryption/EncryptionKey.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/encryption/EncryptionKey.java
@@ -13,14 +13,16 @@
  */
 package io.trino.filesystem.encryption;
 
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.concurrent.ThreadLocalRandom;
 
 import static java.util.Objects.requireNonNull;
 
 public record EncryptionKey(byte[] key, String algorithm)
 {
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
     public EncryptionKey
     {
         requireNonNull(algorithm, "algorithm is null");
@@ -30,7 +32,7 @@ public record EncryptionKey(byte[] key, String algorithm)
     public static EncryptionKey randomAes256()
     {
         byte[] key = new byte[32];
-        ThreadLocalRandom.current().nextBytes(key);
+        SECURE_RANDOM.nextBytes(key);
         return ofAes256(key);
     }
 


### PR DESCRIPTION
EncryptionKey.randomAes256() used ThreadLocalRandom, a predictable, non-cryptographic PRNG, to generate AES-256 key material. These keys are used as S3 SSE-C keys by the filesystem spooling manager to encrypt spooled query results, so they must come from a cryptographically secure source.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
