### PR TITLE
Reduce the size of Web UI

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp/src/App.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/App.tsx
@@ -35,7 +35,7 @@ import trinoLogo from './assets/trino.svg'
 import { QueryDetails } from './components/QueryDetails'
 import { WorkerStatus } from './components/WorkerStatus'
 import { loader } from '@monaco-editor/react'
-import * as monaco from 'monaco-editor'
+import * as monaco from './monaco'
 
 const App = () => {
     const config = useConfigStore()

--- a/core/trino-web-ui/src/main/resources/webapp/src/main.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/main.tsx
@@ -13,10 +13,10 @@
  */
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import '@fontsource/roboto/300.css'
-import '@fontsource/roboto/400.css'
-import '@fontsource/roboto/500.css'
-import '@fontsource/roboto/700.css'
+import '@fontsource/roboto/latin-300.css'
+import '@fontsource/roboto/latin-400.css'
+import '@fontsource/roboto/latin-500.css'
+import '@fontsource/roboto/latin-700.css'
 import App from './App.tsx'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/core/trino-web-ui/src/main/resources/webapp/src/monaco.ts
+++ b/core/trino-web-ui/src/main/resources/webapp/src/monaco.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Slim Monaco build: the root 'monaco-editor' entry point bundles every language it
+// supports plus the TypeScript, CSS and HTML web workers (~12 MB of assets), while the
+// UI only ever displays read-only sql, java and json. Import the editor core and just
+// those language contributions instead; each language mode lazily loads its tokenizer
+// (and for json, its worker) in a separate chunk only when first used.
+import 'monaco-editor/esm/vs/basic-languages/sql/sql.contribution.js'
+import 'monaco-editor/esm/vs/basic-languages/java/java.contribution.js'
+import 'monaco-editor/esm/vs/language/json/monaco.contribution.js'
+
+export * from 'monaco-editor/esm/vs/editor/edcore.main.js'

--- a/core/trino-web-ui/src/main/resources/webapp/src/vite-env.d.ts
+++ b/core/trino-web-ui/src/main/resources/webapp/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+// The deep monaco-editor ESM entry points used by src/monaco.ts ship no declaration
+// files; the editor core re-exports the same API as the typed root entry point.
+declare module 'monaco-editor/esm/vs/editor/edcore.main.js' {
+    export * from 'monaco-editor'
+}
+declare module 'monaco-editor/esm/vs/basic-languages/*'
+declare module 'monaco-editor/esm/vs/language/json/monaco.contribution.js'

--- a/core/trino-web-ui/src/main/resources/webapp/vite.config.ts
+++ b/core/trino-web-ui/src/main/resources/webapp/vite.config.ts
@@ -1,26 +1,38 @@
-import { ConfigEnv, defineConfig, loadEnv  } from 'vite'
+import { ConfigEnv, defineConfig, loadEnv, Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
+
+// Fontsource CSS declares a legacy .woff fallback after each .woff2 source; dropping it
+// keeps the deprecated .woff files out of the bundle (woff2 is supported since ~2016)
+const stripWoffFallback = (): Plugin => ({
+    name: 'strip-woff-fallback',
+    enforce: 'pre',
+    transform(code: string, id: string) {
+        if (id.includes('@fontsource') && id.endsWith('.css')) {
+            return code.replace(/,\s*url\([^)]*\.woff\)\s*format\('woff'\)/g, '')
+        }
+    },
+})
 
 // https://vitejs.dev/config/
 export default defineConfig((mode: ConfigEnv) => {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  const env = loadEnv(mode.mode, process.cwd());
-  const baseUrl = env.VITE_BASE_URL
-  return {
-    base: '/ui',
-    plugins: [react()],
-    server: {
-      proxy: {
-        ['/ui/auth']: {
-          target: baseUrl,
-          changeOrigin: true,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const env = loadEnv(mode.mode, process.cwd())
+    const baseUrl = env.VITE_BASE_URL
+    return {
+        base: '/ui',
+        plugins: [stripWoffFallback(), react()],
+        server: {
+            proxy: {
+                ['/ui/auth']: {
+                    target: baseUrl,
+                    changeOrigin: true,
+                },
+                ['/ui/api']: {
+                    target: baseUrl,
+                    changeOrigin: true,
+                },
+            },
         },
-        ['/ui/api']: {
-          target: baseUrl,
-          changeOrigin: true,
-        },
-      }
     }
-  }
 })


### PR DESCRIPTION
Import the latin-only fontsource CSS instead of the umbrella files that reference every script subset (cyrillic, greek, vietnamese, math, symbols), and strip the legacy woff fallback during the Vite build. This reduces the bundled font assets from 64 files (~830 kB) to 4 woff2 files (~88 kB).

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
