### PR TITLE
Avoid materializing a String or copying a Slice on per-row paths

### DIFF
--- a/core/trino-main/src/main/java/io/trino/json/PathEvaluationVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/json/PathEvaluationVisitor.java
@@ -698,27 +698,30 @@ class PathEvaluationVisitor
 
     private static TypedValue getDatetime(TypedValue typedValue)
     {
-        String value = ((Slice) typedValue.getObjectValue()).toStringUtf8();
+        Slice slice = (Slice) typedValue.getObjectValue();
 
         // The standard datetime shapes are unambiguously distinguishable by their separators:
         // a TIMESTAMP value has a space between date and time, a TIME value has at least one
         // colon, and a DATE value has neither. Dispatch on shape so each input passes through
-        // the matching parser exactly once.
-        if (value.indexOf(' ') >= 0) {
+        // the matching parser exactly once. Only the timestamp and time parsers need the value as a
+        // String, so a date never decodes one.
+        if (slice.indexOfByte(' ') >= 0) {
+            String value = slice.toStringUtf8();
             int precision = extractTimestampPrecision(value);
             if (timestampHasTimeZone(value)) {
                 return TypedValue.fromValueAsObject(createTimestampWithTimeZoneType(precision), parseTimestampWithTimeZone(precision, value));
             }
             return TypedValue.fromValueAsObject(createTimestampType(precision), parseTimestamp(precision, value));
         }
-        if (value.indexOf(':') >= 0) {
+        if (slice.indexOfByte(':') >= 0) {
+            String value = slice.toStringUtf8();
             int precision = extractTimePrecision(value);
             if (timeHasTimeZone(value)) {
                 return TypedValue.fromValueAsObject(createTimeWithTimeZoneType(precision), parseTimeWithTimeZone(precision, value));
             }
             return new TypedValue(createTimeType(precision), parseTime(value));
         }
-        return new TypedValue(DATE, (long) parseDate(value));
+        return new TypedValue(DATE, parseDate(slice));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
@@ -428,7 +428,7 @@ public final class DateTimeFunctions
     {
         if (ISO_8601_DATE_FORMAT.equals(formatString)) {
             try {
-                long days = DateTimeUtils.parseDate(dateTime.toStringUtf8());
+                long days = DateTimeUtils.parseDate(dateTime);
                 return scaleEpochMillisToMicros(days * MILLISECONDS_PER_DAY);
             }
             catch (IllegalArgumentException | ArithmeticException | DateTimeException e) {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JoniRegexpFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JoniRegexpFunctions.java
@@ -55,9 +55,27 @@ public final class JoniRegexpFunctions
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean regexpLike(@SqlType("varchar(x)") Slice source, @SqlType(JoniRegexpType.NAME) JoniRegexp pattern)
     {
-        int offset = source.byteArrayOffset();
-        Matcher matcher = pattern.regex().matcher(source.byteArray(), offset, offset + source.length());
-        return getSearchingOffset(matcher, offset, offset + source.length()) != -1;
+        Matcher matcher = matcher(source, pattern);
+        return search(matcher, source, 0) != -1;
+    }
+
+    static Matcher matcher(Slice source, JoniRegexp pattern)
+    {
+        int base = source.byteArrayOffset();
+        return pattern.regex().matcher(source.byteArray(), base, base + source.length());
+    }
+
+    /**
+     * Searches from {@code at}, a position within the source.
+     * <p>
+     * Joni takes the search bounds as offsets into the array it was given, so they are shifted by
+     * {@link Slice#byteArrayOffset}, while the positions it reports back, including the return value
+     * here, are relative to the start of the source.
+     */
+    static int search(Matcher matcher, Slice source, int at)
+    {
+        int base = source.byteArrayOffset();
+        return getSearchingOffset(matcher, base + at, base + source.length());
     }
 
     private static int getNextStart(Slice source, Matcher matcher)
@@ -93,14 +111,13 @@ public final class JoniRegexpFunctions
     @SqlType("varchar(z)")
     public static Slice regexpReplace(@SqlType("varchar(x)") Slice source, @SqlType(JoniRegexpType.NAME) JoniRegexp pattern, @SqlType("varchar(y)") Slice replacement)
     {
-        Matcher matcher = pattern.matcher(source.getBytes());
+        Matcher matcher = matcher(source, pattern);
         SliceOutput sliceOutput = new DynamicSliceOutput(source.length() + replacement.length() * 5);
 
         int lastEnd = 0;
         int nextStart = 0; // nextStart is the same as lastEnd, unless the last match was zero-width. In such case, nextStart is lastEnd + 1.
         while (true) {
-            int offset = getSearchingOffset(matcher, nextStart, source.length());
-            if (offset == -1) {
+            if (search(matcher, source, nextStart) == -1) {
                 break;
             }
             nextStart = getNextStart(source, matcher);
@@ -209,15 +226,14 @@ public final class JoniRegexpFunctions
     @SqlType("array(varchar(x))")
     public static Block regexpExtractAll(@SqlType("varchar(x)") Slice source, @SqlType(JoniRegexpType.NAME) JoniRegexp pattern, @SqlType(StandardTypes.BIGINT) long groupIndex)
     {
-        Matcher matcher = pattern.matcher(source.getBytes());
+        Matcher matcher = matcher(source, pattern);
         validateGroup(groupIndex, matcher.getEagerRegion());
         BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 32);
         int group = toIntExact(groupIndex);
 
         int nextStart = 0;
         while (true) {
-            int offset = getSearchingOffset(matcher, nextStart, source.length());
-            if (offset == -1) {
+            if (search(matcher, source, nextStart) == -1) {
                 break;
             }
             nextStart = getNextStart(source, matcher);
@@ -252,12 +268,11 @@ public final class JoniRegexpFunctions
     @SqlType("varchar(x)")
     public static Slice regexpExtract(@SqlType("varchar(x)") Slice source, @SqlType(JoniRegexpType.NAME) JoniRegexp pattern, @SqlType(StandardTypes.BIGINT) long groupIndex)
     {
-        Matcher matcher = pattern.matcher(source.getBytes());
+        Matcher matcher = matcher(source, pattern);
         validateGroup(groupIndex, matcher.getEagerRegion());
         int group = toIntExact(groupIndex);
 
-        int offset = getSearchingOffset(matcher, 0, source.length());
-        if (offset == -1) {
+        if (search(matcher, source, 0) == -1) {
             return null;
         }
         Region region = matcher.getEagerRegion();
@@ -277,14 +292,13 @@ public final class JoniRegexpFunctions
     @SqlType("array(varchar(x))")
     public static Block regexpSplit(@SqlType("varchar(x)") Slice source, @SqlType(JoniRegexpType.NAME) JoniRegexp pattern)
     {
-        Matcher matcher = pattern.matcher(source.getBytes());
+        Matcher matcher = matcher(source, pattern);
         BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 32);
 
         int lastEnd = 0;
         int nextStart = 0;
         while (true) {
-            int offset = getSearchingOffset(matcher, nextStart, source.length());
-            if (offset == -1) {
+            if (search(matcher, source, nextStart) == -1) {
                 break;
             }
             nextStart = getNextStart(source, matcher);
@@ -351,15 +365,14 @@ public final class JoniRegexpFunctions
             return -1;
         }
 
-        Matcher matcher = pattern.matcher(source.getBytes());
+        Matcher matcher = matcher(source, pattern);
         long count = 0;
         // convert char position to byte position
         // subtract 1 because codePointCount starts from zero
         int nextStart = SliceUtf8.offsetOfCodePoint(source, (int) start - 1);
         while (true) {
-            int offset = getSearchingOffset(matcher, nextStart, source.length());
             // Check whether offset is negative, offset is -1 if no pattern was found
-            if (offset < 0) {
+            if (search(matcher, source, nextStart) < 0) {
                 return -1;
             }
 
@@ -378,16 +391,15 @@ public final class JoniRegexpFunctions
     @SqlType(StandardTypes.BIGINT)
     public static long regexpCount(@SqlType("varchar(x)") Slice source, @SqlType(JoniRegexpType.NAME) JoniRegexp pattern)
     {
-        Matcher matcher = pattern.matcher(source.getBytes());
+        Matcher matcher = matcher(source, pattern);
 
         int count = 0;
         // Start from zero, implies the first byte
         int nextStart = 0;
         while (true) {
-            // getSearchingOffset returns `source.length` if `nextStart` equals `source.length - 1`.
+            // search returns `source.length` if `nextStart` equals `source.length - 1`.
             // It should return -1 if `nextStart` is greater than `source.length - 1`.
-            int offset = getSearchingOffset(matcher, nextStart, source.length());
-            if (offset < 0) {
+            if (search(matcher, source, nextStart) < 0) {
                 break;
             }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/JoniRegexpReplaceLambdaFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/JoniRegexpReplaceLambdaFunction.java
@@ -31,7 +31,8 @@ import io.trino.type.JoniRegexp;
 import io.trino.type.JoniRegexpType;
 
 import static io.airlift.slice.SliceUtf8.lengthOfCodePointFromStartByte;
-import static io.trino.operator.scalar.JoniRegexpFunctions.getSearchingOffset;
+import static io.trino.operator.scalar.JoniRegexpFunctions.matcher;
+import static io.trino.operator.scalar.JoniRegexpFunctions.search;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 
 @ScalarFunction("regexp_replace")
@@ -48,9 +49,9 @@ public final class JoniRegexpReplaceLambdaFunction
             @SqlType(JoniRegexpType.NAME) JoniRegexp pattern,
             @SqlType("function(array(varchar), varchar(x))") UnaryFunctionInterface replaceFunction)
     {
+        Matcher matcher = matcher(source, pattern);
         // If there is no match we can simply return the original source without doing copy.
-        Matcher matcher = pattern.matcher(source.getBytes());
-        if (getSearchingOffset(matcher, 0, source.length()) == -1) {
+        if (search(matcher, source, 0) == -1) {
             return source;
         }
 
@@ -102,7 +103,7 @@ public final class JoniRegexpReplaceLambdaFunction
             }
             output.appendBytes(replaced);
         }
-        while (getSearchingOffset(matcher, nextStart, source.length()) != -1);
+        while (search(matcher, source, nextStart) != -1);
         // Append the last un-matched part
         output.writeBytes(source, appendPosition, source.length() - appendPosition);
         return output.slice();

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/TimeField.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/TimeField.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.TrinoException;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.util.Locale.ENGLISH;
+
+/**
+ * The field of a TIME or TIME WITH TIME ZONE value that {@code date_trunc}, {@code date_add} and
+ * {@code date_diff} operate on.
+ */
+public enum TimeField
+{
+    MILLISECOND("millisecond"),
+    SECOND("second"),
+    MINUTE("minute"),
+    HOUR("hour");
+
+    private static final TimeField[] VALUES = values();
+
+    private final byte[] name;
+
+    TimeField(String name)
+    {
+        this.name = name.getBytes(US_ASCII);
+    }
+
+    public static TimeField match(Slice unit)
+    {
+        for (TimeField field : VALUES) {
+            if (field.matches(unit)) {
+                return field;
+            }
+        }
+        throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unit.toStringUtf8().toLowerCase(ENGLISH) + "' is not a valid TIME field");
+    }
+
+    private boolean matches(Slice unit)
+    {
+        if (unit.length() != name.length) {
+            return false;
+        }
+        for (int i = 0; i < name.length; i++) {
+            // Each lowercase letter has an ASCII code 0x20 more than the corresponding uppercase letter
+            if ((unit.getByteUnchecked(i) | 0x20) != name[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/time/TimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/time/TimeFunctions.java
@@ -14,7 +14,7 @@
 package io.trino.operator.scalar.time;
 
 import io.airlift.slice.Slice;
-import io.trino.spi.TrinoException;
+import io.trino.operator.scalar.TimeField;
 import io.trino.spi.function.Description;
 import io.trino.spi.function.LiteralParameter;
 import io.trino.spi.function.LiteralParameters;
@@ -22,7 +22,6 @@ import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
-import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.type.TimeType.MAX_PRECISION;
 import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_DAY;
 import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_SECOND;
@@ -36,7 +35,6 @@ import static io.trino.spi.type.Timestamps.SECONDS_PER_DAY;
 import static io.trino.spi.type.Timestamps.SECONDS_PER_MINUTE;
 import static io.trino.spi.type.Timestamps.round;
 import static io.trino.type.DateTimes.HOURS_PER_DAY;
-import static java.util.Locale.ENGLISH;
 import static org.joda.time.DateTimeConstants.MINUTES_PER_DAY;
 
 public final class TimeFunctions
@@ -85,14 +83,11 @@ public final class TimeFunctions
     @SqlType("time(p)")
     public static long truncate(@SqlType("varchar(x)") Slice unit, @SqlType("time(p)") long time)
     {
-        String unitString = unit.toStringUtf8().toLowerCase(ENGLISH);
-
-        return switch (unitString) {
-            case "millisecond" -> time / PICOSECONDS_PER_MILLISECOND * PICOSECONDS_PER_MILLISECOND;
-            case "second" -> time / PICOSECONDS_PER_SECOND * PICOSECONDS_PER_SECOND;
-            case "minute" -> time / PICOSECONDS_PER_MINUTE * PICOSECONDS_PER_MINUTE;
-            case "hour" -> time / PICOSECONDS_PER_HOUR * PICOSECONDS_PER_HOUR;
-            default -> throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString + "' is not a valid TIME field");
+        return switch (TimeField.match(unit)) {
+            case MILLISECOND -> time / PICOSECONDS_PER_MILLISECOND * PICOSECONDS_PER_MILLISECOND;
+            case SECOND -> time / PICOSECONDS_PER_SECOND * PICOSECONDS_PER_SECOND;
+            case MINUTE -> time / PICOSECONDS_PER_MINUTE * PICOSECONDS_PER_MINUTE;
+            case HOUR -> time / PICOSECONDS_PER_HOUR * PICOSECONDS_PER_HOUR;
         };
     }
 
@@ -106,13 +101,11 @@ public final class TimeFunctions
             @SqlType(StandardTypes.BIGINT) long value,
             @SqlType("time(p)") long time)
     {
-        String unitString = unit.toStringUtf8().toLowerCase(ENGLISH);
-        long delta = switch (unitString) {
-            case "millisecond" -> (value % MILLISECONDS_PER_DAY) * PICOSECONDS_PER_MILLISECOND;
-            case "second" -> (value % SECONDS_PER_DAY) * PICOSECONDS_PER_SECOND;
-            case "minute" -> (value % MINUTES_PER_DAY) * PICOSECONDS_PER_MINUTE;
-            case "hour" -> (value % HOURS_PER_DAY) * PICOSECONDS_PER_HOUR;
-            default -> throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString + "' is not a valid TIME field");
+        long delta = switch (TimeField.match(unit)) {
+            case MILLISECOND -> (value % MILLISECONDS_PER_DAY) * PICOSECONDS_PER_MILLISECOND;
+            case SECOND -> (value % SECONDS_PER_DAY) * PICOSECONDS_PER_SECOND;
+            case MINUTE -> (value % MINUTES_PER_DAY) * PICOSECONDS_PER_MINUTE;
+            case HOUR -> (value % HOURS_PER_DAY) * PICOSECONDS_PER_HOUR;
         };
 
         long result = TimeOperators.add(time, delta);
@@ -132,13 +125,11 @@ public final class TimeFunctions
     public static long dateDiff(@SqlType("varchar(x)") Slice unit, @SqlType("time(p)") long time1, @SqlType("time(p)") long time2)
     {
         long delta = time2 - time1;
-        String unitString = unit.toStringUtf8().toLowerCase(ENGLISH);
-        return switch (unitString) {
-            case "millisecond" -> delta / PICOSECONDS_PER_MILLISECOND;
-            case "second" -> delta / PICOSECONDS_PER_SECOND;
-            case "minute" -> delta / PICOSECONDS_PER_MINUTE;
-            case "hour" -> delta / PICOSECONDS_PER_HOUR;
-            default -> throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString + "' is not a valid TIME field");
+        return switch (TimeField.match(unit)) {
+            case MILLISECOND -> delta / PICOSECONDS_PER_MILLISECOND;
+            case SECOND -> delta / PICOSECONDS_PER_SECOND;
+            case MINUTE -> delta / PICOSECONDS_PER_MINUTE;
+            case HOUR -> delta / PICOSECONDS_PER_HOUR;
         };
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/CharToTimestampCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/CharToTimestampCast.java
@@ -36,7 +36,7 @@ public final class CharToTimestampCast
     public static long castToShort(@LiteralParameter("p") long precision, @SqlType("char(x)") Slice value)
     {
         try {
-            return VarcharToTimestampCast.castToShortTimestamp((int) precision, trim(value).toStringUtf8());
+            return VarcharToTimestampCast.castToShortTimestamp((int) precision, trim(value));
         }
         catch (IllegalArgumentException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
@@ -48,7 +48,7 @@ public final class CharToTimestampCast
     public static LongTimestamp castToLong(@LiteralParameter("p") long precision, @SqlType("char(x)") Slice value)
     {
         try {
-            return VarcharToTimestampCast.castToLongTimestamp((int) precision, trim(value).toStringUtf8());
+            return VarcharToTimestampCast.castToLongTimestamp((int) precision, trim(value));
         }
         catch (IllegalArgumentException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/VarcharToTimestampCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/VarcharToTimestampCast.java
@@ -23,6 +23,7 @@ import io.trino.spi.type.LongTimestamp;
 import io.trino.type.DateTimes;
 
 import java.time.DateTimeException;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.regex.Matcher;
@@ -37,6 +38,7 @@ import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.round;
 import static io.trino.type.DateTimes.longTimestamp;
 import static io.trino.type.DateTimes.rescale;
+import static java.lang.Math.min;
 import static java.time.ZoneOffset.UTC;
 
 // fallible
@@ -50,7 +52,7 @@ public final class VarcharToTimestampCast
     public static long castToShort(@LiteralParameter("p") long precision, @SqlType("varchar(x)") Slice value)
     {
         try {
-            return castToShortTimestamp((int) precision, trim(value).toStringUtf8());
+            return castToShortTimestamp((int) precision, trim(value));
         }
         catch (IllegalArgumentException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
@@ -62,11 +64,210 @@ public final class VarcharToTimestampCast
     public static LongTimestamp castToLong(@LiteralParameter("p") long precision, @SqlType("varchar(x)") Slice value)
     {
         try {
-            return castToLongTimestamp((int) precision, trim(value).toStringUtf8());
+            return castToLongTimestamp((int) precision, trim(value));
         }
         catch (IllegalArgumentException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
         }
+    }
+
+    public static long castToShortTimestamp(int precision, Slice value)
+    {
+        checkArgument(precision <= MAX_SHORT_PRECISION, "precision must be less than max short timestamp precision");
+
+        PlainTimestamp parsed = parsePlainTimestamp(value);
+        if (parsed == null) {
+            return castToShortTimestamp(precision, value.toStringUtf8());
+        }
+
+        long fractionValue = parsed.fractionValue();
+        int actualPrecision = parsed.fractionPrecision();
+        if (actualPrecision > precision) {
+            fractionValue = round(fractionValue, actualPrecision - precision);
+        }
+
+        // scale to micros
+        return parsed.epochSecond() * MICROSECONDS_PER_SECOND + rescale(fractionValue, actualPrecision, 6);
+    }
+
+    public static LongTimestamp castToLongTimestamp(int precision, Slice value)
+    {
+        checkArgument(precision > MAX_SHORT_PRECISION && precision <= MAX_PRECISION, "precision out of range");
+
+        PlainTimestamp parsed = parsePlainTimestamp(value);
+        if (parsed == null) {
+            return castToLongTimestamp(precision, value.toStringUtf8());
+        }
+
+        long fractionValue = parsed.fractionValue();
+        int actualPrecision = parsed.fractionPrecision();
+        if (actualPrecision > precision) {
+            fractionValue = round(fractionValue, actualPrecision - precision);
+        }
+
+        return longTimestamp(parsed.epochSecond(), rescale(fractionValue, actualPrecision, 12));
+    }
+
+    /**
+     * The fields of a timestamp with no time zone, read straight from the bytes. It does not escape
+     * the cast, so it costs nothing next to the String, the Matcher, and the group substrings that
+     * the general path allocates for every row.
+     */
+    private record PlainTimestamp(long epochSecond, long fractionValue, int fractionPrecision) {}
+
+    /**
+     * Parses {@code yyyy-MM-dd[ HH:mm[:ss[.fraction]]]}, the shape a timestamp almost always has,
+     * straight from the bytes.
+     * <p>
+     * Returns null for everything else, including a signed year, a time zone, and any spacing the
+     * shape above does not cover, so that the caller falls back to {@link DateTimes#DATETIME_PATTERN},
+     * which accepts all of it.
+     */
+    private static PlainTimestamp parsePlainTimestamp(Slice value)
+    {
+        int length = value.length();
+        int index = 0;
+
+        int yearEnd = digitsEnd(value, index, length);
+        int yearDigits = yearEnd - index;
+        // the pattern accepts any number of year digits, but more than nine cannot be a year
+        if (yearDigits < 4 || yearDigits > 9) {
+            return null;
+        }
+        int year = parseDigits(value, index, yearEnd);
+        index = yearEnd;
+
+        if (index == length || value.getByte(index) != '-') {
+            return null;
+        }
+        index++;
+
+        int monthEnd = digitsEnd(value, index, min(index + 2, length));
+        if (monthEnd == index) {
+            return null;
+        }
+        int month = parseDigits(value, index, monthEnd);
+        index = monthEnd;
+
+        if (index == length || value.getByte(index) != '-') {
+            return null;
+        }
+        index++;
+
+        int dayEnd = digitsEnd(value, index, min(index + 2, length));
+        if (dayEnd == index) {
+            return null;
+        }
+        int day = parseDigits(value, index, dayEnd);
+        index = dayEnd;
+
+        int hour = 0;
+        int minute = 0;
+        int second = 0;
+        long fractionValue = 0;
+        int fractionPrecision = 0;
+
+        if (index != length) {
+            if (value.getByte(index) != ' ') {
+                return null;
+            }
+            index++;
+
+            int hourEnd = digitsEnd(value, index, min(index + 2, length));
+            if (hourEnd == index) {
+                return null;
+            }
+            hour = parseDigits(value, index, hourEnd);
+            index = hourEnd;
+
+            if (index == length || value.getByte(index) != ':') {
+                return null;
+            }
+            index++;
+
+            int minuteEnd = digitsEnd(value, index, min(index + 2, length));
+            if (minuteEnd == index) {
+                return null;
+            }
+            minute = parseDigits(value, index, minuteEnd);
+            index = minuteEnd;
+
+            if (index != length) {
+                if (value.getByte(index) != ':') {
+                    return null;
+                }
+                index++;
+
+                int secondEnd = digitsEnd(value, index, min(index + 2, length));
+                if (secondEnd == index) {
+                    return null;
+                }
+                second = parseDigits(value, index, secondEnd);
+                index = secondEnd;
+
+                if (index != length) {
+                    if (value.getByte(index) != '.') {
+                        return null;
+                    }
+                    index++;
+
+                    int fractionEnd = digitsEnd(value, index, length);
+                    // anything left over is a time zone, which the general path handles
+                    if (fractionEnd == index || fractionEnd != length) {
+                        return null;
+                    }
+                    fractionPrecision = fractionEnd - index;
+                    // the general path parses the fraction with Long.parseLong, which overflows past this
+                    if (fractionPrecision > 18) {
+                        return null;
+                    }
+                    fractionValue = parseLongDigits(value, index, fractionEnd);
+                }
+            }
+        }
+
+        try {
+            // with no time zone the general path resolves against UTC, which never shifts the value
+            return new PlainTimestamp(
+                    LocalDateTime.of(year, month, day, hour, minute, second).toEpochSecond(UTC),
+                    fractionValue,
+                    fractionPrecision);
+        }
+        catch (DateTimeException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
+        }
+    }
+
+    private static int digitsEnd(Slice value, int start, int end)
+    {
+        int index = start;
+        while (index < end && isDigit(value.getByte(index))) {
+            index++;
+        }
+        return index;
+    }
+
+    private static boolean isDigit(byte value)
+    {
+        return value >= '0' && value <= '9';
+    }
+
+    private static int parseDigits(Slice value, int start, int end)
+    {
+        int result = 0;
+        for (int index = start; index < end; index++) {
+            result = (result * 10) + (value.getByte(index) - '0');
+        }
+        return result;
+    }
+
+    private static long parseLongDigits(Slice value, int start, int end)
+    {
+        long result = 0;
+        for (int index = start; index < end; index++) {
+            result = (result * 10) + (value.getByte(index) - '0');
+        }
+        return result;
     }
 
     public static long castToShortTimestamp(int precision, String value)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/VarcharToTimestampCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/VarcharToTimestampCast.java
@@ -21,6 +21,7 @@ import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.LongTimestamp;
 import io.trino.type.DateTimes;
+import io.trino.type.DateTimes.PlainDateTime;
 
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
@@ -37,8 +38,8 @@ import static io.trino.spi.type.TimestampType.MAX_SHORT_PRECISION;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.round;
 import static io.trino.type.DateTimes.longTimestamp;
+import static io.trino.type.DateTimes.parsePlainDateTime;
 import static io.trino.type.DateTimes.rescale;
-import static java.lang.Math.min;
 import static java.time.ZoneOffset.UTC;
 
 // fallible
@@ -75,10 +76,12 @@ public final class VarcharToTimestampCast
     {
         checkArgument(precision <= MAX_SHORT_PRECISION, "precision must be less than max short timestamp precision");
 
-        PlainTimestamp parsed = parsePlainTimestamp(value);
+        PlainDateTime parsed = parsePlainDateTime(value);
         if (parsed == null) {
             return castToShortTimestamp(precision, value.toStringUtf8());
         }
+
+        long epochSecond = epochSecondAtUtc(parsed, value);
 
         long fractionValue = parsed.fractionValue();
         int actualPrecision = parsed.fractionPrecision();
@@ -87,17 +90,19 @@ public final class VarcharToTimestampCast
         }
 
         // scale to micros
-        return parsed.epochSecond() * MICROSECONDS_PER_SECOND + rescale(fractionValue, actualPrecision, 6);
+        return epochSecond * MICROSECONDS_PER_SECOND + rescale(fractionValue, actualPrecision, 6);
     }
 
     public static LongTimestamp castToLongTimestamp(int precision, Slice value)
     {
         checkArgument(precision > MAX_SHORT_PRECISION && precision <= MAX_PRECISION, "precision out of range");
 
-        PlainTimestamp parsed = parsePlainTimestamp(value);
+        PlainDateTime parsed = parsePlainDateTime(value);
         if (parsed == null) {
             return castToLongTimestamp(precision, value.toStringUtf8());
         }
+
+        long epochSecond = epochSecondAtUtc(parsed, value);
 
         long fractionValue = parsed.fractionValue();
         int actualPrecision = parsed.fractionPrecision();
@@ -105,169 +110,22 @@ public final class VarcharToTimestampCast
             fractionValue = round(fractionValue, actualPrecision - precision);
         }
 
-        return longTimestamp(parsed.epochSecond(), rescale(fractionValue, actualPrecision, 12));
+        return longTimestamp(epochSecond, rescale(fractionValue, actualPrecision, 12));
     }
 
     /**
-     * The fields of a timestamp with no time zone, read straight from the bytes. It does not escape
-     * the cast, so it costs nothing next to the String, the Matcher, and the group substrings that
-     * the general path allocates for every row.
+     * With no time zone the pattern based path resolves against UTC, which never shifts the value,
+     * so the fields alone determine the result.
      */
-    private record PlainTimestamp(long epochSecond, long fractionValue, int fractionPrecision) {}
-
-    /**
-     * Parses {@code yyyy-MM-dd[ HH:mm[:ss[.fraction]]]}, the shape a timestamp almost always has,
-     * straight from the bytes.
-     * <p>
-     * Returns null for everything else, including a signed year, a time zone, and any spacing the
-     * shape above does not cover, so that the caller falls back to {@link DateTimes#DATETIME_PATTERN},
-     * which accepts all of it.
-     */
-    private static PlainTimestamp parsePlainTimestamp(Slice value)
+    private static long epochSecondAtUtc(PlainDateTime parsed, Slice value)
     {
-        int length = value.length();
-        int index = 0;
-
-        int yearEnd = digitsEnd(value, index, length);
-        int yearDigits = yearEnd - index;
-        // the pattern accepts any number of year digits, but more than nine cannot be a year
-        if (yearDigits < 4 || yearDigits > 9) {
-            return null;
-        }
-        int year = parseDigits(value, index, yearEnd);
-        index = yearEnd;
-
-        if (index == length || value.getByte(index) != '-') {
-            return null;
-        }
-        index++;
-
-        int monthEnd = digitsEnd(value, index, min(index + 2, length));
-        if (monthEnd == index) {
-            return null;
-        }
-        int month = parseDigits(value, index, monthEnd);
-        index = monthEnd;
-
-        if (index == length || value.getByte(index) != '-') {
-            return null;
-        }
-        index++;
-
-        int dayEnd = digitsEnd(value, index, min(index + 2, length));
-        if (dayEnd == index) {
-            return null;
-        }
-        int day = parseDigits(value, index, dayEnd);
-        index = dayEnd;
-
-        int hour = 0;
-        int minute = 0;
-        int second = 0;
-        long fractionValue = 0;
-        int fractionPrecision = 0;
-
-        if (index != length) {
-            if (value.getByte(index) != ' ') {
-                return null;
-            }
-            index++;
-
-            int hourEnd = digitsEnd(value, index, min(index + 2, length));
-            if (hourEnd == index) {
-                return null;
-            }
-            hour = parseDigits(value, index, hourEnd);
-            index = hourEnd;
-
-            if (index == length || value.getByte(index) != ':') {
-                return null;
-            }
-            index++;
-
-            int minuteEnd = digitsEnd(value, index, min(index + 2, length));
-            if (minuteEnd == index) {
-                return null;
-            }
-            minute = parseDigits(value, index, minuteEnd);
-            index = minuteEnd;
-
-            if (index != length) {
-                if (value.getByte(index) != ':') {
-                    return null;
-                }
-                index++;
-
-                int secondEnd = digitsEnd(value, index, min(index + 2, length));
-                if (secondEnd == index) {
-                    return null;
-                }
-                second = parseDigits(value, index, secondEnd);
-                index = secondEnd;
-
-                if (index != length) {
-                    if (value.getByte(index) != '.') {
-                        return null;
-                    }
-                    index++;
-
-                    int fractionEnd = digitsEnd(value, index, length);
-                    // anything left over is a time zone, which the general path handles
-                    if (fractionEnd == index || fractionEnd != length) {
-                        return null;
-                    }
-                    fractionPrecision = fractionEnd - index;
-                    // the general path parses the fraction with Long.parseLong, which overflows past this
-                    if (fractionPrecision > 18) {
-                        return null;
-                    }
-                    fractionValue = parseLongDigits(value, index, fractionEnd);
-                }
-            }
-        }
-
         try {
-            // with no time zone the general path resolves against UTC, which never shifts the value
-            return new PlainTimestamp(
-                    LocalDateTime.of(year, month, day, hour, minute, second).toEpochSecond(UTC),
-                    fractionValue,
-                    fractionPrecision);
+            return LocalDateTime.of(parsed.year(), parsed.month(), parsed.day(), parsed.hour(), parsed.minute(), parsed.second())
+                    .toEpochSecond(UTC);
         }
         catch (DateTimeException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
         }
-    }
-
-    private static int digitsEnd(Slice value, int start, int end)
-    {
-        int index = start;
-        while (index < end && isDigit(value.getByte(index))) {
-            index++;
-        }
-        return index;
-    }
-
-    private static boolean isDigit(byte value)
-    {
-        return value >= '0' && value <= '9';
-    }
-
-    private static int parseDigits(Slice value, int start, int end)
-    {
-        int result = 0;
-        for (int index = start; index < end; index++) {
-            result = (result * 10) + (value.getByte(index) - '0');
-        }
-        return result;
-    }
-
-    private static long parseLongDigits(Slice value, int start, int end)
-    {
-        long result = 0;
-        for (int index = start; index < end; index++) {
-            result = (result * 10) + (value.getByte(index) - '0');
-        }
-        return result;
     }
 
     public static long castToShortTimestamp(int precision, String value)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/CharToTimestampWithTimeZoneCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/CharToTimestampWithTimeZoneCast.java
@@ -39,7 +39,7 @@ public final class CharToTimestampWithTimeZoneCast
     public static long castToShort(@LiteralParameter("p") long precision, ConnectorSession session, @SqlType("char(x)") Slice value)
     {
         try {
-            return VarcharToTimestampWithTimeZoneCast.toShort((int) precision, trim(value).toStringUtf8(), timezone -> {
+            return VarcharToTimestampWithTimeZoneCast.toShort((int) precision, trim(value), timezone -> {
                 if (timezone == null) {
                     return session.getTimeZoneKey().getZoneId();
                 }
@@ -56,7 +56,7 @@ public final class CharToTimestampWithTimeZoneCast
     public static LongTimestampWithTimeZone castToLong(@LiteralParameter("p") long precision, ConnectorSession session, @SqlType("char(x)") Slice value)
     {
         try {
-            return VarcharToTimestampWithTimeZoneCast.toLong((int) precision, trim(value).toStringUtf8(), timezone -> {
+            return VarcharToTimestampWithTimeZoneCast.toLong((int) precision, trim(value), timezone -> {
                 if (timezone == null) {
                     return session.getTimeZoneKey().getZoneId();
                 }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/VarcharToTimestampWithTimeZoneCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/VarcharToTimestampWithTimeZoneCast.java
@@ -22,6 +22,7 @@ import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.type.DateTimes;
+import io.trino.type.DateTimes.PlainDateTime;
 
 import java.time.DateTimeException;
 import java.time.ZoneId;
@@ -40,6 +41,7 @@ import static io.trino.spi.type.TimestampWithTimeZoneType.MAX_SHORT_PRECISION;
 import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.round;
 import static io.trino.type.DateTimes.longTimestampWithTimeZone;
+import static io.trino.type.DateTimes.parsePlainDateTime;
 import static io.trino.type.DateTimes.rescale;
 
 // fallible
@@ -53,7 +55,7 @@ public final class VarcharToTimestampWithTimeZoneCast
     public static long castToShort(@LiteralParameter("p") long precision, ConnectorSession session, @SqlType("varchar(x)") Slice value)
     {
         try {
-            return toShort((int) precision, trim(value).toStringUtf8(), timezone -> {
+            return toShort((int) precision, trim(value), timezone -> {
                 if (timezone == null) {
                     return session.getTimeZoneKey().getZoneId();
                 }
@@ -70,7 +72,7 @@ public final class VarcharToTimestampWithTimeZoneCast
     public static LongTimestampWithTimeZone castToLong(@LiteralParameter("p") long precision, ConnectorSession session, @SqlType("varchar(x)") Slice value)
     {
         try {
-            return toLong((int) precision, trim(value).toStringUtf8(), timezone -> {
+            return toLong((int) precision, trim(value), timezone -> {
                 if (timezone == null) {
                     return session.getTimeZoneKey().getZoneId();
                 }
@@ -80,6 +82,38 @@ public final class VarcharToTimestampWithTimeZoneCast
         catch (IllegalArgumentException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
         }
+    }
+
+    public static long toShort(int precision, Slice value, Function<String, ZoneId> zoneId)
+    {
+        checkArgument(precision <= MAX_SHORT_PRECISION, "precision must be less than max short timestamp precision");
+
+        PlainDateTime parsed = parsePlainDateTime(value);
+        if (parsed == null) {
+            return toShort(precision, value.toStringUtf8(), zoneId);
+        }
+
+        ZoneId zone;
+        long epochSecond;
+        try {
+            // the value carries no time zone, which is what the pattern based path reports as null
+            zone = zoneId.apply(null);
+            epochSecond = ZonedDateTime.of(parsed.year(), parsed.month(), parsed.day(), parsed.hour(), parsed.minute(), parsed.second(), 0, zone)
+                    .toEpochSecond();
+        }
+        catch (DateTimeException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
+        }
+
+        long fractionValue = parsed.fractionValue();
+        int actualPrecision = parsed.fractionPrecision();
+        if (actualPrecision > precision) {
+            fractionValue = round(fractionValue, actualPrecision - precision);
+        }
+
+        return packDateTimeWithZone(
+                epochSecond * MILLISECONDS_PER_SECOND + rescale(fractionValue, actualPrecision, MAX_SHORT_PRECISION),
+                getTimeZoneKey(zone.getId()));
     }
 
     public static long toShort(int precision, String value, Function<String, ZoneId> zoneId)
@@ -133,6 +167,36 @@ public final class VarcharToTimestampWithTimeZoneCast
 
         long millisOfSecond = rescale(fractionValue, actualPrecision, MAX_SHORT_PRECISION);
         return packDateTimeWithZone(epochSecond * MILLISECONDS_PER_SECOND + millisOfSecond, getTimeZoneKey(zone.getId()));
+    }
+
+    public static LongTimestampWithTimeZone toLong(int precision, Slice value, Function<String, ZoneId> zoneId)
+    {
+        checkArgument(precision > MAX_SHORT_PRECISION && precision <= MAX_PRECISION, "precision out of range");
+
+        PlainDateTime parsed = parsePlainDateTime(value);
+        if (parsed == null) {
+            return toLong(precision, value.toStringUtf8(), zoneId);
+        }
+
+        ZoneId zone;
+        long epochSecond;
+        try {
+            // the value carries no time zone, which is what the pattern based path reports as null
+            zone = zoneId.apply(null);
+            epochSecond = ZonedDateTime.of(parsed.year(), parsed.month(), parsed.day(), parsed.hour(), parsed.minute(), parsed.second(), 0, zone)
+                    .toEpochSecond();
+        }
+        catch (DateTimeException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
+        }
+
+        long fractionValue = parsed.fractionValue();
+        int actualPrecision = parsed.fractionPrecision();
+        if (actualPrecision > precision) {
+            fractionValue = round(fractionValue, actualPrecision - precision);
+        }
+
+        return longTimestampWithTimeZone(epochSecond, rescale(fractionValue, actualPrecision, MAX_PRECISION), zone);
     }
 
     public static LongTimestampWithTimeZone toLong(int precision, String value, Function<String, ZoneId> zoneId)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/DateAdd.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/DateAdd.java
@@ -14,8 +14,8 @@
 package io.trino.operator.scalar.timetz;
 
 import io.airlift.slice.Slice;
+import io.trino.operator.scalar.TimeField;
 import io.trino.operator.scalar.time.TimeOperators;
-import io.trino.spi.TrinoException;
 import io.trino.spi.function.Description;
 import io.trino.spi.function.LiteralParameter;
 import io.trino.spi.function.LiteralParameters;
@@ -24,7 +24,6 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.type.LongTimeWithTimeZone;
 import io.trino.spi.type.StandardTypes;
 
-import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.type.DateTimeEncoding.packTimeWithTimeZone;
 import static io.trino.spi.type.DateTimeEncoding.unpackOffsetMinutes;
 import static io.trino.spi.type.DateTimeEncoding.unpackTimeNanos;
@@ -39,7 +38,6 @@ import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.SECONDS_PER_DAY;
 import static io.trino.spi.type.Timestamps.round;
 import static io.trino.type.DateTimes.HOURS_PER_DAY;
-import static java.util.Locale.ENGLISH;
 import static org.joda.time.DateTimeConstants.MINUTES_PER_DAY;
 
 @Description("Add the specified amount of time to the given time")
@@ -80,13 +78,11 @@ public final class DateAdd
 
     private static long add(long picos, Slice unit, long value)
     {
-        String unitString = unit.toStringAscii().toLowerCase(ENGLISH);
-        long delta = switch (unitString) {
-            case "millisecond" -> (value % MILLISECONDS_PER_DAY) * PICOSECONDS_PER_MILLISECOND;
-            case "second" -> (value % SECONDS_PER_DAY) * PICOSECONDS_PER_SECOND;
-            case "minute" -> (value % MINUTES_PER_DAY) * PICOSECONDS_PER_MINUTE;
-            case "hour" -> (value % HOURS_PER_DAY) * PICOSECONDS_PER_HOUR;
-            default -> throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString + "' is not a valid TIME field");
+        long delta = switch (TimeField.match(unit)) {
+            case MILLISECOND -> (value % MILLISECONDS_PER_DAY) * PICOSECONDS_PER_MILLISECOND;
+            case SECOND -> (value % SECONDS_PER_DAY) * PICOSECONDS_PER_SECOND;
+            case MINUTE -> (value % MINUTES_PER_DAY) * PICOSECONDS_PER_MINUTE;
+            case HOUR -> (value % HOURS_PER_DAY) * PICOSECONDS_PER_HOUR;
         };
         return TimeOperators.add(picos, delta);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/DateDiff.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/DateDiff.java
@@ -14,7 +14,7 @@
 package io.trino.operator.scalar.timetz;
 
 import io.airlift.slice.Slice;
-import io.trino.spi.TrinoException;
+import io.trino.operator.scalar.TimeField;
 import io.trino.spi.function.Description;
 import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarFunction;
@@ -23,7 +23,6 @@ import io.trino.spi.type.LongTimeWithTimeZone;
 import io.trino.spi.type.StandardTypes;
 
 import static io.trino.operator.scalar.timetz.TimeWithTimeZoneOperators.normalize;
-import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MINUTE;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_SECOND;
@@ -32,7 +31,6 @@ import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MINUTE;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_SECOND;
 import static io.trino.type.DateTimes.NANOSECONDS_PER_HOUR;
-import static java.util.Locale.ENGLISH;
 
 @Description("Difference of the given times in the given unit")
 @ScalarFunction("date_diff")
@@ -48,13 +46,11 @@ public final class DateDiff
             @SqlType("time(p) with time zone") long right)
     {
         long nanos = normalize(right) - normalize(left);
-        String unitString = unit.toStringUtf8().toLowerCase(ENGLISH);
-        return switch (unitString) {
-            case "millisecond" -> nanos / NANOSECONDS_PER_MILLISECOND;
-            case "second" -> nanos / NANOSECONDS_PER_SECOND;
-            case "minute" -> nanos / NANOSECONDS_PER_MINUTE;
-            case "hour" -> nanos / NANOSECONDS_PER_HOUR;
-            default -> throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString + "' is not a valid TIME field");
+        return switch (TimeField.match(unit)) {
+            case MILLISECOND -> nanos / NANOSECONDS_PER_MILLISECOND;
+            case SECOND -> nanos / NANOSECONDS_PER_SECOND;
+            case MINUTE -> nanos / NANOSECONDS_PER_MINUTE;
+            case HOUR -> nanos / NANOSECONDS_PER_HOUR;
         };
     }
 
@@ -66,13 +62,11 @@ public final class DateDiff
             @SqlType("time(p) with time zone") LongTimeWithTimeZone right)
     {
         long picos = normalize(right) - normalize(left);
-        String unitString = unit.toStringUtf8().toLowerCase(ENGLISH);
-        return switch (unitString) {
-            case "millisecond" -> picos / PICOSECONDS_PER_MILLISECOND;
-            case "second" -> picos / PICOSECONDS_PER_SECOND;
-            case "minute" -> picos / PICOSECONDS_PER_MINUTE;
-            case "hour" -> picos / PICOSECONDS_PER_HOUR;
-            default -> throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString + "' is not a valid TIME field");
+        return switch (TimeField.match(unit)) {
+            case MILLISECOND -> picos / PICOSECONDS_PER_MILLISECOND;
+            case SECOND -> picos / PICOSECONDS_PER_SECOND;
+            case MINUTE -> picos / PICOSECONDS_PER_MINUTE;
+            case HOUR -> picos / PICOSECONDS_PER_HOUR;
         };
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/DateTrunc.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/DateTrunc.java
@@ -14,14 +14,13 @@
 package io.trino.operator.scalar.timetz;
 
 import io.airlift.slice.Slice;
-import io.trino.spi.TrinoException;
+import io.trino.operator.scalar.TimeField;
 import io.trino.spi.function.Description;
 import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.LongTimeWithTimeZone;
 
-import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.type.DateTimeEncoding.packTimeWithTimeZone;
 import static io.trino.spi.type.DateTimeEncoding.unpackOffsetMinutes;
 import static io.trino.spi.type.DateTimeEncoding.unpackTimeNanos;
@@ -30,7 +29,6 @@ import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MINUTE;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_SECOND;
-import static java.util.Locale.ENGLISH;
 
 @Description("Truncate to the specified precision")
 @ScalarFunction("date_trunc")
@@ -59,14 +57,11 @@ public final class DateTrunc
 
     private static long truncate(long picos, Slice unit)
     {
-        String unitString = unit.toStringUtf8().toLowerCase(ENGLISH);
-
-        return switch (unitString) {
-            case "millisecond" -> picos / PICOSECONDS_PER_MILLISECOND * PICOSECONDS_PER_MILLISECOND;
-            case "second" -> picos / PICOSECONDS_PER_SECOND * PICOSECONDS_PER_SECOND;
-            case "minute" -> picos / PICOSECONDS_PER_MINUTE * PICOSECONDS_PER_MINUTE;
-            case "hour" -> picos / PICOSECONDS_PER_HOUR * PICOSECONDS_PER_HOUR;
-            default -> throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString + "' is not a valid TIME field");
+        return switch (TimeField.match(unit)) {
+            case MILLISECOND -> picos / PICOSECONDS_PER_MILLISECOND * PICOSECONDS_PER_MILLISECOND;
+            case SECOND -> picos / PICOSECONDS_PER_SECOND * PICOSECONDS_PER_SECOND;
+            case MINUTE -> picos / PICOSECONDS_PER_MINUTE * PICOSECONDS_PER_MINUTE;
+            case HOUR -> picos / PICOSECONDS_PER_HOUR * PICOSECONDS_PER_HOUR;
         };
     }
 }

--- a/core/trino-main/src/main/java/io/trino/type/BigintOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/BigintOperators.java
@@ -27,7 +27,8 @@ import io.trino.spi.type.TrinoNumber;
 
 import java.math.BigDecimal;
 
-import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.base.util.NumberFormatter.decimalLength;
+import static io.trino.plugin.base.util.NumberFormatter.formatLong;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
@@ -218,11 +219,9 @@ public final class BigintOperators
     @SqlType("varchar(x)")
     public static Slice castToVarchar(@LiteralParameter("x") long x, @SqlType(StandardTypes.BIGINT) long value)
     {
-        // todo optimize me
-        String stringValue = String.valueOf(value);
-        // String is all-ASCII, so String.length() here returns actual code points count
-        if (stringValue.length() <= x) {
-            return utf8Slice(stringValue);
+        // the rendering is all ASCII, so its length in bytes is also its length in code points
+        if (decimalLength(value) <= x) {
+            return formatLong(value);
         }
 
         throw new TrinoException(INVALID_CAST_ARGUMENT, format("Value %s cannot be represented as varchar(%s)", value, x));

--- a/core/trino-main/src/main/java/io/trino/type/CharOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/CharOperators.java
@@ -80,7 +80,7 @@ public final class CharOperators
     public static long castToBigint(@SqlType("char(x)") Slice slice)
     {
         try {
-            return NumberParser.parseLong(slice, 0, slice.length());
+            return NumberParser.parseTrimmedLong(slice, 0, slice.length());
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to BIGINT", slice.toStringUtf8()));
@@ -94,7 +94,7 @@ public final class CharOperators
     public static long castToInteger(@SqlType("char(x)") Slice slice)
     {
         try {
-            return toIntExact(NumberParser.parseLong(slice, 0, slice.length()));
+            return toIntExact(NumberParser.parseTrimmedLong(slice, 0, slice.length()));
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to INT", slice.toStringUtf8()));
@@ -108,7 +108,7 @@ public final class CharOperators
     public static long castToSmallint(@SqlType("char(x)") Slice slice)
     {
         try {
-            return toShortExact(NumberParser.parseLong(slice, 0, slice.length()));
+            return toShortExact(NumberParser.parseTrimmedLong(slice, 0, slice.length()));
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to SMALLINT", slice.toStringUtf8()));
@@ -122,7 +122,7 @@ public final class CharOperators
     public static long castToTinyint(@SqlType("char(x)") Slice slice)
     {
         try {
-            return toByteExact(NumberParser.parseLong(slice, 0, slice.length()));
+            return toByteExact(NumberParser.parseTrimmedLong(slice, 0, slice.length()));
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to TINYINT", slice.toStringUtf8()));

--- a/core/trino-main/src/main/java/io/trino/type/CharOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/CharOperators.java
@@ -80,7 +80,7 @@ public final class CharOperators
     public static long castToBigint(@SqlType("char(x)") Slice slice)
     {
         try {
-            return Long.parseLong(slice.toStringUtf8().trim());
+            return NumberParser.parseLong(slice, 0, slice.length());
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to BIGINT", slice.toStringUtf8()));
@@ -94,7 +94,7 @@ public final class CharOperators
     public static long castToInteger(@SqlType("char(x)") Slice slice)
     {
         try {
-            return Integer.parseInt(slice.toStringUtf8().trim());
+            return toIntExact(NumberParser.parseLong(slice, 0, slice.length()));
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to INT", slice.toStringUtf8()));
@@ -108,7 +108,7 @@ public final class CharOperators
     public static long castToSmallint(@SqlType("char(x)") Slice slice)
     {
         try {
-            return Short.parseShort(slice.toStringUtf8().trim());
+            return toShortExact(NumberParser.parseLong(slice, 0, slice.length()));
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to SMALLINT", slice.toStringUtf8()));
@@ -122,7 +122,7 @@ public final class CharOperators
     public static long castToTinyint(@SqlType("char(x)") Slice slice)
     {
         try {
-            return Byte.parseByte(slice.toStringUtf8().trim());
+            return toByteExact(NumberParser.parseLong(slice, 0, slice.length()));
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to TINYINT", slice.toStringUtf8()));
@@ -155,5 +155,21 @@ public final class CharOperators
     public static Slice castToBinary(@LiteralParameter("x") long x, @SqlType("char(x)") Slice slice)
     {
         return padSpaces(slice, toIntExact(x));
+    }
+
+    private static long toShortExact(long value)
+    {
+        if (value != (short) value) {
+            throw new ArithmeticException("short overflow");
+        }
+        return value;
+    }
+
+    private static long toByteExact(long value)
+    {
+        if (value != (byte) value) {
+            throw new ArithmeticException("byte overflow");
+        }
+        return value;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/type/DateOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DateOperators.java
@@ -62,7 +62,7 @@ public final class DateOperators
         // Note: update DomainTranslator.Visitor.createVarcharCastToDateComparisonExtractionResult whenever CAST behavior changes.
 
         try {
-            return parseDate(trim(value).toStringUtf8());
+            return parseDate(trim(value));
         }
         catch (IllegalArgumentException | ArithmeticException | DateTimeException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to date: " + value.toStringUtf8(), e);
@@ -76,7 +76,7 @@ public final class DateOperators
     public static long castFromChar(@SqlType("char(x)") Slice value)
     {
         try {
-            return parseDate(trim(value).toStringUtf8());
+            return parseDate(trim(value));
         }
         catch (IllegalArgumentException | ArithmeticException | DateTimeException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to date: " + value.toStringUtf8(), e);

--- a/core/trino-main/src/main/java/io/trino/type/DateTimes.java
+++ b/core/trino-main/src/main/java/io/trino/type/DateTimes.java
@@ -13,6 +13,7 @@
  */
 package io.trino.type;
 
+import io.airlift.slice.Slice;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.DateTimeEncoding;
 import io.trino.spi.type.LongTimeWithTimeZone;
@@ -55,6 +56,7 @@ import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.round;
 import static io.trino.spi.type.Timestamps.roundDiv;
 import static java.lang.Math.floorMod;
+import static java.lang.Math.min;
 import static java.lang.Math.multiplyExact;
 import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
@@ -67,6 +69,161 @@ public final class DateTimes
                     "\\s*(?<timezone>.+)?)?");
     private static final String TIMESTAMP_FORMATTER_PATTERN = "uuuu-MM-dd HH:mm:ss";
     private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern(TIMESTAMP_FORMATTER_PATTERN);
+
+    /**
+     * The fields of a date and time with no time zone, read straight from the bytes.
+     * <p>
+     * The fields are not validated, exactly as {@link #DATETIME_PATTERN} does not validate the groups
+     * it captures. The caller reports an invalid date the way it always has, when it builds the date
+     * and time from them.
+     */
+    public record PlainDateTime(int year, int month, int day, int hour, int minute, int second, long fractionValue, int fractionPrecision) {}
+
+    /**
+     * Parses {@code yyyy-MM-dd[ HH:mm[:ss[.fraction]]]}, the shape a timestamp almost always has,
+     * straight from the bytes.
+     * <p>
+     * Returns null for everything else, including a signed year, a time zone, and any spacing the
+     * shape above does not cover, so that the caller falls back to {@link #DATETIME_PATTERN}, which
+     * accepts all of it.
+     */
+    public static PlainDateTime parsePlainDateTime(Slice value)
+    {
+        int length = value.length();
+        int index = 0;
+
+        int yearEnd = digitsEnd(value, index, length);
+        int yearDigits = yearEnd - index;
+        // the pattern accepts any number of year digits, but more than nine cannot be a year
+        if (yearDigits < 4 || yearDigits > 9) {
+            return null;
+        }
+        int year = parseDigits(value, index, yearEnd);
+        index = yearEnd;
+
+        if (index == length || value.getByte(index) != '-') {
+            return null;
+        }
+        index++;
+
+        int monthEnd = digitsEnd(value, index, min(index + 2, length));
+        if (monthEnd == index) {
+            return null;
+        }
+        int month = parseDigits(value, index, monthEnd);
+        index = monthEnd;
+
+        if (index == length || value.getByte(index) != '-') {
+            return null;
+        }
+        index++;
+
+        int dayEnd = digitsEnd(value, index, min(index + 2, length));
+        if (dayEnd == index) {
+            return null;
+        }
+        int day = parseDigits(value, index, dayEnd);
+        index = dayEnd;
+
+        int hour = 0;
+        int minute = 0;
+        int second = 0;
+        long fractionValue = 0;
+        int fractionPrecision = 0;
+
+        if (index != length) {
+            if (value.getByte(index) != ' ') {
+                return null;
+            }
+            index++;
+
+            int hourEnd = digitsEnd(value, index, min(index + 2, length));
+            if (hourEnd == index) {
+                return null;
+            }
+            hour = parseDigits(value, index, hourEnd);
+            index = hourEnd;
+
+            if (index == length || value.getByte(index) != ':') {
+                return null;
+            }
+            index++;
+
+            int minuteEnd = digitsEnd(value, index, min(index + 2, length));
+            if (minuteEnd == index) {
+                return null;
+            }
+            minute = parseDigits(value, index, minuteEnd);
+            index = minuteEnd;
+
+            if (index != length) {
+                if (value.getByte(index) != ':') {
+                    return null;
+                }
+                index++;
+
+                int secondEnd = digitsEnd(value, index, min(index + 2, length));
+                if (secondEnd == index) {
+                    return null;
+                }
+                second = parseDigits(value, index, secondEnd);
+                index = secondEnd;
+
+                if (index != length) {
+                    if (value.getByte(index) != '.') {
+                        return null;
+                    }
+                    index++;
+
+                    int fractionEnd = digitsEnd(value, index, length);
+                    // anything left over is a time zone, which the pattern handles
+                    if (fractionEnd == index || fractionEnd != length) {
+                        return null;
+                    }
+                    fractionPrecision = fractionEnd - index;
+                    // the pattern based path parses the fraction with Long.parseLong, which overflows past this
+                    if (fractionPrecision > 18) {
+                        return null;
+                    }
+                    fractionValue = parseLongDigits(value, index, fractionEnd);
+                }
+            }
+        }
+
+        return new PlainDateTime(year, month, day, hour, minute, second, fractionValue, fractionPrecision);
+    }
+
+    private static int digitsEnd(Slice value, int start, int end)
+    {
+        int index = start;
+        while (index < end && isDigit(value.getByte(index))) {
+            index++;
+        }
+        return index;
+    }
+
+    private static boolean isDigit(byte value)
+    {
+        return value >= '0' && value <= '9';
+    }
+
+    private static int parseDigits(Slice value, int start, int end)
+    {
+        int result = 0;
+        for (int index = start; index < end; index++) {
+            result = (result * 10) + (value.getByte(index) - '0');
+        }
+        return result;
+    }
+
+    private static long parseLongDigits(Slice value, int start, int end)
+    {
+        long result = 0;
+        for (int index = start; index < end; index++) {
+            result = (result * 10) + (value.getByte(index) - '0');
+        }
+        return result;
+    }
 
     public static final Pattern TIME_PATTERN = Pattern.compile(
             "(?<hour>\\d{1,2}):(?<minute>\\d{1,2})(?::(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?)?" +

--- a/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
@@ -47,6 +47,9 @@ import java.util.function.Predicate;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.base.util.NumberParser.NOT_SHORT_DECIMAL;
+import static io.trino.plugin.base.util.NumberParser.longPowerOfTen;
+import static io.trino.plugin.base.util.NumberParser.parseShortDecimal;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
@@ -611,10 +614,22 @@ public final class DecimalCasts
     @UsedByGeneratedCode
     public static long varcharToShortDecimal(Slice value, long precision, long scale, long tenToScale)
     {
+        int intScale = DecimalConversions.intScale(scale);
+
+        long unscaled = parseShortDecimal(value, 0, value.length(), intScale);
+        if (unscaled != NOT_SHORT_DECIMAL) {
+            // a short decimal has a precision of at most 18, so the bound always fits in a long
+            long bound = longPowerOfTen((int) precision);
+            if (unscaled <= -bound || unscaled >= bound) {
+                throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast VARCHAR '%s' to DECIMAL(%s, %s). Value too large.", value.toStringUtf8(), precision, scale));
+            }
+            return unscaled;
+        }
+
         BigDecimal result;
         String stringValue = value.toString(UTF_8);
         try {
-            result = new BigDecimal(stringValue).setScale(DecimalConversions.intScale(scale), HALF_UP);
+            result = new BigDecimal(stringValue).setScale(intScale, HALF_UP);
         }
         catch (NumberFormatException e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast VARCHAR '%s' to DECIMAL(%s, %s). Value is not a number.", stringValue, precision, scale));

--- a/core/trino-main/src/main/java/io/trino/type/IntegerOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/IntegerOperators.java
@@ -26,7 +26,8 @@ import io.trino.spi.type.TrinoNumber;
 
 import java.math.BigDecimal;
 
-import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.base.util.NumberFormatter.decimalLength;
+import static io.trino.plugin.base.util.NumberFormatter.formatLong;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
@@ -193,11 +194,9 @@ public final class IntegerOperators
     @SqlType("varchar(x)")
     public static Slice castToVarchar(@LiteralParameter("x") long x, @SqlType(StandardTypes.INTEGER) long value)
     {
-        // todo optimize me
-        String stringValue = String.valueOf(value);
-        // String is all-ASCII, so String.length() here returns actual code points count
-        if (stringValue.length() <= x) {
-            return utf8Slice(stringValue);
+        // the rendering is all ASCII, so its length in bytes is also its length in code points
+        if (decimalLength(value) <= x) {
+            return formatLong(value);
         }
 
         throw new TrinoException(INVALID_CAST_ARGUMENT, format("Value %s cannot be represented as varchar(%s)", value, x));

--- a/core/trino-main/src/main/java/io/trino/type/SmallintOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/SmallintOperators.java
@@ -25,7 +25,8 @@ import io.trino.spi.type.TrinoNumber;
 
 import java.math.BigDecimal;
 
-import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.base.util.NumberFormatter.decimalLength;
+import static io.trino.plugin.base.util.NumberFormatter.formatLong;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
@@ -183,11 +184,9 @@ public final class SmallintOperators
     @SqlType("varchar(x)")
     public static Slice castToVarchar(@LiteralParameter("x") long x, @SqlType(StandardTypes.SMALLINT) long value)
     {
-        // todo optimize me
-        String stringValue = String.valueOf(value);
-        // String is all-ASCII, so String.length() here returns actual code points count
-        if (stringValue.length() <= x) {
-            return utf8Slice(stringValue);
+        // the rendering is all ASCII, so its length in bytes is also its length in code points
+        if (decimalLength(value) <= x) {
+            return formatLong(value);
         }
 
         throw new TrinoException(INVALID_CAST_ARGUMENT, format("Value %s cannot be represented as varchar(%s)", value, x));

--- a/core/trino-main/src/main/java/io/trino/type/TinyintOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/TinyintOperators.java
@@ -24,7 +24,8 @@ import io.trino.spi.type.TrinoNumber;
 
 import java.math.BigDecimal;
 
-import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.base.util.NumberFormatter.decimalLength;
+import static io.trino.plugin.base.util.NumberFormatter.formatLong;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
@@ -176,11 +177,9 @@ public final class TinyintOperators
     @SqlType("varchar(x)")
     public static Slice castToVarchar(@LiteralParameter("x") long x, @SqlType(StandardTypes.TINYINT) long value)
     {
-        // todo optimize me
-        String stringValue = String.valueOf(value);
-        // String is all-ASCII, so String.length() here returns actual code points count
-        if (stringValue.length() <= x) {
-            return utf8Slice(stringValue);
+        // the rendering is all ASCII, so its length in bytes is also its length in code points
+        if (decimalLength(value) <= x) {
+            return formatLong(value);
         }
 
         throw new TrinoException(INVALID_CAST_ARGUMENT, format("Value %s cannot be represented as varchar(%s)", value, x));

--- a/core/trino-main/src/main/java/io/trino/type/VarcharOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/VarcharOperators.java
@@ -112,7 +112,7 @@ public final class VarcharOperators
     public static long castToBigint(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return NumberParser.parseLong(slice, 0, slice.length());
+            return NumberParser.parseTrimmedLong(slice, 0, slice.length());
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to BIGINT", slice.toStringUtf8()));
@@ -126,7 +126,7 @@ public final class VarcharOperators
     public static long castToInteger(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return toIntExact(NumberParser.parseLong(slice, 0, slice.length()));
+            return toIntExact(NumberParser.parseTrimmedLong(slice, 0, slice.length()));
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to INT", slice.toStringUtf8()));
@@ -140,7 +140,7 @@ public final class VarcharOperators
     public static long castToSmallint(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return toShortExact(NumberParser.parseLong(slice, 0, slice.length()));
+            return toShortExact(NumberParser.parseTrimmedLong(slice, 0, slice.length()));
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to SMALLINT", slice.toStringUtf8()));
@@ -154,7 +154,7 @@ public final class VarcharOperators
     public static long castToTinyint(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return toByteExact(NumberParser.parseLong(slice, 0, slice.length()));
+            return toByteExact(NumberParser.parseTrimmedLong(slice, 0, slice.length()));
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to TINYINT", slice.toStringUtf8()));

--- a/core/trino-main/src/main/java/io/trino/type/VarcharOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/VarcharOperators.java
@@ -27,6 +27,7 @@ import java.math.BigDecimal;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.type.Reals.toReal;
+import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 
 public final class VarcharOperators
@@ -111,7 +112,7 @@ public final class VarcharOperators
     public static long castToBigint(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return Long.parseLong(slice.toStringUtf8().trim());
+            return NumberParser.parseLong(slice, 0, slice.length());
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to BIGINT", slice.toStringUtf8()));
@@ -125,7 +126,7 @@ public final class VarcharOperators
     public static long castToInteger(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return Integer.parseInt(slice.toStringUtf8().trim());
+            return toIntExact(NumberParser.parseLong(slice, 0, slice.length()));
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to INT", slice.toStringUtf8()));
@@ -139,7 +140,7 @@ public final class VarcharOperators
     public static long castToSmallint(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return Short.parseShort(slice.toStringUtf8().trim());
+            return toShortExact(NumberParser.parseLong(slice, 0, slice.length()));
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to SMALLINT", slice.toStringUtf8()));
@@ -153,7 +154,7 @@ public final class VarcharOperators
     public static long castToTinyint(@SqlType("varchar(x)") Slice slice)
     {
         try {
-            return Byte.parseByte(slice.toStringUtf8().trim());
+            return toByteExact(NumberParser.parseLong(slice, 0, slice.length()));
         }
         catch (Exception e) {
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to TINYINT", slice.toStringUtf8()));
@@ -187,5 +188,21 @@ public final class VarcharOperators
     public static Slice castToBinary(@SqlType("varchar(x)") Slice slice)
     {
         return slice;
+    }
+
+    private static long toShortExact(long value)
+    {
+        if (value != (short) value) {
+            throw new ArithmeticException("short overflow");
+        }
+        return value;
+    }
+
+    private static long toByteExact(long value)
+    {
+        if (value != (byte) value) {
+            throw new ArithmeticException("byte overflow");
+        }
+        return value;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
@@ -14,6 +14,7 @@
 package io.trino.util;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.Slice;
 import io.trino.client.IntervalDayTime;
 import io.trino.client.IntervalYearMonth;
 import io.trino.spi.TrinoException;
@@ -63,7 +64,7 @@ public final class DateTimeUtils
 
     private static final DateTimeFormatter DATE_FORMATTER = ISODateTimeFormat.date().withZoneUTC();
 
-    public static int parseDate(String value)
+    public static int parseDate(Slice value)
     {
         // Note: update DomainTranslator.Visitor.createVarcharCastToDateComparisonExtractionResult whenever varchar->date conversion (CAST) behavior changes.
 
@@ -76,7 +77,8 @@ public final class DateTimeUtils
         if (days.isPresent()) {
             return days.getAsInt();
         }
-        return toIntExact(TimeUnit.MILLISECONDS.toDays(DATE_FORMATTER.parseMillis(value)));
+        // only the fallback formatter needs the value as a String
+        return toIntExact(TimeUnit.MILLISECONDS.toDays(DATE_FORMATTER.parseMillis(value.toStringUtf8())));
     }
 
     /**
@@ -86,9 +88,10 @@ public final class DateTimeUtils
      * @throws DateTimeException when value matches the expected format but is invalid (month or day number out of range)
      */
     @VisibleForTesting
-    static OptionalInt parseIfIso8601DateFormat(String value)
+    static OptionalInt parseIfIso8601DateFormat(Slice value)
     {
-        if (value.length() != 10 || value.charAt(4) != '-' || value.charAt(7) != '-') {
+        // the format is all ASCII, so a byte length of ten is also a length of ten characters
+        if (value.length() != 10 || value.getByte(4) != '-' || value.getByte(7) != '-') {
             return OptionalInt.empty();
         }
 
@@ -116,13 +119,13 @@ public final class DateTimeUtils
      *
      * @return parsed value or empty if any non digit found
      */
-    private static OptionalInt parseIntSimple(String input, int offset, int length)
+    private static OptionalInt parseIntSimple(Slice input, int offset, int length)
     {
         checkArgument(length > 0, "Invalid length %s", length);
 
         int result = 0;
         for (int i = 0; i < length; i++) {
-            int digit = input.charAt(offset + i) - '0';
+            int digit = input.getByte(offset + i) - '0';
             if (digit < 0 || digit > 9) {
                 return OptionalInt.empty();
             }

--- a/core/trino-main/src/test/java/io/trino/json/TestJsonDateTimeTemplate.java
+++ b/core/trino-main/src/test/java/io/trino/json/TestJsonDateTimeTemplate.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.DateTimeException;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
 import static io.trino.spi.type.TimestampType.createTimestampType;
@@ -44,7 +45,7 @@ public class TestJsonDateTimeTemplate
     public void testParseValue()
     {
         TypedValue date = JsonDateTimeTemplate.parse("YYYY-MM-DD").parseValue("2024-01-02");
-        assertThat(date).isEqualTo(new TypedValue(DATE, (long) parseDate("2024-01-02")));
+        assertThat(date).isEqualTo(new TypedValue(DATE, (long) parseDate(utf8Slice("2024-01-02"))));
 
         TypedValue timeWithTimeZone = JsonDateTimeTemplate.parse("HH24:MI:SS.FF3TZH:TZM").parseValue("12:34:56.789+05:30");
         assertThat(timeWithTimeZone).isEqualTo(TypedValue.fromValueAsObject(createTimeWithTimeZoneType(3), parseTimeWithTimeZone(3, "12:34:56.789 +05:30")));
@@ -147,24 +148,24 @@ public class TestJsonDateTimeTemplate
         // Templates that specify only the low-order year digits take the remaining digits from a
         // fixed reference year of 1970, so the result does not depend on the current date.
         assertThat(JsonDateTimeTemplate.parse("Y-MM-DD").parseValue("4-01-02"))
-                .isEqualTo(new TypedValue(DATE, (long) parseDate("1974-01-02")));
+                .isEqualTo(new TypedValue(DATE, (long) parseDate(utf8Slice("1974-01-02"))));
         assertThat(JsonDateTimeTemplate.parse("YY-MM-DD").parseValue("24-01-02"))
-                .isEqualTo(new TypedValue(DATE, (long) parseDate("1924-01-02")));
+                .isEqualTo(new TypedValue(DATE, (long) parseDate(utf8Slice("1924-01-02"))));
         assertThat(JsonDateTimeTemplate.parse("YYY-MM-DD").parseValue("024-01-02"))
-                .isEqualTo(new TypedValue(DATE, (long) parseDate("1024-01-02")));
+                .isEqualTo(new TypedValue(DATE, (long) parseDate(utf8Slice("1024-01-02"))));
         assertThat(JsonDateTimeTemplate.parse("YYYY-MM-DD").parseValue("0024-01-02"))
-                .isEqualTo(new TypedValue(DATE, (long) parseDate("0024-01-02")));
+                .isEqualTo(new TypedValue(DATE, (long) parseDate(utf8Slice("0024-01-02"))));
 
         // RR rounds to the nearest century instead: with a reference year of 1970, values below 50
         // belong to the next century and values from 50 up to the current one.
         assertThat(JsonDateTimeTemplate.parse("RR-MM-DD").parseValue("24-01-02"))
-                .isEqualTo(new TypedValue(DATE, (long) parseDate("2024-01-02")));
+                .isEqualTo(new TypedValue(DATE, (long) parseDate(utf8Slice("2024-01-02"))));
         assertThat(JsonDateTimeTemplate.parse("RR-MM-DD").parseValue("74-01-02"))
-                .isEqualTo(new TypedValue(DATE, (long) parseDate("1974-01-02")));
+                .isEqualTo(new TypedValue(DATE, (long) parseDate(utf8Slice("1974-01-02"))));
 
         // RRRR is fully specified, so there is nothing to round.
         assertThat(JsonDateTimeTemplate.parse("RRRR-MM-DD").parseValue("2024-01-02"))
-                .isEqualTo(new TypedValue(DATE, (long) parseDate("2024-01-02")));
+                .isEqualTo(new TypedValue(DATE, (long) parseDate(utf8Slice("2024-01-02"))));
     }
 
     @Test
@@ -277,7 +278,7 @@ public class TestJsonDateTimeTemplate
         // the quoted text is verbatim) and must be accepted.
         TypedValue timestamp = JsonDateTimeTemplate.parse("YYYY-\"Q\"MM-DD")
                 .parseValue("2024-Q01-02");
-        assertThat(timestamp).isEqualTo(new TypedValue(DATE, (long) parseDate("2024-01-02")));
+        assertThat(timestamp).isEqualTo(new TypedValue(DATE, (long) parseDate(utf8Slice("2024-01-02"))));
 
         // Two adjacent DELIMITER characters remain rejected — that combination is ambiguous.
         assertThatThrownBy(() -> JsonDateTimeTemplate.parse("YYYY--MM"))

--- a/core/trino-main/src/test/java/io/trino/json/TestJsonPathEvaluator.java
+++ b/core/trino-main/src/test/java/io/trino/json/TestJsonPathEvaluator.java
@@ -538,7 +538,7 @@ public class TestJsonPathEvaluator
         assertThat(pathResult(
                 TextNode.valueOf("2024-01-02"),
                 path(true, new IrDatetimeMethod(contextVariable(), Optional.empty(), Optional.empty()))))
-                .isEqualTo(singletonSequence(new TypedValue(DATE, (long) parseDate("2024-01-02"))));
+                .isEqualTo(singletonSequence(new TypedValue(DATE, (long) parseDate(utf8Slice("2024-01-02")))));
 
         // text item: TIME shape
         assertThat(pathResult(
@@ -575,8 +575,8 @@ public class TestJsonPathEvaluator
                 new ArrayNode(JsonNodeFactory.instance, ImmutableList.of(TextNode.valueOf("2024-01-02"), TextNode.valueOf("2024-01-03"))),
                 path(true, new IrDatetimeMethod(contextVariable(), Optional.empty(), Optional.empty()))))
                 .isEqualTo(sequence(
-                        new TypedValue(DATE, (long) parseDate("2024-01-02")),
-                        new TypedValue(DATE, (long) parseDate("2024-01-03"))));
+                        new TypedValue(DATE, (long) parseDate(utf8Slice("2024-01-02"))),
+                        new TypedValue(DATE, (long) parseDate(utf8Slice("2024-01-03")))));
 
         // in strict mode the array is not unwrapped, so it is not a text item
         assertThatThrownBy(() -> evaluate(
@@ -617,7 +617,7 @@ public class TestJsonPathEvaluator
         assertThat(pathResult(
                 TextNode.valueOf("01/02/2024"),
                 path(true, datetimeMethod("MM/DD/YYYY"))))
-                .isEqualTo(singletonSequence(new TypedValue(DATE, (long) parseDate("2024-01-02"))));
+                .isEqualTo(singletonSequence(new TypedValue(DATE, (long) parseDate(utf8Slice("2024-01-02")))));
 
         assertThat(pathResult(
                 TextNode.valueOf("2024-01-02 12:34:56.789"),
@@ -634,15 +634,15 @@ public class TestJsonPathEvaluator
         assertThat(pathResult(
                 TextNode.valueOf("24-01-02"),
                 path(true, datetimeMethod("RR-MM-DD"))))
-                .isEqualTo(singletonSequence(new TypedValue(DATE, (long) parseDate("2024-01-02"))));
+                .isEqualTo(singletonSequence(new TypedValue(DATE, (long) parseDate(utf8Slice("2024-01-02")))));
 
         // multiple inputs -- array is automatically unwrapped in lax mode
         assertThat(pathResult(
                 new ArrayNode(JsonNodeFactory.instance, ImmutableList.of(TextNode.valueOf("01/02/2024"), TextNode.valueOf("01/03/2024"))),
                 path(true, datetimeMethod("MM/DD/YYYY"))))
                 .isEqualTo(sequence(
-                        new TypedValue(DATE, (long) parseDate("2024-01-02")),
-                        new TypedValue(DATE, (long) parseDate("2024-01-03"))));
+                        new TypedValue(DATE, (long) parseDate(utf8Slice("2024-01-02"))),
+                        new TypedValue(DATE, (long) parseDate(utf8Slice("2024-01-03")))));
 
         // the value does not match the template
         assertThatThrownBy(() -> evaluate(

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkRegexpFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkRegexpFunctions.java
@@ -60,6 +60,24 @@ public class BenchmarkRegexpFunctions
         return Re2JRegexpFunctions.regexpLike(data.getSource(), data.getRe2JPattern());
     }
 
+    @Benchmark
+    public Slice benchmarkReplaceJoni(DotStarAroundData data)
+    {
+        return JoniRegexpFunctions.regexpReplace(data.getSource(), data.getJoniPattern(), Slices.EMPTY_SLICE);
+    }
+
+    @Benchmark
+    public long benchmarkCountJoni(DotStarAroundData data)
+    {
+        return JoniRegexpFunctions.regexpCount(data.getSource(), data.getJoniPattern());
+    }
+
+    @Benchmark
+    public Slice benchmarkExtractJoni(DotStarAroundData data)
+    {
+        return JoniRegexpFunctions.regexpExtract(data.getSource(), data.getJoniPattern());
+    }
+
     @State(Thread)
     public static class DotStarAroundData
     {

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestJoniRegexpFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestJoniRegexpFunctions.java
@@ -14,16 +14,28 @@
 package io.trino.operator.scalar;
 
 import com.google.common.io.Resources;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.type.JoniRegexp;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.operator.scalar.JoniRegexpCasts.joniRegexp;
+import static io.trino.operator.scalar.JoniRegexpFunctions.regexpCount;
+import static io.trino.operator.scalar.JoniRegexpFunctions.regexpExtract;
+import static io.trino.operator.scalar.JoniRegexpFunctions.regexpExtractAll;
+import static io.trino.operator.scalar.JoniRegexpFunctions.regexpLike;
+import static io.trino.operator.scalar.JoniRegexpFunctions.regexpPosition;
 import static io.trino.operator.scalar.JoniRegexpFunctions.regexpReplace;
+import static io.trino.operator.scalar.JoniRegexpFunctions.regexpSplit;
 import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.analyzer.RegexLibrary.JONI;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +46,79 @@ public class TestJoniRegexpFunctions
     public TestJoniRegexpFunctions()
     {
         super(JONI);
+    }
+
+    @Test
+    public void testSliceWithNonZeroOffset()
+    {
+        // A slice read out of a block is a view into a shared buffer, so its byteArrayOffset is not
+        // zero. Joni takes the search bounds as offsets into that buffer, but reports match positions
+        // relative to the start of the source, and mixing the two up silently returns wrong values.
+        // A literal produces a slice at offset zero, where the two are the same and the mistake is
+        // invisible, so match against slices at a non zero offset too.
+        for (String value : new String[] {"", "a", "abc", "abcabc", "aXbXc", "123abc456", "über 42 straße", "aaaaaaaaaaaaaaaa"}) {
+            for (String pattern : new String[] {"a", "[0-9]+", "(a)(b)", "X", "", "a+", "(?<name>b)"}) {
+                assertSameAtAnyOffset(value, pattern);
+            }
+        }
+    }
+
+    private static void assertSameAtAnyOffset(String value, String pattern)
+    {
+        Slice plain = utf8Slice(value);
+        Slice shifted = sliceAtNonZeroOffset(value);
+        JoniRegexp regex = joniRegexp(utf8Slice(pattern));
+
+        String context = "value='%s' pattern='%s'".formatted(value, pattern);
+        if (!value.isEmpty()) {
+            // an empty slice is shared and always sits at offset zero, so only assert this for the rest
+            assertThat(shifted.byteArrayOffset()).describedAs(context).isPositive();
+        }
+        assertThat(shifted).describedAs(context).isEqualTo(plain);
+
+        assertThat(regexpLike(shifted, regex))
+                .describedAs("regexpLike %s", context)
+                .isEqualTo(regexpLike(plain, regex));
+        assertThat(regexpCount(shifted, regex))
+                .describedAs("regexpCount %s", context)
+                .isEqualTo(regexpCount(plain, regex));
+        assertThat(regexpPosition(shifted, regex))
+                .describedAs("regexpPosition %s", context)
+                .isEqualTo(regexpPosition(plain, regex));
+        assertThat(regexpExtract(shifted, regex))
+                .describedAs("regexpExtract %s", context)
+                .isEqualTo(regexpExtract(plain, regex));
+        assertThat(regexpReplace(shifted, regex, utf8Slice("<$0>")))
+                .describedAs("regexpReplace %s", context)
+                .isEqualTo(regexpReplace(plain, regex, utf8Slice("<$0>")));
+        assertBlockEquals(regexpSplit(shifted, regex), regexpSplit(plain, regex), "regexpSplit " + context);
+        assertBlockEquals(regexpExtractAll(shifted, regex), regexpExtractAll(plain, regex), "regexpExtractAll " + context);
+    }
+
+    private static void assertBlockEquals(Block actual, Block expected, String context)
+    {
+        assertThat(actual.getPositionCount()).describedAs(context).isEqualTo(expected.getPositionCount());
+        for (int position = 0; position < expected.getPositionCount(); position++) {
+            assertThat(actual.isNull(position)).describedAs(context).isEqualTo(expected.isNull(position));
+            if (!expected.isNull(position)) {
+                assertThat(VARCHAR.getSlice(actual, position))
+                        .describedAs("%s position %s", context, position)
+                        .isEqualTo(VARCHAR.getSlice(expected, position));
+            }
+        }
+    }
+
+    /**
+     * Returns a slice holding {@code value} that starts part way into its backing array, the way a
+     * slice read out of a block does.
+     */
+    private static Slice sliceAtNonZeroOffset(String value)
+    {
+        byte[] bytes = value.getBytes(UTF_8);
+        byte[] padded = new byte[bytes.length + 8];
+        Arrays.fill(padded, (byte) '#');
+        System.arraycopy(bytes, 0, padded, 5, bytes.length);
+        return Slices.wrappedBuffer(padded, 5, bytes.length);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestVarcharToTimestampCast.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestVarcharToTimestampCast.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.timestamp;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.type.LongTimestamp;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The cast reads {@code yyyy-MM-dd[ HH:mm[:ss[.fraction]]]} straight from the bytes, and falls back
+ * to the general pattern for everything else. The pattern based path is unchanged, so it is the
+ * oracle: for every value the two must agree, on the result and on the failure.
+ */
+public class TestVarcharToTimestampCast
+{
+    private static final String[] VALUES = {
+            // the shape the byte parser handles
+            "2020-01-01",
+            "2020-1-1",
+            "2020-01-01 12:34",
+            "2020-01-01 12:34:56",
+            "2020-01-01 1:2:3",
+            "2020-01-01 12:34:56.1",
+            "2020-01-01 12:34:56.123",
+            "2020-01-01 12:34:56.123456",
+            "2020-01-01 12:34:56.123456789",
+            "2020-01-01 12:34:56.123456789012",
+            // rounding of a fraction longer than the precision
+            "2020-01-01 12:34:56.9999999",
+            "2020-01-01 12:34:56.5",
+            "1970-01-01 00:00:00",
+            "1969-12-31 23:59:59.999999",
+            "0001-01-01 00:00:00",
+            "99999-01-01",
+            "999999999-12-31",
+            // leap day
+            "2020-02-29 00:00:00",
+            // a fraction long enough to overflow the pattern based path's Long.parseLong
+            "2020-01-01 12:34:56.1234567890123456789012",
+
+            // shapes the byte parser must hand back to the pattern
+            "+2020-01-01",
+            "-2020-01-01",
+            "2020-01-01 12:34:56 UTC",
+            "2020-01-01 12:34:56 America/New_York",
+            "2020-01-01 12:34:56+05:00",
+            "2020-01-01 12:34:56 +05:00",
+            "2020-01-01 UTC",
+            "2020-01-01 12:34:56   UTC",
+            "2020-01-01  12:34:56",
+
+            // invalid, both paths must fail the same way
+            "",
+            "not a timestamp",
+            "2020-13-01",
+            "2020-01-32",
+            "2020-02-30",
+            "2021-02-29",
+            "2020-01-01 25:00:00",
+            "2020-01-01 12:60:00",
+            "2020-01-01 12:00:61",
+            "2020-01-01T12:00:00",
+            "202-01-01",
+            "2020-01",
+            "2020-01-01 12",
+            "2020-01-01 12:",
+            "2020-01-01 12:34:",
+            "2020-01-01 12:34:56.",
+            "2020-01-01-12:34:56",
+            "abcd-01-01",
+    };
+
+    @Test
+    public void testShortTimestampMatchesPattern()
+    {
+        for (int precision = 0; precision <= 6; precision++) {
+            for (String value : VALUES) {
+                assertShortMatchesPattern(precision, value);
+            }
+        }
+    }
+
+    @Test
+    public void testLongTimestampMatchesPattern()
+    {
+        for (int precision = 7; precision <= 12; precision++) {
+            for (String value : VALUES) {
+                assertLongMatchesPattern(precision, value);
+            }
+        }
+    }
+
+    @Test
+    public void testRandomValuesMatchPattern()
+    {
+        Random random = new Random(4711);
+        for (int i = 0; i < 20_000; i++) {
+            String value = randomTimestamp(random);
+            assertShortMatchesPattern(random.nextInt(7), value);
+            assertLongMatchesPattern(7 + random.nextInt(6), value);
+        }
+    }
+
+    private static String randomTimestamp(Random random)
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append("%04d-%d-%d".formatted(random.nextInt(1, 10000), random.nextInt(0, 15), random.nextInt(0, 35)));
+        if (random.nextBoolean()) {
+            builder.append(' ');
+            builder.append("%d:%d".formatted(random.nextInt(0, 26), random.nextInt(0, 62)));
+            if (random.nextBoolean()) {
+                builder.append(":%d".formatted(random.nextInt(0, 62)));
+                if (random.nextBoolean()) {
+                    builder.append('.');
+                    int digits = 1 + random.nextInt(14);
+                    for (int i = 0; i < digits; i++) {
+                        builder.append((char) ('0' + random.nextInt(10)));
+                    }
+                }
+            }
+        }
+        return builder.toString();
+    }
+
+    private static void assertShortMatchesPattern(int precision, String value)
+    {
+        Slice slice = utf8Slice(value);
+        String context = "precision=%s value='%s'".formatted(precision, value);
+
+        Long expected = null;
+        RuntimeException expectedFailure = null;
+        try {
+            expected = VarcharToTimestampCast.castToShortTimestamp(precision, value);
+        }
+        catch (RuntimeException e) {
+            expectedFailure = e;
+        }
+
+        if (expectedFailure != null) {
+            RuntimeException failure = expectedFailure;
+            assertThatThrownBy(() -> VarcharToTimestampCast.castToShortTimestamp(precision, slice))
+                    .describedAs(context)
+                    .isInstanceOf(failure.getClass())
+                    .hasMessage(failure.getMessage());
+        }
+        else {
+            assertThat(VarcharToTimestampCast.castToShortTimestamp(precision, slice))
+                    .describedAs(context)
+                    .isEqualTo(expected);
+        }
+    }
+
+    private static void assertLongMatchesPattern(int precision, String value)
+    {
+        Slice slice = utf8Slice(value);
+        String context = "precision=%s value='%s'".formatted(precision, value);
+
+        LongTimestamp expected = null;
+        RuntimeException expectedFailure = null;
+        try {
+            expected = VarcharToTimestampCast.castToLongTimestamp(precision, value);
+        }
+        catch (RuntimeException e) {
+            expectedFailure = e;
+        }
+
+        if (expectedFailure != null) {
+            RuntimeException failure = expectedFailure;
+            assertThatThrownBy(() -> VarcharToTimestampCast.castToLongTimestamp(precision, slice))
+                    .describedAs(context)
+                    .isInstanceOf(failure.getClass())
+                    .hasMessage(failure.getMessage());
+        }
+        else {
+            assertThat(VarcharToTimestampCast.castToLongTimestamp(precision, slice))
+                    .describedAs(context)
+                    .isEqualTo(expected);
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestVarcharToTimestampCast.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestVarcharToTimestampCast.java
@@ -14,12 +14,19 @@
 package io.trino.operator.scalar.timestamp;
 
 import io.airlift.slice.Slice;
+import io.trino.operator.scalar.timestamptz.VarcharToTimestampWithTimeZoneCast;
 import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.LongTimestampWithTimeZone;
 import org.junit.jupiter.api.Test;
 
+import java.time.ZoneId;
 import java.util.Random;
+import java.util.function.Function;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.type.TimestampWithTimeZoneType.MAX_PRECISION;
+import static io.trino.spi.type.TimestampWithTimeZoneType.MAX_SHORT_PRECISION;
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -115,6 +122,85 @@ public class TestVarcharToTimestampCast
             String value = randomTimestamp(random);
             assertShortMatchesPattern(random.nextInt(7), value);
             assertLongMatchesPattern(7 + random.nextInt(6), value);
+        }
+    }
+
+    @Test
+    public void testTimestampWithTimeZoneMatchesPattern()
+    {
+        // a value with no time zone resolves against the session zone rather than UTC, so cover a
+        // zone with an offset, and one with daylight saving, where a wrong zone would show up
+        // a short timestamp with time zone is packed as milliseconds, so its precision stops at 3,
+        // not at 6 as it does for a timestamp
+        Random random = new Random(1234);
+        for (ZoneId zone : new ZoneId[] {UTC, ZoneId.of("America/New_York"), ZoneId.of("Asia/Kathmandu"), ZoneId.of("Australia/Lord_Howe")}) {
+            for (String value : VALUES) {
+                assertTimestampWithTimeZoneMatchesPattern(random.nextInt(MAX_SHORT_PRECISION + 1), value, zone);
+                assertLongTimestampWithTimeZoneMatchesPattern(MAX_SHORT_PRECISION + 1 + random.nextInt(MAX_PRECISION - MAX_SHORT_PRECISION), value, zone);
+            }
+            for (int i = 0; i < 2_000; i++) {
+                String value = randomTimestamp(random);
+                assertTimestampWithTimeZoneMatchesPattern(random.nextInt(MAX_SHORT_PRECISION + 1), value, zone);
+                assertLongTimestampWithTimeZoneMatchesPattern(MAX_SHORT_PRECISION + 1 + random.nextInt(MAX_PRECISION - MAX_SHORT_PRECISION), value, zone);
+            }
+        }
+    }
+
+    private static void assertTimestampWithTimeZoneMatchesPattern(int precision, String value, ZoneId sessionZone)
+    {
+        Function<String, ZoneId> zoneId = timezone -> timezone == null ? sessionZone : ZoneId.of(timezone);
+        Slice slice = utf8Slice(value);
+        String context = "precision=%s value='%s' zone=%s".formatted(precision, value, sessionZone);
+
+        Long expected = null;
+        RuntimeException expectedFailure = null;
+        try {
+            expected = VarcharToTimestampWithTimeZoneCast.toShort(precision, value, zoneId);
+        }
+        catch (RuntimeException e) {
+            expectedFailure = e;
+        }
+
+        if (expectedFailure != null) {
+            RuntimeException failure = expectedFailure;
+            assertThatThrownBy(() -> VarcharToTimestampWithTimeZoneCast.toShort(precision, slice, zoneId))
+                    .describedAs(context)
+                    .isInstanceOf(failure.getClass())
+                    .hasMessage(failure.getMessage());
+        }
+        else {
+            assertThat(VarcharToTimestampWithTimeZoneCast.toShort(precision, slice, zoneId))
+                    .describedAs(context)
+                    .isEqualTo(expected);
+        }
+    }
+
+    private static void assertLongTimestampWithTimeZoneMatchesPattern(int precision, String value, ZoneId sessionZone)
+    {
+        Function<String, ZoneId> zoneId = timezone -> timezone == null ? sessionZone : ZoneId.of(timezone);
+        Slice slice = utf8Slice(value);
+        String context = "precision=%s value='%s' zone=%s".formatted(precision, value, sessionZone);
+
+        LongTimestampWithTimeZone expected = null;
+        RuntimeException expectedFailure = null;
+        try {
+            expected = VarcharToTimestampWithTimeZoneCast.toLong(precision, value, zoneId);
+        }
+        catch (RuntimeException e) {
+            expectedFailure = e;
+        }
+
+        if (expectedFailure != null) {
+            RuntimeException failure = expectedFailure;
+            assertThatThrownBy(() -> VarcharToTimestampWithTimeZoneCast.toLong(precision, slice, zoneId))
+                    .describedAs(context)
+                    .isInstanceOf(failure.getClass())
+                    .hasMessage(failure.getMessage());
+        }
+        else {
+            assertThat(VarcharToTimestampWithTimeZoneCast.toLong(precision, slice, zoneId))
+                    .describedAs(context)
+                    .isEqualTo(expected);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
@@ -873,7 +873,7 @@ public class TestDomainTranslator
     {
         // =
         assertPredicateDerives(
-                equal(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2005-9-10"))),
+                equal(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2005-9-10")))),
                 tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
                                 Range.lessThan(VARCHAR, utf8Slice("1")),
                                 Range.range(VARCHAR, utf8Slice("2005-09-10"), true, utf8Slice("2005-09-11"), false),
@@ -882,7 +882,7 @@ public class TestDomainTranslator
                         false)));
         // = with day ending with 9
         assertPredicateDerives(
-                equal(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2005-09-09"))),
+                equal(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2005-09-09")))),
                 tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
                                 Range.lessThan(VARCHAR, utf8Slice("1")),
                                 Range.range(VARCHAR, utf8Slice("2005-09-09"), true, utf8Slice("2005-09-0:"), false),
@@ -892,7 +892,7 @@ public class TestDomainTranslator
                                 Range.greaterThan(VARCHAR, utf8Slice("9"))),
                         false)));
         assertPredicateDerives(
-                equal(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2005-09-19"))),
+                equal(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2005-09-19")))),
                 tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
                                 Range.lessThan(VARCHAR, utf8Slice("1")),
                                 Range.range(VARCHAR, utf8Slice("2005-09-19"), true, utf8Slice("2005-09-1:"), false),
@@ -902,7 +902,7 @@ public class TestDomainTranslator
 
         // !=
         assertPredicateDerives(
-                notEqual(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2005-9-10"))),
+                notEqual(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2005-9-10")))),
                 tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
                                 Range.lessThan(VARCHAR, utf8Slice("2005-09-10")),
                                 Range.range(VARCHAR, utf8Slice("2005-09-11"), true, utf8Slice("2005-9-10"), false),
@@ -911,12 +911,12 @@ public class TestDomainTranslator
 
         // != with single-digit day
         assertUnsupportedPredicate(
-                notEqual(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2005-9-2"))));
+                notEqual(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2005-9-2")))));
         // != with day ending with 9
         assertUnsupportedPredicate(
-                notEqual(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2005-09-09"))));
+                notEqual(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2005-09-09")))));
         assertPredicateDerives(
-                notEqual(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2005-09-19"))),
+                notEqual(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2005-09-19")))),
                 tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
                                 Range.lessThan(VARCHAR, utf8Slice("2005-09-19")),
                                 Range.range(VARCHAR, utf8Slice("2005-09-1:"), true, utf8Slice("2005-9-19"), false),
@@ -925,7 +925,7 @@ public class TestDomainTranslator
 
         // <
         assertPredicateDerives(
-                lessThan(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2005-9-10"))),
+                lessThan(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2005-9-10")))),
                 tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
                                 Range.lessThan(VARCHAR, utf8Slice("2006")),
                                 Range.greaterThan(VARCHAR, utf8Slice("9"))),
@@ -933,7 +933,7 @@ public class TestDomainTranslator
 
         // >
         assertPredicateDerives(
-                greaterThan(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2005-9-10"))),
+                greaterThan(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2005-9-10")))),
                 tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
                                 Range.lessThan(VARCHAR, utf8Slice("1")),
                                 Range.greaterThan(VARCHAR, utf8Slice("2004"))),
@@ -941,30 +941,30 @@ public class TestDomainTranslator
 
         // Regression test for https://github.com/trinodb/trino/issues/14954
         assertPredicateTranslates(
-                greaterThan(new Constant(DATE, (long) DateTimeUtils.parseDate("2001-01-31")), cast(C_VARCHAR, DATE)),
+                greaterThan(new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2001-01-31"))), cast(C_VARCHAR, DATE)),
                 tupleDomain(
                         C_VARCHAR,
                         Domain.create(ValueSet.ofRanges(
                                         Range.lessThan(VARCHAR, utf8Slice("2002")),
                                         Range.greaterThan(VARCHAR, utf8Slice("9"))),
                                 false)),
-                greaterThan(new Constant(DATE, (long) DateTimeUtils.parseDate("2001-01-31")), cast(C_VARCHAR, DATE)));
+                greaterThan(new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2001-01-31"))), cast(C_VARCHAR, DATE)));
 
         // BETWEEN
         assertPredicateTranslates(
-                between(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2001-01-31")), new Constant(DATE, (long) DateTimeUtils.parseDate("2005-09-10"))),
+                between(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2001-01-31"))), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2005-09-10")))),
                 tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
                                 Range.lessThan(VARCHAR, utf8Slice("1")),
                                 Range.range(VARCHAR, utf8Slice("2000"), false, utf8Slice("2006"), false),
                                 Range.greaterThan(VARCHAR, utf8Slice("9"))),
                         false)),
                 and(
-                        greaterThanOrEqual(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2001-01-31"))),
-                        lessThanOrEqual(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2005-09-10")))));
+                        greaterThanOrEqual(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2001-01-31")))),
+                        lessThanOrEqual(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2005-09-10"))))));
 
         // Regression test for https://github.com/trinodb/trino/issues/14954
         assertPredicateTranslates(
-                between(new Constant(DATE, (long) DateTimeUtils.parseDate("2001-01-31")), cast(C_VARCHAR, DATE), cast(C_VARCHAR_1, DATE)),
+                between(new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2001-01-31"))), cast(C_VARCHAR, DATE), cast(C_VARCHAR_1, DATE)),
                 tupleDomain(
                         C_VARCHAR,
                         Domain.create(ValueSet.ofRanges(
@@ -977,8 +977,8 @@ public class TestDomainTranslator
                                         Range.greaterThan(VARCHAR, utf8Slice("2000"))),
                                 false)),
                 and(
-                        greaterThanOrEqual(new Constant(DATE, (long) DateTimeUtils.parseDate("2001-01-31")), cast(C_VARCHAR, DATE)),
-                        lessThanOrEqual(new Constant(DATE, (long) DateTimeUtils.parseDate("2001-01-31")), cast(C_VARCHAR_1, DATE))));
+                        greaterThanOrEqual(new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2001-01-31"))), cast(C_VARCHAR, DATE)),
+                        lessThanOrEqual(new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2001-01-31"))), cast(C_VARCHAR_1, DATE))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapCastInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapCastInComparison.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.SystemSessionProperties.PUSH_FILTER_INTO_VALUES_MAX_ROW_COUNT;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -513,75 +514,75 @@ public class TestUnwrapCastInComparison
         Session losAngelesSession = withZone(session, TimeZoneKey.getTimeZoneKey("America/Los_Angeles"));
 
         // same zone
-        testUnwrap(utcSession, "date", "a > TIMESTAMP '2020-10-26 11:02:18 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2020-10-26"))));
-        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-10-26 11:02:18 Europe/Warsaw'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2020-10-26"))));
-        testUnwrap(losAngelesSession, "date", "a > TIMESTAMP '2020-10-26 11:02:18 America/Los_Angeles'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2020-10-26"))));
+        testUnwrap(utcSession, "date", "a > TIMESTAMP '2020-10-26 11:02:18 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2020-10-26")))));
+        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-10-26 11:02:18 Europe/Warsaw'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2020-10-26")))));
+        testUnwrap(losAngelesSession, "date", "a > TIMESTAMP '2020-10-26 11:02:18 America/Los_Angeles'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2020-10-26")))));
 
         // different zone
-        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-10-26 11:02:18 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2020-10-26"))));
-        testUnwrap(losAngelesSession, "date", "a > TIMESTAMP '2020-10-26 11:02:18 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2020-10-26"))));
+        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-10-26 11:02:18 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2020-10-26")))));
+        testUnwrap(losAngelesSession, "date", "a > TIMESTAMP '2020-10-26 11:02:18 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2020-10-26")))));
 
         // maximum precision
-        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-10-26 11:02:18.123456789321 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2020-10-26"))));
-        testUnwrap(losAngelesSession, "date", "a > TIMESTAMP '2020-10-26 11:02:18.123456789321 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2020-10-26"))));
+        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-10-26 11:02:18.123456789321 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2020-10-26")))));
+        testUnwrap(losAngelesSession, "date", "a > TIMESTAMP '2020-10-26 11:02:18.123456789321 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2020-10-26")))));
 
         // DST forward -- Warsaw changed clock 1h forward on 2020-03-29T01:00 UTC (2020-03-29T02:00 local time)
         // Note that in given session input TIMESTAMP values  2020-03-29 02:31 and 2020-03-29 03:31 produce the same value 2020-03-29 01:31 UTC (conversion is not monotonic)
         // last before
-        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-03-29 00:59:59 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2020-03-29"))));
-        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-03-29 00:59:59.999 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2020-03-29"))));
-        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-03-29 00:59:59.13 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2020-03-29"))));
-        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-03-29 00:59:59.999999 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2020-03-29"))));
-        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-03-29 00:59:59.999999999 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2020-03-29"))));
-        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-03-29 00:59:59.999999999999 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2020-03-29"))));
+        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-03-29 00:59:59 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2020-03-29")))));
+        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-03-29 00:59:59.999 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2020-03-29")))));
+        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-03-29 00:59:59.13 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2020-03-29")))));
+        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-03-29 00:59:59.999999 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2020-03-29")))));
+        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-03-29 00:59:59.999999999 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2020-03-29")))));
+        testUnwrap(warsawSession, "date", "a > TIMESTAMP '2020-03-29 00:59:59.999999999999 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2020-03-29")))));
 
         // equal
-        testUnwrap(utcSession, "date", "a = TIMESTAMP '1981-06-22 00:00:00 UTC'", comparison(EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a = TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", comparison(EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a = TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", comparison(EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a = TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", comparison(EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
+        testUnwrap(utcSession, "date", "a = TIMESTAMP '1981-06-22 00:00:00 UTC'", comparison(EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a = TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", comparison(EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a = TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", comparison(EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a = TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", comparison(EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
 
         // not equal
-        testUnwrap(utcSession, "date", "a <> TIMESTAMP '1981-06-22 00:00:00 UTC'", comparison(NOT_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a <> TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", comparison(NOT_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a <> TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", comparison(NOT_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a <> TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", comparison(NOT_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
+        testUnwrap(utcSession, "date", "a <> TIMESTAMP '1981-06-22 00:00:00 UTC'", comparison(NOT_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a <> TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", comparison(NOT_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a <> TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", comparison(NOT_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a <> TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", comparison(NOT_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
 
         // less than
-        testUnwrap(utcSession, "date", "a < TIMESTAMP '1981-06-22 00:00:00 UTC'", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a < TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a < TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a < TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
+        testUnwrap(utcSession, "date", "a < TIMESTAMP '1981-06-22 00:00:00 UTC'", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a < TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a < TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a < TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
 
         // less than or equal
-        testUnwrap(utcSession, "date", "a <= TIMESTAMP '1981-06-22 00:00:00 UTC'", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a <= TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a <= TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a <= TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
+        testUnwrap(utcSession, "date", "a <= TIMESTAMP '1981-06-22 00:00:00 UTC'", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a <= TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a <= TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a <= TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
 
         // greater than
-        testUnwrap(utcSession, "date", "a > TIMESTAMP '1981-06-22 00:00:00 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a > TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a > TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a > TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
+        testUnwrap(utcSession, "date", "a > TIMESTAMP '1981-06-22 00:00:00 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a > TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a > TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a > TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
 
         // greater than or equal
-        testUnwrap(utcSession, "date", "a >= TIMESTAMP '1981-06-22 00:00:00 UTC'", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a >= TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a >= TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a >= TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
+        testUnwrap(utcSession, "date", "a >= TIMESTAMP '1981-06-22 00:00:00 UTC'", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a >= TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a >= TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a >= TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
 
         // is distinct
-        testUnwrap(utcSession, "date", "a IS DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00 UTC'", not(comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22")))));
-        testUnwrap(utcSession, "date", "a IS DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", not(comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22")))));
-        testUnwrap(utcSession, "date", "a IS DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", not(comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22")))));
-        testUnwrap(utcSession, "date", "a IS DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", not(comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a IS DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00 UTC'", not(comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22"))))));
+        testUnwrap(utcSession, "date", "a IS DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", not(comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22"))))));
+        testUnwrap(utcSession, "date", "a IS DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", not(comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22"))))));
+        testUnwrap(utcSession, "date", "a IS DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", not(comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22"))))));
 
         // is not distinct
-        testUnwrap(utcSession, "date", "a IS NOT DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00 UTC'", comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a IS NOT DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a IS NOT DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
-        testUnwrap(utcSession, "date", "a IS NOT DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
+        testUnwrap(utcSession, "date", "a IS NOT DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00 UTC'", comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a IS NOT DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00.000000 UTC'", comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a IS NOT DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00.000000000 UTC'", comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
+        testUnwrap(utcSession, "date", "a IS NOT DISTINCT FROM TIMESTAMP '1981-06-22 00:00:00.000000000000 UTC'", comparison(IDENTICAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
 
         // null date literal
         testUnwrap("date", "CAST(a AS TIMESTAMP WITH TIME ZONE) = NULL", new Constant(BOOLEAN, null));
@@ -592,7 +593,7 @@ public class TestUnwrapCastInComparison
         testUnwrap("date", "CAST(a AS TIMESTAMP WITH TIME ZONE) IS DISTINCT FROM NULL", not(new IsNull(new Cast(new Reference(DATE, "a"), TIMESTAMP_TZ_MILLIS))));
 
         // timestamp with time zone value on the left
-        testUnwrap(utcSession, "date", "TIMESTAMP '1981-06-22 00:00:00 UTC' = a", comparison(EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1981-06-22"))));
+        testUnwrap(utcSession, "date", "TIMESTAMP '1981-06-22 00:00:00 UTC' = a", comparison(EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1981-06-22")))));
     }
 
     @Test
@@ -950,7 +951,7 @@ public class TestUnwrapCastInComparison
                 TEST_SESSION,
                 FUNCTIONS.getPlannerContext(),
                 new SymbolAllocator(),
-                comparison(operator, new Cast(operand, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2021-06-01"))));
+                comparison(operator, new Cast(operand, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2021-06-01")))));
 
         // Exactly one Let binds the operand (wherever the operator places it in the tree; NOT_EQUAL, for
         // instance, wraps the range in a NOT) and the operand is evaluated a single time: it appears only as
@@ -984,7 +985,7 @@ public class TestUnwrapCastInComparison
                     TEST_SESSION,
                     FUNCTIONS.getPlannerContext(),
                     new SymbolAllocator(),
-                    comparison(operator, new Cast(operand, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2021-06-01"))));
+                    comparison(operator, new Cast(operand, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2021-06-01")))));
 
             assertThat(unwrapped).as("operator %s", operator).isNotInstanceOf(Let.class);
             // The reference stays inline in each comparison rather than being bound once.
@@ -1006,7 +1007,7 @@ public class TestUnwrapCastInComparison
                     TEST_SESSION,
                     FUNCTIONS.getPlannerContext(),
                     new SymbolAllocator(),
-                    comparison(operator, new Cast(operand, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate("2021-06-01"))));
+                    comparison(operator, new Cast(operand, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2021-06-01")))));
 
             assertThat(unwrapped).as("operator %s", operator).isNotInstanceOf(Let.class);
             assertThat(occurrences(unwrapped, operand)).as("operator %s", operator).isGreaterThanOrEqualTo(2);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapYearInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapYearInComparison.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.SystemSessionProperties.PUSH_FILTER_INTO_VALUES_MAX_ROW_COUNT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
@@ -76,10 +77,10 @@ public class TestUnwrapYearInComparison
     @Test
     public void testEquals()
     {
-        testUnwrap("date", "year(a) = -0001", between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("-0001-01-01")), new Constant(DATE, (long) DateTimeUtils.parseDate("-0001-12-31"))));
-        testUnwrap("date", "year(a) = 1960", between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1960-01-01")), new Constant(DATE, (long) DateTimeUtils.parseDate("1960-12-31"))));
-        testUnwrap("date", "year(a) = 2022", between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-01-01")), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-12-31"))));
-        testUnwrap("date", "year(a) = 9999", between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("9999-01-01")), new Constant(DATE, (long) DateTimeUtils.parseDate("9999-12-31"))));
+        testUnwrap("date", "year(a) = -0001", between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("-0001-01-01"))), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("-0001-12-31")))));
+        testUnwrap("date", "year(a) = 1960", between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1960-01-01"))), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1960-12-31")))));
+        testUnwrap("date", "year(a) = 2022", between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2022-01-01"))), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2022-12-31")))));
+        testUnwrap("date", "year(a) = 9999", between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("9999-01-01"))), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("9999-12-31")))));
 
         testUnwrap("timestamp", "year(a) = -0001", between(new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "-0001-01-01 00:00:00.000")), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "-0001-12-31 23:59:59.999"))));
         testUnwrap("timestamp", "year(a) = 1960", between(new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1960-01-01 00:00:00.000")), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1960-12-31 23:59:59.999"))));
@@ -104,17 +105,17 @@ public class TestUnwrapYearInComparison
     @Test
     public void testInPredicate()
     {
-        testUnwrap("date", "year(a) IN (1000, 1400, 1800)", new Logical(OR, ImmutableList.of(between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1000-01-01")), new Constant(DATE, (long) DateTimeUtils.parseDate("1000-12-31"))), between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1400-01-01")), new Constant(DATE, (long) DateTimeUtils.parseDate("1400-12-31"))), between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1800-01-01")), new Constant(DATE, (long) DateTimeUtils.parseDate("1800-12-31"))))));
+        testUnwrap("date", "year(a) IN (1000, 1400, 1800)", new Logical(OR, ImmutableList.of(between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1000-01-01"))), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1000-12-31")))), between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1400-01-01"))), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1400-12-31")))), between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1800-01-01"))), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1800-12-31")))))));
         testUnwrap("timestamp", "year(a) IN (1000, 1400, 1800)", new Logical(OR, ImmutableList.of(between(new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1000-01-01 00:00:00.000")), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1000-12-31 23:59:59.999"))), between(new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1400-01-01 00:00:00.000")), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1400-12-31 23:59:59.999"))), between(new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1800-01-01 00:00:00.000")), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1800-12-31 23:59:59.999"))))));
     }
 
     @Test
     public void testNotEquals()
     {
-        testUnwrap("date", "year(a) <> -0001", new Logical(OR, ImmutableList.of(comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("-0001-01-01"))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("-0001-12-31"))))));
-        testUnwrap("date", "year(a) <> 1960", new Logical(OR, ImmutableList.of(comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1960-01-01"))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1960-12-31"))))));
-        testUnwrap("date", "year(a) <> 2022", new Logical(OR, ImmutableList.of(comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-01-01"))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-12-31"))))));
-        testUnwrap("date", "year(a) <> 9999", new Logical(OR, ImmutableList.of(comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("9999-01-01"))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("9999-12-31"))))));
+        testUnwrap("date", "year(a) <> -0001", new Logical(OR, ImmutableList.of(comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("-0001-01-01")))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("-0001-12-31")))))));
+        testUnwrap("date", "year(a) <> 1960", new Logical(OR, ImmutableList.of(comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1960-01-01")))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1960-12-31")))))));
+        testUnwrap("date", "year(a) <> 2022", new Logical(OR, ImmutableList.of(comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2022-01-01")))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2022-12-31")))))));
+        testUnwrap("date", "year(a) <> 9999", new Logical(OR, ImmutableList.of(comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("9999-01-01")))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("9999-12-31")))))));
 
         testUnwrap("timestamp", "year(a) <> -0001", new Logical(OR, ImmutableList.of(comparison(LESS_THAN, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "-0001-01-01 00:00:00.000"))), comparison(GREATER_THAN, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "-0001-12-31 23:59:59.999"))))));
         testUnwrap("timestamp", "year(a) <> 1960", new Logical(OR, ImmutableList.of(comparison(LESS_THAN, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1960-01-01 00:00:00.000"))), comparison(GREATER_THAN, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1960-12-31 23:59:59.999"))))));
@@ -139,10 +140,10 @@ public class TestUnwrapYearInComparison
     @Test
     public void testLessThan()
     {
-        testUnwrap("date", "year(a) < -0001", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("-0001-01-01"))));
-        testUnwrap("date", "year(a) < 1960", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1960-01-01"))));
-        testUnwrap("date", "year(a) < 2022", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-01-01"))));
-        testUnwrap("date", "year(a) < 9999", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("9999-01-01"))));
+        testUnwrap("date", "year(a) < -0001", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("-0001-01-01")))));
+        testUnwrap("date", "year(a) < 1960", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1960-01-01")))));
+        testUnwrap("date", "year(a) < 2022", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2022-01-01")))));
+        testUnwrap("date", "year(a) < 9999", comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("9999-01-01")))));
 
         testUnwrap("timestamp", "year(a) < -0001", comparison(LESS_THAN, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "-0001-01-01 00:00:00.000"))));
         testUnwrap("timestamp", "year(a) < 1960", comparison(LESS_THAN, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1960-01-01 00:00:00.000"))));
@@ -167,10 +168,10 @@ public class TestUnwrapYearInComparison
     @Test
     public void testLessThanOrEqual()
     {
-        testUnwrap("date", "year(a) <= -0001", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("-0001-12-31"))));
-        testUnwrap("date", "year(a) <= 1960", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1960-12-31"))));
-        testUnwrap("date", "year(a) <= 2022", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-12-31"))));
-        testUnwrap("date", "year(a) <= 9999", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("9999-12-31"))));
+        testUnwrap("date", "year(a) <= -0001", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("-0001-12-31")))));
+        testUnwrap("date", "year(a) <= 1960", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1960-12-31")))));
+        testUnwrap("date", "year(a) <= 2022", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2022-12-31")))));
+        testUnwrap("date", "year(a) <= 9999", comparison(LESS_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("9999-12-31")))));
 
         testUnwrap("timestamp", "year(a) <= -0001", comparison(LESS_THAN_OR_EQUAL, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "-0001-12-31 23:59:59.999"))));
         testUnwrap("timestamp", "year(a) <= 1960", comparison(LESS_THAN_OR_EQUAL, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1960-12-31 23:59:59.999"))));
@@ -195,10 +196,10 @@ public class TestUnwrapYearInComparison
     @Test
     public void testGreaterThan()
     {
-        testUnwrap("date", "year(a) > -0001", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("-0001-12-31"))));
-        testUnwrap("date", "year(a) > 1960", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1960-12-31"))));
-        testUnwrap("date", "year(a) > 2022", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-12-31"))));
-        testUnwrap("date", "year(a) > 9999", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("9999-12-31"))));
+        testUnwrap("date", "year(a) > -0001", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("-0001-12-31")))));
+        testUnwrap("date", "year(a) > 1960", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1960-12-31")))));
+        testUnwrap("date", "year(a) > 2022", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2022-12-31")))));
+        testUnwrap("date", "year(a) > 9999", comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("9999-12-31")))));
 
         testUnwrap("timestamp", "year(a) > -0001", comparison(GREATER_THAN, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "-0001-12-31 23:59:59.999"))));
         testUnwrap("timestamp", "year(a) > 1960", comparison(GREATER_THAN, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1960-12-31 23:59:59.999"))));
@@ -223,10 +224,10 @@ public class TestUnwrapYearInComparison
     @Test
     public void testGreaterThanOrEqual()
     {
-        testUnwrap("date", "year(a) >= -0001", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("-0001-01-01"))));
-        testUnwrap("date", "year(a) >= 1960", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1960-01-01"))));
-        testUnwrap("date", "year(a) >= 2022", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-01-01"))));
-        testUnwrap("date", "year(a) >= 9999", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("9999-01-01"))));
+        testUnwrap("date", "year(a) >= -0001", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("-0001-01-01")))));
+        testUnwrap("date", "year(a) >= 1960", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1960-01-01")))));
+        testUnwrap("date", "year(a) >= 2022", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2022-01-01")))));
+        testUnwrap("date", "year(a) >= 9999", comparison(GREATER_THAN_OR_EQUAL, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("9999-01-01")))));
 
         testUnwrap("timestamp", "year(a) >= -0001", comparison(GREATER_THAN_OR_EQUAL, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "-0001-01-01 00:00:00.000"))));
         testUnwrap("timestamp", "year(a) >= 1960", comparison(GREATER_THAN_OR_EQUAL, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1960-01-01 00:00:00.000"))));
@@ -251,10 +252,10 @@ public class TestUnwrapYearInComparison
     @Test
     public void testDistinctFrom()
     {
-        testUnwrap("date", "year(a) IS DISTINCT FROM -0001", new Logical(OR, ImmutableList.of(new IsNull(new Reference(DATE, "a")), comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("-0001-01-01"))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("-0001-12-31"))))));
-        testUnwrap("date", "year(a) IS DISTINCT FROM 1960", new Logical(OR, ImmutableList.of(new IsNull(new Reference(DATE, "a")), comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1960-01-01"))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("1960-12-31"))))));
-        testUnwrap("date", "year(a) IS DISTINCT FROM 2022", new Logical(OR, ImmutableList.of(new IsNull(new Reference(DATE, "a")), comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-01-01"))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-12-31"))))));
-        testUnwrap("date", "year(a) IS DISTINCT FROM 9999", new Logical(OR, ImmutableList.of(new IsNull(new Reference(DATE, "a")), comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("9999-01-01"))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("9999-12-31"))))));
+        testUnwrap("date", "year(a) IS DISTINCT FROM -0001", new Logical(OR, ImmutableList.of(new IsNull(new Reference(DATE, "a")), comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("-0001-01-01")))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("-0001-12-31")))))));
+        testUnwrap("date", "year(a) IS DISTINCT FROM 1960", new Logical(OR, ImmutableList.of(new IsNull(new Reference(DATE, "a")), comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1960-01-01")))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("1960-12-31")))))));
+        testUnwrap("date", "year(a) IS DISTINCT FROM 2022", new Logical(OR, ImmutableList.of(new IsNull(new Reference(DATE, "a")), comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2022-01-01")))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2022-12-31")))))));
+        testUnwrap("date", "year(a) IS DISTINCT FROM 9999", new Logical(OR, ImmutableList.of(new IsNull(new Reference(DATE, "a")), comparison(LESS_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("9999-01-01")))), comparison(GREATER_THAN, new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("9999-12-31")))))));
 
         testUnwrap("timestamp", "year(a) IS DISTINCT FROM -0001", new Logical(OR, ImmutableList.of(new IsNull(new Reference(createTimestampType(3), "a")), comparison(LESS_THAN, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "-0001-01-01 00:00:00.000"))), comparison(GREATER_THAN, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "-0001-12-31 23:59:59.999"))))));
         testUnwrap("timestamp", "year(a) IS DISTINCT FROM 1960", new Logical(OR, ImmutableList.of(new IsNull(new Reference(createTimestampType(3), "a")), comparison(LESS_THAN, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1960-01-01 00:00:00.000"))), comparison(GREATER_THAN, new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "1960-12-31 23:59:59.999"))))));
@@ -295,7 +296,7 @@ public class TestUnwrapYearInComparison
     {
         // smoke tests for various type combinations
         for (String type : asList("SMALLINT", "INTEGER", "BIGINT", "REAL", "DOUBLE")) {
-            testUnwrap("date", format("year(a) = %s '2022'", type), between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-01-01")), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-12-31"))));
+            testUnwrap("date", format("year(a) = %s '2022'", type), between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2022-01-01"))), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2022-12-31")))));
         }
     }
 
@@ -311,14 +312,14 @@ public class TestUnwrapYearInComparison
                         .build(),
                 output(
                         filter(
-                                between(new Reference(DATE, "A"), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-01-01")), new Constant(DATE, (long) DateTimeUtils.parseDate("2022-12-31"))),
+                                between(new Reference(DATE, "A"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2022-01-01"))), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2022-12-31")))),
                                 values("A"))));
     }
 
     @Test
     public void testLeapYear()
     {
-        testUnwrap("date", "year(a) = 2024", between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate("2024-01-01")), new Constant(DATE, (long) DateTimeUtils.parseDate("2024-12-31"))));
+        testUnwrap("date", "year(a) = 2024", between(new Reference(DATE, "a"), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2024-01-01"))), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2024-12-31")))));
         testUnwrap("timestamp", "year(a) = 2024", between(new Reference(createTimestampType(3), "a"), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "2024-01-01 00:00:00.000")), new Constant(createTimestampType(3), DateTimes.parseTimestamp(3, "2024-12-31 23:59:59.999"))));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -37,6 +37,7 @@ import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.List;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -513,19 +514,19 @@ public class TestSimplifyExpressions
     {
         // the varchar type length is enough to contain the date's representation
         assertSimplifies(
-                new Cast(new Constant(DATE, (long) DateTimeUtils.parseDate("2013-02-02")), createVarcharType(10)),
+                new Cast(new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2013-02-02"))), createVarcharType(10)),
                 new Constant(createVarcharType(10), Slices.utf8Slice("2013-02-02")));
         assertSimplifies(
-                new Cast(new Constant(DATE, (long) DateTimeUtils.parseDate("2013-02-02")), createVarcharType(50)),
+                new Cast(new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2013-02-02"))), createVarcharType(50)),
                 new Constant(createVarcharType(50), Slices.utf8Slice("2013-02-02")));
 
         // cast from date to varchar fails, so the expression is not modified
         assertSimplifies(
-                new Cast(new Constant(DATE, (long) DateTimeUtils.parseDate("2013-02-02")), createVarcharType(3)),
-                new Cast(new Constant(DATE, (long) DateTimeUtils.parseDate("2013-02-02")), createVarcharType(3)));
+                new Cast(new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2013-02-02"))), createVarcharType(3)),
+                new Cast(new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2013-02-02"))), createVarcharType(3)));
         assertSimplifies(
-                comparison(EQUAL, new Cast(new Constant(DATE, (long) DateTimeUtils.parseDate("2013-02-02")), createVarcharType(3)), new Constant(createVarcharType(3), Slices.utf8Slice("2013-02-02"))),
-                comparison(EQUAL, new Cast(new Constant(DATE, (long) DateTimeUtils.parseDate("2013-02-02")), createVarcharType(3)), new Constant(createVarcharType(3), Slices.utf8Slice("2013-02-02"))));
+                comparison(EQUAL, new Cast(new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2013-02-02"))), createVarcharType(3)), new Constant(createVarcharType(3), Slices.utf8Slice("2013-02-02"))),
+                comparison(EQUAL, new Cast(new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2013-02-02"))), createVarcharType(3)), new Constant(createVarcharType(3), Slices.utf8Slice("2013-02-02"))));
     }
 
     private static void assertSimplifies(Expression expression, Expression expected)

--- a/core/trino-main/src/test/java/io/trino/util/BenchmarkParseDate.java
+++ b/core/trino-main/src/test/java/io/trino/util/BenchmarkParseDate.java
@@ -13,6 +13,7 @@
  */
 package io.trino.util;
 
+import io.airlift.slice.Slice;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -26,6 +27,7 @@ import org.openjdk.jmh.runner.RunnerException;
 
 import java.util.concurrent.TimeUnit;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.jmh.Benchmarks.benchmark;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.openjdk.jmh.annotations.Mode.Throughput;
@@ -42,25 +44,24 @@ public class BenchmarkParseDate
     @Benchmark
     public void parseDate(BenchmarkData data, Blackhole blackhole)
     {
-        for (String dt : data.dates) {
-            blackhole.consume(DateTimeUtils.parseDate(dt));
+        for (Slice date : data.dates) {
+            blackhole.consume(DateTimeUtils.parseDate(date));
         }
     }
 
     @State(Thread)
     public static class BenchmarkData
     {
-        String[] dates;
+        Slice[] dates;
 
         @Setup
         public void setup()
         {
-            dates = new String[100];
+            dates = new Slice[100];
             // use the 100 consecutive dates start from 2023-01-01
-            String startDate = "2023-01-01";
-            int days = DateTimeUtils.parseDate(startDate);
+            int days = DateTimeUtils.parseDate(utf8Slice("2023-01-01"));
             for (int i = 0; i < dates.length; i++) {
-                dates[i] = DateTimeUtils.printDate(days + i);
+                dates[i] = utf8Slice(DateTimeUtils.printDate(days + i));
             }
         }
     }

--- a/core/trino-main/src/test/java/io/trino/util/TestDateTimeUtils.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestDateTimeUtils.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.DateTimeException;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.util.DateTimeUtils.parseIfIso8601DateFormat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -30,58 +31,58 @@ public class TestDateTimeUtils
         // valid dates
         assertThat(0)
                 .describedAs("1970-01-01")
-                .isEqualTo(parseIfIso8601DateFormat("1970-01-01").getAsInt());
+                .isEqualTo(parseIfIso8601DateFormat(utf8Slice("1970-01-01")).getAsInt());
         assertThat(31)
                 .describedAs("1970-02-01")
-                .isEqualTo(parseIfIso8601DateFormat("1970-02-01").getAsInt());
+                .isEqualTo(parseIfIso8601DateFormat(utf8Slice("1970-02-01")).getAsInt());
         assertThat(-31)
                 .describedAs("1969-12-01")
-                .isEqualTo(parseIfIso8601DateFormat("1969-12-01").getAsInt());
+                .isEqualTo(parseIfIso8601DateFormat(utf8Slice("1969-12-01")).getAsInt());
         assertThat(19051)
                 .describedAs("2022-02-28")
-                .isEqualTo(parseIfIso8601DateFormat("2022-02-28").getAsInt());
+                .isEqualTo(parseIfIso8601DateFormat(utf8Slice("2022-02-28")).getAsInt());
         assertThat(-719528)
                 .describedAs("0000-01-01")
-                .isEqualTo(parseIfIso8601DateFormat("0000-01-01").getAsInt());
+                .isEqualTo(parseIfIso8601DateFormat(utf8Slice("0000-01-01")).getAsInt());
         assertThat(2932896)
                 .describedAs("9999-12-31")
-                .isEqualTo(parseIfIso8601DateFormat("9999-12-31").getAsInt());
+                .isEqualTo(parseIfIso8601DateFormat(utf8Slice("9999-12-31")).getAsInt());
 
         // format invalid
         // invalid length
-        assertThat(parseIfIso8601DateFormat("1970-2-01")).isEmpty();
+        assertThat(parseIfIso8601DateFormat(utf8Slice("1970-2-01"))).isEmpty();
         // invalid year0
-        assertThat(parseIfIso8601DateFormat("a970-02-10")).isEmpty();
+        assertThat(parseIfIso8601DateFormat(utf8Slice("a970-02-10"))).isEmpty();
         // invalid year1
-        assertThat(parseIfIso8601DateFormat("1p70-02-10")).isEmpty();
+        assertThat(parseIfIso8601DateFormat(utf8Slice("1p70-02-10"))).isEmpty();
         // invalid year2
-        assertThat(parseIfIso8601DateFormat("19%0-02-10")).isEmpty();
+        assertThat(parseIfIso8601DateFormat(utf8Slice("19%0-02-10"))).isEmpty();
         // invalid year3
-        assertThat(parseIfIso8601DateFormat("197o-02-10")).isEmpty();
+        assertThat(parseIfIso8601DateFormat(utf8Slice("197o-02-10"))).isEmpty();
         // invalid dash0
-        assertThat(parseIfIso8601DateFormat("1970_02-01")).isEmpty();
+        assertThat(parseIfIso8601DateFormat(utf8Slice("1970_02-01"))).isEmpty();
         // invalid month0
-        assertThat(parseIfIso8601DateFormat("1970- 2-01")).isEmpty();
+        assertThat(parseIfIso8601DateFormat(utf8Slice("1970- 2-01"))).isEmpty();
         // invalid month1
-        assertThat(parseIfIso8601DateFormat("1970-3.-01")).isEmpty();
+        assertThat(parseIfIso8601DateFormat(utf8Slice("1970-3.-01"))).isEmpty();
         // invalid dash0
-        assertThat(parseIfIso8601DateFormat("1970-02/01")).isEmpty();
+        assertThat(parseIfIso8601DateFormat(utf8Slice("1970-02/01"))).isEmpty();
         // invalid day0
-        assertThat(parseIfIso8601DateFormat("1970-02-/1")).isEmpty();
+        assertThat(parseIfIso8601DateFormat(utf8Slice("1970-02-/1"))).isEmpty();
         // invalid day1
-        assertThat(parseIfIso8601DateFormat("1970-12-0l")).isEmpty();
+        assertThat(parseIfIso8601DateFormat(utf8Slice("1970-12-0l"))).isEmpty();
 
-        assertThat(parseIfIso8601DateFormat("1970/02/01")).isEmpty();
-        assertThat(parseIfIso8601DateFormat("Dec 24 2022")).isEmpty();
+        assertThat(parseIfIso8601DateFormat(utf8Slice("1970/02/01"))).isEmpty();
+        assertThat(parseIfIso8601DateFormat(utf8Slice("Dec 24 2022"))).isEmpty();
 
         // format ok, but illegal value
-        assertThatThrownBy(() -> parseIfIso8601DateFormat("2022-02-29"))
+        assertThatThrownBy(() -> parseIfIso8601DateFormat(utf8Slice("2022-02-29")))
                 .isInstanceOf(DateTimeException.class)
                 .hasMessage("Invalid date 'February 29' as '2022' is not a leap year");
-        assertThatThrownBy(() -> parseIfIso8601DateFormat("1970-32-01"))
+        assertThatThrownBy(() -> parseIfIso8601DateFormat(utf8Slice("1970-32-01")))
                 .isInstanceOf(DateTimeException.class)
                 .hasMessage("Invalid value for MonthOfYear (valid values 1 - 12): 32");
-        assertThatThrownBy(() -> parseIfIso8601DateFormat("1970-02-41"))
+        assertThatThrownBy(() -> parseIfIso8601DateFormat(utf8Slice("1970-02-41")))
                 .isInstanceOf(DateTimeException.class)
                 .hasMessage("Invalid value for DayOfMonth (valid values 1 - 28/31): 41");
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/NumberFormatter.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/NumberFormatter.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.util;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+/**
+ * Renders integers as their ASCII bytes.
+ * <p>
+ * {@link Long#toString} produces a {@link String}, so rendering a value into a slice through it
+ * writes the digits into a {@code String} only to encode them back out to UTF-8 immediately.
+ */
+public final class NumberFormatter
+{
+    private static final long[] POWERS_OF_TEN = {
+            1L, 10L, 100L, 1000L, 10_000L, 100_000L, 1_000_000L, 10_000_000L, 100_000_000L,
+            1_000_000_000L, 10_000_000_000L, 100_000_000_000L, 1_000_000_000_000L,
+            10_000_000_000_000L, 100_000_000_000_000L, 1_000_000_000_000_000L,
+            10_000_000_000_000_000L, 100_000_000_000_000_000L, 1_000_000_000_000_000_000L,
+    };
+
+    private NumberFormatter() {}
+
+    /**
+     * Returns the number of ASCII bytes {@link #formatLong} writes, which is also the number of
+     * characters {@code Long.toString(value)} would return, as the rendering is all ASCII.
+     */
+    public static int decimalLength(long value)
+    {
+        if (value == Long.MIN_VALUE) {
+            // its magnitude has no positive counterpart
+            return 20;
+        }
+
+        int sign = 0;
+        if (value < 0) {
+            sign = 1;
+            value = -value;
+        }
+
+        for (int digits = 1; digits < POWERS_OF_TEN.length; digits++) {
+            if (value < POWERS_OF_TEN[digits]) {
+                return sign + digits;
+            }
+        }
+        return sign + 19;
+    }
+
+    public static Slice formatLong(long value)
+    {
+        byte[] bytes = new byte[decimalLength(value)];
+        int index = bytes.length;
+
+        // accumulate on the negative side, which is the only one that can hold Long.MIN_VALUE
+        boolean negative = value < 0;
+        long magnitude = negative ? value : -value;
+        do {
+            bytes[--index] = (byte) ('0' - (magnitude % 10));
+            magnitude /= 10;
+        }
+        while (magnitude != 0);
+
+        if (negative) {
+            bytes[--index] = '-';
+        }
+        return Slices.wrappedBuffer(bytes);
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/NumberParser.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/NumberParser.java
@@ -114,23 +114,36 @@ public final class NumberParser
     /**
      * Parses an integer exactly as {@code Long.parseLong(value.toStringUtf8().trim())} would,
      * including the exception it throws for malformed input and for overflow.
-     * <p>
-     * Anything that is not ASCII whitespace, a sign, or an ASCII digit falls back to the JDK, which
-     * also accepts digits outside ASCII, such as Arabic-Indic ones.
      */
-    public static long parseLong(Slice slice, int offset, int length)
+    public static long parseTrimmedLong(Slice slice, int offset, int length)
     {
         int index = offset;
         int end = offset + length;
 
-        // String.trim removes every character up to and including the space, and a byte of a multi
-        // byte UTF-8 sequence always has the high bit set, so it is never trimmed
+        // String.trim removes every character up to and including the space, and every byte of a
+        // multi byte UTF-8 sequence has the high bit set, so trimming bytes trims the same
+        // characters that String.trim does
         while (index < end && isTrimmed(slice.getByte(index))) {
             index++;
         }
         while (end > index && isTrimmed(slice.getByte(end - 1))) {
             end--;
         }
+        return parseLong(slice, index, end - index);
+    }
+
+    /**
+     * Parses an integer exactly as {@code Long.parseLong(value.toStringUtf8())} would, including the
+     * exception it throws for malformed input and for overflow. Surrounding whitespace is rejected,
+     * just as the JDK rejects it.
+     * <p>
+     * Anything that is not a sign or an ASCII digit falls back to the JDK, which also accepts digits
+     * outside ASCII, such as Arabic-Indic ones.
+     */
+    public static long parseLong(Slice slice, int offset, int length)
+    {
+        int index = offset;
+        int end = offset + length;
         if (index == end) {
             return parseLongWithJdk(slice, offset, length);
         }
@@ -178,7 +191,7 @@ public final class NumberParser
 
     private static long parseLongWithJdk(Slice slice, int offset, int length)
     {
-        return Long.parseLong(slice.toString(offset, length, UTF_8).trim());
+        return Long.parseLong(slice.toString(offset, length, UTF_8));
     }
 
     private static boolean isTrimmed(byte value)

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/NumberParser.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/NumberParser.java
@@ -15,6 +15,8 @@ package io.trino.plugin.base.util;
 
 import io.airlift.slice.Slice;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * Parses floating point values directly from their ASCII bytes.
  * <p>
@@ -102,7 +104,87 @@ public final class NumberParser
      */
     public static final long NOT_SHORT_DECIMAL = Long.MIN_VALUE;
 
+    /**
+     * Accumulating another digit past this overflows a long.
+     */
+    private static final long MIN_VALUE_BEFORE_LAST_DIGIT = Long.MIN_VALUE / 10;
+
     private NumberParser() {}
+
+    /**
+     * Parses an integer exactly as {@code Long.parseLong(value.toStringUtf8().trim())} would,
+     * including the exception it throws for malformed input and for overflow.
+     * <p>
+     * Anything that is not ASCII whitespace, a sign, or an ASCII digit falls back to the JDK, which
+     * also accepts digits outside ASCII, such as Arabic-Indic ones.
+     */
+    public static long parseLong(Slice slice, int offset, int length)
+    {
+        int index = offset;
+        int end = offset + length;
+
+        // String.trim removes every character up to and including the space, and a byte of a multi
+        // byte UTF-8 sequence always has the high bit set, so it is never trimmed
+        while (index < end && isTrimmed(slice.getByte(index))) {
+            index++;
+        }
+        while (end > index && isTrimmed(slice.getByte(end - 1))) {
+            end--;
+        }
+        if (index == end) {
+            return parseLongWithJdk(slice, offset, length);
+        }
+
+        boolean negative = false;
+        byte first = slice.getByte(index);
+        if (first == '-') {
+            negative = true;
+            index++;
+        }
+        else if (first == '+') {
+            index++;
+        }
+        if (index == end) {
+            return parseLongWithJdk(slice, offset, length);
+        }
+
+        // accumulate towards Long.MIN_VALUE, which has a larger magnitude than Long.MAX_VALUE
+        long value = 0;
+        while (index < end) {
+            int digit = slice.getByte(index) - '0';
+            if (digit < 0 || digit > 9) {
+                return parseLongWithJdk(slice, offset, length);
+            }
+            if (value < MIN_VALUE_BEFORE_LAST_DIGIT) {
+                return parseLongWithJdk(slice, offset, length);
+            }
+            value *= 10;
+            if (value < Long.MIN_VALUE + digit) {
+                return parseLongWithJdk(slice, offset, length);
+            }
+            value -= digit;
+            index++;
+        }
+
+        if (negative) {
+            return value;
+        }
+        if (value == Long.MIN_VALUE) {
+            // the magnitude of Long.MIN_VALUE cannot be represented as a positive long
+            return parseLongWithJdk(slice, offset, length);
+        }
+        return -value;
+    }
+
+    private static long parseLongWithJdk(Slice slice, int offset, int length)
+    {
+        return Long.parseLong(slice.toString(offset, length, UTF_8).trim());
+    }
+
+    private static boolean isTrimmed(byte value)
+    {
+        return value >= 0 && value <= ' ';
+    }
 
     /**
      * Parses a plain decimal into an unscaled long at {@code scale}, rounding half up, exactly as

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/util/TestNumberFormatter.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/util/TestNumberFormatter.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static io.trino.plugin.base.util.NumberFormatter.decimalLength;
+import static io.trino.plugin.base.util.NumberFormatter.formatLong;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestNumberFormatter
+{
+    @Test
+    public void testMatchesJdk()
+    {
+        for (long value : new long[] {
+                0, 1, -1, 9, -9, 10, -10, 99, -99, 100, -100,
+                Long.MAX_VALUE, Long.MIN_VALUE, Long.MAX_VALUE - 1, Long.MIN_VALUE + 1,
+                Integer.MAX_VALUE, Integer.MIN_VALUE, Short.MAX_VALUE, Short.MIN_VALUE, Byte.MAX_VALUE, Byte.MIN_VALUE,
+                1_000_000_000_000_000_000L, -1_000_000_000_000_000_000L,
+        }) {
+            assertMatchesJdk(value);
+        }
+
+        // every power of ten and its neighbours, where the digit count changes
+        for (long power = 1; power <= 1_000_000_000_000_000_000L; power *= 10) {
+            assertMatchesJdk(power - 1);
+            assertMatchesJdk(power);
+            assertMatchesJdk(power + 1);
+            assertMatchesJdk(-power + 1);
+            assertMatchesJdk(-power);
+            assertMatchesJdk(-power - 1);
+        }
+    }
+
+    @Test
+    public void testRandomValuesMatchJdk()
+    {
+        Random random = new Random(20260712);
+        for (int i = 0; i < 500_000; i++) {
+            assertMatchesJdk(random.nextLong());
+            // small values are far more common than uniformly random longs
+            assertMatchesJdk(random.nextLong(-1_000_000, 1_000_000));
+        }
+    }
+
+    /**
+     * The rendering must be identical to the JDK, so that switching a cast to the byte level
+     * formatter cannot change a query result. The length must match too, because the cast rejects a
+     * value that does not fit the target based on it.
+     */
+    private static void assertMatchesJdk(long value)
+    {
+        String expected = Long.toString(value);
+        assertThat(decimalLength(value))
+                .describedAs("decimalLength(%s)", value)
+                .isEqualTo(expected.length());
+        assertThat(formatLong(value).toStringUtf8())
+                .describedAs("formatLong(%s)", value)
+                .isEqualTo(expected);
+    }
+}

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/util/TestNumberParser.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/util/TestNumberParser.java
@@ -126,7 +126,7 @@ public class TestNumberParser
     public void testLongRespectsOffsetAndLength()
     {
         Slice slice = Slices.utf8Slice("xx-123yy");
-        assertThat(NumberParser.parseLong(slice, 2, 4)).isEqualTo(-123);
+        assertThat(NumberParser.parseTrimmedLong(slice, 2, 4)).isEqualTo(-123);
     }
 
     private static String randomInteger(Random random)
@@ -164,14 +164,45 @@ public class TestNumberParser
         }
 
         if (expected == null) {
-            assertThatThrownBy(() -> NumberParser.parseLong(slice, 0, slice.length()))
-                    .describedAs("parseLong(%s)", value)
+            assertThatThrownBy(() -> NumberParser.parseTrimmedLong(slice, 0, slice.length()))
+                    .describedAs("parseTrimmedLong(%s)", value)
                     .isInstanceOf(NumberFormatException.class);
         }
         else {
-            assertThat(NumberParser.parseLong(slice, 0, slice.length()))
-                    .describedAs("parseLong(%s)", value)
+            assertThat(NumberParser.parseTrimmedLong(slice, 0, slice.length()))
+                    .describedAs("parseTrimmedLong(%s)", value)
                     .isEqualTo(expected);
+        }
+    }
+
+    @Test
+    public void testUntrimmedLongMatchesJdk()
+    {
+        // the Hive coercions do not trim, so surrounding whitespace must be rejected
+        for (String value : new String[] {
+                "0", "1", "-1", "+1", "123", "-123", "9223372036854775807", "-9223372036854775808",
+                "9223372036854775808", "-9223372036854775809", "\u0661\u0662\u0663",
+                " 123", "123 ", "  123  ", "\t123", "", " ", "abc", "1.5",
+        }) {
+            Slice slice = Slices.utf8Slice(value);
+
+            Long expected = null;
+            try {
+                expected = Long.parseLong(value);
+            }
+            catch (NumberFormatException _) {
+            }
+
+            if (expected == null) {
+                assertThatThrownBy(() -> NumberParser.parseLong(slice, 0, slice.length()))
+                        .describedAs("parseLong(%s)", value)
+                        .isInstanceOf(NumberFormatException.class);
+            }
+            else {
+                assertThat(NumberParser.parseLong(slice, 0, slice.length()))
+                        .describedAs("parseLong(%s)", value)
+                        .isEqualTo(expected);
+            }
         }
     }
 

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/util/TestNumberParser.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/util/TestNumberParser.java
@@ -87,6 +87,95 @@ public class TestNumberParser
     }
 
     @Test
+    public void testLongMatchesJdk()
+    {
+        for (String value : new String[] {
+                "0", "-0", "+0", "1", "-1", "+1", "123", "-123",
+                "9223372036854775807", "-9223372036854775808",
+                // one past each bound, which must overflow exactly as the JDK does
+                "9223372036854775808", "-9223372036854775809",
+                "99999999999999999999", "-99999999999999999999",
+                "0000000000000000000000123", "-0000000000000000000000123",
+                // String.trim removes everything up to and including the space
+                " 123", "123 ", "  123  ", "\t123\n", "\r123\r",
+                // the JDK accepts digits outside ASCII
+                "١٢٣", " ١٢٣ ", "-١٢٣",
+        }) {
+            assertLongMatchesJdk(value);
+        }
+    }
+
+    @Test
+    public void testMalformedLong()
+    {
+        for (String value : new String[] {"", " ", ".", "-", "+", "1.5", "1e5", "abc", "--1", "1-", "1 5", "12a", "١٢a", " 123"}) {
+            assertLongMatchesJdk(value);
+        }
+    }
+
+    @Test
+    public void testRandomLongsMatchJdk()
+    {
+        Random random = new Random(31337);
+        for (int i = 0; i < 200_000; i++) {
+            assertLongMatchesJdk(randomInteger(random));
+        }
+    }
+
+    @Test
+    public void testLongRespectsOffsetAndLength()
+    {
+        Slice slice = Slices.utf8Slice("xx-123yy");
+        assertThat(NumberParser.parseLong(slice, 2, 4)).isEqualTo(-123);
+    }
+
+    private static String randomInteger(Random random)
+    {
+        StringBuilder builder = new StringBuilder();
+        if (random.nextBoolean()) {
+            builder.append(' ');
+        }
+        if (random.nextBoolean()) {
+            builder.append(random.nextBoolean() ? '-' : '+');
+        }
+        int digits = 1 + random.nextInt(21);
+        for (int i = 0; i < digits; i++) {
+            builder.append((char) ('0' + random.nextInt(10)));
+        }
+        if (random.nextBoolean()) {
+            builder.append(' ');
+        }
+        return builder.toString();
+    }
+
+    /**
+     * The value, and the exception for malformed input and overflow, must be identical to the JDK,
+     * so that switching a cast to the byte level parser cannot change a query result.
+     */
+    private static void assertLongMatchesJdk(String value)
+    {
+        Slice slice = Slices.utf8Slice(value);
+
+        Long expected = null;
+        try {
+            expected = Long.parseLong(value.trim());
+        }
+        catch (NumberFormatException _) {
+        }
+
+        if (expected == null) {
+            assertThatThrownBy(() -> NumberParser.parseLong(slice, 0, slice.length()))
+                    .describedAs("parseLong(%s)", value)
+                    .isInstanceOf(NumberFormatException.class);
+        }
+        else {
+            assertThat(NumberParser.parseLong(slice, 0, slice.length()))
+                    .describedAs("parseLong(%s)", value)
+                    .isEqualTo(expected);
+        }
+    }
+
+    @Test
     public void testShortDecimalMatchesBigDecimal()
     {
         for (int scale : new int[] {0, 1, 2, 6, 12, 18}) {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
@@ -282,7 +282,7 @@ public class TestCheckpointWriter
                                 .put("byt", 10L)
                                 .put("fl", (long) Float.floatToIntBits(0.100f))
                                 .put("dou", 0.101d)
-                                .put("dat", (long) parseDate("2000-01-01"))
+                                .put("dat", (long) parseDate(utf8Slice("2000-01-01")))
                                 .put("row", new SqlRow(0, minMaxRowFieldBlocks))
                                 .buildOrThrow()),
                         Optional.of(ImmutableMap.<String, Object>builder()
@@ -297,7 +297,7 @@ public class TestCheckpointWriter
                                 .put("byt", 20L)
                                 .put("fl", (long) Float.floatToIntBits(0.200f))
                                 .put("dou", 0.202d)
-                                .put("dat", (long) parseDate("3000-01-01"))
+                                .put("dat", (long) parseDate(utf8Slice("3000-01-01")))
                                 .put("row", new SqlRow(0, minMaxRowFieldBlocks))
                                 .buildOrThrow()),
                         Optional.of(ImmutableMap.<String, Object>builder()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/BooleanCoercer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/BooleanCoercer.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import static io.airlift.slice.SliceUtf8.countCodePoints;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.base.util.NumberParser.parseLong;
 import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static java.lang.String.format;
@@ -109,7 +110,8 @@ public final class BooleanCoercer
             try {
                 // Apache Hive reads 0 as false, numeric string as true and non-numeric string as null for ORC file format
                 // https://github.com/apache/orc/blob/fb1c4cb9461d207db652fc253396e57640ed805b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java#L567
-                toType.writeBoolean(blockBuilder, !(Long.parseLong(fromType.getSlice(block, position).toStringUtf8()) == 0));
+                Slice value = fromType.getSlice(block, position);
+                toType.writeBoolean(blockBuilder, parseLong(value, 0, value.length()) != 0);
             }
             catch (NumberFormatException e) {
                 blockBuilder.appendNull();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/IntegerNumberToVarcharCoercer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/IntegerNumberToVarcharCoercer.java
@@ -22,7 +22,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
 import static io.airlift.slice.SliceUtf8.countCodePoints;
-import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.base.util.NumberFormatter.formatLong;
 import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static java.lang.String.format;
 
@@ -38,7 +38,8 @@ public class IntegerNumberToVarcharCoercer<F extends Type>
     protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
     {
         long value = fromType.getLong(block, position);
-        Slice converted = utf8Slice(String.valueOf(value));
+        // the rendering is all ASCII, so its length in bytes is also its length in code points
+        Slice converted = formatLong(value);
         if (!toType.isUnbounded() && countCodePoints(converted) > toType.getBoundedLength()) {
             throw new TrinoException(INVALID_ARGUMENTS, format("Varchar representation of %s exceeds %s bounds", value, toType));
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/VarcharToIntegralNumericCoercers.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/VarcharToIntegralNumericCoercers.java
@@ -14,6 +14,7 @@
 
 package io.trino.plugin.hive.coercions;
 
+import io.airlift.slice.Slice;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -21,6 +22,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.base.util.NumberParser.parseLong;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -55,21 +57,27 @@ public final class VarcharToIntegralNumericCoercers
         protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
         {
             try {
-                String valueToBeCoerced = fromType.getSlice(block, position).toStringUtf8();
-                if (toType.equals(TINYINT) || toType.equals(SMALLINT) || toType.equals(INTEGER)) {
-                    int intValue = Integer.parseInt(valueToBeCoerced);
-                    if (toType.equals(TINYINT)) {
-                        toType.writeLong(blockBuilder, (byte) intValue);
-                    }
-                    else if (toType.equals(SMALLINT)) {
-                        toType.writeLong(blockBuilder, (short) intValue);
-                    }
-                    else {
-                        toType.writeLong(blockBuilder, intValue);
-                    }
+                Slice value = fromType.getSlice(block, position);
+                long parsed = parseLong(value, 0, value.length());
+                if (toType.equals(BIGINT)) {
+                    toType.writeLong(blockBuilder, parsed);
+                    return;
                 }
-                else if (toType.equals(BIGINT)) {
-                    toType.writeLong(blockBuilder, Long.parseLong(valueToBeCoerced));
+
+                // Integer.parseInt rejects anything outside the int range
+                if (parsed != (int) parsed) {
+                    throw new NumberFormatException();
+                }
+                // Hive narrows to tinyint and smallint by truncating rather than by rejecting
+                int intValue = (int) parsed;
+                if (toType.equals(TINYINT)) {
+                    toType.writeLong(blockBuilder, (byte) intValue);
+                }
+                else if (toType.equals(SMALLINT)) {
+                    toType.writeLong(blockBuilder, (short) intValue);
+                }
+                else {
+                    toType.writeLong(blockBuilder, intValue);
                 }
             }
             catch (NumberFormatException e) {
@@ -114,7 +122,8 @@ public final class VarcharToIntegralNumericCoercers
         protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
         {
             try {
-                long value = Long.parseLong(fromType.getSlice(block, position).toStringUtf8());
+                Slice slice = fromType.getSlice(block, position);
+                long value = parseLong(slice, 0, slice.length());
                 if (minValue <= value && value <= maxValue) {
                     toType.writeLong(blockBuilder, value);
                 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestVarcharToIntegralNumericCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestVarcharToIntegralNumericCoercer.java
@@ -54,6 +54,9 @@ public class TestVarcharToIntegralNumericCoercer
         assertVarcharToIntegralCoercion("String", TINYINT, null);
         assertVarcharToIntegralCoercion("1s", TINYINT, null);
         assertVarcharToIntegralCoercion("1e+0", TINYINT, null);
+        // Hive does not trim, so surrounding whitespace is not a number
+        assertVarcharToIntegralCoercion(" 1", TINYINT, null);
+        assertVarcharToIntegralCoercion("1 ", TINYINT, null);
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

### What

A recurring pattern across the engine and the Hive connector: a scalar function or cast takes a Slice, decodes it into a java.lang.String (or copies it into a fresh byte[]), does work that only ever reads ASCII bytes, and throws the intermediate away — once per row.

This replaces those with direct byte access. Nine independent commits, each with a measurement or an explicit note that it has none.

### Why it matters

Most of these run per row on hot paths (casts, regexp_*, Hive schema-evolution coercions), and several were already flagged in-tree: BigintOperators, IntegerOperators, SmallintOperators and TinyintOperators all literally carried // todo optimize me.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
