### PR TITLE
Keep Derby log of EPSG catalog generator out of the source tree

### DIFF
--- a/lib/trino-geospatial-epsg-generator/src/main/java/io/trino/geospatial/epsg/generator/GenerateEpsgCatalog.java
+++ b/lib/trino-geospatial-epsg-generator/src/main/java/io/trino/geospatial/epsg/generator/GenerateEpsgCatalog.java
@@ -65,6 +65,10 @@ public final class GenerateEpsgCatalog
         }
 
         Path outputDirectory = Path.of(args[0]);
+        // Derby (backing the embedded EPSG dataset) writes derby.log to the JVM working directory
+        // by default, which is the repository root when invoked via exec:java. A stray untracked
+        // file there makes gitflow-incremental-builder consider the root module changed.
+        System.setProperty("derby.stream.error.file", Path.of(System.getProperty("java.io.tmpdir"), "derby.log").toString());
         Path resourceDirectory = outputDirectory.resolve("io/trino/geospatial/epsg");
         Files.createDirectories(resourceDirectory);
         Files.deleteIfExists(resourceDirectory.resolve("epsg-catalog.bin.gz"));


### PR DESCRIPTION
## Description

The EPSG catalog generator added in 7bb39f3c57b (`ST_Transform`) runs in-process via `exec:java`, and Derby (backing the embedded EPSG dataset from Apache SIS) writes `derby.log` to the JVM working directory by default — the repository root.

This stray untracked file breaks GIB-based CI jobs: after the `Maven Install` step builds `trino-geospatial-epsg`, the subsequent GIB invocation in the same job sees an untracked root-level file and reports `trino-root` as changed, which marks **every** module as impacted. Jobs that rely on GIB deselecting non-impacted modules (e.g. `test-other-modules` with its `-pl '!...'` exclusion list) then try to build modules whose dependencies were intentionally neither installed nor selected, failing with e.g.:

```
Could not resolve dependencies for project io.trino:trino-kafka-event-listener:trino-plugin:483-SNAPSHOT
Could not find artifact io.trino:trino-kafka:jar:483-SNAPSHOT
```

This hits any PR whose GIB-impacted closure includes `trino-geospatial-epsg` without covering the whole project — e.g. #30294 (a one-file `lib/trino-filesystem` change) fails deterministically across rebases/restarts:

```
[INFO] Changed artifactIds (2):
[INFO] - trino-root                          <-- the stray derby.log
[INFO] - trino-filesystem (but deselected)
```

Fix: point `derby.stream.error.file` at the system temporary directory.

Verified locally: `./mvnw install -pl :trino-geospatial-epsg -am` now writes `derby.log` to `java.io.tmpdir` and leaves `git status` clean.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.