### PR TITLE
Add late materialization for partial TopN

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -217,6 +217,7 @@ public final class SystemSessionProperties
     public static final String IDLE_WRITER_MIN_DATA_SIZE_THRESHOLD = "idle_writer_min_data_size_threshold";
     public static final String CLOSE_IDLE_WRITERS_TRIGGER_DURATION = "close_idle_writers_trigger_duration";
     public static final String COLUMNAR_FILTER_EVALUATION_ENABLED = "columnar_filter_evaluation_enabled";
+    public static final String MASKED_PAGE_ENABLED = "masked_page_enabled";
     public static final String ADAPTIVE_FILTER_REORDERING_ENABLED = "adaptive_filter_reordering_enabled";
     public static final String SPOOLING_ENABLED = "spooling_enabled";
     public static final String DEBUG_ADAPTIVE_PLANNER = "debug_adaptive_planner";
@@ -1112,6 +1113,11 @@ public final class SystemSessionProperties
                         COLUMNAR_FILTER_EVALUATION_ENABLED,
                         "Enables columnar evaluation of filters",
                         featuresConfig.isColumnarFilterEvaluationEnabled(),
+                        false),
+                booleanProperty(
+                        MASKED_PAGE_ENABLED,
+                        "Enable late materialization by passing undecoded masked pages between operators, so a consumer such as partial TopN can defer decoding of columns it may not need",
+                        optimizerConfig.isMaskedPageEnabled(),
                         false),
                 booleanProperty(
                         ADAPTIVE_FILTER_REORDERING_ENABLED,
@@ -2035,6 +2041,11 @@ public final class SystemSessionProperties
     public static boolean isColumnarFilterEvaluationEnabled(Session session)
     {
         return session.getSystemProperty(COLUMNAR_FILTER_EVALUATION_ENABLED, Boolean.class);
+    }
+
+    public static boolean isMaskedPageEnabled(Session session)
+    {
+        return session.getSystemProperty(MASKED_PAGE_ENABLED, Boolean.class);
     }
 
     public static boolean isAdaptiveFilterReorderingEnabled(Session session)

--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -222,6 +222,7 @@ public final class SystemSessionProperties
     public static final String IDLE_WRITER_MIN_DATA_SIZE_THRESHOLD = "idle_writer_min_data_size_threshold";
     public static final String CLOSE_IDLE_WRITERS_TRIGGER_DURATION = "close_idle_writers_trigger_duration";
     public static final String COLUMNAR_FILTER_EVALUATION_ENABLED = "columnar_filter_evaluation_enabled";
+    public static final String MASKED_PAGE_ENABLED = "masked_page_enabled";
     public static final String ADAPTIVE_FILTER_REORDERING_ENABLED = "adaptive_filter_reordering_enabled";
     public static final String SPOOLING_ENABLED = "spooling_enabled";
     public static final String DEBUG_ADAPTIVE_PLANNER = "debug_adaptive_planner";
@@ -1127,6 +1128,11 @@ public final class SystemSessionProperties
                         COLUMNAR_FILTER_EVALUATION_ENABLED,
                         "Enables columnar evaluation of filters",
                         featuresConfig.isColumnarFilterEvaluationEnabled(),
+                        false),
+                booleanProperty(
+                        MASKED_PAGE_ENABLED,
+                        "Enable late materialization by passing undecoded masked pages between operators, so a consumer such as partial TopN can defer decoding of columns it may not need",
+                        optimizerConfig.isMaskedPageEnabled(),
                         false),
                 booleanProperty(
                         ADAPTIVE_FILTER_REORDERING_ENABLED,
@@ -2060,6 +2066,11 @@ public final class SystemSessionProperties
     public static boolean isColumnarFilterEvaluationEnabled(Session session)
     {
         return session.getSystemProperty(COLUMNAR_FILTER_EVALUATION_ENABLED, Boolean.class);
+    }
+
+    public static boolean isMaskedPageEnabled(Session session)
+    {
+        return session.getSystemProperty(MASKED_PAGE_ENABLED, Boolean.class);
     }
 
     public static boolean isAdaptiveFilterReorderingEnabled(Session session)

--- a/core/trino-main/src/main/java/io/trino/operator/Driver.java
+++ b/core/trino-main/src/main/java/io/trino/operator/Driver.java
@@ -50,6 +50,7 @@ import static com.google.common.util.concurrent.Futures.nonCancellationPropagati
 import static com.google.common.util.concurrent.Futures.withTimeout;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.trino.SystemSessionProperties.isMaskedPageEnabled;
 import static io.trino.operator.Operator.NOT_BLOCKED;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.lang.Boolean.TRUE;
@@ -71,6 +72,7 @@ public class Driver
     private static final Duration UNLIMITED_DURATION = new Duration(Long.MAX_VALUE, NANOSECONDS);
 
     private final DriverContext driverContext;
+    private final boolean maskedPageEnabled;
     private final List<Operator> activeOperators;
     // this is present only for debugging
     @SuppressWarnings("unused")
@@ -124,6 +126,7 @@ public class Driver
     private Driver(DriverContext driverContext, List<Operator> operators)
     {
         this.driverContext = requireNonNull(driverContext, "driverContext is null");
+        this.maskedPageEnabled = isMaskedPageEnabled(driverContext.getSession());
         this.allOperators = ImmutableList.copyOf(requireNonNull(operators, "operators is null"));
         checkArgument(allOperators.size() > 1, "At least two operators are required");
         this.activeOperators = new ArrayList<>(operators);
@@ -399,15 +402,32 @@ public class Driver
 
             // if the current operator is not finished and next operator isn't blocked and needs input...
             if (!current.isFinished() && getBlockedFuture(next).isEmpty() && next.needsInput()) {
-                // get an output page from current operator
-                Page page = current.getOutput();
-                current.getOperatorContext().recordGetOutput(operationTimer, page);
+                if (maskedPageEnabled && current.producesMaskedOutput() && next.supportsMaskedInput()) {
+                    // hand off an undecoded masked page so the consumer can decode only what it needs
+                    MaskedPage maskedPage = current.getMaskedOutput();
+                    long maskedPositions = 0;
+                    if (maskedPage != null) {
+                        maskedPositions = maskedPage.getPositionCount();
+                    }
+                    current.getOperatorContext().recordGetMaskedOutput(operationTimer, maskedPositions);
 
-                // if we got an output page, add it to the next operator
-                if (page != null && page.getPositionCount() != 0) {
-                    next.addInput(page);
-                    next.getOperatorContext().recordAddInput(operationTimer, page);
-                    movedPage = true;
+                    if (maskedPage != null && maskedPositions != 0) {
+                        next.addMaskedInput(maskedPage);
+                        next.getOperatorContext().recordAddMaskedInput(operationTimer, maskedPositions);
+                        movedPage = true;
+                    }
+                }
+                else {
+                    // get an output page from current operator
+                    Page page = current.getOutput();
+                    current.getOperatorContext().recordGetOutput(operationTimer, page);
+
+                    // if we got an output page, add it to the next operator
+                    if (page != null && page.getPositionCount() != 0) {
+                        next.addInput(page);
+                        next.getOperatorContext().recordAddInput(operationTimer, page);
+                        movedPage = true;
+                    }
                 }
 
                 if (current instanceof SourceOperator) {

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberBuilder.java
@@ -111,6 +111,46 @@ public class GroupedTopNRowNumberBuilder
                 + groupedTopNRowNumberAccumulator.sizeOf();
     }
 
+    /**
+     * Group IDs of the probed positions and the first position that would enter the top N,
+     * negative when no position would.
+     */
+    public record ProbeResult(int firstPositionToAdd, int[] groupIds) {}
+
+    /**
+     * Determines which positions of the page would enter the top N without adding them. Reads only
+     * the sort channels; the page may carry placeholder blocks in the remaining channels. Requires
+     * a group by hash whose group IDs work completes immediately.
+     */
+    public ProbeResult probe(Page probePage)
+    {
+        if (groupByHash == null) {
+            throw new IllegalStateException("already producing output");
+        }
+        Work<int[]> groupIdsWork = groupByHash.getGroupIds(probePage.getColumns(groupByChannels));
+        verify(groupIdsWork.process(), "group IDs work did not complete immediately");
+        int[] groupIds = groupIdsWork.getResult();
+        int firstPositionToAdd = groupedTopNRowNumberAccumulator.findFirstPositionToAdd(probePage, groupByHash.getGroupCount(), groupIds, comparator, pageManager);
+        return new ProbeResult(firstPositionToAdd, groupIds);
+    }
+
+    /**
+     * Adds all positions of the page using group IDs from a prior {@link #probe} over the same
+     * rows; {@code groupIdsOffset} is the probe position of the page's first row.
+     */
+    public void addPage(Page page, int[] groupIds, int groupIdsOffset)
+    {
+        try (LoadCursor loadCursor = pageManager.add(page)) {
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                loadCursor.advance();
+                groupedTopNRowNumberAccumulator.add(groupIds[groupIdsOffset + position], loadCursor);
+            }
+            verify(!loadCursor.advance());
+        }
+
+        pageManager.compactIfNeeded();
+    }
+
     private void processPage(Page newPage, int groupCount, int[] groupIds)
     {
         int firstPositionToAdd = groupedTopNRowNumberAccumulator.findFirstPositionToAdd(newPage, groupCount, groupIds, comparator, pageManager);

--- a/core/trino-main/src/main/java/io/trino/operator/MaskedPage.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MaskedPage.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.trino.memory.context.LocalMemoryContext;
+import io.trino.operator.project.PageProcessorMetrics;
+import io.trino.operator.project.PageProjection;
+import io.trino.operator.project.PageProjectionsProcessor;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SourcePage;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static io.trino.operator.project.SelectedPositions.positionsRange;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A page whose channels are produced on first access, restricted to a mask of selected positions.
+ * Passed from {@link Operator#getMaskedOutput} to {@link Operator#addMaskedInput} so the consumer
+ * can decide, from a subset of channels, whether the remaining channels need to be produced at all.
+ * A channel accessed via {@link #getBlock} is projected over the whole mask and cached; a later
+ * {@link #materialize} reuses those cached blocks and produces the rest, sharing the producer's
+ * batch-sizing and oversized-batch splitting through {@link PageProjectionsProcessor}.
+ * <p>
+ * A masked page is valid only until the driver next requests output from its producer; the
+ * consumer must produce or copy everything it needs before returning from
+ * {@link Operator#addMaskedInput}.
+ */
+public final class MaskedPage
+{
+    private final ConnectorSession session;
+    private final SourcePage sourcePage;
+    private final PageProjectionsProcessor projectionsProcessor;
+    private final LocalMemoryContext memoryContext;
+    private final PageProcessorMetrics metrics;
+    private final Block[] computedBlocks;
+    private Consumer<Page> outputValidator = _ -> {};
+
+    /**
+     * Applies {@code selectedPositions} to {@code sourcePage} and wraps it. The source page must
+     * not be used directly afterwards.
+     */
+    public static MaskedPage applyMask(
+            ConnectorSession session,
+            SourcePage sourcePage,
+            SelectedPositions selectedPositions,
+            PageProjectionsProcessor projectionsProcessor,
+            LocalMemoryContext memoryContext,
+            PageProcessorMetrics metrics)
+    {
+        if (selectedPositions.isList()) {
+            // copy: source pages wrap the array into blocks that outlive the filter evaluator's
+            // reusable positions buffer
+            int[] positions = Arrays.copyOfRange(
+                    selectedPositions.getPositions(),
+                    selectedPositions.getOffset(),
+                    selectedPositions.getOffset() + selectedPositions.size());
+            sourcePage.selectPositions(positions, 0, positions.length);
+        }
+        else if (selectedPositions.getOffset() != 0 || selectedPositions.size() != sourcePage.getPositionCount()) {
+            sourcePage.selectPositions(selectedPositions.getOffset(), selectedPositions.size());
+        }
+        return new MaskedPage(session, sourcePage, projectionsProcessor, memoryContext, metrics);
+    }
+
+    private MaskedPage(
+            ConnectorSession session,
+            SourcePage sourcePage,
+            PageProjectionsProcessor projectionsProcessor,
+            LocalMemoryContext memoryContext,
+            PageProcessorMetrics metrics)
+    {
+        this.session = requireNonNull(session, "session is null");
+        this.sourcePage = requireNonNull(sourcePage, "sourcePage is null");
+        this.projectionsProcessor = requireNonNull(projectionsProcessor, "projectionsProcessor is null");
+        this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");
+        this.metrics = requireNonNull(metrics, "metrics is null");
+        this.computedBlocks = new Block[projectionsProcessor.getProjectionCount()];
+    }
+
+    public int getPositionCount()
+    {
+        return sourcePage.getPositionCount();
+    }
+
+    public int getChannelCount()
+    {
+        return projectionsProcessor.getProjectionCount();
+    }
+
+    /**
+     * Sets a validator applied to each page produced by {@link #materialize}. Runs on blocks that
+     * are decoded anyway, so deferred channels stay untouched.
+     */
+    void setOutputValidator(Consumer<Page> outputValidator)
+    {
+        this.outputValidator = requireNonNull(outputValidator, "outputValidator is null");
+    }
+
+    /**
+     * Produces the given channel, restricted to the mask. Computed once and cached; a subsequent
+     * {@link #selectPositionsFrom} narrows the cached block.
+     */
+    public Block getBlock(int channel)
+    {
+        Block block = computedBlocks[channel];
+        if (block == null) {
+            PageProjection projection = projectionsProcessor.getProjections().get(channel);
+            SourcePage inputPage = projection.getInputChannels().getInputChannels(sourcePage);
+            block = projection.project(session, inputPage, positionsRange(0, sourcePage.getPositionCount()));
+            computedBlocks[channel] = block;
+            updateMemoryUsage();
+        }
+        return block;
+    }
+
+    /**
+     * Narrows the mask to positions {@code [position, getPositionCount())}. Positions refer to the
+     * current mask, not the original page.
+     */
+    public void selectPositionsFrom(int position)
+    {
+        if (position == 0) {
+            return;
+        }
+        int size = sourcePage.getPositionCount() - position;
+        sourcePage.selectPositions(position, size);
+        for (int channel = 0; channel < computedBlocks.length; channel++) {
+            Block block = computedBlocks[channel];
+            if (block != null) {
+                computedBlocks[channel] = block.getRegion(position, size);
+            }
+        }
+        updateMemoryUsage();
+    }
+
+    private void updateMemoryUsage()
+    {
+        long retainedSizeInBytes = 0;
+        for (Block block : computedBlocks) {
+            if (block != null) {
+                retainedSizeInBytes += block.getRetainedSizeInBytes();
+            }
+        }
+        memoryContext.setBytes(retainedSizeInBytes);
+    }
+
+    /**
+     * Produces all channels restricted to the mask, reusing blocks already produced by
+     * {@link #getBlock} and computing the rest in batches bounded by output size. Must be drained
+     * while this page is valid.
+     */
+    public WorkProcessor<Page> materialize()
+    {
+        return projectionsProcessor.project(session, memoryContext, metrics, sourcePage, positionsRange(0, sourcePage.getPositionCount()), Optional.of(computedBlocks))
+                .map(page -> {
+                    outputValidator.accept(page);
+                    return page;
+                });
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/MaskedPage.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MaskedPage.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.trino.memory.context.LocalMemoryContext;
+import io.trino.operator.project.PageProcessorMetrics;
+import io.trino.operator.project.PageProjection;
+import io.trino.operator.project.PageProjectionsProcessor;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SourcePage;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static io.trino.operator.project.SelectedPositions.positionsRange;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A page whose channels are produced on first access, restricted to a mask of selected positions.
+ * Passed from {@link Operator#getMaskedOutput} to {@link Operator#addMaskedInput} so the consumer
+ * can decide, from a subset of channels, whether the remaining channels need to be produced at all.
+ * A channel accessed via {@link #getBlock} is projected over the whole mask and cached; a later
+ * {@link #materialize} reuses those cached blocks and produces the rest, sharing the producer's
+ * batch-sizing and oversized-batch splitting through {@link PageProjectionsProcessor}.
+ * <p>
+ * A masked page is valid only until the driver next requests output from its producer; the
+ * consumer must produce or copy everything it needs before returning from
+ * {@link Operator#addMaskedInput}.
+ */
+public final class MaskedPage
+{
+    private final ConnectorSession session;
+    private final SourcePage sourcePage;
+    private final PageProjectionsProcessor projectionsProcessor;
+    private final LocalMemoryContext memoryContext;
+    private final PageProcessorMetrics metrics;
+    private final Block[] computedBlocks;
+    private Consumer<Page> outputValidator = _ -> {};
+
+    /**
+     * Applies {@code selectedPositions} to {@code sourcePage} and wraps it. The source page must
+     * not be used directly afterwards.
+     */
+    public static MaskedPage applyMask(
+            ConnectorSession session,
+            SourcePage sourcePage,
+            SelectedPositions selectedPositions,
+            PageProjectionsProcessor projectionsProcessor,
+            LocalMemoryContext memoryContext,
+            PageProcessorMetrics metrics)
+    {
+        if (selectedPositions.isList()) {
+            // offer the selection first so the reader can skip decoding unselected values
+            if (!sourcePage.trySelectPositions(selectedPositions.getPositions(), selectedPositions.getOffset(), selectedPositions.size())) {
+                // copy: source pages wrap the array into blocks that outlive the filter evaluator's
+                // reusable positions buffer
+                int[] positions = Arrays.copyOfRange(
+                        selectedPositions.getPositions(),
+                        selectedPositions.getOffset(),
+                        selectedPositions.getOffset() + selectedPositions.size());
+                sourcePage.selectPositions(positions, 0, positions.length);
+            }
+        }
+        else if (selectedPositions.getOffset() != 0 || selectedPositions.size() != sourcePage.getPositionCount()) {
+            sourcePage.selectPositions(selectedPositions.getOffset(), selectedPositions.size());
+        }
+        return new MaskedPage(session, sourcePage, projectionsProcessor, memoryContext, metrics);
+    }
+
+    private MaskedPage(
+            ConnectorSession session,
+            SourcePage sourcePage,
+            PageProjectionsProcessor projectionsProcessor,
+            LocalMemoryContext memoryContext,
+            PageProcessorMetrics metrics)
+    {
+        this.session = requireNonNull(session, "session is null");
+        this.sourcePage = requireNonNull(sourcePage, "sourcePage is null");
+        this.projectionsProcessor = requireNonNull(projectionsProcessor, "projectionsProcessor is null");
+        this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");
+        this.metrics = requireNonNull(metrics, "metrics is null");
+        this.computedBlocks = new Block[projectionsProcessor.getProjectionCount()];
+    }
+
+    public int getPositionCount()
+    {
+        return sourcePage.getPositionCount();
+    }
+
+    public int getChannelCount()
+    {
+        return projectionsProcessor.getProjectionCount();
+    }
+
+    /**
+     * Sets a validator applied to each page produced by {@link #materialize}. Runs on blocks that
+     * are decoded anyway, so deferred channels stay untouched.
+     */
+    void setOutputValidator(Consumer<Page> outputValidator)
+    {
+        this.outputValidator = requireNonNull(outputValidator, "outputValidator is null");
+    }
+
+    /**
+     * Produces the given channel, restricted to the mask. Computed once and cached; a subsequent
+     * {@link #selectPositionsFrom} narrows the cached block.
+     */
+    public Block getBlock(int channel)
+    {
+        Block block = computedBlocks[channel];
+        if (block == null) {
+            PageProjection projection = projectionsProcessor.getProjections().get(channel);
+            SourcePage inputPage = projection.getInputChannels().getInputChannels(sourcePage);
+            block = projection.project(session, inputPage, positionsRange(0, sourcePage.getPositionCount()));
+            computedBlocks[channel] = block;
+            updateMemoryUsage();
+        }
+        return block;
+    }
+
+    /**
+     * Narrows the mask to positions {@code [position, getPositionCount())}. Positions refer to the
+     * current mask, not the original page.
+     */
+    public void selectPositionsFrom(int position)
+    {
+        if (position == 0) {
+            return;
+        }
+        int size = sourcePage.getPositionCount() - position;
+        sourcePage.selectPositions(position, size);
+        for (int channel = 0; channel < computedBlocks.length; channel++) {
+            Block block = computedBlocks[channel];
+            if (block != null) {
+                computedBlocks[channel] = block.getRegion(position, size);
+            }
+        }
+        updateMemoryUsage();
+    }
+
+    private void updateMemoryUsage()
+    {
+        long retainedSizeInBytes = 0;
+        for (Block block : computedBlocks) {
+            if (block != null) {
+                retainedSizeInBytes += block.getRetainedSizeInBytes();
+            }
+        }
+        memoryContext.setBytes(retainedSizeInBytes);
+    }
+
+    /**
+     * Produces all channels restricted to the mask, reusing blocks already produced by
+     * {@link #getBlock} and computing the rest in batches bounded by output size. Must be drained
+     * while this page is valid.
+     */
+    public WorkProcessor<Page> materialize()
+    {
+        return projectionsProcessor.project(session, memoryContext, metrics, sourcePage, positionsRange(0, sourcePage.getPositionCount()), Optional.of(computedBlocks))
+                .map(page -> {
+                    outputValidator.accept(page);
+                    return page;
+                });
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/Operator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/Operator.java
@@ -15,6 +15,7 @@ package io.trino.operator;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.spi.Page;
+import jakarta.annotation.Nullable;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 
@@ -24,6 +25,43 @@ public interface Operator
     ListenableFuture<Void> NOT_BLOCKED = immediateVoidFuture();
 
     OperatorContext getOperatorContext();
+
+    /**
+     * Whether this operator can emit {@link MaskedPage} output instead of materialized pages. The
+     * driver reads masked output only when the downstream operator returns true from
+     * {@link #supportsMaskedInput}; otherwise {@link #getOutput} is used.
+     */
+    default boolean producesMaskedOutput()
+    {
+        return false;
+    }
+
+    /**
+     * Analog of {@link #getOutput} producing a {@link MaskedPage}. The returned page is valid only
+     * until the next output request on this operator.
+     */
+    @Nullable
+    default MaskedPage getMaskedOutput()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Whether this operator can consume {@link MaskedPage} input instead of materialized pages.
+     */
+    default boolean supportsMaskedInput()
+    {
+        return false;
+    }
+
+    /**
+     * Analog of {@link #addInput} accepting a {@link MaskedPage}. The page is valid only for the
+     * duration of this call; the consumer must decode or copy everything it needs before returning.
+     */
+    default void addMaskedInput(MaskedPage maskedPage)
+    {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Returns a future that will be completed when the operator becomes

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
@@ -178,6 +178,13 @@ public class OperatorContext
         }
     }
 
+    // masked input transfers undecoded bytes, so only positions are recorded here; decoded bytes are counted when the consumer reads them
+    void recordAddMaskedInput(OperationTimer operationTimer, long positions)
+    {
+        operationTimer.recordOperationComplete(addInputTiming);
+        inputPositions.update(positions);
+    }
+
     /**
      * Record the amount of physical bytes that were read by an operator and
      * the time it took to read the data. This metric is valid only for source operators.
@@ -223,6 +230,13 @@ public class OperatorContext
             outputDataSize.update(page.getSizeInBytes());
             outputPositions.update(page.getPositionCount());
         }
+    }
+
+    // masked output transfers undecoded bytes, so only positions are recorded here
+    void recordGetMaskedOutput(OperationTimer operationTimer, long positions)
+    {
+        operationTimer.recordOperationComplete(getOutputTiming);
+        outputPositions.update(positions);
     }
 
     public void recordOutput(long sizeInBytes, long positions)

--- a/core/trino-main/src/main/java/io/trino/operator/OutputValidatingSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OutputValidatingSourceOperator.java
@@ -75,6 +75,23 @@ public class OutputValidatingSourceOperator
     }
 
     @Override
+    public boolean producesMaskedOutput()
+    {
+        return delegate.producesMaskedOutput();
+    }
+
+    @Override
+    public MaskedPage getMaskedOutput()
+    {
+        MaskedPage maskedPage = delegate.getMaskedOutput();
+        if (maskedPage != null) {
+            // masked output validates lazily inside materialize(), so deferred channels stay undecoded
+            maskedPage.setOutputValidator(page -> validateOutputPageTypes(page, outputTypes, debugContextSupplier));
+        }
+        return maskedPage;
+    }
+
+    @Override
     public ListenableFuture<Void> startMemoryRevoke()
     {
         return delegate.startMemoryRevoke();

--- a/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
@@ -27,6 +27,7 @@ import io.trino.operator.WorkProcessor.ProcessState;
 import io.trino.operator.WorkProcessor.TransformationState;
 import io.trino.operator.project.PageProcessor;
 import io.trino.operator.project.PageProcessorMetrics;
+import io.trino.operator.project.SelectedPositions;
 import io.trino.spi.Page;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
@@ -48,14 +49,11 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.LongConsumer;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
-import static io.trino.SystemSessionProperties.isSourcePagesValidationEnabled;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.operator.WorkProcessor.TransformationState.finished;
 import static io.trino.operator.WorkProcessor.TransformationState.ofResult;
@@ -67,7 +65,9 @@ public class ScanFilterAndProjectOperator
         implements WorkProcessorSourceOperator
 {
     private final PageSourceProvider pageSourceProvider;
-    private final WorkProcessor<Page> pages;
+    private final SplitToPages splitToPages;
+    // getOutputPages and getMaskedOutputPages both read from this stream; the driver calls only one of them
+    private final WorkProcessor<SourcePage> sourcePages;
     private final PageProcessorMetrics pageProcessorMetrics = new PageProcessorMetrics();
 
     @Nullable
@@ -96,20 +96,20 @@ public class ScanFilterAndProjectOperator
             int minOutputPageRowCount)
     {
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
-        pages = split.flatTransform(
-                new SplitToPages(
-                        operatorContext.getSession(),
-                        yieldSignal,
-                        pageSourceProvider,
-                        pageProcessor,
-                        table,
-                        tableCredentials,
-                        columns,
-                        dynamicFilter,
-                        types,
-                        operatorContext.aggregateUserMemoryContext(),
-                        minOutputPageSize,
-                        minOutputPageRowCount));
+        this.splitToPages = new SplitToPages(
+                operatorContext.getSession(),
+                yieldSignal,
+                pageSourceProvider,
+                pageProcessor,
+                table,
+                tableCredentials,
+                columns,
+                dynamicFilter,
+                types,
+                operatorContext.aggregateUserMemoryContext(),
+                minOutputPageSize,
+                minOutputPageRowCount);
+        this.sourcePages = split.flatTransform(splitToPages);
     }
 
     @Override
@@ -163,12 +163,25 @@ public class ScanFilterAndProjectOperator
     @Override
     public WorkProcessor<Page> getOutputPages()
     {
-        return pages;
+        return splitToPages.toPages(sourcePages);
+    }
+
+    @Override
+    public boolean producesMaskedOutput()
+    {
+        return true;
+    }
+
+    @Override
+    public WorkProcessor<MaskedPage> getMaskedOutputPages()
+    {
+        return splitToPages.toMaskedPages(sourcePages);
     }
 
     @Override
     public void close()
     {
+        splitToPages.close();
         if (pageSource != null) {
             try {
                 pageSource.close();
@@ -181,7 +194,7 @@ public class ScanFilterAndProjectOperator
     }
 
     private class SplitToPages
-            implements WorkProcessor.Transformation<Split, WorkProcessor<Page>>
+            implements WorkProcessor.Transformation<Split, WorkProcessor<SourcePage>>
     {
         final Session session;
         final DriverYieldSignal yieldSignal;
@@ -233,10 +246,9 @@ public class ScanFilterAndProjectOperator
         }
 
         @Override
-        public TransformationState<WorkProcessor<Page>> process(Split split)
+        public TransformationState<WorkProcessor<SourcePage>> process(Split split)
         {
             if (split == null) {
-                memoryContext.close();
                 return finished();
             }
 
@@ -255,55 +267,40 @@ public class ScanFilterAndProjectOperator
             }
 
             pageSource = source;
-            return ofResult(processPageSource());
+            return ofResult(sourcePages());
         }
 
-        WorkProcessor<Page> processPageSource()
+        WorkProcessor<SourcePage> sourcePages()
         {
-            ConnectorSession connectorSession = session.toConnectorSession();
             return WorkProcessor
                     .create(new ConnectorPageSourceToPages(pageSourceProviderMemoryContext))
-                    .yielding(yieldSignal::isSet)
-                    .flatMap(page -> {
-                        WorkProcessor<Page> workProcessor = pageProcessor.createWorkProcessor(
-                                connectorSession,
-                                outputMemoryContext,
-                                pageProcessorMetrics,
-                                page);
-                        // Note this is monitoring the original source page not the result page
-                        return workProcessor.withProcessStateMonitor(new ProcessedBytesMonitor(page, bytes -> processedBytes += bytes));
-                    })
+                    .yielding(yieldSignal::isSet);
+        }
+
+        WorkProcessor<MaskedPage> toMaskedPages(WorkProcessor<SourcePage> sourcePages)
+        {
+            ConnectorSession connectorSession = session.toConnectorSession();
+            return sourcePages.flatMap(page -> {
+                SelectedPositions selectedPositions = pageProcessor.evaluateFilter(connectorSession, pageProcessorMetrics, page);
+                if (selectedPositions.isEmpty()) {
+                    return WorkProcessor.of();
+                }
+                return WorkProcessor.of(pageProcessor.applyMask(connectorSession, page, selectedPositions, outputMemoryContext, pageProcessorMetrics));
+            });
+        }
+
+        WorkProcessor<Page> toPages(WorkProcessor<SourcePage> sourcePages)
+        {
+            ConnectorSession connectorSession = session.toConnectorSession();
+            return sourcePages
+                    .flatMap(page -> pageProcessor.createWorkProcessor(connectorSession, outputMemoryContext, pageProcessorMetrics, page))
                     .transformProcessor(processor -> mergePages(types, minOutputPageSize.toBytes(), minOutputPageRowCount, processor, localAggregatedMemoryContext))
                     .blocking(() -> memoryContext.setBytes(localAggregatedMemoryContext.getBytes()));
         }
-    }
 
-    static class ProcessedBytesMonitor
-            implements Consumer<ProcessState<Page>>
-    {
-        private final SourcePage page;
-        private final LongConsumer processedBytesConsumer;
-        private long localProcessedBytes;
-
-        public ProcessedBytesMonitor(SourcePage page, LongConsumer processedBytesConsumer)
+        void close()
         {
-            this.page = requireNonNull(page, "page is null");
-            this.processedBytesConsumer = requireNonNull(processedBytesConsumer, "processedBytesConsumer is null");
-            localProcessedBytes = page.getSizeInBytes();
-            processedBytesConsumer.accept(localProcessedBytes);
-        }
-
-        @Override
-        public void accept(ProcessState<Page> state)
-        {
-            update();
-        }
-
-        void update()
-        {
-            long newProcessedBytes = page.getSizeInBytes();
-            processedBytesConsumer.accept(newProcessedBytes - localProcessedBytes);
-            localProcessedBytes = newProcessedBytes;
+            memoryContext.close();
         }
     }
 
@@ -311,6 +308,7 @@ public class ScanFilterAndProjectOperator
             implements WorkProcessor.Process<SourcePage>
     {
         final LocalMemoryContext pageSourceProviderMemoryContext;
+        private SourcePage previousPage;
 
         ConnectorPageSourceToPages(LocalMemoryContext pageSourceProviderMemoryContext)
         {
@@ -320,6 +318,13 @@ public class ScanFilterAndProjectOperator
         @Override
         public ProcessState<SourcePage> process()
         {
+            if (previousPage != null) {
+                // account input bytes once the downstream is done with the prior page: lazily decoded
+                // channels are reflected in getSizeInBytes only after they are read
+                processedBytes += previousPage.getSizeInBytes();
+                previousPage = null;
+            }
+
             if (pageSource.isFinished()) {
                 return ProcessState.finished();
             }
@@ -346,6 +351,7 @@ public class ScanFilterAndProjectOperator
                 return ProcessState.yielded();
             }
 
+            previousPage = page;
             return ProcessState.ofResult(page);
         }
     }
@@ -425,20 +431,18 @@ public class ScanFilterAndProjectOperator
         }
 
         @Override
+        public List<Type> getOutputTypes()
+        {
+            return types;
+        }
+
+        @Override
         public SourceOperator createOperator(DriverContext driverContext)
         {
             checkState(!closed, "Factory is already closed");
             OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, Optional.of(sourceId), getOperatorType());
-
-            WorkProcessorSourceOperatorAdapter operator = new WorkProcessorSourceOperatorAdapter(operatorContext, this);
-
-            if (isSourcePagesValidationEnabled(operatorContext.getSession())) {
-                return new OutputValidatingSourceOperator(
-                        operator,
-                        types,
-                        () -> "ScanFilterAndProjectOperator(%s); taskId=%s; operatorId=%s".formatted(table, operatorContext.getDriverContext().getTaskId(), operatorContext.getOperatorId()));
-            }
-            return operator;
+            // the adapter validates both the regular and masked output streams; no outer wrapper needed
+            return new WorkProcessorSourceOperatorAdapter(operatorContext, this);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
@@ -27,6 +27,7 @@ import io.trino.operator.WorkProcessor.ProcessState;
 import io.trino.operator.WorkProcessor.TransformationState;
 import io.trino.operator.project.PageProcessor;
 import io.trino.operator.project.PageProcessorMetrics;
+import io.trino.operator.project.SelectedPositions;
 import io.trino.spi.Page;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
@@ -48,14 +49,11 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.LongConsumer;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
-import static io.trino.SystemSessionProperties.isSourcePagesValidationEnabled;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.operator.WorkProcessor.TransformationState.finished;
 import static io.trino.operator.WorkProcessor.TransformationState.ofResult;
@@ -67,7 +65,9 @@ public class ScanFilterAndProjectOperator
         implements WorkProcessorSourceOperator
 {
     private final PageSourceProvider pageSourceProvider;
-    private final WorkProcessor<Page> pages;
+    private final SplitToPages splitToPages;
+    // getOutputPages and getMaskedOutputPages both read from this stream; the driver calls only one of them
+    private final WorkProcessor<SourcePage> sourcePages;
     private final PageProcessorMetrics pageProcessorMetrics = new PageProcessorMetrics();
 
     @Nullable
@@ -97,20 +97,20 @@ public class ScanFilterAndProjectOperator
             int minOutputPageRowCount)
     {
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
-        pages = split.flatTransform(
-                new SplitToPages(
-                        operatorContext.getSession(),
-                        yieldSignal,
-                        pageSourceProvider,
-                        pageProcessor,
-                        table,
-                        tableCredentials,
-                        columns,
-                        dynamicFilter,
-                        types,
-                        operatorContext.aggregateUserMemoryContext(),
-                        minOutputPageSize,
-                        minOutputPageRowCount));
+        this.splitToPages = new SplitToPages(
+                operatorContext.getSession(),
+                yieldSignal,
+                pageSourceProvider,
+                pageProcessor,
+                table,
+                tableCredentials,
+                columns,
+                dynamicFilter,
+                types,
+                operatorContext.aggregateUserMemoryContext(),
+                minOutputPageSize,
+                minOutputPageRowCount);
+        this.sourcePages = split.flatTransform(splitToPages);
     }
 
     @Override
@@ -164,12 +164,25 @@ public class ScanFilterAndProjectOperator
     @Override
     public WorkProcessor<Page> getOutputPages()
     {
-        return pages;
+        return splitToPages.toPages(sourcePages);
+    }
+
+    @Override
+    public boolean producesMaskedOutput()
+    {
+        return true;
+    }
+
+    @Override
+    public WorkProcessor<MaskedPage> getMaskedOutputPages()
+    {
+        return splitToPages.toMaskedPages(sourcePages);
     }
 
     @Override
     public void close()
     {
+        splitToPages.close();
         try {
             if (pageSource != null) {
                 pageSource.close();
@@ -188,7 +201,7 @@ public class ScanFilterAndProjectOperator
     }
 
     private class SplitToPages
-            implements WorkProcessor.Transformation<Split, WorkProcessor<Page>>
+            implements WorkProcessor.Transformation<Split, WorkProcessor<SourcePage>>
     {
         final Session session;
         final DriverYieldSignal yieldSignal;
@@ -238,10 +251,9 @@ public class ScanFilterAndProjectOperator
         }
 
         @Override
-        public TransformationState<WorkProcessor<Page>> process(Split split)
+        public TransformationState<WorkProcessor<SourcePage>> process(Split split)
         {
             if (split == null) {
-                memoryContext.close();
                 return finished();
             }
 
@@ -260,64 +272,58 @@ public class ScanFilterAndProjectOperator
             }
 
             pageSource = source;
-            return ofResult(processPageSource());
+            return ofResult(sourcePages());
         }
 
-        WorkProcessor<Page> processPageSource()
+        WorkProcessor<SourcePage> sourcePages()
         {
-            ConnectorSession connectorSession = session.toConnectorSession();
             return WorkProcessor
                     .create(new ConnectorPageSourceToPages())
-                    .yielding(yieldSignal::isSet)
-                    .flatMap(page -> {
-                        WorkProcessor<Page> workProcessor = pageProcessor.createWorkProcessor(
-                                connectorSession,
-                                outputMemoryContext,
-                                pageProcessorMetrics,
-                                page);
-                        // Note this is monitoring the original source page not the result page
-                        return workProcessor.withProcessStateMonitor(new ProcessedBytesMonitor(page, bytes -> processedBytes += bytes));
-                    })
+                    .yielding(yieldSignal::isSet);
+        }
+
+        WorkProcessor<MaskedPage> toMaskedPages(WorkProcessor<SourcePage> sourcePages)
+        {
+            ConnectorSession connectorSession = session.toConnectorSession();
+            return sourcePages.flatMap(page -> {
+                SelectedPositions selectedPositions = pageProcessor.evaluateFilter(connectorSession, pageProcessorMetrics, page);
+                if (selectedPositions.isEmpty()) {
+                    return WorkProcessor.of();
+                }
+                return WorkProcessor.of(pageProcessor.applyMask(connectorSession, page, selectedPositions, outputMemoryContext, pageProcessorMetrics));
+            });
+        }
+
+        WorkProcessor<Page> toPages(WorkProcessor<SourcePage> sourcePages)
+        {
+            ConnectorSession connectorSession = session.toConnectorSession();
+            return sourcePages
+                    .flatMap(page -> pageProcessor.createWorkProcessor(connectorSession, outputMemoryContext, pageProcessorMetrics, page))
                     .transformProcessor(processor -> mergePages(types, minOutputPageSize.toBytes(), minOutputPageRowCount, processor, localAggregatedMemoryContext))
                     .blocking(() -> memoryContext.setBytes(localAggregatedMemoryContext.getBytes()));
         }
-    }
 
-    static class ProcessedBytesMonitor
-            implements Consumer<ProcessState<Page>>
-    {
-        private final SourcePage page;
-        private final LongConsumer processedBytesConsumer;
-        private long localProcessedBytes;
-
-        public ProcessedBytesMonitor(SourcePage page, LongConsumer processedBytesConsumer)
+        void close()
         {
-            this.page = requireNonNull(page, "page is null");
-            this.processedBytesConsumer = requireNonNull(processedBytesConsumer, "processedBytesConsumer is null");
-            localProcessedBytes = page.getSizeInBytes();
-            processedBytesConsumer.accept(localProcessedBytes);
-        }
-
-        @Override
-        public void accept(ProcessState<Page> state)
-        {
-            update();
-        }
-
-        void update()
-        {
-            long newProcessedBytes = page.getSizeInBytes();
-            processedBytesConsumer.accept(newProcessedBytes - localProcessedBytes);
-            localProcessedBytes = newProcessedBytes;
+            memoryContext.close();
         }
     }
 
     private class ConnectorPageSourceToPages
             implements WorkProcessor.Process<SourcePage>
     {
+        private SourcePage previousPage;
+
         @Override
         public ProcessState<SourcePage> process()
         {
+            if (previousPage != null) {
+                // account input bytes once the downstream is done with the prior page: lazily decoded
+                // channels are reflected in getSizeInBytes only after they are read
+                processedBytes += previousPage.getSizeInBytes();
+                previousPage = null;
+            }
+
             if (pageSource.isFinished()) {
                 return ProcessState.finished();
             }
@@ -343,6 +349,7 @@ public class ScanFilterAndProjectOperator
                 return ProcessState.yielded();
             }
 
+            previousPage = page;
             return ProcessState.ofResult(page);
         }
     }
@@ -423,20 +430,18 @@ public class ScanFilterAndProjectOperator
         }
 
         @Override
+        public List<Type> getOutputTypes()
+        {
+            return types;
+        }
+
+        @Override
         public SourceOperator createOperator(DriverContext driverContext)
         {
             checkState(!closed, "Factory is already closed");
             OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, Optional.of(sourceId), getOperatorType());
-
-            WorkProcessorSourceOperatorAdapter operator = new WorkProcessorSourceOperatorAdapter(operatorContext, this);
-
-            if (isSourcePagesValidationEnabled(operatorContext.getSession())) {
-                return new OutputValidatingSourceOperator(
-                        operator,
-                        types,
-                        () -> "ScanFilterAndProjectOperator(%s); taskId=%s; operatorId=%s".formatted(table, operatorContext.getDriverContext().getTaskId(), operatorContext.getOperatorId()));
-            }
-            return operator;
+            // the adapter validates both the regular and masked output streams; no outer wrapper needed
+            return new WorkProcessorSourceOperatorAdapter(operatorContext, this);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -20,9 +20,13 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.metadata.Split;
 import io.trino.metadata.TableHandle;
+import io.trino.operator.project.InputPageProjection;
+import io.trino.operator.project.PageProcessorMetrics;
+import io.trino.operator.project.PageProjectionsProcessor;
 import io.trino.spi.Page;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.EmptyPageSource;
@@ -39,11 +43,15 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static io.trino.SystemSessionProperties.isSourcePagesValidationEnabled;
+import static io.trino.operator.project.PageProcessor.MAX_BATCH_SIZE;
+import static io.trino.operator.project.SelectedPositions.positionsRange;
 import static java.util.Objects.requireNonNull;
 
 public class TableScanOperator
@@ -126,12 +134,20 @@ public class TableScanOperator
     private final List<ColumnHandle> columns;
     private final LocalMemoryContext pageSourceProviderMemoryContext;
     private final LocalMemoryContext pageSourceMemoryContext;
+    // identity projections expose the source page's channels unchanged for masked output
+    private final ConnectorSession connectorSession;
+    private final PageProjectionsProcessor identityPageProcessor;
+    private final PageProcessorMetrics pageProcessorMetrics = new PageProcessorMetrics();
+    private final LocalMemoryContext maskedOutputMemoryContext;
     private final SettableFuture<Void> blocked = SettableFuture.create();
 
     @Nullable
     private Split split;
     @Nullable
     private ConnectorPageSource source;
+    // a handed-off masked page whose decoded bytes are accounted on the next request
+    @Nullable
+    private SourcePage deferredMaskedSourcePage;
 
     private boolean finished;
 
@@ -155,6 +171,12 @@ public class TableScanOperator
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.pageSourceProviderMemoryContext = operatorContext.newLocalUserMemoryContext(TableScanOperator.class.getSimpleName() + "-PageSourceProvider");
         this.pageSourceMemoryContext = operatorContext.newLocalUserMemoryContext(TableScanOperator.class.getSimpleName() + "-ConnectorPageSource");
+        this.connectorSession = operatorContext.getSession().toConnectorSession();
+        this.maskedOutputMemoryContext = operatorContext.newLocalUserMemoryContext(TableScanOperator.class.getSimpleName() + "-MaskedOutput");
+        List<InputPageProjection> projections = IntStream.range(0, this.columns.size())
+                .mapToObj(InputPageProjection::new)
+                .collect(toImmutableList());
+        this.identityPageProcessor = new PageProjectionsProcessor(projections, true, MAX_BATCH_SIZE);
     }
 
     @Override
@@ -209,6 +231,7 @@ public class TableScanOperator
         blocked.set(null);
 
         if (source != null) {
+            recordDeferredMaskedBytes();
             try {
                 source.close();
             }
@@ -266,24 +289,78 @@ public class TableScanOperator
     @Override
     public Page getOutput()
     {
+        recordDeferredMaskedBytes();
+        SourcePage sourcePage = getNextSourcePage();
+        if (source == null) {
+            return null;
+        }
+        Page page = null;
+        if (sourcePage != null) {
+            page = sourcePage.getPage();
+        }
+        int positionCount = 0;
+        long sizeInBytes = 0;
+        if (page != null) {
+            positionCount = page.getPositionCount();
+            sizeInBytes = page.getSizeInBytes();
+        }
+        recordStats(positionCount, sizeInBytes);
+        return page;
+    }
+
+    @Override
+    public boolean producesMaskedOutput()
+    {
+        return true;
+    }
+
+    @Override
+    public MaskedPage getMaskedOutput()
+    {
+        // the previous masked page has now been consumed, so account the bytes the consumer decoded from it
+        recordDeferredMaskedBytes();
+        SourcePage sourcePage = getNextSourcePage();
+        if (source == null) {
+            return null;
+        }
+        int positionCount = 0;
+        if (sourcePage != null) {
+            positionCount = sourcePage.getPositionCount();
+        }
+        // record positions now; decoded bytes are counted on the next request, once the consumer has read them
+        recordStats(positionCount, 0);
+        if (sourcePage == null || positionCount == 0) {
+            return null;
+        }
+        deferredMaskedSourcePage = sourcePage;
+        return MaskedPage.applyMask(connectorSession, sourcePage, positionsRange(0, positionCount), identityPageProcessor, maskedOutputMemoryContext, pageProcessorMetrics);
+    }
+
+    private void recordDeferredMaskedBytes()
+    {
+        if (deferredMaskedSourcePage != null) {
+            // columns the consumer never decoded are not loaded, so getSizeInBytes counts only the bytes actually decoded
+            operatorContext.recordProcessedInput(deferredMaskedSourcePage.getSizeInBytes(), 0);
+            deferredMaskedSourcePage = null;
+        }
+    }
+
+    @Nullable
+    private SourcePage getNextSourcePage()
+    {
         if (split == null) {
             return null;
         }
         if (source == null) {
             source = pageSourceProvider.createPageSource(operatorContext.getSession(), split, table, tableCredentials, columns, DynamicFilter.EMPTY, pageSourceMemoryContext::setBytes);
         }
+        return source.getNextSourcePage();
+    }
 
-        SourcePage sourcePage = source.getNextSourcePage();
-        Page page = null;
-        if (sourcePage != null) {
-            page = sourcePage.getPage();
-        }
-
-        // update operator stats
+    private void recordStats(long positionCount, long sizeInBytes)
+    {
         long endCompletedBytes = source.getCompletedBytes();
         long endReadTimeNanos = source.getReadTimeNanos();
-        long positionCount = page == null ? 0 : page.getPositionCount();
-        long sizeInBytes = page == null ? 0 : page.getSizeInBytes();
         long endCompletedPositions = source.getCompletedPositions().orElse(completedPositions + positionCount);
         operatorContext.recordPhysicalInputWithTiming(
                 endCompletedBytes - completedBytes,
@@ -297,6 +374,5 @@ public class TableScanOperator
         // updating memory usage should happen after page is loaded.
         pageSourceProviderMemoryContext.setBytes(pageSourceProvider.getMemoryUsage());
         operatorContext.setLatestConnectorMetrics(source.getMetrics());
-        return page;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -21,9 +21,13 @@ import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.metadata.Split;
 import io.trino.metadata.TableHandle;
+import io.trino.operator.project.InputPageProjection;
+import io.trino.operator.project.PageProcessorMetrics;
+import io.trino.operator.project.PageProjectionsProcessor;
 import io.trino.spi.Page;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableCredentials;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.EmptyPageSource;
@@ -40,11 +44,15 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static io.trino.SystemSessionProperties.isSourcePagesValidationEnabled;
+import static io.trino.operator.project.PageProcessor.MAX_BATCH_SIZE;
+import static io.trino.operator.project.SelectedPositions.positionsRange;
 import static java.util.Objects.requireNonNull;
 
 public class TableScanOperator
@@ -132,12 +140,20 @@ public class TableScanOperator
     private final Optional<ConnectorTableCredentials> tableCredentials;
     private final List<ColumnHandle> columns;
     private final LocalMemoryContext pageSourceMemoryContext;
+    // identity projections expose the source page's channels unchanged for masked output
+    private final ConnectorSession connectorSession;
+    private final PageProjectionsProcessor identityPageProcessor;
+    private final PageProcessorMetrics pageProcessorMetrics = new PageProcessorMetrics();
+    private final LocalMemoryContext maskedOutputMemoryContext;
     private final SettableFuture<Void> blocked = SettableFuture.create();
 
     @Nullable
     private Split split;
     @Nullable
     private ConnectorPageSource source;
+    // a handed-off masked page whose decoded bytes are accounted on the next request
+    @Nullable
+    private SourcePage deferredMaskedSourcePage;
 
     private boolean finished;
     private boolean released;
@@ -161,6 +177,12 @@ public class TableScanOperator
         this.tableCredentials = requireNonNull(tableCredentials, "tableCredentials is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.pageSourceMemoryContext = operatorContext.newLocalUserMemoryContext(TableScanOperator.class.getSimpleName() + "-ConnectorPageSource");
+        this.connectorSession = operatorContext.getSession().toConnectorSession();
+        this.maskedOutputMemoryContext = operatorContext.newLocalUserMemoryContext(TableScanOperator.class.getSimpleName() + "-MaskedOutput");
+        List<InputPageProjection> projections = IntStream.range(0, this.columns.size())
+                .mapToObj(InputPageProjection::new)
+                .collect(toImmutableList());
+        this.identityPageProcessor = new PageProjectionsProcessor(projections, true, MAX_BATCH_SIZE);
     }
 
     @Override
@@ -223,6 +245,7 @@ public class TableScanOperator
         blocked.set(null);
 
         if (source != null) {
+            recordDeferredMaskedBytes();
             try {
                 source.close();
             }
@@ -276,6 +299,65 @@ public class TableScanOperator
     @Override
     public Page getOutput()
     {
+        recordDeferredMaskedBytes();
+        SourcePage sourcePage = getNextSourcePage();
+        if (source == null) {
+            return null;
+        }
+        Page page = null;
+        if (sourcePage != null) {
+            page = sourcePage.getPage();
+        }
+        int positionCount = 0;
+        long sizeInBytes = 0;
+        if (page != null) {
+            positionCount = page.getPositionCount();
+            sizeInBytes = page.getSizeInBytes();
+        }
+        recordStats(positionCount, sizeInBytes);
+        return page;
+    }
+
+    @Override
+    public boolean producesMaskedOutput()
+    {
+        return true;
+    }
+
+    @Override
+    public MaskedPage getMaskedOutput()
+    {
+        // the previous masked page has now been consumed, so account the bytes the consumer decoded from it
+        recordDeferredMaskedBytes();
+        SourcePage sourcePage = getNextSourcePage();
+        if (source == null) {
+            return null;
+        }
+        int positionCount = 0;
+        if (sourcePage != null) {
+            positionCount = sourcePage.getPositionCount();
+        }
+        // record positions now; decoded bytes are counted on the next request, once the consumer has read them
+        recordStats(positionCount, 0);
+        if (sourcePage == null || positionCount == 0) {
+            return null;
+        }
+        deferredMaskedSourcePage = sourcePage;
+        return MaskedPage.applyMask(connectorSession, sourcePage, positionsRange(0, positionCount), identityPageProcessor, maskedOutputMemoryContext, pageProcessorMetrics);
+    }
+
+    private void recordDeferredMaskedBytes()
+    {
+        if (deferredMaskedSourcePage != null) {
+            // columns the consumer never decoded are not loaded, so getSizeInBytes counts only the bytes actually decoded
+            operatorContext.recordProcessedInput(deferredMaskedSourcePage.getSizeInBytes(), 0);
+            deferredMaskedSourcePage = null;
+        }
+    }
+
+    @Nullable
+    private SourcePage getNextSourcePage()
+    {
         if (split == null) {
             return null;
         }
@@ -285,18 +367,13 @@ public class TableScanOperator
                 return null;
             }
         }
+        return source.getNextSourcePage();
+    }
 
-        SourcePage sourcePage = source.getNextSourcePage();
-        Page page = null;
-        if (sourcePage != null) {
-            page = sourcePage.getPage();
-        }
-
-        // update operator stats
+    private void recordStats(long positionCount, long sizeInBytes)
+    {
         long endCompletedBytes = source.getCompletedBytes();
         long endReadTimeNanos = source.getReadTimeNanos();
-        long positionCount = page == null ? 0 : page.getPositionCount();
-        long sizeInBytes = page == null ? 0 : page.getSizeInBytes();
         long endCompletedPositions = source.getCompletedPositions().orElse(completedPositions + positionCount);
         operatorContext.recordPhysicalInputWithTiming(
                 endCompletedBytes - completedBytes,
@@ -308,6 +385,5 @@ public class TableScanOperator
         readTimeNanos = endReadTimeNanos;
 
         operatorContext.setLatestConnectorMetrics(source.getMetrics());
-        return page;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/TopNOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNOperator.java
@@ -16,8 +16,10 @@ package io.trino.operator;
 import com.google.common.collect.ImmutableList;
 import io.trino.operator.WorkProcessor.TransformationState;
 import io.trino.spi.Page;
+import io.trino.spi.metrics.Metrics;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.plan.PlanNodeId;
+import jakarta.annotation.Nullable;
 
 import java.util.List;
 
@@ -36,9 +38,10 @@ public class TopNOperator
             PlanNodeId planNodeId,
             List<? extends Type> types,
             int n,
+            List<Integer> sortChannels,
             PageWithPositionComparator comparator)
     {
-        return createAdapterOperatorFactory(new Factory(operatorId, planNodeId, types, n, comparator));
+        return createAdapterOperatorFactory(new Factory(operatorId, planNodeId, types, n, sortChannels, comparator));
     }
 
     private static class Factory
@@ -48,6 +51,7 @@ public class TopNOperator
         private final PlanNodeId planNodeId;
         private final List<Type> sourceTypes;
         private final int n;
+        private final List<Integer> sortChannels;
         private final PageWithPositionComparator comparator;
         private boolean closed;
 
@@ -56,12 +60,14 @@ public class TopNOperator
                 PlanNodeId planNodeId,
                 List<? extends Type> types,
                 int n,
+                List<Integer> sortChannels,
                 PageWithPositionComparator comparator)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.sourceTypes = ImmutableList.copyOf(requireNonNull(types, "types is null"));
             this.n = n;
+            this.sortChannels = ImmutableList.copyOf(requireNonNull(sortChannels, "sortChannels is null"));
             this.comparator = requireNonNull(comparator, "comparator is null");
         }
 
@@ -76,6 +82,7 @@ public class TopNOperator
                     sourcePages,
                     sourceTypes,
                     n,
+                    sortChannels,
                     comparator);
         }
 
@@ -106,30 +113,37 @@ public class TopNOperator
         @Override
         public Factory duplicate()
         {
-            return new Factory(operatorId, planNodeId, sourceTypes, n, comparator);
+            return new Factory(operatorId, planNodeId, sourceTypes, n, sortChannels, comparator);
         }
     }
 
+    @Nullable
+    private final TopNProcessor topNProcessor;
     private final WorkProcessor<Page> pages;
+    // masked input only helps when some channels are not sort channels and can be left undecoded
+    private final boolean hasNonSortChannels;
 
     private TopNOperator(
             OperatorContext operatorContext,
             WorkProcessor<Page> sourcePages,
             List<Type> types,
             int n,
+            List<Integer> sortChannels,
             PageWithPositionComparator comparator)
     {
+        this.hasNonSortChannels = sortChannels.size() < types.size();
         if (n == 0) {
+            topNProcessor = null;
             pages = WorkProcessor.of();
         }
         else {
-            pages = sourcePages.transform(
-                    new TopNPages(
-                            new TopNProcessor(
-                                    operatorContext.aggregateUserMemoryContext(),
-                                    types,
-                                    n,
-                                    comparator)));
+            topNProcessor = new TopNProcessor(
+                    operatorContext.aggregateUserMemoryContext(),
+                    types,
+                    n,
+                    sortChannels,
+                    comparator);
+            pages = sourcePages.transform(new TopNPages(topNProcessor));
         }
     }
 
@@ -137,6 +151,27 @@ public class TopNOperator
     public WorkProcessor<Page> getOutputPages()
     {
         return pages;
+    }
+
+    @Override
+    public boolean supportsMaskedInput()
+    {
+        return topNProcessor != null && hasNonSortChannels;
+    }
+
+    @Override
+    public void addMaskedInput(MaskedPage maskedPage)
+    {
+        topNProcessor.addMaskedInput(maskedPage);
+    }
+
+    @Override
+    public Metrics getMetrics()
+    {
+        if (topNProcessor == null) {
+            return Metrics.EMPTY;
+        }
+        return topNProcessor.getMetrics();
     }
 
     private static final class TopNPages

--- a/core/trino-main/src/main/java/io/trino/operator/TopNProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNProcessor.java
@@ -13,9 +13,15 @@
  */
 package io.trino.operator;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.memory.context.LocalMemoryContext;
+import io.trino.plugin.base.metrics.LongCount;
 import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.metrics.Metrics;
 import io.trino.spi.type.Type;
 
 import java.util.Iterator;
@@ -31,20 +37,28 @@ import static java.util.Objects.requireNonNull;
  */
 public class TopNProcessor
 {
+    public static final String SKIPPED_DECODE_POSITIONS = "Skipped decode positions";
+
     private final LocalMemoryContext localUserMemoryContext;
 
+    private final List<Type> types;
+    private final List<Integer> sortChannels;
     private final GroupedTopNRowNumberBuilder topNBuilder;
     private Iterator<Page> outputIterator;
+    private long skippedDecodePositions;
 
     public TopNProcessor(
             AggregatedMemoryContext aggregatedMemoryContext,
             List<Type> types,
             int n,
+            List<Integer> sortChannels,
             PageWithPositionComparator comparator)
     {
         requireNonNull(aggregatedMemoryContext, "aggregatedMemoryContext is null");
         checkArgument(n > 0, "n must be > 0, found: %s", n);
         this.localUserMemoryContext = aggregatedMemoryContext.newLocalMemoryContext(TopNProcessor.class.getSimpleName());
+        this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
+        this.sortChannels = ImmutableList.copyOf(requireNonNull(sortChannels, "sortChannels is null"));
 
         topNBuilder = new GroupedTopNRowNumberBuilder(
                 types,
@@ -61,6 +75,48 @@ public class TopNProcessor
         // there is no grouping so work will always be done
         verify(done);
         updateMemoryReservation();
+    }
+
+    /**
+     * Decodes only the sort channels to find which positions enter the top N; the remaining
+     * channels are decoded only for the surviving positions of a contributing page.
+     */
+    public void addMaskedInput(MaskedPage maskedPage)
+    {
+        int positionCount = maskedPage.getPositionCount();
+        GroupedTopNRowNumberBuilder.ProbeResult probeResult = topNBuilder.probe(probePage(maskedPage));
+        int firstPositionToAdd = probeResult.firstPositionToAdd();
+        if (firstPositionToAdd < 0) {
+            // no position enters the top N, so payload channels are never decoded for this page
+            skippedDecodePositions += positionCount;
+            return;
+        }
+        // payload channels are decoded only from firstPositionToAdd onward
+        skippedDecodePositions += firstPositionToAdd;
+        maskedPage.selectPositionsFrom(firstPositionToAdd);
+        int groupIdsOffset = firstPositionToAdd;
+        Iterator<Page> batches = maskedPage.materialize().iterator();
+        while (batches.hasNext()) {
+            Page batch = batches.next();
+            topNBuilder.addPage(batch, probeResult.groupIds(), groupIdsOffset);
+            groupIdsOffset += batch.getPositionCount();
+            updateMemoryReservation();
+        }
+    }
+
+    private Page probePage(MaskedPage maskedPage)
+    {
+        int positionCount = maskedPage.getPositionCount();
+        Block[] blocks = new Block[types.size()];
+        for (int channel = 0; channel < blocks.length; channel++) {
+            if (sortChannels.contains(channel)) {
+                blocks[channel] = maskedPage.getBlock(channel);
+            }
+            else {
+                blocks[channel] = RunLengthEncodedBlock.create(types.get(channel), null, positionCount);
+            }
+        }
+        return new Page(positionCount, blocks);
     }
 
     public Page getOutput()
@@ -84,6 +140,14 @@ public class TopNProcessor
     public boolean noMoreOutput()
     {
         return outputIterator != null && !outputIterator.hasNext();
+    }
+
+    public Metrics getMetrics()
+    {
+        if (skippedDecodePositions == 0) {
+            return Metrics.EMPTY;
+        }
+        return new Metrics(ImmutableMap.of(SKIPPED_DECODE_POSITIONS, new LongCount(skippedDecodePositions)));
     }
 
     private void updateMemoryReservation()

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorOperator.java
@@ -25,6 +25,23 @@ public interface WorkProcessorOperator
     WorkProcessor<Page> getOutputPages();
 
     /**
+     * Whether this operator can consume {@link MaskedPage} input instead of materialized pages.
+     */
+    default boolean supportsMaskedInput()
+    {
+        return false;
+    }
+
+    /**
+     * Analog of {@link Operator#addInput} accepting a {@link MaskedPage}, valid only for the
+     * duration of this call.
+     */
+    default void addMaskedInput(MaskedPage maskedPage)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Returns {@link OperatorInfo}. This method must be thread safe.
      * This method might be called after operator is closed to obtain
      * final {@link OperatorInfo}.

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorOperatorAdapter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorOperatorAdapter.java
@@ -134,6 +134,18 @@ public class WorkProcessorOperatorAdapter
     }
 
     @Override
+    public boolean supportsMaskedInput()
+    {
+        return workProcessorOperator.supportsMaskedInput();
+    }
+
+    @Override
+    public void addMaskedInput(MaskedPage maskedPage)
+    {
+        workProcessorOperator.addMaskedInput(maskedPage);
+    }
+
+    @Override
     public Page getOutput()
     {
         if (!pages.process()) {

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperator.java
@@ -24,6 +24,23 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public interface WorkProcessorSourceOperator
         extends WorkProcessorOperator
 {
+    /**
+     * Whether this operator can emit a {@link MaskedPage} stream via {@link #getMaskedOutputPages}.
+     */
+    default boolean producesMaskedOutput()
+    {
+        return false;
+    }
+
+    /**
+     * Alternative output stream of {@link MaskedPage}s for a downstream masked-input consumer. This
+     * stream and {@link #getOutputPages} share the same source, so at most one may be built.
+     */
+    default WorkProcessor<MaskedPage> getMaskedOutputPages()
+    {
+        throw new UnsupportedOperationException();
+    }
+
     default DataSize getPhysicalInputDataSize()
     {
         return DataSize.ofBytes(0);

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
@@ -18,11 +18,16 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.trino.metadata.Split;
 import io.trino.spi.Page;
 import io.trino.spi.metrics.Metrics;
+import io.trino.spi.type.Type;
 import io.trino.sql.planner.plan.PlanNodeId;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.List;
+import java.util.function.Supplier;
 
+import static io.trino.SystemSessionProperties.isSourcePagesValidationEnabled;
+import static io.trino.operator.PageValidations.validateOutputPageTypes;
 import static io.trino.operator.WorkProcessor.ProcessState.blocked;
 import static io.trino.operator.WorkProcessor.ProcessState.finished;
 import static io.trino.operator.WorkProcessor.ProcessState.ofResult;
@@ -35,8 +40,13 @@ public class WorkProcessorSourceOperatorAdapter
     private final OperatorContext operatorContext;
     private final PlanNodeId sourceId;
     private final WorkProcessorSourceOperator sourceOperator;
-    private final WorkProcessor<Page> pages;
+    private final boolean validateOutputPages;
+    private final List<Type> outputTypes;
+    private final Supplier<String> debugContext;
     private final SplitBuffer splitBuffer;
+
+    // committed to the regular or masked stream on first output; both share one source, so only one is ever built
+    private WorkProcessor<?> pages;
 
     private boolean operatorFinishing;
 
@@ -59,10 +69,42 @@ public class WorkProcessorSourceOperatorAdapter
                         operatorContext,
                         operatorContext.getDriverContext().getYieldSignal(),
                         WorkProcessor.create(splitBuffer));
-        this.pages = sourceOperator.getOutputPages()
+        this.validateOutputPages = isSourcePagesValidationEnabled(operatorContext.getSession());
+        this.outputTypes = sourceOperatorFactory.getOutputTypes();
+        this.debugContext = () -> "%s; taskId=%s; operatorId=%s".formatted(
+                operatorContext.getOperatorType(),
+                operatorContext.getDriverContext().getTaskId(),
+                operatorContext.getOperatorId());
+        operatorContext.setInfoSupplier(() -> sourceOperator.getOperatorInfo().orElse(null));
+    }
+
+    private WorkProcessor<Page> regularOutput()
+    {
+        WorkProcessor<Page> outputPages = sourceOperator.getOutputPages()
                 .withProcessStateMonitor(_ -> updateOperatorStats())
                 .finishWhen(() -> operatorFinishing);
-        operatorContext.setInfoSupplier(() -> sourceOperator.getOperatorInfo().orElse(null));
+        if (validateOutputPages) {
+            outputPages = outputPages.map(page -> {
+                validateOutputPageTypes(page, outputTypes, debugContext);
+                return page;
+            });
+        }
+        return outputPages;
+    }
+
+    private WorkProcessor<MaskedPage> maskedOutput()
+    {
+        WorkProcessor<MaskedPage> maskedPages = sourceOperator.getMaskedOutputPages()
+                .withProcessStateMonitor(_ -> updateOperatorStats())
+                .finishWhen(() -> operatorFinishing);
+        if (validateOutputPages) {
+            // masked output validates lazily inside materialize(), so deferred channels stay undecoded
+            maskedPages = maskedPages.map(maskedPage -> {
+                maskedPage.setOutputValidator(page -> validateOutputPageTypes(page, outputTypes, debugContext));
+                return maskedPage;
+            });
+        }
+        return maskedPages;
     }
 
     @Override
@@ -96,7 +138,7 @@ public class WorkProcessorSourceOperatorAdapter
     @Override
     public ListenableFuture<Void> isBlocked()
     {
-        if (!pages.isBlocked()) {
+        if (pages == null || !pages.isBlocked()) {
             return NOT_BLOCKED;
         }
 
@@ -118,6 +160,9 @@ public class WorkProcessorSourceOperatorAdapter
     @Override
     public Page getOutput()
     {
+        if (pages == null) {
+            pages = regularOutput();
+        }
         if (!pages.process()) {
             return null;
         }
@@ -126,7 +171,30 @@ public class WorkProcessorSourceOperatorAdapter
             return null;
         }
 
-        return pages.getResult();
+        return (Page) pages.getResult();
+    }
+
+    @Override
+    public boolean producesMaskedOutput()
+    {
+        return sourceOperator.producesMaskedOutput();
+    }
+
+    @Override
+    public MaskedPage getMaskedOutput()
+    {
+        if (pages == null) {
+            pages = maskedOutput();
+        }
+        if (!pages.process()) {
+            return null;
+        }
+
+        if (pages.isFinished()) {
+            return null;
+        }
+
+        return (MaskedPage) pages.getResult();
     }
 
     @Override
@@ -139,7 +207,7 @@ public class WorkProcessorSourceOperatorAdapter
     @Override
     public boolean isFinished()
     {
-        return pages.isFinished();
+        return pages != null && pages.isFinished();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorFactory.java
@@ -14,7 +14,10 @@
 package io.trino.operator;
 
 import io.trino.metadata.Split;
+import io.trino.spi.type.Type;
 import io.trino.sql.planner.plan.PlanNodeId;
+
+import java.util.List;
 
 public interface WorkProcessorSourceOperatorFactory
 {
@@ -25,6 +28,8 @@ public interface WorkProcessorSourceOperatorFactory
     PlanNodeId getPlanNodeId();
 
     String getOperatorType();
+
+    List<Type> getOutputTypes();
 
     WorkProcessorSourceOperator create(
             OperatorContext operatorContext,

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -15,19 +15,15 @@ package io.trino.operator.project;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.trino.annotation.NotThreadSafe;
-import io.trino.array.ReferenceCountMap;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.WorkProcessor;
-import io.trino.operator.WorkProcessor.ProcessState;
 import io.trino.spi.Page;
-import io.trino.spi.block.Block;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.DictionaryId;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SourcePage;
 import io.trino.sql.gen.columnar.FilterEvaluator;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -35,16 +31,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Function;
-import java.util.function.ObjLongConsumer;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Verify.verify;
-import static com.google.common.base.Verify.verifyNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.airlift.slice.SizeOf.instanceSize;
-import static io.airlift.slice.SizeOf.sizeOf;
-import static io.trino.operator.WorkProcessor.ProcessState.finished;
-import static io.trino.operator.WorkProcessor.ProcessState.ofResult;
 import static io.trino.operator.project.SelectedPositions.positionsRange;
 import static io.trino.spi.block.DictionaryId.randomDictionaryId;
 import static java.util.Objects.requireNonNull;
@@ -59,31 +47,29 @@ public class PageProcessor
     private final DictionarySourceIdFunction dictionarySourceIdFunction = new DictionarySourceIdFunction();
     private final Optional<FilterEvaluator> filterEvaluator;
     private final Optional<FilterEvaluator> dynamicFilterEvaluator;
-    private final List<PageProjection> projections;
-    // identity projections return a subset of the input page and cannot expand output size
-    private final boolean identityProjections;
-
-    private int projectBatchSize;
+    private final PageProjectionsProcessor projectionsProcessor;
 
     public PageProcessor(Optional<FilterEvaluator> filterEvaluator, Optional<FilterEvaluator> dynamicFilterEvaluator, List<? extends PageProjection> projections, OptionalInt initialBatchSize)
     {
         this.filterEvaluator = requireNonNull(filterEvaluator, "filterEvaluator is null");
         this.dynamicFilterEvaluator = requireNonNull(dynamicFilterEvaluator, "dynamicFilterEvaluator is null");
-        this.identityProjections = !projections.isEmpty() && projections.stream().allMatch(InputPageProjection.class::isInstance);
-        this.projections = projections.stream()
+        boolean identityProjections = !projections.isEmpty() && projections.stream().allMatch(InputPageProjection.class::isInstance);
+        List<PageProjection> dictionaryAwareProjections = projections.stream()
                 .map(projection -> {
                     if (projection.getInputChannels().size() == 1 && projection.isDeterministic()) {
-                        return new DictionaryAwarePageProjection(projection, dictionarySourceIdFunction);
+                        return (PageProjection) new DictionaryAwarePageProjection(projection, dictionarySourceIdFunction);
                     }
-                    return projection;
+                    return (PageProjection) projection;
                 })
                 .collect(toImmutableList());
+        int initialProjectBatchSize;
         if (identityProjections) {
-            this.projectBatchSize = MAX_BATCH_SIZE;
+            initialProjectBatchSize = MAX_BATCH_SIZE;
         }
         else {
-            this.projectBatchSize = initialBatchSize.orElse(1);
+            initialProjectBatchSize = initialBatchSize.orElse(1);
         }
+        this.projectionsProcessor = new PageProjectionsProcessor(dictionaryAwareProjections, identityProjections, initialProjectBatchSize);
     }
 
     @VisibleForTesting
@@ -129,186 +115,18 @@ public class PageProcessor
             return WorkProcessor.of();
         }
 
-        if (projections.isEmpty()) {
+        if (projectionsProcessor.getProjectionCount() == 0) {
             // retained memory for empty page is negligible
             return WorkProcessor.of(new Page(selectedPositions.size()));
         }
 
-        return WorkProcessor.create(new ProjectSelectedPositions(session, memoryContext, metrics, page, selectedPositions));
-    }
-
-    private class ProjectSelectedPositions
-            implements WorkProcessor.Process<Page>
-    {
-        private static final long INSTANCE_SIZE = instanceSize(ProjectSelectedPositions.class);
-
-        private final ConnectorSession session;
-        private final LocalMemoryContext memoryContext;
-        private final PageProcessorMetrics metrics;
-
-        private SourcePage page;
-        private final Block[] previouslyComputedResults;
-        private SelectedPositions selectedPositions;
-
-        private ProjectSelectedPositions(
-                ConnectorSession session,
-                LocalMemoryContext memoryContext,
-                PageProcessorMetrics metrics,
-                SourcePage page,
-                SelectedPositions selectedPositions)
-        {
-            checkArgument(!selectedPositions.isEmpty(), "selectedPositions is empty");
-
-            this.session = session;
-            this.metrics = metrics;
-            this.page = page;
-            this.memoryContext = memoryContext;
-            this.selectedPositions = selectedPositions;
-            this.previouslyComputedResults = new Block[projections.size()];
-        }
-
-        @Override
-        public ProcessState<Page> process()
-        {
-            while (true) {
-                if (selectedPositions.isEmpty()) {
-                    return finished();
-                }
-
-                int batchSize = Math.min(selectedPositions.size(), projectBatchSize);
-                ProcessBatchResult result = processBatch(batchSize);
-
-                if (result.isPageTooLarge()) {
-                    // the page buffer filled up, so halve the batch size and retry
-                    verify(batchSize > 1);
-                    projectBatchSize = projectBatchSize / 2;
-                    continue;
-                }
-
-                verify(result.isSuccess());
-                Page resultPage = result.getPage();
-                if (!identityProjections) {
-                    // output size is bounded by the input page, so no need to measure it or adapt the batch size
-                    updateBatchSize(resultPage.getPositionCount(), resultPage.getSizeInBytes());
-                }
-
-                // remove batch from selectedPositions and previouslyComputedResults
-                selectedPositions = selectedPositions.subRange(batchSize, selectedPositions.size());
-                for (int i = 0; i < previouslyComputedResults.length; i++) {
-                    if (previouslyComputedResults[i] != null && previouslyComputedResults[i].getPositionCount() > batchSize) {
-                        previouslyComputedResults[i] = previouslyComputedResults[i].getRegion(batchSize, previouslyComputedResults[i].getPositionCount() - batchSize);
-                    }
-                    else {
-                        previouslyComputedResults[i] = null;
-                    }
-                }
-
-                if (!selectedPositions.isEmpty()) {
-                    // there are still some positions to process therefore we need to retain page and account its memory
-                    updateRetainedSize();
-                }
-                else {
-                    page = null;
-                    Arrays.fill(previouslyComputedResults, null);
-                    memoryContext.setBytes(0);
-                }
-
-                return ofResult(resultPage);
-            }
-        }
-
-        private void updateBatchSize(int positionCount, long pageSize)
-        {
-            // if we produced a large page, halve the batch size for the next call
-            if (positionCount > 1 && pageSize > MAX_PAGE_SIZE_IN_BYTES) {
-                projectBatchSize = projectBatchSize / 2;
-            }
-
-            // if we produced a small page, double the batch size for the next call
-            if (pageSize < MIN_PAGE_SIZE_IN_BYTES && projectBatchSize < MAX_BATCH_SIZE) {
-                projectBatchSize = projectBatchSize * 2;
-            }
-        }
-
-        private void updateRetainedSize()
-        {
-            RetainedBytesByPartVisitor visitor = new RetainedBytesByPartVisitor();
-
-            page.retainedBytesForEachPart(visitor);
-
-            for (Block previouslyComputedResult : previouslyComputedResults) {
-                if (previouslyComputedResult != null) {
-                    previouslyComputedResult.retainedBytesForEachPart(visitor);
-                }
-            }
-
-            long retainedSizeInBytes = INSTANCE_SIZE +
-                    selectedPositions.getRetainedSizeInBytes() +
-                    sizeOf(previouslyComputedResults) +
-                    visitor.getRetainedSizeInBytes();
-
-            memoryContext.setBytes(retainedSizeInBytes);
-        }
-
-        private static final class RetainedBytesByPartVisitor
-                implements ObjLongConsumer<Object>
-        {
-            private final ReferenceCountMap referenceCountMap = new ReferenceCountMap();
-            private long retainedSizeInBytes;
-
-            public long getRetainedSizeInBytes()
-            {
-                return retainedSizeInBytes;
-            }
-
-            @Override
-            public void accept(Object object, long size)
-            {
-                // increment the size only when it is the first reference
-                if (referenceCountMap.incrementAndGetWithExtraIdentity(object, size) == 1) {
-                    retainedSizeInBytes += size;
-                }
-            }
-        }
-
-        private ProcessBatchResult processBatch(int batchSize)
-        {
-            Block[] blocks = new Block[projections.size()];
-
-            long pageSize = 0;
-            SelectedPositions positionsBatch = selectedPositions.subRange(0, batchSize);
-            for (int i = 0; i < projections.size(); i++) {
-                if (!identityProjections && positionsBatch.size() > 1 && pageSize > MAX_PAGE_SIZE_IN_BYTES) {
-                    return ProcessBatchResult.processBatchTooLarge();
-                }
-
-                // if possible, use previouslyComputedResults produced in prior optimistic failure attempt
-                PageProjection projection = projections.get(i);
-                if (previouslyComputedResults[i] != null && previouslyComputedResults[i].getPositionCount() >= batchSize) {
-                    blocks[i] = previouslyComputedResults[i].getRegion(0, batchSize);
-                }
-                else {
-                    SourcePage inputChannelsSourcePage = projection.getInputChannels().getInputChannels(page);
-                    long projectionStartNanos = System.nanoTime();
-                    Block result = projection.project(session, inputChannelsSourcePage, positionsBatch);
-                    metrics.recordProjectionTime(System.nanoTime() - projectionStartNanos);
-
-                    previouslyComputedResults[i] = result;
-                    blocks[i] = previouslyComputedResults[i];
-                }
-
-                if (!identityProjections) {
-                    pageSize += blocks[i].getSizeInBytes();
-                }
-            }
-            return ProcessBatchResult.processBatchSuccess(new Page(positionsBatch.size(), blocks));
-        }
+        return projectionsProcessor.project(session, memoryContext, metrics, page, selectedPositions);
     }
 
     @VisibleForTesting
     public List<PageProjection> getProjections()
     {
-        return projections;
+        return projectionsProcessor.getProjections();
     }
 
     @NotThreadSafe
@@ -326,41 +144,6 @@ public class PageProcessor
         public void reset()
         {
             dictionarySourceIds.clear();
-        }
-    }
-
-    private record ProcessBatchResult(ProcessBatchState state, Page page)
-    {
-        public boolean isPageTooLarge()
-        {
-            return state == ProcessBatchState.PAGE_TOO_LARGE;
-        }
-
-        public boolean isSuccess()
-        {
-            return state == ProcessBatchState.SUCCESS;
-        }
-
-        public Page getPage()
-        {
-            verify(state == ProcessBatchState.SUCCESS);
-            return verifyNotNull(page);
-        }
-
-        public static ProcessBatchResult processBatchTooLarge()
-        {
-            return new ProcessBatchResult(ProcessBatchState.PAGE_TOO_LARGE, null);
-        }
-
-        public static ProcessBatchResult processBatchSuccess(Page page)
-        {
-            return new ProcessBatchResult(ProcessBatchState.SUCCESS, requireNonNull(page));
-        }
-
-        private enum ProcessBatchState
-        {
-            PAGE_TOO_LARGE,
-            SUCCESS,
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -16,6 +16,7 @@ package io.trino.operator.project;
 import com.google.common.annotations.VisibleForTesting;
 import io.trino.annotation.NotThreadSafe;
 import io.trino.memory.context.LocalMemoryContext;
+import io.trino.operator.MaskedPage;
 import io.trino.operator.WorkProcessor;
 import io.trino.spi.Page;
 import io.trino.spi.block.DictionaryBlock;
@@ -98,6 +99,21 @@ public class PageProcessor
             return WorkProcessor.of();
         }
 
+        SelectedPositions selectedPositions = evaluateFilter(session, metrics, page);
+        if (selectedPositions.isEmpty()) {
+            return WorkProcessor.of();
+        }
+
+        if (projectionsProcessor.getProjectionCount() == 0) {
+            // retained memory for empty page is negligible
+            return WorkProcessor.of(new Page(selectedPositions.size()));
+        }
+
+        return projectionsProcessor.project(session, memoryContext, metrics, page, selectedPositions);
+    }
+
+    public SelectedPositions evaluateFilter(ConnectorSession session, PageProcessorMetrics metrics, SourcePage page)
+    {
         SelectedPositions selectedPositions = positionsRange(0, page.getPositionCount());
         if (dynamicFilterEvaluator.isPresent()) {
             FilterEvaluator.SelectionResult dynamicFilterResult = dynamicFilterEvaluator.get().evaluate(session, selectedPositions, page);
@@ -111,16 +127,19 @@ public class PageProcessor
             metrics.recordFilterTime(filterResult.filterTimeNanos());
         }
 
-        if (selectedPositions.isEmpty()) {
-            return WorkProcessor.of();
-        }
+        return selectedPositions;
+    }
 
-        if (projectionsProcessor.getProjectionCount() == 0) {
-            // retained memory for empty page is negligible
-            return WorkProcessor.of(new Page(selectedPositions.size()));
-        }
-
-        return projectionsProcessor.project(session, memoryContext, metrics, page, selectedPositions);
+    /**
+     * Wraps {@code page} as a {@link MaskedPage} whose channels are produced on demand from
+     * {@code selectedPositions}, deferring projections until a channel is accessed. The mask must
+     * be non-empty and the source page is consumed.
+     */
+    public MaskedPage applyMask(ConnectorSession session, SourcePage page, SelectedPositions selectedPositions, LocalMemoryContext memoryContext, PageProcessorMetrics metrics)
+    {
+        // limit the scope of the dictionary ids to just one page
+        dictionarySourceIdFunction.reset();
+        return MaskedPage.applyMask(session, page, selectedPositions, projectionsProcessor, memoryContext, metrics);
     }
 
     @VisibleForTesting

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -16,6 +16,7 @@ package io.trino.operator.project;
 import com.google.common.annotations.VisibleForTesting;
 import io.trino.annotation.NotThreadSafe;
 import io.trino.memory.context.LocalMemoryContext;
+import io.trino.operator.MaskedPage;
 import io.trino.operator.WorkProcessor;
 import io.trino.spi.Page;
 import io.trino.spi.block.DictionaryBlock;
@@ -99,19 +100,7 @@ public class PageProcessor
             return WorkProcessor.of();
         }
 
-        SelectedPositions selectedPositions = positionsRange(0, page.getPositionCount());
-        if (dynamicFilterEvaluator.isPresent()) {
-            FilterEvaluator.SelectionResult dynamicFilterResult = dynamicFilterEvaluator.get().evaluate(session, selectedPositions, page);
-            selectedPositions = dynamicFilterResult.selectedPositions();
-            metrics.recordDynamicFilterMetrics(dynamicFilterResult.filterTimeNanos(), selectedPositions.size());
-        }
-
-        if (filterEvaluator.isPresent()) {
-            FilterEvaluator.SelectionResult filterResult = filterEvaluator.get().evaluate(session, selectedPositions, page);
-            selectedPositions = filterResult.selectedPositions();
-            metrics.recordFilterTime(filterResult.filterTimeNanos());
-        }
-
+        SelectedPositions selectedPositions = evaluateFilter(session, metrics, page);
         if (selectedPositions.isEmpty()) {
             return WorkProcessor.of();
         }
@@ -141,6 +130,36 @@ public class PageProcessor
         }
 
         return projectionsProcessor.project(session, memoryContext, metrics, page, selectedPositions);
+    }
+
+    public SelectedPositions evaluateFilter(ConnectorSession session, PageProcessorMetrics metrics, SourcePage page)
+    {
+        SelectedPositions selectedPositions = positionsRange(0, page.getPositionCount());
+        if (dynamicFilterEvaluator.isPresent()) {
+            FilterEvaluator.SelectionResult dynamicFilterResult = dynamicFilterEvaluator.get().evaluate(session, selectedPositions, page);
+            selectedPositions = dynamicFilterResult.selectedPositions();
+            metrics.recordDynamicFilterMetrics(dynamicFilterResult.filterTimeNanos(), selectedPositions.size());
+        }
+
+        if (filterEvaluator.isPresent()) {
+            FilterEvaluator.SelectionResult filterResult = filterEvaluator.get().evaluate(session, selectedPositions, page);
+            selectedPositions = filterResult.selectedPositions();
+            metrics.recordFilterTime(filterResult.filterTimeNanos());
+        }
+
+        return selectedPositions;
+    }
+
+    /**
+     * Wraps {@code page} as a {@link MaskedPage} whose channels are produced on demand from
+     * {@code selectedPositions}, deferring projections until a channel is accessed. The mask must
+     * be non-empty and the source page is consumed.
+     */
+    public MaskedPage applyMask(ConnectorSession session, SourcePage page, SelectedPositions selectedPositions, LocalMemoryContext memoryContext, PageProcessorMetrics metrics)
+    {
+        // limit the scope of the dictionary ids to just one page
+        dictionarySourceIdFunction.reset();
+        return MaskedPage.applyMask(session, page, selectedPositions, projectionsProcessor, memoryContext, metrics);
     }
 
     private static boolean isAllPositions(SelectedPositions selectedPositions, int positionCount)

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -15,19 +15,15 @@ package io.trino.operator.project;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.trino.annotation.NotThreadSafe;
-import io.trino.array.ReferenceCountMap;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.WorkProcessor;
-import io.trino.operator.WorkProcessor.ProcessState;
 import io.trino.spi.Page;
-import io.trino.spi.block.Block;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.DictionaryId;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SourcePage;
 import io.trino.sql.gen.columnar.FilterEvaluator;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -35,16 +31,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Function;
-import java.util.function.ObjLongConsumer;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Verify.verify;
-import static com.google.common.base.Verify.verifyNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.airlift.slice.SizeOf.instanceSize;
-import static io.airlift.slice.SizeOf.sizeOf;
-import static io.trino.operator.WorkProcessor.ProcessState.finished;
-import static io.trino.operator.WorkProcessor.ProcessState.ofResult;
 import static io.trino.operator.project.SelectedPositions.positionsRange;
 import static io.trino.spi.block.DictionaryId.randomDictionaryId;
 import static java.util.Objects.requireNonNull;
@@ -59,32 +47,30 @@ public class PageProcessor
     private final DictionarySourceIdFunction dictionarySourceIdFunction = new DictionarySourceIdFunction();
     private final Optional<FilterEvaluator> filterEvaluator;
     private final Optional<FilterEvaluator> dynamicFilterEvaluator;
-    private final List<PageProjection> projections;
-    // identity projections return a subset of the input page and cannot expand output size
-    private final boolean identityProjections;
-
-    private int projectBatchSize;
+    private final PageProjectionsProcessor projectionsProcessor;
 
     public PageProcessor(Optional<FilterEvaluator> filterEvaluator, Optional<FilterEvaluator> dynamicFilterEvaluator, List<? extends PageProjection> projections, OptionalInt initialBatchSize)
     {
         this.filterEvaluator = requireNonNull(filterEvaluator, "filterEvaluator is null");
         this.dynamicFilterEvaluator = requireNonNull(dynamicFilterEvaluator, "dynamicFilterEvaluator is null");
-        this.identityProjections = !projections.isEmpty() && projections.stream().allMatch(InputPageProjection.class::isInstance);
-        this.projections = projections.stream()
+        boolean identityProjections = !projections.isEmpty() && projections.stream().allMatch(InputPageProjection.class::isInstance);
+        List<PageProjection> dictionaryAwareProjections = projections.stream()
                 .map(projection -> {
                     // input projections preserve the encoding of their input on their own
                     if (projection.getInputChannels().size() == 1 && projection.isDeterministic() && !(projection instanceof InputPageProjection)) {
                         return new DictionaryAwarePageProjection(projection, dictionarySourceIdFunction);
                     }
-                    return projection;
+                    return (PageProjection) projection;
                 })
                 .collect(toImmutableList());
+        int initialProjectBatchSize;
         if (identityProjections) {
-            this.projectBatchSize = MAX_BATCH_SIZE;
+            initialProjectBatchSize = MAX_BATCH_SIZE;
         }
         else {
-            this.projectBatchSize = initialBatchSize.orElse(1);
+            initialProjectBatchSize = initialBatchSize.orElse(1);
         }
+        this.projectionsProcessor = new PageProjectionsProcessor(dictionaryAwareProjections, identityProjections, initialProjectBatchSize);
     }
 
     @VisibleForTesting
@@ -130,7 +116,7 @@ public class PageProcessor
             return WorkProcessor.of();
         }
 
-        if (projections.isEmpty()) {
+        if (projectionsProcessor.getProjectionCount() == 0) {
             // retained memory for empty page is negligible
             return WorkProcessor.of(new Page(selectedPositions.size()));
         }
@@ -154,7 +140,7 @@ public class PageProcessor
             }
         }
 
-        return WorkProcessor.create(new ProjectSelectedPositions(session, memoryContext, metrics, page, selectedPositions));
+        return projectionsProcessor.project(session, memoryContext, metrics, page, selectedPositions);
     }
 
     private static boolean isAllPositions(SelectedPositions selectedPositions, int positionCount)
@@ -162,178 +148,10 @@ public class PageProcessor
         return !selectedPositions.isList() && selectedPositions.getOffset() == 0 && selectedPositions.size() == positionCount;
     }
 
-    private class ProjectSelectedPositions
-            implements WorkProcessor.Process<Page>
-    {
-        private static final long INSTANCE_SIZE = instanceSize(ProjectSelectedPositions.class);
-
-        private final ConnectorSession session;
-        private final LocalMemoryContext memoryContext;
-        private final PageProcessorMetrics metrics;
-
-        private SourcePage page;
-        private final Block[] previouslyComputedResults;
-        private SelectedPositions selectedPositions;
-
-        private ProjectSelectedPositions(
-                ConnectorSession session,
-                LocalMemoryContext memoryContext,
-                PageProcessorMetrics metrics,
-                SourcePage page,
-                SelectedPositions selectedPositions)
-        {
-            checkArgument(!selectedPositions.isEmpty(), "selectedPositions is empty");
-
-            this.session = session;
-            this.metrics = metrics;
-            this.page = page;
-            this.memoryContext = memoryContext;
-            this.selectedPositions = selectedPositions;
-            this.previouslyComputedResults = new Block[projections.size()];
-        }
-
-        @Override
-        public ProcessState<Page> process()
-        {
-            while (true) {
-                if (selectedPositions.isEmpty()) {
-                    return finished();
-                }
-
-                int batchSize = Math.min(selectedPositions.size(), projectBatchSize);
-                ProcessBatchResult result = processBatch(batchSize);
-
-                if (result.isPageTooLarge()) {
-                    // the page buffer filled up, so halve the batch size and retry
-                    verify(batchSize > 1);
-                    projectBatchSize = projectBatchSize / 2;
-                    continue;
-                }
-
-                verify(result.isSuccess());
-                Page resultPage = result.getPage();
-                if (!identityProjections) {
-                    // output size is bounded by the input page, so no need to measure it or adapt the batch size
-                    updateBatchSize(resultPage.getPositionCount(), resultPage.getSizeInBytes());
-                }
-
-                // remove batch from selectedPositions and previouslyComputedResults
-                selectedPositions = selectedPositions.subRange(batchSize, selectedPositions.size());
-                for (int i = 0; i < previouslyComputedResults.length; i++) {
-                    if (previouslyComputedResults[i] != null && previouslyComputedResults[i].getPositionCount() > batchSize) {
-                        previouslyComputedResults[i] = previouslyComputedResults[i].getRegion(batchSize, previouslyComputedResults[i].getPositionCount() - batchSize);
-                    }
-                    else {
-                        previouslyComputedResults[i] = null;
-                    }
-                }
-
-                if (!selectedPositions.isEmpty()) {
-                    // there are still some positions to process therefore we need to retain page and account its memory
-                    updateRetainedSize();
-                }
-                else {
-                    page = null;
-                    Arrays.fill(previouslyComputedResults, null);
-                    memoryContext.setBytes(0);
-                }
-
-                return ofResult(resultPage);
-            }
-        }
-
-        private void updateBatchSize(int positionCount, long pageSize)
-        {
-            // if we produced a large page, halve the batch size for the next call
-            if (positionCount > 1 && pageSize > MAX_PAGE_SIZE_IN_BYTES) {
-                projectBatchSize = projectBatchSize / 2;
-            }
-
-            // if we produced a small page, double the batch size for the next call
-            if (pageSize < MIN_PAGE_SIZE_IN_BYTES && projectBatchSize < MAX_BATCH_SIZE) {
-                projectBatchSize = projectBatchSize * 2;
-            }
-        }
-
-        private void updateRetainedSize()
-        {
-            RetainedBytesByPartVisitor visitor = new RetainedBytesByPartVisitor();
-
-            page.retainedBytesForEachPart(visitor);
-
-            for (Block previouslyComputedResult : previouslyComputedResults) {
-                if (previouslyComputedResult != null) {
-                    previouslyComputedResult.retainedBytesForEachPart(visitor);
-                }
-            }
-
-            long retainedSizeInBytes = INSTANCE_SIZE +
-                    selectedPositions.getRetainedSizeInBytes() +
-                    sizeOf(previouslyComputedResults) +
-                    visitor.getRetainedSizeInBytes();
-
-            memoryContext.setBytes(retainedSizeInBytes);
-        }
-
-        private static final class RetainedBytesByPartVisitor
-                implements ObjLongConsumer<Object>
-        {
-            private final ReferenceCountMap referenceCountMap = new ReferenceCountMap();
-            private long retainedSizeInBytes;
-
-            public long getRetainedSizeInBytes()
-            {
-                return retainedSizeInBytes;
-            }
-
-            @Override
-            public void accept(Object object, long size)
-            {
-                // increment the size only when it is the first reference
-                if (referenceCountMap.incrementAndGetWithExtraIdentity(object, size) == 1) {
-                    retainedSizeInBytes += size;
-                }
-            }
-        }
-
-        private ProcessBatchResult processBatch(int batchSize)
-        {
-            Block[] blocks = new Block[projections.size()];
-
-            long pageSize = 0;
-            SelectedPositions positionsBatch = selectedPositions.subRange(0, batchSize);
-            for (int i = 0; i < projections.size(); i++) {
-                if (!identityProjections && positionsBatch.size() > 1 && pageSize > MAX_PAGE_SIZE_IN_BYTES) {
-                    return ProcessBatchResult.processBatchTooLarge();
-                }
-
-                // if possible, use previouslyComputedResults produced in prior optimistic failure attempt
-                PageProjection projection = projections.get(i);
-                if (previouslyComputedResults[i] != null && previouslyComputedResults[i].getPositionCount() >= batchSize) {
-                    blocks[i] = previouslyComputedResults[i].getRegion(0, batchSize);
-                }
-                else {
-                    SourcePage inputChannelsSourcePage = projection.getInputChannels().getInputChannels(page);
-                    long projectionStartNanos = System.nanoTime();
-                    Block result = projection.project(session, inputChannelsSourcePage, positionsBatch);
-                    metrics.recordProjectionTime(System.nanoTime() - projectionStartNanos);
-
-                    previouslyComputedResults[i] = result;
-                    blocks[i] = previouslyComputedResults[i];
-                }
-
-                if (!identityProjections) {
-                    pageSize += blocks[i].getSizeInBytes();
-                }
-            }
-            return ProcessBatchResult.processBatchSuccess(new Page(positionsBatch.size(), blocks));
-        }
-    }
-
     @VisibleForTesting
     public List<PageProjection> getProjections()
     {
-        return projections;
+        return projectionsProcessor.getProjections();
     }
 
     @NotThreadSafe
@@ -351,41 +169,6 @@ public class PageProcessor
         public void reset()
         {
             dictionarySourceIds.clear();
-        }
-    }
-
-    private record ProcessBatchResult(ProcessBatchState state, Page page)
-    {
-        public boolean isPageTooLarge()
-        {
-            return state == ProcessBatchState.PAGE_TOO_LARGE;
-        }
-
-        public boolean isSuccess()
-        {
-            return state == ProcessBatchState.SUCCESS;
-        }
-
-        public Page getPage()
-        {
-            verify(state == ProcessBatchState.SUCCESS);
-            return verifyNotNull(page);
-        }
-
-        public static ProcessBatchResult processBatchTooLarge()
-        {
-            return new ProcessBatchResult(ProcessBatchState.PAGE_TOO_LARGE, null);
-        }
-
-        public static ProcessBatchResult processBatchSuccess(Page page)
-        {
-            return new ProcessBatchResult(ProcessBatchState.SUCCESS, requireNonNull(page));
-        }
-
-        private enum ProcessBatchState
-        {
-            PAGE_TOO_LARGE,
-            SUCCESS,
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProjectionsProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProjectionsProcessor.java
@@ -25,6 +25,7 @@ import io.trino.spi.connector.SourcePage;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.ObjLongConsumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -79,10 +80,26 @@ public final class PageProjectionsProcessor
             SourcePage page,
             SelectedPositions selectedPositions)
     {
+        return project(session, memoryContext, metrics, page, selectedPositions, Optional.empty());
+    }
+
+    /**
+     * Projects {@code selectedPositions} of {@code page}. When {@code precomputedChannels} is
+     * present it seeds the optimistic reuse cache with already-computed blocks (indexed by
+     * projection); missing entries are computed lazily. The array is consumed, not copied.
+     */
+    public WorkProcessor<Page> project(
+            ConnectorSession session,
+            LocalMemoryContext memoryContext,
+            PageProcessorMetrics metrics,
+            SourcePage page,
+            SelectedPositions selectedPositions,
+            Optional<Block[]> precomputedChannels)
+    {
         if (selectedPositions.isEmpty()) {
             return WorkProcessor.of();
         }
-        return WorkProcessor.create(new ProjectSelectedPositions(session, memoryContext, metrics, page, selectedPositions));
+        return WorkProcessor.create(new ProjectSelectedPositions(session, memoryContext, metrics, page, selectedPositions, precomputedChannels));
     }
 
     private class ProjectSelectedPositions
@@ -103,16 +120,18 @@ public final class PageProjectionsProcessor
                 LocalMemoryContext memoryContext,
                 PageProcessorMetrics metrics,
                 SourcePage page,
-                SelectedPositions selectedPositions)
+                SelectedPositions selectedPositions,
+                Optional<Block[]> precomputedChannels)
         {
             checkArgument(!selectedPositions.isEmpty(), "selectedPositions is empty");
+            precomputedChannels.ifPresent(channels -> checkArgument(channels.length == projections.size(), "precomputedChannels size mismatch"));
 
             this.session = session;
             this.metrics = metrics;
             this.page = page;
             this.memoryContext = memoryContext;
             this.selectedPositions = selectedPositions;
-            this.previouslyComputedResults = new Block[projections.size()];
+            this.previouslyComputedResults = precomputedChannels.orElseGet(() -> new Block[projections.size()]);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProjectionsProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProjectionsProcessor.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.project;
+
+import io.trino.annotation.NotThreadSafe;
+import io.trino.array.ReferenceCountMap;
+import io.trino.memory.context.LocalMemoryContext;
+import io.trino.operator.WorkProcessor;
+import io.trino.operator.WorkProcessor.ProcessState;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SourcePage;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.ObjLongConsumer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.base.Verify.verifyNotNull;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static io.trino.operator.WorkProcessor.ProcessState.finished;
+import static io.trino.operator.WorkProcessor.ProcessState.ofResult;
+import static io.trino.operator.project.PageProcessor.MAX_BATCH_SIZE;
+import static io.trino.operator.project.PageProcessor.MAX_PAGE_SIZE_IN_BYTES;
+import static io.trino.operator.project.PageProcessor.MIN_PAGE_SIZE_IN_BYTES;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Evaluates a fixed list of projections over the selected positions of a page, emitting one output
+ * page per batch. The batch size adapts to the produced output size and a batch whose output
+ * crosses {@link PageProcessor#MAX_PAGE_SIZE_IN_BYTES} is halved and retried, bounding transient
+ * memory of a single wide page. Batch size and the optimistic reuse of already-computed blocks
+ * persist across pages, so the instance is reused for the whole stream of one operator.
+ */
+@NotThreadSafe
+public final class PageProjectionsProcessor
+{
+    private final List<PageProjection> projections;
+    // identity projections return a subset of the input page and cannot expand output size
+    private final boolean identityProjections;
+    private int projectBatchSize;
+
+    public PageProjectionsProcessor(List<? extends PageProjection> projections, boolean identityProjections, int initialBatchSize)
+    {
+        this.projections = projections.stream().collect(toImmutableList());
+        this.identityProjections = identityProjections;
+        this.projectBatchSize = initialBatchSize;
+    }
+
+    public List<PageProjection> getProjections()
+    {
+        return projections;
+    }
+
+    public int getProjectionCount()
+    {
+        return projections.size();
+    }
+
+    public WorkProcessor<Page> project(
+            ConnectorSession session,
+            LocalMemoryContext memoryContext,
+            PageProcessorMetrics metrics,
+            SourcePage page,
+            SelectedPositions selectedPositions)
+    {
+        if (selectedPositions.isEmpty()) {
+            return WorkProcessor.of();
+        }
+        return WorkProcessor.create(new ProjectSelectedPositions(session, memoryContext, metrics, page, selectedPositions));
+    }
+
+    private class ProjectSelectedPositions
+            implements WorkProcessor.Process<Page>
+    {
+        private static final long INSTANCE_SIZE = instanceSize(ProjectSelectedPositions.class);
+
+        private final ConnectorSession session;
+        private final LocalMemoryContext memoryContext;
+        private final PageProcessorMetrics metrics;
+
+        private SourcePage page;
+        private final Block[] previouslyComputedResults;
+        private SelectedPositions selectedPositions;
+
+        private ProjectSelectedPositions(
+                ConnectorSession session,
+                LocalMemoryContext memoryContext,
+                PageProcessorMetrics metrics,
+                SourcePage page,
+                SelectedPositions selectedPositions)
+        {
+            checkArgument(!selectedPositions.isEmpty(), "selectedPositions is empty");
+
+            this.session = session;
+            this.metrics = metrics;
+            this.page = page;
+            this.memoryContext = memoryContext;
+            this.selectedPositions = selectedPositions;
+            this.previouslyComputedResults = new Block[projections.size()];
+        }
+
+        @Override
+        public ProcessState<Page> process()
+        {
+            while (true) {
+                if (selectedPositions.isEmpty()) {
+                    return finished();
+                }
+
+                int batchSize = Math.min(selectedPositions.size(), projectBatchSize);
+                ProcessBatchResult result = processBatch(batchSize);
+
+                if (result.isPageTooLarge()) {
+                    // the page buffer filled up, so halve the batch size and retry
+                    verify(batchSize > 1);
+                    projectBatchSize = projectBatchSize / 2;
+                    continue;
+                }
+
+                verify(result.isSuccess());
+                Page resultPage = result.getPage();
+                if (!identityProjections) {
+                    // output size is bounded by the input page, so no need to measure it or adapt the batch size
+                    updateBatchSize(resultPage.getPositionCount(), resultPage.getSizeInBytes());
+                }
+
+                // remove batch from selectedPositions and previouslyComputedResults
+                selectedPositions = selectedPositions.subRange(batchSize, selectedPositions.size());
+                for (int i = 0; i < previouslyComputedResults.length; i++) {
+                    if (previouslyComputedResults[i] != null && previouslyComputedResults[i].getPositionCount() > batchSize) {
+                        previouslyComputedResults[i] = previouslyComputedResults[i].getRegion(batchSize, previouslyComputedResults[i].getPositionCount() - batchSize);
+                    }
+                    else {
+                        previouslyComputedResults[i] = null;
+                    }
+                }
+
+                if (!selectedPositions.isEmpty()) {
+                    // there are still some positions to process therefore we need to retain page and account its memory
+                    updateRetainedSize();
+                }
+                else {
+                    page = null;
+                    Arrays.fill(previouslyComputedResults, null);
+                    memoryContext.setBytes(0);
+                }
+
+                return ofResult(resultPage);
+            }
+        }
+
+        private void updateBatchSize(int positionCount, long pageSize)
+        {
+            // if we produced a large page, halve the batch size for the next call
+            if (positionCount > 1 && pageSize > MAX_PAGE_SIZE_IN_BYTES) {
+                projectBatchSize = projectBatchSize / 2;
+            }
+
+            // if we produced a small page, double the batch size for the next call
+            if (pageSize < MIN_PAGE_SIZE_IN_BYTES && projectBatchSize < MAX_BATCH_SIZE) {
+                projectBatchSize = projectBatchSize * 2;
+            }
+        }
+
+        private void updateRetainedSize()
+        {
+            RetainedBytesByPartVisitor visitor = new RetainedBytesByPartVisitor();
+
+            page.retainedBytesForEachPart(visitor);
+
+            for (Block previouslyComputedResult : previouslyComputedResults) {
+                if (previouslyComputedResult != null) {
+                    previouslyComputedResult.retainedBytesForEachPart(visitor);
+                }
+            }
+
+            long retainedSizeInBytes = INSTANCE_SIZE +
+                    selectedPositions.getRetainedSizeInBytes() +
+                    sizeOf(previouslyComputedResults) +
+                    visitor.getRetainedSizeInBytes();
+
+            memoryContext.setBytes(retainedSizeInBytes);
+        }
+
+        private static final class RetainedBytesByPartVisitor
+                implements ObjLongConsumer<Object>
+        {
+            private final ReferenceCountMap referenceCountMap = new ReferenceCountMap();
+            private long retainedSizeInBytes;
+
+            public long getRetainedSizeInBytes()
+            {
+                return retainedSizeInBytes;
+            }
+
+            @Override
+            public void accept(Object object, long size)
+            {
+                // increment the size only when it is the first reference
+                if (referenceCountMap.incrementAndGetWithExtraIdentity(object, size) == 1) {
+                    retainedSizeInBytes += size;
+                }
+            }
+        }
+
+        private ProcessBatchResult processBatch(int batchSize)
+        {
+            Block[] blocks = new Block[projections.size()];
+
+            long pageSize = 0;
+            SelectedPositions positionsBatch = selectedPositions.subRange(0, batchSize);
+            for (int i = 0; i < projections.size(); i++) {
+                if (!identityProjections && positionsBatch.size() > 1 && pageSize > MAX_PAGE_SIZE_IN_BYTES) {
+                    return ProcessBatchResult.processBatchTooLarge();
+                }
+
+                // if possible, use previouslyComputedResults produced in prior optimistic failure attempt
+                PageProjection projection = projections.get(i);
+                if (previouslyComputedResults[i] != null && previouslyComputedResults[i].getPositionCount() >= batchSize) {
+                    blocks[i] = previouslyComputedResults[i].getRegion(0, batchSize);
+                }
+                else {
+                    SourcePage inputChannelsSourcePage = projection.getInputChannels().getInputChannels(page);
+                    long projectionStartNanos = System.nanoTime();
+                    Block result = projection.project(session, inputChannelsSourcePage, positionsBatch);
+                    metrics.recordProjectionTime(System.nanoTime() - projectionStartNanos);
+
+                    previouslyComputedResults[i] = result;
+                    blocks[i] = previouslyComputedResults[i];
+                }
+
+                if (!identityProjections) {
+                    pageSize += blocks[i].getSizeInBytes();
+                }
+            }
+            return ProcessBatchResult.processBatchSuccess(new Page(positionsBatch.size(), blocks));
+        }
+    }
+
+    private record ProcessBatchResult(ProcessBatchState state, Page page)
+    {
+        public boolean isPageTooLarge()
+        {
+            return state == ProcessBatchState.PAGE_TOO_LARGE;
+        }
+
+        public boolean isSuccess()
+        {
+            return state == ProcessBatchState.SUCCESS;
+        }
+
+        public Page getPage()
+        {
+            verify(state == ProcessBatchState.SUCCESS);
+            return verifyNotNull(page);
+        }
+
+        public static ProcessBatchResult processBatchTooLarge()
+        {
+            return new ProcessBatchResult(ProcessBatchState.PAGE_TOO_LARGE, null);
+        }
+
+        public static ProcessBatchResult processBatchSuccess(Page page)
+        {
+            return new ProcessBatchResult(ProcessBatchState.SUCCESS, requireNonNull(page));
+        }
+
+        private enum ProcessBatchState
+        {
+            PAGE_TOO_LARGE,
+            SUCCESS,
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -1841,6 +1841,7 @@ public class LocalExecutionPlanner
                     node.getId(),
                     source.getTypes(),
                     (int) node.getCount(),
+                    sortChannels,
                     orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, sortOrders));
 
             return new PhysicalOperation(operator, source.getLayout(), source);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -1842,6 +1842,7 @@ public class LocalExecutionPlanner
                     node.getId(),
                     source.getTypes(),
                     (int) node.getCount(),
+                    sortChannels,
                     orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, sortOrders));
 
             return new PhysicalOperation(operator, source.getLayout(), source);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
@@ -92,6 +92,7 @@ public class OptimizerConfig
     private boolean forceSingleNodeOutput;
     private boolean useExactPartitioning;
     private boolean useCostBasedPartitioning = true;
+    private boolean maskedPageEnabled = true;
     private int pushFilterIntoValuesMaxRowCount = 100;
     // adaptive partial aggregation
     private boolean adaptivePartialAggregationEnabled = true;
@@ -794,6 +795,19 @@ public class OptimizerConfig
     public OptimizerConfig setUseCostBasedPartitioning(boolean useCostBasedPartitioning)
     {
         this.useCostBasedPartitioning = useCostBasedPartitioning;
+        return this;
+    }
+
+    public boolean isMaskedPageEnabled()
+    {
+        return maskedPageEnabled;
+    }
+
+    @Config("optimizer.masked-page-enabled")
+    @ConfigDescription("Enable late materialization by passing undecoded masked pages between operators, so a consumer such as partial TopN can defer decoding of columns it may not need")
+    public OptimizerConfig setMaskedPageEnabled(boolean maskedPageEnabled)
+    {
+        this.maskedPageEnabled = maskedPageEnabled;
         return this;
     }
 

--- a/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
@@ -90,6 +90,7 @@ public class TestOptimizerConfig
                 .setMinInputRowsPerTask(10_000_000L)
                 .setUseExactPartitioning(false)
                 .setUseCostBasedPartitioning(true)
+                .setMaskedPageEnabled(true)
                 .setPushFilterIntoValuesMaxRowCount(100)
                 .setUnsafePushdownAllowed(false));
     }
@@ -148,6 +149,7 @@ public class TestOptimizerConfig
                 .put("optimizer.min-input-rows-per-task", "1000000")
                 .put("optimizer.use-exact-partitioning", "true")
                 .put("optimizer.use-cost-based-partitioning", "false")
+                .put("optimizer.masked-page-enabled", "false")
                 .put("optimizer.push-filter-into-values-max-row-count", "5")
                 .put("optimizer.allow-unsafe-pushdown", "true")
                 .buildOrThrow();
@@ -203,6 +205,7 @@ public class TestOptimizerConfig
                 .setMinInputRowsPerTask(1_000_000L)
                 .setUseExactPartitioning(true)
                 .setUseCostBasedPartitioning(false)
+                .setMaskedPageEnabled(false)
                 .setPushFilterIntoValuesMaxRowCount(5)
                 .setUnsafePushdownAllowed(true);
         assertFullMapping(properties, expected);

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkTopNOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkTopNOperator.java
@@ -101,6 +101,7 @@ public class BenchmarkTopNOperator
                     new PlanNodeId("test"),
                     types,
                     Integer.valueOf(topN),
+                    sortChannels,
                     orderingCompiler.compilePageWithPositionComparator(
                             sortTypes,
                             sortChannels,

--- a/core/trino-main/src/test/java/io/trino/operator/TestScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestScanFilterAndProjectOperator.java
@@ -57,7 +57,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
@@ -65,7 +64,6 @@ import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.trino.RowPagesBuilder.rowPagesBuilder;
 import static io.trino.SessionTestUtils.TEST_SESSION;
-import static io.trino.block.BlockAssertions.createIntsBlock;
 import static io.trino.operator.OperatorAssertion.toMaterializedResult;
 import static io.trino.operator.PageAssertions.assertPageEquals;
 import static io.trino.spi.function.OperatorType.EQUAL;
@@ -203,18 +201,10 @@ public class TestScanFilterAndProjectOperator
         }
     }
 
-    @Test
-    public void testPageSourceLazyLoad()
-            throws Exception
+    private static ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory createLazyLoadFactory(TestingSourcePage input)
     {
-        Block inputBlock = BlockAssertions.createLongSequenceBlock(0, 100);
-        // If column 1 is loaded, test will fail
-        TestingSourcePage input = new TestingSourcePage(100, inputBlock, null);
-        DriverContext driverContext = newDriverContext();
-
         PageProcessor pageProcessor = new PageProcessor(Optional.of(new PageFilterEvaluator(new SelectAllFilter())), ImmutableList.of(new LazyPagePageProjection()));
-
-        ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(
+        return new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(
                 0,
                 new PlanNodeId("test"),
                 new PlanNodeId("0"),
@@ -227,6 +217,18 @@ public class TestScanFilterAndProjectOperator
                 ImmutableList.of(BIGINT),
                 DataSize.ofBytes(0),
                 0);
+    }
+
+    @Test
+    public void testPageSourceLazyLoad()
+            throws Exception
+    {
+        Block inputBlock = BlockAssertions.createLongSequenceBlock(0, 100);
+        // If column 1 is loaded, test will fail
+        TestingSourcePage input = new TestingSourcePage(100, inputBlock, null);
+        DriverContext driverContext = newDriverContext();
+
+        ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = createLazyLoadFactory(input);
 
         try (SourceOperator operator = factory.createOperator(driverContext)) {
             operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
@@ -236,6 +238,39 @@ public class TestScanFilterAndProjectOperator
             MaterializedResult actual = toMaterializedResult(driverContext.getSession(), ImmutableList.of(BIGINT), toPages(operator));
 
             assertThat(actual).containsExactlyElementsOf(expected);
+
+            // input bytes account only decoded channels; column 1 is never loaded
+            assertThat(operator.getOperatorContext().getInputDataSize().getTotalCount())
+                    .isEqualTo(inputBlock.getSizeInBytes());
+        }
+    }
+
+    @Test
+    public void testMaskedOutputLazyLoad()
+            throws Exception
+    {
+        Block inputBlock = BlockAssertions.createLongSequenceBlock(0, 100);
+        // If column 1 is loaded, test will fail
+        TestingSourcePage input = new TestingSourcePage(100, inputBlock, null);
+        DriverContext driverContext = newDriverContext();
+
+        ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = createLazyLoadFactory(input);
+
+        try (SourceOperator operator = factory.createOperator(driverContext)) {
+            operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
+            operator.noMoreSplits();
+
+            // source-pages validation is on by default; masked output must remain available under it
+            assertThat(operator.producesMaskedOutput()).isTrue();
+
+            MaterializedResult expected = toMaterializedResult(driverContext.getSession(), ImmutableList.of(BIGINT), ImmutableList.of(new Page(inputBlock)));
+            MaterializedResult actual = toMaterializedResult(driverContext.getSession(), ImmutableList.of(BIGINT), toMaskedPages(operator));
+
+            assertThat(actual).containsExactlyElementsOf(expected);
+
+            // input bytes account only decoded channels; column 1 is never loaded
+            assertThat(operator.getOperatorContext().getInputDataSize().getTotalCount())
+                    .isEqualTo(inputBlock.getSizeInBytes());
         }
     }
 
@@ -276,30 +311,32 @@ public class TestScanFilterAndProjectOperator
         }
     }
 
-    @Test
-    public void testRecordMaterializedBytes()
+    private static List<Page> toMaskedPages(SourceOperator operator)
     {
-        Block block = createIntsBlock(1, 2, 3);
-        SourcePage page = new TestingSourcePage(3, block, block, block);
+        ImmutableList.Builder<Page> outputPages = ImmutableList.builder();
 
-        page.getBlock(1);
+        int nullPages = 0;
+        while (!operator.isFinished()) {
+            MaskedPage maskedPage = operator.getMaskedOutput();
+            if (maskedPage == null) {
+                assertThat(nullPages < 1_000_000)
+                        .describedAs("Too many null pages; infinite loop?")
+                        .isTrue();
+                nullPages++;
+                continue;
+            }
+            nullPages = 0;
+            // masked pages are valid only until the next output request, so materialize fully now
+            WorkProcessor<Page> materialized = maskedPage.materialize();
+            while (materialized.process()) {
+                if (materialized.isFinished()) {
+                    break;
+                }
+                outputPages.add(materialized.getResult());
+            }
+        }
 
-        AtomicLong sizeInBytes = new AtomicLong();
-        ScanFilterAndProjectOperator.ProcessedBytesMonitor monitor = new ScanFilterAndProjectOperator.ProcessedBytesMonitor(page, sizeInBytes::getAndAdd);
-
-        assertThat(sizeInBytes.get()).isEqualTo(block.getSizeInBytes() * 1);
-
-        page.getBlock(2);
-        monitor.update();
-        assertThat(sizeInBytes.get()).isEqualTo(block.getSizeInBytes() * 2);
-
-        page.getBlock(1);
-        monitor.update();
-        assertThat(sizeInBytes.get()).isEqualTo(block.getSizeInBytes() * 2);
-
-        page.getBlock(0);
-        monitor.update();
-        assertThat(sizeInBytes.get()).isEqualTo(block.getSizeInBytes() * 3);
+        return outputPages.build();
     }
 
     private static List<Page> toPages(Operator operator)

--- a/core/trino-main/src/test/java/io/trino/operator/TestScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestScanFilterAndProjectOperator.java
@@ -63,7 +63,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
@@ -71,7 +70,6 @@ import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.trino.RowPagesBuilder.rowPagesBuilder;
 import static io.trino.SessionTestUtils.TEST_SESSION;
-import static io.trino.block.BlockAssertions.createIntsBlock;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.operator.OperatorAssertion.toMaterializedResult;
 import static io.trino.operator.PageAssertions.assertPageEquals;
@@ -260,18 +258,10 @@ public class TestScanFilterAndProjectOperator
         }
     }
 
-    @Test
-    public void testPageSourceLazyLoad()
-            throws Exception
+    private static ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory createLazyLoadFactory(TestingSourcePage input)
     {
-        Block inputBlock = BlockAssertions.createLongSequenceBlock(0, 100);
-        // If column 1 is loaded, test will fail
-        TestingSourcePage input = new TestingSourcePage(100, inputBlock, null);
-        DriverContext driverContext = newDriverContext();
-
         PageProcessor pageProcessor = new PageProcessor(Optional.of(new PageFilterEvaluator(new SelectAllFilter())), ImmutableList.of(new LazyPagePageProjection()));
-
-        ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(
+        return new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(
                 0,
                 new PlanNodeId("test"),
                 new PlanNodeId("0"),
@@ -285,6 +275,18 @@ public class TestScanFilterAndProjectOperator
                 DataSize.ofBytes(0),
                 0,
                 newSimpleAggregatedMemoryContext());
+    }
+
+    @Test
+    public void testPageSourceLazyLoad()
+            throws Exception
+    {
+        Block inputBlock = BlockAssertions.createLongSequenceBlock(0, 100);
+        // If column 1 is loaded, test will fail
+        TestingSourcePage input = new TestingSourcePage(100, inputBlock, null);
+        DriverContext driverContext = newDriverContext();
+
+        ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = createLazyLoadFactory(input);
 
         try (SourceOperator operator = factory.createOperator(driverContext)) {
             operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
@@ -294,6 +296,39 @@ public class TestScanFilterAndProjectOperator
             MaterializedResult actual = toMaterializedResult(driverContext.getSession(), ImmutableList.of(BIGINT), toPages(operator));
 
             assertThat(actual).containsExactlyElementsOf(expected);
+
+            // input bytes account only decoded channels; column 1 is never loaded
+            assertThat(operator.getOperatorContext().getInputDataSize().getTotalCount())
+                    .isEqualTo(inputBlock.getSizeInBytes());
+        }
+    }
+
+    @Test
+    public void testMaskedOutputLazyLoad()
+            throws Exception
+    {
+        Block inputBlock = BlockAssertions.createLongSequenceBlock(0, 100);
+        // If column 1 is loaded, test will fail
+        TestingSourcePage input = new TestingSourcePage(100, inputBlock, null);
+        DriverContext driverContext = newDriverContext();
+
+        ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = createLazyLoadFactory(input);
+
+        try (SourceOperator operator = factory.createOperator(driverContext)) {
+            operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
+            operator.noMoreSplits();
+
+            // source-pages validation is on by default; masked output must remain available under it
+            assertThat(operator.producesMaskedOutput()).isTrue();
+
+            MaterializedResult expected = toMaterializedResult(driverContext.getSession(), ImmutableList.of(BIGINT), ImmutableList.of(new Page(inputBlock)));
+            MaterializedResult actual = toMaterializedResult(driverContext.getSession(), ImmutableList.of(BIGINT), toMaskedPages(operator));
+
+            assertThat(actual).containsExactlyElementsOf(expected);
+
+            // input bytes account only decoded channels; column 1 is never loaded
+            assertThat(operator.getOperatorContext().getInputDataSize().getTotalCount())
+                    .isEqualTo(inputBlock.getSizeInBytes());
         }
     }
 
@@ -335,30 +370,32 @@ public class TestScanFilterAndProjectOperator
         }
     }
 
-    @Test
-    public void testRecordMaterializedBytes()
+    private static List<Page> toMaskedPages(SourceOperator operator)
     {
-        Block block = createIntsBlock(1, 2, 3);
-        SourcePage page = new TestingSourcePage(3, block, block, block);
+        ImmutableList.Builder<Page> outputPages = ImmutableList.builder();
 
-        page.getBlock(1);
+        int nullPages = 0;
+        while (!operator.isFinished()) {
+            MaskedPage maskedPage = operator.getMaskedOutput();
+            if (maskedPage == null) {
+                assertThat(nullPages < 1_000_000)
+                        .describedAs("Too many null pages; infinite loop?")
+                        .isTrue();
+                nullPages++;
+                continue;
+            }
+            nullPages = 0;
+            // masked pages are valid only until the next output request, so materialize fully now
+            WorkProcessor<Page> materialized = maskedPage.materialize();
+            while (materialized.process()) {
+                if (materialized.isFinished()) {
+                    break;
+                }
+                outputPages.add(materialized.getResult());
+            }
+        }
 
-        AtomicLong sizeInBytes = new AtomicLong();
-        ScanFilterAndProjectOperator.ProcessedBytesMonitor monitor = new ScanFilterAndProjectOperator.ProcessedBytesMonitor(page, sizeInBytes::getAndAdd);
-
-        assertThat(sizeInBytes.get()).isEqualTo(block.getSizeInBytes() * 1);
-
-        page.getBlock(2);
-        monitor.update();
-        assertThat(sizeInBytes.get()).isEqualTo(block.getSizeInBytes() * 2);
-
-        page.getBlock(1);
-        monitor.update();
-        assertThat(sizeInBytes.get()).isEqualTo(block.getSizeInBytes() * 2);
-
-        page.getBlock(0);
-        monitor.update();
-        assertThat(sizeInBytes.get()).isEqualTo(block.getSizeInBytes() * 3);
+        return outputPages.build();
     }
 
     private static List<Page> toPages(Operator operator)

--- a/core/trino-main/src/test/java/io/trino/operator/TestTopNOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTopNOperator.java
@@ -210,6 +210,34 @@ public class TestTopNOperator
         }
     }
 
+    @Test
+    public void testSupportsMaskedInput()
+            throws Exception
+    {
+        // sort channel is a subset of output channels: non-sort channels can be left undecoded
+        OperatorFactory mixed = topNOperatorFactory(
+                ImmutableList.of(BIGINT, DOUBLE),
+                2,
+                ImmutableList.of(0),
+                ImmutableList.of(DESC_NULLS_LAST));
+        try (Operator operator = mixed.createOperator(driverContext)) {
+            assertThat(operator.supportsMaskedInput()).isTrue();
+        }
+
+        // every channel is a sort channel: nothing to defer
+        OperatorFactory allSort = topNOperatorFactory(
+                ImmutableList.of(BIGINT),
+                2,
+                ImmutableList.of(0),
+                ImmutableList.of(DESC_NULLS_LAST));
+        DriverContext otherContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
+                .addPipelineContext(0, true, true, false)
+                .addDriverContext();
+        try (Operator operator = allSort.createOperator(otherContext)) {
+            assertThat(operator.supportsMaskedInput()).isFalse();
+        }
+    }
+
     private OperatorFactory topNOperatorFactory(
             List<Type> types,
             int n,
@@ -224,6 +252,7 @@ public class TestTopNOperator
                 new PlanNodeId("test"),
                 types,
                 n,
+                sortChannels,
                 orderingCompiler.compilePageWithPositionComparator(sortTypes, sortChannels, sortOrders));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorSourceOperatorAdapter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorSourceOperatorAdapter.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.airlift.units.Duration;
@@ -20,6 +21,7 @@ import io.trino.metadata.Split;
 import io.trino.plugin.base.metrics.LongCount;
 import io.trino.spi.Page;
 import io.trino.spi.metrics.Metrics;
+import io.trino.spi.type.Type;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.testing.TestingTaskContext;
 import org.junit.jupiter.api.AfterAll;
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static io.trino.SessionTestUtils.TEST_SESSION;
@@ -124,6 +127,12 @@ public class TestWorkProcessorSourceOperatorAdapter
         public String getOperatorType()
         {
             return "test";
+        }
+
+        @Override
+        public List<Type> getOutputTypes()
+        {
+            return ImmutableList.of();
         }
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/FixedSourcePage.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/FixedSourcePage.java
@@ -91,4 +91,10 @@ final class FixedSourcePage
     {
         page = page.getPositions(positions, offset, size);
     }
+
+    @Override
+    public void selectPositions(int offset, int size)
+    {
+        page = page.getRegion(offset, size);
+    }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/MemoryUsageReportingPageSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/MemoryUsageReportingPageSource.java
@@ -169,5 +169,12 @@ public final class MemoryUsageReportingPageSource
             sourcePage.selectPositions(positions, offset, size);
             memoryContext.setBytes(pageSource.getMemoryUsage());
         }
+
+        @Override
+        public void selectPositions(int offset, int size)
+        {
+            sourcePage.selectPositions(offset, size);
+            memoryContext.setBytes(pageSource.getMemoryUsage());
+        }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/MemoryUsageReportingPageSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/MemoryUsageReportingPageSource.java
@@ -177,5 +177,12 @@ public final class MemoryUsageReportingPageSource
             sourcePage.selectPositions(positions, offset, size);
             memoryContext.setBytes(pageSource.getMemoryUsage());
         }
+
+        @Override
+        public void selectPositions(int offset, int size)
+        {
+            sourcePage.selectPositions(offset, size);
+            memoryContext.setBytes(pageSource.getMemoryUsage());
+        }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/SourcePage.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/SourcePage.java
@@ -107,4 +107,18 @@ public interface SourcePage
      * the underlying reader to filter positions on subsequent reads.
      */
     void selectPositions(int[] positions, int offset, int size);
+
+    /**
+     * Masks this page to the contiguous position range {@code [offset, offset + size)}.
+     * Equivalent to {@link #selectPositions(int[], int, int)} with the identity array for that
+     * range; implementations may narrow via a region view rather than a gather.
+     */
+    default void selectPositions(int offset, int size)
+    {
+        int[] positions = new int[size];
+        for (int i = 0; i < size; i++) {
+            positions[i] = offset + i;
+        }
+        selectPositions(positions, 0, size);
+    }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/SourcePage.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/SourcePage.java
@@ -120,4 +120,18 @@ public interface SourcePage
      * the underlying reader to filter positions on subsequent reads.
      */
     void selectPositions(int[] positions, int offset, int size);
+
+    /**
+     * Masks this page to the contiguous position range {@code [offset, offset + size)}.
+     * Equivalent to {@link #selectPositions(int[], int, int)} with the identity array for that
+     * range; implementations may narrow via a region view rather than a gather.
+     */
+    default void selectPositions(int offset, int size)
+    {
+        int[] positions = new int[size];
+        for (int i = 0; i < size; i++) {
+            positions[i] = offset + i;
+        }
+        selectPositions(positions, 0, size);
+    }
 }

--- a/docs/src/main/sphinx/admin/properties-optimizer.md
+++ b/docs/src/main/sphinx/admin/properties-optimizer.md
@@ -265,3 +265,15 @@ A value of `0` disables this optimization.
 
 When enabled the cost based optimizer is used to determine if repartitioning the output of an
 already partitioned stage is necessary.
+
+## `optimizer.masked-page-enabled`
+
+- **Type:** {ref}`prop-type-boolean`
+- **Default value:** `true`
+- **Session property:** `masked_page_enabled`
+
+Enable late materialization between supporting operators by passing undecoded
+"masked" pages, so that a consumer can defer decoding of columns it may not need.
+For example, an `ORDER BY ... LIMIT n` query reads only the sort columns to decide
+which rows can enter the result, and decodes the remaining selected columns only for
+the rows that survive. This reduces work when most rows are discarded by the `LIMIT`.

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcRecordReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcRecordReader.java
@@ -483,7 +483,7 @@ public class OrcRecordReader
 
         public OrcSourcePage(int positionCount)
         {
-            selectedPositions = new SelectedPositions(positionCount, null);
+            selectedPositions = new SelectedPositions(positionCount, 0, null);
             retainedSizeInBytes = shallowRetainedSizeInBytes();
         }
 
@@ -586,9 +586,25 @@ public class OrcRecordReader
                 }
             }
         }
+
+        @Override
+        public void selectPositions(int offset, int size)
+        {
+            selectedPositions = selectedPositions.selectPositions(offset, size);
+            retainedSizeInBytes = shallowRetainedSizeInBytes();
+            for (int i = 0; i < blocks.length; i++) {
+                Block block = blocks[i];
+                if (block != null) {
+                    // loaded blocks already reflect the previous selection, so the incoming range applies to them directly
+                    block = block.getRegion(offset, size);
+                    retainedSizeInBytes += block.getRetainedSizeInBytes();
+                    blocks[i] = block;
+                }
+            }
+        }
     }
 
-    private record SelectedPositions(int positionCount, @Nullable int[] positions)
+    private record SelectedPositions(int positionCount, int offset, @Nullable int[] positions)
     {
         private static final long INSTANCE_SIZE = instanceSize(SelectedPositions.class);
 
@@ -601,7 +617,10 @@ public class OrcRecordReader
         public Block apply(Block block)
         {
             if (positions == null) {
-                return block;
+                if (offset == 0) {
+                    return block;
+                }
+                return block.getRegion(offset, positionCount);
             }
             return block.getPositions(positions, 0, positionCount);
         }
@@ -610,7 +629,7 @@ public class OrcRecordReader
         {
             long[] rowNumbers = new long[positionCount];
             for (int i = 0; i < positionCount; i++) {
-                int position = positions == null ? i : positions[i];
+                int position = positions == null ? offset + i : positions[i];
                 rowNumbers[i] = filePosition + position;
             }
             return new LongArrayBlock(positionCount, Optional.empty(), rowNumbers);
@@ -620,17 +639,28 @@ public class OrcRecordReader
         public SelectedPositions selectPositions(int[] positions, int offset, int size)
         {
             if (this.positions == null) {
+                int[] newPositions = new int[size];
                 for (int i = 0; i < size; i++) {
                     checkIndex(offset + i, positionCount);
+                    newPositions[i] = this.offset + positions[offset + i];
                 }
-                return new SelectedPositions(size, Arrays.copyOfRange(positions, offset, offset + size));
+                return new SelectedPositions(size, 0, newPositions);
             }
 
             int[] newPositions = new int[size];
             for (int i = 0; i < size; i++) {
                 newPositions[i] = this.positions[positions[offset + i]];
             }
-            return new SelectedPositions(size, newPositions);
+            return new SelectedPositions(size, 0, newPositions);
+        }
+
+        @CheckReturnValue
+        public SelectedPositions selectPositions(int rangeOffset, int size)
+        {
+            if (this.positions == null) {
+                return new SelectedPositions(size, this.offset + rangeOffset, null);
+            }
+            return new SelectedPositions(size, 0, Arrays.copyOfRange(this.positions, rangeOffset, rangeOffset + size));
         }
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -299,7 +299,7 @@ public class ParquetReader
 
         public ParquetSourcePage(int positionCount)
         {
-            selectedPositions = new SelectedPositions(positionCount, null);
+            selectedPositions = new SelectedPositions(positionCount, 0, null);
             retainedSizeInBytes = shallowRetainedSizeInBytes();
         }
 
@@ -399,9 +399,25 @@ public class ParquetReader
                 }
             }
         }
+
+        @Override
+        public void selectPositions(int offset, int size)
+        {
+            selectedPositions = selectedPositions.selectPositions(offset, size);
+            retainedSizeInBytes = shallowRetainedSizeInBytes();
+            for (int i = 0; i < blocks.length; i++) {
+                Block block = blocks[i];
+                if (block != null) {
+                    // loaded blocks already reflect the previous selection, so the incoming range applies to them directly
+                    block = block.getRegion(offset, size);
+                    retainedSizeInBytes += block.getRetainedSizeInBytes();
+                    blocks[i] = block;
+                }
+            }
+        }
     }
 
-    private record SelectedPositions(int positionCount, @Nullable int[] positions)
+    private record SelectedPositions(int positionCount, int offset, @Nullable int[] positions)
     {
         private static final long INSTANCE_SIZE = instanceSize(SelectedPositions.class);
 
@@ -414,7 +430,10 @@ public class ParquetReader
         public Block apply(Block block)
         {
             if (positions == null) {
-                return block;
+                if (offset == 0) {
+                    return block;
+                }
+                return block.getRegion(offset, positionCount);
             }
             return block.getPositions(positions, 0, positionCount);
         }
@@ -423,7 +442,7 @@ public class ParquetReader
         {
             long[] rowNumbers = new long[positionCount];
             for (int i = 0; i < positionCount; i++) {
-                int position = positions == null ? i : positions[i];
+                int position = positions == null ? offset + i : positions[i];
                 rowNumbers[i] = startRowNumber + position;
             }
             return new LongArrayBlock(positionCount, Optional.empty(), rowNumbers);
@@ -433,17 +452,28 @@ public class ParquetReader
         public SelectedPositions selectPositions(int[] positions, int offset, int size)
         {
             if (this.positions == null) {
+                int[] newPositions = new int[size];
                 for (int i = 0; i < size; i++) {
                     checkIndex(offset + i, positionCount);
+                    newPositions[i] = this.offset + positions[offset + i];
                 }
-                return new SelectedPositions(size, Arrays.copyOfRange(positions, offset, offset + size));
+                return new SelectedPositions(size, 0, newPositions);
             }
 
             int[] newPositions = new int[size];
             for (int i = 0; i < size; i++) {
                 newPositions[i] = this.positions[positions[offset + i]];
             }
-            return new SelectedPositions(size, newPositions);
+            return new SelectedPositions(size, 0, newPositions);
+        }
+
+        @CheckReturnValue
+        public SelectedPositions selectPositions(int rangeOffset, int size)
+        {
+            if (this.positions == null) {
+                return new SelectedPositions(size, this.offset + rangeOffset, null);
+            }
+            return new SelectedPositions(size, 0, Arrays.copyOfRange(this.positions, rangeOffset, rangeOffset + size));
         }
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -507,6 +507,26 @@ public class ParquetReader
             resetSelectionTracking();
         }
 
+        @Override
+        public void selectPositions(int offset, int size)
+        {
+            selectedPositionsReadModes = null;
+            selectedPositions = selectedPositions.selectPositions(offset, size);
+            sizeInBytes = 0;
+            retainedSizeInBytes = shallowRetainedSizeInBytes();
+            for (int i = 0; i < blocks.length; i++) {
+                Block block = blocks[i];
+                if (block != null) {
+                    // loaded blocks already reflect the previous selection, so the incoming range applies to them directly
+                    block = block.getRegion(offset, size);
+                    sizeInBytes += block.getSizeInBytes();
+                    retainedSizeInBytes += block.getRetainedSizeInBytes();
+                    blocks[i] = block;
+                }
+            }
+            resetSelectionTracking();
+        }
+
         private void resetSelectionTracking()
         {
             unloadedSelectedColumns = countUnloadedColumns();
@@ -579,11 +599,17 @@ public class ParquetReader
         }
     }
 
+    /**
+     * When {@code positions} is null, the selection is the contiguous range
+     * {@code [rangeOffset, rangeOffset + positionCount)} of the original page.
+     * Otherwise {@code rangeOffset} is zero and the selection is listed in {@code positions}.
+     */
     private record SelectedPositions(
             int originalPositionCount,
             int positionCount,
             @Nullable int[] positions,
             int positionsOffset,
+            int rangeOffset,
             SelectionAnalysis analysis)
     {
         private static final long INSTANCE_SIZE = instanceSize(SelectedPositions.class);
@@ -591,7 +617,7 @@ public class ParquetReader
 
         private static SelectedPositions allPositions(int positionCount)
         {
-            return new SelectedPositions(positionCount, positionCount, null, 0, SelectionAnalysis.analyzed(true, positionCount == 0 ? 0 : 1, 0));
+            return new SelectedPositions(positionCount, positionCount, null, 0, 0, SelectionAnalysis.analyzed(true, positionCount == 0 ? 0 : 1, 0));
         }
 
         public long retainedSizeInBytes()
@@ -678,7 +704,10 @@ public class ParquetReader
         public Block apply(Block block)
         {
             if (positions == null) {
-                return block;
+                if (rangeOffset == 0) {
+                    return block;
+                }
+                return block.getRegion(rangeOffset, positionCount);
             }
             return block.getPositions(positions, positionsOffset, positionCount);
         }
@@ -687,7 +716,7 @@ public class ParquetReader
         {
             long[] rowNumbers = new long[positionCount];
             for (int i = 0; i < positionCount; i++) {
-                int position = positions == null ? i : positions[positionsOffset + i];
+                int position = positions == null ? rangeOffset + i : positions[positionsOffset + i];
                 if (batchRowNumbers == null) {
                     rowNumbers[i] = batchStartRow + position;
                 }
@@ -707,7 +736,7 @@ public class ParquetReader
                 for (int i = 0; i < size; i++) {
                     int selectedPosition = positions[offset + i];
                     checkIndex(selectedPosition, positionCount);
-                    newPositions[i] = selectedPosition;
+                    newPositions[i] = rangeOffset + selectedPosition;
                 }
             }
             else {
@@ -723,23 +752,43 @@ public class ParquetReader
 
         public SelectedPositions selectPositionsView(int[] positions, int offset, int size)
         {
-            if (this.positions != null) {
+            // incoming positions are relative to a narrowed range, so they cannot be used as a view of the original page
+            if (this.positions != null || rangeOffset != 0) {
                 return selectPositions(positions, offset, size);
             }
             checkFromIndexSize(offset, size, positions.length);
-            return new SelectedPositions(originalPositionCount, size, positions, offset, new SelectionAnalysis());
+            return new SelectedPositions(originalPositionCount, size, positions, offset, 0, new SelectionAnalysis());
+        }
+
+        @CheckReturnValue
+        public SelectedPositions selectPositions(int offset, int size)
+        {
+            checkFromIndexSize(offset, size, positionCount);
+            if (positions == null) {
+                int newRangeOffset = rangeOffset + offset;
+                int skippedPositionCount = max(newRangeOffset, originalPositionCount - newRangeOffset - size);
+                return new SelectedPositions(
+                        originalPositionCount,
+                        size,
+                        null,
+                        0,
+                        newRangeOffset,
+                        SelectionAnalysis.analyzed(true, size == 0 ? 0 : 1, skippedPositionCount));
+            }
+            int[] newPositions = Arrays.copyOfRange(positions, positionsOffset + offset, positionsOffset + offset + size);
+            return create(originalPositionCount, newPositions, 0, size);
         }
 
         public SelectedPositions retainedCopy()
         {
             analyze();
             int[] retainedPositions = Arrays.copyOfRange(positions, positionsOffset, positionsOffset + positionCount);
-            return new SelectedPositions(originalPositionCount, positionCount, retainedPositions, 0, analysis);
+            return new SelectedPositions(originalPositionCount, positionCount, retainedPositions, 0, 0, analysis);
         }
 
         private static SelectedPositions create(int originalPositionCount, int[] positions, int offset, int size)
         {
-            return new SelectedPositions(originalPositionCount, size, positions, offset, new SelectionAnalysis());
+            return new SelectedPositions(originalPositionCount, size, positions, offset, 0, new SelectionAnalysis());
         }
 
         private void analyze()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TransformConnectorPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TransformConnectorPageSource.java
@@ -379,5 +379,17 @@ public final class TransformConnectorPageSource
                 }
             }
         }
+
+        @Override
+        public void selectPositions(int offset, int size)
+        {
+            sourcePage.selectPositions(offset, size);
+            for (int i = 0; i < blocks.length; i++) {
+                Block block = blocks[i];
+                if (block != null) {
+                    blocks[i] = block.getRegion(offset, size);
+                }
+            }
+        }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TransformConnectorPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TransformConnectorPageSource.java
@@ -399,5 +399,17 @@ public final class TransformConnectorPageSource
                 }
             }
         }
+
+        @Override
+        public void selectPositions(int offset, int size)
+        {
+            sourcePage.selectPositions(offset, size);
+            for (int i = 0; i < blocks.length; i++) {
+                Block block = blocks[i];
+                if (block != null) {
+                    blocks[i] = block.getRegion(offset, size);
+                }
+            }
+        }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rcfile/RcFilePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rcfile/RcFilePageSource.java
@@ -183,7 +183,7 @@ public class RcFilePageSource
 
         public RcFileSourcePage(int positionCount)
         {
-            selectedPositions = new SelectedPositions(positionCount, null);
+            selectedPositions = new SelectedPositions(positionCount, 0, null);
             retainedSizeInBytes = shallowRetainedSizeInBytes();
         }
 
@@ -286,9 +286,25 @@ public class RcFilePageSource
                 }
             }
         }
+
+        @Override
+        public void selectPositions(int offset, int size)
+        {
+            selectedPositions = selectedPositions.selectPositions(offset, size);
+            retainedSizeInBytes = shallowRetainedSizeInBytes();
+            for (int i = 0; i < blocks.length; i++) {
+                Block block = blocks[i];
+                if (block != null) {
+                    // loaded blocks already reflect the previous selection, so the incoming range applies to them directly
+                    block = block.getRegion(offset, size);
+                    retainedSizeInBytes += block.getRetainedSizeInBytes();
+                    blocks[i] = block;
+                }
+            }
+        }
     }
 
-    private record SelectedPositions(int positionCount, @Nullable int[] positions)
+    private record SelectedPositions(int positionCount, int offset, @Nullable int[] positions)
     {
         private static final long INSTANCE_SIZE = instanceSize(SelectedPositions.class);
 
@@ -301,7 +317,10 @@ public class RcFilePageSource
         public Block apply(Block block)
         {
             if (positions == null) {
-                return block;
+                if (offset == 0) {
+                    return block;
+                }
+                return block.getRegion(offset, positionCount);
             }
             return block.getPositions(positions, 0, positionCount);
         }
@@ -310,17 +329,28 @@ public class RcFilePageSource
         public SelectedPositions selectPositions(int[] positions, int offset, int size)
         {
             if (this.positions == null) {
+                int[] newPositions = new int[size];
                 for (int i = 0; i < size; i++) {
                     checkIndex(offset + i, positionCount);
+                    newPositions[i] = this.offset + positions[offset + i];
                 }
-                return new SelectedPositions(size, Arrays.copyOfRange(positions, offset, offset + size));
+                return new SelectedPositions(size, 0, newPositions);
             }
 
             int[] newPositions = new int[size];
             for (int i = 0; i < size; i++) {
                 newPositions[i] = this.positions[positions[offset + i]];
             }
-            return new SelectedPositions(size, newPositions);
+            return new SelectedPositions(size, 0, newPositions);
+        }
+
+        @CheckReturnValue
+        public SelectedPositions selectPositions(int rangeOffset, int size)
+        {
+            if (this.positions == null) {
+                return new SelectedPositions(size, this.offset + rangeOffset, null);
+            }
+            return new SelectedPositions(size, 0, Arrays.copyOfRange(this.positions, rangeOffset, rangeOffset + size));
         }
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/testing/TestLateMaterializationQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/testing/TestLateMaterializationQueries.java
@@ -52,6 +52,13 @@ final class TestLateMaterializationQueries
     }
 
     @Test
+    void testScanWithoutFilter()
+    {
+        // no filter or projection: a table scan hands masked pages straight to the partial TopN
+        assertDecodeSkipped("SELECT * FROM orders ORDER BY orderkey LIMIT 10");
+    }
+
+    @Test
     void testProjectionWithoutFilter()
     {
         // computed projection without a filter still hands masked pages to the partial TopN

--- a/testing/trino-tests/src/test/java/io/trino/testing/TestLateMaterializationQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/testing/TestLateMaterializationQueries.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import io.trino.Session;
+import io.trino.plugin.hive.HiveQueryRunner;
+import io.trino.spi.QueryId;
+import io.trino.spi.metrics.Count;
+import io.trino.testing.QueryRunner.MaterializedResultWithPlan;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+
+import static io.trino.operator.TopNProcessor.SKIPPED_DECODE_POSITIONS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestLateMaterializationQueries
+        extends AbstractTestQueryFramework
+{
+    private Session maskedPagesDisabled;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        QueryRunner runner = HiveQueryRunner.builder().build();
+        // masked page hand-off narrows a real Parquet source page, so read from a Parquet-backed table
+        runner.execute("CREATE TABLE orders WITH (format = 'PARQUET') AS SELECT * FROM tpch.tiny.orders");
+        // masked page hand-off is on by default; compare against it explicitly disabled
+        maskedPagesDisabled = Session.builder(runner.getDefaultSession())
+                .setSystemProperty("masked_page_enabled", "false")
+                .build();
+        return runner;
+    }
+
+    @Test
+    void testIdentityProjection()
+    {
+        assertDecodeSkipped("SELECT * FROM orders WHERE orderkey % 7 = 0 ORDER BY orderkey LIMIT 10");
+    }
+
+    @Test
+    void testProjectionWithoutFilter()
+    {
+        // computed projection without a filter still hands masked pages to the partial TopN
+        assertDecodeSkipped("SELECT orderkey + 1, comment FROM orders ORDER BY totalprice, orderkey LIMIT 10");
+    }
+
+    @Test
+    void testPrunedAndReorderedChannels()
+    {
+        assertDecodeSkipped("SELECT comment, orderkey FROM orders WHERE orderkey % 7 = 0 ORDER BY totalprice, orderkey LIMIT 10");
+    }
+
+    @Test
+    void testComputedSortChannel()
+    {
+        assertDecodeSkipped("SELECT orderkey, comment FROM orders WHERE orderkey % 7 = 0 ORDER BY totalprice / 2, orderkey LIMIT 10");
+    }
+
+    @Test
+    void testComputedPayloadChannels()
+    {
+        assertDecodeSkipped("SELECT orderkey + 1, upper(comment) FROM orders WHERE orderkey % 7 = 0 ORDER BY totalprice, orderkey LIMIT 10");
+    }
+
+    @Test
+    void testAllSortChannels()
+    {
+        // every output column is a sort channel: nothing to skip, so the masked path is not taken
+        assertNoDecodeSkipped("SELECT orderkey, totalprice FROM orders WHERE orderkey % 7 = 0 ORDER BY orderkey, totalprice LIMIT 10");
+    }
+
+    @Test
+    void testEmptyResult()
+    {
+        // no row survives the filter, so no position is ever skipped
+        assertNoDecodeSkipped("SELECT * FROM orders WHERE orderkey < 0 ORDER BY orderkey LIMIT 10");
+    }
+
+    private void assertDecodeSkipped(@Language("SQL") String sql)
+    {
+        assertThat(skippedDecodePositions(sql)).isPositive();
+    }
+
+    private void assertNoDecodeSkipped(@Language("SQL") String sql)
+    {
+        assertThat(skippedDecodePositions(sql)).isZero();
+    }
+
+    private long skippedDecodePositions(@Language("SQL") String sql)
+    {
+        MaterializedResultWithPlan masked = getDistributedQueryRunner().executeWithPlan(getSession(), sql);
+        MaterializedResult unmasked = getDistributedQueryRunner().execute(maskedPagesDisabled, sql);
+        // every query is ordered, so compare row order too: masked TopN must not reorder survivors
+        assertThat(masked.result().getMaterializedRows())
+                .as("For query: %s", sql)
+                .containsExactlyElementsOf(unmasked.getMaterializedRows());
+
+        // only the partial TopN fed by the masked source emits the metric, so summing over all TopN operators is exact
+        return topNSkippedDecodePositions(masked.queryId());
+    }
+
+    private long topNSkippedDecodePositions(QueryId queryId)
+    {
+        return getDistributedQueryRunner().getCoordinator()
+                .getQueryManager()
+                .getFullQueryInfo(queryId)
+                .getQueryStats()
+                .getOperatorSummaries()
+                .stream()
+                .filter(summary -> summary.getOperatorType().equals("TopNOperator"))
+                .map(summary -> summary.getMetrics().getMetrics().get(SKIPPED_DECODE_POSITIONS))
+                .filter(Objects::nonNull)
+                .mapToLong(metric -> ((Count<?>) metric).getTotal())
+                .sum();
+    }
+}


### PR DESCRIPTION
## Description

Adds late materialization for the partial `TopN` operator. When a partial `TopN` sits directly on top of a scan (optionally with a filter and/or projection), only the sort channels are needed to decide which rows survive the `LIMIT`, yet today all payload columns are decoded eagerly for every input row and then mostly discarded.

A `MaskedPage` carries a still-undecoded `SourcePage` plus the projections that would produce the operator's output. Adjacent operators negotiate the hand-off once at construction (`producesMaskedOutput()` / `supportsMaskedInput()`); when both agree, the driver moves a `MaskedPage` across the boundary instead of a materialized `Page`. The partial `TopN` probes only the sort channels, then materializes the payload for just the surviving prefix, so the payload of rejected rows is never decoded.

The hand-off is enabled for both `ScanFilterAndProjectOperator` and a plain `TableScanOperator`, and controlled by the `optimizer.masked-page-enabled` config property (default on). It is guarded structurally rather than by a cost model: a partial `TopN` only accepts masked input when it has at least one non-sort output channel, so queries that order by every column they output are unaffected.

## Additional context and related issues

Measured on ClickBench (Parquet on the Hive connector), where the hand-off fires on four queries: q23 (`SELECT *` over a filtered scan, 104 non-sort columns) is ~25% faster; q24-q26 order by every output column, so nothing is deferred and they stay within noise of baseline. Queries where `TopN` sits over an aggregation (TPC-H, TPC-DS) are unaffected.

## Release notes

```
## General
* Improve performance of ``ORDER BY ... LIMIT N`` queries over a table scan by deferring decoding of columns not needed to evaluate the ordering. This can be disabled with the ``optimizer.masked-page-enabled`` config property. ({issue}`30309`)
```
