### PR TITLE
Pack partial row constructors by estimated bytecode size

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/RowConstructorCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/RowConstructorCodeGenerator.java
@@ -36,6 +36,8 @@ import java.util.List;
 
 import static io.airlift.bytecode.Access.PUBLIC;
 import static io.airlift.bytecode.Access.a;
+import static io.airlift.bytecode.BytecodeUtils.fitsMethodSizeLimit;
+import static io.airlift.bytecode.BytecodeUtils.isJitCompilable;
 import static io.airlift.bytecode.Parameter.arg;
 import static io.airlift.bytecode.ParameterizedType.type;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantFalse;
@@ -55,9 +57,6 @@ public class RowConstructorCodeGenerator
     private final List<Expression> arguments;
     // Arbitrary value chosen to balance the code size vs performance trade off. Not perf tested.
     static final int MEGAMORPHIC_FIELD_COUNT = 64;
-
-    // number of fields to initialize in a single method for large rows
-    private static final int LARGE_ROW_BATCH_SIZE = 100;
 
     public RowConstructorCodeGenerator(Row row)
     {
@@ -123,17 +122,17 @@ public class RowConstructorCodeGenerator
         Variable fieldBuilders = scope.getOrCreateTempVariable(BlockBuilder[].class);
         block.append(fieldBuilders.set(invokeStatic(RowConstructorCodeGenerator.class, "createFieldBlockBuildersForSingleRow", BlockBuilder[].class, constantType(binder, rowType))));
 
-        Variable blockBuilder = scope.getOrCreateTempVariable(BlockBuilder.class);
-        for (int i = 0; i < arguments.size(); i += LARGE_ROW_BATCH_SIZE) {
-            MethodDefinition partialRowConstructor = generatePartialRowConstructor(i, Math.min(i + LARGE_ROW_BATCH_SIZE, arguments.size()), context);
+        int field = 0;
+        while (field < arguments.size()) {
+            PartialRowConstructor partialRowConstructor = generatePartialRowConstructor(field, context);
             block.getVariable(scope.getThis());
             for (Parameter argument : context.getContextArguments()) {
                 block.getVariable(argument);
             }
             block.getVariable(fieldBuilders);
-            block.invokeVirtual(partialRowConstructor);
+            block.invokeVirtual(partialRowConstructor.method());
+            field = partialRowConstructor.nextField();
         }
-        scope.releaseTempVariableForReuse(blockBuilder);
 
         block.append(invokeStatic(RowConstructorCodeGenerator.class, "createSqlRowFromFieldBuildersForSingleRow", SqlRow.class, fieldBuilders));
         scope.releaseTempVariableForReuse(fieldBuilders);
@@ -141,7 +140,7 @@ public class RowConstructorCodeGenerator
         return block;
     }
 
-    private MethodDefinition generatePartialRowConstructor(int start, int end, BytecodeGeneratorContext parentContext)
+    private PartialRowConstructor generatePartialRowConstructor(int start, BytecodeGeneratorContext parentContext)
     {
         ClassDefinition classDefinition = parentContext.getClassDefinition();
         CallSiteBinder binder = parentContext.getCallSiteBinder();
@@ -172,27 +171,58 @@ public class RowConstructorCodeGenerator
                 parentContext.getContextArguments());
         Variable blockBuilder = scope.getOrCreateTempVariable(BlockBuilder.class);
         List<Type> types = rowType.getFieldTypes();
-        for (int i = start; i < end; i++) {
-            Type fieldType = types.get(i);
 
-            block.append(blockBuilder.set(fieldBuilders.getElement(constantInt(i))));
+        // Pack fields greedily by estimated bytecode size instead of a fixed field count:
+        // a fixed count of fields with bulky initialization (e.g. CASE over varchar or
+        // LongTimestampWithTimeZone values) can exceed the JVM method size limit
+        int field = start;
+        while (field < arguments.size()) {
+            Type fieldType = types.get(field);
 
-            block.comment("Clean wasNull and Generate + " + i + "-th field of row");
+            BytecodeBlock fieldInitialization = new BytecodeBlock();
+            fieldInitialization.append(blockBuilder.set(fieldBuilders.getElement(constantInt(field))));
 
-            block.append(context.wasNull().set(constantFalse()));
-            block.append(context.generate(arguments.get(i)));
-            Variable field = scope.getOrCreateTempVariable(binder.getAccessibleType(fieldType.getJavaType()));
-            block.putVariable(field);
-            block.append(new IfStatement()
+            fieldInitialization.comment("Clean wasNull and Generate + " + field + "-th field of row");
+
+            fieldInitialization.append(context.wasNull().set(constantFalse()));
+            fieldInitialization.append(context.generate(arguments.get(field)));
+            Variable fieldVariable = scope.getOrCreateTempVariable(binder.getAccessibleType(fieldType.getJavaType()));
+            fieldInitialization.putVariable(fieldVariable);
+            fieldInitialization.append(new IfStatement()
                     .condition(context.wasNull())
                     .ifTrue(blockBuilder.invoke("appendNull", BlockBuilder.class).pop())
-                    .ifFalse(constantType(binder, fieldType).writeValue(blockBuilder, field).pop()));
-            scope.releaseTempVariableForReuse(field);
+                    .ifFalse(constantType(binder, fieldType).writeValue(blockBuilder, fieldVariable).pop()));
+            scope.releaseTempVariableForReuse(fieldVariable);
+
+            BytecodeBlock candidate = new BytecodeBlock()
+                    .append(block)
+                    .append(fieldInitialization);
+            // always emit at least one field, so an oversized single field still makes progress
+            if (field > start && !fitsPartialRowConstructor(candidate, scope)) {
+                // this field goes into the next partial method; discarding the block generated
+                // for it is safe as the measuring pass has no side effects
+                break;
+            }
+            block.append(fieldInitialization);
+            field++;
         }
 
         block.ret();
-        return methodDefinition;
+        return new PartialRowConstructor(methodDefinition, field);
     }
+
+    /**
+     * Keeps partial row constructors below HotSpot's HugeMethodLimit, above which a method is
+     * never JIT compiled. The hard JVM method size limit is checked separately because
+     * {@code -XX:-DontCompileHugeMethods} makes the JIT limit vacuous, and a partial method
+     * exceeding 64KB fails at class generation time.
+     */
+    private static boolean fitsPartialRowConstructor(BytecodeNode node, Scope scope)
+    {
+        return isJitCompilable(node, scope) && fitsMethodSizeLimit(node, scope);
+    }
+
+    private record PartialRowConstructor(MethodDefinition method, int nextField) {}
 
     @UsedByGeneratedCode
     public static BlockBuilder[] createFieldBlockBuildersForSingleRow(Type type)

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestPageFunctionCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestPageFunctionCompiler.java
@@ -78,6 +78,7 @@ import static io.airlift.bytecode.Parameter.arg;
 import static io.airlift.bytecode.ParameterizedType.type;
 import static io.airlift.slice.Slices.allocate;
 import static io.trino.block.BlockAssertions.createRepeatedValuesBlock;
+import static io.trino.block.BlockAssertions.createStringsBlock;
 import static io.trino.operator.scalar.ArrayTransformFunction.ARRAY_TRANSFORM_NAME;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
@@ -85,6 +86,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationReturnConvent
 import static io.trino.spi.function.OperatorType.ADD;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
 import static io.trino.sql.gen.RowConstructorCodeGenerator.MEGAMORPHIC_FIELD_COUNT;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN;
@@ -305,6 +307,30 @@ public class TestPageFunctionCompiler
         Page page = createLongBlockPage(0, 1, 2, 3, 4);
         SourcePage inputPage = compiled.getInputChannels().getInputChannels(SourcePage.create(page));
         assertThat(compiled.filter(SESSION, inputPage).size()).isEqualTo(2);
+    }
+
+    @Test
+    public void testLargeRowConstructorWithBulkyFields()
+    {
+        // Regression test for https://github.com/trinodb/trino/issues/30311: partial row constructor
+        // methods were packed by a fixed field count, so a batch of fields with bulky initialization
+        // bytecode (e.g. nested rows over varchar values) exceeded the 64KB JVM method size limit
+        int fieldCount = 120;
+        RowType nestedRowType = RowType.anonymous(nCopies(8, VARCHAR));
+        RowType rowType = RowType.anonymous(nCopies(fieldCount, nestedRowType));
+
+        Expression nestedRow = new Row(nCopies(8, new Reference(VARCHAR, "$col_0")), nestedRowType);
+        Expression row = new Row(nCopies(fieldCount, nestedRow), rowType);
+
+        PageProjection projection = FUNCTION_RESOLUTION.getPageFunctionCompiler()
+                .compileProjection(row, ImmutableMap.of(new Symbol(VARCHAR, "$col_0"), 0), Optional.empty())
+                .get();
+
+        Page page = new Page(createStringsBlock("abc", "xyz"));
+        Block result = project(projection, page, SelectedPositions.positionsRange(0, page.getPositionCount()));
+        assertThat(result.getPositionCount()).isEqualTo(2);
+        assertThat(rowType.getObjectValue(result, 0)).isEqualTo(nCopies(fieldCount, nCopies(8, "abc")));
+        assertThat(rowType.getObjectValue(result, 1)).isEqualTo(nCopies(fieldCount, nCopies(8, "xyz")));
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
@@ -57,6 +58,7 @@ import static io.trino.testing.MaterializedResult.resultBuilder;
 import static java.util.Locale.ENGLISH;
 import static java.util.Map.entry;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_PATH;
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_POS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -218,6 +220,23 @@ public abstract class BaseIcebergSystemTables
                     .isEqualTo(new MaterializedRow(DEFAULT_PRECISION, 1, 1, 0L, null));
             assertThat(computeScalar("SELECT data.new_col FROM \"" + table.getName() + "$partitions\""))
                     .isNull();
+        }
+    }
+
+    @Test
+    public void testPartitionsTableWithManyColumns()
+    {
+        // Regression test for https://github.com/trinodb/trino/issues/30311: the data column builds one
+        // ROW(min, max, null_count, nan_count) per column, and packing those fields into partial row
+        // constructors by a fixed count exceeded the 64KB JVM method size limit for bulky field types
+        String columns = IntStream.rangeClosed(1, 121)
+                .mapToObj(column -> "col_%03d timestamp(6) with time zone".formatted(column))
+                .collect(joining(", "));
+
+        try (TestTable table = newTrinoTable("test_partitions_many_columns", "(" + columns + ")")) {
+            assertUpdate("INSERT INTO " + table.getName() + " (col_001) VALUES TIMESTAMP '2022-01-01 12:00:00.000000 UTC'", 1);
+            assertThat(computeActual("SELECT data FROM \"" + table.getName() + "$partitions\"").getRowCount())
+                    .isEqualTo(1);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -571,7 +571,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>bytecode</artifactId>
-                <version>1.6</version>
+                <version>1.7</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Row constructors with more than 64 fields are split into helper methods of 100 fields each, so a batch of fields with bulky initialization bytecode (e.g. varchar or timestamp with time zone stats rows built by the Iceberg $partitions view) could exceed the 64KB JVM method size limit. Pack fields greedily instead, measuring each field's generated bytecode with ASM's CodeSizeEvaluator and starting a new method when the running estimate would exceed 8000 bytes (HotSpot's JIT limit).

Fixes #30311

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
