### PR TITLE
Keep dynamic filter IN predicates out of the compiler cache via a per-type class

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/AndFilterEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/AndFilterEvaluator.java
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
 public final class AndFilterEvaluator
         implements FilterEvaluator
 {
-    public static Optional<Supplier<FilterEvaluator>> createAndExpressionEvaluator(ColumnarFilterCompiler compiler, Logical logical, Map<Symbol, Integer> layout, boolean filterReorderingEnabled)
+    public static Optional<Supplier<FilterEvaluator>> createAndExpressionEvaluator(ColumnarFilterCompiler compiler, Logical logical, Map<Symbol, Integer> layout, boolean filterReorderingEnabled, boolean dynamicFilter)
     {
         checkArgument(logical.operator() == Logical.Operator.AND, "logical %s should be AND", logical);
 
@@ -42,7 +42,7 @@ public final class AndFilterEvaluator
 
         ImmutableList.Builder<Supplier<FilterEvaluator>> builder = ImmutableList.builderWithExpectedSize(terms.size());
         for (Expression expression : terms) {
-            Optional<Supplier<FilterEvaluator>> subExpressionEvaluator = FilterEvaluator.createColumnarFilterEvaluator(expression, layout, compiler, filterReorderingEnabled);
+            Optional<Supplier<FilterEvaluator>> subExpressionEvaluator = FilterEvaluator.createColumnarFilterEvaluator(expression, layout, compiler, filterReorderingEnabled, dynamicFilter);
             if (subExpressionEvaluator.isEmpty()) {
                 return Optional.empty();
             }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/ColumnarFilterCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/ColumnarFilterCompiler.java
@@ -35,6 +35,7 @@ import io.trino.operator.project.InputChannels;
 import io.trino.operator.project.PageFieldsToInputParametersRewriter;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
+import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.gen.CallSiteBinder;
 import io.trino.sql.ir.Call;
@@ -44,6 +45,7 @@ import io.trino.sql.ir.IsNull;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.CompilerConfig;
 import io.trino.sql.planner.Symbol;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import jakarta.annotation.Nullable;
 import org.objectweb.asm.MethodTooLargeException;
 import org.weakref.jmx.Managed;
@@ -90,6 +92,8 @@ public class ColumnarFilterCompiler
     // Optional is used to cache failure to generate filter for unsupported cases
     private final NonEvictableCache<Expression, Optional<Class<? extends ColumnarFilter>>> filterCache;
     private final CacheStatsMBean filterCacheStats;
+    // One generated IN class per (value type, set class), shared across dynamic filters.
+    private final NonEvictableCache<InSetDynamicFilterKey, Class<? extends ColumnarFilter>> inSetDynamicFilterCache;
 
     @Inject
     public ColumnarFilterCompiler(PlannerContext plannerContext, CompilerConfig config)
@@ -113,6 +117,7 @@ public class ColumnarFilterCompiler
             filterCache = null;
             filterCacheStats = null;
         }
+        inSetDynamicFilterCache = buildNonEvictableCache(CacheBuilder.newBuilder().maximumSize(64));
     }
 
     @Nullable
@@ -135,6 +140,13 @@ public class ColumnarFilterCompiler
 
     public Optional<Supplier<ColumnarFilter>> generateFilter(Expression filter, Map<Symbol, Integer> layout)
     {
+        return generateFilter(filter, layout, false);
+    }
+
+    // dynamicFilter=true routes IN predicates to a separate per-type class, bypassing filterCache so
+    // their large value lists are not retained in the cache.
+    public Optional<Supplier<ColumnarFilter>> generateFilter(Expression filter, Map<Symbol, Integer> layout, boolean dynamicFilter)
+    {
         // Compact the layout to consecutive indices (0, 1, 2, ...). The compiled filter uses these
         // compact indices to access blocks from the InputChannelsSourcePage, which translates
         // compact index back to the original page channel. This must be done before compilation
@@ -143,6 +155,13 @@ public class ColumnarFilterCompiler
         PageFieldsToInputParametersRewriter.Result result = rewritePageFieldsToInputParameters(filter, layout);
         Map<Symbol, Integer> compactLayout = result.compactLayout();
         InputChannels inputChannels = result.inputChannels();
+
+        if (dynamicFilter && filter instanceof In in) {
+            Optional<InSetDynamicFilterGenerator> generator = InSetDynamicFilterGenerator.tryCreate(in, compactLayout, metadata, functionManager);
+            if (generator.isPresent()) {
+                return Optional.of(compileInSetDynamicFilter(generator.get(), inputChannels));
+            }
+        }
 
         Optional<Class<? extends ColumnarFilter>> filterClass;
         if (filterCache == null) {
@@ -170,6 +189,31 @@ public class ColumnarFilterCompiler
             }
         });
     }
+
+    // Caches the value-independent IN filter class per (value type, set class) and binds the value set
+    // for the current filter. The generator decides eligibility; this only handles reuse and instantiation.
+    private Supplier<ColumnarFilter> compileInSetDynamicFilter(InSetDynamicFilterGenerator generator, InputChannels inputChannels)
+    {
+        Class<? extends LongSet> setClass = generator.setClass();
+        Class<? extends ColumnarFilter> clazz;
+        try {
+            clazz = inSetDynamicFilterCache.get(new InSetDynamicFilterKey(generator.valueType(), setClass), generator::generateColumnarFilter);
+        }
+        catch (ExecutionException e) {
+            throw new UncheckedExecutionException(e);
+        }
+        LongSet valueSet = generator.valueSet();
+        return () -> {
+            try {
+                return clazz.getConstructor(InputChannels.class, setClass).newInstance(inputChannels, valueSet);
+            }
+            catch (ReflectiveOperationException e) {
+                throw new TrinoException(COMPILER_ERROR, e);
+            }
+        };
+    }
+
+    private record InSetDynamicFilterKey(Type valueType, Class<? extends LongSet> setClass) {}
 
     private Optional<Class<? extends ColumnarFilter>> generateFilterInternal(Expression filter, Map<Symbol, Integer> layout)
     {

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/DynamicPageFilter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/DynamicPageFilter.java
@@ -80,9 +80,8 @@ public final class DynamicPageFilter
         this.filterReorderingEnabled = filterReorderingEnabled;
     }
 
-    // Compiled dynamic filter is fixed per-split and generated duration page source creation.
-    // Page source implementations may subsequently implement blocking on completion of dynamic filters, but since
-    // that occurs after page source creation, we cannot be guaranteed a completed dynamic filter here for initial splits
+    // Compiled dynamic filter is generated once per split at PageProcessor#createWorkProcessor.
+    // The supplied FilterEvaluator should not be shared across splits.
     public synchronized Supplier<FilterEvaluator> createDynamicPageFilterEvaluator(ColumnarFilterCompiler compiler, DynamicFilter dynamicFilter)
     {
         requireNonNull(dynamicFilter, "dynamicFilter is null");
@@ -129,7 +128,7 @@ public final class DynamicPageFilter
                     Expression expression = domainTranslator.toPredicate(entry.getValue(), symbol.toSymbolReference());
                     // Run the expression derived from TupleDomain through IR optimizer to simplify predicates. E.g. SimplifyContinuousInValues
                     expression = irExpressionOptimizer.process(expression, session, symbolAllocator, ImmutableMap.of()).orElse(expression);
-                    return createColumnarFilterEvaluator(expression, sourceLayout, compiler, filterReorderingEnabled);
+                    return createColumnarFilterEvaluator(expression, sourceLayout, compiler, filterReorderingEnabled, true);
                 })
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/FilterEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/FilterEvaluator.java
@@ -68,12 +68,12 @@ public sealed interface FilterEvaluator
             boolean filterReorderingEnabled)
     {
         if (columnarFilterEvaluationEnabled && filter.isPresent()) {
-            return createColumnarFilterEvaluator(filter.get(), layout, columnarFilterCompiler, filterReorderingEnabled);
+            return createColumnarFilterEvaluator(filter.get(), layout, columnarFilterCompiler, filterReorderingEnabled, false);
         }
         return Optional.empty();
     }
 
-    static Optional<Supplier<FilterEvaluator>> createColumnarFilterEvaluator(Expression expression, Map<Symbol, Integer> layout, ColumnarFilterCompiler compiler, boolean filterReorderingEnabled)
+    static Optional<Supplier<FilterEvaluator>> createColumnarFilterEvaluator(Expression expression, Map<Symbol, Integer> layout, ColumnarFilterCompiler compiler, boolean filterReorderingEnabled, boolean dynamicFilter)
     {
         return switch (expression) {
             case Constant constant when constant.value() instanceof Boolean booleanValue -> booleanValue ? Optional.of(SelectAllEvaluator::new) : Optional.of(SelectNoneEvaluator::new);
@@ -82,16 +82,16 @@ public sealed interface FilterEvaluator
                     // "not(is_null(reference))" is handled explicitly as it is easy.
                     // more generic cases like "not(equal(reference, constant))" are not handled yet
                     if (call.arguments().getFirst() instanceof IsNull isNull) {
-                        yield createIsNotNullExpressionEvaluator(compiler, call, isNull, layout);
+                        yield createIsNotNullExpressionEvaluator(compiler, call, isNull, layout, dynamicFilter);
                     }
                     yield Optional.empty();
                 }
-                yield createCallExpressionEvaluator(compiler, call, layout);
+                yield createCallExpressionEvaluator(compiler, call, layout, dynamicFilter);
             }
-            case IsNull isNull -> createIsNullExpressionEvaluator(compiler, isNull, layout);
-            case Logical logical when logical.operator() == Logical.Operator.AND -> createAndExpressionEvaluator(compiler, logical, layout, filterReorderingEnabled);
-            case Logical logical when logical.operator() == Logical.Operator.OR -> createOrExpressionEvaluator(compiler, logical, layout, filterReorderingEnabled);
-            case In in -> createInExpressionEvaluator(compiler, in, layout);
+            case IsNull isNull -> createIsNullExpressionEvaluator(compiler, isNull, layout, dynamicFilter);
+            case Logical logical when logical.operator() == Logical.Operator.AND -> createAndExpressionEvaluator(compiler, logical, layout, filterReorderingEnabled, dynamicFilter);
+            case Logical logical when logical.operator() == Logical.Operator.OR -> createOrExpressionEvaluator(compiler, logical, layout, filterReorderingEnabled, dynamicFilter);
+            case In in -> createInExpressionEvaluator(compiler, in, layout, dynamicFilter);
             default -> Optional.empty();
         };
     }
@@ -109,15 +109,15 @@ public sealed interface FilterEvaluator
         return terms.stream().noneMatch(term -> mayFail(plannerContext, term));
     }
 
-    private static Optional<Supplier<FilterEvaluator>> createInExpressionEvaluator(ColumnarFilterCompiler compiler, In in, Map<Symbol, Integer> layout)
+    private static Optional<Supplier<FilterEvaluator>> createInExpressionEvaluator(ColumnarFilterCompiler compiler, In in, Map<Symbol, Integer> layout, boolean dynamicFilter)
     {
-        Optional<Supplier<ColumnarFilter>> compiledFilter = compiler.generateFilter(in, layout);
+        Optional<Supplier<ColumnarFilter>> compiledFilter = compiler.generateFilter(in, layout, dynamicFilter);
         return compiledFilter.map(filterSupplier -> () -> createDictionaryAwareEvaluator(filterSupplier.get()));
     }
 
-    private static Optional<Supplier<FilterEvaluator>> createCallExpressionEvaluator(ColumnarFilterCompiler compiler, Call call, Map<Symbol, Integer> layout)
+    private static Optional<Supplier<FilterEvaluator>> createCallExpressionEvaluator(ColumnarFilterCompiler compiler, Call call, Map<Symbol, Integer> layout, boolean dynamicFilter)
     {
-        Optional<Supplier<ColumnarFilter>> compiledFilter = compiler.generateFilter(call, layout);
+        Optional<Supplier<ColumnarFilter>> compiledFilter = compiler.generateFilter(call, layout, dynamicFilter);
         boolean isDeterministic = DeterminismEvaluator.isDeterministic(call);
         return compiledFilter.map(filterSupplier -> () -> {
             ColumnarFilter filter = filterSupplier.get();
@@ -125,23 +125,23 @@ public sealed interface FilterEvaluator
         });
     }
 
-    private static Optional<Supplier<FilterEvaluator>> createIsNotNullExpressionEvaluator(ColumnarFilterCompiler compiler, Call call, IsNull isNull, Map<Symbol, Integer> layout)
+    private static Optional<Supplier<FilterEvaluator>> createIsNotNullExpressionEvaluator(ColumnarFilterCompiler compiler, Call call, IsNull isNull, Map<Symbol, Integer> layout, boolean dynamicFilter)
     {
         checkArgument(isNotExpression(call), "call %s should be not", call);
         checkArgument(call.arguments().size() == 1);
         Type argumentType = isNull.value().type();
         checkArgument(!argumentType.equals(UNKNOWN), "argumentType %s should not be UNKNOWN", argumentType);
 
-        Optional<Supplier<ColumnarFilter>> compiledFilter = compiler.generateFilter(call, layout);
+        Optional<Supplier<ColumnarFilter>> compiledFilter = compiler.generateFilter(call, layout, dynamicFilter);
         return compiledFilter.map(filterSupplier -> () -> createDictionaryAwareEvaluator(filterSupplier.get()));
     }
 
-    private static Optional<Supplier<FilterEvaluator>> createIsNullExpressionEvaluator(ColumnarFilterCompiler compiler, IsNull isNull, Map<Symbol, Integer> layout)
+    private static Optional<Supplier<FilterEvaluator>> createIsNullExpressionEvaluator(ColumnarFilterCompiler compiler, IsNull isNull, Map<Symbol, Integer> layout, boolean dynamicFilter)
     {
         Type argumentType = isNull.value().type();
         checkArgument(!argumentType.equals(UNKNOWN), "argumentType %s should not be UNKNOWN", argumentType);
 
-        Optional<Supplier<ColumnarFilter>> compiledFilter = compiler.generateFilter(isNull, layout);
+        Optional<Supplier<ColumnarFilter>> compiledFilter = compiler.generateFilter(isNull, layout, dynamicFilter);
         return compiledFilter.map(filterSupplier -> () -> createDictionaryAwareEvaluator(filterSupplier.get()));
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/InColumnarFilterGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/InColumnarFilterGenerator.java
@@ -158,8 +158,16 @@ public class InColumnarFilterGenerator
         Set<?> constantValuesSet = toFastutilHashSet(constantValues, valueType, hashCodeMethodHandle, equalsMethodHandle);
         Binding constant = callSiteBinder.bind(constantValuesSet, constantValuesSet.getClass());
 
-        generateFilterRangeMethod(callSiteBinder, classDefinition, constantValuesSet, constant);
-        generateFilterListMethod(callSiteBinder, classDefinition, constantValuesSet, constant);
+        generateInFilterRangeMethod(
+                classDefinition,
+                valueReference,
+                layout,
+                (scope, position, result) -> generateSetContainsCall(callSiteBinder, scope, constantValuesSet, constant, position, result));
+        generateInFilterListMethod(
+                classDefinition,
+                valueReference,
+                layout,
+                (scope, position, result) -> generateSetContainsCall(callSiteBinder, scope, constantValuesSet, constant, position, result));
 
         return createClassInstance(callSiteBinder, classDefinition);
     }
@@ -178,105 +186,6 @@ public class InColumnarFilterGenerator
 
         body.append(thisVariable.setField(inputChannelsField, inputChannelsParam));
         body.ret();
-    }
-
-    private void generateFilterRangeMethod(CallSiteBinder binder, ClassDefinition classDefinition, Set<?> constantValuesSet, Binding constant)
-    {
-        Parameter session = arg("session", ConnectorSession.class);
-        Parameter outputPositions = arg("outputPositions", int[].class);
-        Parameter offset = arg("offset", int.class);
-        Parameter size = arg("size", int.class);
-        Parameter page = arg("page", SourcePage.class);
-
-        MethodDefinition method = classDefinition.declareMethod(
-                a(PUBLIC),
-                "filterPositionsRange",
-                type(int.class),
-                ImmutableList.of(session, outputPositions, offset, size, page));
-        Scope scope = method.getScope();
-        BytecodeBlock body = method.getBody();
-
-        declareBlockVariables(ImmutableList.of(valueReference), layout, page, scope, body);
-
-        Variable outputPositionsCount = scope.declareVariable("outputPositionsCount", body, constantInt(0));
-        Variable position = scope.declareVariable(int.class, "position");
-        Variable result = scope.declareVariable(boolean.class, "result");
-
-        IfStatement ifStatement = new IfStatement()
-                .condition(generateBlockMayHaveNull(ImmutableList.of(valueReference), layout, scope));
-        body.append(ifStatement);
-
-        ifStatement.ifTrue(new ForLoop("nullable range based loop")
-                .initialize(position.set(offset))
-                .condition(lessThan(position, add(offset, size)))
-                .update(position.increment())
-                .body(new IfStatement()
-                        .condition(generateBlockPositionNotNull(ImmutableList.of(valueReference), layout, scope, position))
-                        .ifTrue(new BytecodeBlock()
-                                .append(generateSetContainsCall(binder, scope, constantValuesSet, constant, position, result))
-                                .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount)))));
-
-        ifStatement.ifFalse(new ForLoop("non-nullable range based loop")
-                .initialize(position.set(offset))
-                .condition(lessThan(position, add(offset, size)))
-                .update(position.increment())
-                .body(new BytecodeBlock()
-                        .append(generateSetContainsCall(binder, scope, constantValuesSet, constant, position, result))
-                        .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount))));
-
-        body.append(outputPositionsCount.ret());
-    }
-
-    private void generateFilterListMethod(CallSiteBinder binder, ClassDefinition classDefinition, Set<?> constantValuesSet, Binding constant)
-    {
-        Parameter session = arg("session", ConnectorSession.class);
-        Parameter outputPositions = arg("outputPositions", int[].class);
-        Parameter activePositions = arg("activePositions", int[].class);
-        Parameter offset = arg("offset", int.class);
-        Parameter size = arg("size", int.class);
-        Parameter page = arg("page", SourcePage.class);
-
-        MethodDefinition method = classDefinition.declareMethod(
-                a(PUBLIC),
-                "filterPositionsList",
-                type(int.class),
-                ImmutableList.of(session, outputPositions, activePositions, offset, size, page));
-        Scope scope = method.getScope();
-        BytecodeBlock body = method.getBody();
-
-        declareBlockVariables(ImmutableList.of(valueReference), layout, page, scope, body);
-
-        Variable outputPositionsCount = scope.declareVariable("outputPositionsCount", body, constantInt(0));
-        Variable index = scope.declareVariable(int.class, "index");
-        Variable position = scope.declareVariable(int.class, "position");
-        Variable result = scope.declareVariable(boolean.class, "result");
-
-        IfStatement ifStatement = new IfStatement()
-                .condition(generateBlockMayHaveNull(ImmutableList.of(valueReference), layout, scope));
-        body.append(ifStatement);
-
-        ifStatement.ifTrue(new ForLoop("nullable positions loop")
-                .initialize(index.set(offset))
-                .condition(lessThan(index, add(offset, size)))
-                .update(index.increment())
-                .body(new BytecodeBlock()
-                        .append(position.set(activePositions.getElement(index)))
-                        .append(new IfStatement()
-                                .condition(generateBlockPositionNotNull(ImmutableList.of(valueReference), layout, scope, position))
-                                .ifTrue(new BytecodeBlock()
-                                        .append(generateSetContainsCall(binder, scope, constantValuesSet, constant, position, result))
-                                        .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount))))));
-
-        ifStatement.ifFalse(new ForLoop("non-nullable positions loop")
-                .initialize(index.set(offset))
-                .condition(lessThan(index, add(offset, size)))
-                .update(index.increment())
-                .body(new BytecodeBlock()
-                        .append(position.set(activePositions.getElement(index)))
-                        .append(generateSetContainsCall(binder, scope, constantValuesSet, constant, position, result))
-                        .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount))));
-
-        body.append(outputPositionsCount.ret());
     }
 
     private BytecodeBlock generateSetContainsCall(CallSiteBinder binder, Scope scope, Set<?> constantValuesSet, Binding constant, BytecodeExpression position, Variable result)
@@ -396,5 +305,111 @@ public class InColumnarFilterGenerator
             }
         }
         return true;
+    }
+
+    // Emits the per-position membership test for a single-column IN filter, setting result to the outcome.
+    @FunctionalInterface
+    interface ContainsCallGenerator
+    {
+        BytecodeBlock generate(Scope scope, BytecodeExpression position, Variable result);
+    }
+
+    static void generateInFilterRangeMethod(ClassDefinition classDefinition, Reference valueReference, Map<Symbol, Integer> layout, ContainsCallGenerator containsCall)
+    {
+        Parameter session = arg("session", ConnectorSession.class);
+        Parameter outputPositions = arg("outputPositions", int[].class);
+        Parameter offset = arg("offset", int.class);
+        Parameter size = arg("size", int.class);
+        Parameter page = arg("page", SourcePage.class);
+
+        MethodDefinition method = classDefinition.declareMethod(
+                a(PUBLIC),
+                "filterPositionsRange",
+                type(int.class),
+                ImmutableList.of(session, outputPositions, offset, size, page));
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        declareBlockVariables(ImmutableList.of(valueReference), layout, page, scope, body);
+
+        Variable outputPositionsCount = scope.declareVariable("outputPositionsCount", body, constantInt(0));
+        Variable position = scope.declareVariable(int.class, "position");
+        Variable result = scope.declareVariable(boolean.class, "result");
+
+        IfStatement ifStatement = new IfStatement()
+                .condition(generateBlockMayHaveNull(ImmutableList.of(valueReference), layout, scope));
+        body.append(ifStatement);
+
+        ifStatement.ifTrue(new ForLoop("nullable range based loop")
+                .initialize(position.set(offset))
+                .condition(lessThan(position, add(offset, size)))
+                .update(position.increment())
+                .body(new IfStatement()
+                        .condition(generateBlockPositionNotNull(ImmutableList.of(valueReference), layout, scope, position))
+                        .ifTrue(new BytecodeBlock()
+                                .append(containsCall.generate(scope, position, result))
+                                .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount)))));
+
+        ifStatement.ifFalse(new ForLoop("non-nullable range based loop")
+                .initialize(position.set(offset))
+                .condition(lessThan(position, add(offset, size)))
+                .update(position.increment())
+                .body(new BytecodeBlock()
+                        .append(containsCall.generate(scope, position, result))
+                        .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount))));
+
+        body.append(outputPositionsCount.ret());
+    }
+
+    static void generateInFilterListMethod(ClassDefinition classDefinition, Reference valueReference, Map<Symbol, Integer> layout, ContainsCallGenerator containsCall)
+    {
+        Parameter session = arg("session", ConnectorSession.class);
+        Parameter outputPositions = arg("outputPositions", int[].class);
+        Parameter activePositions = arg("activePositions", int[].class);
+        Parameter offset = arg("offset", int.class);
+        Parameter size = arg("size", int.class);
+        Parameter page = arg("page", SourcePage.class);
+
+        MethodDefinition method = classDefinition.declareMethod(
+                a(PUBLIC),
+                "filterPositionsList",
+                type(int.class),
+                ImmutableList.of(session, outputPositions, activePositions, offset, size, page));
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        declareBlockVariables(ImmutableList.of(valueReference), layout, page, scope, body);
+
+        Variable outputPositionsCount = scope.declareVariable("outputPositionsCount", body, constantInt(0));
+        Variable index = scope.declareVariable(int.class, "index");
+        Variable position = scope.declareVariable(int.class, "position");
+        Variable result = scope.declareVariable(boolean.class, "result");
+
+        IfStatement ifStatement = new IfStatement()
+                .condition(generateBlockMayHaveNull(ImmutableList.of(valueReference), layout, scope));
+        body.append(ifStatement);
+
+        ifStatement.ifTrue(new ForLoop("nullable positions loop")
+                .initialize(index.set(offset))
+                .condition(lessThan(index, add(offset, size)))
+                .update(index.increment())
+                .body(new BytecodeBlock()
+                        .append(position.set(activePositions.getElement(index)))
+                        .append(new IfStatement()
+                                .condition(generateBlockPositionNotNull(ImmutableList.of(valueReference), layout, scope, position))
+                                .ifTrue(new BytecodeBlock()
+                                        .append(containsCall.generate(scope, position, result))
+                                        .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount))))));
+
+        ifStatement.ifFalse(new ForLoop("non-nullable positions loop")
+                .initialize(index.set(offset))
+                .condition(lessThan(index, add(offset, size)))
+                .update(index.increment())
+                .body(new BytecodeBlock()
+                        .append(position.set(activePositions.getElement(index)))
+                        .append(containsCall.generate(scope, position, result))
+                        .append(updateOutputPositions(result, position, outputPositions, outputPositionsCount))));
+
+        body.append(outputPositionsCount.ret());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/InSetDynamicFilterGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/InSetDynamicFilterGenerator.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen.columnar;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.bytecode.BytecodeBlock;
+import io.airlift.bytecode.ClassDefinition;
+import io.airlift.bytecode.FieldDefinition;
+import io.airlift.bytecode.MethodDefinition;
+import io.airlift.bytecode.Parameter;
+import io.airlift.bytecode.Scope;
+import io.airlift.bytecode.Variable;
+import io.airlift.bytecode.expression.BytecodeExpression;
+import io.trino.metadata.FunctionManager;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.operator.project.InputChannels;
+import io.trino.spi.type.Type;
+import io.trino.sql.gen.CallSiteBinder;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.In;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.Symbol;
+import it.unimi.dsi.fastutil.longs.LongSet;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.bytecode.Access.FINAL;
+import static io.airlift.bytecode.Access.PRIVATE;
+import static io.airlift.bytecode.Access.PUBLIC;
+import static io.airlift.bytecode.Access.a;
+import static io.airlift.bytecode.Parameter.arg;
+import static io.airlift.bytecode.ParameterizedType.type;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
+import static io.trino.spi.function.OperatorType.EQUAL;
+import static io.trino.spi.function.OperatorType.HASH_CODE;
+import static io.trino.sql.gen.SqlTypeBytecodeExpression.constantType;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.createClassInstance;
+import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.generateGetInputChannels;
+import static io.trino.sql.gen.columnar.InColumnarFilterGenerator.generateInFilterListMethod;
+import static io.trino.sql.gen.columnar.InColumnarFilterGenerator.generateInFilterRangeMethod;
+import static io.trino.util.CompilerUtils.makeClassName;
+import static io.trino.util.FastutilSetHelper.toFastutilHashSet;
+import static java.util.Objects.requireNonNull;
+
+// Generates an IN filter that reads its value set from an instance field, so one class per
+// (value type, set class) is reused across dynamic filters with a stable JVM class identity.
+public final class InSetDynamicFilterGenerator
+{
+    private final Reference valueReference;
+    private final Map<Symbol, Integer> layout;
+    private final Type valueType;
+    private final Class<? extends LongSet> setClass;
+    private final LongSet valueSet;
+    private final int valueChannel;
+
+    // Returns empty when the IN predicate is not an eligible long-backed dynamic filter, so the caller
+    // falls back to the shared cache path.
+    public static Optional<InSetDynamicFilterGenerator> tryCreate(In in, Map<Symbol, Integer> layout, Metadata metadata, FunctionManager functionManager)
+    {
+        if (!(in.value() instanceof Reference valueReference) || valueReference.type().getJavaType() != long.class) {
+            return Optional.empty();
+        }
+        ImmutableSet.Builder<Object> valuesBuilder = ImmutableSet.builder();
+        for (Expression expression : in.valueList()) {
+            if (!(expression instanceof Constant constant) || constant.value() == null) {
+                return Optional.empty();
+            }
+            valuesBuilder.add(constant.value());
+        }
+        Set<Object> values = valuesBuilder.build();
+        if (values.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Type valueType = valueReference.type();
+        // Small integer IN lists compile to a lookupswitch with tiny baked data; leave them on the
+        // shared cache path where the switch is faster and retention is not a concern.
+        if (InColumnarFilterGenerator.useSwitchCaseGeneration(valueType, in.valueList())) {
+            return Optional.empty();
+        }
+        ResolvedFunction resolvedEquals = metadata.resolveOperator(EQUAL, ImmutableList.of(valueType, valueType));
+        ResolvedFunction resolvedHashCode = metadata.resolveOperator(HASH_CODE, ImmutableList.of(valueType));
+        MethodHandle equalsHandle = functionManager.getScalarFunctionImplementation(resolvedEquals, simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL)).getMethodHandle();
+        MethodHandle hashCodeHandle = functionManager.getScalarFunctionImplementation(resolvedHashCode, simpleConvention(FAIL_ON_NULL, NEVER_NULL)).getMethodHandle();
+        LongSet valueSet = (LongSet) toFastutilHashSet(values, valueType, hashCodeHandle, equalsHandle);
+        return Optional.of(new InSetDynamicFilterGenerator(valueReference, layout, valueSet));
+    }
+
+    private InSetDynamicFilterGenerator(Reference valueReference, Map<Symbol, Integer> layout, LongSet valueSet)
+    {
+        this.valueReference = requireNonNull(valueReference, "valueReference is null");
+        this.layout = requireNonNull(layout, "layout is null");
+        this.valueSet = requireNonNull(valueSet, "valueSet is null");
+        this.valueType = valueReference.type();
+        this.setClass = valueSet.getClass().asSubclass(LongSet.class);
+        Integer channel = layout.get(Symbol.from(valueReference));
+        checkState(channel != null, "Reference not in layout: %s", valueReference.name());
+        valueChannel = channel;
+    }
+
+    public Type valueType()
+    {
+        return valueType;
+    }
+
+    public Class<? extends LongSet> setClass()
+    {
+        return setClass;
+    }
+
+    public LongSet valueSet()
+    {
+        return valueSet;
+    }
+
+    public Class<? extends ColumnarFilter> generateColumnarFilter()
+    {
+        ClassDefinition classDefinition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                makeClassName(ColumnarFilter.class.getSimpleName() + "_in_dynamic", Optional.empty()),
+                type(Object.class),
+                type(ColumnarFilter.class));
+        CallSiteBinder callSiteBinder = new CallSiteBinder();
+
+        FieldDefinition inputChannelsField = generateGetInputChannels(classDefinition);
+        FieldDefinition valueSetField = classDefinition.declareField(a(PRIVATE, FINAL), "valueSet", setClass);
+        generateConstructor(classDefinition, inputChannelsField, valueSetField, setClass);
+
+        generateInFilterRangeMethod(
+                classDefinition,
+                valueReference,
+                layout,
+                (scope, position, result) -> generateSetContainsCall(callSiteBinder, valueSetField, scope, position, result));
+        generateInFilterListMethod(
+                classDefinition,
+                valueReference,
+                layout,
+                (scope, position, result) -> generateSetContainsCall(callSiteBinder, valueSetField, scope, position, result));
+
+        return createClassInstance(callSiteBinder, classDefinition);
+    }
+
+    private static void generateConstructor(ClassDefinition classDefinition, FieldDefinition inputChannelsField, FieldDefinition valueSetField, Class<? extends LongSet> setClass)
+    {
+        Parameter inputChannelsParam = arg("inputChannels", InputChannels.class);
+        Parameter valueSetParam = arg("valueSet", setClass);
+        MethodDefinition constructorDefinition = classDefinition.declareConstructor(a(PUBLIC), inputChannelsParam, valueSetParam);
+
+        BytecodeBlock body = constructorDefinition.getBody();
+        Variable thisVariable = constructorDefinition.getThis();
+
+        body.comment("super();")
+                .append(thisVariable)
+                .invokeConstructor(Object.class);
+        body.append(thisVariable.setField(inputChannelsField, inputChannelsParam));
+        body.append(thisVariable.setField(valueSetField, valueSetParam));
+        body.ret();
+    }
+
+    private BytecodeBlock generateSetContainsCall(CallSiteBinder binder, FieldDefinition valueSetField, Scope scope, BytecodeExpression position, Variable result)
+    {
+        Type valueType = valueReference.type();
+        BytecodeExpression value = constantType(binder, valueType)
+                .invoke("getLong", long.class, scope.getVariable("block_" + valueChannel), position);
+        return new BytecodeBlock()
+                .comment("valueSet.contains(<stackValue>)")
+                .append(result.set(scope.getThis()
+                        .getField(valueSetField)
+                        .invoke("contains", boolean.class, value)));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/OrFilterEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/OrFilterEvaluator.java
@@ -33,14 +33,14 @@ import static io.trino.sql.gen.columnar.FilterEvaluator.isReorderingSafe;
 public final class OrFilterEvaluator
         implements FilterEvaluator
 {
-    public static Optional<Supplier<FilterEvaluator>> createOrExpressionEvaluator(ColumnarFilterCompiler compiler, Logical logical, Map<Symbol, Integer> layout, boolean filterReorderingEnabled)
+    public static Optional<Supplier<FilterEvaluator>> createOrExpressionEvaluator(ColumnarFilterCompiler compiler, Logical logical, Map<Symbol, Integer> layout, boolean filterReorderingEnabled, boolean dynamicFilter)
     {
         checkArgument(logical.operator() == Logical.Operator.OR, "logical %s should be OR", logical);
         checkArgument(logical.terms().size() >= 2, "OR expression %s should have at least 2 arguments", logical);
 
         ImmutableList.Builder<Supplier<FilterEvaluator>> builder = ImmutableList.builder();
         for (Expression expression : logical.terms()) {
-            Optional<Supplier<FilterEvaluator>> subExpressionEvaluator = FilterEvaluator.createColumnarFilterEvaluator(expression, layout, compiler, filterReorderingEnabled);
+            Optional<Supplier<FilterEvaluator>> subExpressionEvaluator = FilterEvaluator.createColumnarFilterEvaluator(expression, layout, compiler, filterReorderingEnabled, dynamicFilter);
             if (subExpressionEvaluator.isEmpty()) {
                 return Optional.empty();
             }

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestColumnarFilters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestColumnarFilters.java
@@ -419,7 +419,7 @@ public class TestColumnarFilters
                 100,
                 createLongSequenceBlock(0, 100),
                 createLongSequenceBlock(0, 100));
-        FilterEvaluator filterEvaluator = createColumnarFilterEvaluator(andFilter, layout, COMPILER, true).orElseThrow().get();
+        FilterEvaluator filterEvaluator = createColumnarFilterEvaluator(andFilter, layout, COMPILER, true, false).orElseThrow().get();
         filterEvaluator.evaluate(FULL_CONNECTOR_SESSION, SelectedPositions.positionsRange(0, 100), testingPage);
 
         // col_b (channel 1) should not have been loaded because the first conjunct returned no positions
@@ -451,7 +451,7 @@ public class TestColumnarFilters
                 100,
                 createLongSequenceBlock(0, 100),
                 createLongSequenceBlock(0, 100));
-        FilterEvaluator filterEvaluator = createColumnarFilterEvaluator(orFilter, layout, COMPILER, true).orElseThrow().get();
+        FilterEvaluator filterEvaluator = createColumnarFilterEvaluator(orFilter, layout, COMPILER, true, false).orElseThrow().get();
         filterEvaluator.evaluate(FULL_CONNECTOR_SESSION, SelectedPositions.positionsRange(0, 100), testingPage);
 
         // col_b (channel 1) should not have been loaded because the first conjunct selected all rows
@@ -930,12 +930,12 @@ public class TestColumnarFilters
 
     private static void assertThatColumnarFilterEvaluationIsSupported(Expression filterExpression)
     {
-        assertThat(createColumnarFilterEvaluator(filterExpression, LAYOUT, COMPILER, true)).isPresent();
+        assertThat(createColumnarFilterEvaluator(filterExpression, LAYOUT, COMPILER, true, false)).isPresent();
     }
 
     private static void assertThatColumnarFilterEvaluationIsNotSupported(Expression filterExpression)
     {
-        assertThat(createColumnarFilterEvaluator(filterExpression, LAYOUT, COMPILER, true)).isEmpty();
+        assertThat(createColumnarFilterEvaluator(filterExpression, LAYOUT, COMPILER, true, false)).isEmpty();
     }
 
     @ScalarFunction("custom_is_distinct_from")

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestDynamicPageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestDynamicPageFilter.java
@@ -352,6 +352,31 @@ public class TestDynamicPageFilter
     }
 
     @Test
+    public void testDynamicFilterSkipsCompilerCache()
+    {
+        ColumnarFilterCompiler compiler = new ColumnarFilterCompiler(PLANNER_CONTEXT, new CompilerConfig());
+        ColumnHandle column = new TestingColumnHandle("column");
+        Symbol symbol = new Symbol(BIGINT, "A");
+        DynamicPageFilter pageFilter = new DynamicPageFilter(
+                PLANNER_CONTEXT,
+                SESSION,
+                ImmutableMap.of(symbol, column),
+                ImmutableMap.of(symbol, 0),
+                1,
+                true);
+        TestingDynamicFilter dynamicFilter = new TestingDynamicFilter(1);
+        // 8+ values skip the lookupswitch path so the dynamic filter takes the set-field route
+        dynamicFilter.update(TupleDomain.withColumnDomains(
+                ImmutableMap.of(column, multipleValues(BIGINT, ImmutableList.of(1L, 3L, 5L, 7L, 9L, 11L, 13L, 15L)))));
+
+        FilterEvaluator filterEvaluator = pageFilter.createDynamicPageFilterEvaluator(compiler, dynamicFilter).get();
+        filterPage(SourcePage.create(new Page(createLongSequenceBlock(0, 10))), filterEvaluator);
+
+        assertThat(compiler.getFilterCache().getRequestCount()).isEqualTo(0);
+        assertThat(compiler.getFilterCache().getLoadCount()).isEqualTo(0);
+    }
+
+    @Test
     public void testIneffectiveFilter()
     {
         ColumnHandle column = new TestingColumnHandle("column");

--- a/core/trino-main/src/test/java/io/trino/sql/gen/columnar/TestColumnarFilterCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/columnar/TestColumnarFilterCompiler.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.gen.columnar;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.spi.Page;
@@ -20,6 +21,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.connector.SourcePage;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.In;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.Symbol;
 import org.junit.jupiter.api.Test;
@@ -67,6 +69,45 @@ public class TestColumnarFilterCompiler
         int count = filter.filterPositionsRange(SESSION, output, 0, 5, page);
         // values > 2 at positions 3, 4
         assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    public void testDynamicFilterInReusesGeneratedClass()
+    {
+        ColumnarFilterCompiler compiler = FUNCTION_RESOLUTION.getColumnarFilterCompiler(100);
+        Map<Symbol, Integer> layout = ImmutableMap.of(new Symbol(BIGINT, "$col_0"), 0);
+        Reference reference = new Reference(BIGINT, "$col_0");
+        // Lists of 8+ values skip the lookupswitch path and take the set-field route
+        Expression in1 = new In(reference, ImmutableList.of(
+                new Constant(BIGINT, 1L),
+                new Constant(BIGINT, 3L),
+                new Constant(BIGINT, 5L),
+                new Constant(BIGINT, 7L),
+                new Constant(BIGINT, 9L),
+                new Constant(BIGINT, 11L),
+                new Constant(BIGINT, 13L),
+                new Constant(BIGINT, 15L)));
+        Expression in2 = new In(reference, ImmutableList.of(
+                new Constant(BIGINT, 0L),
+                new Constant(BIGINT, 2L),
+                new Constant(BIGINT, 4L),
+                new Constant(BIGINT, 6L),
+                new Constant(BIGINT, 8L),
+                new Constant(BIGINT, 10L),
+                new Constant(BIGINT, 12L),
+                new Constant(BIGINT, 14L)));
+
+        ColumnarFilter filter1 = compiler.generateFilter(in1, layout, true).orElseThrow().get();
+        ColumnarFilter filter2 = compiler.generateFilter(in2, layout, true).orElseThrow().get();
+
+        // Different value sets share one generated class and stay out of the shared cache
+        assertThat(filter2.getClass()).isEqualTo(filter1.getClass());
+        assertThat(compiler.getFilterCache().getLoadCount()).isEqualTo(0);
+
+        SourcePage page = filter1.getInputChannels().getInputChannels(SourcePage.create(new Page(createLongSequenceBlock(0, 10))));
+        int[] output = new int[10];
+        // matches values 1, 3, 5, 7, 9
+        assertThat(filter1.filterPositionsRange(SESSION, output, 0, 10, page)).isEqualTo(5);
     }
 
     @Test


### PR DESCRIPTION
## Description

Dynamic filter predicates are per-query and single-use, so their generated filter classes should not accumulate in the shared columnar `filterCache`. This keeps them out with a value-independent generated class: the IN value set is held as an instance field instead of being baked into the bytecode as a constant, so one class is generated per (value type, concrete fastutil set class) and reused across all dynamic filters. The value sets are per-instance data collected with the query rather than retained in the cache, and the generated class keeps a stable JVM identity. Keying by the concrete set class keeps the field's `contains` call monomorphic.

Small integer IN lists still compile to a `lookupswitch` through the shared cache, where the switch is faster and the baked data is too small to be a retention concern. Non-dynamic-filter predicates are unchanged.

Scoped to long-backed IN lists (bigint, integer, date, and similar), which covers the common join-key case. Other java types fall back to the shared cache.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Reduce worker memory usage for queries with selective joins. ({issue}`30321`)
```
