### PR TITLE
Convert char values through the engine's cast in JSON path predicates

### DIFF
--- a/core/trino-main/src/main/java/io/trino/jsonpath/CachingResolver.java
+++ b/core/trino-main/src/main/java/io/trino/jsonpath/CachingResolver.java
@@ -32,6 +32,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.trino.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.jsonpath.CachingResolver.ResolvedOperatorAndCoercions.RESOLUTION_ERROR;
 import static io.trino.jsonpath.CachingResolver.ResolvedOperatorAndCoercions.operators;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -52,11 +53,25 @@ public class CachingResolver
 
     private final Metadata metadata;
     private final NonEvictableCache<NodeAndTypes, ResolvedOperatorAndCoercions> operators = buildNonEvictableCache(CacheBuilder.newBuilder().maximumSize(MAX_CACHE_SIZE));
+    private final NonEvictableCache<Type, ResolvedFunction> varcharCoercions = buildNonEvictableCache(CacheBuilder.newBuilder().maximumSize(MAX_CACHE_SIZE));
 
     public CachingResolver(Metadata metadata)
     {
         requireNonNull(metadata, "metadata is null");
         this.metadata = metadata;
+    }
+
+    /// Resolves the engine's conversion from `type` to `varchar`. Which cast this is depends on
+    /// the legacy varchar-to-char coercion setting, so the path language sees the same text as
+    /// the rest of the engine under either setting.
+    public ResolvedFunction getVarcharCoercion(Type type)
+    {
+        try {
+            return varcharCoercions.get(type, () -> metadata.getCoercion(type, VARCHAR));
+        }
+        catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public ResolvedOperatorAndCoercions getOperators(IrPathNode node, OperatorType operatorType, Type leftType, Type rightType)

--- a/core/trino-main/src/main/java/io/trino/jsonpath/PathPredicateEvaluationVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/jsonpath/PathPredicateEvaluationVisitor.java
@@ -50,7 +50,6 @@ import static io.trino.jsonpath.ir.IrComparisonPredicate.Operator.EQUAL;
 import static io.trino.jsonpath.ir.IrComparisonPredicate.Operator.NOT_EQUAL;
 import static io.trino.jsonpath.ir.SqlJsonLiteralConverter.getTextTypedValue;
 import static io.trino.jsonpath.ir.SqlJsonLiteralConverter.getTypedValue;
-import static io.trino.spi.type.Chars.padSpaces;
 import static io.trino.sql.analyzer.ExpressionAnalyzer.isCharacterStringType;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
@@ -505,12 +504,16 @@ class PathPredicateEvaluationVisitor
         return scalars.build();
     }
 
-    private static Slice getText(Object object)
+    private Slice getText(Object object)
     {
         if (object instanceof TypedValue typedValue) {
-            if (isCharacterStringType(typedValue.getType())) {
-                if (typedValue.getType() instanceof CharType charType) {
-                    return padSpaces((Slice) typedValue.getObjectValue(), charType);
+            Type type = typedValue.getType();
+            if (isCharacterStringType(type)) {
+                if (type instanceof CharType) {
+                    // Convert through the engine's registered char -> varchar cast rather than
+                    // padding here, so the path language sees the same text as every other
+                    // conversion — including when the legacy padding coercion is enabled.
+                    return (Slice) invoker.invoke(resolver.getVarcharCoercion(type), ImmutableList.of(typedValue.getObjectValue()));
                 }
                 return (Slice) typedValue.getObjectValue();
             }

--- a/core/trino-main/src/test/java/io/trino/jsonpath/TestLegacyCharJsonPathPredicate.java
+++ b/core/trino-main/src/test/java/io/trino/jsonpath/TestLegacyCharJsonPathPredicate.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jsonpath;
+
+import io.trino.sql.query.QueryAssertions;
+import io.trino.testing.StandaloneQueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestLegacyCharJsonPathPredicate
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        // With the legacy coercion enabled, the padding char -> varchar cast is registered in
+        // place of the default trimming one. The path language converts char parameters through
+        // whichever cast is registered, so it pads here too.
+        assertions = new QueryAssertions(new StandaloneQueryRunner(
+                testSessionBuilder().build(),
+                builder -> builder.addProperty("deprecated.legacy-varchar-to-char-coercion", "true")));
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testCharacterParameterIsPadded()
+    {
+        // Under legacy semantics char(5) 'ab' converts to 'ab   ', so it is not a prefix of "abc".
+        assertThat(assertions.query(
+                "SELECT json_exists('{\"s\":\"abc\"}', 'lax $.s ? (@ starts with $prefix)' PASSING CAST('ab' AS char(5)) AS \"prefix\")"))
+                .matches("VALUES false");
+
+        // ... and it does match a value that carries the padding.
+        assertThat(assertions.query(
+                "SELECT json_exists('{\"s\":\"ab   c\"}', 'lax $.s ? (@ starts with $prefix)' PASSING CAST('ab' AS char(5)) AS \"prefix\")"))
+                .matches("VALUES true");
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonExistsFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonExistsFunction.java
@@ -316,4 +316,24 @@ public class TestJsonExistsFunction
                 "SELECT json_exists('{\"s\":\"A\"}', 'lax $.s ? (@ like_regex \"\\x{41}\")')"))
                 .matches("VALUES true");
     }
+
+    @Test
+    public void testCharacterParameterTrailingSpaces()
+    {
+        // A char(n) parameter carries no significant trailing spaces: casting it to varchar
+        // yields the unpadded value, and the path language must see the same text. Padding it
+        // to the declared length would make the predicate look for "ab   " and never match.
+        assertThat(assertions.query(
+                "SELECT json_exists('{\"s\":\"abc\"}', 'lax $.s ? (@ starts with $prefix)' PASSING CAST('ab' AS char(5)) AS \"prefix\")"))
+                .matches("VALUES true");
+
+        assertThat(assertions.query(
+                "SELECT json_exists('[\"ab\"]', 'lax $[0] ? (@ == $value)' PASSING CAST('ab' AS char(5)) AS \"value\")"))
+                .matches("VALUES true");
+
+        // A char parameter matched against a regex sees the same unpadded text.
+        assertThat(assertions.query(
+                "SELECT json_exists('{\"s\":\"ab\"}', 'lax $.s ? (@ like_regex \"^ab$\")')"))
+                .matches("VALUES true");
+    }
 }


### PR DESCRIPTION
## Description

The JSON path engine padded `char` values out to their declared length before using them as text, which contradicts how `char` behaves everywhere else in the engine.

`PathPredicateEvaluationVisitor.getText` feeds three predicates — `starts with`, `like_regex`, and comparison — so a `char` parameter was matched in its padded form:

```sql
SELECT json_exists('{"s":"abc"}', 'lax $.s ? (@ starts with $prefix)' PASSING CAST('ab' AS char(5)) AS "prefix");
```

This looked for `'ab   '`, so it never matched, and returned `false` silently rather than raising an error.

Trino stores `char` values without trailing spaces, and the default `CharToVarcharCast` yields the unpadded value ("trailing spaces are not re-introduced"). The path engine was the only place that re-introduced padding.

Instead of hardcoding either behavior, the path engine now converts a `char` value through the engine's **registered** char-to-varchar cast, resolved via `Metadata.getCoercion` and cached per type in `CachingResolver`. That is the same registration `deprecated.legacy-varchar-to-char-coercion` already switches in `SystemFunctionBundle`, so the padding question follows the configured semantics automatically:

* default → trimming cast → `char(5) 'ab'` is `'ab'`, so `starts with $prefix` matches `"abc"`
* `deprecated.legacy-varchar-to-char-coercion=true` → padding cast → `'ab   '`, so it does not match `"abc"`, and does match `"ab   c"`

Both branches are covered by tests: `TestJsonExistsFunction#testCharacterParameterTrailingSpaces` for the default, and a new `TestLegacyCharJsonPathPredicate` for the legacy setting.

## Additional context and related issues

Worth noting explicitly, since it is a deliberate deviation: under a strict reading of SQL, `CHAR(5) 'ab'` *is* the five-character value `'ab   '`, and a PAD SPACE collation would compare it padded — so the previous padding behavior is arguably the conformant one. Trino has already made the opposite choice for `char` everywhere else (storage, casts, comparisons), and this change makes the path engine consistent with the rest of the engine rather than an island. Under the legacy coercion setting the padded behavior is still available.

One implementation note for reviewers: the conversion is now a cached `MethodHandle` invocation per value, where it was previously an inline `padSpaces`. Resolution is cached per type in `CachingResolver`, so this is the same shape the comparison path already pays for its coercions.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix JSON path predicates (`starts with`, `like_regex`, and comparisons) not matching when passed a `char` value, which was padded to its declared length before comparison.
```
