### PR TITLE
Add map_contains_key function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -318,6 +318,7 @@ import static io.trino.operator.scalar.JsonToMapCast.JSON_TO_MAP;
 import static io.trino.operator.scalar.JsonToRowCast.JSON_TO_ROW;
 import static io.trino.operator.scalar.Least.LEAST;
 import static io.trino.operator.scalar.MapConstructor.MAP_CONSTRUCTOR;
+import static io.trino.operator.scalar.MapContainsKeyFunction.MAP_CONTAINS_KEY;
 import static io.trino.operator.scalar.MapElementAtFunction.MAP_ELEMENT_AT;
 import static io.trino.operator.scalar.MapFilterFunction.MAP_FILTER_FUNCTION;
 import static io.trino.operator.scalar.MapToJsonCast.MAP_TO_JSON;
@@ -578,6 +579,7 @@ public final class SystemFunctionBundle
                 .scalar(ArrayToArrayCast.class)
                 .functions(ARRAY_TO_ELEMENT_CONCAT_FUNCTION, ELEMENT_TO_ARRAY_CONCAT_FUNCTION)
                 .function(MAP_ELEMENT_AT)
+                .function(MAP_CONTAINS_KEY)
                 .function(new MapConcatFunction(blockTypeOperators))
                 .function(new MapToMapCast(blockTypeOperators))
                 .function(ARRAY_FLATTEN_FUNCTION)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapContainsKeyFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapContainsKeyFunction.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.annotation.UsedByGeneratedCode;
+import io.trino.metadata.SqlScalarFunction;
+import io.trino.spi.block.SqlMap;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencies;
+import io.trino.spi.function.FunctionDependencyDeclaration;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.Signature;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.Type;
+
+import java.lang.invoke.MethodHandle;
+
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
+import static io.trino.spi.function.OperatorType.EQUAL;
+import static io.trino.spi.function.OperatorType.INDETERMINATE;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.TypeTemplates.mapType;
+import static io.trino.spi.type.TypeTemplates.typeVariable;
+import static io.trino.util.Failures.internalError;
+import static io.trino.util.Reflection.methodHandle;
+
+public class MapContainsKeyFunction
+        extends SqlScalarFunction
+{
+    public static final MapContainsKeyFunction MAP_CONTAINS_KEY = new MapContainsKeyFunction();
+
+    private static final MethodHandle METHOD_HANDLE_BOOLEAN = methodHandle(MapContainsKeyFunction.class, "containsKey", SqlMap.class, boolean.class);
+    private static final MethodHandle METHOD_HANDLE_LONG = methodHandle(MapContainsKeyFunction.class, "containsKey", SqlMap.class, long.class);
+    private static final MethodHandle METHOD_HANDLE_DOUBLE = methodHandle(MapContainsKeyFunction.class, "containsKey", SqlMap.class, double.class);
+    private static final MethodHandle METHOD_HANDLE_OBJECT = methodHandle(MapContainsKeyFunction.class, "containsKey", MethodHandle.class, SqlMap.class, Object.class);
+
+    private MapContainsKeyFunction()
+    {
+        super(FunctionMetadata.scalarBuilder("map_contains_key")
+                .signature(Signature.builder()
+                        .typeVariable("K")
+                        .typeVariable("V")
+                        .returnType(BOOLEAN)
+                        .argumentType(mapType(typeVariable("K"), typeVariable("V")))
+                        .argumentType(typeVariable("K"))
+                        .build())
+                .description("Determines whether the given map contains the given key")
+                .build());
+    }
+
+    @Override
+    public FunctionDependencyDeclaration getFunctionDependencies()
+    {
+        return FunctionDependencyDeclaration.builder()
+                .addOperatorSignature(EQUAL, ImmutableList.of(typeVariable("K"), typeVariable("K")))
+                .addOperatorSignature(INDETERMINATE, ImmutableList.of(typeVariable("K")))
+                .build();
+    }
+
+    @Override
+    public SpecializedSqlScalarFunction specialize(BoundSignature boundSignature, FunctionDependencies functionDependencies)
+    {
+        MapType mapType = (MapType) boundSignature.getArgumentType(0);
+        Type keyType = mapType.getKeyType();
+
+        MethodHandle methodHandle;
+        if (keyType.getJavaType() == boolean.class) {
+            methodHandle = METHOD_HANDLE_BOOLEAN;
+        }
+        else if (keyType.getJavaType() == long.class) {
+            methodHandle = METHOD_HANDLE_LONG;
+        }
+        else if (keyType.getJavaType() == double.class) {
+            methodHandle = METHOD_HANDLE_DOUBLE;
+        }
+        else {
+            MethodHandle keyIndeterminate = functionDependencies.getOperatorImplementation(
+                    INDETERMINATE,
+                    ImmutableList.of(keyType),
+                    simpleConvention(FAIL_ON_NULL, NEVER_NULL)).getMethodHandle();
+            methodHandle = METHOD_HANDLE_OBJECT.bindTo(keyIndeterminate);
+        }
+
+        return new ChoicesSpecializedSqlScalarFunction(
+                boundSignature,
+                FAIL_ON_NULL,
+                ImmutableList.of(NEVER_NULL, NEVER_NULL),
+                methodHandle);
+    }
+
+    @UsedByGeneratedCode
+    public static boolean containsKey(SqlMap sqlMap, boolean key)
+    {
+        return sqlMap.seekKeyExact(key) != -1;
+    }
+
+    @UsedByGeneratedCode
+    public static boolean containsKey(SqlMap sqlMap, long key)
+    {
+        return sqlMap.seekKeyExact(key) != -1;
+    }
+
+    @UsedByGeneratedCode
+    public static boolean containsKey(SqlMap sqlMap, double key)
+    {
+        return sqlMap.seekKeyExact(key) != -1;
+    }
+
+    @UsedByGeneratedCode
+    public static boolean containsKey(MethodHandle keyIndeterminate, SqlMap sqlMap, Object key)
+    {
+        boolean indeterminate;
+        try {
+            indeterminate = (boolean) keyIndeterminate.invoke(key);
+        }
+        catch (Throwable t) {
+            throw internalError(t);
+        }
+        if (indeterminate) {
+            // a null-containing key can never be present (map construction rejects such keys), so membership is false.
+            // resolving it here keeps the result deterministic rather than depending on hash-bucket collisions in seekKeyExact.
+            return false;
+        }
+        return sqlMap.seekKeyExact(key) != -1;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/type/TestMapOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestMapOperators.java
@@ -816,6 +816,103 @@ public class TestMapOperators
     }
 
     @Test
+    public void testContainsKey()
+    {
+        // empty map
+        assertThat(assertions.function("map_contains_key", "map(CAST(ARRAY[] AS ARRAY(BIGINT)), CAST(ARRAY[] AS ARRAY(BIGINT)))", "1"))
+                .isEqualTo(false);
+
+        // missing key
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[1], ARRAY[1e0])", "2"))
+                .isEqualTo(false);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[1.0], ARRAY['a'])", "2.0"))
+                .isEqualTo(false);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY['a'], ARRAY[true])", "'b'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[true], ARRAY[ARRAY[1]])", "false"))
+                .isEqualTo(false);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[ARRAY[1]], ARRAY[1])", "ARRAY[2]"))
+                .isEqualTo(false);
+
+        // present key whose value is null (element_at cannot distinguish this from a missing key)
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[1], ARRAY[null])", "1"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[1.0E0], ARRAY[null])", "1.0E0"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[TRUE], ARRAY[null])", "TRUE"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY['puppies'], ARRAY[null])", "'puppies'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[ARRAY[1]], ARRAY[null])", "ARRAY[1]"))
+                .isEqualTo(true);
+
+        // present key with non-null value, across key types
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[1, 3], ARRAY[2, 4])", "3"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[BIGINT '1', 3], ARRAY[BIGINT '2', 4])", "3"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[1.5E0, 2.5E0], ARRAY[2, 4])", "2.5E0"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY['puppies'], ARRAY['kittens'])", "'puppies'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[TRUE, FALSE], ARRAY[2, 4])", "TRUE"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[ARRAY[1, 2], ARRAY[3]], ARRAY[1e0, 2e0])", "ARRAY[1, 2]"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[TIMESTAMP '2020-05-10 12:34:56.123456789', TIMESTAMP '2222-05-10 12:34:56.123456789'], ARRAY[1, 2])", "TIMESTAMP '2222-05-10 12:34:56.123456789'"))
+                .isEqualTo(true);
+
+        // key types exercising each specialized dispatch: real (long), long decimal (Int128), row (structural)
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[REAL '1.5', REAL '2.5'], ARRAY[2, 4])", "REAL '2.5'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[DECIMAL '12345678901234567890'], ARRAY[1])", "DECIMAL '12345678901234567890'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[DECIMAL '12345678901234567890'], ARRAY[1])", "DECIMAL '99999999999999999999'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[ROW(1, 2)], ARRAY[9])", "ROW(1, 2)"))
+                .isEqualTo(true);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[ROW(1, 2)], ARRAY[9])", "ROW(1, 3)"))
+                .isEqualTo(false);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[nan()], ARRAY[1])", "nan()"))
+                .isEqualTo(false);
+
+        // null key or null map yields null
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[1], ARRAY[2])", "CAST(NULL AS INTEGER)"))
+                .isNull(BOOLEAN);
+
+        assertThat(assertions.function("map_contains_key", "CAST(NULL AS MAP(INTEGER, INTEGER))", "1"))
+                .isNull(BOOLEAN);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[ARRAY[1]], ARRAY[9])", "ARRAY[CAST(NULL AS INTEGER)]"))
+                .isEqualTo(false);
+
+        assertThat(assertions.function("map_contains_key", "map(ARRAY[ROW(1, 2)], ARRAY[9])", "ROW(1, CAST(NULL AS INTEGER))"))
+                .isEqualTo(false);
+
+        assertThat(assertions.function("map_contains_key", "map(CAST(ARRAY[] AS ARRAY(ARRAY(INTEGER))), CAST(ARRAY[] AS ARRAY(INTEGER)))", "ARRAY[CAST(NULL AS INTEGER)]"))
+                .isEqualTo(false);
+    }
+
+    @Test
     public void testSubscript()
     {
         assertThat(assertions.expression("a[1]")

--- a/docs/src/main/sphinx/functions/list-by-topic.md
+++ b/docs/src/main/sphinx/functions/list-by-topic.md
@@ -385,6 +385,7 @@ For more details, see {doc}`map`
 - {func}`element_at`
 - {func}`map`
 - {func}`map_concat`
+- {func}`map_contains_key`
 - {func}`map_entries`
 - {func}`map_filter`
 - {func}`map_from_entries`

--- a/docs/src/main/sphinx/functions/list.md
+++ b/docs/src/main/sphinx/functions/list.md
@@ -277,6 +277,7 @@
 - {func}`map`
 - {func}`map_agg`
 - {func}`map_concat`
+- {func}`map_contains_key`
 - {func}`map_entries`
 - {func}`map_filter`
 - {func}`map_from_entries`

--- a/docs/src/main/sphinx/functions/map.md
+++ b/docs/src/main/sphinx/functions/map.md
@@ -120,6 +120,25 @@ Returns the union of all the given maps. If a key is found in multiple given map
 that key's value in the resulting map comes from the last one of those maps.
 :::
 
+:::{function} map_contains_key(map(K,V), key) -> boolean
+Returns whether the map contains an entry for `key`. Unlike
+`element_at(map, key) IS NOT NULL`, this returns `true` even when the key is
+present with a `NULL` value. Returns `NULL` if either argument is `NULL`. A
+structural `key` that contains a `NULL` element can never match a map key, so
+the result is `false`.
+
+```
+SELECT map_contains_key(MAP(ARRAY[1, 2], ARRAY['x', 'y']), 1);
+-- true
+
+SELECT map_contains_key(MAP(ARRAY[1, 2], ARRAY['x', 'y']), 3);
+-- false
+
+SELECT map_contains_key(MAP(ARRAY[1], ARRAY[NULL]), 1);
+-- true
+```
+:::
+
 :::{function} map_filter(map(K,V), function(K,V,boolean)) -> map(K,V)
 Constructs a map from those entries of `map` for which `function` returns true:
 


### PR DESCRIPTION
## Description
Adds `map_contains_key(map(K,V), key) → boolean`, the map key-membership counterpart to array `contains`. Unlike `element_at(m, k) IS NOT NULL`, it correctly returns true when a key is present with a NULL value, and it avoids materializing map_keys(m) of the way/workaround of testing a key with `contains(map_keys(m), k)`. 


## Additional context and related issues
Similar function exists in other database engines:
- Spark SQL: `map_contains_key(map, key)`.
- DuckDB: `map_contains(map, key)`.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Add the `map_contains_key` function.
```
