### PR TITLE
Expose iceberg maintenance procedures on mv storage table

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -856,6 +856,12 @@ public interface Metadata
      */
     Optional<MaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName);
 
+    /**
+     * If the specified name identifies the backing storage table of a materialized view, returns the name of that
+     * materialized view; otherwise returns {@link Optional#empty()}.
+     */
+    Optional<QualifiedObjectName> getMaterializedViewForStorageTable(Session session, QualifiedObjectName tableName);
+
     Map<String, Object> getMaterializedViewProperties(Session session, QualifiedObjectName objectName, MaterializedViewDefinition materializedViewDefinition);
 
     /**

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1897,6 +1897,26 @@ public final class MetadataManager
     }
 
     @Override
+    public Optional<QualifiedObjectName> getMaterializedViewForStorageTable(Session session, QualifiedObjectName tableName)
+    {
+        if (cannotExist(tableName)) {
+            return Optional.empty();
+        }
+
+        Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, tableName.catalogName());
+        if (catalog.isPresent()) {
+            CatalogMetadata catalogMetadata = catalog.get();
+            CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle(session, tableName, Optional.empty(), Optional.empty());
+            ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
+
+            ConnectorSession connectorSession = session.toConnectorSession(catalogHandle);
+            return metadata.getMaterializedViewForStorageTable(connectorSession, tableName.asSchemaTableName())
+                    .map(materializedViewName -> new QualifiedObjectName(tableName.catalogName(), materializedViewName.getSchemaName(), materializedViewName.getTableName()));
+        }
+        return Optional.empty();
+    }
+
+    @Override
     public Map<String, Object> getMaterializedViewProperties(Session session, QualifiedObjectName viewName, MaterializedViewDefinition materializedViewDefinition)
     {
         Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, viewName.catalogName());

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1273,10 +1273,18 @@ class StatementAnalyzer
             TableHandle tableHandle = redirection.tableHandle()
                     .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, table, "Table '%s' does not exist", tableName));
 
-            accessControl.checkCanExecuteTableProcedure(
-                    session.toSecurityContext(),
-                    tableName,
-                    procedureName);
+            // When the target is a materialized view storage table, authorize the maintenance procedure as a refresh
+            // of the owning materialized view rather than as an execute-table-procedure on the synthetic storage name.
+            Optional<QualifiedObjectName> materializedViewName = metadata.getMaterializedViewForStorageTable(session, tableName);
+            if (materializedViewName.isPresent()) {
+                accessControl.checkCanRefreshMaterializedView(session.toSecurityContext(), materializedViewName.get());
+            }
+            else {
+                accessControl.checkCanExecuteTableProcedure(
+                        session.toSecurityContext(),
+                        tableName,
+                        procedureName);
+            }
 
             if (!accessControl.getRowFilters(session.toSecurityContext(), tableName).isEmpty()) {
                 throw semanticException(NOT_SUPPORTED, node, "ALTER TABLE EXECUTE is not supported for table with row filter");

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -1407,6 +1407,15 @@ public class TracingConnectorMetadata
     }
 
     @Override
+    public Optional<SchemaTableName> getMaterializedViewForStorageTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        Span span = startSpan("getMaterializedViewForStorageTable", tableName);
+        try (var _ = scopedSpan(span)) {
+            return delegate.getMaterializedViewForStorageTable(session, tableName);
+        }
+    }
+
+    @Override
     public Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition materializedViewDefinition)
     {
         Span span = startSpan("getMaterializedViewProperties", viewName);

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -1574,6 +1574,15 @@ public class TracingMetadata
     }
 
     @Override
+    public Optional<QualifiedObjectName> getMaterializedViewForStorageTable(Session session, QualifiedObjectName tableName)
+    {
+        Span span = startSpan("getMaterializedViewForStorageTable", tableName);
+        try (var _ = scopedSpan(span)) {
+            return delegate.getMaterializedViewForStorageTable(session, tableName);
+        }
+    }
+
+    @Override
     public Map<String, Object> getMaterializedViewProperties(Session session, QualifiedObjectName objectName, MaterializedViewDefinition materializedViewDefinition)
     {
         Span span = startSpan("getMaterializedViewProperties", objectName);

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -1062,6 +1062,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public Optional<QualifiedObjectName> getMaterializedViewForStorageTable(Session session, QualifiedObjectName tableName)
+    {
+        return Optional.empty();
+    }
+
+    @Override
     public Map<String, Object> getMaterializedViewProperties(Session session, QualifiedObjectName viewName, MaterializedViewDefinition materializedViewDefinition)
     {
         throw new UnsupportedOperationException();

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1759,6 +1759,17 @@ public interface ConnectorMetadata
         return Optional.empty();
     }
 
+    /**
+     * If {@code tableName} identifies the backing storage table of a materialized view, returns the name of that
+     * materialized view; otherwise returns {@link Optional#empty()}. Used by the engine to authorize
+     * operations (e.g. {@code ALTER TABLE ... EXECUTE OPTIMIZE}) run against a materialized view storage table
+     * as being run against the materialized view itself.
+     */
+    default Optional<SchemaTableName> getMaterializedViewForStorageTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        return Optional.empty();
+    }
+
     default Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition materializedViewDefinition)
     {
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support materialized views");

--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -2174,6 +2174,15 @@ The Iceberg connector supports the {ref}`WHEN STALE <mv-when-stale>` clause in
 {doc}`/sql/create-materialized-view` to control the behavior when a materialized
 view is stale. 
 
+You can perform physical maintenance of the storage table with {ref}`ALTER TABLE
+EXECUTE <alter-table-execute>` by referencing the storage table directly as
+`"mv_name$materialized_view_storage"`. Only the `optimize`, `optimize_manifests`,
+`expire_snapshots`, and `remove_orphan_files` procedures are supported; other
+procedures are rejected because they would desynchronize the storage table from
+the materialized view. Running a procedure requires the privilege to refresh the
+materialized view, and preserves the metadata used to determine freshness, so a
+subsequent `REFRESH MATERIALIZED VIEW` can still be incremental.
+
 Dropping a materialized view with {doc}`/sql/drop-materialized-view` removes
 the definition and the storage table.
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -1225,6 +1225,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public Optional<SchemaTableName> getMaterializedViewForStorageTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getMaterializedViewForStorageTable(session, tableName);
+        }
+    }
+
+    @Override
     public Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition viewDefinition)
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewSummary.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewSummary.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotUpdate;
+import org.apache.iceberg.Table;
+
+import java.util.List;
+import java.util.Map;
+
+public final class IcebergMaterializedViewSummary
+{
+    // Snapshot summary properties tracking the tables/functions a materialized view depends on, and its snapshot ids.
+    public static final String DEPENDS_ON_TABLES = "dependsOnTables";
+    public static final String DEPENDS_ON_TABLE_FUNCTIONS = "dependsOnTableFunctions";
+    public static final String DEPENDS_ON_NON_DETERMINISTIC_FUNCTIONS = "dependsOnNonDeterministicFunctions";
+    // Value should be ISO-8601 formatted time instant
+    public static final String TRINO_QUERY_START_TIME = "trino-query-start-time";
+
+    private static final List<String> DEPENDENCY_SUMMARY_PROPERTIES = ImmutableList.of(
+            DEPENDS_ON_TABLES,
+            DEPENDS_ON_TABLE_FUNCTIONS,
+            DEPENDS_ON_NON_DETERMINISTIC_FUNCTIONS,
+            TRINO_QUERY_START_TIME);
+
+    private IcebergMaterializedViewSummary() {}
+
+    /**
+     * Carries forward the materialized view dependency summary properties from the table's current snapshot onto the
+     * given snapshot update. Maintenance operations that commit a new snapshot on a materialized view storage table
+     * (OPTIMIZE, optimize_manifests) would otherwise drop these properties, which would
+     * break freshness computation and demote the next incremental refresh to a full refresh. This is a no-op for
+     * ordinary tables, which do not carry these properties.
+     */
+    public static void carryForwardMaterializedViewDependencies(Table table, SnapshotUpdate<?> snapshotUpdate)
+    {
+        Snapshot currentSnapshot = table.currentSnapshot();
+        if (currentSnapshot == null) {
+            return;
+        }
+        Map<String, String> summary = currentSnapshot.summary();
+        for (String key : DEPENDENCY_SUMMARY_PROPERTIES) {
+            String value = summary.get(key);
+            if (value != null) {
+                snapshotUpdate.set(key, value);
+            }
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -299,6 +299,11 @@ import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_MISSING_METADATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_UNSUPPORTED_VIEW_DIALECT;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.DEPENDS_ON_NON_DETERMINISTIC_FUNCTIONS;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.DEPENDS_ON_TABLES;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.DEPENDS_ON_TABLE_FUNCTIONS;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.TRINO_QUERY_START_TIME;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.carryForwardMaterializedViewDependencies;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.FILE_MODIFIED_TIME;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.FILE_PATH;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.LAST_UPDATED_SEQUENCE_NUMBER;
@@ -496,12 +501,14 @@ public class IcebergMetadata
 
     public static final int GET_METADATA_BATCH_SIZE = 1000;
     private static final MapSplitter MAP_SPLITTER = Splitter.on(",").trimResults().omitEmptyStrings().withKeyValueSeparator("=");
-
-    private static final String DEPENDS_ON_TABLES = "dependsOnTables";
-    private static final String DEPENDS_ON_TABLE_FUNCTIONS = "dependsOnTableFunctions";
-    private static final String DEPENDS_ON_NON_DETERMINISTIC_FUNCTIONS = "dependsOnNonDeterministicFunctions";
-    // Value should be ISO-8601 formatted time instant
-    private static final String TRINO_QUERY_START_TIME = "trino-query-start-time";
+    // Any procedure added here that commits a NEW snapshot must call
+    // IcebergMaterializedViewSummary.carryForwardMaterializedViewDependencies before committing, otherwise the
+    // materialized view's dependency summary is dropped and the next refresh is demoted from incremental to full.
+    private static final Set<IcebergTableProcedureId> MATERIALIZED_VIEW_STORAGE_ALLOWED_PROCEDURES = Sets.immutableEnumSet(
+            OPTIMIZE,
+            OPTIMIZE_MANIFESTS,
+            EXPIRE_SNAPSHOTS,
+            REMOVE_ORPHAN_FILES);
 
     private final CatalogName catalogName;
     private final TypeManager typeManager;
@@ -1781,6 +1788,10 @@ public class IcebergMetadata
             throw new IllegalArgumentException("Unknown procedure '" + procedureName + "'");
         }
 
+        if (getMaterializedViewForStorageTable(session, tableHandle.getSchemaTableName()).isPresent() && !MATERIALIZED_VIEW_STORAGE_ALLOWED_PROCEDURES.contains(procedureId)) {
+            throw new TrinoException(NOT_SUPPORTED, "Table procedure %s is not supported on a materialized view storage table".formatted(procedureName));
+        }
+
         return switch (procedureId) {
             case OPTIMIZE -> getTableHandleForOptimize(tableHandle, icebergTable, executeProperties);
             case OPTIMIZE_MANIFESTS -> getTableHandleForOptimizeManifests(session, tableHandle);
@@ -2198,6 +2209,7 @@ public class IcebergMetadata
         rewriteFiles.dataSequenceNumber(snapshot.sequenceNumber());
         rewriteFiles.validateFromSnapshot(snapshot.snapshotId());
         rewriteFiles.scanManifestsWith(icebergScanExecutor);
+        carryForwardMaterializedViewDependencies(icebergTable, rewriteFiles);
         commitUpdate(rewriteFiles, session, "optimize");
 
         long newSnapshotId = icebergTable.currentSnapshot().snapshotId();
@@ -4143,6 +4155,16 @@ public class IcebergMetadata
     public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
         return catalog.getMaterializedView(session, viewName);
+    }
+
+    @Override
+    public Optional<SchemaTableName> getMaterializedViewForStorageTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        if (!isMaterializedViewStorage(tableName.getTableName())) {
+            return Optional.empty();
+        }
+        SchemaTableName materializedViewName = new SchemaTableName(tableName.getSchemaName(), tableNameFrom(tableName.getTableName()));
+        return getMaterializedView(session, materializedViewName).isPresent() ? Optional.of(materializedViewName) : Optional.empty();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/OptimizeManifests.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/OptimizeManifests.java
@@ -50,6 +50,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.carryForwardMaterializedViewDependencies;
 import static io.trino.plugin.iceberg.IcebergUtil.loadDataManifestsFromSnapshot;
 import static java.lang.Math.toIntExact;
 import static org.apache.iceberg.IcebergManifestUtils.liveEntries;
@@ -106,8 +107,9 @@ public final class OptimizeManifests
                     }
                     return clusteredPartitionValues.get(value);
                 })
-                .scanManifestsWith(icebergScanExecutor)
-                .commit();
+                .scanManifestsWith(icebergScanExecutor);
+        carryForwardMaterializedViewDependencies(table, rewriteManifests);
+        rewriteManifests.commit();
 
         CommitReport report = reporter.commitReport();
         if (report == null) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -5756,7 +5756,7 @@ public abstract class BaseIcebergConnectorTest
     public void testOptimize()
             throws Exception
     {
-        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion < IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
+        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion <= IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
             String tableName = "test_optimize_" + randomNameSuffix();
             assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar) WITH (format_version = " + formatVersion + ")");
 
@@ -5817,7 +5817,7 @@ public abstract class BaseIcebergConnectorTest
     public void testOptimizeMaterializedViewStorageTable()
             throws Exception
     {
-        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion < IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
+        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion <= IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
             String tableName = "test_optimize_" + randomNameSuffix();
             assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar) WITH (format_version = " + formatVersion + ")");
             String mvName = "test_optimize_mv_" + randomNameSuffix();
@@ -5886,7 +5886,7 @@ public abstract class BaseIcebergConnectorTest
     public void testOptimizeForPartitionedTable()
             throws IOException
     {
-        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion < IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
+        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion <= IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
             // This test will have its own session to make sure partitioning is indeed forced and is not a result
             // of session configuration
             Session session = testSessionBuilder()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -5814,6 +5814,75 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testOptimizeMaterializedViewStorageTable()
+            throws Exception
+    {
+        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion < IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
+            String tableName = "test_optimize_" + randomNameSuffix();
+            assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar) WITH (format_version = " + formatVersion + ")");
+            String mvName = "test_optimize_mv_" + randomNameSuffix();
+            assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " WITH (format_version = " + formatVersion + ")" + " AS SELECT * FROM " + tableName);
+
+            // DistributedQueryRunner sets node-scheduler.include-coordinator by default, so include coordinator
+            int workerCount = getQueryRunner().getNodeCount();
+
+            // optimize an empty storage table
+            assertQuerySucceeds(withSingleWriterPerTask(getSession()), "ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE OPTIMIZE");
+            assertThat(getSnapshotIds(mvName)).isEmpty();
+
+            assertUpdate("INSERT INTO " + tableName + " VALUES (11, 'eleven')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (12, 'zwölf')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (13, 'trzynaście')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (14, 'quatorze')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (15, 'пʼятнадцять')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+            List<String> initialFiles = getActiveFiles(mvName);
+            assertThat(initialFiles)
+                    .hasSize(5)
+                    // Verify we have sufficiently many test rows with respect to worker count.
+                    .hasSizeGreaterThan(workerCount);
+
+            // For optimize we need to set task_min_writer_count to 1, otherwise it will create more than one file.
+            assertUpdate(
+                    withSingleWriterPerTask(getSession()),
+                    "ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE OPTIMIZE",
+                    "VALUES ('rewritten_data_files_count', 5), ('removed_delete_files_count', 0), ('added_data_files_count', 1)");
+            assertThat(query("SELECT sum(key), listagg(value, ' ') WITHIN GROUP (ORDER BY key) FROM " + mvName))
+                    .matches("VALUES (BIGINT '65', VARCHAR 'eleven zwölf trzynaście quatorze пʼятнадцять')");
+            List<String> updatedFiles = getActiveFiles(mvName);
+            assertThat(updatedFiles)
+                    .hasSizeBetween(1, workerCount)
+                    .doesNotContainAnyElementsOf(initialFiles);
+            // No files should be removed (this is expire_snapshots's job, when it exists)
+            assertThat(getAllDataFilesFromMvStorageTableDirectory(mvName))
+                    .containsExactlyInAnyOrderElementsOf(concat(initialFiles, updatedFiles));
+
+            // optimize with low retention threshold, nothing should change
+            // For optimize we need to set task_min_writer_count to 1, otherwise it will create more than one file.
+            computeActual(withSingleWriterPerTask(getSession()), "ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE OPTIMIZE (file_size_threshold => '33B')");
+            assertThat(query("SELECT sum(key), listagg(value, ' ') WITHIN GROUP (ORDER BY key) FROM " + mvName))
+                    .matches("VALUES (BIGINT '65', VARCHAR 'eleven zwölf trzynaście quatorze пʼятнадцять')");
+            assertThat(getActiveFiles(mvName)).isEqualTo(updatedFiles);
+            assertThat(getAllDataFilesFromMvStorageTableDirectory(mvName))
+                    .containsExactlyInAnyOrderElementsOf(concat(initialFiles, updatedFiles));
+
+            // optimize with delimited procedure name
+            assertQueryFails("ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE \"optimize\"", "Table procedure not registered: optimize");
+            assertUpdate("ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE \"OPTIMIZE\"");
+            // optimize with delimited parameter name (and procedure name)
+            assertUpdate("ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE \"OPTIMIZE\" (\"file_size_threshold\" => '33B')"); // TODO (https://github.com/trinodb/trino/issues/11326) this should fail
+            assertUpdate("ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE \"OPTIMIZE\" (\"FILE_SIZE_THRESHOLD\" => '33B')");
+            assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
     public void testOptimizeForPartitionedTable()
             throws IOException
     {
@@ -6220,20 +6289,36 @@ public abstract class BaseIcebergConnectorTest
 
     protected String getTableLocation(String tableName)
     {
+        return getLocationFromShowCreate("SHOW CREATE TABLE " + tableName);
+    }
+
+    protected String getMvStorageTableLocation(String mvName)
+    {
+        return getLocationFromShowCreate("SHOW CREATE MATERIALIZED VIEW " + mvName);
+    }
+
+    private String getLocationFromShowCreate(String showCreateStatement)
+    {
         Pattern locationPattern = Pattern.compile(".*location = '(.*?)'.*", Pattern.DOTALL);
-        Matcher m = locationPattern.matcher((String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue());
+        Matcher m = locationPattern.matcher((String) computeActual(showCreateStatement).getOnlyValue());
         if (m.find()) {
             String location = m.group(1);
             verify(!m.find(), "Unexpected second match");
             return location;
         }
-        throw new IllegalStateException("Location not found in SHOW CREATE TABLE result");
+        throw new IllegalStateException("Location not found in " + showCreateStatement + " result");
     }
 
     protected List<String> getAllDataFilesFromTableDirectory(String tableName)
             throws IOException
     {
         return listFiles(getIcebergTableDataPath(getTableLocation(tableName)));
+    }
+
+    protected List<String> getAllDataFilesFromMvStorageTableDirectory(String mvName)
+            throws IOException
+    {
+        return listFiles(getIcebergTableDataPath(getMvStorageTableLocation(mvName)));
     }
 
     @Test
@@ -6938,6 +7023,42 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testExpireSnapshotsMaterializedViewStorageTable()
+            throws Exception
+    {
+        String tableName = "test_expiring_snapshots_" + randomNameSuffix();
+        String mvName = "test_expiring_snapshots_mv_" + randomNameSuffix();
+        Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
+        assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer)");
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + tableName);
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2)", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        assertThat(query("SELECT sum(value), listagg(key, ' ') WITHIN GROUP (ORDER BY key) FROM " + mvName))
+                .matches("VALUES (BIGINT '3', VARCHAR 'one two')");
+
+        List<Long> initialSnapshots = getSnapshotIds(mvName);
+        String tableLocation = getMvStorageTableLocation(mvName);
+        List<String> initialFiles = getAllMetadataFilesFromTableDirectory(tableLocation);
+        assertQuerySucceeds(sessionWithShortRetentionUnlocked, "ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')");
+
+        assertThat(query("SELECT sum(value), listagg(key, ' ') WITHIN GROUP (ORDER BY key) FROM " + mvName))
+                .matches("VALUES (BIGINT '3', VARCHAR 'one two')");
+        List<String> updatedFiles = getAllMetadataFilesFromTableDirectory(tableLocation);
+        List<Long> updatedSnapshots = getSnapshotIds(mvName);
+        // MV refresh writes no per-snapshot Puffin .stats file (unlike a plain INSERT), so EXPIRE_SNAPSHOTS
+        // reclaims only manifest lists here — one fewer file than the plain-table case in testExpireSnapshots.
+        assertThat(updatedFiles).hasSize(initialFiles.size() - 1);
+        assertThat(updatedSnapshots.size()).isLessThan(initialSnapshots.size());
+        assertThat(updatedSnapshots).hasSize(1);
+        assertThat(initialSnapshots).containsAll(updatedSnapshots);
+    }
+
+    @Test
     public void testExpireSnapshotsPartitionedTable()
             throws Exception
     {
@@ -7185,6 +7306,44 @@ public abstract class BaseIcebergConnectorTest
         assertQuery("SELECT * FROM " + tableName, "VALUES ('one', 1), ('three', 3)");
 
         List<String> updatedDataFiles = getAllDataFilesFromTableDirectory(tableName);
+        assertThat(updatedDataFiles.size()).isLessThan(initialDataFiles.size());
+        assertThat(updatedDataFiles).doesNotContain(orphanFile1, orphanFile2);
+    }
+
+    @Test
+    public void testRemoveOrphanFilesMaterializedViewStorageTable()
+            throws Exception
+    {
+        String tableName = "test_deleting_orphan_files_unnecessary_files" + randomNameSuffix();
+        String mvName = "test_deleting_orphan_files_unnecessary_files_mv_" + randomNameSuffix();
+        Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
+        assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer)");
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + tableName);
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2), ('three', 3)", 2);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 2);
+        assertUpdate("DELETE FROM " + tableName + " WHERE key = 'two'", 1);
+        // performs full refresh as there has been a DELETE, so refresh goes through whole table (2 rows)
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 2);
+        String location = getMvStorageTableLocation(mvName);
+        String orphanFile1 = getIcebergTableDataPath(location) + "/invalidData1." + format;
+        String orphanFile2 = getIcebergTableDataPath(location) + "/invalidData2." + format;
+        int orphanFile1Bytes = 123;
+        int orphanFile2Bytes = 456;
+        int totalOrphanBytes = orphanFile1Bytes + orphanFile2Bytes;
+        createFile(orphanFile1, new byte[orphanFile1Bytes]);
+        createFile(orphanFile2, new byte[orphanFile2Bytes]);
+        List<String> initialDataFiles = getAllDataFilesFromMvStorageTableDirectory(mvName);
+        assertThat(initialDataFiles).contains(orphanFile1, orphanFile2);
+
+        assertUpdate(
+                sessionWithShortRetentionUnlocked,
+                "ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')",
+                "VALUES ('processed_manifests_count', 5), ('active_files_count', 17), ('scanned_files_count', 19), ('deleted_files_count', 2), ('deleted_bytes', " + totalOrphanBytes + ")");
+        assertQuery("SELECT * FROM " + tableName, "VALUES ('one', 1), ('three', 3)");
+
+        List<String> updatedDataFiles = getAllDataFilesFromMvStorageTableDirectory(mvName);
         assertThat(updatedDataFiles.size()).isLessThan(initialDataFiles.size());
         assertThat(updatedDataFiles).doesNotContain(orphanFile1, orphanFile2);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -78,6 +78,7 @@ import static io.trino.spi.function.table.TableFunctionProcessorState.Processed.
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.testing.MaterializedResult.DEFAULT_PRECISION;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.DROP_MATERIALIZED_VIEW;
+import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.EXECUTE_TABLE_PROCEDURE;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.REFRESH_MATERIALIZED_VIEW;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.RENAME_MATERIALIZED_VIEW;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
@@ -1070,6 +1071,161 @@ public abstract class BaseIcebergMaterializedViewTest
 
         assertUpdate("DROP MATERIALIZED VIEW " + mvName);
         assertUpdate("DROP TABLE base_table1_mv_copy");
+    }
+
+    @Test
+    public void testStorageTableMaintenanceAuthorizedByRefreshPrivilege()
+    {
+        String mvName = "test_optimize_ac_mv_" + randomNameSuffix();
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM base_table1");
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 6);
+
+        String storageTable = mvName + "$materialized_view_storage";
+
+        // Maintenance on the storage table is authorized as a refresh of the materialized view.
+        assertAccessDenied(
+                "ALTER TABLE \"" + storageTable + "\" EXECUTE OPTIMIZE",
+                "Cannot refresh materialized view .*" + mvName + ".*",
+                privilege(mvName, REFRESH_MATERIALIZED_VIEW));
+
+        // It is NOT gated by the execute-table-procedure privilege on the storage table name.
+        assertAccessAllowed(
+                "ALTER TABLE \"" + storageTable + "\" EXECUTE OPTIMIZE",
+                privilege(storageTable + ".OPTIMIZE", EXECUTE_TABLE_PROCEDURE));
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+    }
+
+    @Test
+    public void testUnsafeProcedureRejectedOnStorageTable()
+    {
+        String mvName = "test_unsafe_procedure_mv_" + randomNameSuffix();
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM base_table1");
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 6);
+
+        String storageTable = "\"" + mvName + "$materialized_view_storage\"";
+
+        // Procedures that would change the storage table's logical contents or desync it from the materialized view
+        // are rejected; only physical maintenance is allowed.
+        assertQueryFails(
+                "ALTER TABLE " + storageTable + " EXECUTE DROP_EXTENDED_STATS",
+                "Table procedure DROP_EXTENDED_STATS is not supported on a materialized view storage table");
+
+        long snapshotId = (long) computeScalar("SELECT snapshot_id FROM \"" + mvName + "$snapshots\" ORDER BY committed_at LIMIT 1");
+        assertQueryFails(
+                "ALTER TABLE " + storageTable + " EXECUTE ROLLBACK_TO_SNAPSHOT(" + snapshotId + ")",
+                "Table procedure ROLLBACK_TO_SNAPSHOT is not supported on a materialized view storage table");
+
+        assertQueryFails(
+                "ALTER TABLE " + storageTable + " EXECUTE ADD_FILES_FROM_TABLE(schema_name => CURRENT_SCHEMA, table_name => 'base_table1')",
+                "Table procedure ADD_FILES_FROM_TABLE is not supported on a materialized view storage table");
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+    }
+
+    @Test
+    public void testStorageOptimizePreservesDependencyMetadata()
+    {
+        String sourceTable = "test_optimize_preserve_src_" + randomNameSuffix();
+        String mvName = "test_optimize_preserve_mv_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + sourceTable + " (id BIGINT)");
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 1, 2, 3", 3);
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + sourceTable);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 3);
+
+        // Baseline: a refresh after a single-row insert is incremental (only the delta is written).
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 4", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        // OPTIMIZE the storage table between refreshes.
+        assertUpdate("ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE OPTIMIZE");
+
+        // The dependency metadata survives the optimize snapshot.
+        assertThat((String) computeScalar(
+                "SELECT element_at(summary, 'dependsOnTables') FROM \"" + mvName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1"))
+                .isNotNull()
+                .contains(sourceTable);
+
+        // OPTIMIZE with no source change must not make the MV stale.
+        assertFreshness(mvName, "FRESH");
+
+        // The next refresh stays incremental: only the new delta row is written, not a full re-scan.
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 5", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertThat(computeScalar("SELECT count(*) FROM " + mvName)).isEqualTo(5L);
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        assertUpdate("DROP TABLE " + sourceTable);
+    }
+
+    @Test
+    public void testStorageExpireSnapshotsPreservesDependencyMetadata()
+    {
+        String sourceTable = "test_expire_preserve_src_" + randomNameSuffix();
+        String mvName = "test_expire_preserve_mv_" + randomNameSuffix();
+        Session shortRetentionSession = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "expire_snapshots_min_retention", "0s")
+                .build();
+        assertUpdate("CREATE TABLE " + sourceTable + " (id BIGINT)");
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 1, 2, 3", 3);
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + sourceTable);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 3);
+
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 4", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        assertUpdate(shortRetentionSession, "ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')");
+
+        // EXPIRE_SNAPSHOTS commits no new snapshot; the dependency metadata stays on the retained current snapshot.
+        String dependencyMetadataAfterExpire = (String) computeScalar(
+                "SELECT element_at(summary, 'dependsOnTables') FROM \"" + mvName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1");
+        assertThat(dependencyMetadataAfterExpire)
+                .isNotNull()
+                .contains(sourceTable);
+
+        assertFreshness(mvName, "FRESH");
+
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 5", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertThat(computeScalar("SELECT count(*) FROM " + mvName)).isEqualTo(5L);
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        assertUpdate("DROP TABLE " + sourceTable);
+    }
+
+    @Test
+    public void testStorageRemoveOrphanFilesPreservesDependencyMetadata()
+    {
+        String sourceTable = "test_remove_orphan_preserve_src_" + randomNameSuffix();
+        String mvName = "test_remove_orphan_preserve_mv_" + randomNameSuffix();
+        Session shortRetentionSession = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "remove_orphan_files_min_retention", "0s")
+                .build();
+        assertUpdate("CREATE TABLE " + sourceTable + " (id BIGINT)");
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 1, 2, 3", 3);
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + sourceTable);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 3);
+
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 4", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        assertUpdate(shortRetentionSession, "ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')");
+
+        // REMOVE_ORPHAN_FILES only deletes unreferenced files; the dependency metadata stays on the untouched current snapshot.
+        String dependencyMetadataAfterRemoveOrphans = (String) computeScalar(
+                "SELECT element_at(summary, 'dependsOnTables') FROM \"" + mvName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1");
+        assertThat(dependencyMetadataAfterRemoveOrphans)
+                .isNotNull()
+                .contains(sourceTable);
+
+        assertFreshness(mvName, "FRESH");
+
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 5", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertThat(computeScalar("SELECT count(*) FROM " + mvName)).isEqualTo(5L);
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        assertUpdate("DROP TABLE " + sourceTable);
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergOptimizeManifestsProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergOptimizeManifestsProcedure.java
@@ -129,6 +129,54 @@ final class TestIcebergOptimizeManifestsProcedure
     }
 
     @Test
+    void testOptimizeManifestsOnMaterializedViewStorageTable()
+    {
+        try (TestTable table = newTrinoTable("test_optimize_manifests_on_mv_storage_table", "(x int)")) {
+            String mvName = "test_optimize_manifests_mv_" + randomNameSuffix();
+            assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + table.getName());
+
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 1", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 2", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+            Set<String> manifestFiles = manifestFiles(mvName);
+            assertThat(manifestFiles).hasSize(2);
+
+            // The two data manifests are combined into one.
+            assertUpdate(
+                    "ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE optimize_manifests",
+                    "VALUES " +
+                            "('rewritten_manifests_count', 2), " +
+                            "('added_manifests_count', 1), " +
+                            "('kept_manifests_count', 0), " +
+                            "('processed_manifest_entries_count', 2)");
+            Set<String> optimizedManifestFiles = manifestFiles(mvName);
+            assertThat(optimizedManifestFiles).hasSize(1);
+            assertThat(Sets.intersection(optimizedManifestFiles, manifestFiles)).isEmpty();
+
+            assertThat(query("SELECT * FROM " + mvName))
+                    .matches("VALUES 1, 2");
+
+            String dependencyMetadataAfterOptimizeManifests = (String) computeScalar(
+                    "SELECT element_at(summary, 'dependsOnTables') FROM \"" + mvName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1");
+            assertThat(dependencyMetadataAfterOptimizeManifests)
+                    .isNotNull()
+                    .contains(table.getName());
+
+            assertThat((String) computeScalar("SELECT freshness FROM system.metadata.materialized_views WHERE catalog_name = CURRENT_CATALOG AND schema_name = CURRENT_SCHEMA AND name = '" + mvName + "'"))
+                    .isEqualTo("FRESH");
+
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 3", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertThat(query("SELECT * FROM " + mvName))
+                    .matches("VALUES 1, 2, 3");
+
+            assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        }
+    }
+
+    @Test
     void testSplitManifests()
     {
         try (TestTable table = newTrinoTable("test_optimize_manifests", "(x int)")) {

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseMetadata.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseMetadata.java
@@ -952,6 +952,12 @@ public class LakehouseMetadata
     }
 
     @Override
+    public Optional<SchemaTableName> getMaterializedViewForStorageTable(ConnectorSession session, SchemaTableName tableName)
+    {
+        return icebergMetadata.getMaterializedViewForStorageTable(session, tableName);
+    }
+
+    @Override
     public Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition materializedViewDefinition)
     {
         return icebergMetadata.getMaterializedViewProperties(session, viewName, materializedViewDefinition);


### PR DESCRIPTION
## Description

#### This PR aims to address the problem of lacking capabilities to manage storage table of iceberg materialized views.

As storage tables are hidden and not registered in metastore, utilising the `$materialized_view_storage` suffix can abstract away storage table name and make it available under materialized view name itself.

Connector checks against allow-listed procedure names, that are guaranteed to keep the MV storage table in consistent state and retain any custom properties, carried by the MV implementation, on the snapshots.
Execution of procedures for MV storage table is checked against `REFRESH MATERIALIZED VIEW` access check, as ideally all those optimisations could become part of `REFRESH` itself one day, and those can be thought of extension of `REFRESH`.


## Additional context and related issues

Follow-up of: https://github.com/trinodb/trino/pull/30218

Completes: https://github.com/trinodb/trino/issues/21797


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
##General
* Authorize `ALTER TABLE ... EXECUTE` on a materialized view storage table as `REFRESH MATERIALIZED VIEW` on the owning materialized view.

##Iceberg connector                                                                                                                                                                                                 
* Add support for running `OPTIMIZE`, `OPTIMIZE_MANIFESTS`, `EXPIRE_SNAPSHOTS`, `REMOVE_ORPHAN_FILES` on materialized view storage table through `ALTER TABLE "mv$materialized_view_storage" EXECUTE`

##SPI                                                                                                                                                                                                                               
* Add ConnectorMetadata.getMaterializedViewForStorageTable to resolve a storage table name to its owning materialized view.
```
