### PR TITLE
Add Redis Cluster support to Redis connector

### DIFF
--- a/docs/src/main/sphinx/connector/redis.md
+++ b/docs/src/main/sphinx/connector/redis.md
@@ -18,7 +18,7 @@ string and hash types are supported.
 Requirements for using the connector in a catalog to connect to a Redis data
 source are:
 
-- Redis 5.0.14 or higher (Redis Cluster is not supported)
+- Redis 5.0.14 or higher (Redis Cluster is supported with `redis.cluster.enabled=true`)
 - Network access, by default on port 6379, from the Trino coordinator and
   workers to Redis.
 
@@ -59,6 +59,7 @@ The following configuration properties are available:
 | `redis.database-index`              | Redis database index                                                                              |
 | `redis.user`                        | Redis server username                                                                             |
 | `redis.password`                    | Redis server password                                                                             |
+| `redis.cluster.enabled`             | Whether Redis cluster mode is enabled (default: `false`)                                          |
 | `redis.tls.enabled`                 | Whether TLS security is enabled                                                                   |
 | `redis.tls.keystore-path`           | Path to the {doc}`JKS </security/inspect-jks>` or PKCS12 key store file                           |
 | `redis.tls.keystore-password`       | Password for the key store                                                                        |
@@ -91,7 +92,45 @@ The `hostname:port` pair for the Redis server.
 
 This property is required; there is no default.
 
-Redis Cluster is not supported.
+### `redis.cluster.enabled`
+
+Enables Redis Cluster mode. When set to `true`, Trino discovers the cluster slot
+topology by issuing a `CLUSTER SLOTS` command to one of the seed nodes specified
+in `redis.nodes`. Trino builds a routing table mapping all 16,384 Redis hash slots
+to their owning primary nodes and creates one scan split per primary so each Trino
+worker independently scans one shard.
+
+When key predicates (`=` or `IN`) are pushed down, Trino routes each key to its
+slot-owning primary so each key is fetched only from the correct node.
+
+You can list one or more seed nodes in `redis.nodes`; each is tried in turn until one
+responds, so discovery does not depend on a single seed being available:
+
+```text
+redis.cluster.enabled=true
+redis.nodes=seed-1:6379,seed-2:6379
+```
+
+The following constraints apply when `redis.cluster.enabled=true`:
+
+- `redis.database-index` must be `0` (Redis Cluster only supports database 0)
+- `zset` key format is not supported (a ZSET key resides on a single node and cannot be split)
+- The Trino coordinator and all workers must be able to reach every primary node at the
+  address it advertises through `CLUSTER SLOTS`. In deployments behind NAT, Docker, or
+  Kubernetes, configure the Redis nodes with `cluster-announce-ip` and
+  `cluster-announce-port` set to addresses reachable from Trino; otherwise split scanning
+  fails to connect to the discovered shards.
+- Redis users require `CLUSTER SLOTS` plus read permissions such as `SCAN`, `GET`, and
+  `HGETALL`.
+- During concurrent writes, normal Redis `SCAN` semantics apply. During cluster topology
+  changes (failover or resharding), Trino retries `MOVED` and `ASK` redirections up to a
+  bounded number of attempts. If retries are exhausted, the query fails with a transient
+  error so the user can retry, rather than returning incomplete results.
+
+Cluster mode can be combined with TLS (`redis.tls.enabled=true`) and password
+authentication (`redis.password`) for secure production deployments.
+
+This property is optional; the default is `false` (standalone mode).
 
 ### `redis.scan-count`
 

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisClientManager.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisClientManager.java
@@ -19,14 +19,27 @@ import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import io.trino.spi.HostAddress;
 import jakarta.annotation.PreDestroy;
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.Connection;
 import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Protocol;
 import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.util.JedisClusterCRC16;
+import redis.clients.jedis.util.SafeEncoder;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -48,6 +61,10 @@ public class RedisClientManager
     private final boolean keyPrefixSchemaTable;
     private final int redisScanCount;
     private final Set<RedisClientConfigurator> clientConfigurators;
+    private final Set<HostAddress> seedNodes;
+    private final boolean clusterEnabled;
+
+    private final AtomicReference<RedisClusterTopology> clusterTopology = new AtomicReference<>();
 
     @Inject
     RedisClientManager(RedisConnectorConfig redisConnectorConfig, Set<RedisClientConfigurator> clientConfigurators)
@@ -62,6 +79,11 @@ public class RedisClientManager
         this.keyPrefixSchemaTable = redisConnectorConfig.isKeyPrefixSchemaTable();
         this.redisScanCount = redisConnectorConfig.getRedisScanCount();
         this.clientConfigurators = ImmutableSet.copyOf(clientConfigurators);
+        this.seedNodes = redisConnectorConfig.getNodes();
+        this.clusterEnabled = redisConnectorConfig.isClusterEnabled();
+        checkArgument(
+                !clusterEnabled || redisDataBaseIndex == 0,
+                "redis.database-index must be 0 when redis.cluster.enabled is true because Redis Cluster only supports database index 0");
     }
 
     @PreDestroy
@@ -75,6 +97,7 @@ public class RedisClientManager
                 log.warn(e, "While closing RedisClient %s:", entry.getKey());
             }
         }
+        clusterTopology.set(null);
     }
 
     public char getRedisKeyDelimiter()
@@ -97,33 +120,215 @@ public class RedisClientManager
         return redisScanCount;
     }
 
+    public boolean isClusterEnabled()
+    {
+        return clusterEnabled;
+    }
+
     public RedisClient getClient(HostAddress host)
     {
         requireNonNull(host, "host is null");
         return clientCache.computeIfAbsent(host, this::createClient);
     }
 
+    /**
+     * Returns the current cluster topology, discovering it from the seed nodes
+     * on first access.  Only applicable when {@code redis.cluster.enabled=true}.
+     */
+    public RedisClusterTopology getClusterTopology()
+    {
+        RedisClusterTopology topology = clusterTopology.get();
+        if (topology == null) {
+            topology = RedisClusterTopology.discover(seedNodes, baseClientConfigBuilder().build());
+            if (!clusterTopology.compareAndSet(null, topology)) {
+                topology = clusterTopology.get();
+            }
+        }
+        return topology;
+    }
+
+    /**
+     * Forces a re-discovery of the cluster topology from the seed nodes.
+     * Called after a MOVED redirect indicates the cached topology is stale.
+     * Clients for primaries that are no longer in the new topology are closed
+     * and removed from the cache to avoid leaking connections to departed nodes.
+     */
+    public RedisClusterTopology refreshTopology()
+    {
+        RedisClusterTopology oldTopology = clusterTopology.get();
+        RedisClusterTopology newTopology = RedisClusterTopology.discover(seedNodes, baseClientConfigBuilder().build());
+        clusterTopology.set(newTopology);
+
+        // Close clients for primaries that are no longer in the topology
+        if (oldTopology != null) {
+            Set<HostAddress> stalePrimaries = new HashSet<>(oldTopology.getPrimaries());
+            stalePrimaries.removeAll(newTopology.getPrimaries());
+            for (HostAddress stale : stalePrimaries) {
+                RedisClient staleClient = clientCache.remove(stale);
+                if (staleClient != null) {
+                    try {
+                        staleClient.close();
+                        log.info("Closed stale RedisClient for departed primary %s", stale);
+                    }
+                    catch (Exception e) {
+                        log.warn(e, "While closing stale RedisClient for %s:", stale);
+                    }
+                }
+            }
+        }
+        return newTopology;
+    }
+
+    /**
+     * Returns the primary node that owns the slot for the given key.
+     */
+    public HostAddress getPrimaryForKey(String key)
+    {
+        return getClusterTopology().getPrimaryForKey(key);
+    }
+
+    /**
+     * Returns a client for the primary that owns the slot for the given key.
+     */
+    public RedisClient getClientForKey(String key)
+    {
+        return getClient(getPrimaryForKey(key));
+    }
+
+    /**
+     * Returns the Redis hash slot for the given key.
+     */
+    public static int getSlot(String key)
+    {
+        return JedisClusterCRC16.getSlot(key);
+    }
+
+    /**
+     * Parses a MOVED or ASK redirection error and returns the target host.
+     *
+     * @return the target HostAddress, or null if the exception is not a redirection
+     */
+    public static HostAddress parseRedirectionTarget(JedisDataException exception)
+    {
+        String message = exception.getMessage();
+        if (message == null) {
+            return null;
+        }
+        // Format: "MOVED <slot> <ip:port>" or "ASK <slot> <ip:port>"
+        if (!message.startsWith("MOVED") && !message.startsWith("ASK")) {
+            return null;
+        }
+        String[] parts = message.split("\\s+", -1);
+        if (parts.length < 3) {
+            return null;
+        }
+        return HostAddress.fromString(parts[2]).withDefaultPort(6379);
+    }
+
+    /**
+     * Returns true if the given exception is a MOVED or ASK redirection.
+     */
+    public static boolean isRedirectionError(JedisDataException exception)
+    {
+        String message = exception.getMessage();
+        return message != null && (message.startsWith("MOVED") || message.startsWith("ASK"));
+    }
+
+    /**
+     * Returns true if the given exception is a MOVED redirection (topology change).
+     */
+    public static boolean isMovedRedirection(JedisDataException exception)
+    {
+        String message = exception.getMessage();
+        return message != null && message.startsWith("MOVED");
+    }
+
+    /**
+     * Returns true if the given exception is an ASK redirection (temporary).
+     */
+    public static boolean isAskRedirection(JedisDataException exception)
+    {
+        String message = exception.getMessage();
+        return message != null && message.startsWith("ASK");
+    }
+
+    /**
+     * Sends ASKING followed by GET on a fresh connection to the target node.
+     * Required for ASK redirects where the slot is in migrating state.
+     *
+     * @return the string value, or null if the key does not exist
+     */
+    public String askAndGet(HostAddress target, String key)
+    {
+        DefaultJedisClientConfig clientConfig = baseClientConfigBuilder().build();
+        try (Connection connection = new Connection(
+                new HostAndPort(target.getHostText(), target.getPort()),
+                clientConfig)) {
+            connection.sendCommand(new CommandArguments(Protocol.Command.ASKING));
+            connection.getStatusCodeReply();
+            connection.sendCommand(new CommandArguments(Protocol.Command.GET).add(key));
+            Object reply = connection.getOne();
+            return reply == null ? null : SafeEncoder.encode((byte[]) reply);
+        }
+    }
+
+    /**
+     * Sends ASKING followed by HGETALL on a fresh connection to the target node.
+     * Required for ASK redirects where the slot is in migrating state.
+     *
+     * @return a map of field names to values, or an empty map if the key does not exist
+     */
+    public Map<String, String> askAndGetAll(HostAddress target, String key)
+    {
+        DefaultJedisClientConfig clientConfig = baseClientConfigBuilder().build();
+        try (Connection connection = new Connection(
+                new HostAndPort(target.getHostText(), target.getPort()),
+                clientConfig)) {
+            connection.sendCommand(new CommandArguments(Protocol.Command.ASKING));
+            connection.getStatusCodeReply();
+            connection.sendCommand(new CommandArguments(Protocol.Command.HGETALL).add(key));
+            Object reply = connection.getOne();
+            if (reply == null) {
+                return Map.of();
+            }
+            @SuppressWarnings("unchecked")
+            List<Object> entries = (List<Object>) reply;
+            Map<String, String> result = new HashMap<>();
+            for (int i = 0; i + 1 < entries.size(); i += 2) {
+                String field = SafeEncoder.encode((byte[]) entries.get(i));
+                String value = SafeEncoder.encode((byte[]) entries.get(i + 1));
+                result.put(field, value);
+            }
+            return result;
+        }
+    }
+
     private RedisClient createClient(HostAddress host)
     {
         log.info("Creating new RedisClient for %s", host);
 
-        DefaultJedisClientConfig.Builder clientConfigBuilder = DefaultJedisClientConfig.builder()
-                .connectionTimeoutMillis(toIntExact(redisConnectTimeout.toMillis()))
-                .socketTimeoutMillis(toIntExact(redisConnectTimeout.toMillis()))
-                .database(redisDataBaseIndex);
-
-        if (redisUser != null && !redisUser.isEmpty()) {
-            clientConfigBuilder.user(redisUser);
-        }
-        if (redisPassword != null && !redisPassword.isEmpty()) {
-            clientConfigBuilder.password(redisPassword);
-        }
-
-        clientConfigurators.forEach(configurator -> configurator.configure(clientConfigBuilder));
+        DefaultJedisClientConfig clientConfig = baseClientConfigBuilder()
+                .database(redisDataBaseIndex)
+                .build();
 
         return RedisClient.builder()
                 .hostAndPort(host.getHostText(), host.getPort())
-                .clientConfig(clientConfigBuilder.build())
+                .clientConfig(clientConfig)
                 .build();
+    }
+
+    private DefaultJedisClientConfig.Builder baseClientConfigBuilder()
+    {
+        DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder()
+                .connectionTimeoutMillis(toIntExact(redisConnectTimeout.toMillis()))
+                .socketTimeoutMillis(toIntExact(redisConnectTimeout.toMillis()));
+        if (redisUser != null && !redisUser.isEmpty()) {
+            builder.user(redisUser);
+        }
+        if (redisPassword != null && !redisPassword.isEmpty()) {
+            builder.password(redisPassword);
+        }
+        clientConfigurators.forEach(configurator -> configurator.configure(builder));
+        return builder;
     }
 }

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisClusterTopology.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisClusterTopology.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redis;
+
+import com.google.common.collect.ImmutableSet;
+import io.airlift.log.Logger;
+import io.trino.spi.HostAddress;
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.util.JedisClusterCRC16;
+import redis.clients.jedis.util.SafeEncoder;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents the slot-to-primary routing topology of a Redis Cluster, discovered
+ * via the {@code CLUSTER SLOTS} command.  Maps all 16,384 Redis hash slots to
+ * their owning primary node and provides key-based routing.
+ * <p>
+ * The topology is an immutable snapshot; call {@link #discover} to build a new
+ * instance from the live cluster.
+ */
+public final class RedisClusterTopology
+{
+    private static final Logger log = Logger.get(RedisClusterTopology.class);
+
+    public static final int TOTAL_SLOTS = 16384;
+
+    private final HostAddress[] slotToPrimary;
+    private final Set<HostAddress> primaries;
+
+    private RedisClusterTopology(HostAddress[] slotToPrimary, Set<HostAddress> primaries)
+    {
+        this.slotToPrimary = slotToPrimary;
+        this.primaries = ImmutableSet.copyOf(primaries);
+    }
+
+    /**
+     * Returns the primary node that owns the slot for the given key.
+     */
+    public HostAddress getPrimaryForKey(String key)
+    {
+        return getPrimaryForSlot(JedisClusterCRC16.getSlot(key));
+    }
+
+    /**
+     * Returns the primary node that owns the given slot.
+     */
+    public HostAddress getPrimaryForSlot(int slot)
+    {
+        checkArgument(slot >= 0 && slot < TOTAL_SLOTS, "slot out of range: %s", slot);
+        HostAddress primary = slotToPrimary[slot];
+        checkArgument(primary != null, "no primary assigned for slot %s; topology may be incomplete", slot);
+        return primary;
+    }
+
+    /**
+     * Returns all primary nodes in this topology.
+     */
+    public Set<HostAddress> getPrimaries()
+    {
+        return primaries;
+    }
+
+    /**
+     * Returns true if every slot 0..16383 is assigned to a primary.
+     */
+    public boolean isComplete()
+    {
+        for (HostAddress primary : slotToPrimary) {
+            if (primary == null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Discovers the cluster topology from one of the given seed nodes using
+     * the {@code CLUSTER SLOTS} command.  Each seed is tried in turn until one
+     * responds with a complete topology.
+     *
+     * @throws IllegalStateException if no seed can provide a complete topology
+     */
+    public static RedisClusterTopology discover(Set<HostAddress> seedNodes, DefaultJedisClientConfig clientConfig)
+    {
+        requireNonNull(seedNodes, "seedNodes is null");
+        requireNonNull(clientConfig, "clientConfig is null");
+        checkArgument(!seedNodes.isEmpty(), "seedNodes is empty");
+
+        List<Exception> failures = new ArrayList<>();
+        for (HostAddress seed : seedNodes) {
+            try (Connection connection = new Connection(
+                    new HostAndPort(seed.getHostText(), seed.getPort()),
+                    clientConfig)) {
+                connection.sendCommand(new CommandArguments(Protocol.Command.CLUSTER).add("SLOTS"));
+                Object response = connection.getOne();
+                RedisClusterTopology topology = parseClusterSlots(response);
+                if (topology.isComplete()) {
+                    log.info("Discovered Redis Cluster topology with %d primaries from seed %s", topology.getPrimaries().size(), seed);
+                    return topology;
+                }
+                failures.add(new IllegalStateException("Seed node " + seed + " returned an incomplete slot map"));
+            }
+            catch (RuntimeException e) {
+                log.warn(e, "Failed to discover Redis cluster topology from seed %s", seed);
+                failures.add(e);
+            }
+        }
+        IllegalStateException exception = new IllegalStateException(
+                "Unable to discover a complete Redis Cluster topology from any configured seed node: " + seedNodes);
+        failures.forEach(exception::addSuppressed);
+        throw exception;
+    }
+
+    /**
+     * Parses the raw RESP response of {@code CLUSTER SLOTS} into a topology.
+     * <p>
+     * The response is a list of slot-range entries.  Each entry is:
+     * <pre>
+     * [startSlot, endSlot, [masterIp, masterPort, masterId], [replicaIp, replicaPort, replicaId], ...]
+     * </pre>
+     */
+    static RedisClusterTopology parseClusterSlots(Object response)
+    {
+        requireNonNull(response, "response is null");
+        checkArgument(response instanceof List, "expected a list for CLUSTER SLOTS response, got %s", response.getClass());
+
+        HostAddress[] slotToPrimary = new HostAddress[TOTAL_SLOTS];
+        Set<HostAddress> primaries = new HashSet<>();
+
+        @SuppressWarnings("unchecked")
+        List<Object> slotRanges = (List<Object>) response;
+
+        for (Object slotRangeObj : slotRanges) {
+            checkArgument(slotRangeObj instanceof List, "expected a list for slot range, got %s", slotRangeObj.getClass());
+            @SuppressWarnings("unchecked")
+            List<Object> slotRange = (List<Object>) slotRangeObj;
+
+            checkArgument(slotRange.size() >= 3, "slot range must have at least 3 elements, got %s", slotRange.size());
+
+            int startSlot = ((Long) slotRange.get(0)).intValue();
+            int endSlot = ((Long) slotRange.get(1)).intValue();
+
+            @SuppressWarnings("unchecked")
+            List<Object> masterInfo = (List<Object>) slotRange.get(2);
+            checkArgument(masterInfo.size() >= 2, "master info must have at least 2 elements");
+
+            String masterIp = SafeEncoder.encode((byte[]) masterInfo.get(0));
+            int masterPort = ((Long) masterInfo.get(1)).intValue();
+            HostAddress primary = HostAddress.fromParts(masterIp, masterPort);
+            primaries.add(primary);
+
+            for (int slot = startSlot; slot <= endSlot; slot++) {
+                checkArgument(slot >= 0 && slot < TOTAL_SLOTS, "slot out of range: %s", slot);
+                slotToPrimary[slot] = primary;
+            }
+        }
+
+        return new RedisClusterTopology(slotToPrimary, primaries);
+    }
+}

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorConfig.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorConfig.java
@@ -52,6 +52,7 @@ public class RedisConnectorConfig
     private boolean hideInternalColumns = true;
     private boolean keyPrefixSchemaTable;
     private boolean tlsEnabled;
+    private boolean clusterEnabled;
 
     @NotNull
     public File getTableDescriptionDir()
@@ -257,6 +258,19 @@ public class RedisConnectorConfig
     public RedisConnectorConfig setTlsEnabled(boolean tlsEnabled)
     {
         this.tlsEnabled = tlsEnabled;
+        return this;
+    }
+
+    public boolean isClusterEnabled()
+    {
+        return clusterEnabled;
+    }
+
+    @Config("redis.cluster.enabled")
+    @ConfigDescription("Whether Redis cluster mode is enabled. When true, each cluster master node is scanned independently")
+    public RedisConnectorConfig setClusterEnabled(boolean clusterEnabled)
+    {
+        this.clusterEnabled = clusterEnabled;
         return this;
     }
 

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisRecordCursor.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisRecordCursor.java
@@ -21,6 +21,8 @@ import io.trino.decoder.DecoderColumnHandle;
 import io.trino.decoder.FieldValueProvider;
 import io.trino.decoder.RowDecoder;
 import io.trino.plugin.redis.decoder.RedisRowDecoder;
+import io.trino.spi.HostAddress;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.predicate.Domain;
@@ -33,12 +35,14 @@ import io.trino.spi.type.Type;
 import jakarta.annotation.Nullable;
 import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.resps.ScanResult;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -52,6 +56,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.decoder.FieldValueProviders.booleanValueProvider;
 import static io.trino.decoder.FieldValueProviders.bytesValueProvider;
 import static io.trino.decoder.FieldValueProviders.longValueProvider;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
@@ -63,6 +68,7 @@ public class RedisRecordCursor
 {
     private static final Logger log = Logger.get(RedisRecordCursor.class);
     private static final String EMPTY_STRING = "";
+    private static final int MAX_REDIRECTION_RETRIES = 5;
 
     private final RowDecoder keyDecoder;
     private final RowDecoder valueDecoder;
@@ -71,11 +77,13 @@ public class RedisRecordCursor
     private final List<RedisColumnHandle> columnHandles;
 
     private final RedisClient client;
+    private final RedisClientManager clientManager;
     private final ScanParams scanParams;
     private final int maxKeysPerFetch;
     private final char keyDelimiter;
     private final boolean isKeyPrefixSchemaTable;
     private final int scanCount;
+    private final boolean clusterEnabled;
 
     private ScanResult<String> redisCursor;
     private List<String> keys;
@@ -102,15 +110,21 @@ public class RedisRecordCursor
         this.split = split;
         this.columnHandles = columnHandles;
 
+        this.clientManager = clientManager;
         this.client = clientManager.getClient(split.getNodes().get(0));
         this.keyDelimiter = clientManager.getRedisKeyDelimiter();
         this.isKeyPrefixSchemaTable = clientManager.isKeyPrefixSchemaTable();
         this.scanCount = clientManager.getRedisScanCount();
+        this.clusterEnabled = clientManager.isClusterEnabled();
         this.scanParams = setScanParams();
         this.maxKeysPerFetch = clientManager.getRedisMaxKeysPerFetch();
         this.currentRowGroup = new LinkedList<>();
 
-        if (split.getConstraint().isAll()) {
+        if (split.getClusterKeysOptional().isPresent()) {
+            // Predicate-routed split: keys are pre-assigned to this primary by slot
+            keys = new ArrayList<>(split.getClusterKeysOptional().get());
+        }
+        else if (split.getConstraint().isAll()) {
             fetchKeys();
         }
         else {
@@ -209,6 +223,8 @@ public class RedisRecordCursor
             String keyString = currentKeys.get(i);
             Object object = hashValues.get(i);
             if (object instanceof JedisDataException jedisDataException) {
+                // Redirections should have been handled in fetchData with retry.
+                // If we get here, it's a non-redirection error.
                 throw jedisDataException;
             }
             Map<String, String> hashValueMap = (Map<String, String>) object;
@@ -318,6 +334,11 @@ public class RedisRecordCursor
     @Override
     public void close() {}
 
+    private static boolean isRedirectionError(JedisDataException exception)
+    {
+        return RedisClientManager.isRedirectionError(exception);
+    }
+
     private ScanParams setScanParams()
     {
         if (split.getKeyDataType() == RedisDataType.STRING) {
@@ -408,16 +429,321 @@ public class RedisRecordCursor
         hashValues = null;
 
         switch (split.getValueDataType()) {
-            case STRING -> stringValues = client.mget(currentKeys.toArray(new String[0]));
+            case STRING -> {
+                if (clusterEnabled) {
+                    stringValues = fetchStringValuesCluster(currentKeys);
+                }
+                else {
+                    stringValues = client.mget(currentKeys.toArray(new String[0]));
+                }
+            }
             case HASH -> {
-                try (Pipeline pipeline = client.pipelined()) {
-                    for (String key : currentKeys) {
-                        pipeline.hgetAll(key);
-                    }
-                    hashValues = pipeline.syncAndReturnAll();
+                if (clusterEnabled) {
+                    hashValues = fetchHashValuesCluster(currentKeys);
+                }
+                else {
+                    hashValues = fetchHashValuesStandalone(currentKeys);
                 }
             }
             default -> log.warn("Redis value of type %s is unsupported", split.getValueDataType());
+        }
+    }
+
+    /**
+     * Fetches string values from a cluster primary with MOVED/ASK retry and
+     * primary-failover handling.  When the split's primary becomes unreachable,
+     * the topology is refreshed and keys are resolved to the new primary.
+     */
+    private static List<String> toArrayList(String[] results)
+    {
+        // List.of rejects null elements, but Redis GET may legitimately return null.
+        return new ArrayList<>(Arrays.asList(results));
+    }
+
+    private List<String> fetchStringValuesCluster(List<String> currentKeys)
+    {
+        String[] results = new String[currentKeys.size()];
+        List<Integer> pendingIndices = new ArrayList<>();
+        List<String> pendingKeys = new ArrayList<>();
+        for (int i = 0; i < currentKeys.size(); i++) {
+            pendingIndices.add(i);
+            pendingKeys.add(currentKeys.get(i));
+        }
+
+        for (int attempt = 0; attempt < MAX_REDIRECTION_RETRIES && !pendingKeys.isEmpty(); attempt++) {
+            List<Object> replies;
+            try {
+                try (Pipeline pipeline = client.pipelined()) {
+                    for (String key : pendingKeys) {
+                        pipeline.get(key);
+                    }
+                    replies = pipeline.syncAndReturnAll();
+                }
+            }
+            catch (JedisConnectionException e) {
+                if (!clusterEnabled) {
+                    throw e;
+                }
+                log.warn(e, "Redis cluster primary unreachable for split %s; refreshing topology", split.getNodes());
+                List<Integer> nextPendingIndices = new ArrayList<>();
+                List<String> nextPendingKeys = resolveKeysAfterConnectionFailure(pendingKeys, pendingIndices, results, RedisClient::get, nextPendingIndices);
+                if (nextPendingKeys.isEmpty()) {
+                    break;
+                }
+                pendingIndices = nextPendingIndices;
+                pendingKeys = nextPendingKeys;
+                continue;
+            }
+
+            List<Integer> nextPendingIndices = new ArrayList<>();
+            List<String> nextPendingKeys = new ArrayList<>();
+
+            for (int i = 0; i < replies.size(); i++) {
+                int originalIndex = pendingIndices.get(i);
+                String key = pendingKeys.get(i);
+                Object reply = replies.get(i);
+
+                if (reply instanceof JedisDataException jedisDataException) {
+                    if (isRedirectionError(jedisDataException)) {
+                        HostAddress target = RedisClientManager.parseRedirectionTarget(jedisDataException);
+                        if (target == null) {
+                            throw new TrinoException(
+                                    GENERIC_INTERNAL_ERROR,
+                                    "Malformed cluster redirection error for key " + key + ": " + jedisDataException.getMessage());
+                        }
+                        // Retry on the target node
+                        try {
+                            String value;
+                            if (RedisClientManager.isAskRedirection(jedisDataException)) {
+                                // ASK: slot is migrating, must send ASKING before command
+                                value = clientManager.askAndGet(target, key);
+                            }
+                            else {
+                                // MOVED: topology changed, retry with normal GET on target
+                                RedisClient targetClient = clientManager.getClient(target);
+                                value = targetClient.get(key);
+                            }
+                            results[originalIndex] = value;
+                        }
+                        catch (JedisDataException retryException) {
+                            if (RedisClientManager.isAskRedirection(retryException)) {
+                                // MOVED target returned ASK — slot is migrating, follow ASK
+                                HostAddress askTarget = RedisClientManager.parseRedirectionTarget(retryException);
+                                if (askTarget != null) {
+                                    results[originalIndex] = clientManager.askAndGet(askTarget, key);
+                                }
+                                else {
+                                    throw new TrinoException(
+                                            GENERIC_INTERNAL_ERROR,
+                                            "Malformed ASK redirection from MOVED target for key " + key + ": " + retryException.getMessage());
+                                }
+                            }
+                            else if (isRedirectionError(retryException)) {
+                                // Still redirected after retry — queue for next attempt
+                                nextPendingIndices.add(originalIndex);
+                                nextPendingKeys.add(key);
+                            }
+                            else {
+                                throw retryException;
+                            }
+                        }
+                        // On MOVED, refresh the cached topology
+                        if (RedisClientManager.isMovedRedirection(jedisDataException)) {
+                            log.info("MOVED redirect for key %s, refreshing cluster topology", key);
+                            clientManager.refreshTopology();
+                        }
+                    }
+                    else {
+                        throw jedisDataException;
+                    }
+                }
+                else {
+                    results[originalIndex] = (String) reply;
+                }
+            }
+
+            pendingIndices = nextPendingIndices;
+            pendingKeys = nextPendingKeys;
+        }
+
+        if (!pendingKeys.isEmpty()) {
+            throw new TrinoException(
+                    GENERIC_INTERNAL_ERROR,
+                    "Exhausted " + MAX_REDIRECTION_RETRIES + " retries for cluster redirection(s) on keys: " + pendingKeys);
+        }
+
+        return toArrayList(results);
+    }
+
+    /**
+     * Fetches hash values from a cluster primary with MOVED/ASK retry and
+     * primary-failover handling.
+     */
+    private List<Object> fetchHashValuesCluster(List<String> currentKeys)
+    {
+        Object[] results = new Object[currentKeys.size()];
+        List<Integer> pendingIndices = new ArrayList<>();
+        List<String> pendingKeys = new ArrayList<>();
+        for (int i = 0; i < currentKeys.size(); i++) {
+            pendingIndices.add(i);
+            pendingKeys.add(currentKeys.get(i));
+        }
+
+        for (int attempt = 0; attempt < MAX_REDIRECTION_RETRIES && !pendingKeys.isEmpty(); attempt++) {
+            List<Object> replies;
+            try {
+                try (Pipeline pipeline = client.pipelined()) {
+                    for (String key : pendingKeys) {
+                        pipeline.hgetAll(key);
+                    }
+                    replies = pipeline.syncAndReturnAll();
+                }
+            }
+            catch (JedisConnectionException e) {
+                if (!clusterEnabled) {
+                    throw e;
+                }
+                log.warn(e, "Redis cluster primary unreachable for hash split %s; refreshing topology", split.getNodes());
+                List<Integer> nextPendingIndices = new ArrayList<>();
+                List<String> nextPendingKeys = resolveKeysAfterConnectionFailure(pendingKeys, pendingIndices, results, RedisClient::hgetAll, nextPendingIndices);
+                if (nextPendingKeys.isEmpty()) {
+                    break;
+                }
+                pendingIndices = nextPendingIndices;
+                pendingKeys = nextPendingKeys;
+                continue;
+            }
+
+            List<Integer> nextPendingIndices = new ArrayList<>();
+            List<String> nextPendingKeys = new ArrayList<>();
+
+            for (int i = 0; i < replies.size(); i++) {
+                int originalIndex = pendingIndices.get(i);
+                String key = pendingKeys.get(i);
+                Object reply = replies.get(i);
+
+                if (reply instanceof JedisDataException jedisDataException) {
+                    if (isRedirectionError(jedisDataException)) {
+                        HostAddress target = RedisClientManager.parseRedirectionTarget(jedisDataException);
+                        if (target == null) {
+                            throw new TrinoException(
+                                    GENERIC_INTERNAL_ERROR,
+                                    "Malformed cluster redirection error for key " + key + ": " + jedisDataException.getMessage());
+                        }
+                        try {
+                            Map<String, String> value;
+                            if (RedisClientManager.isAskRedirection(jedisDataException)) {
+                                // ASK: slot is migrating, must send ASKING before command
+                                value = clientManager.askAndGetAll(target, key);
+                            }
+                            else {
+                                // MOVED: topology changed, retry with normal HGETALL on target
+                                RedisClient targetClient = clientManager.getClient(target);
+                                value = targetClient.hgetAll(key);
+                            }
+                            results[originalIndex] = value;
+                        }
+                        catch (JedisDataException retryException) {
+                            if (RedisClientManager.isAskRedirection(retryException)) {
+                                // MOVED target returned ASK — slot is migrating, follow ASK
+                                HostAddress askTarget = RedisClientManager.parseRedirectionTarget(retryException);
+                                if (askTarget != null) {
+                                    results[originalIndex] = clientManager.askAndGetAll(askTarget, key);
+                                }
+                                else {
+                                    throw new TrinoException(
+                                            GENERIC_INTERNAL_ERROR,
+                                            "Malformed ASK redirection from MOVED target for hash key " + key + ": " + retryException.getMessage());
+                                }
+                            }
+                            else if (isRedirectionError(retryException)) {
+                                nextPendingIndices.add(originalIndex);
+                                nextPendingKeys.add(key);
+                            }
+                            else {
+                                throw retryException;
+                            }
+                        }
+                        if (RedisClientManager.isMovedRedirection(jedisDataException)) {
+                            log.info("MOVED redirect for hash key %s, refreshing cluster topology", key);
+                            clientManager.refreshTopology();
+                        }
+                    }
+                    else {
+                        throw jedisDataException;
+                    }
+                }
+                else {
+                    results[originalIndex] = reply;
+                }
+            }
+
+            pendingIndices = nextPendingIndices;
+            pendingKeys = nextPendingKeys;
+        }
+
+        if (!pendingKeys.isEmpty()) {
+            throw new TrinoException(
+                    GENERIC_INTERNAL_ERROR,
+                    "Exhausted " + MAX_REDIRECTION_RETRIES + " retries for cluster redirection(s) on hash keys: " + pendingKeys);
+        }
+
+        return new ArrayList<>(Arrays.asList(results));
+    }
+
+    private List<String> resolveKeysAfterConnectionFailure(
+            List<String> pendingKeys,
+            List<Integer> pendingIndices,
+            Object[] results,
+            KeyFetcher fetcher,
+            List<Integer> nextPendingIndices)
+    {
+        clientManager.refreshTopology();
+        if (split.getClusterKeysOptional().isEmpty()) {
+            throw new TrinoException(
+                    GENERIC_INTERNAL_ERROR,
+                    "Redis cluster primary became unreachable during scan");
+        }
+
+        List<String> nextPendingKeys = new ArrayList<>();
+        for (int i = 0; i < pendingKeys.size(); i++) {
+            String key = pendingKeys.get(i);
+            int originalIndex = pendingIndices.get(i);
+            try {
+                RedisClient primaryClient = clientManager.getClientForKey(key);
+                Object value = fetcher.fetch(primaryClient, key);
+                results[originalIndex] = value;
+            }
+            catch (JedisDataException dataException) {
+                if (isRedirectionError(dataException)) {
+                    nextPendingIndices.add(originalIndex);
+                    nextPendingKeys.add(key);
+                }
+                else {
+                    throw dataException;
+                }
+            }
+            catch (JedisConnectionException e) {
+                nextPendingIndices.add(originalIndex);
+                nextPendingKeys.add(key);
+            }
+        }
+        return nextPendingKeys;
+    }
+
+    @FunctionalInterface
+    private interface KeyFetcher
+    {
+        Object fetch(RedisClient client, String key);
+    }
+
+    private List<Object> fetchHashValuesStandalone(List<String> currentKeys)
+    {
+        try (Pipeline pipeline = client.pipelined()) {
+            for (String key : currentKeys) {
+                pipeline.hgetAll(key);
+            }
+            return pipeline.syncAndReturnAll();
         }
     }
 }

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplit.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplit.java
@@ -20,8 +20,10 @@ import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.predicate.TupleDomain;
+import jakarta.annotation.Nullable;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
@@ -52,6 +54,8 @@ public final class RedisSplit
 
     private final TupleDomain<ColumnHandle> constraint;
 
+    private final Optional<List<String>> clusterKeys;
+
     @JsonCreator
     public RedisSplit(
             @JsonProperty("schemaName") String schemaName,
@@ -62,7 +66,8 @@ public final class RedisSplit
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
             @JsonProperty("start") long start,
             @JsonProperty("end") long end,
-            @JsonProperty("nodes") List<HostAddress> nodes)
+            @JsonProperty("nodes") List<HostAddress> nodes,
+            @Nullable @JsonProperty("clusterKeys") List<String> clusterKeys)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -75,6 +80,9 @@ public final class RedisSplit
         this.end = end;
         this.valueDataType = toRedisDataType(valueDataFormat);
         this.keyDataType = toRedisDataType(keyDataFormat);
+        this.clusterKeys = clusterKeys == null
+                ? Optional.empty()
+                : Optional.of(ImmutableList.copyOf(clusterKeys));
     }
 
     @JsonProperty
@@ -141,6 +149,18 @@ public final class RedisSplit
         return end;
     }
 
+    @JsonProperty
+    @Nullable
+    public List<String> getClusterKeys()
+    {
+        return clusterKeys.orElse(null);
+    }
+
+    public Optional<List<String>> getClusterKeysOptional()
+    {
+        return clusterKeys;
+    }
+
     @Override
     public List<HostAddress> getAddresses()
     {
@@ -157,7 +177,8 @@ public final class RedisSplit
                 + estimatedSizeOf(keyName)
                 + estimatedSizeOf(valueDataFormat)
                 + estimatedSizeOf(nodes, HostAddress::getRetainedSizeInBytes)
-                + constraint.getRetainedSizeInBytes(columnHandle -> ((RedisColumnHandle) columnHandle).getRetainedSizeInBytes());
+                + constraint.getRetainedSizeInBytes(columnHandle -> ((RedisColumnHandle) columnHandle).getRetainedSizeInBytes())
+                + clusterKeys.map(keys -> estimatedSizeOf(keys, key -> estimatedSizeOf(key))).orElse(0L);
     }
 
     public static RedisDataType toRedisDataType(String dataFormat)
@@ -182,6 +203,7 @@ public final class RedisSplit
                 .add("end", end)
                 .add("nodes", nodes)
                 .add("constraint", constraint)
+                .add("clusterKeys", clusterKeys.orElse(null))
                 .toString();
     }
 }

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplitManager.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplitManager.java
@@ -13,10 +13,14 @@
  */
 package io.trino.plugin.redis;
 
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ListMultimap;
 import com.google.inject.Inject;
+import io.airlift.slice.Slice;
 import io.trino.spi.HostAddress;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
@@ -26,13 +30,21 @@ import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.FixedSplitSource;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.Ranges;
+import io.trino.spi.predicate.SortedRangeSet;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkState;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -43,6 +55,7 @@ public class RedisSplitManager
 {
     private final Set<HostAddress> nodes;
     private final RedisClientManager clientManager;
+    private final boolean clusterEnabled;
 
     private static final long REDIS_MAX_SPLITS = 100;
     private static final long REDIS_STRIDE_SPLITS = 100;
@@ -55,6 +68,7 @@ public class RedisSplitManager
         requireNonNull(redisConnectorConfig, "redisConnectorConfig is null");
         this.nodes = ImmutableSet.copyOf(redisConnectorConfig.getNodes());
         this.clientManager = requireNonNull(clientManager, "clientManager is null");
+        this.clusterEnabled = redisConnectorConfig.isClusterEnabled();
     }
 
     @Override
@@ -72,6 +86,66 @@ public class RedisSplitManager
 
         checkState(!nodes.isEmpty(), "No Redis nodes available");
         ImmutableList.Builder<ConnectorSplit> builder = ImmutableList.builder();
+
+        // In cluster mode, discover the slot topology via CLUSTER SLOTS and create
+        // one scan split per primary.  When key predicates are pushed down, route
+        // each key to its slot owner so each key is fetched from the correct primary.
+        if (clusterEnabled) {
+            if (redisTableHandle.keyDataFormat().equals("zset")) {
+                throw new TrinoException(NOT_SUPPORTED,
+                        "ZSET key format is not supported with redis.cluster.enabled=true. "
+                                + "A ZSET key resides on a single cluster node and cannot be split across shards.");
+            }
+
+            // Refresh the topology so we don't create splits for a failed primary.
+            // This is especially important after a failover, when a promoted replica
+            // has taken over the failed primary's slots.
+            clientManager.refreshTopology();
+            RedisClusterTopology topology = clientManager.getClusterTopology();
+
+            // Check for pushed-down key predicates (=, IN) that can be routed by slot
+            List<String> pushdownKeys = extractPushdownKeys(redisTableHandle.constraint());
+            if (!pushdownKeys.isEmpty()) {
+                // Route each key to its slot-owning primary
+                ListMultimap<HostAddress, String> keysByPrimary = ArrayListMultimap.create();
+                for (String key : pushdownKeys) {
+                    HostAddress primary = topology.getPrimaryForKey(key);
+                    keysByPrimary.put(primary, key);
+                }
+                for (HostAddress primary : keysByPrimary.keySet()) {
+                    RedisSplit split = new RedisSplit(
+                            redisTableHandle.schemaName(),
+                            redisTableHandle.tableName(),
+                            redisTableHandle.keyDataFormat(),
+                            redisTableHandle.valueDataFormat(),
+                            redisTableHandle.keyName(),
+                            redisTableHandle.constraint(),
+                            0,
+                            -1,
+                            ImmutableList.of(primary),
+                            keysByPrimary.get(primary));
+                    builder.add(split);
+                }
+            }
+            else {
+                // Full scan: one split per primary, each scans its own shard
+                for (HostAddress primary : topology.getPrimaries()) {
+                    RedisSplit split = new RedisSplit(
+                            redisTableHandle.schemaName(),
+                            redisTableHandle.tableName(),
+                            redisTableHandle.keyDataFormat(),
+                            redisTableHandle.valueDataFormat(),
+                            redisTableHandle.keyName(),
+                            redisTableHandle.constraint(),
+                            0,
+                            -1,
+                            ImmutableList.of(primary),
+                            null);
+                    builder.add(split);
+                }
+            }
+            return new FixedSplitSource(builder.build());
+        }
 
         long numberOfKeys = 1;
         // when Redis keys are provides in a zset, create multiple
@@ -102,10 +176,50 @@ public class RedisSplitManager
                     redisTableHandle.constraint(),
                     startIndex,
                     endIndex,
-                    nodes);
+                    nodes,
+                    null);
 
             builder.add(split);
         }
         return new FixedSplitSource(builder.build());
+    }
+
+    /**
+     * Extracts pushed-down key values from the constraint when they are
+     * equality (=) or IN predicates on the key column.
+     *
+     * @return list of key string values, or empty list if no pushdown is possible
+     */
+    private List<String> extractPushdownKeys(TupleDomain<ColumnHandle> constraint)
+    {
+        if (constraint.isAll()) {
+            return ImmutableList.of();
+        }
+        Map<ColumnHandle, Domain> domains = constraint.getDomains().orElse(null);
+        if (domains == null) {
+            return ImmutableList.of();
+        }
+        for (Map.Entry<ColumnHandle, Domain> entry : domains.entrySet()) {
+            if (!((RedisColumnHandle) entry.getKey()).isKeyDecoder()) {
+                continue;
+            }
+            Domain domain = entry.getValue();
+            if (domain.isSingleValue()) {
+                return ImmutableList.of(((Slice) domain.getSingleValue()).toStringUtf8());
+            }
+            ValueSet valueSet = domain.getValues();
+            if (valueSet instanceof SortedRangeSet sortedRangeSet) {
+                Ranges ranges = sortedRangeSet.getRanges();
+                List<Range> rangeList = ranges.getOrderedRanges();
+                if (rangeList.stream().allMatch(Range::isSingleValue)) {
+                    ImmutableList.Builder<String> keys = ImmutableList.builder();
+                    for (Range range : rangeList) {
+                        keys.add(((Slice) range.getSingleValue()).toStringUtf8());
+                    }
+                    return keys.build();
+                }
+            }
+        }
+        return ImmutableList.of();
     }
 }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
@@ -21,6 +21,7 @@ import io.airlift.log.Logger;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.base.util.Closables;
 import io.trino.plugin.redis.util.CodecSupplier;
+import io.trino.plugin.redis.util.RedisCluster;
 import io.trino.plugin.redis.util.RedisServer;
 import io.trino.plugin.redis.util.RedisTestUtils;
 import io.trino.plugin.tpch.TpchPlugin;
@@ -56,13 +57,20 @@ public final class RedisQueryRunner
         return new Builder(redisServer);
     }
 
+    public static Builder builder(RedisCluster redisCluster)
+    {
+        return new Builder(redisCluster);
+    }
+
     public static class Builder
             extends DistributedQueryRunner.Builder<Builder>
     {
-        private final RedisServer redisServer;
+        private RedisServer redisServer;
+        private RedisCluster redisCluster;
         private final Map<String, String> connectorProperties = new HashMap<>();
         private String dataFormat;
         private List<TpchTable<?>> initialTables = ImmutableList.of();
+        private boolean clusterMode;
 
         private Builder(RedisServer redisServer)
         {
@@ -71,6 +79,15 @@ public final class RedisQueryRunner
                     .setSchema(TPCH_SCHEMA)
                     .build());
             this.redisServer = requireNonNull(redisServer, "redisServer is null");
+        }
+
+        private Builder(RedisCluster redisCluster)
+        {
+            super(testSessionBuilder()
+                    .setCatalog("redis")
+                    .setSchema(TPCH_SCHEMA)
+                    .build());
+            this.redisCluster = requireNonNull(redisCluster, "redisCluster is null");
         }
 
         @CanIgnoreReturnValue
@@ -94,6 +111,13 @@ public final class RedisQueryRunner
             return this;
         }
 
+        @CanIgnoreReturnValue
+        public Builder setClusterMode(boolean clusterMode)
+        {
+            this.clusterMode = clusterMode;
+            return this;
+        }
+
         @Override
         public DistributedQueryRunner build()
                 throws Exception
@@ -105,17 +129,29 @@ public final class RedisQueryRunner
 
                 Map<SchemaTableName, RedisTableDescription> tableDescriptions = createTpchTableDescriptions(queryRunner.getPlannerContext().getTypeManager(), initialTables, dataFormat);
 
-                installRedisPlugin(redisServer, queryRunner, tableDescriptions, connectorProperties);
+                if (redisCluster != null) {
+                    installRedisPlugin(redisCluster, queryRunner, tableDescriptions, connectorProperties);
+                }
+                else {
+                    installRedisPlugin(redisServer, queryRunner, tableDescriptions, connectorProperties);
+                }
 
                 TestingTrinoClient trinoClient = queryRunner.getClient();
 
                 log.info("Loading data...");
                 long startTime = System.nanoTime();
                 for (TpchTable<?> table : initialTables) {
-                    loadTpchTable(redisServer, trinoClient, table, dataFormat);
+                    if (redisCluster != null) {
+                        loadTpchTable(redisCluster, trinoClient, table, dataFormat, clusterMode);
+                    }
+                    else {
+                        loadTpchTable(redisServer, trinoClient, table, dataFormat, clusterMode);
+                    }
                 }
                 log.info("Loading complete in %s", nanosSince(startTime).toString(SECONDS));
-                redisServer.closeClient();
+                if (redisServer != null) {
+                    redisServer.closeClient();
+                }
                 return queryRunner;
             }
             catch (Throwable e) {
@@ -125,7 +161,7 @@ public final class RedisQueryRunner
         }
     }
 
-    private static void loadTpchTable(RedisServer redisServer, TestingTrinoClient trinoClient, TpchTable<?> table, String dataFormat)
+    private static void loadTpchTable(RedisServer redisServer, TestingTrinoClient trinoClient, TpchTable<?> table, String dataFormat, boolean clusterMode)
     {
         long start = System.nanoTime();
         log.info("Running import for %s", table.getTableName());
@@ -134,7 +170,22 @@ public final class RedisQueryRunner
                 trinoClient,
                 redisTableName(table),
                 new QualifiedObjectName("tpch", TINY_SCHEMA_NAME, table.getTableName().toLowerCase(ENGLISH)),
-                dataFormat);
+                dataFormat,
+                clusterMode);
+        log.info("Imported %s in %s", table.getTableName(), nanosSince(start).convertToMostSuccinctTimeUnit());
+    }
+
+    private static void loadTpchTable(RedisCluster redisCluster, TestingTrinoClient trinoClient, TpchTable<?> table, String dataFormat, boolean clusterMode)
+    {
+        long start = System.nanoTime();
+        log.info("Running import for %s", table.getTableName());
+        RedisTestUtils.loadTpchTable(
+                redisCluster,
+                trinoClient,
+                redisTableName(table),
+                new QualifiedObjectName("tpch", TINY_SCHEMA_NAME, table.getTableName().toLowerCase(ENGLISH)),
+                dataFormat,
+                clusterMode);
         log.info("Imported %s in %s", table.getTableName(), nanosSince(start).convertToMostSuccinctTimeUnit());
     }
 

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterAuth.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterAuth.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redis;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.redis.util.RedisCluster;
+import io.trino.plugin.redis.util.RedisServer;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.tpch.TpchTable.NATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests Redis Cluster mode with password authentication.  Verifies that
+ * topology discovery, slot routing, and query execution all work when
+ * the Redis cluster requires a password.
+ */
+final class TestRedisClusterAuth
+        extends AbstractTestQueryFramework
+{
+    private RedisCluster redisCluster;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        redisCluster = closeAfterClass(new RedisCluster(3, 7000, 0, false, true));
+        return RedisQueryRunner.builder(redisCluster)
+                .addConnectorProperties(ImmutableMap.of(
+                        "redis.cluster.enabled", "true",
+                        "redis.password", RedisServer.PASSWORD))
+                .setDataFormat("string")
+                .setClusterMode(true)
+                .setInitialTables(ImmutableList.of(NATION))
+                .build();
+    }
+
+    @Test
+    void testAuthClusterFullScan()
+    {
+        assertThat(query("SELECT count(*) FROM nation")).matches("VALUES BIGINT '25'");
+    }
+
+    @Test
+    void testAuthClusterPredicateRouting()
+    {
+        assertThat(query("SELECT name FROM nation WHERE nationkey = 0")).matches("VALUES CAST('ALGERIA' AS VARCHAR(25))");
+        assertThat(query("SELECT name FROM nation WHERE nationkey = 24")).matches("VALUES CAST('UNITED STATES' AS VARCHAR(25))");
+    }
+}

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterConcurrentResharding.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterConcurrentResharding.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redis;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.redis.util.RedisCluster;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.tpch.TpchTable.NATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that a Trino query returns correct results when a Redis Cluster slot
+ * is migrated while the query is in flight.  This exercises the connector's
+ * MOVED/ASK redirect handling under real concurrent topology change.
+ */
+final class TestRedisClusterConcurrentResharding
+        extends AbstractTestQueryFramework
+{
+    private RedisCluster redisCluster;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        redisCluster = closeAfterClass(new RedisCluster());
+        return RedisQueryRunner.builder(redisCluster)
+                .addConnectorProperties(ImmutableMap.of("redis.cluster.enabled", "true"))
+                .setDataFormat("string")
+                .setClusterMode(true)
+                .setInitialTables(ImmutableList.of(NATION))
+                .build();
+    }
+
+    @Test
+    void testQueryDuringResharding()
+            throws Exception
+    {
+        String key = "tpch:nation:0";
+        int sourceIndex = redisCluster.getPrimaryIndexForSlot(redisCluster.getKeySlot(key));
+        int targetIndex = (sourceIndex + 1) % 3;
+
+        // Start a full scan in a background thread
+        CompletableFuture<Long> queryFuture = CompletableFuture.supplyAsync(() ->
+                (Long) computeActual("SELECT count(*) FROM nation").getMaterializedRows().get(0).getField(0));
+
+        // Give the query a moment to start, then migrate the slot
+        Thread.sleep(100);
+        redisCluster.migrateSlot(redisCluster.getKeySlot(key), targetIndex);
+
+        // The query should complete successfully despite the concurrent migration.
+        // SCAN is not a consistent snapshot, so during slot migration a key may
+        // be transiently missed (24 instead of 25).  This is expected Redis behavior.
+        Long count = queryFuture.get(60, TimeUnit.SECONDS);
+        assertThat(count).isBetween(24L, 25L);
+
+        // After migration completes, a fresh query must return the full count.
+        Long postMigrationCount = (Long) computeActual("SELECT count(*) FROM nation")
+                .getMaterializedRows().get(0).getField(0);
+        assertThat(postMigrationCount).isEqualTo(25L);
+    }
+
+    @Test
+    void testPredicateQueryDuringResharding()
+            throws Exception
+    {
+        String key = "tpch:nation:0";
+        int sourceIndex = redisCluster.getPrimaryIndexForSlot(redisCluster.getKeySlot(key));
+        int targetIndex = (sourceIndex + 1) % 3;
+
+        // Start a predicate query in a background thread
+        CompletableFuture<String> queryFuture = CompletableFuture.supplyAsync(() ->
+                (String) computeActual("SELECT name FROM nation WHERE nationkey = 0").getMaterializedRows().get(0).getField(0));
+
+        // Give the query a moment to start, then migrate the slot
+        Thread.sleep(100);
+        redisCluster.migrateSlot(redisCluster.getKeySlot(key), targetIndex);
+
+        // The query should complete successfully despite the concurrent migration
+        String name = queryFuture.get(60, TimeUnit.SECONDS);
+        assertThat(name).isEqualTo("ALGERIA");
+    }
+}

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterConnectorSmokeTest.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterConnectorSmokeTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redis;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.redis.util.RedisCluster;
+import io.trino.testing.BaseConnectorSmokeTest;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+
+final class TestRedisClusterConnectorSmokeTest
+        extends BaseConnectorSmokeTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        RedisCluster redisCluster = closeAfterClass(new RedisCluster());
+        return RedisQueryRunner.builder(redisCluster)
+                .addConnectorProperties(ImmutableMap.of("redis.cluster.enabled", "true"))
+                .setDataFormat("string")
+                .setClusterMode(true)
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
+    }
+
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return switch (connectorBehavior) {
+            case SUPPORTS_CREATE_MATERIALIZED_VIEW,
+                 SUPPORTS_CREATE_SCHEMA,
+                 SUPPORTS_CREATE_TABLE,
+                 SUPPORTS_CREATE_VIEW,
+                 SUPPORTS_DELETE,
+                 SUPPORTS_INSERT,
+                 SUPPORTS_MERGE,
+                 SUPPORTS_RENAME_TABLE,
+                 SUPPORTS_UPDATE -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
+}

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterFailover.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterFailover.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redis;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.redis.util.RedisCluster;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.tpch.TpchTable.NATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests Redis Cluster failover by killing a primary and verifying the connector
+ * discovers the promoted replica and still returns the correct data.
+ */
+final class TestRedisClusterFailover
+        extends AbstractTestQueryFramework
+{
+    private RedisCluster redisCluster;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        // 3 primaries with 1 replica each
+        redisCluster = closeAfterClass(new RedisCluster(3, 7000, 3));
+        return RedisQueryRunner.builder(redisCluster)
+                .addConnectorProperties(ImmutableMap.of("redis.cluster.enabled", "true"))
+                .setDataFormat("string")
+                .setClusterMode(true)
+                .setInitialTables(ImmutableList.of(NATION))
+                .build();
+    }
+
+    @Test
+    void testFailover()
+    {
+        String key = "tpch:nation:0";
+        String query = "SELECT name FROM nation WHERE nationkey = 0";
+
+        // Baseline query to populate the connector's topology cache
+        assertThat(query(query)).matches("VALUES CAST('ALGERIA' AS VARCHAR(25))");
+
+        int sourceIndex = redisCluster.getPrimaryIndexForSlot(redisCluster.getKeySlot(key));
+
+        // Kill the primary that owns the key and wait for the replica to take over
+        redisCluster.killPrimaryAndWaitForFailover(sourceIndex);
+
+        // The connector must refresh topology and still return the value
+        assertThat(query(query)).matches("VALUES CAST('ALGERIA' AS VARCHAR(25))");
+    }
+}

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterNodeDiscovery.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterNodeDiscovery.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redis;
+
+import io.trino.spi.HostAddress;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static io.trino.plugin.redis.RedisClusterTopology.parseClusterSlots;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestRedisClusterNodeDiscovery
+{
+    @Test
+    void testParseClusterSlotsThreeMasters()
+    {
+        // Simulates CLUSTER SLOTS RESP response for a 3-master cluster:
+        // [startSlot, endSlot, [ip, port, id], [replicaIp, replicaPort, replicaId], ...]
+        List<Object> response = List.of(
+                List.of(0L, 5460L, List.of("127.0.0.1".getBytes(StandardCharsets.UTF_8), 30001L, "master-id-1".getBytes(StandardCharsets.UTF_8)), List.of("127.0.0.1".getBytes(StandardCharsets.UTF_8), 30004L, "replica-id-1".getBytes(StandardCharsets.UTF_8))),
+                List.of(5461L, 10922L, List.of("127.0.0.1".getBytes(StandardCharsets.UTF_8), 30002L, "master-id-2".getBytes(StandardCharsets.UTF_8)), List.of("127.0.0.1".getBytes(StandardCharsets.UTF_8), 30005L, "replica-id-2".getBytes(StandardCharsets.UTF_8))),
+                List.of(10923L, 16383L, List.of("127.0.0.1".getBytes(StandardCharsets.UTF_8), 30003L, "master-id-3".getBytes(StandardCharsets.UTF_8)), List.of("127.0.0.1".getBytes(StandardCharsets.UTF_8), 30006L, "replica-id-3".getBytes(StandardCharsets.UTF_8))));
+
+        RedisClusterTopology topology = parseClusterSlots(response);
+
+        assertThat(topology.isComplete()).isTrue();
+        assertThat(topology.getPrimaries()).containsExactlyInAnyOrder(
+                HostAddress.fromParts("127.0.0.1", 30001),
+                HostAddress.fromParts("127.0.0.1", 30002),
+                HostAddress.fromParts("127.0.0.1", 30003));
+    }
+
+    @Test
+    void testSlotRouting()
+    {
+        List<Object> response = List.of(
+                List.of(0L, 5460L, List.of("127.0.0.1".getBytes(StandardCharsets.UTF_8), 30001L, "id-1".getBytes(StandardCharsets.UTF_8))),
+                List.of(5461L, 10922L, List.of("127.0.0.1".getBytes(StandardCharsets.UTF_8), 30002L, "id-2".getBytes(StandardCharsets.UTF_8))),
+                List.of(10923L, 16383L, List.of("127.0.0.1".getBytes(StandardCharsets.UTF_8), 30003L, "id-3".getBytes(StandardCharsets.UTF_8))));
+
+        RedisClusterTopology topology = parseClusterSlots(response);
+
+        // Slot 0 should route to primary at 30001
+        assertThat(topology.getPrimaryForSlot(0)).isEqualTo(HostAddress.fromParts("127.0.0.1", 30001));
+        // Slot 5461 should route to primary at 30002
+        assertThat(topology.getPrimaryForSlot(5461)).isEqualTo(HostAddress.fromParts("127.0.0.1", 30002));
+        // Slot 10923 should route to primary at 30003
+        assertThat(topology.getPrimaryForSlot(10923)).isEqualTo(HostAddress.fromParts("127.0.0.1", 30003));
+    }
+
+    @Test
+    void testIncompleteTopology()
+    {
+        // Only covers slots 0-8191, missing 8192-16383
+        List<Object> response = List.of(
+                List.of(0L, 8191L, List.of("127.0.0.1".getBytes(StandardCharsets.UTF_8), 30001L, "id-1".getBytes(StandardCharsets.UTF_8))));
+
+        RedisClusterTopology topology = parseClusterSlots(response);
+
+        assertThat(topology.isComplete()).isFalse();
+        assertThat(topology.getPrimaries()).containsExactly(HostAddress.fromParts("127.0.0.1", 30001));
+        // Accessing an unassigned slot should fail
+        assertThatThrownBy(() -> topology.getPrimaryForSlot(8192))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no primary assigned for slot");
+    }
+
+    @Test
+    void testEmptyResponse()
+    {
+        List<Object> response = List.of();
+
+        RedisClusterTopology topology = parseClusterSlots(response);
+
+        assertThat(topology.isComplete()).isFalse();
+        assertThat(topology.getPrimaries()).isEmpty();
+    }
+
+    @Test
+    void testSinglePrimaryOwnsAllSlots()
+    {
+        List<Object> response = List.of(
+                List.of(0L, 16383L, List.of("127.0.0.1".getBytes(StandardCharsets.UTF_8), 6379L, "single-master".getBytes(StandardCharsets.UTF_8))));
+
+        RedisClusterTopology topology = parseClusterSlots(response);
+
+        assertThat(topology.isComplete()).isTrue();
+        assertThat(topology.getPrimaries()).containsExactly(HostAddress.fromParts("127.0.0.1", 6379));
+        // Every slot should route to the single primary
+        for (int slot = 0; slot < RedisClusterTopology.TOTAL_SLOTS; slot += 1000) {
+            assertThat(topology.getPrimaryForSlot(slot)).isEqualTo(HostAddress.fromParts("127.0.0.1", 6379));
+        }
+    }
+}

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterRedirectRetry.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterRedirectRetry.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redis;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.redis.util.RedisCluster;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.tpch.TpchTable.NATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that Trino's Redis connector correctly retries on MOVED and ASK redirects
+ * while a slot is migrating between primaries.
+ */
+final class TestRedisClusterRedirectRetry
+        extends AbstractTestQueryFramework
+{
+    private RedisCluster redisCluster;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        redisCluster = closeAfterClass(new RedisCluster());
+        return RedisQueryRunner.builder(redisCluster)
+                .addConnectorProperties(ImmutableMap.of("redis.cluster.enabled", "true"))
+                .setDataFormat("string")
+                .setClusterMode(true)
+                .setInitialTables(ImmutableList.of(NATION))
+                .build();
+    }
+
+    @Test
+    void testMovedRetry()
+    {
+        String key = "tpch:nation:0";
+        String query = "SELECT name FROM nation WHERE nationkey = 0";
+
+        // Baseline query to populate the connector's topology cache
+        assertThat(query(query)).matches("VALUES CAST('ALGERIA' AS VARCHAR(25))");
+
+        int sourceIndex = redisCluster.getPrimaryIndexForSlot(redisCluster.getKeySlot(key));
+        int targetIndex = (sourceIndex + 1) % 3;
+
+        // Move the slot and the key to another primary; cluster will return MOVED
+        redisCluster.migrateSlotAndKey(key, sourceIndex, targetIndex);
+
+        // The connector must follow the MOVED redirect and still return the value
+        assertThat(query(query)).matches("VALUES CAST('ALGERIA' AS VARCHAR(25))");
+    }
+
+    @Test
+    void testAskRetry()
+    {
+        String key = "tpch:nation:0";
+        String query = "SELECT name FROM nation WHERE nationkey = 0";
+
+        // Baseline query to populate the connector's topology cache
+        assertThat(query(query)).matches("VALUES CAST('ALGERIA' AS VARCHAR(25))");
+
+        int sourceIndex = redisCluster.getPrimaryIndexForSlot(redisCluster.getKeySlot(key));
+        int targetIndex = (sourceIndex + 2) % 3;
+
+        // Put the slot into MIGRATING/IMPORTING state and move the key without
+        // finalizing ownership. The source primary returns ASK to the target.
+        redisCluster.prepareAskingSlot(key, sourceIndex, targetIndex);
+
+        // The connector must send ASKING to the target and still return the value
+        assertThat(query(query)).matches("VALUES CAST('ALGERIA' AS VARCHAR(25))");
+
+        // Restore a stable slot owner so the shared cluster is not left mid-migration
+        redisCluster.finalizeSlotMigration(key, targetIndex);
+    }
+}

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterResharding.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterResharding.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redis;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.redis.util.RedisCluster;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.tpch.TpchTable.NATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that Trino's Redis connector returns complete results after a slot is
+ * migrated from one primary to another (resharding).
+ */
+final class TestRedisClusterResharding
+        extends AbstractTestQueryFramework
+{
+    private RedisCluster redisCluster;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        redisCluster = closeAfterClass(new RedisCluster());
+        return RedisQueryRunner.builder(redisCluster)
+                .addConnectorProperties(ImmutableMap.of("redis.cluster.enabled", "true"))
+                .setDataFormat("string")
+                .setClusterMode(true)
+                .setInitialTables(ImmutableList.of(NATION))
+                .build();
+    }
+
+    @Test
+    void testFullScanAfterResharding()
+    {
+        String key = "tpch:nation:0";
+        String query = "SELECT count(*) FROM nation";
+
+        // Baseline count
+        assertThat(query(query)).matches("VALUES BIGINT '25'");
+
+        int sourceIndex = redisCluster.getPrimaryIndexForSlot(redisCluster.getKeySlot(key));
+        int targetIndex = (sourceIndex + 1) % 3;
+
+        // Migrate the whole slot (and every key in it) to another primary
+        redisCluster.migrateSlot(redisCluster.getKeySlot(key), targetIndex);
+
+        // Full scan must still return all 25 rows without data loss
+        assertThat(query(query)).matches("VALUES BIGINT '25'");
+    }
+}

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterRouting.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterRouting.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redis;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.redis.util.RedisCluster;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.tpch.TpchTable.getTables;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests Redis Cluster routing with a real multi-primary cluster (3 primaries).
+ * Verifies cross-shard scans, predicate routing, and data completeness.
+ */
+final class TestRedisClusterRouting
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        RedisCluster redisCluster = closeAfterClass(new RedisCluster());
+        return RedisQueryRunner.builder(redisCluster)
+                .addConnectorProperties(ImmutableMap.of("redis.cluster.enabled", "true"))
+                .setDataFormat("string")
+                .setClusterMode(true)
+                .setInitialTables(getTables())
+                .build();
+    }
+
+    /**
+     * Verifies that a full scan across all shards returns the complete expected row count.
+     * With 3 primaries and slots divided evenly, keys are distributed across all shards.
+     */
+    @Test
+    void testFullScanAcrossShards()
+    {
+        // nation has 25 rows, region has 5 rows — all should be returned regardless of shard distribution
+        assertThat(query("SELECT count(*) FROM nation")).matches("VALUES BIGINT '25'");
+        assertThat(query("SELECT count(*) FROM region")).matches("VALUES BIGINT '5'");
+    }
+
+    /**
+     * Verifies that predicate pushdown with equality (=) routes to the correct shard.
+     */
+    @Test
+    void testEqualityPredicateRouting()
+    {
+        // Query a specific nation by key — should route to the owning primary
+        assertThat(query("SELECT nationkey FROM nation WHERE nationkey = 0")).matches("VALUES BIGINT '0'");
+        assertThat(query("SELECT nationkey FROM nation WHERE nationkey = 15")).matches("VALUES BIGINT '15'");
+        assertThat(query("SELECT nationkey FROM nation WHERE nationkey = 24")).matches("VALUES BIGINT '24'");
+    }
+
+    /**
+     * Verifies that IN predicates with keys on different shards are routed correctly.
+     */
+    @Test
+    void testInPredicateRoutingAcrossShards()
+    {
+        // Keys 0, 10, 20 are likely on different shards — all should be returned
+        assertThat(query("SELECT count(*) FROM nation WHERE nationkey IN (0, 5, 10, 15, 20)"))
+                .matches("VALUES BIGINT '5'");
+    }
+
+    /**
+     * Verifies that data values are correct across shards (not just counts).
+     */
+    @Test
+    void testValuesAcrossShards()
+    {
+        assertThat(query("SELECT name FROM nation WHERE nationkey = 0")).matches("VALUES CAST('ALGERIA' AS VARCHAR(25))");
+        assertThat(query("SELECT name FROM nation WHERE nationkey = 1")).matches("VALUES CAST('ARGENTINA' AS VARCHAR(25))");
+        assertThat(query("SELECT name FROM nation WHERE nationkey = 24")).matches("VALUES CAST('UNITED STATES' AS VARCHAR(25))");
+    }
+
+    /**
+     * Verifies that a join across cluster-scanned tables works correctly.
+     */
+    @Test
+    void testJoinAcrossShards()
+    {
+        assertThat(query(
+                "SELECT n.name, r.name FROM nation n JOIN region r ON n.regionkey = r.regionkey WHERE n.nationkey = 0"))
+                .matches("VALUES (CAST('ALGERIA' AS VARCHAR(25)), CAST('AFRICA' AS VARCHAR(25)))");
+    }
+}

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterSeedResilience.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterSeedResilience.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redis;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.plugin.redis.util.RedisCluster;
+import io.trino.spi.HostAddress;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.DefaultJedisClientConfig;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestRedisClusterSeedResilience
+{
+    @Test
+    void testDiscoveryWithFirstDeadSeed()
+    {
+        try (RedisCluster redisCluster = new RedisCluster()) {
+            Set<HostAddress> seeds = new LinkedHashSet<>();
+            // First seed is unavailable
+            seeds.add(HostAddress.fromParts("127.0.0.1", 1));
+            // Remaining seeds are the real cluster primaries
+            Set<HostAddress> expected = ImmutableSet.copyOf(
+                    redisCluster.getSeedAddresses().stream()
+                            .map(seed -> HostAddress.fromParts(seed.getHost(), seed.getPort()))
+                            .toList());
+            seeds.addAll(expected);
+
+            RedisClusterTopology topology = RedisClusterTopology.discover(
+                    seeds,
+                    DefaultJedisClientConfig.builder().build());
+
+            assertThat(topology.isComplete()).isTrue();
+            assertThat(topology.getPrimaries()).containsExactlyInAnyOrderElementsOf(expected);
+        }
+    }
+}

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterTls.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisClusterTls.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redis;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.redis.util.RedisCluster;
+import io.trino.plugin.redis.util.RedisServer;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.tpch.TpchTable.NATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests Redis Cluster mode with TLS encryption.  Verifies that topology
+ * discovery, slot routing, and query execution all work over TLS.
+ */
+final class TestRedisClusterTls
+        extends AbstractTestQueryFramework
+{
+    private RedisCluster redisCluster;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        redisCluster = closeAfterClass(new RedisCluster(3, 7000, 0, true, false));
+        return RedisQueryRunner.builder(redisCluster)
+                .addConnectorProperties(ImmutableMap.of(
+                        "redis.cluster.enabled", "true",
+                        "redis.tls.enabled", "true",
+                        "redis.tls.keystore-path", RedisServer.getKeystorePath(),
+                        "redis.tls.keystore-password", RedisServer.TLS_STORE_PASSWORD,
+                        "redis.tls.truststore-path", RedisServer.getTruststorePath(),
+                        "redis.tls.truststore-password", RedisServer.TLS_STORE_PASSWORD))
+                .setDataFormat("string")
+                .setClusterMode(true)
+                .setInitialTables(ImmutableList.of(NATION))
+                .build();
+    }
+
+    @Test
+    void testTlsClusterFullScan()
+    {
+        assertThat(query("SELECT count(*) FROM nation")).matches("VALUES BIGINT '25'");
+    }
+
+    @Test
+    void testTlsClusterPredicateRouting()
+    {
+        assertThat(query("SELECT name FROM nation WHERE nationkey = 0")).matches("VALUES CAST('ALGERIA' AS VARCHAR(25))");
+        assertThat(query("SELECT name FROM nation WHERE nationkey = 24")).matches("VALUES CAST('UNITED STATES' AS VARCHAR(25))");
+    }
+}

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorConfig.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorConfig.java
@@ -27,6 +27,8 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDe
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestRedisConnectorConfig
 {
@@ -48,7 +50,8 @@ public class TestRedisConnectorConfig
                 .setRedisScanCount(100)
                 .setRedisMaxKeysPerFetch(100)
                 .setHideInternalColumns(true)
-                .setTlsEnabled(false));
+                .setTlsEnabled(false)
+                .setClusterEnabled(false));
     }
 
     @Test
@@ -70,6 +73,7 @@ public class TestRedisConnectorConfig
                 .put("redis.user", "test")
                 .put("redis.password", "secret")
                 .put("redis.tls.enabled", "true")
+                .put("redis.cluster.enabled", "true")
                 .buildOrThrow();
 
         RedisConnectorConfig expected = new RedisConnectorConfig()
@@ -87,8 +91,46 @@ public class TestRedisConnectorConfig
                 .setRedisPassword("secret")
                 .setRedisKeyDelimiter(",")
                 .setKeyPrefixSchemaTable(true)
-                .setTlsEnabled(true);
+                .setTlsEnabled(true)
+                .setClusterEnabled(true);
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testClusterModeAllowsDefaultDatabaseIndex()
+    {
+        assertThatCode(() -> new RedisClientManager(
+                new RedisConnectorConfig()
+                        .setNodes(ImmutableList.of("localhost:6379"))
+                        .setClusterEnabled(true)
+                        .setRedisDataBaseIndex(0),
+                ImmutableSet.of()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void testClusterModeRejectsNonZeroDatabaseIndex()
+    {
+        assertThatThrownBy(() -> new RedisClientManager(
+                new RedisConnectorConfig()
+                        .setNodes(ImmutableList.of("localhost:6379"))
+                        .setClusterEnabled(true)
+                        .setRedisDataBaseIndex(1),
+                ImmutableSet.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("redis.database-index must be 0 when redis.cluster.enabled is true");
+    }
+
+    @Test
+    public void testStandaloneModeAllowsNonZeroDatabaseIndex()
+    {
+        assertThatCode(() -> new RedisClientManager(
+                new RedisConnectorConfig()
+                        .setNodes(ImmutableList.of("localhost:6379"))
+                        .setClusterEnabled(false)
+                        .setRedisDataBaseIndex(5),
+                ImmutableSet.of()))
+                .doesNotThrowAnyException();
     }
 }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisCluster.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisCluster.java
@@ -1,0 +1,807 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redis.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.log.Logger;
+import io.trino.plugin.redis.RedisClusterTopology;
+import org.testcontainers.containers.GenericContainer;
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.RedisClusterClient;
+import redis.clients.jedis.SslOptions;
+import redis.clients.jedis.util.SafeEncoder;
+
+import java.io.Closeable;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+
+import static com.google.common.base.Preconditions.checkState;
+import static org.testcontainers.utility.MountableFile.forClasspathResource;
+
+/**
+ * Manages a real multi-primary Redis Cluster using a single Docker container
+ * running multiple Redis instances on different ports.
+ * <p>
+ * Starts {@code numPrimaries} Redis instances with cluster mode enabled within
+ * one container, forms them into a cluster by distributing hash slots evenly,
+ * and provides seed addresses and a {@link RedisClusterClient} for cluster-aware
+ * data loading.
+ * <p>
+ * Using a single container avoids cross-container networking issues: all Redis
+ * instances share the same network namespace and can reach each other via
+ * {@code 127.0.0.1}. Fixed port bindings (7000, 7001, ...) make the advertised
+ * addresses reachable from the test JVM as well.
+ */
+public class RedisCluster
+        implements Closeable
+{
+    private static final Logger log = Logger.get(RedisCluster.class);
+
+    private static final int DEFAULT_NUM_PRIMARIES = 3;
+    private static final int DEFAULT_NUM_REPLICAS = 0;
+    private static final int DEFAULT_BASE_PORT = 7000;
+    private static final int CLUSTER_TIMEOUT_MILLIS = 5000;
+    private static final String CONTAINER_CERTS_DIR = "/etc/redis/certs/";
+
+    // RedisCluster uses fixed host port bindings, so only one cluster can be active at a time.
+    private static final Semaphore CLUSTER_SEMAPHORE = new Semaphore(1);
+
+    private GenericContainer<?> container;
+    private final List<RedisClient> clients;
+    private final List<RedisClient> replicaClients;
+    private final List<HostAndPort> jedisSeedAddresses;
+    private final List<com.google.common.net.HostAndPort> seedAddresses;
+    private RedisClusterClient redisClusterClient;
+    private final boolean tls;
+    private final boolean auth;
+
+    public RedisCluster()
+    {
+        this(DEFAULT_NUM_PRIMARIES, DEFAULT_BASE_PORT, DEFAULT_NUM_REPLICAS, false, false);
+    }
+
+    public RedisCluster(int numPrimaries, int basePort)
+    {
+        this(numPrimaries, basePort, DEFAULT_NUM_REPLICAS, false, false);
+    }
+
+    public RedisCluster(int numPrimaries, int basePort, int numReplicas)
+    {
+        this(numPrimaries, basePort, numReplicas, false, false);
+    }
+
+    public RedisCluster(int numPrimaries, int basePort, int numReplicas, boolean tls, boolean auth)
+    {
+        this.tls = tls;
+        this.auth = auth;
+        clients = new ArrayList<>(numPrimaries);
+        replicaClients = new ArrayList<>(numReplicas);
+        jedisSeedAddresses = new ArrayList<>(numPrimaries);
+        seedAddresses = new ArrayList<>(numPrimaries);
+
+        // RedisCluster binds fixed host ports; serialize so concurrent tests do not conflict.
+        CLUSTER_SEMAPHORE.acquireUninterruptibly();
+        boolean acquired = true;
+
+        try {
+            startCluster(numPrimaries, basePort, numReplicas);
+            acquired = false;
+        }
+        finally {
+            if (acquired) {
+                CLUSTER_SEMAPHORE.release();
+            }
+        }
+    }
+
+    private void startCluster(int numPrimaries, int basePort, int numReplicas)
+    {
+        // Build the command to start all Redis instances in a single container.
+        // Each instance gets its own data directory to avoid AOF/cluster-config file conflicts.
+        List<Integer> primaryPorts = new ArrayList<>(numPrimaries);
+        for (int i = 0; i < numPrimaries; i++) {
+            primaryPorts.add(basePort + i);
+        }
+
+        List<Integer> replicaPorts = new ArrayList<>(numReplicas);
+        for (int i = 0; i < numReplicas; i++) {
+            replicaPorts.add(basePort + numPrimaries + i);
+        }
+
+        List<Integer> allPorts = new ArrayList<>(primaryPorts);
+        allPorts.addAll(replicaPorts);
+
+        StringBuilder command = new StringBuilder();
+        command.append("mkdir -p");
+        for (int i = 0; i < allPorts.size(); i++) {
+            command.append(" /data/").append(i);
+        }
+        command.append("; ");
+
+        for (int i = 0; i < allPorts.size(); i++) {
+            int port = allPorts.get(i);
+            command.append("redis-server");
+            if (tls) {
+                // Use a plaintext port for internal cluster bus communication and
+                // a separate TLS port for client connections.  --cluster-announce-port
+                // makes CLUSTER SLOTS return the TLS port so clients connect via TLS.
+                command.append(" --port ").append(port)
+                        .append(" --tls-port ").append(port + 1000)
+                        .append(" --cluster-announce-port ").append(port + 1000)
+                        .append(" --cluster-announce-bus-port ").append(port + 10000)
+                        .append(" --tls-cert-file ").append(CONTAINER_CERTS_DIR).append("redis.crt")
+                        .append(" --tls-key-file ").append(CONTAINER_CERTS_DIR).append("redis.key")
+                        .append(" --tls-ca-cert-file ").append(CONTAINER_CERTS_DIR).append("ca.crt");
+            }
+            else {
+                command.append(" --port ").append(port);
+            }
+            command.append(" --cluster-enabled yes")
+                    .append(" --cluster-config-file nodes.conf")
+                    .append(" --cluster-node-timeout ").append(CLUSTER_TIMEOUT_MILLIS)
+                    .append(" --dir /data/").append(i)
+                    .append(" --appendonly no");
+            if (auth) {
+                command.append(" --requirepass ").append(RedisServer.PASSWORD);
+                command.append(" --masterauth ").append(RedisServer.PASSWORD);
+            }
+            command.append(" & ");
+        }
+        command.append("wait");
+
+        // Expose client ports (TLS ports for TLS mode, plain ports otherwise) with fixed bindings
+        // so cluster-announce-port is reachable from the test JVM.
+        List<Integer> clientPorts = new ArrayList<>(allPorts.size());
+        for (int port : allPorts) {
+            clientPorts.add(tls ? port + 1000 : port);
+        }
+        ImmutableList.Builder<String> portBindings = ImmutableList.builder();
+        for (int clientPort : clientPorts) {
+            portBindings.add(clientPort + ":" + clientPort);
+        }
+
+        container = new GenericContainer<>("redis:" + RedisServer.LATEST_VERSION)
+                .withExposedPorts(clientPorts.toArray(new Integer[0]))
+                .withCommand("/bin/sh", "-c", command.toString());
+        if (tls) {
+            container.withCopyFileToContainer(forClasspathResource("tls/ca.crt", 0644), CONTAINER_CERTS_DIR + "ca.crt")
+                    .withCopyFileToContainer(forClasspathResource("tls/redis.crt", 0644), CONTAINER_CERTS_DIR + "redis.crt")
+                    .withCopyFileToContainer(forClasspathResource("tls/redis.key", 0644), CONTAINER_CERTS_DIR + "redis.key");
+        }
+        container.setPortBindings(portBindings.build());
+        container.start();
+
+        // Create clients for each Redis instance and set cluster-announce-ip/port
+        String announceIp = "127.0.0.1";
+        for (int i = 0; i < numPrimaries; i++) {
+            int port = primaryPorts.get(i);
+            int clientPort = tls ? port + 1000 : port;
+            RedisClient client = RedisClient.builder()
+                    .hostAndPort(announceIp, clientPort)
+                    .clientConfig(buildClientConfig())
+                    .build();
+            try (Connection connection = client.getPool().getResource()) {
+                connection.sendCommand(Protocol.Command.CONFIG, "SET", "cluster-announce-ip", announceIp);
+                connection.getStatusCodeReply();
+                connection.sendCommand(Protocol.Command.CONFIG, "SET", "cluster-announce-port", Integer.toString(clientPort));
+                connection.getStatusCodeReply();
+                connection.sendCommand(Protocol.Command.CONFIG, "SET", "cluster-announce-bus-port", Integer.toString(port + 10000));
+                connection.getStatusCodeReply();
+            }
+            clients.add(client);
+            jedisSeedAddresses.add(new HostAndPort(announceIp, clientPort));
+            seedAddresses.add(com.google.common.net.HostAndPort.fromParts(announceIp, clientPort));
+        }
+
+        for (int i = 0; i < numReplicas; i++) {
+            int port = replicaPorts.get(i);
+            int clientPort = tls ? port + 1000 : port;
+            RedisClient client = RedisClient.builder()
+                    .hostAndPort(announceIp, clientPort)
+                    .clientConfig(buildClientConfig())
+                    .build();
+            try (Connection connection = client.getPool().getResource()) {
+                connection.sendCommand(Protocol.Command.CONFIG, "SET", "cluster-announce-ip", announceIp);
+                connection.getStatusCodeReply();
+                connection.sendCommand(Protocol.Command.CONFIG, "SET", "cluster-announce-port", Integer.toString(clientPort));
+                connection.getStatusCodeReply();
+                connection.sendCommand(Protocol.Command.CONFIG, "SET", "cluster-announce-bus-port", Integer.toString(port + 10000));
+                connection.getStatusCodeReply();
+            }
+            replicaClients.add(client);
+        }
+
+        // Form the cluster: MEET all nodes, distribute slots, and attach replicas
+        formCluster(primaryPorts, replicaPorts);
+
+        // Create RedisClusterClient for cluster-aware data loading
+        redisClusterClient = RedisClusterClient.builder()
+                .nodes(ImmutableSet.copyOf(jedisSeedAddresses))
+                .clientConfig(buildClientConfig())
+                .build();
+    }
+
+    private void formCluster(List<Integer> primaryPorts, List<Integer> replicaPorts)
+    {
+        int numPrimaries = primaryPorts.size();
+
+        // Meet all primary nodes from the first primary
+        RedisClient firstClient = clients.get(0);
+        for (int i = 1; i < numPrimaries; i++) {
+            try (Connection connection = firstClient.getPool().getResource()) {
+                connection.sendCommand(Protocol.Command.CLUSTER, "MEET", "127.0.0.1", Integer.toString(primaryPorts.get(i)));
+                connection.getStatusCodeReply();
+            }
+        }
+
+        // Meet replica nodes from the first primary so they join the cluster
+        for (int port : replicaPorts) {
+            try (Connection connection = firstClient.getPool().getResource()) {
+                connection.sendCommand(Protocol.Command.CLUSTER, "MEET", "127.0.0.1", Integer.toString(port));
+                connection.getStatusCodeReply();
+            }
+        }
+
+        // Distribute slots evenly across primaries
+        int slotsPerNode = RedisClusterTopology.TOTAL_SLOTS / numPrimaries;
+        int remainder = RedisClusterTopology.TOTAL_SLOTS % numPrimaries;
+        int currentSlot = 0;
+        for (int i = 0; i < numPrimaries; i++) {
+            int slotsForThisNode = slotsPerNode + (i < remainder ? 1 : 0);
+            if (slotsForThisNode > 0) {
+                int endSlot = currentSlot + slotsForThisNode - 1;
+                try (Connection connection = clients.get(i).getPool().getResource()) {
+                    connection.sendCommand(
+                            Protocol.Command.CLUSTER,
+                            "ADDSLOTSRANGE",
+                            Integer.toString(currentSlot),
+                            Integer.toString(endSlot));
+                    connection.getStatusCodeReply();
+                }
+                currentSlot = endSlot + 1;
+            }
+        }
+
+        // Wait for cluster to be ready
+        waitForClusterReady();
+
+        // Verify all slots are assigned
+        verifyClusterState();
+
+        // Attach replicas to primaries if any were requested
+        if (!replicaClients.isEmpty()) {
+            assignReplicas();
+        }
+    }
+
+    private void waitForClusterReady()
+    {
+        long deadlineMillis = System.currentTimeMillis() + 60_000;
+        while (System.currentTimeMillis() < deadlineMillis) {
+            boolean allReady = true;
+            for (RedisClient client : clients) {
+                String info;
+                try (Connection connection = client.getPool().getResource()) {
+                    connection.sendCommand(Protocol.Command.CLUSTER, "INFO");
+                    info = SafeEncoder.encode((byte[]) connection.getOne());
+                }
+                catch (Exception e) {
+                    allReady = false;
+                    break;
+                }
+                if (info == null || !info.contains("cluster_state:ok")) {
+                    allReady = false;
+                    break;
+                }
+            }
+            if (allReady) {
+                return;
+            }
+            try {
+                Thread.sleep(500);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while waiting for Redis cluster to be ready", e);
+            }
+        }
+        throw new IllegalStateException("Redis cluster did not become ready within 60 seconds");
+    }
+
+    private void verifyClusterState()
+    {
+        try (Connection connection = clients.get(0).getPool().getResource()) {
+            connection.sendCommand(Protocol.Command.CLUSTER, "SLOTS");
+            Object response = connection.getOne();
+            checkState(response instanceof List, "CLUSTER SLOTS returned unexpected type: %s", response.getClass());
+            @SuppressWarnings("unchecked")
+            List<Object> slotRanges = (List<Object>) response;
+            int assignedSlots = 0;
+            for (Object slotRangeObj : slotRanges) {
+                @SuppressWarnings("unchecked")
+                List<Object> slotRange = (List<Object>) slotRangeObj;
+                int startSlot = ((Long) slotRange.get(0)).intValue();
+                int endSlot = ((Long) slotRange.get(1)).intValue();
+                assignedSlots += (endSlot - startSlot + 1);
+            }
+            checkState(assignedSlots == RedisClusterTopology.TOTAL_SLOTS,
+                    "Cluster has %s assigned slots, expected %s",
+                    assignedSlots,
+                    RedisClusterTopology.TOTAL_SLOTS);
+        }
+    }
+
+    /**
+     * Returns the seed addresses for the cluster, suitable for use as {@code redis.nodes}.
+     */
+    public List<com.google.common.net.HostAndPort> getSeedAddresses()
+    {
+        return ImmutableList.copyOf(seedAddresses);
+    }
+
+    /**
+     * Returns a comma-separated list of seed addresses for the {@code redis.nodes} property.
+     */
+    public String getSeedAddressesString()
+    {
+        return seedAddresses.stream()
+                .map(com.google.common.net.HostAndPort::toString)
+                .reduce((a, b) -> a + "," + b)
+                .orElseThrow();
+    }
+
+    /**
+     * Returns a {@link RedisClusterClient} for cluster-aware data loading.
+     */
+    public RedisClusterClient getRedisClusterClient()
+    {
+        return redisClusterClient;
+    }
+
+    /**
+     * Returns a {@link RedisClient} connected to the first primary, for direct operations.
+     */
+    public RedisClient getClient()
+    {
+        return clients.get(0);
+    }
+
+    /**
+     * Returns a {@link RedisClient} connected to the primary at the given index.
+     */
+    public RedisClient getClient(int index)
+    {
+        return clients.get(index);
+    }
+
+    /**
+     * Returns the client port of the primary at the given index.
+     */
+    public int getPort(int index)
+    {
+        return jedisSeedAddresses.get(index).getPort();
+    }
+
+    /**
+     * Returns the internal (plaintext) port of the primary at the given index,
+     * used for MIGRATE commands which connect inside the container without TLS.
+     */
+    public int getInternalPort(int index)
+    {
+        int clientPort = jedisSeedAddresses.get(index).getPort();
+        return tls ? clientPort - 1000 : clientPort;
+    }
+
+    public int getKeySlot(String key)
+    {
+        try (Connection connection = clients.get(0).getPool().getResource()) {
+            connection.sendCommand(Protocol.Command.CLUSTER, "KEYSLOT", key);
+            Object reply = connection.getOne();
+            checkState(reply != null, "CLUSTER KEYSLOT returned null for %s", key);
+            return ((Long) reply).intValue();
+        }
+    }
+
+    public int getPrimaryIndexForSlot(int slot)
+    {
+        try (Connection connection = clients.get(0).getPool().getResource()) {
+            connection.sendCommand(Protocol.Command.CLUSTER, "SLOTS");
+            Object response = connection.getOne();
+            checkState(response instanceof List, "CLUSTER SLOTS returned unexpected type: %s", response.getClass());
+            @SuppressWarnings("unchecked")
+            List<Object> slotRanges = (List<Object>) response;
+            for (Object slotRangeObj : slotRanges) {
+                @SuppressWarnings("unchecked")
+                List<Object> slotRange = (List<Object>) slotRangeObj;
+                int startSlot = ((Long) slotRange.get(0)).intValue();
+                int endSlot = ((Long) slotRange.get(1)).intValue();
+                if (slot >= startSlot && slot <= endSlot) {
+                    @SuppressWarnings("unchecked")
+                    List<Object> masterInfo = (List<Object>) slotRange.get(2);
+                    int masterPort = ((Long) masterInfo.get(1)).intValue();
+                    for (int i = 0; i < clients.size(); i++) {
+                        if (jedisSeedAddresses.get(i).getPort() == masterPort) {
+                            return i;
+                        }
+                    }
+                    throw new IllegalStateException("No primary found for port " + masterPort);
+                }
+            }
+        }
+        throw new IllegalStateException("No primary found for slot " + slot);
+    }
+
+    public void migrateSlotAndKey(String key, int sourceIndex, int targetIndex)
+    {
+        int slot = getKeySlot(key);
+        String sourceNodeId = getNodeId(sourceIndex);
+        String targetNodeId = getNodeId(targetIndex);
+        int targetPort = getInternalPort(targetIndex);
+
+        // Mark slot as migrating on source and importing on target
+        try (Connection connection = clients.get(sourceIndex).getPool().getResource()) {
+            connection.sendCommand(Protocol.Command.CLUSTER, "SETSLOT", Integer.toString(slot), "MIGRATING", targetNodeId);
+            connection.getStatusCodeReply();
+        }
+        try (Connection connection = clients.get(targetIndex).getPool().getResource()) {
+            connection.sendCommand(Protocol.Command.CLUSTER, "SETSLOT", Integer.toString(slot), "IMPORTING", sourceNodeId);
+            connection.getStatusCodeReply();
+        }
+
+        // MIGRATE KEYS atomically moves the key (handles DUMP/RESTORE/DEL/TTL server-side)
+        try (Connection connection = clients.get(sourceIndex).getPool().getResource()) {
+            connection.sendCommand(
+                    Protocol.Command.MIGRATE,
+                    "127.0.0.1",
+                    Integer.toString(targetPort),
+                    "",
+                    "0",
+                    "5000",
+                    "REPLACE",
+                    "KEYS",
+                    key);
+            connection.getStatusCodeReply();
+        }
+
+        // Finalize ownership on all primaries so clients get MOVED from source to target
+        for (RedisClient client : clients) {
+            try (Connection connection = client.getPool().getResource()) {
+                connection.sendCommand(Protocol.Command.CLUSTER, "SETSLOT", Integer.toString(slot), "NODE", targetNodeId);
+                connection.getStatusCodeReply();
+            }
+        }
+
+        waitForClusterReady();
+    }
+
+    /**
+     * Finalizes a slot migration by assigning slot ownership to the target
+     * without moving any keys.  Use after {@link #prepareAskingSlot} to restore
+     * a stable cluster state — the key has already been moved.
+     */
+    public void finalizeSlotMigration(String key, int targetIndex)
+    {
+        int slot = getKeySlot(key);
+        String targetNodeId = getNodeId(targetIndex);
+        for (RedisClient client : clients) {
+            try (Connection connection = client.getPool().getResource()) {
+                connection.sendCommand(Protocol.Command.CLUSTER, "SETSLOT", Integer.toString(slot), "NODE", targetNodeId);
+                connection.getStatusCodeReply();
+            }
+        }
+        waitForClusterReady();
+    }
+
+    public void migrateSlot(int slot, int targetIndex)
+    {
+        int sourceIndex = getPrimaryIndexForSlot(slot);
+        String sourceNodeId = getNodeId(sourceIndex);
+        String targetNodeId = getNodeId(targetIndex);
+        RedisClient sourceClient = clients.get(sourceIndex);
+        RedisClient targetClient = clients.get(targetIndex);
+        int targetPort = getInternalPort(targetIndex);
+
+        try (Connection connection = sourceClient.getPool().getResource()) {
+            connection.sendCommand(Protocol.Command.CLUSTER, "SETSLOT", Integer.toString(slot), "MIGRATING", targetNodeId);
+            connection.getStatusCodeReply();
+        }
+        try (Connection connection = targetClient.getPool().getResource()) {
+            connection.sendCommand(Protocol.Command.CLUSTER, "SETSLOT", Integer.toString(slot), "IMPORTING", sourceNodeId);
+            connection.getStatusCodeReply();
+        }
+
+        // Move all keys in the slot using MIGRATE (handles ASKING/RESTORE/DEL/TTL).
+        // CLUSTER GETKEYSINSLOT has no cursor, so we delete each batch and call
+        // again until the slot is empty.
+        while (true) {
+            List<String> keys = getKeysInSlot(sourceClient, slot);
+            if (keys.isEmpty()) {
+                break;
+            }
+            List<String> migrateArgs = new ArrayList<>();
+            migrateArgs.add("127.0.0.1");
+            migrateArgs.add(Integer.toString(targetPort));
+            migrateArgs.add("");
+            migrateArgs.add("0");
+            migrateArgs.add("5000");
+            migrateArgs.add("REPLACE");
+            migrateArgs.add("KEYS");
+            migrateArgs.addAll(keys);
+            try (Connection connection = sourceClient.getPool().getResource()) {
+                connection.sendCommand(Protocol.Command.MIGRATE, migrateArgs.toArray(new String[0]));
+                connection.getStatusCodeReply();
+            }
+        }
+
+        // Finalize ownership on all primaries
+        for (RedisClient client : clients) {
+            try (Connection connection = client.getPool().getResource()) {
+                connection.sendCommand(Protocol.Command.CLUSTER, "SETSLOT", Integer.toString(slot), "NODE", targetNodeId);
+                connection.getStatusCodeReply();
+            }
+        }
+
+        waitForClusterReady();
+    }
+
+    private List<String> getKeysInSlot(RedisClient client, int slot)
+    {
+        try (Connection connection = client.getPool().getResource()) {
+            connection.sendCommand(Protocol.Command.CLUSTER, "GETKEYSINSLOT", Integer.toString(slot), "1000");
+            Object reply = connection.getOne();
+            if (reply == null) {
+                return List.of();
+            }
+            checkState(reply instanceof List, "CLUSTER GETKEYSINSLOT returned unexpected type: %s", reply.getClass());
+            @SuppressWarnings("unchecked")
+            List<Object> entries = (List<Object>) reply;
+            if (entries.isEmpty()) {
+                return List.of();
+            }
+            List<String> keys = new ArrayList<>(entries.size());
+            for (Object entry : entries) {
+                keys.add(SafeEncoder.encode((byte[]) entry));
+            }
+            return keys;
+        }
+    }
+
+    public void prepareAskingSlot(String key, int sourceIndex, int targetIndex)
+    {
+        int slot = getKeySlot(key);
+        String sourceNodeId = getNodeId(sourceIndex);
+        String targetNodeId = getNodeId(targetIndex);
+        int targetPort = getInternalPort(targetIndex);
+
+        // Mark slot as migrating/importing, move key, but do not set NODE owner
+        try (Connection connection = clients.get(sourceIndex).getPool().getResource()) {
+            connection.sendCommand(Protocol.Command.CLUSTER, "SETSLOT", Integer.toString(slot), "MIGRATING", targetNodeId);
+            connection.getStatusCodeReply();
+        }
+        try (Connection connection = clients.get(targetIndex).getPool().getResource()) {
+            connection.sendCommand(Protocol.Command.CLUSTER, "SETSLOT", Integer.toString(slot), "IMPORTING", sourceNodeId);
+            connection.getStatusCodeReply();
+        }
+
+        // MIGRATE KEYS atomically moves the key (handles DUMP/RESTORE/DEL/TTL server-side)
+        try (Connection connection = clients.get(sourceIndex).getPool().getResource()) {
+            connection.sendCommand(
+                    Protocol.Command.MIGRATE,
+                    "127.0.0.1",
+                    Integer.toString(targetPort),
+                    "",
+                    "0",
+                    "5000",
+                    "REPLACE",
+                    "KEYS",
+                    key);
+            connection.getStatusCodeReply();
+        }
+
+        // Slot remains in MIGRATING/IMPORTING state; source returns ASK target.
+        // cluster_state is fail because the slot has no owner, so we wait briefly
+        // for the cluster bus to propagate the importing/migrating state.
+        try {
+            Thread.sleep(500);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting for ASK slot state", e);
+        }
+    }
+
+    private void assignReplicas()
+    {
+        for (int i = 0; i < replicaClients.size(); i++) {
+            int primaryIndex = i % clients.size();
+            String primaryNodeId = getNodeId(clients.get(primaryIndex));
+            try (Connection connection = replicaClients.get(i).getPool().getResource()) {
+                connection.sendCommand(Protocol.Command.CLUSTER, "REPLICATE", primaryNodeId);
+                connection.getStatusCodeReply();
+            }
+        }
+
+        long deadlineMillis = System.currentTimeMillis() + 60_000;
+        while (System.currentTimeMillis() < deadlineMillis) {
+            boolean allConnected = true;
+            for (int i = 0; i < replicaClients.size(); i++) {
+                int primaryIndex = i % clients.size();
+                String primaryNodeId = getNodeId(clients.get(primaryIndex));
+                String expectedLine = "slave " + primaryNodeId;
+                try (Connection connection = replicaClients.get(i).getPool().getResource()) {
+                    connection.sendCommand(Protocol.Command.CLUSTER, "NODES");
+                    String info = SafeEncoder.encode((byte[]) connection.getOne());
+                    if (!info.contains("myself,slave") || !info.contains(expectedLine) || !info.contains("connected")) {
+                        allConnected = false;
+                        break;
+                    }
+                }
+                catch (Exception e) {
+                    allConnected = false;
+                    break;
+                }
+            }
+            if (allConnected) {
+                return;
+            }
+            try {
+                Thread.sleep(500);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while waiting for replicas to connect", e);
+            }
+        }
+        throw new IllegalStateException("Replicas did not become connected within 60 seconds");
+    }
+
+    private String getNodeId(int primaryIndex)
+    {
+        return getNodeId(clients.get(primaryIndex));
+    }
+
+    private String getNodeId(RedisClient client)
+    {
+        try (Connection connection = client.getPool().getResource()) {
+            connection.sendCommand(Protocol.Command.CLUSTER, "NODES");
+            String info = SafeEncoder.encode((byte[]) connection.getOne());
+            for (String line : info.split("\n", -1)) {
+                String[] parts = line.trim().split("\\s+", -1);
+                if (parts.length >= 3 && parts[2].contains("myself")) {
+                    return parts[0];
+                }
+            }
+            throw new IllegalStateException("Could not find node id in CLUSTER NODES output");
+        }
+    }
+
+    /**
+     * Stops the primary at the given index and waits for its replica to be promoted.
+     * Returns the index of the new primary (the replica's former index).
+     */
+    public int killPrimaryAndWaitForFailover(int primaryIndex)
+    {
+        checkState(!replicaClients.isEmpty(), "No replicas configured, cannot fail over");
+        checkState(primaryIndex < clients.size() && primaryIndex < replicaClients.size(),
+                "Primary %s has no configured replica",
+                primaryIndex);
+
+        RedisClient primary = clients.get(primaryIndex);
+        RedisClient replica = replicaClients.get(primaryIndex);
+
+        // Shut down the primary so the cluster marks it as fail
+        try (Connection connection = primary.getPool().getResource()) {
+            connection.sendCommand(Protocol.Command.SHUTDOWN, "NOSAVE");
+        }
+        catch (Exception e) {
+            // SHUTDOWN closes the connection, so an exception is expected
+            log.info("Sent SHUTDOWN to primary %s", primaryIndex);
+        }
+
+        primary.close();
+
+        // Promoted replica is now a primary; keep a stable client for it
+        clients.set(primaryIndex, replica);
+
+        // Wait for the replica to be promoted to master
+        String replicaNodeId = getNodeId(replica);
+        long deadlineMillis = System.currentTimeMillis() + 60_000;
+        while (System.currentTimeMillis() < deadlineMillis) {
+            try (Connection connection = replica.getPool().getResource()) {
+                connection.sendCommand(Protocol.Command.CLUSTER, "NODES");
+                String info = SafeEncoder.encode((byte[]) connection.getOne());
+                if (info.contains(replicaNodeId) && info.contains("myself,master") && info.contains("connected")) {
+                    break;
+                }
+            }
+            catch (Exception e) {
+                // replica may still be starting up; keep waiting
+            }
+            try {
+                Thread.sleep(500);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while waiting for failover", e);
+            }
+        }
+
+        waitForClusterReady();
+
+        return primaryIndex;
+    }
+
+    private DefaultJedisClientConfig buildClientConfig()
+    {
+        DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder();
+        if (tls) {
+            builder.sslOptions(buildSslOptions());
+        }
+        if (auth) {
+            builder.password(RedisServer.PASSWORD);
+        }
+        return builder.build();
+    }
+
+    private static SslOptions buildSslOptions()
+    {
+        return SslOptions.builder()
+                .keystore(new File(RedisServer.getKeystorePath()), RedisServer.TLS_STORE_PASSWORD.toCharArray())
+                .truststore(new File(RedisServer.getTruststorePath()), RedisServer.TLS_STORE_PASSWORD.toCharArray())
+                .build();
+    }
+
+    @Override
+    public void close()
+    {
+        try {
+            redisClusterClient.close();
+        }
+        catch (Exception e) {
+            // ignore
+        }
+        for (RedisClient client : clients) {
+            try {
+                client.close();
+            }
+            catch (Exception e) {
+                // ignore
+            }
+        }
+        for (RedisClient client : replicaClients) {
+            try {
+                client.close();
+            }
+            catch (Exception e) {
+                // ignore
+            }
+        }
+        try {
+            container.close();
+        }
+        catch (Exception e) {
+            // ignore
+        }
+        finally {
+            CLUSTER_SEMAPHORE.release();
+        }
+    }
+}

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisLoader.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisLoader.java
@@ -24,6 +24,7 @@ import io.trino.spi.type.VarcharType;
 import io.trino.testing.AbstractTestingTrinoClient;
 import io.trino.testing.ResultsSession;
 import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.RedisClusterClient;
 
 import java.util.List;
 import java.util.Map;
@@ -43,10 +44,12 @@ public class RedisLoader
         extends AbstractTestingTrinoClient<Void>
 {
     private final RedisClient client;
+    private final RedisClusterClient redisClusterClient;
     private final String tableName;
     private final String dataFormat;
     private final AtomicLong count = new AtomicLong();
     private final JsonEncoder jsonEncoder;
+    private final boolean clusterMode;
 
     public RedisLoader(
             TestingTrinoServer trinoServer,
@@ -55,11 +58,48 @@ public class RedisLoader
             String tableName,
             String dataFormat)
     {
+        this(trinoServer, defaultSession, client, null, tableName, dataFormat, false);
+    }
+
+    public RedisLoader(
+            TestingTrinoServer trinoServer,
+            Session defaultSession,
+            RedisClient client,
+            String tableName,
+            String dataFormat,
+            boolean clusterMode)
+    {
+        this(trinoServer, defaultSession, client, null, tableName, dataFormat, clusterMode);
+    }
+
+    public RedisLoader(
+            TestingTrinoServer trinoServer,
+            Session defaultSession,
+            RedisClusterClient redisClusterClient,
+            String tableName,
+            String dataFormat,
+            boolean clusterMode)
+    {
+        this(trinoServer, defaultSession, null, redisClusterClient, tableName, dataFormat, clusterMode);
+    }
+
+    private RedisLoader(
+            TestingTrinoServer trinoServer,
+            Session defaultSession,
+            RedisClient client,
+            RedisClusterClient redisClusterClient,
+            String tableName,
+            String dataFormat,
+            boolean clusterMode)
+    {
         super(trinoServer, defaultSession);
-        this.client = requireNonNull(client, "client is null");
+        this.client = client;
+        this.redisClusterClient = redisClusterClient;
         this.tableName = tableName;
         this.dataFormat = dataFormat;
+        this.clusterMode = clusterMode;
         jsonEncoder = new JsonEncoder();
+        checkState(clusterMode ? redisClusterClient != null : client != null, "client or redisClusterClient must be non-null");
     }
 
     @Override
@@ -100,16 +140,18 @@ public class RedisLoader
                                 builder.put(columns.get(i).getName(), value);
                             }
                         }
-                        client.set(redisKey, jsonEncoder.toString(builder.buildOrThrow()));
+                        setClusterAware(redisKey, jsonEncoder.toString(builder.buildOrThrow()));
                     }
                     case "hash" -> {
-                        // add keys to zset
-                        String redisZset = "keyset:" + tableName;
-                        client.zadd(redisZset, count.get(), redisKey);
+                        // add keys to zset (only in standalone mode; zset not supported in cluster)
+                        if (!clusterMode) {
+                            String redisZset = "keyset:" + tableName;
+                            client.zadd(redisZset, (double) count.get(), redisKey);
+                        }
 
                         // add values to Hash
                         for (int i = 0; i < fields.size(); i++) {
-                            client.hset(redisKey, columns.get(i).getName(), fields.get(i).toString());
+                            hsetClusterAware(redisKey, columns.get(i).getName(), fields.get(i).toString());
                         }
                     }
                     default -> throw new AssertionError("unhandled value type: " + dataFormat);
@@ -145,6 +187,26 @@ public class RedisLoader
                 return value;
             }
             throw new AssertionError("unhandled type: " + type);
+        }
+
+        private void setClusterAware(String key, String value)
+        {
+            if (clusterMode) {
+                redisClusterClient.set(key, value);
+            }
+            else {
+                client.set(key, value);
+            }
+        }
+
+        private void hsetClusterAware(String key, String field, String value)
+        {
+            if (clusterMode) {
+                redisClusterClient.hset(key, field, value);
+            }
+            else {
+                client.hset(key, field, value);
+            }
         }
     }
 }

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisServer.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisServer.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.redis.util;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
 import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Connection;
@@ -20,6 +21,7 @@ import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.RedisClient;
 import redis.clients.jedis.SslOptions;
+import redis.clients.jedis.util.SafeEncoder;
 
 import java.io.Closeable;
 import java.io.File;
@@ -49,15 +51,20 @@ public class RedisServer
 
     public RedisServer(String version, boolean setAccessControl)
     {
-        this(version, setAccessControl, false);
+        this(version, setAccessControl, false, false);
     }
 
     public static RedisServer createTlsServer()
     {
-        return new RedisServer(LATEST_VERSION, false, true);
+        return new RedisServer(LATEST_VERSION, false, true, false);
     }
 
-    private RedisServer(String version, boolean setAccessControl, boolean tls)
+    public static RedisServer createClusterServer()
+    {
+        return new RedisServer(LATEST_VERSION, false, false, true);
+    }
+
+    private RedisServer(String version, boolean setAccessControl, boolean tls, boolean cluster)
     {
         container = new GenericContainer<>("redis:" + version)
                 .withExposedPorts(PORT);
@@ -66,6 +73,15 @@ public class RedisServer
         }
         if (tls) {
             configureTls(container);
+        }
+        if (cluster) {
+            container.withCommand("redis-server", "--cluster-enabled", "yes", "--cluster-config-file", "nodes.conf", "--cluster-node-timeout", "5000");
+            // Publish the Redis port on the same host port. A runtime CONFIG SET of
+            // cluster-announce-port is not reliably reflected in the CLUSTER NODES "myself" entry
+            // on Redis 7.0, so the connector would otherwise discover the internal port 6379 and
+            // fail to connect. Binding host 6379 -> container 6379 makes the advertised address
+            // (127.0.0.1:6379) reachable from the test JVM.
+            container.setPortBindings(ImmutableList.of(PORT + ":" + PORT));
         }
         container.start();
 
@@ -82,6 +98,9 @@ public class RedisServer
                 .build();
         if (setAccessControl) {
             aclSetUser(USER, "on", ">" + PASSWORD, "~*:*", "+@all");
+        }
+        if (cluster) {
+            initializeCluster();
         }
     }
 
@@ -128,6 +147,49 @@ public class RedisServer
             connection.sendCommand(Protocol.Command.ACL, args);
             connection.getStatusCodeReply();
         }
+    }
+
+    // Turns the single container into a one-node Redis Cluster that owns all 16384 slots.
+    // The Redis port is published on the same host port (see setPortBindings above), so the address
+    // returned by CLUSTER NODES (127.0.0.1:6379) is reachable from the test JVM. This exercises the
+    // full cluster code path (node discovery, per-node scan, pipelined single-key fetch) in CI
+    // without the node-address advertisement problems of a multi-container cluster.
+    private void initializeCluster()
+    {
+        String announceIp = container.getHost();
+        if (announceIp.equals("localhost")) {
+            announceIp = "127.0.0.1";
+        }
+        int announcePort = container.getMappedPort(PORT);
+        try (Connection connection = redisClient.getPool().getResource()) {
+            connection.sendCommand(Protocol.Command.CONFIG, "SET", "cluster-announce-ip", announceIp);
+            connection.getStatusCodeReply();
+            connection.sendCommand(Protocol.Command.CONFIG, "SET", "cluster-announce-port", Integer.toString(announcePort));
+            connection.getStatusCodeReply();
+            connection.sendCommand(Protocol.Command.CLUSTER, "ADDSLOTSRANGE", "0", "16383");
+            connection.getStatusCodeReply();
+            waitForClusterReady(connection);
+        }
+    }
+
+    private static void waitForClusterReady(Connection connection)
+    {
+        long deadlineMillis = System.currentTimeMillis() + 30_000;
+        while (System.currentTimeMillis() < deadlineMillis) {
+            connection.sendCommand(Protocol.Command.CLUSTER, "INFO");
+            String info = SafeEncoder.encode((byte[]) connection.getOne());
+            if (info != null && info.contains("cluster_state:ok")) {
+                return;
+            }
+            try {
+                Thread.sleep(200);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Interrupted while waiting for Redis cluster to be ready", e);
+            }
+        }
+        throw new IllegalStateException("Redis cluster did not become ready within 30 seconds");
     }
 
     private static void configureTls(GenericContainer<?> container)

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisTestUtils.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisTestUtils.java
@@ -56,6 +56,32 @@ public final class RedisTestUtils
         tpchLoader.execute(format("SELECT * from %s", tpchTableName));
     }
 
+    public static void loadTpchTable(RedisServer redisServer, TestingTrinoClient trinoClient, String tableName, QualifiedObjectName tpchTableName, String dataFormat, boolean clusterMode)
+    {
+        RedisLoader tpchLoader = new RedisLoader(trinoClient.getServer(), trinoClient.getDefaultSession(), redisServer.getClient(), tableName, dataFormat, clusterMode);
+        tpchLoader.execute(format("SELECT * from %s", tpchTableName));
+    }
+
+    public static void installRedisPlugin(RedisCluster redisCluster, QueryRunner queryRunner, Map<SchemaTableName, RedisTableDescription> tableDescriptions, Map<String, String> connectorProperties)
+    {
+        queryRunner.installPlugin(new TestingRedisPlugin(tableDescriptions));
+
+        connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
+        connectorProperties.putIfAbsent("redis.nodes", redisCluster.getSeedAddressesString());
+        connectorProperties.putIfAbsent("redis.table-names", Joiner.on(",").join(tableDescriptions.keySet()));
+        connectorProperties.putIfAbsent("redis.default-schema", "default");
+        connectorProperties.putIfAbsent("redis.hide-internal-columns", "true");
+        connectorProperties.putIfAbsent("redis.key-prefix-schema-table", "true");
+
+        queryRunner.createCatalog("redis", "redis", connectorProperties);
+    }
+
+    public static void loadTpchTable(RedisCluster redisCluster, TestingTrinoClient trinoClient, String tableName, QualifiedObjectName tpchTableName, String dataFormat, boolean clusterMode)
+    {
+        RedisLoader tpchLoader = new RedisLoader(trinoClient.getServer(), trinoClient.getDefaultSession(), redisCluster.getRedisClusterClient(), tableName, dataFormat, clusterMode);
+        tpchLoader.execute(format("SELECT * from %s", tpchTableName));
+    }
+
     public static Map.Entry<SchemaTableName, RedisTableDescription> loadTpchTableDescription(
             JsonCodec<RedisTableDescription> tableDescriptionJsonCodec,
             SchemaTableName schemaTableName,


### PR DESCRIPTION
## Description

The Redis connector currently only supports standalone Redis deployments. This PR adds redis.cluster.enabled=true to enable Redis Cluster support by auto-discovering all primary nodes via the CLUSTER SLOTS command and scanning each shard independently.

redis.cluster.enabled=true
redis.nodes=seed-1:6379,seed-2:6379

## Approach

- On split generation, when redis.cluster.enabled=true, the connector issues CLUSTER SLOTS to a seed node and discovers all healthy primary nodes with their slot ranges.
- One split is created per primary, so each worker independently scans one shard via SCAN, giving complete coverage across all 16,384 hash slots.
- When key predicates (= or IN) are pushed down, Trino routes each key to its slot-owning primary so each key is fetched only from the correct node.
- Value fetching in cluster mode uses pipelined single-key commands (GET/HGETALL) instead of multi-key MGET, which would otherwise fail with CROSSSLOT since scanned keys span multiple slots on a primary.
- During topology changes (failover or resharding), the connector retries MOVED and ASK redirections up to a bounded number of attempts. If retries are exhausted, the query fails with a transient error rather than returning incomplete results.
- Multiple seed nodes are supported; each is tried in turn until one responds, so discovery does not depend on a single seed being available.

## Constraints (documented)

- redis.database-index must be 0 (Redis Cluster only supports database 0).
zset key format is not supported in cluster mode (a ZSET key lives on a single node and its members cannot be split across shards).
- The Trino coordinator and all workers must be able to reach every primary node at the address it advertises through CLUSTER SLOTS. In deployments behind NAT, Docker, or Kubernetes, configure the Redis nodes with cluster-announce-ip and cluster-announce-port set to addresses reachable from Trino.
- Redis users require CLUSTER SLOTS plus read permissions such as SCAN, GET, and HGETALL.

## Testing
- Unit tests: Config property validation (TestRedisConnectorConfig), multi-master discovery parsing (TestRedisClusterNodeDiscovery).
- Integration tests (real Redis Cluster via Testcontainers, 3 primaries):
- TestRedisClusterConnectorSmokeTest — end-to-end smoke test
- TestRedisClusterRouting — cross-shard scans, predicate routing, data completeness
- TestRedisClusterAuth — cluster mode with password authentication
- TestRedisClusterTls — cluster mode with TLS encryption
- TestRedisClusterFailover — primary kill + replica promotion, stale client cleanup
- TestRedisClusterResharding — slot migration, post-migration query correctness
- TestRedisClusterRedirectRetry — MOVED and ASK redirect handling
- TestRedisClusterConcurrentResharding — query during in-flight slot migration
- TestRedisClusterSeedResilience — dead first seed, fallback to next
- Full trino-redis suite: 687 tests, 0 failures, 0 errors.

## Release notes
## Redis
* Add support for Redis Cluster mode via the redis.cluster.enabled configuration property