### PR TITLE
Clean up Delta Lake deletion vector sidecars after failed writes

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -270,6 +270,7 @@ import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getColumnMappin
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getDeletionVectorsEnabled;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getLocation;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getPartitionedBy;
+import static io.trino.plugin.deltalake.delete.DeletionVectors.toFileName;
 import static io.trino.plugin.deltalake.metastore.DeltaLakeTableMetadataScheduler.containsSchemaString;
 import static io.trino.plugin.deltalake.metastore.DeltaLakeTableMetadataScheduler.getLastTransactionVersion;
 import static io.trino.plugin.deltalake.metastore.DeltaLakeTableMetadataScheduler.isSameTransactionVersion;
@@ -3486,12 +3487,11 @@ public class DeltaLakeMetadata
     {
         Location location = Location.of(tableLocation);
         List<Location> filesToDelete = dataFiles.stream()
-                // DataFileInfo entries with a deletionVector reference existing source files
-                // (via sourceReferencePath), not newly-written files. Skip them to avoid
-                // deleting active data files that are still referenced in the delta log.
-                .filter(info -> info.deletionVector().isEmpty())
-                .map(DataFileInfo::path)
-                .map(location::appendPath)
+                // DataFileInfo entries with a deletion vector reference existing source files,
+                // so clean up the newly written sidecar instead of the active data file.
+                .map(info -> info.deletionVector()
+                        .map(deletionVector -> location.appendPath(toFileName(deletionVector.pathOrInlineDv())))
+                        .orElseGet(() -> location.appendPath(info.path())))
                 .collect(toImmutableList());
         try {
             TrinoFileSystem fileSystem = fileSystemFactory.create(session, tableCredentials);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFlociAndLockBasedSynchronizerSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFlociAndLockBasedSynchronizerSmokeTest.java
@@ -87,17 +87,31 @@ public class TestDeltaLakeFlociAndLockBasedSynchronizerSmokeTest
         testWritesLocked("DELETE FROM %s WHERE a_number = 1");
     }
 
+    @Test
+    public void testDeletionVectorWriteLocked()
+            throws Exception
+    {
+        testWritesLocked("DELETE FROM %s WHERE a_number = 1", true);
+    }
+
     private void testWritesLocked(String writeStatement)
+            throws Exception
+    {
+        testWritesLocked(writeStatement, false);
+    }
+
+    private void testWritesLocked(String writeStatement, boolean deletionVectorsEnabled)
             throws Exception
     {
         String tableName = "test_writes_locked" + randomNameSuffix();
         try {
             assertUpdate(
-                    format("CREATE TABLE %s (a_number, a_string) WITH (location = 's3://%s/%s') AS " +
+                    format("CREATE TABLE %s (a_number, a_string) WITH (location = 's3://%s/%s', deletion_vectors_enabled = %s) AS " +
                                     "VALUES (1, 'ala'), (2, 'ma')",
                             tableName,
                             bucketName,
-                            tableName),
+                            tableName,
+                            deletionVectorsEnabled),
                     2);
 
             Set<String> originalFiles = ImmutableSet.copyOf(getTableFiles(tableName));


### PR DESCRIPTION
## Description

When a Delta Lake write creates a deletion vector and then fails to commit, `cleanupFailedWrite()` must preserve the referenced source Parquet file while removing the newly written deletion-vector sidecar. The current cleanup skips the entire `DataFileInfo` entry, which preserves the source file but leaves an orphaned sidecar.

Resolve UUID-backed deletion-vector paths with `DeletionVectors.toFileName()` and clean up the sidecar instead of the active source file. Entries without a deletion vector continue to clean up their newly written data file.

## Additional context and related issues

This follows #29362, which fixed the active-source-file deletion issue. The deterministic lock-based S3 regression forces a failed DV-enabled `DELETE` and verifies that the complete object listing contains only the original files and the transaction-log lock.

Focused test:

```bash
./mvnw -pl :trino-delta-lake \
    '-Dtest=TestDeltaLakeFlociAndLockBasedSynchronizerSmokeTest#testDeletionVectorWriteLocked' test
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake connector
* Fix deletion-vector files being left behind after failed writes.
```
