### PR TITLE
Prevent comparison rewrite loops

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
@@ -248,20 +248,19 @@ public class UnwrapCastInComparison
             if (lowBound.isEmpty() || highBound.isEmpty()) {
                 return Optional.empty();
             }
+            ComparisonBound normalizedLow = lowBound.orElseThrow();
+            ComparisonBound normalizedHigh = highBound.orElseThrow();
 
             // Rebuild an inclusive BETWEEN when the two comparisons form a lower/upper pair whose strict ends have
             // an inclusive neighbor; otherwise keep them as a conjunction.
-            Optional<Object> inclusiveLow = inclusiveLowBound(sourceType, lowBound.get());
-            Optional<Object> inclusiveHigh = inclusiveHighBound(sourceType, highBound.get());
+            Optional<Object> inclusiveLow = inclusiveLowBound(sourceType, normalizedLow);
+            Optional<Object> inclusiveHigh = inclusiveHighBound(sourceType, normalizedHigh);
             if (inclusiveLow.isEmpty() || inclusiveHigh.isEmpty()) {
                 // The conjunction references the cast source in both halves; bind a non-trivial source once so it is
-                // evaluated a single time, and recompute each half against the bound operand.
-                return Optional.of(bindSourceIfNecessary(source, operand -> {
-                    Cast boundCast = new Cast(operand, cast.type(), cast.kind());
-                    return and(
-                            unwrapCast(GREATER_THAN_OR_EQUAL, boundCast, range.min()),
-                            unwrapCast(LESS_THAN_OR_EQUAL, boundCast, range.max()));
-                }));
+                // evaluated a single time, and rebuild each comparison against the bound operand.
+                return Optional.of(bindSourceIfNecessary(source, operand -> and(
+                        comparison(plannerContext.getMetadata(), normalizedLow.operator(), operand, new Constant(sourceType, normalizedLow.value())),
+                        comparison(plannerContext.getMetadata(), normalizedHigh.operator(), operand, new Constant(sourceType, normalizedHigh.value())))));
             }
             if (compare(sourceType, inclusiveLow.get(), inclusiveHigh.get()) > 0) {
                 return Optional.of(falseIfNotNull(source));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
@@ -195,13 +195,14 @@ public class UnwrapCastInComparison
             if (!(matchComparison(expression) instanceof Comparison comparison)) {
                 return expression;
             }
-            // The unwrap logic expects the cast on the left. A comparison whose cast operand is on the
-            // right (e.g. the canonical form of cast(x) > literal, which is literal < cast(x)) is flipped
-            // so the cast lands on the left; the rebuilt comparison is canonicalized again on the way out.
-            if (comparison.right() instanceof Cast && !(comparison.left() instanceof Cast)) {
-                return unwrapCast(comparison.operator().flip(), comparison.right(), comparison.left());
+            // The unwrap logic expects the cast on the left. Try the flipped form when the cast is on the right,
+            // but preserve the original comparison when it cannot be unwrapped.
+            if (comparison.right() instanceof Cast) {
+                return tryUnwrapCast(comparison.operator().flip(), comparison.right(), comparison.left())
+                        .orElse(expression);
             }
-            return unwrapCast(comparison.operator(), comparison.left(), comparison.right());
+            return tryUnwrapCast(comparison.operator(), comparison.left(), comparison.right())
+                    .orElse(expression);
         }
 
         @Override
@@ -221,10 +222,12 @@ public class UnwrapCastInComparison
             Expression source = cast.expression();
             Type sourceType = source.type();
             // Unwrap each half of the BETWEEN independently, as the lower and upper comparison against the cast.
-            Expression low = unwrapCast(GREATER_THAN_OR_EQUAL, cast, range.min());
-            Expression high = unwrapCast(LESS_THAN_OR_EQUAL, cast, range.max());
+            Expression low = tryUnwrapCast(GREATER_THAN_OR_EQUAL, cast, range.min())
+                    .orElseGet(() -> comparison(plannerContext.getMetadata(), GREATER_THAN_OR_EQUAL, cast, range.min()));
+            Expression high = tryUnwrapCast(LESS_THAN_OR_EQUAL, cast, range.max())
+                    .orElseGet(() -> comparison(plannerContext.getMetadata(), LESS_THAN_OR_EQUAL, cast, range.max()));
 
-            // unwrapCast collapses a bound to a constant truth value when the literal falls outside the source
+            // Unwrapping can collapse a bound to a constant truth value when the literal falls outside the source
             // type range: a never-satisfied bound empties the range, an always-satisfied bound drops out.
             if (isNeverSatisfied(low, source) || isNeverSatisfied(high, source)) {
                 return Optional.of(falseIfNotNull(source));
@@ -323,31 +326,31 @@ public class UnwrapCastInComparison
             };
         }
 
-        private Expression unwrapCast(ComparisonOperator operator, Expression originalLeft, Expression originalRight)
+        private Optional<Expression> tryUnwrapCast(ComparisonOperator operator, Expression originalLeft, Expression originalRight)
         {
             // Canonicalization is handled by CanonicalizeExpressionRewriter
             if (!(originalLeft instanceof Cast cast)) {
-                return comparison(plannerContext.getMetadata(), operator, originalLeft, originalRight);
+                return Optional.empty();
             }
 
             Expression right = optimizer.process(originalRight, session, symbolAllocator, ImmutableMap.of()).orElse(originalRight);
 
             if (right instanceof Constant constant && constant.value() == null) {
-                return switch (operator) {
+                return Optional.of(switch (operator) {
                     case EQUAL, NOT_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL -> new Constant(BOOLEAN, null);
                     case IDENTICAL -> new IsNull(cast);
-                };
+                });
             }
 
             if (!(right instanceof Constant(Type _, Object rightValue))) {
-                return comparison(plannerContext.getMetadata(), operator, cast, originalRight);
+                return Optional.empty();
             }
 
             Type sourceType = cast.expression().type();
             Type targetType = originalRight.type();
 
             if (sourceType instanceof TimestampType timestampType && targetType == DATE) {
-                return unwrapTimestampToDateCast(timestampType, operator, cast.expression(), (long) rightValue).orElse(comparison(plannerContext.getMetadata(), operator, cast, originalRight));
+                return unwrapTimestampToDateCast(timestampType, operator, cast.expression(), (long) rightValue);
             }
 
             if (targetType instanceof TimestampWithTimeZoneType timestampWithTimeZoneType) {
@@ -356,12 +359,11 @@ public class UnwrapCastInComparison
             }
 
             if (sourceType instanceof CharType charType && targetType instanceof VarcharType varcharType) {
-                return unwrapCharToVarcharCast(charType, varcharType, operator, cast.expression(), (Slice) rightValue)
-                        .orElse(comparison(plannerContext.getMetadata(), operator, cast, originalRight));
+                return unwrapCharToVarcharCast(charType, varcharType, operator, cast.expression(), (Slice) rightValue);
             }
 
             if (!hasInjectiveImplicitCoercion(sourceType, targetType, rightValue)) {
-                return comparison(plannerContext.getMetadata(), operator, cast, originalRight);
+                return Optional.empty();
             }
 
             // Handle comparison against NaN.
@@ -369,14 +371,14 @@ public class UnwrapCastInComparison
             if (isFloatingPointNaN(targetType, rightValue)) {
                 switch (operator) {
                     case EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL -> {
-                        return falseIfNotNull(cast.expression());
+                        return Optional.of(falseIfNotNull(cast.expression()));
                     }
                     case NOT_EQUAL -> {
-                        return trueIfNotNull(cast.expression());
+                        return Optional.of(trueIfNotNull(cast.expression()));
                     }
                     case IDENTICAL -> {
                         if (!typeHasNaN(sourceType)) {
-                            return FALSE;
+                            return Optional.of(FALSE);
                         }
                         // NaN on the right of comparison will be cast to source type later
                     }
@@ -402,22 +404,22 @@ public class UnwrapCastInComparison
                     int upperBoundComparison = compare(targetType, rightValue, maxInTargetType);
                     if (upperBoundComparison > 0) {
                         // larger than maximum representable value
-                        return switch (operator) {
+                        return Optional.of(switch (operator) {
                             case EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL -> falseIfNotNull(cast.expression());
                             case NOT_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL -> trueIfNotNull(cast.expression());
                             case IDENTICAL -> FALSE;
-                        };
+                        });
                     }
 
                     if (upperBoundComparison == 0) {
                         // equal to max representable value
-                        return switch (operator) {
+                        return Optional.of(switch (operator) {
                             case GREATER_THAN -> falseIfNotNull(cast.expression());
                             case GREATER_THAN_OR_EQUAL -> comparison(plannerContext.getMetadata(), EQUAL, cast.expression(), new Constant(sourceType, max));
                             case LESS_THAN_OR_EQUAL -> trueIfNotNull(cast.expression());
                             case LESS_THAN -> comparison(plannerContext.getMetadata(), NOT_EQUAL, cast.expression(), new Constant(sourceType, max));
                             case EQUAL, NOT_EQUAL, IDENTICAL -> comparison(plannerContext.getMetadata(), operator, cast.expression(), new Constant(sourceType, max));
-                        };
+                        });
                     }
 
                     Object min = sourceRange.get().getMin();
@@ -426,22 +428,22 @@ public class UnwrapCastInComparison
                     int lowerBoundComparison = compare(targetType, rightValue, minInTargetType);
                     if (lowerBoundComparison < 0) {
                         // smaller than minimum representable value
-                        return switch (operator) {
+                        return Optional.of(switch (operator) {
                             case NOT_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL -> trueIfNotNull(cast.expression());
                             case EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL -> falseIfNotNull(cast.expression());
                             case IDENTICAL -> FALSE;
-                        };
+                        });
                     }
 
                     if (lowerBoundComparison == 0) {
                         // equal to min representable value
-                        return switch (operator) {
+                        return Optional.of(switch (operator) {
                             case LESS_THAN -> falseIfNotNull(cast.expression());
                             case LESS_THAN_OR_EQUAL -> comparison(plannerContext.getMetadata(), EQUAL, cast.expression(), new Constant(sourceType, min));
                             case GREATER_THAN_OR_EQUAL -> trueIfNotNull(cast.expression());
                             case GREATER_THAN -> comparison(plannerContext.getMetadata(), NOT_EQUAL, cast.expression(), new Constant(sourceType, min));
                             case EQUAL, NOT_EQUAL, IDENTICAL -> comparison(plannerContext.getMetadata(), operator, cast.expression(), new Constant(sourceType, min));
-                        };
+                        });
                     }
                 }
             }
@@ -452,7 +454,7 @@ public class UnwrapCastInComparison
             }
             catch (OperatorNotFoundException e) {
                 // Without a cast between target -> source, there's nothing more we can do
-                return comparison(plannerContext.getMetadata(), operator, cast, originalRight);
+                return Optional.empty();
             }
 
             Object literalInSourceType;
@@ -466,7 +468,7 @@ public class UnwrapCastInComparison
                 //  3. out of range or otherwise unrepresentable value
                 // Since we can't distinguish between those cases, take the conservative option
                 // and bail out.
-                return comparison(plannerContext.getMetadata(), operator, cast, originalRight);
+                return Optional.empty();
             }
 
             if (targetType.isOrderable()) {
@@ -476,7 +478,7 @@ public class UnwrapCastInComparison
 
                 if (literalVsRoundtripped > 0) {
                     // cast rounded down
-                    return switch (operator) {
+                    return Optional.of(switch (operator) {
                         case EQUAL -> falseIfNotNull(cast.expression());
                         case NOT_EQUAL -> trueIfNotNull(cast.expression());
                         case IDENTICAL -> FALSE;
@@ -489,12 +491,12 @@ public class UnwrapCastInComparison
                         // We expect implicit coercions to be order-preserving, so the result of converting back from target -> source cannot produce a value
                         // larger than the next value in the source type
                         case GREATER_THAN, GREATER_THAN_OR_EQUAL -> comparison(plannerContext.getMetadata(), GREATER_THAN, cast.expression(), new Constant(sourceType, literalInSourceType));
-                    };
+                    });
                 }
 
                 if (literalVsRoundtripped < 0) {
                     // cast rounded up
-                    return switch (operator) {
+                    return Optional.of(switch (operator) {
                         case EQUAL -> falseIfNotNull(cast.expression());
                         case NOT_EQUAL -> trueIfNotNull(cast.expression());
                         case IDENTICAL -> FALSE;
@@ -504,11 +506,11 @@ public class UnwrapCastInComparison
                         case GREATER_THAN, GREATER_THAN_OR_EQUAL -> sourceRange.isPresent() && compare(sourceType, sourceRange.get().getMax(), literalInSourceType) == 0 ?
                                 comparison(plannerContext.getMetadata(), EQUAL, cast.expression(), new Constant(sourceType, literalInSourceType)) :
                                 comparison(plannerContext.getMetadata(), GREATER_THAN_OR_EQUAL, cast.expression(), new Constant(sourceType, literalInSourceType));
-                    };
+                    });
                 }
             }
 
-            return comparison(plannerContext.getMetadata(), operator, cast.expression(), new Constant(sourceType, literalInSourceType));
+            return Optional.of(comparison(plannerContext.getMetadata(), operator, cast.expression(), new Constant(sourceType, literalInSourceType)));
         }
 
         private Optional<Expression> unwrapCharToVarcharCast(CharType charType, VarcharType varcharType, ComparisonOperator operator, Expression charExpression, Slice value)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapDateTruncInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapDateTruncInComparison.java
@@ -144,14 +144,14 @@ public class UnwrapDateTruncInComparison
             if (!(matchComparison(expression) instanceof Comparison comparison)) {
                 return expression;
             }
-            // The unwrap logic expects date_trunc(...) on the left. A comparison whose date_trunc operand is
-            // on the right (e.g. the canonical form of date_trunc(...) > literal, which is literal <
-            // date_trunc(...)) is flipped so the date_trunc call lands on the left; the rebuilt comparison is
-            // canonicalized again on the way out.
-            if (isDateTruncCall(comparison.right()) && !isDateTruncCall(comparison.left())) {
-                return unwrapDateTrunc(comparison.operator().flip(), comparison.right(), comparison.left());
+            // The unwrap logic expects date_trunc(...) on the left. Try the flipped form when the call is on the
+            // right, but preserve the original comparison when it cannot be unwrapped.
+            if (isDateTruncCall(comparison.right())) {
+                return tryUnwrapDateTrunc(comparison.operator().flip(), comparison.right(), comparison.left())
+                        .orElse(expression);
             }
-            return unwrapDateTrunc(comparison.operator(), comparison.left(), comparison.right());
+            return tryUnwrapDateTrunc(comparison.operator(), comparison.left(), comparison.right())
+                    .orElse(expression);
         }
 
         private static boolean isDateTruncCall(Expression expression)
@@ -162,7 +162,7 @@ public class UnwrapDateTruncInComparison
         }
 
         // Simplify `date_trunc(unit, d) ? value`
-        private Expression unwrapDateTrunc(ComparisonOperator operator, Expression left, Expression originalRight)
+        private Optional<Expression> tryUnwrapDateTrunc(ComparisonOperator operator, Expression left, Expression originalRight)
         {
             // Expect date_trunc on the left side and value on the right side of the comparison.
             // This is provided by CanonicalizeExpressionRewriter.
@@ -170,47 +170,47 @@ public class UnwrapDateTruncInComparison
             if (!(left instanceof Call call) ||
                     !call.function().name().equals(builtinFunctionName("date_trunc")) ||
                     call.arguments().size() != 2) {
-                return comparison(plannerContext.getMetadata(), operator, left, originalRight);
+                return Optional.empty();
             }
 
             Expression unitExpression = call.arguments().get(0);
             if (!(unitExpression.type() instanceof VarcharType) || !(unitExpression instanceof Constant)) {
-                return comparison(plannerContext.getMetadata(), operator, left, originalRight);
+                return Optional.empty();
             }
             Slice unitName = (Slice) evaluator.evaluate(unitExpression, session, ImmutableMap.of());
             if (unitName == null) {
-                return comparison(plannerContext.getMetadata(), operator, left, originalRight);
+                return Optional.empty();
             }
 
             Expression argument = call.arguments().get(1);
             Expression right = optimizer.process(originalRight, session, symbolAllocator, ImmutableMap.of()).orElse(originalRight);
 
             if (right instanceof Constant constant && constant.value() == null) {
-                return switch (operator) {
+                return Optional.of(switch (operator) {
                     case EQUAL, NOT_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL -> new Constant(BOOLEAN, null);
                     case IDENTICAL -> new IsNull(argument);
-                };
+                });
             }
 
             if (!(right instanceof Constant(Type rightType, Object rightValue))) {
-                return comparison(plannerContext.getMetadata(), operator, left, originalRight);
+                return Optional.empty();
             }
             if (rightType instanceof TimestampWithTimeZoneType) {
                 // Cannot replace with a range due to how date_trunc operates on value's local date/time.
                 // I.e. unwrapping is possible only when values are all of some fixed zone and the zone is known.
-                return comparison(plannerContext.getMetadata(), operator, left, originalRight);
+                return Optional.empty();
             }
 
             ResolvedFunction resolvedFunction = call.function();
 
             Optional<SupportedUnit> unitIfSupported = Enums.getIfPresent(SupportedUnit.class, unitName.toStringUtf8().toUpperCase(Locale.ENGLISH)).toJavaUtil();
             if (unitIfSupported.isEmpty()) {
-                return comparison(plannerContext.getMetadata(), operator, left, originalRight);
+                return Optional.empty();
             }
             SupportedUnit unit = unitIfSupported.get();
             if (rightType == DATE && (unit == SupportedUnit.DAY || unit == SupportedUnit.HOUR)) {
                 // DAY case handled by CanonicalizeExpressionRewriter, other is illegal, will fail
-                return comparison(plannerContext.getMetadata(), operator, left, originalRight);
+                return Optional.empty();
             }
 
             Object rangeLow = functionInvoker.invoke(resolvedFunction, session.toConnectorSession(), ImmutableList.of(unitName, rightValue));
@@ -218,7 +218,7 @@ public class UnwrapDateTruncInComparison
             verify(compare <= 0, "Truncation of %s value %s resulted in a bigger value %s", rightType, rightValue, rangeLow);
             boolean rightValueAtRangeLow = compare == 0;
 
-            return switch (operator) {
+            return Optional.of(switch (operator) {
                 case EQUAL -> {
                     if (!rightValueAtRangeLow) {
                         yield falseIfNotNull(argument);
@@ -272,7 +272,7 @@ public class UnwrapDateTruncInComparison
                     }
                     yield comparison(plannerContext.getMetadata(), GREATER_THAN, argument, new Constant(rightType, calculateRangeEndInclusive(rangeLow, rightType, unit)));
                 }
-            };
+            });
         }
 
         public Expression trueIfNotNull(Expression argument)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapYearInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapYearInComparison.java
@@ -122,13 +122,14 @@ public class UnwrapYearInComparison
             if (!(matchComparison(expression) instanceof Comparison comparison)) {
                 return expression;
             }
-            // The unwrap logic expects year(...) on the left. A comparison whose year operand is on the
-            // right (e.g. the canonical form of year(x) > literal, which is literal < year(x)) is flipped
-            // so the year call lands on the left; the rebuilt comparison is canonicalized again on the way out.
-            if (isYearCall(comparison.right()) && !isYearCall(comparison.left())) {
-                return unwrapYear(comparison.operator().flip(), comparison.right(), comparison.left());
+            // The unwrap logic expects year(...) on the left. Try the flipped form when the call is on the right,
+            // but preserve the original comparison when it cannot be unwrapped.
+            if (isYearCall(comparison.right())) {
+                return tryUnwrapYear(comparison.operator().flip(), comparison.right(), comparison.left())
+                        .orElse(expression);
             }
-            return unwrapYear(comparison.operator(), comparison.left(), comparison.right());
+            return tryUnwrapYear(comparison.operator(), comparison.left(), comparison.right())
+                    .orElse(expression);
         }
 
         private static boolean isYearCall(Expression expression)
@@ -162,13 +163,6 @@ public class UnwrapYearInComparison
             }
 
             return or(comparisonExpressions.build());
-        }
-
-        // Simplify `year(d) ? value`
-        private Expression unwrapYear(ComparisonOperator operator, Expression left, Expression originalRight)
-        {
-            return tryUnwrapYear(operator, left, originalRight)
-                    .orElseGet(() -> comparison(metadata, operator, left, originalRight));
         }
 
         // Returns the unwrapped form of `year(d) ? value`, or empty when the comparison cannot be unwrapped

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestIssue30347.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestIssue30347.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import io.trino.Session;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIssue30347
+{
+    @Test
+    public void test()
+    {
+        try (QueryAssertions assertions = new QueryAssertions()) {
+            Session session = assertions.sessionBuilder()
+                    .setSystemProperty("iterative_optimizer_timeout", "1s")
+                    .build();
+
+            assertThat(assertions.query(
+                    session,
+                    """
+                    WITH test_data(test_date, test_timestamp) AS (VALUES (DATE '2026-07-15', TIMESTAMP '2026-07-15'))
+                    SELECT test_date = date_trunc('day', test_timestamp) FROM test_data
+                    """))
+                    .matches("VALUES true");
+
+            assertThat(assertions.query(
+                    session,
+                    """
+                    WITH test_data(test_year, test_timestamp) AS (VALUES (SMALLINT '2026', TIMESTAMP '2026-07-15'))
+                    SELECT test_year = year(test_timestamp) FROM test_data
+                    """))
+                    .matches("VALUES true");
+        }
+    }
+}


### PR DESCRIPTION
## Description

Prevent comparison-unwrapping rules from repeatedly reordering expressions when an unwrap attempt is ineffective.

Comparison IR canonicalizes greater-than operators by reversing operands. The cast, `date_trunc`, and `year` rules moved their target operand to the left, but previously returned that reordered expression even when they could not unwrap it. With two different unwrap candidates, the rules could reverse each other's output indefinitely until the iterative optimizer timed out.

Ineffective unwrap attempts now return empty so the visitor preserves the original comparison. A preparatory commit also avoids repeated cast unwrapping while rebuilding `BETWEEN` bounds.

## Additional context and related issues

Fixes #30347.

The regression test reproduces the optimizer timeout on the pre-fix base commit. The focused regression and related rule suites pass (38 tests), along with validation, formatting, and Checkstyle.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix optimizer timeout for comparisons involving casts and date/time functions. ({issue}`30347`)
```
