### PR TITLE
Add sort by progress in web ui

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp/src/components/QueryList.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/QueryList.tsx
@@ -49,7 +49,29 @@ const ERROR_TYPE = {
     EXTERNAL: (queryInfo: QueryInfo) => queryInfo.state === 'FAILED' && queryInfo.errorType === 'EXTERNAL',
 } as const
 
+const ACTIVE_QUERY_STATES = [
+    'QUEUED',
+    'WAITING_FOR_RESOURCES',
+    'DISPATCHING',
+    'PLANNING',
+    'STARTING',
+    'RUNNING',
+    'FINISHING',
+] as const
+
 const SORT_TYPE = {
+    PROGRESS: (queryInfo: QueryInfo) => {
+        let value = 0
+        const index = ACTIVE_QUERY_STATES.findIndex((state) => state === queryInfo.state)
+        if (index !== -1) {
+            value = (ACTIVE_QUERY_STATES.length - index) * 1e15
+        }
+        return (
+            value +
+            (100 - (queryInfo.queryStats.processPercentage ?? 100)) * 1e12 +
+            Date.parse(queryInfo.queryStats.createTime)
+        )
+    },
     CREATED: (queryInfo: QueryInfo) => Date.parse(queryInfo.queryStats.createTime),
     ELAPSED: (queryInfo: QueryInfo) => parseDuration(queryInfo.queryStats.elapsedTime),
     EXECUTION: (queryInfo: QueryInfo) => parseDuration(queryInfo.queryStats.executionTime),
@@ -96,7 +118,7 @@ export const QueryList = () => {
         'INSUFFICIENT_RESOURCES',
         'EXTERNAL',
     ] as (keyof typeof ERROR_TYPE)[])
-    const [sortType, setSortType] = useLocalStorageState('sortType', 'CREATED' as keyof typeof SORT_TYPE)
+    const [sortType, setSortType] = useLocalStorageState('sortType', 'PROGRESS' as keyof typeof SORT_TYPE)
     const [sortOrder, setSortOrder] = useLocalStorageState('sortOrder', 'DESCENDING' as keyof typeof SORT_ORDER)
     const [reorderInterval, setReorderInterval] = useLocalStorageState('reorderInterval', 5000 as number)
     const [maxQueries, setMaxQueries] = useLocalStorageState('maxQueries', 100 as number)
@@ -449,6 +471,7 @@ export const QueryList = () => {
                                 MenuProps={smallDropdownMenuPropsSx}
                                 value={sortType}
                             >
+                                {renderSortTypeSelectItem('PROGRESS', 'Progress')}
                                 {renderSortTypeSelectItem('CREATED', 'Creation time')}
                                 {renderSortTypeSelectItem('ELAPSED', 'Elapsed time')}
                                 {renderSortTypeSelectItem('CPU', 'CPU time')}


### PR DESCRIPTION
## Description
The current default sort by created is not very useful to me. When showing all query types and sorting on creation time, quick finished queries move the running queries out of view.

The goal of this new sorting option is to order the queries by progression in 3 blocks:

1. Queries with state `QUEUED, WAITING_FOR_RESOURCES, DISPATCHING, PLANNING, STARTING, RUNNING or FINISHING` are ordered by state, creation time
2. Running queries are ordered by progressPercentage from 0 to 100% (creation time for items with the same percentage)
3. Queries with a done state are ordered by creation time

This way, the query makes a natural fall through the list (when sorted descending), where quick queries fall quicker through the list and slower queries move slowly towards the queries with the done state.

<img width="1640" height="260" alt="image" src="https://github.com/user-attachments/assets/17477448-9f6e-47c6-a188-f169c101cdac" />


Calcuation explaination:
```javascript
    PROGRESS: (queryInfo: QueryInfo) => {
        let value = 0
        const index = ACTIVE_QUERY_STATES.findIndex((state) => state === queryInfo.state)
        if (index !== -1) {
            value = (ACTIVE_QUERY_STATES.length - index) * 1e15
            // A queued query has state index 0 in the array, the array length is 7 so `(7 - 0) * 1e15 = 7.000.000.000.000.000`
            // A starting query has state index 4 in the array, the array length is 7 so `(7 - 4) * 1e15 = 3.000.000.000.000.000`
            // A running query has state index 5 in the array, the array length is 7 so `(7 - 5) * 1e15 = 2.000.000.000.000.000`
            // A finishing query has state index 6 in the array, the array length is 7 so `(7 - 5) * 1e15 = 1.000.000.000.000.000`
        }
        // A finished or failed query has no state index in the array, so `0`
        return (
            value +
            (100 - (queryInfo.queryStats.processPercentage ?? 100)) * 1e12 +
            // Only a running query and a finished query have a processPercentage.
            // When the progress is 0%, `(100 - 0) * 1e12 = 100.000.000.000.000` is added
            // When the progress is 1%, `(100 - 1) * 1e12 = 99.000.000.000.000` is added
            // When the progress is 99%, `(100 - 99) * 1e12 = 10.000.000.000.000` is added
            // When it is a failed task, the processPercentage is undefined and 100 will be used. `(100 - 100) * 1e12 = 0`
            
            Date.parse(queryInfo.queryStats.createTime)
            // At last, the timestamp is added, for example 1.784.143.217.002
            // it will not conflict the calculation before the year 2535
        )
    },
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
## General
* Add sort by progression in web ui
```
