### PR TITLE
Store Iceberg metrics: geometry, geography bounds

### DIFF
--- a/lib/trino-parquet/pom.xml
+++ b/lib/trino-parquet/pom.xml
@@ -107,6 +107,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-filesystem</artifactId>
             <scope>provided</scope>
@@ -255,5 +260,23 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <!--
+                        parquet-column's GeospatialStatistics.Builder has a private update(Geometry)
+                        overload, so javac must load org.locationtech.jts.geom.Geometry on the compile
+                        classpath even though our production code never references JTS directly. Declaring
+                        jts-core at compile scope satisfies javac; this override tells dependency:analyze
+                        not to demote it to test scope on our behalf.
+                    -->
+                    <ignoredNonTestScopedDependencies>
+                        <ignoredDependency>org.locationtech.jts:jts-core</ignoredDependency>
+                    </ignoredNonTestScopedDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetMetadataConverter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetMetadataConverter.java
@@ -16,6 +16,9 @@ package io.trino.parquet;
 import io.trino.parquet.metadata.IndexReference;
 import org.apache.parquet.column.EncodingStats;
 import org.apache.parquet.column.statistics.BinaryStatistics;
+import org.apache.parquet.column.statistics.geospatial.BoundingBox;
+import org.apache.parquet.column.statistics.geospatial.GeospatialStatistics;
+import org.apache.parquet.column.statistics.geospatial.GeospatialTypes;
 import org.apache.parquet.format.BoundaryOrder;
 import org.apache.parquet.format.BsonType;
 import org.apache.parquet.format.ColumnChunk;
@@ -71,7 +74,9 @@ import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -351,6 +356,70 @@ public final class ParquetMetadataConverter
             }
         }
         return statsBuilder.build();
+    }
+
+    public static GeospatialStatistics fromParquetGeospatialStatistics(org.apache.parquet.format.GeospatialStatistics formatStats)
+    {
+        if (formatStats == null) {
+            return null;
+        }
+
+        BoundingBox bbox = null;
+        if (formatStats.isSetBbox()) {
+            org.apache.parquet.format.BoundingBox formatBbox = formatStats.getBbox();
+            // parquet-column BoundingBox uses +/-Infinity to signal "empty" for a dimension (see isEmpty()).
+            // NaN would mark the dimension as invalid instead, which is the wrong signal for Z or M being unset.
+            bbox = new BoundingBox(
+                    formatBbox.isSetXmin() ? formatBbox.getXmin() : Double.POSITIVE_INFINITY,
+                    formatBbox.isSetXmax() ? formatBbox.getXmax() : Double.NEGATIVE_INFINITY,
+                    formatBbox.isSetYmin() ? formatBbox.getYmin() : Double.POSITIVE_INFINITY,
+                    formatBbox.isSetYmax() ? formatBbox.getYmax() : Double.NEGATIVE_INFINITY,
+                    formatBbox.isSetZmin() ? formatBbox.getZmin() : Double.POSITIVE_INFINITY,
+                    formatBbox.isSetZmax() ? formatBbox.getZmax() : Double.NEGATIVE_INFINITY,
+                    formatBbox.isSetMmin() ? formatBbox.getMmin() : Double.POSITIVE_INFINITY,
+                    formatBbox.isSetMmax() ? formatBbox.getMmax() : Double.NEGATIVE_INFINITY);
+        }
+
+        GeospatialTypes geospatialTypes = null;
+        if (formatStats.isSetGeospatial_types()) {
+            geospatialTypes = new GeospatialTypes(new HashSet<>(formatStats.getGeospatial_types()));
+        }
+
+        return new GeospatialStatistics(bbox, geospatialTypes);
+    }
+
+    public static org.apache.parquet.format.GeospatialStatistics toParquetGeospatialStatistics(GeospatialStatistics stats)
+    {
+        if (stats == null || !stats.isValid()) {
+            return null;
+        }
+
+        org.apache.parquet.format.GeospatialStatistics formatStats = new org.apache.parquet.format.GeospatialStatistics();
+
+        BoundingBox bbox = stats.getBoundingBox();
+        if (bbox != null && bbox.isValid() && !bbox.isXYEmpty()) {
+            org.apache.parquet.format.BoundingBox formatBbox = new org.apache.parquet.format.BoundingBox(
+                    bbox.getXMin(), bbox.getXMax(), bbox.getYMin(), bbox.getYMax());
+            if (!bbox.isZEmpty()) {
+                formatBbox.setZmin(bbox.getZMin());
+                formatBbox.setZmax(bbox.getZMax());
+            }
+            if (!bbox.isMEmpty()) {
+                formatBbox.setMmin(bbox.getMMin());
+                formatBbox.setMmax(bbox.getMMax());
+            }
+            formatStats.setBbox(formatBbox);
+        }
+
+        GeospatialTypes geospatialTypes = stats.getGeospatialTypes();
+        if (geospatialTypes != null && geospatialTypes.isValid() && !geospatialTypes.getTypes().isEmpty()) {
+            formatStats.setGeospatial_types(new ArrayList<>(geospatialTypes.getTypes()));
+        }
+
+        if (!formatStats.isSetBbox() && !formatStats.isSetGeospatial_types()) {
+            return null;
+        }
+        return formatStats;
     }
 
     public static IndexReference toColumnIndexReference(ColumnChunk columnChunk)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/ParquetMetadata.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/ParquetMetadata.java
@@ -25,6 +25,7 @@ import io.trino.parquet.crypto.FileDecryptionContext;
 import io.trino.parquet.crypto.ModuleType;
 import io.trino.parquet.reader.MetadataReader;
 import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.statistics.geospatial.GeospatialStatistics;
 import org.apache.parquet.format.ColumnChunk;
 import org.apache.parquet.format.ColumnCryptoMetaData;
 import org.apache.parquet.format.ColumnMetaData;
@@ -46,6 +47,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -57,6 +59,7 @@ import java.util.Set;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.parquet.ParquetMetadataConverter.convertEncodingStats;
+import static io.trino.parquet.ParquetMetadataConverter.fromParquetGeospatialStatistics;
 import static io.trino.parquet.ParquetMetadataConverter.getEncoding;
 import static io.trino.parquet.ParquetMetadataConverter.getLogicalTypeAnnotation;
 import static io.trino.parquet.ParquetMetadataConverter.getPrimitive;
@@ -212,6 +215,61 @@ public class ParquetMetadata
         }
 
         return blocks;
+    }
+
+    /**
+     * Returns per-column geospatial statistics merged across all row groups in this file.
+     * A column is included only if every row group in which it appears carries a
+     * geospatial statistics record. Columns whose chunks disagree (some set, some unset)
+     * are omitted, mirroring the drop semantics applied to standard column statistics.
+     */
+    public Map<ColumnPath, GeospatialStatistics> getGeospatialStatisticsByColumn()
+    {
+        List<RowGroup> rowGroups = parquetMetadata.getRow_groups();
+        if (rowGroups == null || rowGroups.isEmpty()) {
+            return ImmutableMap.of();
+        }
+
+        Map<ColumnPath, GeospatialStatistics> merged = new HashMap<>();
+        Set<ColumnPath> dropped = new HashSet<>();
+
+        for (RowGroup rowGroup : rowGroups) {
+            List<ColumnChunk> columns = rowGroup.getColumns();
+            if (columns == null) {
+                continue;
+            }
+            for (ColumnChunk columnChunk : columns) {
+                ColumnMetaData metaData = columnChunk.getMeta_data();
+                if (metaData == null) {
+                    // Encrypted column whose metadata is unvailable in plaintext
+                    continue;
+                }
+                ColumnPath columnPath = getPath(metaData.getPath_in_schema());
+                if (dropped.contains(columnPath)) {
+                    continue;
+                }
+                if (!metaData.isSetGeospatial_statistics()) {
+                    dropped.add(columnPath);
+                    merged.remove(columnPath);
+                    continue;
+                }
+                GeospatialStatistics chunkStats = fromParquetGeospatialStatistics(metaData.getGeospatial_statistics());
+                if (chunkStats == null) {
+                    dropped.add(columnPath);
+                    merged.remove(columnPath);
+                    continue;
+                }
+                GeospatialStatistics accumulator = merged.get(columnPath);
+                if (accumulator == null) {
+                    merged.put(columnPath, chunkStats.copy());
+                }
+                else {
+                    accumulator.merge(chunkStats);
+                }
+            }
+        }
+
+        return ImmutableMap.copyOf(merged);
     }
 
     @VisibleForTesting

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
@@ -23,6 +23,7 @@ import io.trino.parquet.writer.valuewriter.DateValueWriter;
 import io.trino.parquet.writer.valuewriter.DoubleValueWriter;
 import io.trino.parquet.writer.valuewriter.FixedLenByteArrayLongDecimalValueWriter;
 import io.trino.parquet.writer.valuewriter.FixedLenByteArrayShortDecimalValueWriter;
+import io.trino.parquet.writer.valuewriter.GeometryValueWriter;
 import io.trino.parquet.writer.valuewriter.Int32ShortDecimalValueWriter;
 import io.trino.parquet.writer.valuewriter.Int64ShortDecimalValueWriter;
 import io.trino.parquet.writer.valuewriter.Int96TimestampValueWriter;
@@ -167,6 +168,9 @@ final class ParquetWriters
         }
         if (type instanceof VarcharType || type instanceof CharType || type instanceof VarbinaryType) {
             // Binary writer is suitable also for char data, as UTF-8 encoding is used on both sides.
+            if (type instanceof VarbinaryType && parquetType.getLogicalTypeAnnotation() instanceof LogicalTypeAnnotation.GeometryLogicalTypeAnnotation) {
+                return new GeometryValueWriter(valuesWriter, type, parquetType);
+            }
             return new BinaryValueWriter(valuesWriter, type, parquetType);
         }
         if (type instanceof UuidType) {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
@@ -23,6 +23,7 @@ import io.trino.parquet.writer.repdef.RepLevelWriterProvider;
 import io.trino.parquet.writer.repdef.RepLevelWriterProvider.RepetitionLevelWriter;
 import io.trino.parquet.writer.repdef.RepLevelWriterProviders;
 import io.trino.parquet.writer.valuewriter.ColumnDescriptorValuesWriter;
+import io.trino.parquet.writer.valuewriter.GeometryValueWriter;
 import io.trino.parquet.writer.valuewriter.PrimitiveValueWriter;
 import io.trino.plugin.base.io.ChunkedSliceOutput;
 import jakarta.annotation.Nullable;
@@ -34,6 +35,7 @@ import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.EncodingStats;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.column.statistics.geospatial.GeospatialStatistics;
 import org.apache.parquet.column.values.bloomfilter.BloomFilter;
 import org.apache.parquet.format.ColumnMetaData;
 import org.apache.parquet.format.CompressionCodec;
@@ -212,6 +214,13 @@ public class PrimitiveColumnWriter
                 totalCompressedSize,
                 -1);
         columnMetaData.setStatistics(ParquetMetadataConverter.toParquetStatistics(columnStatistics, MAX_STATISTICS_LENGTH_IN_BYTES));
+        if (primitiveValueWriter instanceof GeometryValueWriter geometryValueWriter) {
+            GeospatialStatistics geoStats = geometryValueWriter.getGeospatialStatisticsBuilder().build();
+            org.apache.parquet.format.GeospatialStatistics formatGeoStats = ParquetMetadataConverter.toParquetGeospatialStatistics(geoStats);
+            if (formatGeoStats != null) {
+                columnMetaData.setGeospatial_statistics(formatGeoStats);
+            }
+        }
         ImmutableList.Builder<PageEncodingStats> pageEncodingStats = ImmutableList.builder();
         dataPagesWithEncoding.entrySet().stream()
                 .map(encodingAndCount -> new PageEncodingStats(PageType.DATA_PAGE, encodingAndCount.getKey(), encodingAndCount.getValue()))

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/GeometryValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/GeometryValueWriter.java
@@ -17,26 +17,34 @@ import io.airlift.slice.Slice;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.column.statistics.geospatial.GeospatialStatistics;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType;
 
 import static java.util.Objects.requireNonNull;
 
-public class BinaryValueWriter
-        extends PrimitiveValueWriter
+/**
+ * Writes VARBINARY values annotated with a Geometry logical type, additionally
+ * feeding each WKB payload through a parquet-column
+ * {@link org.apache.parquet.column.statistics.geospatial.GeospatialStatistics.Builder}
+ * so that the resulting bounding box can be emitted on the column chunk's
+ * {@code geospatial_statistics} thrift field.
+ */
+public class GeometryValueWriter
+        extends BinaryValueWriter
 {
-    private final Type type;
+    private final GeospatialStatistics.Builder geospatialStatisticsBuilder;
 
-    public BinaryValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    public GeometryValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
     {
-        super(parquetType, valuesWriter);
-        this.type = requireNonNull(type, "type is null");
+        super(valuesWriter, type, parquetType);
+        this.geospatialStatisticsBuilder = GeospatialStatistics.newBuilder(parquetType);
     }
 
-    protected Type getType()
+    public GeospatialStatistics.Builder getGeospatialStatisticsBuilder()
     {
-        return type;
+        return geospatialStatisticsBuilder;
     }
 
     @Override
@@ -44,15 +52,15 @@ public class BinaryValueWriter
     {
         ValuesWriter valuesWriter = requireNonNull(getValuesWriter(), "valuesWriter is null");
         Statistics<?> statistics = requireNonNull(getStatistics(), "statistics is null");
+        Type type = getType();
         boolean mayHaveNull = block.mayHaveNull();
         for (int i = 0; i < block.getPositionCount(); i++) {
             if (!mayHaveNull || !block.isNull(i)) {
                 Slice slice = type.getSlice(block, i);
-                // fromReusedByteArray must be used instead of fromConstantByteArray to avoid retaining entire
-                // base byte array of the Slice in DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter
                 Binary binary = Binary.fromReusedByteArray(slice.byteArray(), slice.byteArrayOffset(), slice.length());
                 valuesWriter.writeBytes(binary);
                 statistics.updateStats(binary);
+                geospatialStatisticsBuilder.update(binary);
             }
         }
     }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestParquetMetadataConverter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestParquetMetadataConverter.java
@@ -14,6 +14,8 @@
 package io.trino.parquet;
 
 import org.apache.parquet.column.statistics.BinaryStatistics;
+import org.apache.parquet.format.BoundingBox;
+import org.apache.parquet.format.GeospatialStatistics;
 import org.apache.parquet.format.LogicalType;
 import org.apache.parquet.format.Statistics;
 import org.apache.parquet.io.api.Binary;
@@ -22,8 +24,10 @@ import org.apache.parquet.schema.Types;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static io.trino.parquet.ParquetMetadataConverter.convertToLogicalType;
+import static io.trino.parquet.ParquetMetadataConverter.fromParquetGeospatialStatistics;
 import static io.trino.parquet.ParquetMetadataConverter.fromParquetStatistics;
 import static io.trino.parquet.ParquetMetadataConverter.getLogicalTypeAnnotation;
 import static io.trino.parquet.ParquetMetadataConverter.isMinMaxStatsSupported;
@@ -269,5 +273,53 @@ class TestParquetMetadataConverter
         assertThat(statistics.isSetMax()).isFalse();
         assertThat(statistics.isSetMin_value()).isFalse();
         assertThat(statistics.isSetMax_value()).isFalse();
+    }
+
+    @Test
+    void testFromParquetGeospatialStatisticsNull()
+    {
+        assertThat(fromParquetGeospatialStatistics(null)).isNull();
+    }
+
+    @Test
+    void testFromParquetGeospatialStatisticsXyBoundingBox()
+    {
+        BoundingBox formatBbox = new BoundingBox(-10.0, 10.0, -20.0, 20.0);
+        GeospatialStatistics formatStats = new GeospatialStatistics();
+        formatStats.setBbox(formatBbox);
+
+        org.apache.parquet.column.statistics.geospatial.GeospatialStatistics stats = fromParquetGeospatialStatistics(formatStats);
+
+        assertThat(stats).isNotNull();
+        org.apache.parquet.column.statistics.geospatial.BoundingBox bbox = stats.getBoundingBox();
+        assertThat(bbox).isNotNull();
+        assertThat(bbox.isValid()).isTrue();
+        assertThat(bbox.getXMin()).isEqualTo(-10.0);
+        assertThat(bbox.getXMax()).isEqualTo(10.0);
+        assertThat(bbox.getYMin()).isEqualTo(-20.0);
+        assertThat(bbox.getYMax()).isEqualTo(20.0);
+        assertThat(bbox.isZEmpty()).isTrue();
+        assertThat(bbox.isMEmpty()).isTrue();
+    }
+
+    @Test
+    void testFromParquetGeospatialStatisticsXyzmAndGeospatialTypes()
+    {
+        BoundingBox formatBbox = new BoundingBox(1.0, 2.0, 3.0, 4.0)
+                .setZmin(5.0).setZmax(6.0)
+                .setMmin(7.0).setMmax(8.0);
+        GeospatialStatistics formatStats = new GeospatialStatistics();
+        formatStats.setBbox(formatBbox);
+        formatStats.setGeospatial_types(List.of(1, 2, 3));
+
+        org.apache.parquet.column.statistics.geospatial.GeospatialStatistics stats = fromParquetGeospatialStatistics(formatStats);
+
+        assertThat(stats).isNotNull();
+        org.apache.parquet.column.statistics.geospatial.BoundingBox bbox = stats.getBoundingBox();
+        assertThat(bbox.getZMin()).isEqualTo(5.0);
+        assertThat(bbox.getZMax()).isEqualTo(6.0);
+        assertThat(bbox.getMMin()).isEqualTo(7.0);
+        assertThat(bbox.getMMax()).isEqualTo(8.0);
+        assertThat(stats.getGeospatialTypes().getTypes()).containsExactlyInAnyOrder(1, 2, 3);
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriterGeospatialStatistics.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriterGeospatialStatistics.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.ParquetReaderOptions;
+import io.trino.parquet.metadata.ParquetMetadata;
+import io.trino.parquet.reader.MetadataReader;
+import io.trino.parquet.reader.TestingParquetDataSource;
+import io.trino.spi.Page;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import org.apache.parquet.format.BoundingBox;
+import org.apache.parquet.format.ColumnChunk;
+import org.apache.parquet.format.CompressionCodec;
+import org.apache.parquet.format.GeospatialStatistics;
+import org.apache.parquet.format.RowGroup;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Type.Repetition;
+import org.apache.parquet.schema.Types;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.io.WKBWriter;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestParquetWriterGeospatialStatistics
+{
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+    private static final String COLUMN_NAME = "geom";
+
+    @Test
+    void writeGeometryColumnEmitsGeospatialStatistics()
+            throws Exception
+    {
+        MessageType messageType = geometryMessageType(LogicalTypeAnnotation.geometryType("OGC:CRS84"));
+
+        Slice writtenBytes = writeGeometryFile(messageType, ImmutableList.of(
+                point2d(-10.0, -20.0),
+                point2d(10.0, 20.0),
+                point2d(3.0, 4.0)));
+
+        GeospatialStatistics stats = readOnlyGeospatialStatistics(writtenBytes);
+        assertThat(stats).isNotNull();
+        assertThat(stats.isSetBbox()).isTrue();
+
+        BoundingBox bbox = stats.getBbox();
+        assertThat(bbox.getXmin()).isEqualTo(-10.0);
+        assertThat(bbox.getXmax()).isEqualTo(10.0);
+        assertThat(bbox.getYmin()).isEqualTo(-20.0);
+        assertThat(bbox.getYmax()).isEqualTo(20.0);
+        assertThat(bbox.isSetZmin()).isFalse();
+        assertThat(bbox.isSetMmin()).isFalse();
+    }
+
+    @Test
+    void writeGeometryColumnCapturesZExtent()
+            throws Exception
+    {
+        MessageType messageType = geometryMessageType(LogicalTypeAnnotation.geometryType("OGC:CRS84"));
+
+        Slice writtenBytes = writeGeometryFile(messageType, ImmutableList.of(
+                point3d(-1.0, -2.0, 5.0),
+                point3d(2.0, 3.0, 15.0)));
+
+        GeospatialStatistics stats = readOnlyGeospatialStatistics(writtenBytes);
+        assertThat(stats).isNotNull();
+
+        BoundingBox bbox = stats.getBbox();
+        assertThat(bbox.getXmin()).isEqualTo(-1.0);
+        assertThat(bbox.getXmax()).isEqualTo(2.0);
+        assertThat(bbox.getYmin()).isEqualTo(-2.0);
+        assertThat(bbox.getYmax()).isEqualTo(3.0);
+        assertThat(bbox.isSetZmin()).isTrue();
+        assertThat(bbox.getZmin()).isEqualTo(5.0);
+        assertThat(bbox.getZmax()).isEqualTo(15.0);
+    }
+
+    @Test
+    void writeGeometryColumnSkipsStatsWhenAllValuesNull()
+            throws Exception
+    {
+        MessageType messageType = geometryMessageType(LogicalTypeAnnotation.geometryType("OGC:CRS84"));
+
+        BlockBuilder builder = VARBINARY.createBlockBuilder(null, 3);
+        builder.appendNull();
+        builder.appendNull();
+        builder.appendNull();
+
+        Slice writtenBytes = writeParquetFile(messageType, ImmutableList.of(new Page(builder.build())));
+
+        GeospatialStatistics stats = readOnlyGeospatialStatistics(writtenBytes);
+        // An all-null column produces no valid bounding box; the field should be omitted entirely.
+        assertThat(stats).isNull();
+    }
+
+    @Test
+    void writeVarbinaryColumnDoesNotEmitGeospatialStatistics()
+            throws Exception
+    {
+        MessageType messageType = Types.buildMessage()
+                .addField(Types.primitive(PrimitiveTypeName.BINARY, Repetition.OPTIONAL).named(COLUMN_NAME))
+                .named("trino_test");
+
+        BlockBuilder builder = VARBINARY.createBlockBuilder(null, 2);
+        VARBINARY.writeSlice(builder, Slices.wrappedBuffer(new byte[] {0x1, 0x2, 0x3}));
+        VARBINARY.writeSlice(builder, Slices.wrappedBuffer(new byte[] {0x4, 0x5, 0x6}));
+
+        Slice writtenBytes = writeParquetFile(messageType, ImmutableList.of(new Page(builder.build())));
+
+        assertThat(readOnlyGeospatialStatistics(writtenBytes)).isNull();
+    }
+
+    @Test
+    void writeGeographyColumnRemainsUnsetForNow()
+            throws Exception
+    {
+        // parquet-column 1.17.1 returns a NoopBuilder for Geography annotations, so geospatial
+        // statistics should not be emitted. This test documents that behavior — it will need
+        // adjustment when upstream lands geography support.
+        MessageType messageType = geometryMessageType(LogicalTypeAnnotation.geographyType());
+
+        Slice writtenBytes = writeGeometryFile(messageType, ImmutableList.of(point2d(1.0, 2.0)));
+
+        assertThat(readOnlyGeospatialStatistics(writtenBytes)).isNull();
+    }
+
+    private static Slice writeGeometryFile(MessageType messageType, List<byte[]> wkbValues)
+            throws Exception
+    {
+        BlockBuilder builder = VARBINARY.createBlockBuilder(null, wkbValues.size());
+        for (byte[] wkb : wkbValues) {
+            VARBINARY.writeSlice(builder, Slices.wrappedBuffer(wkb));
+        }
+        return writeParquetFile(messageType, ImmutableList.of(new Page(builder.build())));
+    }
+
+    private static Slice writeParquetFile(MessageType messageType, List<Page> pages)
+            throws Exception
+    {
+        Map<List<String>, Type> primitiveTypes = Map.of(ImmutableList.of(COLUMN_NAME), (Type) VarbinaryType.VARBINARY);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ParquetWriter writer = new ParquetWriter(
+                outputStream,
+                messageType,
+                primitiveTypes,
+                ParquetWriterOptions.builder().build(),
+                CompressionCodec.UNCOMPRESSED,
+                "test-version",
+                Optional.of(DateTimeZone.UTC),
+                Optional.empty())) {
+            for (Page page : pages) {
+                writer.write(page);
+            }
+        }
+        return Slices.wrappedBuffer(outputStream.toByteArray());
+    }
+
+    private static GeospatialStatistics readOnlyGeospatialStatistics(Slice writtenBytes)
+            throws Exception
+    {
+        TestingParquetDataSource dataSource = new TestingParquetDataSource(writtenBytes, ParquetReaderOptions.defaultOptions());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        List<RowGroup> rowGroups = parquetMetadata.getParquetMetadata().getRow_groups();
+        assertThat(rowGroups).hasSize(1);
+        List<ColumnChunk> columns = rowGroups.get(0).getColumns();
+        assertThat(columns).hasSize(1);
+        return columns.get(0).getMeta_data().isSetGeospatial_statistics()
+                ? columns.get(0).getMeta_data().getGeospatial_statistics()
+                : null;
+    }
+
+    private static MessageType geometryMessageType(LogicalTypeAnnotation annotation)
+    {
+        PrimitiveType column = Types.primitive(PrimitiveTypeName.BINARY, Repetition.OPTIONAL)
+                .as(annotation)
+                .named(COLUMN_NAME);
+        return Types.buildMessage().addField(column).named("trino_test");
+    }
+
+    private static byte[] point2d(double x, double y)
+    {
+        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(x, y));
+        return new WKBWriter().write(point);
+    }
+
+    private static byte[] point3d(double x, double y, double z)
+    {
+        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(x, y, z));
+        return new WKBWriter(3).write(point);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/ParquetUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/ParquetUtil.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.MetricsModes.MetricsMode;
 import org.apache.iceberg.MetricsUtil;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.geospatial.GeospatialBound;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.parquet.ParquetSchemaUtil;
 import org.apache.iceberg.types.Conversions;
@@ -33,11 +34,15 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.BinaryUtil;
 import org.apache.iceberg.util.UnicodeUtil;
 import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.column.statistics.geospatial.BoundingBox;
+import org.apache.parquet.column.statistics.geospatial.GeospatialStatistics;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type.ID;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -88,6 +93,8 @@ public final class ParquetUtil
         Map<Integer, Long> nullValueCounts = new HashMap<>();
         Map<Integer, Literal<?>> lowerBounds = new HashMap<>();
         Map<Integer, Literal<?>> upperBounds = new HashMap<>();
+        Map<Integer, ByteBuffer> geoLowerBounds = new HashMap<>();
+        Map<Integer, ByteBuffer> geoUpperBounds = new HashMap<>();
         Set<Integer> missingStats = new HashSet<>();
 
         // ignore metrics for fields we failed to determine reliable IDs
@@ -146,14 +153,101 @@ public final class ParquetUtil
 
         updateFromFieldMetrics(fieldMetricsMap, metricsConfig, fileSchema, lowerBounds, upperBounds);
 
+        collectGeospatialBounds(metadata, parquetTypeWithIds, fileSchema, metricsConfig, geoLowerBounds, geoUpperBounds);
+
         return new Metrics(
                 rowCount,
                 columnSizes,
                 valueCounts,
                 nullValueCounts,
                 createNanValueCounts(fieldMetricsMap.values().stream(), metricsConfig, fileSchema),
-                toBufferMap(fileSchema, lowerBounds),
-                toBufferMap(fileSchema, upperBounds));
+                mergeBounds(toBufferMap(fileSchema, lowerBounds), geoLowerBounds),
+                mergeBounds(toBufferMap(fileSchema, upperBounds), geoUpperBounds));
+    }
+
+    private static void collectGeospatialBounds(
+            ParquetMetadata metadata,
+            MessageType parquetTypeWithIds,
+            Schema fileSchema,
+            MetricsConfig metricsConfig,
+            Map<Integer, ByteBuffer> geoLowerBounds,
+            Map<Integer, ByteBuffer> geoUpperBounds)
+    {
+        Map<ColumnPath, GeospatialStatistics> geoStatsByColumn = metadata.getGeospatialStatisticsByColumn();
+        if (geoStatsByColumn.isEmpty()) {
+            return;
+        }
+
+        for (Entry<ColumnPath, GeospatialStatistics> entry : geoStatsByColumn.entrySet()) {
+            String[] path = entry.getKey().toArray();
+            // Iceberg 1.11's MessageTypeToType does not yet map GEOMETRY/GEOGRAPHY logical annotations to
+            // Types.GeometryType/GeographyType (it falls through to BINARY), so consult the parquet
+            // logical annotation and field id directly rather than the derived Iceberg field type.
+            if (!parquetTypeWithIds.containsPath(path)) {
+                continue;
+            }
+            PrimitiveType parquetPrimitive = parquetTypeWithIds.getType(path).asPrimitiveType();
+            LogicalTypeAnnotation annotation = parquetPrimitive.getLogicalTypeAnnotation();
+            if (!(annotation instanceof LogicalTypeAnnotation.GeometryLogicalTypeAnnotation)
+                    && !(annotation instanceof LogicalTypeAnnotation.GeographyLogicalTypeAnnotation)) {
+                continue;
+            }
+            ID parquetId = parquetPrimitive.getId();
+            if (parquetId == null) {
+                continue;
+            }
+            int fieldId = parquetId.intValue();
+
+            MetricsMode metricsMode = MetricsUtil.metricsMode(fileSchema, metricsConfig, fieldId);
+            // Bounding boxes are not truncatable, so any mode that collects bounds behaves like Full.
+            if (metricsMode == MetricsModes.None.get() || metricsMode == MetricsModes.Counts.get()) {
+                continue;
+            }
+
+            GeospatialStatistics stats = entry.getValue();
+            if (stats == null) {
+                continue;
+            }
+            BoundingBox bbox = stats.getBoundingBox();
+            if (bbox == null || !bbox.isValid() || bbox.isXYEmpty()) {
+                continue;
+            }
+
+            geoLowerBounds.put(fieldId, toGeospatialBound(bbox, true).toByteBuffer());
+            geoUpperBounds.put(fieldId, toGeospatialBound(bbox, false).toByteBuffer());
+        }
+    }
+
+    private static GeospatialBound toGeospatialBound(BoundingBox bbox, boolean lower)
+    {
+        double x = lower ? bbox.getXMin() : bbox.getXMax();
+        double y = lower ? bbox.getYMin() : bbox.getYMax();
+        boolean hasZ = !bbox.isZEmpty();
+        boolean hasM = !bbox.isMEmpty();
+        if (!hasZ && !hasM) {
+            return GeospatialBound.createXY(x, y);
+        }
+        if (hasZ && !hasM) {
+            return GeospatialBound.createXYZ(x, y, lower ? bbox.getZMin() : bbox.getZMax());
+        }
+        if (!hasZ) {
+            return GeospatialBound.createXYM(x, y, lower ? bbox.getMMin() : bbox.getMMax());
+        }
+        return GeospatialBound.createXYZM(
+                x,
+                y,
+                lower ? bbox.getZMin() : bbox.getZMax(),
+                lower ? bbox.getMMin() : bbox.getMMax());
+    }
+
+    private static Map<Integer, ByteBuffer> mergeBounds(Map<Integer, ByteBuffer> primary, Map<Integer, ByteBuffer> geo)
+    {
+        if (geo.isEmpty()) {
+            return primary;
+        }
+        Map<Integer, ByteBuffer> merged = new HashMap<>(primary);
+        merged.putAll(geo);
+        return merged;
     }
 
     private static void updateFromFieldMetrics(
@@ -265,6 +359,9 @@ public final class ParquetUtil
                     case FIXED, BINARY -> {
                         lowerBounds.put(id, BinaryUtil.truncateBinaryMin((Literal<ByteBuffer>) min, truncateLength));
                     }
+                    case GEOMETRY, GEOGRAPHY -> {
+                        // Geospatial bounds are handled separately; never routed through this Literal-based path.
+                    }
                     default -> {
                         lowerBounds.put(id, min);
                     }
@@ -301,6 +398,9 @@ public final class ParquetUtil
                         if (truncatedMaxBinary != null) {
                             upperBounds.put(id, truncatedMaxBinary);
                         }
+                    }
+                    case GEOMETRY, GEOGRAPHY -> {
+                        // Geospatial bounds are handled separately; never routed through this Literal-based path.
                     }
                     default -> {
                         upperBounds.put(id, max);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/util/TestParquetUtilGeospatialBounds.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/util/TestParquetUtilGeospatialBounds.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.util;
+
+import io.trino.parquet.ParquetDataSourceId;
+import io.trino.parquet.metadata.ParquetMetadata;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.parquet.format.BoundingBox;
+import org.apache.parquet.format.ColumnChunk;
+import org.apache.parquet.format.ColumnMetaData;
+import org.apache.parquet.format.CompressionCodec;
+import org.apache.parquet.format.Encoding;
+import org.apache.parquet.format.FieldRepetitionType;
+import org.apache.parquet.format.FileMetaData;
+import org.apache.parquet.format.GeographyType;
+import org.apache.parquet.format.GeometryType;
+import org.apache.parquet.format.GeospatialStatistics;
+import org.apache.parquet.format.LogicalType;
+import org.apache.parquet.format.RowGroup;
+import org.apache.parquet.format.SchemaElement;
+import org.apache.parquet.format.Type;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestParquetUtilGeospatialBounds
+{
+    @Test
+    void testGeometryBoundsAreCollected()
+            throws Exception
+    {
+        FileMetaData fileMetaData = buildFileMetaData(
+                "geom",
+                LogicalType.GEOMETRY(new GeometryType().setCrs("OGC:CRS84")),
+                bboxWithXy(-10.0, 10.0, -20.0, 20.0),
+                42);
+
+        ParquetMetadata metadata = new ParquetMetadata(fileMetaData, new ParquetDataSourceId("test"), Optional.empty());
+
+        // Sanity: raw thrift geospatial stats are exposed via the accessor.
+        assertThat(metadata.getGeospatialStatisticsByColumn())
+                .as("expected getGeospatialStatisticsByColumn to include geom")
+                .isNotEmpty();
+
+        Metrics metrics = ParquetUtil.footerMetrics(metadata, Stream.empty(), MetricsConfig.getDefault());
+
+        ByteBuffer lower = metrics.lowerBounds().get(42);
+        ByteBuffer upper = metrics.upperBounds().get(42);
+        assertThat(lower).as("lower bound for geom").isNotNull();
+        assertThat(upper).as("upper bound for geom").isNotNull();
+
+        GeospatialBound lowerBound = GeospatialBound.fromByteBuffer(lower.order(ByteOrder.LITTLE_ENDIAN));
+        GeospatialBound upperBound = GeospatialBound.fromByteBuffer(upper.order(ByteOrder.LITTLE_ENDIAN));
+        assertThat(lowerBound.x()).isEqualTo(-10.0);
+        assertThat(lowerBound.y()).isEqualTo(-20.0);
+        assertThat(lowerBound.hasZ()).isFalse();
+        assertThat(lowerBound.hasM()).isFalse();
+        assertThat(upperBound.x()).isEqualTo(10.0);
+        assertThat(upperBound.y()).isEqualTo(20.0);
+    }
+
+    @Test
+    void testGeographyBoundsAreCollected()
+            throws Exception
+    {
+        FileMetaData fileMetaData = buildFileMetaData(
+                "geog",
+                LogicalType.GEOGRAPHY(new GeographyType().setCrs("OGC:CRS84")),
+                bboxWithXy(1.5, 2.5, 3.5, 4.5),
+                7);
+
+        ParquetMetadata metadata = new ParquetMetadata(fileMetaData, new ParquetDataSourceId("test"), Optional.empty());
+
+        Metrics metrics = ParquetUtil.footerMetrics(metadata, Stream.empty(), MetricsConfig.getDefault());
+
+        ByteBuffer lower = metrics.lowerBounds().get(7);
+        ByteBuffer upper = metrics.upperBounds().get(7);
+        assertThat(lower).isNotNull();
+        assertThat(upper).isNotNull();
+
+        GeospatialBound lowerBound = GeospatialBound.fromByteBuffer(lower.order(ByteOrder.LITTLE_ENDIAN));
+        GeospatialBound upperBound = GeospatialBound.fromByteBuffer(upper.order(ByteOrder.LITTLE_ENDIAN));
+        assertThat(lowerBound.x()).isEqualTo(1.5);
+        assertThat(lowerBound.y()).isEqualTo(3.5);
+        assertThat(upperBound.x()).isEqualTo(2.5);
+        assertThat(upperBound.y()).isEqualTo(4.5);
+    }
+
+    @Test
+    void testGeometryBoundsMergedAcrossRowGroups()
+            throws Exception
+    {
+        FileMetaData fileMetaData = buildMultiRowGroupFileMetaData(
+                "geom",
+                LogicalType.GEOMETRY(new GeometryType().setCrs("OGC:CRS84")),
+                List.of(
+                        bboxWithXy(-5.0, 5.0, -6.0, 6.0),
+                        bboxWithXy(-20.0, -1.0, -30.0, 4.0)),
+                42);
+
+        ParquetMetadata metadata = new ParquetMetadata(fileMetaData, new ParquetDataSourceId("test"), Optional.empty());
+
+        Metrics metrics = ParquetUtil.footerMetrics(metadata, Stream.empty(), MetricsConfig.getDefault());
+
+        GeospatialBound lower = GeospatialBound.fromByteBuffer(metrics.lowerBounds().get(42).order(ByteOrder.LITTLE_ENDIAN));
+        GeospatialBound upper = GeospatialBound.fromByteBuffer(metrics.upperBounds().get(42).order(ByteOrder.LITTLE_ENDIAN));
+        assertThat(lower.x()).isEqualTo(-20.0);
+        assertThat(lower.y()).isEqualTo(-30.0);
+        assertThat(upper.x()).isEqualTo(5.0);
+        assertThat(upper.y()).isEqualTo(6.0);
+    }
+
+    @Test
+    void testGeometryBoundsDroppedWhenAnyRowGroupMissingStats()
+            throws Exception
+    {
+        // Second row group carries no geospatial stats; the column should be dropped from bounds.
+        FileMetaData fileMetaData = buildMultiRowGroupFileMetaData(
+                "geom",
+                LogicalType.GEOMETRY(new GeometryType().setCrs("OGC:CRS84")),
+                Arrays.asList(bboxWithXy(-5.0, 5.0, -6.0, 6.0), null),
+                42);
+
+        ParquetMetadata metadata = new ParquetMetadata(fileMetaData, new ParquetDataSourceId("test"), Optional.empty());
+
+        Metrics metrics = ParquetUtil.footerMetrics(metadata, Stream.empty(), MetricsConfig.getDefault());
+
+        assertThat(metrics.lowerBounds().get(42)).isNull();
+        assertThat(metrics.upperBounds().get(42)).isNull();
+    }
+
+    @Test
+    void testGeometryBoundsSkippedWhenBoundingBoxAbsent()
+            throws Exception
+    {
+        FileMetaData fileMetaData = buildFileMetaData(
+                "geom",
+                LogicalType.GEOMETRY(new GeometryType().setCrs("OGC:CRS84")),
+                null,
+                42);
+
+        ParquetMetadata metadata = new ParquetMetadata(fileMetaData, new ParquetDataSourceId("test"), Optional.empty());
+
+        Metrics metrics = ParquetUtil.footerMetrics(metadata, Stream.empty(), MetricsConfig.getDefault());
+
+        assertThat(metrics.lowerBounds().get(42)).isNull();
+        assertThat(metrics.upperBounds().get(42)).isNull();
+    }
+
+    private static BoundingBox bboxWithXy(double xmin, double xmax, double ymin, double ymax)
+    {
+        return new BoundingBox()
+                .setXmin(xmin)
+                .setXmax(xmax)
+                .setYmin(ymin)
+                .setYmax(ymax);
+    }
+
+    private static FileMetaData buildMultiRowGroupFileMetaData(String columnName, LogicalType logicalType, List<BoundingBox> bboxPerRowGroup, int fieldId)
+    {
+        SchemaElement root = new SchemaElement().setName("root").setNum_children(1);
+        SchemaElement column = new SchemaElement()
+                .setName(columnName)
+                .setType(Type.BYTE_ARRAY)
+                .setRepetition_type(FieldRepetitionType.OPTIONAL)
+                .setLogicalType(logicalType)
+                .setField_id(fieldId);
+
+        List<RowGroup> rowGroups = new ArrayList<>(bboxPerRowGroup.size());
+        for (BoundingBox bbox : bboxPerRowGroup) {
+            ColumnMetaData columnMetaData = new ColumnMetaData(
+                    Type.BYTE_ARRAY,
+                    List.of(Encoding.PLAIN),
+                    List.of(columnName),
+                    CompressionCodec.UNCOMPRESSED,
+                    10L,
+                    200L,
+                    100L,
+                    4L);
+            columnMetaData.setTotal_compressed_size(100L);
+            if (bbox != null) {
+                columnMetaData.setGeospatial_statistics(new GeospatialStatistics().setBbox(bbox));
+            }
+            ColumnChunk columnChunk = new ColumnChunk(4L);
+            columnChunk.setMeta_data(columnMetaData);
+            rowGroups.add(new RowGroup(List.of(columnChunk), 100L, 10L));
+        }
+
+        return new FileMetaData(1, List.of(root, column), 10L * bboxPerRowGroup.size(), rowGroups);
+    }
+
+    private static FileMetaData buildFileMetaData(String columnName, LogicalType logicalType, BoundingBox bbox, int fieldId)
+    {
+        // Root schema element
+        SchemaElement root = new SchemaElement().setName("root").setNum_children(1);
+        SchemaElement column = new SchemaElement()
+                .setName(columnName)
+                .setType(Type.BYTE_ARRAY)
+                .setRepetition_type(FieldRepetitionType.OPTIONAL)
+                .setLogicalType(logicalType)
+                .setField_id(fieldId);
+
+        ColumnMetaData columnMetaData = new ColumnMetaData(
+                Type.BYTE_ARRAY,
+                List.of(Encoding.PLAIN),
+                List.of(columnName),
+                CompressionCodec.UNCOMPRESSED,
+                10L,
+                200L,
+                100L,
+                4L);
+        columnMetaData.setTotal_compressed_size(100L);
+        if (bbox != null) {
+            columnMetaData.setGeospatial_statistics(new GeospatialStatistics().setBbox(bbox));
+        }
+
+        ColumnChunk columnChunk = new ColumnChunk(4L);
+        columnChunk.setMeta_data(columnMetaData);
+
+        RowGroup rowGroup = new RowGroup(List.of(columnChunk), 100L, 10L);
+
+        return new FileMetaData(1, List.of(root, column), 10L, List.of(rowGroup));
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Iceberg now records per-column geospatial bounds in the manifest so readers can prune files by bounding box. Trino already writes the Parquet geometry/geography logical annotation, but neither side of the metrics pipeline propagated the bounds: the standard Parquet `Statistics` min/max is unset for geospatial columns by spec, and `Conversions.toByteBuffer` has no case for `GEOMETRY` / `GEOGRAPHY`.

This PR addresses both reader and writer:
*  Files written by other engines (Spark, PyIceberg) have their per-file bounds surfaced when Trino refreshes the manifest.
* Files written by Trino itself carry `geospatial_statistics` on each column chunk, populating the same bounds on write.

* Fixes #30077 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Builds on #29761, which landed the Parquet geometry/geography logical
annotations. That PR added a TODO in `ParquetUtil.java` pointing at
issue #30077; this PR resolves it.

### Reader

Parquet 1.17 carries geospatial bounds in a separate
`ColumnMetaData.geospatial_statistics` Thrift field, which Trino's
reader did not surface. Expose the field via a new
`ParquetMetadata.getGeospatialStatisticsByColumn()` accessor that walks
the raw row groups, converts each chunk through a new
`ParquetMetadataConverter.fromParquetGeospatialStatistics` helper, and
merges by `ColumnPath` using parquet-column's `BoundingBox.merge`.
Columns whose chunks disagree (some set, some unset) are dropped,
matching existing `missingStats` semantics.

`ParquetUtil.footerMetrics` consumes that map: for every column whose
Parquet logical annotation is `Geometry` or `Geography`, it serializes
the merged min and max corners via `GeospatialBound.toByteBuffer()`
and places them in the returned `Metrics.lowerBounds` / `upperBounds`.
Iceberg 1.11's `MessageTypeToType` visitor does not yet map `GEOMETRY`
/ `GEOGRAPHY`, so we key on the Parquet logical annotation rather than
the derived Iceberg field type. Bounds bypass `toBufferMap` /
`Conversions.toByteBuffer` entirely.

### Writer

`VARBINARY` columns whose `PrimitiveType` carries a `Geometry` logical
annotation are routed to a new `GeometryValueWriter` that mirrors
`BinaryValueWriter` but also feeds each WKB value through
`GeospatialStatistics.Builder` from parquet-column (which parses WKB
via JTS and accumulates a `BoundingBox`). `PrimitiveColumnWriter.getColumnMetaData()`
emits the resulting statistics onto the Thrift `ColumnMetaData` via a
new `ParquetMetadataConverter.toParquetGeospatialStatistics` helper.

`IcebergPageSink` converts EWKB to WKB before the writer sees the
value, so the writer receives standard WKB bytes and can hand them to
the JTS-backed builder unchanged. The `Geography` annotation isn't
yet supported upstream by `GeospatialStatistics.newBuilder` — it
returns a no-op builder — so that path remains a no-op pending 
geography support in parquet-column.

### Test dependency

Production code does not reference JTS directly, but parquet-column's
GeospatialStatistics.Builder has a private update(`Geometry`) overload
alongside its public update(`Binary`), so javac's overload resolution
loads `org.locationtech.jts.geom.Geometry` when compiling
`GeometryValueWriter`. Declare `org.locationtech.jts:jts-core` at compile
scope in `lib/trino-parquet/pom.xml`, and add an
`ignoredNonTestScopedDependencies` entry on `maven-dependency-plugin` so
`dependency:analyze-only` does not push it back to test scope.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Populate geometry and geography column bounds in Iceberg manifests
when writing Parquet, and surface bounds from files written by other
engines. ({issue}`30077`)

## Parquet
* Read and write the `geospatial_statistics` field on Parquet column
chunk metadata for columns with the `GEOMETRY` logical annotation.
```
