### PR TITLE
Use full screen width in web ui

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp/src/components/Layout.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/Layout.tsx
@@ -17,7 +17,6 @@ import {
     Avatar,
     AppBar,
     Box,
-    Container,
     IconButton,
     List,
     ListItem,
@@ -398,7 +397,7 @@ export const RootLayout = (props: { children: React.ReactNode }) => {
             </Drawer>
             <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
                 <Toolbar />
-                <Container maxWidth="lg">{props.children}</Container>
+                <Box sx={{ flexGrow: 1, px: 3 }}>{props.children}</Box>
             </Box>
         </Box>
     )


### PR DESCRIPTION
## Description
I have a large screen, but only 1200px are used in the web ui as the mui container is used. I think the used width should be decided by the user, not the developers. With this change, the full width of the container is used and there is more space available to render the query. As suggested by @koszti , only the main page uses full width, the details and worker pages still use the narrow container.

Current master:
<img width="2560" height="1475" alt="Screenshot 2026-07-15 at 21-56-31 Trino" src="https://github.com/user-attachments/assets/7e2f2c5f-c106-49cd-b933-e8ae536959e5" />

This branch:
<img width="2560" height="1475" alt="Screenshot 2026-07-17 at 17-12-26 Trino" src="https://github.com/user-attachments/assets/2921a350-4c21-4d29-a66c-6ff663c4d8c4" />
<img width="2560" height="1475" alt="Screenshot 2026-07-17 at 17-12-36 Trino" src="https://github.com/user-attachments/assets/fb6d7da4-4597-43c5-b6b3-c8f3a810af3f" />
<img width="2560" height="1475" alt="Screenshot 2026-07-17 at 17-12-44 Trino" src="https://github.com/user-attachments/assets/e05625f2-0fd8-4c6c-8120-a7544bbb1b86" />


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
## General
* Use all screen width in the web ui front page
```
