### PR TITLE
Skip Iceberg Glue column comment caching when content is invalid

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.services.glue.model.ResourceNumberLimitExceededExc
 import software.amazon.awssdk.services.glue.model.StorageDescriptor;
 import software.amazon.awssdk.services.glue.model.Table;
 import software.amazon.awssdk.services.glue.model.TableInput;
+import software.amazon.awssdk.services.glue.model.ValidationException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -137,7 +138,8 @@ public class GlueIcebergTableOperations
                 case AlreadyExistsException _,
                      EntityNotFoundException _,
                      InvalidInputException _,
-                     ResourceNumberLimitExceededException _ -> io().deleteFile(newMetadataLocation);
+                     ResourceNumberLimitExceededException _,
+                     ValidationException _ -> io().deleteFile(newMetadataLocation);
                 default -> {}
             }
             throw new TrinoException(ICEBERG_COMMIT_ERROR, "Cannot commit table creation", e);
@@ -201,7 +203,7 @@ public class GlueIcebergTableOperations
             // CommitFailedException is handled as a special case in the Iceberg library. This commit will automatically retry
             throw new CommitFailedException(e, "Failed to commit to Glue table: %s.%s", database, tableName);
         }
-        catch (EntityNotFoundException | InvalidInputException | ResourceNumberLimitExceededException e) {
+        catch (EntityNotFoundException | InvalidInputException | ResourceNumberLimitExceededException | ValidationException e) {
             // Signal a non-retriable commit failure and eventually clean up metadata files corresponding to the current transaction
             throw new TrinoException(ICEBERG_COMMIT_ERROR, "Cannot commit table update", e);
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergUtil.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.builderWithExpectedSize;
@@ -63,6 +64,8 @@ public final class GlueIcebergUtil
     private static final int GLUE_COLUMN_COMMENT_LENGTH_LIMIT = 255;
     // Limit per Glue API docs (https://docs.aws.amazon.com/glue/latest/webapi/API_Column.html as of this writing)
     private static final int GLUE_COLUMN_PARAMETER_LENGTH_LIMIT = 512000;
+    // Column comment pattern per Glue API docs (https://docs.aws.amazon.com/glue/latest/webapi/API_Column.html as of this writing)
+    private static final Pattern GLUE_COLUMN_COMMENT_PATTERN = Pattern.compile("[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*");
 
     public static TableInput getTableInput(
             TypeManager typeManager,
@@ -127,9 +130,11 @@ public final class GlueIcebergUtil
         boolean firstColumn = true;
         for (Types.NestedField icebergColumn : icebergColumns) {
             String glueTypeString = toGlueTypeStringLossy(icebergColumn.type());
+            String columnComment = requireNonNullElse(icebergColumn.doc(), "");
             if (icebergColumn.name().length() > GLUE_COLUMN_NAME_LENGTH_LIMIT ||
-                    requireNonNullElse(icebergColumn.doc(), "").length() > GLUE_COLUMN_COMMENT_LENGTH_LIMIT ||
-                    glueTypeString.length() > GLUE_COLUMN_TYPE_LENGTH_LIMIT) {
+                    columnComment.length() > GLUE_COLUMN_COMMENT_LENGTH_LIMIT ||
+                    glueTypeString.length() > GLUE_COLUMN_TYPE_LENGTH_LIMIT ||
+                    !GLUE_COLUMN_COMMENT_PATTERN.matcher(columnComment).matches()) {
                 return Optional.empty();
             }
             String trinoTypeId = TypeConverter.toTrinoType(icebergColumn.type(), typeManager).getTypeId().getId();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestGlueIcebergUtil.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestGlueIcebergUtil.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog.glue;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -94,6 +95,37 @@ public class TestGlueIcebergUtil
             assertThat(column.type()).isEqualTo(expectedLossyGlueType.get(column.name()));
             assertThat(column.parameters())
                     .containsEntry(COLUMN_TRINO_TYPE_ID_PROPERTY, toTrinoType(expectedGlueTypes.get(column.name()), TESTING_TYPE_MANAGER).getTypeId().getId());
+        }
+    }
+
+    @Test
+    public void testSkipGlueCachingWhenColumnCommentContainsCharactersGlueRejects()
+    {
+        for (String rejectedColumnContent : ImmutableList.of("line one\nline two", "carriage\rreturn", "null\0char")) {
+            Schema schema = new Schema(ImmutableList.of(
+                    Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+                    Types.NestedField.optional(2, "value", Types.StringType.get(), rejectedColumnContent)));
+            TableMetadata metadata = newTableMetadata(
+                    schema,
+                    PartitionSpec.unpartitioned(),
+                    SortOrder.unsorted(),
+                    "s3://test-bucket/test-table",
+                    ImmutableMap.of(FORMAT_VERSION, "3"));
+
+            TableInput tableInput = getTableInput(
+                    TESTING_TYPE_MANAGER,
+                    "test_table",
+                    Optional.empty(),
+                    metadata,
+                    metadata.location(),
+                    "s3://test-bucket/test-table/metadata/00001.metadata.json",
+                    ImmutableMap.of(),
+                    true);
+
+            assertThat(tableInput.storageDescriptor().hasColumns())
+                    .as("Glue caching should be skipped when column comment contains: %s",
+                            rejectedColumnContent.replace("\n", "\\n").replace("\r", "\\r").replace("\0", "\\0"))
+                    .isFalse();
         }
     }
 }


### PR DESCRIPTION
## Description

Glue prevents certain characters (e.g. newline) from being used in column comments. Previously, when invalid content is used, Glue rejects the comment with a `ValidationError`. Trino does not handle this properly and surfaces a `CommitStateUnknownException`.

Instead, we can validate the column comment content, and skip Glue caching if it is invalid. Additionally, we can handle `ValidationExceptions` as `ICEBERG_COMMIT_ERRORs` to avoid orphaning files.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Previously, if we try adding a column comment with a newline, we get the following error, and the metadata file is not cleaned up:
```
trino:jcf> CREATE TABLE iceberg.jcf.t_manual (c1 int);
CREATE TABLE
trino:jcf> COMMENT ON COLUMN iceberg.jcf.t_manual.c1 IS 'line one
         -> line two';

Query ... failed: Failed to set column comment: 1 validation error detected: Value 'line one
line two' at 'table.storageDescriptor.columns.1.member.comment' failed to satisfy constraint: Member must satisfy regular expression pattern: [\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\t]* (Service: Glue, Status Code: 400, Request ID: ...) (SDK Attempt Count: 1)
Cannot determine whether the commit was successful or not, the underlying data files may or may not be needed. Manual intervention via the Remove Orphan Files Action can remove these files when a connection to the Catalog can be re-established if the commit was actually unsuccessful.
Please check to see whether or not your commit was successful before retrying this commit. Retrying an already successful operation will result in duplicate records or unintentional modifications.
At this time no files will be deleted including possibly unused manifest lists.
```

Now, the commit succeeds:
```
trino:jcf> CREATE TABLE iceberg.jcf.t_manual (c1 int);
CREATE TABLE
trino:jcf> COMMENT ON COLUMN iceberg.jcf.t_manual.c1 IS 'line one
         -> line two';
COMMENT
trino:jcf> SELECT column_name, comment FROM iceberg.information_schema.columns
         ->   WHERE table_schema='jcf' AND table_name='t_manual';
 column_name | comment
-------------+----------
 c1          | line one
             | line two
(1 row)


trino:jcf> CREATE TABLE iceberg.jcf.t_create (
         ->   c1 int COMMENT 'multi
         -> line'
         -> );
CREATE TABLE
trino:jcf> SELECT column_name, comment FROM iceberg.information_schema.columns
         ->     WHERE table_schema='jcf' AND table_name='t_create';
 column_name | comment
-------------+---------
 c1          | multi
             | line
(1 row)
```

For other `ValidationErrors`, we wouldn't see a `CommitStateUnknownException`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Fix Glue validation errors from preventing column comment updates.
```
