### PR TITLE
Use Trino colors in web ui

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp/src/components/LinearProgressWithLabel.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/LinearProgressWithLabel.tsx
@@ -30,7 +30,7 @@ export const LinearProgressWithLabel = (props: LinearProgressWithLabelProps) => 
             </Box>
             <>
                 <Box sx={{ width: '100%', mr: 1 }}>
-                    <LinearProgress variant="determinate" color="info" value={value} />
+                    <LinearProgress variant="determinate" color="secondary" value={value} />
                 </Box>
                 <Box sx={{ minWidth: 35 }}>
                     <Typography

--- a/core/trino-web-ui/src/main/resources/webapp/src/components/MetricCard.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/MetricCard.tsx
@@ -14,7 +14,10 @@
 import { Link as RouterLink } from 'react-router-dom'
 import { Card, CardActionArea, CardContent, Grid, Tooltip, Typography } from '@mui/material'
 import { SparkLineChart } from '@mui/x-charts/SparkLineChart'
-import { styled } from '@mui/material/styles'
+import { styled, useTheme } from '@mui/material/styles'
+import { lineClasses } from '@mui/x-charts/LineChart'
+import { chartsAxisHighlightClasses } from '@mui/x-charts/ChartsAxisHighlight'
+import type { Theme } from '@mui/material/styles'
 
 interface IMetricCardProps {
     title: string
@@ -33,9 +36,11 @@ const StyledLink = styled(RouterLink)(({ theme }) => ({
 }))
 
 export const MetricCard = (props: IMetricCardProps) => {
+    const theme = useTheme<Theme>()
     const { title, values, numberFormatter, link, tooltip } = props
     const lastValue = values[values.length - 1]
     const maxValue = Math.max(...values, 1)
+    const color = theme.palette.secondary.main
 
     return (
         <Card variant="outlined">
@@ -46,10 +51,12 @@ export const MetricCard = (props: IMetricCardProps) => {
                             <Tooltip placement="top-start" title={tooltip}>
                                 {link ? (
                                     <StyledLink to={link}>
-                                        <Typography variant="h6">{title}</Typography>
+                                        <Typography variant="h6" color="textPrimary">
+                                            {title}
+                                        </Typography>
                                     </StyledLink>
                                 ) : (
-                                    <Typography variant="h6" color="info">
+                                    <Typography variant="h6" color="textPrimary">
                                         {title}
                                     </Typography>
                                 )}
@@ -76,6 +83,15 @@ export const MetricCard = (props: IMetricCardProps) => {
                                 area
                                 showHighlight
                                 showTooltip
+                                color={color}
+                                sx={{
+                                    [`& .${lineClasses.area}`]: {
+                                        fillOpacity: 0.2,
+                                    },
+                                    [`& .${lineClasses.line}`]: {
+                                        strokeWidth: 2,
+                                    },
+                                }}
                             />
                         </Grid>
                     </Grid>

--- a/core/trino-web-ui/src/main/resources/webapp/src/components/QueryStageCard.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/QueryStageCard.tsx
@@ -69,7 +69,8 @@ import {
     parseDuration,
 } from '../utils/utils'
 import { CodeBlock } from './CodeBlock'
-import { styled } from '@mui/material/styles'
+import { styled, useTheme } from '@mui/material/styles'
+import type { Theme } from '@mui/material/styles'
 
 interface IQueryStageCard {
     key: string
@@ -235,6 +236,7 @@ export const QueryStageCard = ({ stage, taskRetriesEnabled }: IQueryStageCard) =
     )
 
     const renderHistogram = (tasks: QueryTask[], timeField: 'totalScheduledTime' | 'totalCpuTime') => {
+        const theme = useTheme<Theme>()
         const inputData = tasks.map((task) => parseDuration(task.stats[timeField]) || 0)
 
         const numBuckets = Math.min(175, Math.floor(Math.sqrt(inputData.length)))
@@ -268,11 +270,13 @@ export const QueryStageCard = ({ stage, taskRetriesEnabled }: IQueryStageCard) =
                 series={[{ data: histogramData, valueFormatter: (value) => `${value} tasks` }]}
                 margin={{ left: 6, right: 0, top: 10, bottom: 6 }}
                 height={112}
+                colors={[theme.palette.secondary.main]}
             />
         )
     }
 
     const renderTasksTimeBarChart = (tasks: QueryTask[], timeField: 'totalScheduledTime' | 'totalCpuTime') => {
+        const theme = useTheme<Theme>()
         const orderedTasks = tasks.slice().sort((a, b) => a.taskStatus.taskId.localeCompare(b.taskStatus.taskId))
 
         const xAxisData: string[] = orderedTasks.map((task) => `Task ${getTaskIdSuffix(task.taskStatus.taskId)}`)
@@ -296,6 +300,7 @@ export const QueryStageCard = ({ stage, taskRetriesEnabled }: IQueryStageCard) =
                 ]}
                 margin={{ left: 6, right: 0, top: 10, bottom: 6 }}
                 height={100}
+                colors={[theme.palette.secondary.main]}
             />
         )
     }

--- a/core/trino-web-ui/src/main/resources/webapp/src/theme.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/theme.tsx
@@ -3,11 +3,18 @@ import { createTheme } from '@mui/material/styles'
 export const lightTheme = createTheme({
     palette: {
         mode: 'light',
+        background: {
+            default: '#fff',
+            paper: '#f6f9f9',
+        },
         primary: {
-            main: '#0b1367',
+            main: '#000033',
         },
         secondary: {
-            main: '#f50057',
+            main: '#001c93',
+        },
+        info: {
+            main: '#001c93',
         },
     },
     components: {
@@ -19,18 +26,38 @@ export const lightTheme = createTheme({
                 },
             },
         },
+        MuiAppBar: {
+            styleOverrides: {
+                root: {
+                    backgroundColor: '#000033',
+                },
+            },
+        },
     },
 })
 
 export const darkTheme = createTheme({
     palette: {
         mode: 'dark',
+        background: {
+            default: '#272727',
+            paper: '#212121',
+        },
+        primary: {
+            main: '#fff',
+        },
+        secondary: {
+            main: '#006ef8',
+        },
+        info: {
+            main: '#9e9e9e',
+        },
     },
     components: {
         MuiLink: {
             styleOverrides: {
                 root: {
-                    color: '#dd33fa',
+                    color: '#006ef8',
                     textDecoration: 'none',
                 },
             },


### PR DESCRIPTION
## Description
The current ui uses the default mui colors, lets use Trino colors as used on trino.io: 
```
--trino-black: #212121;
--trino-dark-blue: #000033;
--trino-cobalt-blue: #001c93;
--trino-pink: #dd00a1;
--trino-orange: #f88600;
--trino-yellow: #f8b600;
--trino-grey: #9e9e9e;
```
<img width="1280" height="1475" alt="Screenshot 2026-07-17 at 17-02-52 Trino" src="https://github.com/user-attachments/assets/a0a5880f-2103-4465-9688-0b723909f1b8" />
<img width="1280" height="1475" alt="Screenshot 2026-07-17 at 17-03-04 Trino" src="https://github.com/user-attachments/assets/8a676d94-05ef-4a72-8f4c-c5bd59679c11" />

<img width="1280" height="1475" alt="Screenshot 2026-07-17 at 17-04-24 Trino" src="https://github.com/user-attachments/assets/534f0d16-6727-4949-9b8f-3fca536dc203" />
<img width="1280" height="1475" alt="Screenshot 2026-07-17 at 17-04-38 Trino" src="https://github.com/user-attachments/assets/e98c6537-04d9-4064-835c-9b0bb5b5a0b7" />


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
## General
* Use Trino colors in web ui
```
