### PR TITLE
Fix Delta Lake deletion vector serialization

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/delete/DeletionVectors.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/delete/DeletionVectors.java
@@ -48,7 +48,6 @@ public final class DeletionVectors
     private static final int PORTABLE_ROARING_BITMAP_MAGIC_NUMBER = 1681511377;
     private static final int MAGIC_NUMBER_BYTE_SIZE = 4;
     private static final int BIT_MAP_COUNT_BYTE_SIZE = 8;
-    private static final int BIT_MAP_KEY_BYTE_SIZE = 4;
     private static final int FORMAT_VERSION_V1 = 1;
 
     private static final String UUID_MARKER = "u"; // relative path with random prefix on disk
@@ -96,7 +95,10 @@ public final class DeletionVectors
             pathOrInlineDv = randomPrefix + pathOrInlineDv;
             location = location.appendPath(randomPrefix);
         }
-        int sizeInBytes = MAGIC_NUMBER_BYTE_SIZE + BIT_MAP_COUNT_BYTE_SIZE + BIT_MAP_KEY_BYTE_SIZE + deletedRows.serializedSizeInBytes();
+        for (int index = 0; index < deletedRows.length(); index++) {
+            deletedRows.get(index).runOptimize();
+        }
+        int sizeInBytes = MAGIC_NUMBER_BYTE_SIZE + BIT_MAP_COUNT_BYTE_SIZE + deletedRows.serializedSizeInBytes();
         long cardinality = deletedRows.cardinality();
 
         checkArgument(sizeInBytes > 0, "sizeInBytes must be positive: %s", sizeInBytes);
@@ -133,7 +135,6 @@ public final class DeletionVectors
         for (int i = 0; i < bitmaps.length(); i++) {
             buffer.putInt(i); // Bitmap index
             RoaringBitmap bitmap = bitmaps.get(i);
-            bitmap.runOptimize();
             bitmap.serialize(buffer);
         }
         return buffer.array();

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/delete/TestDeletionVectors.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/delete/TestDeletionVectors.java
@@ -16,6 +16,7 @@ package io.trino.plugin.deltalake.delete;
 import com.google.common.io.Resources;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.memory.MemoryFileSystem;
 import io.trino.plugin.deltalake.transactionlog.DeletionVectorEntry;
 import org.junit.jupiter.api.Test;
 
@@ -27,6 +28,7 @@ import static io.trino.hdfs.HdfsTestUtils.HDFS_FILE_SYSTEM_FACTORY;
 import static io.trino.plugin.deltalake.DeltaTestingConnectorSession.SESSION;
 import static io.trino.plugin.deltalake.delete.DeletionVectors.readDeletionVectors;
 import static io.trino.plugin.deltalake.delete.DeletionVectors.toFileName;
+import static io.trino.plugin.deltalake.delete.DeletionVectors.writeDeletionVectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -54,6 +56,44 @@ public class TestDeletionVectors
         DeletionVectorEntry deletionVector = new DeletionVectorEntry("i", "wi5b=000010000siXQKl0rr91000f55c8Xg0@@D72lkbi5=-{L", OptionalInt.empty(), 40, 1);
         assertThatThrownBy(() -> readDeletionVectors(fileSystem, Location.of("s3://bucket/table"), deletionVector))
                 .hasMessageContaining("Unsupported storage type for deletion vector: i");
+    }
+
+    @Test
+    public void testWriteDeletionVector()
+            throws Exception
+    {
+        TrinoFileSystem fileSystem = new MemoryFileSystem();
+        Location tableLocation = Location.of("memory:///table");
+        RoaringBitmapArray deletedRows = new RoaringBitmapArray();
+        deletedRows.add(1);
+
+        DeletionVectorEntry deletionVector = writeDeletionVectors(fileSystem, tableLocation, deletedRows, 0);
+
+        assertThat(deletionVector.sizeInBytes()).isEqualTo(34);
+        assertThat(deletionVector.cardinality()).isEqualTo(1);
+        assertThat(fileSystem.newInputFile(tableLocation.appendPath(toFileName(deletionVector.pathOrInlineDv()))).length())
+                .isEqualTo(deletionVector.sizeInBytes() + 9); // 1 byte (version) + 4 bytes (sizeInBytes) + 4 bytes (checksum)
+        assertThat(readDeletionVectors(fileSystem, tableLocation, deletionVector).contains(1)).isTrue();
+    }
+
+    @Test
+    public void testWriteRunOptimizedDeletionVector()
+            throws Exception
+    {
+        TrinoFileSystem fileSystem = new MemoryFileSystem();
+        Location tableLocation = Location.of("memory:///table");
+        RoaringBitmapArray deletedRows = new RoaringBitmapArray();
+        for (int position = 0; position < 10_000; position++) {
+            deletedRows.add(position);
+        }
+
+        DeletionVectorEntry deletionVector = writeDeletionVectors(fileSystem, tableLocation, deletedRows, 0);
+
+        assertThat(deletionVector.sizeInBytes()).isEqualTo(31);
+        assertThat(deletionVector.cardinality()).isEqualTo(10_000);
+        assertThat(fileSystem.newInputFile(tableLocation.appendPath(toFileName(deletionVector.pathOrInlineDv()))).length())
+                .isEqualTo(deletionVector.sizeInBytes() + 9); // 1 byte (version) + 4 bytes (sizeInBytes) + 4 bytes (checksum)
+        assertThat(readDeletionVectors(fileSystem, tableLocation, deletionVector).cardinality()).isEqualTo(10_000);
     }
 
     @Test


### PR DESCRIPTION
## Description

Fix deletion-vector sidecars written by the Delta Lake connector with an oversized serialized payload.

`RoaringBitmapArray.serializedSizeInBytes()` already includes the four-byte key for each bitmap, so the writer must not add another bitmap key when calculating `sizeInBytes`. The writer must also run-optimize the bitmaps before calculating their serialized size; optimization can substantially shrink a bitmap.

Without these changes, the sidecar payload contains trailing zero bytes and advertises an incorrect size. Readers that require the serialized bitmap to consume the declared payload can reject the deletion vector.

## Additional context and related issues

The regressions cover both size errors:

- a single deleted row must produce a 34-byte payload and a 43-byte sidecar, instead of the previous 38-byte payload
- 10,000 contiguous deleted rows must produce a 31-byte run-compressed payload and a 40-byte sidecar, instead of the previous 8,228-byte payload

Both cases verify checksum-valid readback.

Focused test:

```bash
./mvnw -pl :trino-delta-lake -Dtest=TestDeletionVectors,TestRoaringBitmapArray test
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake connector
* Fix compatibility of deletion vectors written by Trino with other Delta Lake readers.
```
