### PR TITLE
Avoid Alluxio read buffer allocation for positioned reads

### DIFF
--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInput.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInput.java
@@ -55,7 +55,8 @@ public class AlluxioInput
         this.inputFile = requireNonNull(inputFile, "inputFile is null");
         this.fileLength = requireNonNull(status, "status is null").getLength();
         this.statistics = requireNonNull(statistics, "statistics is null");
-        this.helper = new AlluxioInputHelper(tracer, inputFile.location(), cacheKey, status, cacheManager, configuration, statistics);
+        // Positioned reads are already correctly sized by the caller, so skip the small-read buffer
+        this.helper = new AlluxioInputHelper(tracer, inputFile.location(), cacheKey, status, cacheManager, configuration, statistics, false);
         this.externalReadBytes = new AtomicLong();
     }
 

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputHelper.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputHelper.java
@@ -67,7 +67,8 @@ public class AlluxioInputHelper
             URIStatus status,
             CacheManager cacheManager,
             AlluxioConfiguration configuration,
-            AlluxioCacheStats statistics)
+            AlluxioCacheStats statistics,
+            boolean bufferSmallReads)
     {
         this.tracer = requireNonNull(tracer, "tracer is null");
         this.status = requireNonNull(status, "status is null");
@@ -77,9 +78,10 @@ public class AlluxioInputHelper
         this.pageSize = (int) requireNonNull(configuration, "configuration is null").getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE);
         this.statistics = requireNonNull(statistics, "statistics is null");
         this.location = requireNonNull(location, "location is null");
-        // Buffer to reduce the cost of doing page aligned reads for small sequential reads pattern
         this.bufferSize = pageSize;
-        this.readBuffer = new byte[bufferSize];
+        // Buffer to reduce the cost of page aligned reads for small sequential reads. Positioned reads
+        // are already correctly sized by the caller, so they skip the buffer and avoid its per-input cost.
+        this.readBuffer = bufferSmallReads ? new byte[bufferSize] : null;
         this.cacheReadBytes = new AtomicLong();
     }
 
@@ -103,7 +105,7 @@ public class AlluxioInputHelper
         if (length == 0) {
             return 0;
         }
-        if (position < bufferStartPosition || position >= bufferEndPosition) {
+        if (readBuffer == null || position < bufferStartPosition || position >= bufferEndPosition) {
             return 0;
         }
         int bytesToCopy = min(length, Ints.saturatedCast(bufferEndPosition - position));
@@ -146,7 +148,7 @@ public class AlluxioInputHelper
         }
         CacheContext cacheContext = status.getCacheContext();
         PageId pageId = new PageId(cacheContext.getCacheIdentifier(), currentPage);
-        if (bytesLeftInPage > length && bufferSize > length) { // Read page into buffer
+        if (readBuffer != null && bytesLeftInPage > length && bufferSize > length) { // Read page into buffer
             int putBytes = putBuffer(currentPageOffset, pageId, cacheContext);
             if (putBytes <= 0) {
                 return putBytes;

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputStream.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputStream.java
@@ -62,7 +62,8 @@ public class AlluxioInputStream
         this.location = inputFile.location();
         this.statistics = requireNonNull(statistics, "statistics is null");
         this.key = requireNonNull(key, "key is null");
-        this.helper = new AlluxioInputHelper(tracer, inputFile.location(), key, status, cacheManager, configuration, statistics);
+        // Sequential reads arrive in small arbitrary chunks, so buffer small reads to amortize page aligned reads
+        this.helper = new AlluxioInputHelper(tracer, inputFile.location(), key, status, cacheManager, configuration, statistics, true);
     }
 
     @Override

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystemAccessOperations.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystemAccessOperations.java
@@ -178,7 +178,7 @@ public class TestAlluxioCacheFileSystemAccessOperations
                 ImmutableMultiset.<CacheOperationSpan>builder()
                         .add(new CacheOperationSpan("Alluxio.readCached", location.toString(), 0, PAGE_SIZE + 10))
                         .add(new CacheOperationSpan("AlluxioCacheManager.get", cacheKey(location, cacheKeyProvider.currentCacheVersion()), 0, PAGE_SIZE))
-                        .add(new CacheOperationSpan("AlluxioCacheManager.get", cacheKey(location, cacheKeyProvider.currentCacheVersion()), PAGE_SIZE, PAGE_SIZE))
+                        .add(new CacheOperationSpan("AlluxioCacheManager.get", cacheKey(location, cacheKeyProvider.currentCacheVersion()), PAGE_SIZE, 10))
                         .add(new CacheOperationSpan("Input.readFully", location.toString(), PAGE_SIZE, PAGE_SIZE))
                         .add(new CacheOperationSpan("Alluxio.writeCache", location.toString(), PAGE_SIZE, PAGE_SIZE))
                         .add(new CacheOperationSpan("AlluxioCacheManager.put", cacheKey(location, cacheKeyProvider.currentCacheVersion()), PAGE_SIZE, PAGE_SIZE))
@@ -187,7 +187,7 @@ public class TestAlluxioCacheFileSystemAccessOperations
         assertCacheOperations(location, Arrays.copyOf(content, PAGE_SIZE + 10),
                 ImmutableMultiset.<CacheOperationSpan>builder()
                         .add(new CacheOperationSpan("AlluxioCacheManager.get", cacheKey(location, cacheKeyProvider.currentCacheVersion()), 0, PAGE_SIZE))
-                        .add(new CacheOperationSpan("AlluxioCacheManager.get", cacheKey(location, cacheKeyProvider.currentCacheVersion()), PAGE_SIZE, PAGE_SIZE))
+                        .add(new CacheOperationSpan("AlluxioCacheManager.get", cacheKey(location, cacheKeyProvider.currentCacheVersion()), PAGE_SIZE, 10))
                         .add(new CacheOperationSpan("Alluxio.readCached", location.toString(), PAGE_SIZE + 10))
                         .build());
 
@@ -351,7 +351,7 @@ public class TestAlluxioCacheFileSystemAccessOperations
         assertCacheOperations(8, location, readContent, readTimes,
                 ImmutableMultiset.<CacheOperationSpan>builder()
                         .addCopies(new CacheOperationSpan("Alluxio.readCached", location.toString(), 8, 2), readTimes)
-                        .addCopies(new CacheOperationSpan("AlluxioCacheManager.get", cacheKey(location, cacheKeyProvider.currentCacheVersion()), 0, 11), 2)
+                        .addCopies(new CacheOperationSpan("AlluxioCacheManager.get", cacheKey(location, cacheKeyProvider.currentCacheVersion()), 8, 2), readTimes)
                         .add(new CacheOperationSpan("Input.readFully", location.toString(), 0, 11))
                         .add(new CacheOperationSpan("AlluxioCacheManager.put", cacheKey(location, cacheKeyProvider.currentCacheVersion()), 0, 11))
                         .add(new CacheOperationSpan("Alluxio.writeCache", location.toString(), 0, 11))


### PR DESCRIPTION
## Description

`AlluxioInputHelper` allocates a per-input page-sized `readBuffer` to amortize small sequential reads, a pattern only `AlluxioInputStream` produces. Positioned reads through `AlluxioInput` (driven by `AbstractParquetDataSource`) are already issued as single pre-sized requests, so the buffer never helped them but still cost one idle page-sized allocation per open input. With a 1 MB page size, a heap dump showed 79 MB across 79 open Parquet inputs.

The buffer is now allocated only for `AlluxioInputStream`; `AlluxioInput` opts out.

## Additional context and related issues

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
