### PR TITLE
Fix nested LIST Parquet ClassCastException

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -70,40 +70,66 @@ public final class ParquetTypeUtils
         return groupColumnIO;
     }
 
-    /* For backward-compatibility, the type of elements in LIST-annotated structures should always be determined by the following rules:
-     * 1. If the repeated field is not a group, then its type is the element type and elements are required.
-     * 2. If the repeated field is a group with multiple fields, then its type is the element type and elements are required.
-     * 3. If the repeated field is a group with one field and is named either array or uses the LIST-annotated group's name with _tuple appended then the repeated type is the element type and elements are required.
-     * 4. Otherwise, the repeated field's type is the element type with the repeated field's repetition.
-     * https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists
+    /**
+     * Resolve the element ColumnIO of a LIST-annotated group given its (single) REPEATED child.
+     * <p>
+     * Follows the <a href="https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#lists">
+     * Parquet spec backward-compatibility rules</a>, but disambiguates the legacy single-field
+     * case using the caller-provided Trino element type:
+     * <ul>
+     *   <li>If the repeated field is not a group, it is the element (e.g. {@code repeated int32 x}).</li>
+     *   <li>If the repeated field is a group carrying its own {@code LIST}, {@code MAP}, or other
+     *       logical type annotation, the repeated group IS the element. This covers the
+     *       {@code SingleLevelArraySchemaConverter} encoding of nested lists/maps used by legacy
+     *       Hive writes.</li>
+     *   <li>If the repeated field is a group with multiple fields, it is the element (a struct).</li>
+     *   <li>If the repeated field is a group with one field and is named either {@code array} or
+     *       {@code <parent>_tuple}, it is the element ONLY when the caller expects a RowType.
+     *       This is the ambiguous legacy case: the same schema can encode either
+     *       {@code list<row(f)>} (spec rule 4) or {@code list<T>} where T happens to be nested
+     *       under a legacy-named wrapper. See issue #27766.</li>
+     *   <li>Otherwise, the single child is the element (modern 3-level {@code list.element}, or a
+     *       legacy-named wrapper around a non-struct element).</li>
+     * </ul>
      */
-    public static ColumnIO getArrayElementColumn(ColumnIO columnIO)
+    public static ColumnIO getArrayElementColumn(Type elementType, ColumnIO repeatedFieldColumnIO)
     {
-        while (columnIO instanceof GroupColumnIO && !columnIO.getType().isRepetition(REPEATED)) {
-            columnIO = ((GroupColumnIO) columnIO).getChild(0);
+        if (!repeatedFieldColumnIO.getType().isRepetition(REPEATED)) {
+            throw new TrinoException(NOT_SUPPORTED, format(
+                    "Unsupported schema for Parquet column (%s), child of a LIST-annotated group must be REPEATED",
+                    repeatedFieldColumnIO.getType()));
         }
 
-        /* If array has a standard 3-level structure with middle level repeated group with a single field:
-         *  optional group my_list (LIST) {
-         *     repeated group element {
-         *        required binary str (UTF8);
-         *     };
-         *  }
-         */
-        if (columnIO instanceof GroupColumnIO groupColumnIO &&
-                columnIO.getType().getLogicalTypeAnnotation() == null &&
-                groupColumnIO.getChildrenCount() == 1 &&
-                !columnIO.getName().equals("array") &&
-                !columnIO.getName().equals(columnIO.getParent().getName() + "_tuple")) {
-            return groupColumnIO.getChild(0);
+        // A repeated primitive is the element.
+        if (!(repeatedFieldColumnIO instanceof GroupColumnIO repeatedGroup)) {
+            return repeatedFieldColumnIO;
         }
 
-        /* Backward-compatibility support for 2-level arrays where a repeated field is not a group:
-         *   optional group my_list (LIST) {
-         *      repeated int32 element;
-         *   }
-         */
-        return columnIO;
+        // A repeated group carrying its own logical type annotation (LIST, MAP, ...) is itself the
+        // element. Legacy Hive writes (SingleLevelArraySchemaConverter) use this shape to encode
+        // nested lists and maps.
+        if (repeatedGroup.getType().getLogicalTypeAnnotation() != null) {
+            return repeatedGroup;
+        }
+
+        // A repeated group with multiple fields is the element (a struct).
+        if (repeatedGroup.getChildrenCount() != 1) {
+            return repeatedGroup;
+        }
+
+        // Disambiguated legacy-named single-field repeated group.
+        // Historically this branch always treated the repeated group as the element (a 1-field
+        // struct), which broke schemas like #27766 where the caller wants a nested list/primitive.
+        // Only apply this interpretation when the caller expects a RowType.
+        String name = repeatedGroup.getName();
+        boolean legacyName = name.equals("array") || name.equals(repeatedGroup.getParent().getName() + "_tuple");
+        if (legacyName && elementType instanceof RowType) {
+            return repeatedGroup;
+        }
+
+        // Modern 3-level list, or a legacy-named wrapper around a non-struct element: the single
+        // child is the element.
+        return repeatedGroup.getChild(0);
     }
 
     public static Map<List<String>, ColumnDescriptor> getDescriptors(MessageType fileSchema, MessageType requestedSchema)
@@ -359,7 +385,7 @@ public final class ParquetTypeUtils
             if (groupColumnIO.getChildrenCount() != 1) {
                 return Optional.empty();
             }
-            Optional<Field> field = constructField(arrayType.getElementType(), getArrayElementColumn(groupColumnIO.getChild(0)), false);
+            Optional<Field> field = constructField(arrayType.getElementType(), getArrayElementColumn(arrayType.getElementType(), groupColumnIO.getChild(0)), false);
             return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, ImmutableList.of(field)));
         }
         PrimitiveColumnIO primitiveColumnIO = (PrimitiveColumnIO) columnIO;

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestNestedListDecoding.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestNestedListDecoding.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet;
+
+import io.trino.parquet.metadata.ParquetMetadata;
+import io.trino.parquet.reader.FileParquetDataSource;
+import io.trino.parquet.reader.MetadataReader;
+import io.trino.parquet.reader.ParquetReader;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.Type;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.parquet.ParquetTestUtils.createParquetReader;
+import static io.trino.spi.type.RowType.field;
+import static io.trino.spi.type.RowType.rowType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.nio.file.Files.createTempFile;
+import static java.util.Collections.singletonList;
+import static org.apache.parquet.hadoop.ParquetFileWriter.Mode.OVERWRITE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+/**
+ * End-to-end decode coverage for the nested legacy LIST shape from
+ * <a href="https://github.com/trinodb/trino/issues/27766">#27766</a>. Unlike
+ * {@link TestParquetTypeUtils}, which stops at {@code constructField}, these tests write a real
+ * file with the ambiguous middle {@code array} group and read it back through the full reader so
+ * the definition/repetition-level handling of the unwrapped shape is exercised.
+ */
+// ExampleParquetWriter is not thread-safe
+@TestInstance(PER_CLASS)
+@Execution(SAME_THREAD)
+public final class TestNestedListDecoding
+{
+    // The #27766 shape: a LIST whose middle repeated group is named "array" and whose single
+    // child is itself a LIST group. The same bytes decode as array(array(varchar)) or as
+    // array(row(inner_list)) depending on the caller's requested Trino type.
+    private static final MessageType SCHEMA = MessageTypeParser.parseMessageType(
+            """
+            message schema {
+              optional group nested_list (LIST) {
+                repeated group array {
+                  optional group inner_list (LIST) {
+                    repeated group array {
+                      optional binary element (STRING);
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+    @Test
+    public void testReadAsNestedArray()
+            throws IOException
+    {
+        File file = writeSampleFile();
+        Type type = new ArrayType(new ArrayType(VARCHAR));
+
+        assertThat(readColumn(file, type)).containsExactly(
+                List.of(List.of("a", "b"), List.of("c")), // [["a", "b"], ["c"]]
+                singletonList(null),                       // [null] (null inner list)
+                List.of(List.of()),                        // [[]] (empty inner list)
+                List.of(),                                 // [] (empty outer list)
+                null);                                     // null (absent outer list)
+    }
+
+    @Test
+    public void testReadAsArrayOfStructPreservesLegacyInterpretation()
+            throws IOException
+    {
+        // The same file, read as array(row(inner_list array(varchar))): the middle "array" group
+        // is resolved as a single-field struct (the pre-#27766 legacy interpretation), so every
+        // outer element is wrapped in a row.
+        File file = writeSampleFile();
+        Type type = new ArrayType(rowType(field("inner_list", new ArrayType(VARCHAR))));
+
+        assertThat(readColumn(file, type)).containsExactly(
+                List.of(List.of(List.of("a", "b")), List.of(List.of("c"))), // [row(["a", "b"]), row(["c"])]
+                List.of(singletonList(null)),                               // [row(null)]
+                List.of(List.of(List.of())),                                // [row([])]
+                List.of(),                                                  // []
+                null);                                                      // null
+    }
+
+    private static File writeSampleFile()
+            throws IOException
+    {
+        File file = createTempFile("nested-list", ".parquet").toFile();
+        file.deleteOnExit();
+
+        ExampleParquetWriter.Builder builder = ExampleParquetWriter.builder(new Path(file.getAbsolutePath()))
+                .withType(SCHEMA)
+                .withConf(new Configuration())
+                .withWriteMode(OVERWRITE);
+
+        try (ParquetWriter<Group> writer = builder.build()) {
+            SimpleGroupFactory factory = new SimpleGroupFactory(SCHEMA);
+
+            // [["a", "b"], ["c"]]
+            Group row0 = factory.newGroup();
+            Group outer0 = row0.addGroup("nested_list");
+            Group inner00 = outer0.addGroup("array").addGroup("inner_list");
+            inner00.addGroup("array").append("element", "a");
+            inner00.addGroup("array").append("element", "b");
+            outer0.addGroup("array").addGroup("inner_list").addGroup("array").append("element", "c");
+            writer.write(row0);
+
+            // [null] — outer element present, inner_list absent (null)
+            Group row1 = factory.newGroup();
+            row1.addGroup("nested_list").addGroup("array");
+            writer.write(row1);
+
+            // [[]] — outer element present, inner_list present but empty
+            Group row2 = factory.newGroup();
+            row2.addGroup("nested_list").addGroup("array").addGroup("inner_list");
+            writer.write(row2);
+
+            // [] — outer list present but empty
+            Group row3 = factory.newGroup();
+            row3.addGroup("nested_list");
+            writer.write(row3);
+
+            // null — outer list absent
+            writer.write(factory.newGroup());
+        }
+        return file;
+    }
+
+    private static List<Object> readColumn(File file, Type type)
+            throws IOException
+    {
+        try (FileParquetDataSource source = new FileParquetDataSource(file, ParquetReaderOptions.defaultOptions())) {
+            ParquetMetadata metadata = MetadataReader.readFooter(source, ParquetReaderOptions.defaultOptions(), Optional.empty(), Optional.empty());
+            try (ParquetReader reader = createParquetReader(source, metadata, List.of(type), List.of("nested_list"))) {
+                List<Object> values = new ArrayList<>();
+                SourcePage page;
+                while ((page = reader.nextPage()) != null) {
+                    Block block = page.getBlock(0);
+                    for (int position = 0; position < block.getPositionCount(); position++) {
+                        values.add(type.getObjectValue(block, position));
+                    }
+                }
+                return values;
+            }
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestParquetTypeUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestParquetTypeUtils.java
@@ -1,0 +1,328 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet;
+
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import org.apache.parquet.io.ColumnIO;
+import org.apache.parquet.io.ColumnIOFactory;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.parquet.ParquetTypeUtils.constructField;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RowType.field;
+import static io.trino.spi.type.RowType.rowType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestParquetTypeUtils
+{
+    /**
+     * Regression for <a href="https://github.com/trinodb/trino/issues/27766">#27766</a>:
+     * nested LIST-annotated groups where the middle repeated group is named
+     * {@code array}, whose single child is itself a LIST group, used to be
+     * misresolved and blow up with {@code ClassCastException}.
+     */
+    @Test
+    public void testNestedLegacyArrayList()
+    {
+        MessageType schema = MessageTypeParser.parseMessageType(
+                """
+                message schema {
+                  optional group nested_list (LIST) {
+                    repeated group array {
+                      optional group inner_list (LIST) {
+                        repeated group array {
+                          optional binary element (STRING);
+                        }
+                      }
+                    }
+                  }
+                }
+                """);
+        Type trinoType = new ArrayType(new ArrayType(VARCHAR));
+
+        Field field = constructField(trinoType, columnIO(schema)).orElseThrow();
+
+        assertNestedArrayOfPrimitive(field, trinoType, VARCHAR);
+    }
+
+    @Test
+    public void testStandardThreeLevelNestedList()
+    {
+        // Modern spec-compliant 3-level shape at both levels — must keep working.
+        MessageType schema = MessageTypeParser.parseMessageType(
+                """
+                message schema {
+                  optional group outer (LIST) {
+                    repeated group list {
+                      optional group element (LIST) {
+                        repeated group list {
+                          optional binary element (STRING);
+                        }
+                      }
+                    }
+                  }
+                }
+                """);
+        Type trinoType = new ArrayType(new ArrayType(VARCHAR));
+
+        Field field = constructField(trinoType, columnIO(schema)).orElseThrow();
+
+        assertNestedArrayOfPrimitive(field, trinoType, VARCHAR);
+    }
+
+    @Test
+    public void testLegacyTwoLevelArrayOfInt()
+    {
+        MessageType schema = MessageTypeParser.parseMessageType(
+                """
+                message schema {
+                  optional group values (LIST) {
+                    repeated int32 element;
+                  }
+                }
+                """);
+        Type trinoType = new ArrayType(INTEGER);
+
+        GroupField outer = (GroupField) constructField(trinoType, columnIO(schema)).orElseThrow();
+
+        assertThat(outer.getType()).isEqualTo(trinoType);
+        PrimitiveField element = (PrimitiveField) outer.getChildren().get(0).orElseThrow();
+        assertThat(element.getType()).isEqualTo(INTEGER);
+    }
+
+    @Test
+    public void testLegacyMultiFieldStructArray()
+    {
+        // Spec rule 2: repeated group with >1 field IS the element (a struct).
+        MessageType schema = MessageTypeParser.parseMessageType(
+                """
+                message schema {
+                  optional group pairs (LIST) {
+                    repeated group array {
+                      required int32 a;
+                      required int32 b;
+                    }
+                  }
+                }
+                """);
+        Type trinoType = new ArrayType(rowType(field("a", INTEGER), field("b", INTEGER)));
+
+        GroupField outer = (GroupField) constructField(trinoType, columnIO(schema)).orElseThrow();
+
+        assertThat(outer.getType()).isEqualTo(trinoType);
+        GroupField row = (GroupField) outer.getChildren().get(0).orElseThrow();
+        assertThat(row.getType()).isInstanceOf(RowType.class);
+        assertThat(row.getChildren()).hasSize(2);
+        assertThat(((PrimitiveField) row.getChildren().get(0).orElseThrow()).getType()).isEqualTo(INTEGER);
+        assertThat(((PrimitiveField) row.getChildren().get(1).orElseThrow()).getType()).isEqualTo(INTEGER);
+    }
+
+    /**
+     * Regression for the {@code SingleLevelArraySchemaConverter} shape: nested
+     * arrays are encoded with the middle repeated group carrying its own
+     * {@code LIST} annotation. The repeated group IS the element.
+     */
+    @Test
+    public void testSingleLevelSchemaNestedArrays()
+    {
+        MessageType schema = MessageTypeParser.parseMessageType(
+                """
+                message schema {
+                  optional group test (LIST) {
+                    repeated group array (LIST) {
+                      repeated int32 array;
+                    }
+                  }
+                }
+                """);
+        Type trinoType = new ArrayType(new ArrayType(INTEGER));
+
+        GroupField outer = (GroupField) constructField(trinoType, columnIO(schema)).orElseThrow();
+
+        assertThat(outer.getType()).isEqualTo(trinoType);
+        GroupField inner = (GroupField) outer.getChildren().get(0).orElseThrow();
+        assertThat(inner.getType()).isInstanceOf(ArrayType.class);
+        PrimitiveField leaf = (PrimitiveField) inner.getChildren().get(0).orElseThrow();
+        assertThat(leaf.getType()).isEqualTo(INTEGER);
+    }
+
+    @Test
+    public void testSingleLevelSchemaDeeplyNestedArrays()
+    {
+        // Matches the shape from AbstractTestParquetReader.testSingleLevelSchemaNestedArrays
+        // when nestingLevel produces 5 middle LIST-annotated repeated groups terminating
+        // in a repeated primitive.
+        MessageType schema = MessageTypeParser.parseMessageType(
+                """
+                message schema {
+                  optional group test (LIST) {
+                    repeated group array (LIST) {
+                      repeated group array (LIST) {
+                        repeated group array (LIST) {
+                          repeated group array (LIST) {
+                            repeated int32 array;
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                """);
+        Type trinoType = new ArrayType(new ArrayType(new ArrayType(new ArrayType(new ArrayType(INTEGER)))));
+
+        Field field = constructField(trinoType, columnIO(schema)).orElseThrow();
+
+        // Walk down 5 array levels ending in a primitive integer.
+        Field current = field;
+        for (int level = 0; level < 5; level++) {
+            GroupField group = (GroupField) current;
+            assertThat(group.getType()).isInstanceOf(ArrayType.class);
+            current = group.getChildren().get(0).orElseThrow();
+        }
+        assertThat(((PrimitiveField) current).getType()).isEqualTo(INTEGER);
+    }
+
+    /**
+     * Regression for the {@code SingleLevelArraySchemaConverter} shape when the
+     * element is a MAP: the middle repeated group carries a MAP annotation.
+     * The repeated group IS the element.
+     */
+    @Test
+    public void testSingleLevelSchemaArrayOfMap()
+    {
+        MessageType schema = MessageTypeParser.parseMessageType(
+                """
+                message schema {
+                  optional group test (LIST) {
+                    repeated group array (MAP) {
+                      repeated group map (MAP_KEY_VALUE) {
+                        required binary key (STRING);
+                        optional int32 value;
+                      }
+                    }
+                  }
+                }
+                """);
+        MapType mapType = new MapType(VARCHAR, INTEGER, new TypeOperators());
+        Type trinoType = new ArrayType(mapType);
+
+        GroupField outer = (GroupField) constructField(trinoType, columnIO(schema)).orElseThrow();
+
+        assertThat(outer.getType()).isEqualTo(trinoType);
+        GroupField mapField = (GroupField) outer.getChildren().get(0).orElseThrow();
+        assertThat(mapField.getType()).isInstanceOf(MapType.class);
+    }
+
+    @Test
+    public void testLegacySingleFieldStructArray()
+    {
+        // Spec rule 3: repeated group with a single field, named "array", where the
+        // caller expects a row(...) — the repeated group IS the element.
+        MessageType schema = MessageTypeParser.parseMessageType(
+                """
+                message schema {
+                  optional group boxes (LIST) {
+                    repeated group array {
+                      required int32 f;
+                    }
+                  }
+                }
+                """);
+        Type trinoType = new ArrayType(rowType(field("f", INTEGER)));
+
+        GroupField outer = (GroupField) constructField(trinoType, columnIO(schema)).orElseThrow();
+
+        assertThat(outer.getType()).isEqualTo(trinoType);
+        GroupField row = (GroupField) outer.getChildren().get(0).orElseThrow();
+        assertThat(row.getType()).isInstanceOf(RowType.class);
+        assertThat(row.getChildren()).hasSize(1);
+        assertThat(((PrimitiveField) row.getChildren().get(0).orElseThrow()).getType()).isEqualTo(INTEGER);
+    }
+
+    @Test
+    public void testLegacyTupleNamedSingleFieldStructArray()
+    {
+        // Same as testLegacySingleFieldStructArray, but the repeated group uses the other legacy
+        // name form: <parent>_tuple. This exercises the second half of the legacyName predicate.
+        MessageType schema = MessageTypeParser.parseMessageType(
+                """
+                message schema {
+                  optional group boxes (LIST) {
+                    repeated group boxes_tuple {
+                      required int32 f;
+                    }
+                  }
+                }
+                """);
+        Type trinoType = new ArrayType(rowType(field("f", INTEGER)));
+
+        GroupField outer = (GroupField) constructField(trinoType, columnIO(schema)).orElseThrow();
+
+        assertThat(outer.getType()).isEqualTo(trinoType);
+        GroupField row = (GroupField) outer.getChildren().get(0).orElseThrow();
+        assertThat(row.getType()).isInstanceOf(RowType.class);
+        assertThat(row.getChildren()).hasSize(1);
+        assertThat(((PrimitiveField) row.getChildren().get(0).orElseThrow()).getType()).isEqualTo(INTEGER);
+    }
+
+    @Test
+    public void testListChildNotRepeatedThrows()
+    {
+        // Malformed LIST: the single child is OPTIONAL, not REPEATED. This is a bad file,
+        // not a caller bug, so it must surface as NOT_SUPPORTED rather than an internal error.
+        MessageType schema = MessageTypeParser.parseMessageType(
+                """
+                message schema {
+                  optional group bad_list (LIST) {
+                    optional int32 element;
+                  }
+                }
+                """);
+        Type trinoType = new ArrayType(INTEGER);
+
+        assertTrinoExceptionThrownBy(() -> constructField(trinoType, columnIO(schema)))
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessageContaining("must be REPEATED");
+    }
+
+    private static void assertNestedArrayOfPrimitive(Field field, Type expectedType, Type expectedLeafType)
+    {
+        GroupField outer = (GroupField) field;
+        assertThat(outer.getType()).isEqualTo(expectedType);
+        assertThat(outer.getChildren()).hasSize(1);
+
+        GroupField inner = (GroupField) outer.getChildren().get(0).orElseThrow();
+        assertThat(inner.getType()).isInstanceOf(ArrayType.class);
+        assertThat(inner.getChildren()).hasSize(1);
+
+        PrimitiveField leaf = (PrimitiveField) inner.getChildren().get(0).orElseThrow();
+        assertThat(leaf.getType()).isEqualTo(expectedLeafType);
+    }
+
+    private static ColumnIO columnIO(MessageType schema)
+    {
+        MessageColumnIO messageColumnIO = new ColumnIOFactory().getColumnIO(schema, schema, true);
+        return messageColumnIO.getChild(0);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetColumnIOConverter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetColumnIOConverter.java
@@ -96,7 +96,7 @@ public final class IcebergParquetColumnIOConverter
             checkArgument(subColumns.size() == 1, "Not an array: %s", context);
             ColumnIdentity elementIdentity = getOnlyElement(subColumns);
             // TODO validate column ID
-            Optional<Field> field = constructField(new FieldContext(arrayType.getElementType(), elementIdentity), getArrayElementColumn(groupColumnIO.getChild(0)));
+            Optional<Field> field = constructField(new FieldContext(arrayType.getElementType(), elementIdentity), getArrayElementColumn(arrayType.getElementType(), groupColumnIO.getChild(0)));
             return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, ImmutableList.of(field)));
         }
         if (type == VARIANT) {


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

`ParquetTypeUtils.getArrayElementColumn` resolved the element ColumnIO of a LIST group purely from the Parquet schema, unconditionally applying the spec's backward-compatibility rule 4 (single-field repeated group named `array` or `<parent>_tuple` → the group IS the element). For a schema like

```
  optional group nested_list (LIST) {
    repeated group array {
      optional group inner_list (LIST) {
        repeated group array {
          optional binary element (STRING);
        }
      }
    }
  }
```

That decision is ambiguous: The caller may actually want `array(array(...))` rather than `array(row(inner_list))`. The wrong branch caused `constructField` to fall through to the primitive path and cast a `GroupColumnIO`
to `PrimitiveColumnIO`.

This commit takes the caller-supplied Trino element type as a tiebreaker: Keep the legacy rule-4 interpretation only when the caller expects a `RowType`, else unwrap the single child.

* Fixes #27766 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

 All non-test call sites already have the Trino type in scope.

The one non-`ParquetTypeUtils` caller is `IcebergParquetColumnIOConverter`, which is updated to pass
`arrayType.getElementType()` in the same way. Hive (`ParquetPageSourceFactory`), Redshift (`RedshiftPageSourceProvider`), and the Parquet writer (`ParquetWriter`) call `constructField` only, not `getArrayElementColumn` directly, and are unaffected.

This PR adds `TestParquetTypeUtils`.

The existing end-to-end nested-array reader tests in `AbstractTestParquetReader` (`testNestedArrays`, `testArrayOfArrayOfStructOfArray`, `testStructOfTwoNestedArrays`, `testSingleLevelSchemaNestedArrays`, `testStructOfTwoNestedSingleLevelSchemaArrays`) — which cover both modern and legacy `SingleLevelArraySchemaConverter` shapes end-to-end — continue to pass unchanged.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive connector
* Fix `ClassCastException` when reading a Parquet file with a nested `LIST` column that uses the legacy `array`-named repeated group encoding, e.g. `array(array(varchar))`. ({issue}`27766`)

## Iceberg connector
* Fix `ClassCastException` when reading a Parquet file with a nested `LIST` column that uses the legacy `array`-named repeated group encoding, e.g. `array(array(varchar))`. ({issue}`27766`)

## Delta Lake connector
* Fix `ClassCastException` when reading a Parquet file with a nested `LIST` column that uses the legacy `array`-named repeated group encoding, e.g. `array(array(varchar))`. ({issue}`27766`)

## Hudi connector
* Fix `ClassCastException` when reading a Parquet file with a nested `LIST` column that uses the legacy `array`-named repeated group encoding, e.g. `array(array(varchar))`. ({issue}`27766`)
```

