### PR TITLE
Swap Guava's toImmutableMap for Collectors.toMap

### DIFF
--- a/core/trino-main/src/main/java/io/trino/exchange/ExchangeMetricsCollector.java
+++ b/core/trino-main/src/main/java/io/trino/exchange/ExchangeMetricsCollector.java
@@ -37,10 +37,10 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
-import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
 public class ExchangeMetricsCollector
@@ -90,7 +90,7 @@ public class ExchangeMetricsCollector
             return ImmutableMap.of();
         }
         return exchanges.stream()
-                .collect(toMap(
+                .collect(toImmutableMap(
                         Exchange::getId,
                         Exchange::getMetrics));
     }

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -95,6 +95,7 @@ import java.util.function.Supplier;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.nullToEmpty;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.trino.SystemSessionProperties.getRetryPolicy;
@@ -126,7 +127,6 @@ import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static java.util.stream.Collectors.toMap;
 
 @ThreadSafe
 public class QueryStateMachine
@@ -445,7 +445,7 @@ public class QueryStateMachine
             Map<ExchangeId, Metrics> metrics = exchangeMetricsCollector.collectMetrics(queryId);
             this.exchangeMetrics.set(
                     metrics.entrySet().stream()
-                            .collect(toMap(entry -> entry.getKey().getId(), Map.Entry::getValue)));
+                            .collect(toImmutableMap(entry -> entry.getKey().getId(), Map.Entry::getValue)));
         }
         catch (RuntimeException e) {
             QUERY_STATE_LOG.error(e, "Error collecting query exchange metrics: %s", queryId);

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/SplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/SplitAssigner.java
@@ -27,9 +27,9 @@ import java.util.Map;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
 
 /**
  * An implementation is not required to be thread safe
@@ -73,7 +73,7 @@ interface SplitAssigner
                     .add("partitionId", partitionId)
                     .add("planNodeId", planNodeId)
                     .add("readyForScheduling", readyForScheduling)
-                    .add("splits", splits.asMap().entrySet().stream().collect(toMap(
+                    .add("splits", splits.asMap().entrySet().stream().collect(toImmutableMap(
                             Map.Entry::getKey,
                             entry -> entry.getValue().size())))
                     .add("noMoreSplits", noMoreSplits)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SortExpressionExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SortExpressionExtractor.java
@@ -28,13 +28,13 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN_OR_EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN_OR_EQUAL;
 import static io.trino.sql.ir.IrExpressions.matchComparison;
 import static io.trino.sql.planner.SymbolsExtractor.extractAll;
 import static java.util.Comparator.comparing;
 import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toMap;
 
 /**
  * Extracts sort expression to be used for creating {@link SortedPositionLinks} from join filter expression.
@@ -68,7 +68,7 @@ public final class SortExpressionExtractor
                 .filter(DeterminismEvaluator::isDeterministic)
                 .map(visitor::process)
                 .flatMap(List::stream)
-                .collect(toMap(SortExpressionContext::getSortExpression, identity(), SortExpressionExtractor::merge))
+                .collect(toImmutableMap(SortExpressionContext::getSortExpression, identity(), SortExpressionExtractor::merge))
                 .values());
 
         // For now heuristically pick sort expression which has most search expressions assigned to it.

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionThroughExchange.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionThroughExchange.java
@@ -33,8 +33,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.matching.Capture.newCapture;
 import static io.trino.sql.planner.ExpressionSymbolInliner.inlineSymbols;
 import static io.trino.sql.planner.iterative.rule.Util.restrictOutputs;
@@ -119,7 +119,7 @@ public class PushProjectionThroughExchange
             Set<Symbol> partitioningHashAndOrderingOutputs = outputBuilder.build();
 
             Map<Symbol, Expression> translationMap = outputToInputMap.entrySet().stream()
-                    .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().toSymbolReference()));
+                    .collect(toImmutableMap(Entry::getKey, entry -> entry.getValue().toSymbolReference()));
 
             for (Entry<Symbol, Expression> projection : project.getAssignments().entrySet()) {
                 // Skip identity projection if symbol is in outputs already

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SingleDistinctAggregationToGroupBy.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SingleDistinctAggregationToGroupBy.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.sql.planner.plan.AggregationNode.singleAggregation;
 import static io.trino.sql.planner.plan.AggregationNode.singleGroupingSet;
 import static io.trino.sql.planner.plan.Patterns.aggregation;
@@ -143,7 +144,7 @@ public class SingleDistinctAggregationToGroupBy
                                 // remove DISTINCT flag from function calls
                                 aggregation.getAggregations()
                                         .entrySet().stream()
-                                        .collect(Collectors.toMap(
+                                        .collect(toImmutableMap(
                                                 Map.Entry::getKey,
                                                 e -> removeDistinct(e.getValue()))))
                         .setPreGroupedSymbols(ImmutableList.of())

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -100,6 +100,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.spi.predicate.TupleDomain.extractFixedValues;
 import static io.trino.sql.planner.SystemPartitioningHandle.ARBITRARY_DISTRIBUTION;
 import static io.trino.sql.planner.optimizations.ActualProperties.Global.arbitraryPartition;
@@ -113,7 +114,6 @@ import static io.trino.sql.planner.plan.RowsPerMatch.ONE;
 import static io.trino.sql.planner.plan.RowsPerMatch.WINDOW;
 import static io.trino.sql.planner.plan.SkipToPosition.PAST_LAST;
 import static java.lang.String.format;
-import static java.util.stream.Collectors.toMap;
 
 public final class PropertyDerivations
 {
@@ -677,7 +677,7 @@ public final class PropertyDerivations
             checkState(entries != null);
 
             Map<Symbol, NullableValue> constants = entries.stream()
-                    .collect(toMap(Entry::getKey, Entry::getValue));
+                    .collect(toImmutableMap(Entry::getKey, Entry::getValue));
 
             ImmutableList.Builder<LocalProperty<Symbol>> localProperties = ImmutableList.builder();
             node.getOrderingScheme().ifPresent(orderingScheme -> localProperties.addAll(orderingScheme.toLocalProperties()));
@@ -880,7 +880,7 @@ public final class PropertyDerivations
 
             Map<Symbol, NullableValue> symbolConstants = globalConstants.entrySet().stream()
                     .filter(entry -> assignments.containsKey(entry.getKey()))
-                    .collect(toMap(entry -> assignments.get(entry.getKey()), Entry::getValue));
+                    .collect(toImmutableMap(entry -> assignments.get(entry.getKey()), Entry::getValue));
             properties.constants(symbolConstants);
 
             // Partitioning properties

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
@@ -57,6 +57,7 @@ import java.util.concurrent.Executor;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.partition;
 import static com.google.common.collect.Multimaps.toMultimap;
@@ -67,7 +68,6 @@ import static io.trino.filesystem.s3.S3SseCUtils.encoded;
 import static io.trino.filesystem.s3.S3SseCUtils.md5Checksum;
 import static io.trino.filesystem.s3.S3SseRequestConfigurator.setEncryptionSettings;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toMap;
 
 final class S3FileSystem
         implements TrinoFileSystem
@@ -420,7 +420,7 @@ final class S3FileSystem
     {
         return headers.entrySet().stream()
                 .filter(entry -> !entry.getKey().equalsIgnoreCase("host"))
-                .collect(toMap(Entry::getKey, Entry::getValue));
+                .collect(toImmutableMap(Entry::getKey, Entry::getValue));
     }
 
     @SuppressWarnings("ResultOfObjectAllocationIgnored")

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystemManager.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystemManager.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkState;
-import static java.util.stream.Collectors.toMap;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
 public final class HdfsFileSystemManager
 {
@@ -65,7 +65,7 @@ public final class HdfsFileSystemManager
     {
         return bootstrap.configure()
                 .stream()
-                .collect(toMap(ConfigPropertyMetadata::name, ConfigPropertyMetadata::securitySensitive));
+                .collect(toImmutableMap(ConfigPropertyMetadata::name, ConfigPropertyMetadata::securitySensitive));
     }
 
     public TrinoFileSystemFactory create()

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
@@ -59,12 +59,12 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.orc.OrcReader.validateFile;
@@ -520,7 +520,7 @@ public final class OrcWriter
         recordValidation(validation -> validation.setFileStatistics(fileStats));
 
         Map<String, Slice> userMetadata = this.userMetadata.entrySet().stream()
-                .collect(Collectors.toMap(Entry::getKey, entry -> utf8Slice(entry.getValue())));
+                .collect(toImmutableMap(Entry::getKey, entry -> utf8Slice(entry.getValue())));
 
         Footer footer = new Footer(
                 fileRowCount,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
@@ -491,7 +491,7 @@ public class CheckpointWriter
     {
         return valuesOptional.map(
                 values -> {
-                    Map<String, Type> fieldTypes = valuesType.getFields().stream().collect(toMap(
+                    Map<String, Type> fieldTypes = valuesType.getFields().stream().collect(toImmutableMap(
                             // anonymous row fields are not expected here
                             field -> field.getName().orElseThrow(),
                             RowType.Field::getType));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -355,7 +355,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toMap;
 
 public class HiveMetadata
         implements TransactionalMetadata
@@ -3391,7 +3390,7 @@ public class HiveMetadata
 
         return withColumnDomains(
                 partitionColumns.stream()
-                        .collect(toMap(identity(), column -> buildColumnDomain(column, partitions))));
+                        .collect(toImmutableMap(identity(), column -> buildColumnDomain(column, partitions))));
     }
 
     private static Domain buildColumnDomain(ColumnHandle column, List<HivePartition> partitions)
@@ -3521,7 +3520,7 @@ public class HiveMetadata
 
         List<String> bucketedBy = bucketInfo.get().bucketedBy();
         Map<String, HiveType> hiveTypeMap = tableMetadata.getColumns().stream()
-                .collect(toMap(ColumnMetadata::getName, column -> toHiveType(column.getType())));
+                .collect(toImmutableMap(ColumnMetadata::getName, column -> toHiveType(column.getType())));
         return Optional.of(new ConnectorTableLayout(
                 new HivePartitioningHandle(
                         bucketInfo.get().bucketingVersion(),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Functions.identity;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.hive.formats.HiveClassNames.AVRO_CONTAINER_INPUT_FORMAT_CLASS;
 import static io.trino.hive.formats.HiveClassNames.AVRO_CONTAINER_OUTPUT_FORMAT_CLASS;
 import static io.trino.hive.formats.HiveClassNames.AVRO_SERDE_CLASS;
@@ -59,7 +60,6 @@ import static io.trino.hive.formats.HiveClassNames.TWITTER_ELEPHANTBIRD_PROTOBUF
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toMap;
 
 public enum HiveStorageFormat
 {
@@ -198,7 +198,7 @@ public enum HiveStorageFormat
 
     private static final Map<SerdeAndInputFormat, HiveStorageFormat> HIVE_STORAGE_FORMATS = ImmutableMap.<SerdeAndInputFormat, HiveStorageFormat>builder()
             .putAll(Arrays.stream(values()).collect(
-                    toMap(format -> new SerdeAndInputFormat(format.getSerde(), format.getInputFormat()), identity())))
+                    toImmutableMap(format -> new SerdeAndInputFormat(format.getSerde(), format.getInputFormat()), identity())))
             .put(new SerdeAndInputFormat(PARQUET_HIVE_SERDE_CLASS, "parquet.hive.DeprecatedParquetInputFormat"), PARQUET)
             .put(new SerdeAndInputFormat(PARQUET_HIVE_SERDE_CLASS, "org.apache.hadoop.mapred.TextInputFormat"), PARQUET)
             .put(new SerdeAndInputFormat(PARQUET_HIVE_SERDE_CLASS, "parquet.hive.MapredParquetInputFormat"), PARQUET)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
@@ -62,6 +62,7 @@ import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.trino.hive.formats.HiveClassNames.HIVE_IGNORE_KEY_OUTPUT_FORMAT_CLASS;
 import static io.trino.metastore.AcidOperation.CREATE_TABLE;
@@ -98,7 +99,6 @@ import static java.util.UUID.randomUUID;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
 
 public class HiveWriterFactory
 {
@@ -571,7 +571,7 @@ public class HiveWriterFactory
 
         // verify we can write all input columns to the file
         Map<String, DataColumn> inputColumnMap = dataColumns.stream()
-                .collect(toMap(DataColumn::name, identity()));
+                .collect(toImmutableMap(DataColumn::name, identity()));
         Set<String> missingColumns = Sets.difference(inputColumnMap.keySet(), new HashSet<>(fileColumnNames));
         if (!missingColumns.isEmpty()) {
             throw new TrinoException(HIVE_INVALID_METADATA, format("Table '%s.%s' does not have columns %s", schemaName, tableName, missingColumns));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -147,7 +147,6 @@ import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.function.Predicate.not;
 import static java.util.function.UnaryOperator.identity;
 import static java.util.stream.Collectors.toCollection;
-import static java.util.stream.Collectors.toMap;
 
 public class GlueHiveMetastore
         implements HiveMetastore
@@ -988,7 +987,7 @@ public class GlueHiveMetastore
                 partitionNames,
                 (cachePartition, missingPartitions) -> batchGetPartition(databaseName, tableName, missingPartitions, cachePartition));
         Map<PartitionName, Partition> partitionValuesToPartitionMap = partitions.stream()
-                .collect(toMap(partition -> new PartitionName(partition.getValues()), identity()));
+                .collect(toImmutableMap(partition -> new PartitionName(partition.getValues()), identity()));
 
         ImmutableMap.Builder<PartitionName, Optional<Partition>> resultBuilder = ImmutableMap.builder();
         for (PartitionName partitionName : partitionNames) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -55,6 +55,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.metastore.Table.TABLE_COMMENT;
 import static io.trino.plugin.hive.HiveMetadata.TRINO_QUERY_ID_NAME;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.metastoreFunctionName;
@@ -393,10 +394,10 @@ public class BridgingHiveMetastore
         }
 
         Map<String, List<String>> partitionNameToPartitionValuesMap = partitionNames.stream()
-                .collect(Collectors.toMap(identity(), Partitions::toPartitionValues));
+                .collect(toImmutableMap(identity(), Partitions::toPartitionValues));
         Map<List<String>, Partition> partitionValuesToPartitionMap = delegate.getPartitionsByNames(table.getDatabaseName(), table.getTableName(), partitionNames).stream()
                 .map(partition -> fromMetastoreApiPartition(table, partition))
-                .collect(Collectors.toMap(Partition::getValues, identity()));
+                .collect(toImmutableMap(Partition::getValues, identity()));
         ImmutableMap.Builder<String, Optional<Partition>> resultBuilder = ImmutableMap.builder();
         for (Entry<String, List<String>> entry : partitionNameToPartitionValuesMap.entrySet()) {
             Partition partition = partitionValuesToPartitionMap.get(entry.getValue());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/PartitionProjection.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/projection/PartitionProjection.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.cartesianProduct;
 import static io.trino.metastore.Partitions.escapePathName;
@@ -138,7 +139,7 @@ public final class PartitionProjection
     public Map<String, Optional<Partition>> getProjectedPartitionsByNames(Table table, List<String> partitionNames)
     {
         return partitionNames.stream()
-                .collect(Collectors.toMap(
+                .collect(toImmutableMap(
                         partitionName -> partitionName,
                         partitionName -> Optional.of(buildPartitionObject(table, partitionName))));
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketing.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketing.java
@@ -47,9 +47,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Lists.cartesianProduct;
 import static io.trino.hive.thrift.metastore.hive_metastoreConstants.TABLE_BUCKETING_VERSION;
 import static io.trino.plugin.hive.HiveColumnHandle.BUCKET_COLUMN_NAME;
@@ -191,7 +191,7 @@ public final class HiveBucketing
 
         HiveTimestampPrecision timestampPrecision = getTimestampPrecision(session);
         Map<String, HiveColumnHandle> map = getRegularColumnHandles(table, typeManager, timestampPrecision).stream()
-                .collect(Collectors.toMap(HiveColumnHandle::getName, identity()));
+                .collect(toImmutableMap(HiveColumnHandle::getName, identity()));
 
         ImmutableList.Builder<HiveColumnHandle> bucketColumns = ImmutableList.builder();
         for (String bucketColumnName : hiveBucketProperty.get().bucketedBy()) {

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiReadOptimizedDirectoryLister.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiReadOptimizedDirectoryLister.java
@@ -33,9 +33,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.Math.min;
 import static org.apache.hudi.common.table.view.HoodieTableFileSystemView.fileListingBasedFileSystemView;
 
@@ -66,7 +66,7 @@ public class HudiReadOptimizedDirectoryLister
         this.partitionColumns = hiveTable.getPartitionColumns();
         this.maxSplitSize = maxSplitSize;
         this.allPartitionInfoMap = hivePartitionNames.stream()
-                .collect(Collectors.toMap(
+                .collect(toImmutableMap(
                         Function.identity(),
                         hivePartitionName -> new HiveHudiPartitionInfo(
                                 hivePartitionName,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableStatisticsReader.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableStatisticsReader.java
@@ -80,7 +80,6 @@ import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.Long.parseLong;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toUnmodifiableMap;
 import static org.apache.iceberg.IcebergManifestUtils.liveEntries;
 
@@ -314,7 +313,7 @@ public final class TableStatisticsReader
         }
 
         Map<Long, StatisticsFile> statsFileBySnapshot = icebergTable.statisticsFiles().stream()
-                .collect(toMap(
+                .collect(toImmutableMap(
                         StatisticsFile::snapshotId,
                         identity(),
                         (file1, file2) -> {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DefaultDeletionVectorWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DefaultDeletionVectorWriter.java
@@ -62,6 +62,7 @@ import java.util.UUID;
 import java.util.function.Function;
 
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_WRITER_DATA_ERROR;
@@ -69,7 +70,6 @@ import static io.trino.plugin.iceberg.IcebergUtil.getColumnHandle;
 import static io.trino.plugin.iceberg.IcebergUtil.getLocationProvider;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toMap;
 import static org.apache.iceberg.FileFormat.PUFFIN;
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_PATH;
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_POS;
@@ -113,7 +113,7 @@ public class DefaultDeletionVectorWriter
         long snapshotId = table.getSnapshotId().orElseThrow(() -> new TrinoException(ICEBERG_BAD_DATA, "Missing base snapshot id for v3 deletion vector rewrite"));
 
         // deletion vector info may contain multiple entries for the same data file; merge them here
-        Map<String, DeletionVector.Builder> deletionVectorBuilders = deletionVectorInfos.stream().collect(toMap(
+        Map<String, DeletionVector.Builder> deletionVectorBuilders = deletionVectorInfos.stream().collect(toImmutableMap(
                 DeletionVectorInfo::dataFilePath,
                 info -> DeletionVector.builder().deserialize(info.serializedDeletionVector()),
                 DeletionVector.Builder::addAll));
@@ -137,7 +137,7 @@ public class DefaultDeletionVectorWriter
             // determine which of the new deletion vectors need merging
             Map<String, DeletionVector.Builder> deletionVectorsWithLegacyDelete = deletionVectorBuilders.entrySet().stream()
                     .filter(entry -> existingDeletes.fileScopedDeletes().containsKey(entry.getKey()) || !existingDeletes.partitionScopedDeletes().isEmpty())
-                    .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+                    .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
 
             if (!deletionVectorsWithLegacyDelete.isEmpty()) {
                 // process the file-scoped delete files
@@ -173,7 +173,7 @@ public class DefaultDeletionVectorWriter
         // finalize the deletion vectors
         Map<String, DeletionVector> deletionVectors = deletionVectorBuilders.entrySet().stream()
                 .map(entry -> Map.entry(entry.getKey(), entry.getValue().build()))
-                .collect(toMap(
+                .collect(toImmutableMap(
                         Map.Entry::getKey,
                         // at this point there should not be an empty deletion vector
                         entry -> entry.getValue().orElseThrow(() -> new VerifyException("Delection vector is empty"))));
@@ -263,7 +263,7 @@ public class DefaultDeletionVectorWriter
                 writer.finish();
 
                 Map<String, DeletionVectorInfo> partitionInfo = deletionVectorInfos.stream()
-                        .collect(toMap(
+                        .collect(toImmutableMap(
                                 DeletionVectorInfo::dataFilePath,
                                 Function.identity(),
                                 (left, right) -> {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/ParquetUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/ParquetUtil.java
@@ -56,9 +56,9 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toMap;
 import static org.apache.iceberg.MetricsUtil.createNanValueCounts;
 import static org.apache.iceberg.parquet.ParquetUtil.extractTimestampInt96;
 
@@ -94,7 +94,7 @@ public final class ParquetUtil
         MessageType parquetTypeWithIds = getParquetTypeWithIds(metadata, nameMapping);
         Schema fileSchema = ParquetSchemaUtil.convertAndPrune(parquetTypeWithIds);
 
-        Map<Integer, FieldMetrics<?>> fieldMetricsMap = fieldMetrics.collect(toMap(FieldMetrics::id, identity()));
+        Map<Integer, FieldMetrics<?>> fieldMetricsMap = fieldMetrics.collect(toImmutableMap(FieldMetrics::id, identity()));
 
         List<BlockMetadata> blocks = metadata.getBlocks();
         for (BlockMetadata block : blocks) {

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
@@ -56,7 +56,6 @@ import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static java.lang.Math.floorDiv;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toMap;
 
 public class KafkaFilterManager
 {
@@ -127,7 +126,7 @@ public class KafkaFilterManager
                     if (offsetTimestampRanged.get().begin() > INVALID_KAFKA_RANGE_INDEX) {
                         long partitionBeginTimestamp = floorDiv(offsetTimestampRanged.get().begin(), MICROSECONDS_PER_MILLISECOND);
                         Map<TopicPartition, Long> partitionBeginTimestamps = partitionBeginOffsets.entrySet().stream()
-                                .collect(toMap(Map.Entry::getKey, _ -> partitionBeginTimestamp));
+                                .collect(toImmutableMap(Map.Entry::getKey, _ -> partitionBeginTimestamp));
                         Map<TopicPartition, Optional<Long>> beginOffsets = findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partitionBeginTimestamps);
                         partitionBeginOffsets = overridePartitionBeginOffsets(partitionBeginOffsets, beginOffsets::get);
                     }
@@ -135,7 +134,7 @@ public class KafkaFilterManager
                         if (offsetTimestampRanged.get().end() > INVALID_KAFKA_RANGE_INDEX) {
                             long partitionEndTimestamp = floorDiv(offsetTimestampRanged.get().end(), MICROSECONDS_PER_MILLISECOND);
                             Map<TopicPartition, Long> partitionEndTimestamps = partitionEndOffsets.entrySet().stream()
-                                    .collect(toMap(Map.Entry::getKey, _ -> partitionEndTimestamp));
+                                    .collect(toImmutableMap(Map.Entry::getKey, _ -> partitionEndTimestamp));
                             Map<TopicPartition, Optional<Long>> endOffsets = findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partitionEndTimestamps);
                             partitionEndOffsets = overridePartitionEndOffsets(partitionEndOffsets, endOffsets::get);
                         }
@@ -184,7 +183,7 @@ public class KafkaFilterManager
     {
         Map<TopicPartition, OffsetAndTimestamp> topicPartitionOffsetAndTimestamps = kafkaConsumer.offsetsForTimes(timestamps);
         return topicPartitionOffsetAndTimestamps.entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, entry -> Optional.ofNullable(entry.getValue()).map(OffsetAndTimestamp::offset)));
+                .collect(toImmutableMap(Map.Entry::getKey, entry -> Optional.ofNullable(entry.getValue()).map(OffsetAndTimestamp::offset)));
     }
 
     private static Map<TopicPartition, Long> overridePartitionBeginOffsets(

--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/transport/http/OpenLineageHttpTransportConfig.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/transport/http/OpenLineageHttpTransportConfig.java
@@ -27,8 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.String.format;
 
 public class OpenLineageHttpTransportConfig
@@ -116,7 +116,7 @@ public class OpenLineageHttpTransportConfig
         try {
             this.headers = headers
                     .stream()
-                    .collect(Collectors.toMap(keyValue -> keyValue.split(":", 2)[0], keyValue -> keyValue.split(":", 2)[1]));
+                    .collect(toImmutableMap(keyValue -> keyValue.split(":", 2)[0], keyValue -> keyValue.split(":", 2)[1]));
         }
         catch (IndexOutOfBoundsException e) {
             throw new IllegalArgumentException(format("Cannot parse http headers from property openlineage-event-listener.transport.headers; value provided was %s, " +
@@ -137,7 +137,7 @@ public class OpenLineageHttpTransportConfig
         try {
             this.urlParams = urlParas
                     .stream()
-                    .collect(Collectors.toMap(kvs -> kvs.split(":", 2)[0], kvs -> kvs.split(":", 2)[1]));
+                    .collect(toImmutableMap(kvs -> kvs.split(":", 2)[0], kvs -> kvs.split(":", 2)[1]));
         }
         catch (IndexOutOfBoundsException e) {
             throw new IllegalArgumentException(format("Cannot parse url params from property openlineage-event-listener.transport.url-params; value provided was %s, " +

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
@@ -78,9 +78,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Maps.asMap;
 import static io.trino.plugin.tpch.util.PredicateUtils.convertToPredicate;
@@ -559,7 +559,7 @@ public class TpchMetadata
     private static TupleDomain<ColumnHandle> toTupleDomain(Map<TpchColumnHandle, Set<NullableValue>> predicate)
     {
         return TupleDomain.withColumnDomains(predicate.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> {
+                .collect(toImmutableMap(Map.Entry::getKey, entry -> {
                     Type type = entry.getKey().type();
                     return entry.getValue().stream()
                             .map(nullableValue -> Domain.singleValue(type, nullableValue.getValue()))


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

`Collectors.toMap` returns a `HashMap` with no iteration-order guarantee and no reuse-time immutability. `ImmutableMap.toImmutableMap` preserves insertion order and enforces immutability, matching the existing guidance in `.github/DEVELOPMENT.md` to prefer Guava's immutable collections over JDK unmodifiable ones.

This commit converts 34 call sites across `core/trino-main`, `lib/`, and `plugin/` where both the key and value functions are provably non-null and the resulting map is only read after collection. Sites have been left as `Collectors.toMap` when:

- The map is mutated after collection (`.put`, `.putAll`, `.remove`, `computeIfPresent`) — e.g. `Session#withDefaultProperties`, `TopologicalOrderSubPlanVisitor`, `CounterBasedAnonymizer`, `AvroHiveFileWriter`, `KafkaRecordSet`, `FileHiveMetastore#commentTable`.
- The value function can produce `null` — `ImmutableMap` disallows null keys and values (see the discussion in #6429).
- The file is in `core/trino-spi` or `client/trino-client`, which do not depend on Guava.

This commit was motivated by #6800, but only addresses a minority of the toMap instances found. Whether it resolves the issue is an open question.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: