### PR TITLE
Do not shade product tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -880,7 +880,11 @@ jobs:
             core/trino-server/target/*.tar.gz
             impacted-features.log
             testing/trino-product-tests-launcher/target/*.jar
-            testing/trino-product-tests/target/*-executable.jar
+            testing/trino-product-tests/target/trino-product-tests-*.jar
+            !testing/trino-product-tests/target/*-sources.jar
+            !testing/trino-product-tests/target/*-tests.jar
+            !testing/trino-product-tests/target/*-test-sources.jar
+            testing/trino-product-tests/target/lib/*.jar
             client/trino-cli/target/*-executable.jar
           retention-days: 1
       - id: prepare-matrix-template

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteDescribe.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteDescribe.java
@@ -99,8 +99,11 @@ public class SuiteDescribe
         @Option(names = "--suite", paramLabel = "<suite>", description = "Name of the suite(s) to run (comma separated)", required = true, split = ",")
         public List<String> suites;
 
-        @Option(names = "--test-jar", paramLabel = "<jar>", description = "Path to test JAR " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/${product-tests.name}-${project.version}-executable.jar")
+        @Option(names = "--test-jar", paramLabel = "<jar>", description = "Path to test JAR " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/${product-tests.name}-${project.version}.jar")
         public File testJar;
+
+        @Option(names = "--test-libs", paramLabel = "<dir>", description = "Path to the directory with test JAR dependencies " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/lib")
+        public File testLibs;
 
         @Option(names = "--format", description = "Table output format: ${COMPLETION-CANDIDATES} " + DEFAULT_VALUE, defaultValue = "TEXT")
         public SuiteDescribeFormat format;
@@ -250,6 +253,7 @@ public class SuiteDescribe
             testRunOptions.extraOptions = suiteTestRun.getExtraOptions();
             testRunOptions.testArguments = suiteTestRun.getTemptoRunArguments();
             testRunOptions.testJar = describeOptions.testJar;
+            testRunOptions.testLibs = describeOptions.testLibs;
             testRunOptions.reportsDir = Path.of(format("testing/trino-product-tests/target/%s/%s/%s", suiteName, environmentConfig.getConfigName(), suiteTestRun.getEnvironmentName()));
             testRunOptions.startupRetries = null;
             testRunOptions.logsDirBase = Optional.empty();

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteRun.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteRun.java
@@ -111,8 +111,11 @@ public class SuiteRun
         @Option(names = "--suite", paramLabel = "<suite>", description = "Name of the suite(s) to run (comma separated)", required = true, split = ",")
         public List<String> suites;
 
-        @Option(names = "--test-jar", paramLabel = "<jar>", description = "Path to test JAR " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/${product-tests.name}-${project.version}-executable.jar")
+        @Option(names = "--test-jar", paramLabel = "<jar>", description = "Path to test JAR " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/${product-tests.name}-${project.version}.jar")
         public File testJar;
+
+        @Option(names = "--test-libs", paramLabel = "<dir>", description = "Path to the directory with test JAR dependencies " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/lib")
+        public File testLibs;
 
         @Option(names = "--cli-executable", paramLabel = "<jar>", description = "Path to CLI executable " + DEFAULT_VALUE, defaultValue = "${cli.bin}")
         public File cliJar;
@@ -312,6 +315,7 @@ public class SuiteRun
             testRunOptions.extraOptions = suiteTestRun.getExtraOptions();
             testRunOptions.testArguments = suiteTestRun.getTemptoRunArguments();
             testRunOptions.testJar = suiteRunOptions.testJar;
+            testRunOptions.testLibs = suiteRunOptions.testLibs;
             testRunOptions.cliJar = suiteRunOptions.cliJar;
             testRunOptions.impactedFeatures = suiteRunOptions.impactedFeatures;
             String suiteRunId = suiteRunId(runId, suiteName, suiteTestRun, environmentConfig);

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/TestRun.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/TestRun.java
@@ -54,6 +54,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.testing.SystemEnvironmentUtils.isEnvSet;
@@ -108,8 +109,11 @@ public final class TestRun
     {
         private static final String DEFAULT_VALUE = "(default: ${DEFAULT-VALUE})";
 
-        @Option(names = "--test-jar", paramLabel = "<jar>", description = "Path to test JAR " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/${product-tests.name}-${project.version}-executable.jar")
+        @Option(names = "--test-jar", paramLabel = "<jar>", description = "Path to test JAR " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/${product-tests.name}-${project.version}.jar")
         public File testJar;
+
+        @Option(names = "--test-libs", paramLabel = "<dir>", description = "Path to the directory with test JAR dependencies " + DEFAULT_VALUE, defaultValue = "${product-tests.module}/target/lib")
+        public File testLibs;
 
         @Option(names = "--cli-executable", paramLabel = "<jar>", description = "Path to CLI executable " + DEFAULT_VALUE, defaultValue = "${cli.bin}")
         public File cliJar;
@@ -154,12 +158,14 @@ public final class TestRun
             implements Callable<Integer>
     {
         private static final String CONTAINER_REPORTS_DIR = "/docker/test-reports";
+        private static final String TESTS_MAIN_CLASS = "io.trino.tests.product.TemptoProductTestRunner";
         private final EnvironmentFactory environmentFactory;
         private final boolean debug;
         private final boolean debugSuspend;
         private final boolean ipv6;
         private final JdkProvider jdkProvider;
         private final File testJar;
+        private final File testLibs;
         private final File cliJar;
         private final List<String> testArguments;
         private final String environment;
@@ -192,6 +198,7 @@ public final class TestRun
             this.debugSuspend = testRunOptions.debugSuspend;
             this.jdkProvider = requireNonNull(jdkProvider, "jdkProvider is null");
             this.testJar = requireNonNull(testRunOptions.testJar, "testRunOptions.testJar is null");
+            this.testLibs = requireNonNull(testRunOptions.testLibs, "testRunOptions.testLibs is null");
             this.cliJar = requireNonNull(testRunOptions.cliJar, "testRunOptions.cliJar is null");
             this.testArguments = ImmutableList.copyOf(requireNonNull(testRunOptions.testArguments, "testRunOptions.testArguments is null"));
             this.environment = requireNonNull(testRunOptions.environment, "testRunOptions.environment is null");
@@ -349,8 +356,9 @@ public final class TestRun
 
                 // Install Java distribution if necessary
                 jdkProvider.applyTo(container)
-                        // the test jar is hundreds MB and file system bind is much more efficient
+                        // the test classpath is hundreds MB and file system bind is much more efficient
                         .withFileSystemBind(testJar.getPath(), "/docker/test.jar", READ_ONLY)
+                        .withFileSystemBind(testLibsDirectory().getPath(), "/docker/test-lib", READ_ONLY)
                         .withFileSystemBind(cliJar.getPath(), "/docker/trino-cli", READ_ONLY)
                         .withCopyFileToContainer(forClasspathResource("docker/trino-product-tests/common/standard/set-trino-cli.sh"), "/etc/profile.d/set-trino-cli.sh")
                         .withCommand(ImmutableList.<String>builder()
@@ -365,8 +373,9 @@ public final class TestRun
                                         "-DProgressLoggingListener.enabled=false")
                                 .addAll(temptoJavaOptions)
                                 .add(
-                                        "-jar",
-                                        "/docker/test.jar",
+                                        "-cp",
+                                        "/docker/test.jar:/docker/test-lib/*",
+                                        TESTS_MAIN_CLASS,
                                         "--config",
                                         String.join(",", ImmutableList.<String>builder()
                                                 .add("tempto-configuration.yaml") // this comes from classpath
@@ -383,6 +392,12 @@ public final class TestRun
             builder.setAttached(attach);
 
             return builder.build(getStandardListeners(logsDirBase));
+        }
+
+        private File testLibsDirectory()
+        {
+            checkState(testLibs.isDirectory(), "Test dependencies directory %s does not exist. Build the trino-product-tests module to populate it.", testLibs);
+            return testLibs;
         }
 
         private static Iterable<? extends String> reportsDirOptions(Path path)

--- a/testing/trino-product-tests/pom.xml
+++ b/testing/trino-product-tests/pom.xml
@@ -14,7 +14,6 @@
     <description>Trino - Product tests</description>
 
     <properties>
-        <main-class>io.trino.tests.product.TemptoProductTestRunner</main-class>
         <air.check.skip-duplicate-finder>true</air.check.skip-duplicate-finder>
     </properties>
 
@@ -464,57 +463,33 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <configuration>
                     <ignoredUnusedDeclaredDependencies>
-                        <!-- Legacy product tests execute test classes from the executable artifact, so Kafka must be
+                        <!-- Legacy product tests execute test classes from the test runtime classpath, so Kafka must be
                              available at runtime even though the analyzer does not see it from main classes. -->
                         <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka-clients</ignoredUnusedDeclaredDependency>
                     </ignoredUnusedDeclaredDependencies>
                     <ignoredNonTestScopedDependencies>
-                        <!-- Legacy product tests execute test classes from the executable artifact, so Kafka must be
+                        <!-- Legacy product tests execute test classes from the test runtime classpath, so Kafka must be
                              available at runtime even though the analyzer classifies it as test-only. -->
                         <ignoredNonTestScopedDependency>org.apache.kafka:kafka-clients</ignoredNonTestScopedDependency>
                     </ignoredNonTestScopedDependencies>
                 </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>copy-runtime-classpath</id>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>copy-dependencies</goal>
                         </goals>
                         <phase>package</phase>
                         <configuration>
-                            <!--
-                            trino-product-tests has a dependency on SQL Server (mssql-jdbc) which is a signed jar.
-                            Its invalidated when we repackage it into an uber jar. Hence to avoid
-                            Error: A JNI error has occurred, please check your installation and try again
-                            Exception in thread "main" java.lang.SecurityException: Invalid signature file digest for Manifest main attributes
-
-                            We remove signed information from META-INF
-                            -->
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <shadedClassifierName>executable</shadedClassifierName>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <manifestEntries>
-                                        <Main-Class>${main-class}</Main-Class>
-                                    </manifestEntries>
-                                </transformer>
-                            </transformers>
+                            <!-- The product test launcher mounts this directory together with the module jar
+                                 into the tests container and runs the tests with a wildcard classpath.
+                                 This replaces the former shaded executable uber-jar, which was slow to build
+                                 and rebuilt from scratch on every invocation. -->
+                            <!-- This execution packages the test runtime classpath, it is not a check.
+                                 Override the airbase plugin-level skip so it still runs with -Dair.check.skip-all. -->
+                            <skip>false</skip>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>
                 </executions>

--- a/testing/trino-product-tests/pom.xml
+++ b/testing/trino-product-tests/pom.xml
@@ -98,6 +98,24 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-hive</artifactId>
+            <exclusions>
+                <!-- Product tests only use the Thrift metastore client classes from trino-hive.
+                     Exclude the connector runtime's heavy transitive dependencies (cloud filesystems,
+                     Alluxio cache with RocksDB and gRPC, Coral, fastutil) which are never used at
+                     test runtime and would otherwise dominate the test classpath size. -->
+                <exclusion>
+                    <groupId>io.trino</groupId>
+                    <artifactId>trino-filesystem-manager</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.trino.coral</groupId>
+                    <artifactId>coral</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>it.unimi.dsi</groupId>
+                    <artifactId>fastutil</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Building the product tests executable uber-jar dominated the module build: maven-shade-plugin rewrote 183k entries (1 GB uncompressed, 419 MB compressed) on every package invocation, with no incrementality. A warm clean build took 33 s, of which shading accounted for ~17 s.

Replace the shaded jar with dependency:copy-dependencies, which copies the runtime classpath into target/lib. The launcher now mounts that directory into the tests container next to the thin module jar and starts Tempto with a wildcard classpath (-cp) instead of java -jar. A wildcard classpath avoids the Class-Path manifest fragility around SNAPSHOT file naming, and copying is incremental, so repeat builds no longer pay any packaging cost.

Additionally, exclude heavy trino-hive transitive dependencies that product tests never use at runtime - they only need the Thrift metastore client and HiveTimestampPrecision from that module:
- trino-filesystem-manager, which alone pulls the Azure and GCS filesystems and the Alluxio cache with its RocksDB natives (~250 MB of native libraries for every platform) and gRPC stack
- coral
- fastutil

Results:
- clean module build: 33 s -> 9.5 s
- incremental rebuild with -Dair.check.skip-all=true: ~26 s -> 3.2 s
- CI artifact shrinks from a single 419 MB jar to 243 MB of individual jars, which every product test suite job downloads

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
