### PR TITLE
Fix web UI build and run frontend checks in CI

### DIFF
--- a/core/trino-web-ui/pom.xml
+++ b/core/trino-web-ui/pom.xml
@@ -108,7 +108,7 @@
                         <goals>
                             <goal>bun</goal>
                         </goals>
-                        <phase>verify</phase>
+                        <phase>test</phase>
                         <configuration>
                             <arguments>run ${frontend.check.goal}</arguments>
                             <workingDirectory>src/main/resources/webapp-legacy/src</workingDirectory>
@@ -120,7 +120,7 @@
                         <goals>
                             <goal>bun</goal>
                         </goals>
-                        <phase>verify</phase>
+                        <phase>test</phase>
                         <configuration>
                             <arguments>run ${frontend.check.goal}</arguments>
                             <workingDirectory>src/main/resources/webapp</workingDirectory>

--- a/core/trino-web-ui/src/main/resources/webapp/src/components/MetricCard.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/MetricCard.tsx
@@ -16,7 +16,6 @@ import { Card, CardActionArea, CardContent, Grid, Tooltip, Typography } from '@m
 import { SparkLineChart } from '@mui/x-charts/SparkLineChart'
 import { styled, useTheme } from '@mui/material/styles'
 import { lineClasses } from '@mui/x-charts/LineChart'
-import { chartsAxisHighlightClasses } from '@mui/x-charts/ChartsAxisHighlight'
 import type { Theme } from '@mui/material/styles'
 
 interface IMetricCardProps {

--- a/core/trino-web-ui/src/main/resources/webapp/src/components/QueryList.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/QueryList.tsx
@@ -68,7 +68,7 @@ const SORT_TYPE = {
         }
         return (
             value +
-            (100 - (queryInfo.queryStats.processPercentage ?? 100)) * 1e12 +
+            (100 - (queryInfo.queryStats.progressPercentage ?? 100)) * 1e12 +
             Date.parse(queryInfo.queryStats.createTime)
         )
     },

--- a/core/trino-web-ui/src/main/resources/webapp/src/components/QueryStageCard.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/QueryStageCard.tsx
@@ -111,6 +111,7 @@ const KpiRow = ({ label, value, isLast = false }: { label: string; value: string
 
 export const QueryStageCard = ({ stage, taskRetriesEnabled }: IQueryStageCard) => {
     const { stageStats } = stage
+    const theme = useTheme<Theme>()
 
     const [workerTaskPath, setWorkerTaskPath] = useState<WorkerTaskPath | null>(null)
     const [workerTaskJson, setWorkerTaskJson] = useState<string | null>(null)
@@ -236,7 +237,6 @@ export const QueryStageCard = ({ stage, taskRetriesEnabled }: IQueryStageCard) =
     )
 
     const renderHistogram = (tasks: QueryTask[], timeField: 'totalScheduledTime' | 'totalCpuTime') => {
-        const theme = useTheme<Theme>()
         const inputData = tasks.map((task) => parseDuration(task.stats[timeField]) || 0)
 
         const numBuckets = Math.min(175, Math.floor(Math.sqrt(inputData.length)))
@@ -276,7 +276,6 @@ export const QueryStageCard = ({ stage, taskRetriesEnabled }: IQueryStageCard) =
     }
 
     const renderTasksTimeBarChart = (tasks: QueryTask[], timeField: 'totalScheduledTime' | 'totalCpuTime') => {
-        const theme = useTheme<Theme>()
         const orderedTasks = tasks.slice().sort((a, b) => a.taskStatus.taskId.localeCompare(b.taskStatus.taskId))
 
         const xAxisData: string[] = orderedTasks.map((task) => `Task ${getTaskIdSuffix(task.taskStatus.taskId)}`)


### PR DESCRIPTION
## Description

The web UI build is currently broken on master. The type-check and lint gate (`bun run check`: `tsc`, ESLint, Prettier, license check) is bound to the Maven `verify` phase and gated on `<skip>${skipTests}</skip>`. In CI:

- the **Maven Install** step reaches `verify` but always passes `-DskipTests`, so the check is skipped; and
- the **Maven Tests** step runs `mvn test` (no `-DskipTests`) but stops at the `test` phase, before `verify`.

So the gate never runs on pull requests, and two recently merged changes broke it undetected:

- #30350 — `queryStats.processPercentage` should be `progressPercentage` (`error TS2551`)
- #30354 — an unused `ChartsAxisHighlight` import (`error TS6133`), and two `useTheme()` calls placed inside plain helper functions rather than a component or hook (`react-hooks/rules-of-hooks`)

This PR corrects those errors and binds the frontend `check` executions to the `test` phase, so they run in the existing CI test step while still honoring `-DskipTests` for Java-only builds.

## Additional context and related issues

Verified locally with `./mvnw install -pl :trino-web-ui` (green) and `./mvnw test -pl :trino-web-ui -DskipTests=false`, which now executes the full `bun run check` in the `test` phase.

Fixes https://github.com/trinodb/trino/issues/30376

## Release notes

`(x) This is not user-visible or is docs only, and no release notes are required.`