### PR TITLE
Fix JSON simplified accessor item methods on nested members

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
@@ -103,6 +103,15 @@ public class FunctionResolver
 
     private boolean isFunctionKind(Session session, QualifiedName name, FunctionKind functionKind, AccessControl accessControl)
     {
+        // A name with more than three parts cannot resolve to a function, so it is not a function
+        // of any kind. This is a boolean probe (e.g. the aggregate/window pre-pass over every
+        // FunctionCall), so answer false rather than letting toPath throw "Invalid function name":
+        // an over-long name here is a JSON simplified-accessor item-method chain such as
+        // j.a.b.integer(), which the expression analyzer intercepts later. A genuinely invalid
+        // function call still fails, with the same message, at actual resolution.
+        if (name.getParts().size() > 3) {
+            return false;
+        }
         for (CatalogSchemaFunctionName catalogSchemaFunctionName : toPath(session, name, accessControl)) {
             Collection<CatalogFunctionMetadata> candidates = metadata.getFunctions(session, catalogSchemaFunctionName);
             if (!candidates.isEmpty()) {

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonSimplifiedAccessor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonSimplifiedAccessor.java
@@ -450,6 +450,45 @@ public class TestJsonSimplifiedAccessor
     }
 
     @Test
+    public void testItemMethodOnNestedMember()
+    {
+        // A dotted chain of two or more members before an item method (no subscript to break the
+        // run) parses as a FunctionCall with an over-long name; it must still resolve as an item
+        // method rather than being rejected as an invalid function name.
+        assertThat(assertions.query(
+                """
+                SELECT j.o.qty.integer()
+                FROM (VALUES (JSON '{"o":{"qty":3}}')) AS t(j)
+                """))
+                .matches("VALUES INTEGER '3'");
+
+        assertThat(assertions.query(
+                """
+                SELECT j.o.amt.decimal(18, 2)
+                FROM (VALUES (JSON '{"o":{"amt":19.95}}')) AS t(j)
+                """))
+                .matches("VALUES CAST(19.95 AS DECIMAL(18, 2))");
+
+        assertThat(assertions.query(
+                """
+                SELECT j.c.name.string()
+                FROM (VALUES (JSON '{"c":{"name":"Ada"}}')) AS t(j)
+                """))
+                .matches("VALUES CAST('Ada' AS VARCHAR)");
+    }
+
+    @Test
+    public void testItemMethodOnDeeplyNestedMember()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT j.a.b.c.d.integer()
+                FROM (VALUES (JSON '{"a":{"b":{"c":{"d":42}}}}')) AS t(j)
+                """))
+                .matches("VALUES INTEGER '42'");
+    }
+
+    @Test
     public void testArrayWildcardAccessor()
     {
         assertThat(assertions.query(


### PR DESCRIPTION
## Description

A JSON simplified-accessor chain with an item method preceded by two or more
dotted members — for example `j.o.qty.integer()` — failed with
`Invalid function name`, even though a single member (`j.qty.integer()`) or a
chain broken by a subscript (`j.items[0].bigint()`) worked fine.

The whole chain parses as a single `FunctionCall` whose qualified name carries
every dotted part. Before the expression analyzer intercepts it as an item
method (which handles chains of any depth), an aggregate/window pre-pass probes
every `FunctionCall` via `FunctionResolver.isAggregationFunction`, which calls
`toPath`. `toPath` throws `Invalid function name` for any name with more than
three parts, so analysis aborts before the item-method handling runs. A
subscript sidesteps this only because it makes the chain a `MethodCall`, which
has no qualified name to probe.

The fix makes the boolean "is this a function of kind X" probe answer `false`
for an over-long name instead of throwing: such a name cannot resolve to a
function, so it is not an aggregation or window function of any kind, and the
item-method interception downstream handles it. A genuinely invalid four-part
function call still fails, at actual resolution, with the same message.

## Additional context and related issues

`TestJsonSimplifiedAccessor` gains coverage for two-or-more-member chains
before `integer()` / `decimal()` / `string()`, and for a four-deep member
chain.

## Release notes

(x) Release notes are required, with the following suggested text:

```
## General
* Fix `Invalid function name` failure when a JSON simplified accessor applies an
  item method (such as `integer()`) after two or more nested member accesses,
  for example `json_value.a.b.integer()`.
```
