### PR TITLE
BigQuery: support location property for CREATE SCHEMA

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.md
+++ b/docs/src/main/sphinx/connector/bigquery.md
@@ -499,6 +499,19 @@ the following features:
 ```{include} sql-delete-limitation.fragment
 ```
 
+### Schema properties
+
+The connector supports setting the location of a schema when it is created with
+the {doc}`/sql/create-schema` statement and the `location` schema property. The
+value must be a [BigQuery dataset location](https://cloud.google.com/bigquery/docs/locations),
+for example `US`, `EU`, or `asia-northeast1`. When the property is omitted,
+BigQuery applies its own default location.
+
+```sql
+CREATE SCHEMA example.example_schema
+WITH (location = 'asia-northeast1');
+```
+
 ### Wildcard table
 
 The connector provides support to query multiple tables using a concise

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnector.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnector.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.bootstrap.LifeCycleManager;
@@ -47,6 +48,7 @@ public class BigQueryConnector
     private final Set<ConnectorTableFunction> connectorTableFunctions;
     private final Set<Procedure> procedures;
     private final List<PropertyMetadata<?>> sessionProperties;
+    private final List<PropertyMetadata<?>> schemaProperties;
 
     @Inject
     public BigQueryConnector(
@@ -57,7 +59,8 @@ public class BigQueryConnector
             BigQueryPageSinkProvider pageSinkProvider,
             Set<ConnectorTableFunction> connectorTableFunctions,
             Set<Procedure> procedures,
-            Set<SessionPropertiesProvider> sessionPropertiesProviders)
+            Set<SessionPropertiesProvider> sessionPropertiesProviders,
+            BigQuerySchemaProperties schemaProperties)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
@@ -69,6 +72,7 @@ public class BigQueryConnector
         this.sessionProperties = sessionPropertiesProviders.stream()
                 .flatMap(sessionPropertiesProvider -> sessionPropertiesProvider.getSessionProperties().stream())
                 .collect(toImmutableList());
+        this.schemaProperties = ImmutableList.copyOf(requireNonNull(schemaProperties, "schemaProperties is null").getSchemaProperties());
     }
 
     @Override
@@ -129,6 +133,12 @@ public class BigQueryConnector
     public List<PropertyMetadata<?>> getSessionProperties()
     {
         return sessionProperties;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSchemaProperties()
+    {
+        return schemaProperties;
     }
 
     @Override

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
@@ -83,6 +83,7 @@ public class BigQueryConnectorModule
             binder.bind(BigQueryPageSourceProvider.class).in(Scopes.SINGLETON);
             binder.bind(BigQueryPageSinkProvider.class).in(Scopes.SINGLETON);
             binder.bind(ViewMaterializationCache.class).in(Scopes.SINGLETON);
+            binder.bind(BigQuerySchemaProperties.class).in(Scopes.SINGLETON);
             configBinder(binder).bindConfig(BigQueryConfig.class);
             configBinder(binder).bindConfig(BigQueryRpcConfig.class);
             newOptionalBinder(binder, BigQueryArrowBufferAllocator.class);

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -508,9 +508,9 @@ public class BigQueryMetadata
     public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, TrinoPrincipal owner)
     {
         BigQueryClient client = bigQueryClientFactory.create(session);
-        checkArgument(properties.isEmpty(), "Can't have properties for schema creation");
-        DatasetInfo datasetInfo = DatasetInfo.newBuilder(client.toDatasetId(schemaName)).build();
-        client.createSchema(datasetInfo);
+        DatasetInfo.Builder datasetInfoBuilder = DatasetInfo.newBuilder(client.toDatasetId(schemaName));
+        BigQuerySchemaProperties.location(properties).ifPresent(datasetInfoBuilder::setLocation);
+        client.createSchema(datasetInfoBuilder.build());
     }
 
     @Override

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySchemaProperties.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySchemaProperties.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.session.PropertyMetadata.stringProperty;
+import static java.util.Objects.requireNonNull;
+
+public final class BigQuerySchemaProperties
+{
+    public static final String LOCATION_PROPERTY = "location";
+
+    private final List<PropertyMetadata<?>> schemaProperties;
+
+    @Inject
+    public BigQuerySchemaProperties()
+    {
+        schemaProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .add(stringProperty(
+                        LOCATION_PROPERTY,
+                        "BigQuery dataset location, e.g. US, EU, asia-northeast1. Defaults to the BigQuery API's default (US) when unset.",
+                        null,
+                        false))
+                .build();
+    }
+
+    public List<PropertyMetadata<?>> getSchemaProperties()
+    {
+        return schemaProperties;
+    }
+
+    public static Optional<String> location(Map<String, Object> schemaProperties)
+    {
+        requireNonNull(schemaProperties, "schemaProperties is null");
+        return Optional.ofNullable((String) schemaProperties.get(LOCATION_PROPERTY));
+    }
+}

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQuerySchemaProperties.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQuerySchemaProperties.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.plugin.bigquery.BigQuerySchemaProperties.LOCATION_PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestBigQuerySchemaProperties
+{
+    @Test
+    public void testLocationAbsent()
+    {
+        assertThat(BigQuerySchemaProperties.location(ImmutableMap.of())).isEmpty();
+    }
+
+    @Test
+    public void testLocationPresent()
+    {
+        assertThat(BigQuerySchemaProperties.location(ImmutableMap.of(LOCATION_PROPERTY, "asia-northeast1")))
+                .contains("asia-northeast1");
+    }
+}


### PR DESCRIPTION
Fixes #30366

Right now createSchema() just rejects any WITH properties outright, so there's no way to tell Trino where to put a BigQuery dataset - it always ends up wherever BigQuery defaults to (US), regardless of the project's actual region. I added a location schema property that follows the same pattern as the Iceberg connector's location property (BigQuerySchemaProperties -> getSchemaProperties() -> wired through the Guice module and the connector). createSchema() reads it if it's there and passes it along to DatasetInfo.Builder before creating the dataset. If you don't set it, nothing changes - BigQuery still picks the default.

CREATE SCHEMA example.example_schema
WITH (location = 'asia-northeast1');

Added a small test for the property parsing and a docs section. Built and ran it locally on JDK 25 - tests pass.

Re-opening this after signing the Individual CLA (the original PR got closed when I deleted the head repo).