### PR TITLE
Add support for S3 object tags on written objects

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
@@ -13,6 +13,8 @@
  */
 package io.trino.filesystem.s3;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
 import io.trino.filesystem.s3.S3FileSystemConfig.ObjectCannedAcl;
 import io.trino.filesystem.s3.S3FileSystemConfig.S3SseType;
 import io.trino.filesystem.s3.S3FileSystemConfig.StorageClassType;
@@ -23,12 +25,17 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.services.s3.model.RequestPayer;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.nullToEmpty;
 import static io.trino.filesystem.s3.S3FileSystemConfig.S3SseType.CUSTOMER;
 import static io.trino.filesystem.s3.S3FileSystemConfig.S3SseType.KMS;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY;
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_OBJECT_TAGS;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY;
 import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY;
 import static java.util.Objects.requireNonNull;
@@ -39,7 +46,9 @@ record S3Context(
         S3SseContext s3SseContext,
         Optional<AwsCredentialsProvider> credentialsProviderOverride,
         StorageClassType storageClass,
-        ObjectCannedAcl cannedAcl)
+        ObjectCannedAcl cannedAcl,
+        Map<String, String> objectTags,
+        Set<String> objectTagsPrefixes)
 {
     private static final int MIN_PART_SIZE = 5 * 1024 * 1024; // S3 requirement
 
@@ -48,6 +57,8 @@ record S3Context(
         checkArgument(partSize >= MIN_PART_SIZE, "partSize must be at least %s bytes", MIN_PART_SIZE);
         requireNonNull(s3SseContext, "sseContext is null");
         requireNonNull(credentialsProviderOverride, "credentialsProviderOverride is null");
+        requireNonNull(objectTags, "objectTags is null");
+        requireNonNull(objectTagsPrefixes, "objectTagsPrefixes is null");
     }
 
     public RequestPayer requestPayer()
@@ -57,24 +68,35 @@ record S3Context(
 
     public S3Context withKmsKeyId(String kmsKeyId)
     {
-        return new S3Context(partSize, requesterPays, S3SseContext.withKmsKeyId(kmsKeyId), credentialsProviderOverride, storageClass, cannedAcl);
+        return new S3Context(partSize, requesterPays, S3SseContext.withKmsKeyId(kmsKeyId), credentialsProviderOverride, storageClass, cannedAcl, objectTags, objectTagsPrefixes);
     }
 
     public S3Context withCredentials(ConnectorIdentity identity)
     {
+        S3Context context = this;
         if (identity.getExtraCredentials().containsKey(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY)) {
             AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(AwsSessionCredentials.create(
                     identity.getExtraCredentials().get(EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY),
                     identity.getExtraCredentials().get(EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY),
                     identity.getExtraCredentials().get(EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY)));
-            return withCredentialsProviderOverride(credentialsProvider);
+            context = context.withCredentialsProviderOverride(credentialsProvider);
         }
-        return this;
+        if (identity.getExtraCredentials().containsKey(EXTRA_CREDENTIALS_OBJECT_TAGS)) {
+            Map<String, String> mergedTags = new HashMap<>(context.objectTags());
+            mergedTags.putAll(parseTags(identity.getExtraCredentials().get(EXTRA_CREDENTIALS_OBJECT_TAGS)));
+            context = context.withObjectTags(mergedTags);
+        }
+        return context;
     }
 
     public S3Context withSseCustomerKey(String key)
     {
-        return new S3Context(partSize, requesterPays, S3SseContext.withSseCustomerKey(key), credentialsProviderOverride, storageClass, cannedAcl);
+        return new S3Context(partSize, requesterPays, S3SseContext.withSseCustomerKey(key), credentialsProviderOverride, storageClass, cannedAcl, objectTags, objectTagsPrefixes);
+    }
+
+    public S3Context withObjectTags(Map<String, String> objectTags)
+    {
+        return new S3Context(partSize, requesterPays, s3SseContext, credentialsProviderOverride, storageClass, cannedAcl, ImmutableMap.copyOf(objectTags), objectTagsPrefixes);
     }
 
     public S3Context withCredentialsProviderOverride(AwsCredentialsProvider credentialsProviderOverride)
@@ -85,12 +107,27 @@ record S3Context(
                 s3SseContext,
                 Optional.of(credentialsProviderOverride),
                 storageClass,
-                cannedAcl);
+                cannedAcl,
+                objectTags,
+                objectTagsPrefixes);
     }
 
     public void applyCredentialProviderOverride(AwsRequestOverrideConfiguration.Builder builder)
     {
         credentialsProviderOverride.ifPresent(builder::credentialsProvider);
+    }
+
+    private static Map<String, String> parseTags(String tags)
+    {
+        Map<String, String> parsed = Splitter.on(',').omitEmptyStrings().trimResults()
+                .withKeyValueSeparator(Splitter.on('=').limit(2))
+                .split(nullToEmpty(tags));
+        checkArgument(parsed.size() <= 10, "Maximum 10 object tags allowed");
+        parsed.forEach((key, value) -> {
+            checkArgument(key.length() <= 128, "Object tag key too long: %s", key);
+            checkArgument(value.length() <= 256, "Object tag value too long for key '%s': %s", key, value);
+        });
+        return parsed;
     }
 
     record S3SseContext(S3SseType sseType, Optional<String> sseKmsKeyId, Optional<S3SseCustomerKey> sseCustomerKey)

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
@@ -124,6 +124,7 @@ record S3Context(
                 .split(nullToEmpty(tags));
         checkArgument(parsed.size() <= 10, "Maximum 10 object tags allowed");
         parsed.forEach((key, value) -> {
+            checkArgument(!key.isEmpty(), "Object tag key must not be empty");
             checkArgument(key.length() <= 128, "Object tag key too long: %s", key);
             checkArgument(value.length() <= 256, "Object tag value too long for key '%s': %s", key, value);
         });

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -14,6 +14,7 @@
 package io.trino.filesystem.s3;
 
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 import io.airlift.configuration.Config;
@@ -33,6 +34,7 @@ import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -177,6 +179,8 @@ public class S3FileSystemConfig
     private int maxErrorRetries = 20;
     private boolean crossRegionAccessEnabled;
     private String applicationId = "Trino";
+    private Map<String, String> objectTags = ImmutableMap.of();
+    private Set<String> objectTagsPrefixes = ImmutableSet.of();
 
     public String getAwsAccessKey()
     {
@@ -658,5 +662,53 @@ public class S3FileSystemConfig
     {
         this.applicationId = applicationId;
         return this;
+    }
+
+    @NotNull
+    public Map<String, String> getObjectTags()
+    {
+        return objectTags;
+    }
+
+    @Config("s3.object-tags")
+    @ConfigDescription("Key-value pairs to be added as S3 object tags on written objects. Format: key1=value1,key2=value2")
+    public S3FileSystemConfig setObjectTags(String objectTags)
+    {
+        this.objectTags = Splitter.on(',')
+                .omitEmptyStrings()
+                .trimResults()
+                .withKeyValueSeparator(Splitter.on('=').limit(2))
+                .split(nullToEmpty(objectTags));
+        return this;
+    }
+
+    @NotNull
+    public Set<String> getObjectTagsPrefixes()
+    {
+        return objectTagsPrefixes;
+    }
+
+    @Config("s3.object-tags.prefixes")
+    @ConfigDescription("Comma-separated list of S3 key substrings. If set, object tags are only applied to objects whose key contains one of these substrings. If empty, tags apply to all objects.")
+    public S3FileSystemConfig setObjectTagsPrefixes(Set<String> objectTagsPrefixes)
+    {
+        this.objectTagsPrefixes = ImmutableSet.copyOf(objectTagsPrefixes);
+        return this;
+    }
+
+    @AssertTrue(message = "s3.object-tags: maximum 10 tags per object, key max 128 chars, value max 256 chars")
+    public boolean isObjectTagsValid()
+    {
+        if (objectTags.size() > 10) {
+            return false;
+        }
+        return objectTags.entrySet().stream().allMatch(e ->
+                e.getKey().length() <= 128 && e.getValue().length() <= 256);
+    }
+
+    @AssertTrue(message = "s3.object-tags.prefixes is only meaningful when s3.object-tags is configured")
+    public boolean isObjectTagsPrefixesValid()
+    {
+        return objectTagsPrefixes.isEmpty() || !objectTags.isEmpty();
     }
 }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -689,21 +689,21 @@ public class S3FileSystemConfig
     }
 
     @Config("s3.object-tags.prefixes")
-    @ConfigDescription("Comma-separated list of S3 key substrings. If set, object tags are only applied to objects whose key contains one of these substrings. If empty, tags apply to all objects.")
+    @ConfigDescription("Comma-separated list of S3 key substrings. If set, object tags are only applied to objects whose key starts with a configured prefix or contains it at a path-segment boundary (preceded by '/'). If empty, tags apply to all objects.")
     public S3FileSystemConfig setObjectTagsPrefixes(Set<String> objectTagsPrefixes)
     {
         this.objectTagsPrefixes = ImmutableSet.copyOf(objectTagsPrefixes);
         return this;
     }
 
-    @AssertTrue(message = "s3.object-tags: maximum 10 tags per object, key max 128 chars, value max 256 chars")
+    @AssertTrue(message = "s3.object-tags: maximum 10 tags per object, key max 128 chars and must be non-empty, value max 256 chars")
     public boolean isObjectTagsValid()
     {
         if (objectTags.size() > 10) {
             return false;
         }
         return objectTags.entrySet().stream().allMatch(e ->
-                e.getKey().length() <= 128 && e.getValue().length() <= 256);
+                !e.getKey().isEmpty() && e.getKey().length() <= 128 && e.getValue().length() <= 256);
     }
 
     @AssertTrue(message = "s3.object-tags.prefixes is only meaningful when s3.object-tags is configured")

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
@@ -106,7 +106,9 @@ final class S3FileSystemLoader
                         config.getSseCustomerKey()),
                 Optional.empty(),
                 config.getStorageClass(),
-                config.getCannedAcl());
+                config.getCannedAcl(),
+                ImmutableMap.copyOf(config.getObjectTags()),
+                config.getObjectTagsPrefixes());
     }
 
     @Override

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputStream.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputStream.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
+import software.amazon.awssdk.utils.http.SdkHttpUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -45,7 +46,9 @@ import java.io.SequenceInputStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
@@ -68,6 +71,7 @@ import static java.util.Objects.checkFromIndexSize;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static java.util.stream.Collectors.joining;
 import static software.amazon.awssdk.core.internal.util.Mimetype.MIMETYPE_OCTET_STREAM;
 
 final class S3OutputStream
@@ -294,12 +298,15 @@ final class S3OutputStream
                     .bucket(location.bucket())
                     .key(location.key())
                     .storageClass(storageClass)
-                    .applyMutation(builder ->
-                            key.ifPresentOrElse(
-                                    encryption -> builder.sseCustomerKey(encoded(encryption))
-                                            .sseCustomerAlgorithm(encryption.algorithm())
-                                            .sseCustomerKeyMD5(md5Checksum(encryption)),
-                                    () -> setEncryptionSettings(builder, context.s3SseContext())))
+                    .applyMutation(builder -> {
+                        key.ifPresentOrElse(
+                                encryption -> builder.sseCustomerKey(encoded(encryption))
+                                        .sseCustomerAlgorithm(encryption.algorithm())
+                                        .sseCustomerKeyMD5(md5Checksum(encryption)),
+                                () -> setEncryptionSettings(builder, context.s3SseContext()));
+                        buildTaggingHeader(context.objectTags(), context.objectTagsPrefixes(), location.key())
+                                .ifPresent(builder::tagging);
+                    })
                     .build();
 
             uploadId = Optional.of(client.createMultipartUpload(request).uploadId());
@@ -409,6 +416,8 @@ final class S3OutputStream
                         builder.sseCustomerKeyMD5(md5Checksum(encryption));
                     });
                     setEncryptionSettings(builder, context.s3SseContext());
+                    buildTaggingHeader(context.objectTags(), context.objectTagsPrefixes(), location.key())
+                            .ifPresent(builder::tagging);
                 })
                 .build();
 
@@ -432,6 +441,20 @@ final class S3OutputStream
             }
             throw new IOException("Put failed for bucket [%s] key [%s]: %s".formatted(location.bucket(), location.key(), putObjectException), putObjectException);
         }
+    }
+
+    @VisibleForTesting
+    static Optional<String> buildTaggingHeader(Map<String, String> objectTags, Set<String> prefixes, String s3Key)
+    {
+        if (objectTags.isEmpty()) {
+            return Optional.empty();
+        }
+        if (!prefixes.isEmpty() && prefixes.stream().noneMatch(prefix -> s3Key.startsWith(prefix) || s3Key.contains("/" + prefix))) {
+            return Optional.empty();
+        }
+        return Optional.of(objectTags.entrySet().stream()
+                .map(entry -> SdkHttpUtils.urlEncode(entry.getKey()) + "=" + SdkHttpUtils.urlEncode(entry.getValue()))
+                .collect(joining("&")));
     }
 
     interface DataStreamProvider

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
@@ -262,6 +262,42 @@ public abstract class AbstractTestS3FileSystem
         return location;
     }
 
+    protected boolean isObjectTaggingSupported()
+    {
+        return false;
+    }
+
+    @Test
+    void testObjectTagsOnWrite()
+            throws IOException
+    {
+        if (!isObjectTaggingSupported()) {
+            return;
+        }
+        try (S3Client s3Client = createS3Client()) {
+            String key = "tagged-file.parquet";
+            byte[] contents = "tagged content".getBytes(UTF_8);
+
+            getFileSystem().newOutputFile(getRootLocation().appendPath(key))
+                    .createOrOverwrite(contents);
+
+            var tagResponse = s3Client.getObjectTagging(r -> r.bucket(bucket()).key(key));
+            assertThat(tagResponse.tagSet())
+                    .hasSize(2)
+                    .anySatisfy(tag -> {
+                        assertThat(tag.key()).isEqualTo("env");
+                        assertThat(tag.value()).isEqualTo("test");
+                    })
+                    .anySatisfy(tag -> {
+                        assertThat(tag.key()).isEqualTo("source");
+                        assertThat(tag.value()).isEqualTo("trino-test");
+                    });
+
+            // Clean up the tagged file
+            s3Client.deleteObject(delete -> delete.bucket(bucket()).key(key));
+        }
+    }
+
     protected class TempDirectory
             implements Closeable
     {

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
@@ -14,6 +14,7 @@
 package io.trino.filesystem.s3;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -38,6 +39,7 @@ import static io.trino.filesystem.s3.S3FileSystemConfig.RetryMode.STANDARD;
 import static io.trino.filesystem.s3.S3FileSystemConfig.SignerType.Aws4Signer;
 import static io.trino.filesystem.s3.S3FileSystemConfig.StorageClassType.STANDARD_IA;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestS3FileSystemConfig
 {
@@ -79,7 +81,9 @@ public class TestS3FileSystemConfig
                 .setHttpProxyPassword(null)
                 .setHttpProxyPreemptiveBasicProxyAuth(false)
                 .setCrossRegionAccessEnabled(false)
-                .setApplicationId("Trino"));
+                .setApplicationId("Trino")
+                .setObjectTags(null)
+                .setObjectTagsPrefixes(ImmutableSet.of()));
     }
 
     private static void addCommonProperties(ImmutableMap.Builder<String, String> builder)
@@ -111,7 +115,9 @@ public class TestS3FileSystemConfig
                 .put("s3.http-proxy.password", "test")
                 .put("s3.http-proxy.preemptive-basic-auth", "true")
                 .put("s3.application-id", "application id")
-                .put("s3.cross-region-access", "true");
+                .put("s3.cross-region-access", "true")
+                .put("s3.object-tags", "key1=value1,key2=value2")
+                .put("s3.object-tags.prefixes", "data/,extra/");
     }
 
     private static S3FileSystemConfig setCommonConfig(S3FileSystemConfig config)
@@ -144,7 +150,9 @@ public class TestS3FileSystemConfig
                 .setHttpProxyPassword("test")
                 .setHttpProxyPreemptiveBasicProxyAuth(true)
                 .setCrossRegionAccessEnabled(true)
-                .setApplicationId("application id");
+                .setApplicationId("application id")
+                .setObjectTags("key1=value1,key2=value2")
+                .setObjectTagsPrefixes(ImmutableSet.of("data/", "extra/"));
     }
 
     @Test
@@ -323,5 +331,43 @@ public class TestS3FileSystemConfig
                         .setExternalId("external-id")
                         .setStsEndpoint("sts.example.com")
                         .setStsRegion("us-west-2"));
+    }
+
+    @Test
+    public void testObjectTagsTooManyTags()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig().setObjectTags("a=b,b=c,c=d,d=e,e=f,f=g,g=h,h=i,i=j,j=k,k=l"),
+                "objectTagsValid",
+                "s3.object-tags: maximum 10 tags per object, key max 128 chars, value max 256 chars",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testObjectTagsPrefixesWithoutTags()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig().setObjectTagsPrefixes(ImmutableSet.of("data/")),
+                "objectTagsPrefixesValid",
+                "s3.object-tags.prefixes is only meaningful when s3.object-tags is configured",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testObjectTagsPrefixesWithTags()
+    {
+        assertValidates(
+                new S3FileSystemConfig()
+                        .setObjectTags("env=prod")
+                        .setObjectTagsPrefixes(ImmutableSet.of("data/")));
+    }
+
+    @Test
+    public void testObjectTagsPrefixesEmpty()
+    {
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setObjectTags("env=prod")
+                .setObjectTagsPrefixes(ImmutableSet.of());
+        assertThat(config.getObjectTagsPrefixes()).isEmpty();
     }
 }

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
@@ -339,7 +339,7 @@ public class TestS3FileSystemConfig
         assertFailsValidation(
                 new S3FileSystemConfig().setObjectTags("a=b,b=c,c=d,d=e,e=f,f=g,g=h,h=i,i=j,j=k,k=l"),
                 "objectTagsValid",
-                "s3.object-tags: maximum 10 tags per object, key max 128 chars, value max 256 chars",
+                "s3.object-tags: maximum 10 tags per object, key max 128 chars and must be non-empty, value max 256 chars",
                 AssertTrue.class);
     }
 

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemS3Mock.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemS3Mock.java
@@ -14,7 +14,9 @@
 package io.trino.filesystem.s3;
 
 import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
+import com.google.common.collect.ImmutableSet;
 import io.opentelemetry.api.OpenTelemetry;
+import io.trino.spi.security.ConnectorIdentity;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -25,6 +27,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 import java.net.URI;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Testcontainers
@@ -67,8 +71,15 @@ public class TestS3FileSystemS3Mock
                         .setRegion(Region.US_EAST_1.id())
                         .setPathStyleAccess(true)
                         .setStreamingPartSize(STREAMING_PART_SIZE)
-                        .setSignerType(S3FileSystemConfig.SignerType.AwsS3V4Signer),
+                        .setSignerType(S3FileSystemConfig.SignerType.AwsS3V4Signer)
+                        .setObjectTags("env=test,source=trino-test"),
                 new S3FileSystemStats());
+    }
+
+    @Override
+    protected boolean isObjectTaggingSupported()
+    {
+        return true;
     }
 
     @Test
@@ -96,5 +107,50 @@ public class TestS3FileSystemS3Mock
         // this is S3Mock bug, see https://github.com/adobe/S3Mock/issues/2789
         assertThatThrownBy(super::testReadingEmptyFile)
                 .hasMessageContaining("Failed to open S3 file: s3://test-bucket/inputStream/");
+    }
+
+    @Test
+    void testObjectTagsPrefixFilter()
+            throws Exception
+    {
+        S3FileSystemFactory prefixFilterFactory = new S3FileSystemFactory(
+                OpenTelemetry.noop(),
+                new S3FileSystemConfig()
+                        .setAwsAccessKey("accesskey")
+                        .setAwsSecretKey("secretkey")
+                        .setEndpoint(S3_MOCK.getHttpEndpoint())
+                        .setRegion(Region.US_EAST_1.id())
+                        .setPathStyleAccess(true)
+                        .setStreamingPartSize(STREAMING_PART_SIZE)
+                        .setSignerType(S3FileSystemConfig.SignerType.AwsS3V4Signer)
+                        .setObjectTags("env=test")
+                        .setObjectTagsPrefixes(ImmutableSet.of("data/")),
+                new S3FileSystemStats());
+        try {
+            var fileSystem = prefixFilterFactory.create(ConnectorIdentity.ofUser("test"));
+            try (S3Client s3Client = createS3Client()) {
+                String taggedKey = "data/00000-0-uuid.parquet";
+                String untaggedKey = "metadata/00000-uuid.metadata.json";
+                byte[] contents = "test content".getBytes(UTF_8);
+
+                fileSystem.newOutputFile(getRootLocation().appendPath(taggedKey))
+                        .createOrOverwrite(contents);
+                fileSystem.newOutputFile(getRootLocation().appendPath(untaggedKey))
+                        .createOrOverwrite(contents);
+
+                var dataTagResponse = s3Client.getObjectTagging(r -> r.bucket(bucket()).key(taggedKey));
+                assertThat(dataTagResponse.tagSet()).isNotEmpty();
+
+                var metaTagResponse = s3Client.getObjectTagging(r -> r.bucket(bucket()).key(untaggedKey));
+                assertThat(metaTagResponse.tagSet()).isEmpty();
+
+                // Clean up
+                s3Client.deleteObject(delete -> delete.bucket(bucket()).key(taggedKey));
+                s3Client.deleteObject(delete -> delete.bucket(bucket()).key(untaggedKey));
+            }
+        }
+        finally {
+            prefixFilterFactory.destroy();
+        }
     }
 }

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3OutputStreamTagging.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3OutputStreamTagging.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static io.trino.filesystem.s3.S3OutputStream.buildTaggingHeader;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestS3OutputStreamTagging
+{
+    @Test
+    void testEmptyTags()
+    {
+        assertThat(buildTaggingHeader(ImmutableMap.of(), ImmutableSet.of(), "any-key")).isEmpty();
+    }
+
+    @Test
+    void testMatchingPrefix()
+    {
+        Map<String, String> tags = ImmutableMap.of("env", "prod", "team", "data platform");
+        Set<String> prefixes = ImmutableSet.of("data/");
+        assertThat(buildTaggingHeader(tags, prefixes, "db/table/data/file.parquet"))
+                .hasValue("env=prod&team=data%20platform");
+    }
+
+    @Test
+    void testNonMatchingPrefix()
+    {
+        Map<String, String> tags = ImmutableMap.of("env", "prod");
+        Set<String> prefixes = ImmutableSet.of("data/");
+        assertThat(buildTaggingHeader(tags, prefixes, "db/table/metadata/file.json")).isEmpty();
+    }
+
+    @Test
+    void testEmptyPrefixes()
+    {
+        Map<String, String> tags = ImmutableMap.of("env", "prod");
+        assertThat(buildTaggingHeader(tags, ImmutableSet.of(), "any-key"))
+                .hasValue("env=prod");
+    }
+
+    @Test
+    void testMultiplePrefixes()
+    {
+        Map<String, String> tags = ImmutableMap.of("env", "prod");
+        Set<String> prefixes = ImmutableSet.of("data/", "extra/");
+        assertThat(buildTaggingHeader(tags, prefixes, "db/table/extra/file.parquet"))
+                .hasValue("env=prod");
+        assertThat(buildTaggingHeader(tags, prefixes, "db/table/data/file.parquet"))
+                .hasValue("env=prod");
+        assertThat(buildTaggingHeader(tags, prefixes, "db/table/metadata/file.json")).isEmpty();
+    }
+
+    @Test
+    void testSpecialCharacters()
+    {
+        Map<String, String> tags = ImmutableMap.of("filter", "a=b&c=d");
+        assertThat(buildTaggingHeader(tags, ImmutableSet.of(), "any-key"))
+                .hasValue("filter=a%3Db%26c%3Dd");
+    }
+
+    @Test
+    void testSpacesInValues()
+    {
+        Map<String, String> tags = ImmutableMap.of("team", "data platform");
+        assertThat(buildTaggingHeader(tags, ImmutableSet.of(), "any-key"))
+                .hasValue("team=data%20platform");
+    }
+}

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3Retries.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3Retries.java
@@ -13,6 +13,8 @@
  */
 package io.trino.filesystem.s3;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import eu.rekawek.toxiproxy.Proxy;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import eu.rekawek.toxiproxy.model.ToxicDirection;
@@ -200,7 +202,9 @@ public class TestS3Retries
                         config.getSseCustomerKey()),
                 Optional.empty(),
                 config.getStorageClass(),
-                config.getCannedAcl());
+                config.getCannedAcl(),
+                ImmutableMap.of(),
+                ImmutableSet.of());
 
         // The toxicity is randomized, so iterate for more determinism
         for (int iteration = 0; iteration < attempts; iteration++) {

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/s3/S3FileSystemConstants.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/s3/S3FileSystemConstants.java
@@ -18,6 +18,7 @@ public final class S3FileSystemConstants
     public static final String EXTRA_CREDENTIALS_ACCESS_KEY_PROPERTY = "internal$s3_aws_access_key";
     public static final String EXTRA_CREDENTIALS_SECRET_KEY_PROPERTY = "internal$s3_aws_secret_key";
     public static final String EXTRA_CREDENTIALS_SESSION_TOKEN_PROPERTY = "internal$s3_aws_session_token";
+    public static final String EXTRA_CREDENTIALS_OBJECT_TAGS = "internal$s3_object_tags";
 
     private S3FileSystemConstants() {}
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/DefaultIcebergFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/DefaultIcebergFileSystemFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
@@ -36,6 +37,30 @@ public class DefaultIcebergFileSystemFactory
     @Override
     public TrinoFileSystem create(ConnectorIdentity identity, Map<String, String> fileIoProperties)
     {
-        return fileSystemFactory.create(identity);
+        return fileSystemFactory.create(enrichIdentityWithObjectTags(identity, fileIoProperties));
+    }
+
+    @Override
+    public TrinoFileSystem create(ConnectorIdentity identity, IcebergTableCredentials tableCredentials)
+    {
+        return create(identity, tableCredentials.fileIoProperties());
+    }
+
+    private static ConnectorIdentity enrichIdentityWithObjectTags(ConnectorIdentity identity, Map<String, String> fileIoProperties)
+    {
+        String objectTags = fileIoProperties.get("s3.object-tags");
+        if (objectTags == null) {
+            return identity;
+        }
+        return ConnectorIdentity.forUser(identity.getUser())
+                .withGroups(identity.getGroups())
+                .withPrincipal(identity.getPrincipal())
+                .withEnabledSystemRoles(identity.getEnabledSystemRoles())
+                .withConnectorRole(identity.getConnectorRole())
+                .withExtraCredentials(ImmutableMap.<String, String>builder()
+                        .putAll(identity.getExtraCredentials())
+                        .put("internal$s3_object_tags", objectTags)
+                        .buildOrThrow())
+                .build();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/DefaultIcebergFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/DefaultIcebergFileSystemFactory.java
@@ -21,6 +21,7 @@ import io.trino.spi.security.ConnectorIdentity;
 
 import java.util.Map;
 
+import static io.trino.filesystem.s3.S3FileSystemConstants.EXTRA_CREDENTIALS_OBJECT_TAGS;
 import static java.util.Objects.requireNonNull;
 
 public class DefaultIcebergFileSystemFactory
@@ -59,7 +60,7 @@ public class DefaultIcebergFileSystemFactory
                 .withConnectorRole(identity.getConnectorRole())
                 .withExtraCredentials(ImmutableMap.<String, String>builder()
                         .putAll(identity.getExtraCredentials())
-                        .put("internal$s3_object_tags", objectTags)
+                        .put(EXTRA_CREDENTIALS_OBJECT_TAGS, objectTags)
                         .buildOrThrow())
                 .build();
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.types.Types;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -122,7 +123,7 @@ public class IcebergPageSinkProvider
                 locationProvider,
                 fileWriterFactory,
                 pageIndexerFactory,
-                fileSystemFactory.create(session.getIdentity(), tableCredentials),
+                fileSystemFactory.create(session.getIdentity(), enrichWithTableTags(tableCredentials, tableHandle.storageProperties())),
                 tableHandle.partitionColumns(),
                 jsonCodec,
                 session,
@@ -159,7 +160,7 @@ public class IcebergPageSinkProvider
                         locationProvider,
                         fileWriterFactory,
                         pageIndexerFactory,
-                        fileSystemFactory.create(session.getIdentity(), tableCredentials.map(IcebergTableCredentials.class::cast).get()),
+                        fileSystemFactory.create(session.getIdentity(), enrichWithTableTags(tableCredentials.map(IcebergTableCredentials.class::cast).get(), optimizeHandle.tableStorageProperties())),
                         optimizeHandle.partitionColumns(),
                         jsonCodec,
                         session,
@@ -211,7 +212,7 @@ public class IcebergPageSinkProvider
                 formatVersion,
                 locationProvider,
                 fileWriterFactory,
-                fileSystemFactory.create(session.getIdentity(), icebergTableCredentials),
+                fileSystemFactory.create(session.getIdentity(), enrichWithTableTags(icebergTableCredentials, tableHandle.storageProperties())),
                 jsonCodec,
                 session,
                 tableHandle.fileFormat(),
@@ -219,5 +220,16 @@ public class IcebergPageSinkProvider
                 partitionsSpecs,
                 pageSink,
                 schema.columns().size());
+    }
+
+    private static IcebergTableCredentials enrichWithTableTags(IcebergTableCredentials tableCredentials, Map<String, String> storageProperties)
+    {
+        String tableTags = storageProperties.get("write.object-tags");
+        if (tableTags == null) {
+            return tableCredentials;
+        }
+        Map<String, String> enrichedFileIoProperties = new HashMap<>(tableCredentials.fileIoProperties());
+        enrichedFileIoProperties.put("s3.object-tags", tableTags);
+        return new IcebergTableCredentials(enrichedFileIoProperties, tableCredentials.storageCredentials());
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
@@ -90,7 +90,7 @@ public class IcebergRestCatalogFileSystemFactory
                 }
             });
         }
-        return fileSystemFactory.create(identity);
+        return fileSystemFactory.create(enrichIdentityWithObjectTags(identity, fileIoProperties));
     }
 
     @Override
@@ -114,7 +114,7 @@ public class IcebergRestCatalogFileSystemFactory
                 }
             });
         }
-        return fileSystemFactory.create(identity);
+        return fileSystemFactory.create(enrichIdentityWithObjectTags(identity, tableCredentials.fileIoProperties()));
     }
 
     private TrinoFileSystem getTrinoFileSystem(Location location, ConnectorIdentity identity, CachedVendedCredentialsProviders cached)
@@ -313,6 +313,24 @@ public class IcebergRestCatalogFileSystemFactory
             }
         }
         return Optional.empty();
+    }
+
+    private static ConnectorIdentity enrichIdentityWithObjectTags(ConnectorIdentity identity, Map<String, String> fileIoProperties)
+    {
+        String objectTags = fileIoProperties.get("s3.object-tags");
+        if (objectTags == null) {
+            return identity;
+        }
+        return ConnectorIdentity.forUser(identity.getUser())
+                .withGroups(identity.getGroups())
+                .withPrincipal(identity.getPrincipal())
+                .withEnabledSystemRoles(identity.getEnabledSystemRoles())
+                .withConnectorRole(identity.getConnectorRole())
+                .withExtraCredentials(ImmutableMap.<String, String>builder()
+                        .putAll(identity.getExtraCredentials())
+                        .put("internal$s3_object_tags", objectTags)
+                        .buildOrThrow())
+                .build();
     }
 
     private static void addOptionalProperty(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
@@ -73,6 +73,7 @@ public class IcebergRestCatalogFileSystemFactory
     @Override
     public TrinoFileSystem create(ConnectorIdentity identity, Map<String, String> fileIoProperties)
     {
+        ConnectorIdentity enrichedIdentity = enrichIdentityWithObjectTags(identity, fileIoProperties);
         if (vendedCredentialsEnabled) {
             return new IcebergRestCatalogFileSystem(new IcebergRestCatalogFileSystemLoader()
             {
@@ -84,19 +85,20 @@ public class IcebergRestCatalogFileSystemFactory
                     }
                     CachedVendedCredentialsProviders cached = uncheckedCacheGet(
                             vendedCredentialsProvidersCache,
-                            createVendedCredentialsCacheKey(identity, fileIoProperties, this.storageCredentials),
+                            createVendedCredentialsCacheKey(enrichedIdentity, fileIoProperties, this.storageCredentials),
                             () -> createVendedCredentialsProviders(fileIoProperties, this.storageCredentials));
 
-                    return getTrinoFileSystem(location, identity, cached);
+                    return getTrinoFileSystem(location, enrichedIdentity, cached);
                 }
             });
         }
-        return fileSystemFactory.create(enrichIdentityWithObjectTags(identity, fileIoProperties));
+        return fileSystemFactory.create(enrichedIdentity);
     }
 
     @Override
     public TrinoFileSystem create(ConnectorIdentity identity, IcebergTableCredentials tableCredentials)
     {
+        ConnectorIdentity enrichedIdentity = enrichIdentityWithObjectTags(identity, tableCredentials.fileIoProperties());
         if (vendedCredentialsEnabled) {
             return new IcebergRestCatalogFileSystem(new IcebergRestCatalogFileSystemLoader()
             {
@@ -108,14 +110,14 @@ public class IcebergRestCatalogFileSystemFactory
                     }
                     CachedVendedCredentialsProviders cached = uncheckedCacheGet(
                             vendedCredentialsProvidersCache,
-                            createVendedCredentialsCacheKey(identity, tableCredentials.fileIoProperties(), tableCredentials.storageCredentials()),
+                            createVendedCredentialsCacheKey(enrichedIdentity, tableCredentials.fileIoProperties(), tableCredentials.storageCredentials()),
                             () -> createVendedCredentialsProviders(tableCredentials.fileIoProperties(), tableCredentials.storageCredentials()));
 
-                    return getTrinoFileSystem(location, identity, cached);
+                    return getTrinoFileSystem(location, enrichedIdentity, cached);
                 }
             });
         }
-        return fileSystemFactory.create(enrichIdentityWithObjectTags(identity, tableCredentials.fileIoProperties()));
+        return fileSystemFactory.create(enrichedIdentity);
     }
 
     private TrinoFileSystem getTrinoFileSystem(Location location, ConnectorIdentity identity, CachedVendedCredentialsProviders cached)
@@ -137,9 +139,10 @@ public class IcebergRestCatalogFileSystemFactory
                 .withEnabledSystemRoles(identity.getEnabledSystemRoles())
                 .withConnectorRole(identity.getConnectorRole())
                 .withExtraCredentials(ImmutableMap.<String, String>builder()
+                        .putAll(identity.getExtraCredentials())
                         .putAll(cached.extraCredentials())
                         .putAll(ImmutableMap.copyOf(vendedCredentials.map(VendedCredentials::toExtraCredentials).orElse(ImmutableMap.of())))
-                        .buildOrThrow())
+                        .buildKeepingLast())
                 .build();
 
         return fileSystemFactory.create(identityWithExtraCredentials);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogFileSystemFactory.java
@@ -21,6 +21,7 @@ import io.trino.cache.EvictableCacheBuilder;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.s3.S3FileSystemConstants;
 import io.trino.plugin.iceberg.IcebergFileSystemFactory;
 import io.trino.plugin.iceberg.IcebergStorageCredentials;
 import io.trino.plugin.iceberg.IcebergTableCredentials;
@@ -328,7 +329,7 @@ public class IcebergRestCatalogFileSystemFactory
                 .withConnectorRole(identity.getConnectorRole())
                 .withExtraCredentials(ImmutableMap.<String, String>builder()
                         .putAll(identity.getExtraCredentials())
-                        .put("internal$s3_object_tags", objectTags)
+                        .put(S3FileSystemConstants.EXTRA_CREDENTIALS_OBJECT_TAGS, objectTags)
                         .buildOrThrow())
                 .build();
     }


### PR DESCRIPTION
## Description

Adds support for attaching S3 object tags to objects written through Trino's S3 filesystem, enabling S3 Lifecycle Policies to transition objects between storage classes based on tags.

## Changes

Two configuration surfaces:

**Global** — S3 filesystem config (`S3FileSystemConfig`):
```properties
s3.object-tags=env=prod,team=data-platform
s3.object-tags.prefixes=data/
```
- `s3.object-tags`: key=value pairs applied as S3 object tags on writes
- `s3.object-tags.prefixes`: comma-separated S3 key substrings; only matching objects get tagged (empty = all objects)

**Per-table** — Iceberg-native table property:
```sql
ALTER TABLE t SET TBLPROPERTIES ('write.object-tags' = 'lifecycle=data-to-ia');
```

Table tags merge with global tags; table wins on key conflicts.

## Why prefix filtering matters

Setting `s3.object-tags.prefixes=data/` keeps metadata/manifest files tag-free, enabling a single **tag-only** bucket-wide S3 lifecycle rule. Without it, you'd need per-table lifecycle rules since S3 prefix filters anchor to the key start.

## Files changed

| File | Description |
|------|-------------|
| `S3FileSystemConstants.java` | Add `EXTRA_CREDENTIALS_OBJECT_TAGS` constant |
| `S3FileSystemConfig.java` | Add `s3.object-tags` and `s3.object-tags.prefixes` config |
| `S3Context.java` | Plumb tags through context with merge logic |
| `S3FileSystemLoader.java` | Pass config tags to S3Context |
| `S3OutputStream.java` | Apply `.tagging()` to PutObject and CreateMultipartUpload |
| `IcebergPageSinkProvider.java` | Route per-table tags via `extraCredentials` |

## Related

- Fixes #30389
- [Iceberg S3 Tags docs](https://iceberg.apache.org/docs/latest/aws/#s3-tags)

## Release notes

```
Iceberg/Hive/Delta Lake
* Add support for S3 object tags on written objects via
  the `s3.object-tags` configuration property and the
  `write.object-tags` Iceberg table property.
  This allows applying S3 Lifecycle Policies to transition
  Iceberg data files between storage classes based on tags.
  Use `s3.object-tags.prefixes` to restrict tagging to
  specific key prefixes (e.g., `data/`), keeping metadata
  files tag-free for safe bucket-wide lifecycle rules.
```