### PR TITLE
Limit task.info.max-age in tests

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
@@ -86,6 +86,11 @@ public final class StandaloneQueryRunner
                         .put("query.client.timeout", "10m")
                         .put("exchange.http-client.idle-timeout", "1h")
                         .put("node-scheduler.min-candidates", "1")
+                        // Purge finished-task info quickly so per-task stats are not retained, preserving memory on CI.
+                        // Must stay above task.info-update-interval so the coordinator can fetch a task's final
+                        // TaskInfo (incl. SpoolingOutputStats needed by fault-tolerant execution) before it is evicted.
+                        .put("task.info.max-age", "2s")
+                        .put("task.info-update-interval", "1s")
                         .buildOrThrow());
         serverProcessor.accept(builder);
         this.server = builder.build();

--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -313,7 +313,12 @@ public final class DistributedQueryRunner
                 .put("exchange.http-client.min-threads", "1") // default 8
                 .put("exchange.page-buffer-client.max-callback-threads", "5") // default 25
                 .put("exchange.http-client.idle-timeout", "1h")
-                .put("task.max-index-memory", "16kB"); // causes index joins to fault load
+                .put("task.max-index-memory", "16kB") // causes index joins to fault load
+                // Purge finished-task info quickly so per-task stats are not retained, preserving memory on CI.
+                // Must stay above task.info-update-interval so the coordinator can fetch a task's final
+                // TaskInfo (incl. SpoolingOutputStats needed by fault-tolerant execution) before it is evicted.
+                .put("task.info.max-age", "2s")
+                .put("task.info-update-interval", "1s");
         if (coordinator) {
             propertiesBuilder.put("node-scheduler.include-coordinator", "true");
             propertiesBuilder.put("join-distribution-type", "PARTITIONED");


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Tasks use significant memory, making the
SqlTaskManager retain about 50MB per instance.
With multiple tests running in parallel, this brings the heap usage close to the ci limits.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
