### PR TITLE
Do not capture Let-bound symbols when desugaring lambdas

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/LambdaCaptureDesugaringRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/LambdaCaptureDesugaringRewriter.java
@@ -23,6 +23,7 @@ import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.ExpressionRewriter;
 import io.trino.sql.ir.ExpressionTreeRewriter;
 import io.trino.sql.ir.Lambda;
+import io.trino.sql.ir.Let;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
@@ -103,9 +104,32 @@ public final class LambdaCaptureDesugaringRewriter
         }
 
         @Override
+        public Expression rewriteLet(Let node, Context context, ExpressionTreeRewriter<Context> treeRewriter)
+        {
+            // The value is evaluated in the enclosing scope, so its references are genuine captures.
+            Expression value = treeRewriter.rewrite(node.value(), context);
+
+            // The bound symbol is local to the body and must not be treated as a captured symbol.
+            Expression body = treeRewriter.rewrite(node.body(), context.withLetBoundSymbol(node.name()));
+
+            // Nested lambda will return the bound symbol as a capture, so we must explicitly exclude
+            // it at this boundary. Otherwise, it would be propagated upward beyond the point of its
+            // definition, and reported as a subexpression's free variable.
+            context.getReferencedSymbols().remove(node.name());
+
+            if (value != node.value() || body != node.body()) {
+                return new Let(node.name(), value, body);
+            }
+            return node;
+        }
+
+        @Override
         public Expression rewriteReference(Reference node, Context context, ExpressionTreeRewriter<Context> treeRewriter)
         {
-            context.getReferencedSymbols().add(new Symbol(node.type(), node.name()));
+            Symbol symbol = new Symbol(node.type(), node.name());
+            if (!context.isLetBoundSymbol(symbol)) {
+                context.getReferencedSymbols().add(symbol);
+            }
             return null;
         }
     }
@@ -114,15 +138,17 @@ public final class LambdaCaptureDesugaringRewriter
     {
         // Use linked hash set to guarantee deterministic iteration order
         final LinkedHashSet<Symbol> referencedSymbols;
+        final Set<Symbol> letBoundSymbols;
 
         public Context()
         {
-            this(new LinkedHashSet<>());
+            this(new LinkedHashSet<>(), ImmutableSet.of());
         }
 
-        private Context(LinkedHashSet<Symbol> referencedSymbols)
+        private Context(LinkedHashSet<Symbol> referencedSymbols, Set<Symbol> letBoundSymbols)
         {
             this.referencedSymbols = referencedSymbols;
+            this.letBoundSymbols = letBoundSymbols;
         }
 
         public LinkedHashSet<Symbol> getReferencedSymbols()
@@ -130,9 +156,24 @@ public final class LambdaCaptureDesugaringRewriter
             return referencedSymbols;
         }
 
+        public boolean isLetBoundSymbol(Symbol symbol)
+        {
+            return letBoundSymbols.contains(symbol);
+        }
+
         public Context withReferencedSymbols(LinkedHashSet<Symbol> symbols)
         {
-            return new Context(symbols);
+            // A Let binding from an enclosing scope is a free variable inside a nested lambda, so
+            // it must be captured there. Drop the bindings when crossing a lambda boundary.
+            return new Context(symbols, ImmutableSet.of());
+        }
+
+        public Context withLetBoundSymbol(Symbol symbol)
+        {
+            return new Context(referencedSymbols, ImmutableSet.<Symbol>builder()
+                    .addAll(letBoundSymbols)
+                    .add(symbol)
+                    .build());
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestLambdaCaptureDesugaringRewriter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestLambdaCaptureDesugaringRewriter.java
@@ -17,15 +17,21 @@ import com.google.common.collect.ImmutableList;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.spi.function.OperatorType;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.FunctionType;
+import io.trino.sql.ir.Array;
 import io.trino.sql.ir.Bind;
 import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.Lambda;
+import io.trino.sql.ir.Let;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
 import static io.trino.sql.planner.iterative.rule.LambdaCaptureDesugaringRewriter.rewrite;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,6 +39,7 @@ public class TestLambdaCaptureDesugaringRewriter
 {
     private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
     private static final ResolvedFunction ADD_INTEGER = FUNCTIONS.resolveOperator(OperatorType.ADD, ImmutableList.of(INTEGER, INTEGER));
+    private static final ResolvedFunction TRANSFORM = FUNCTIONS.resolveFunction("transform", fromTypes(new ArrayType(INTEGER), new FunctionType(ImmutableList.of(INTEGER), INTEGER)));
 
     @Test
     public void testRewriteBasicLambda()
@@ -68,5 +75,153 @@ public class TestLambdaCaptureDesugaringRewriter
                         new Lambda(
                                 ImmutableList.of(new Symbol(INTEGER, "a_1"), new Symbol(INTEGER, "a_0")),
                                 new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "a_1"), new Reference(INTEGER, "a_0"))))));
+    }
+
+    @Test
+    public void testLetBoundSymbolIsNotCaptured()
+    {
+        SymbolAllocator allocator = new SymbolAllocator(ImmutableList.of(new Symbol(INTEGER, "a")));
+
+        // x -> let b = a + x in b + b
+        // `b` is bound within the lambda body, so it is not a free variable and must not be
+        // captured. Only `a` is.
+        Lambda lambda = new Lambda(
+                ImmutableList.of(new Symbol(INTEGER, "x")),
+                new Let(new Symbol(INTEGER, "b"),
+                        new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "a"), new Reference(INTEGER, "x"))),
+                        new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "b"), new Reference(INTEGER, "b")))));
+
+        Expression rewritten = rewrite(lambda, allocator);
+
+        assertThat(rewritten).isEqualTo(new Bind(
+                ImmutableList.of(new Reference(INTEGER, "a")),
+                new Lambda(
+                        ImmutableList.of(new Symbol(INTEGER, "a_0"), new Symbol(INTEGER, "x")),
+                        new Let(new Symbol(INTEGER, "b"),
+                                new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "a_0"), new Reference(INTEGER, "x"))),
+                                new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "b"), new Reference(INTEGER, "b")))))));
+
+        // the rewrite is a fixed point: re-running it must not capture the binding again
+        assertThat(rewrite(rewritten, allocator)).isEqualTo(rewritten);
+    }
+
+    @Test
+    public void testLetBoundSymbolFromEnclosingScopeIsCaptured()
+    {
+        SymbolAllocator allocator = new SymbolAllocator(ImmutableList.of(new Symbol(INTEGER, "a"), new Symbol(INTEGER, "b")));
+
+        // let b = a in (x -> b + x)
+        // `b` is bound outside the lambda, so it is a free variable of the lambda and must be
+        // captured, but it is no longer free above the Let.
+        assertThat(
+                rewrite(
+                        new Let(new Symbol(INTEGER, "b"),
+                                new Reference(INTEGER, "a"),
+                                new Lambda(
+                                        ImmutableList.of(new Symbol(INTEGER, "x")),
+                                        new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "b"), new Reference(INTEGER, "x"))))),
+                        allocator))
+                .isEqualTo(new Let(
+                        new Symbol(INTEGER, "b"),
+                        new Reference(INTEGER, "a"),
+                        new Bind(
+                                ImmutableList.of(new Reference(INTEGER, "b")),
+                                new Lambda(
+                                        ImmutableList.of(new Symbol(INTEGER, "b_0"), new Symbol(INTEGER, "x")),
+                                        new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "b_0"), new Reference(INTEGER, "x")))))));
+    }
+
+    @Test
+    public void testLetBoundSymbolCapturedByNestedLambdaIsNotPropagatedPastLet()
+    {
+        SymbolAllocator allocator = new SymbolAllocator(ImmutableList.of(new Symbol(INTEGER, "a"), new Symbol(INTEGER, "b")));
+
+        // y -> let b = a + y in (x -> b + x)
+        // The nested lambda reports `b` as a capture, but `b` is bound by the Let, so it must not be
+        // propagated to the enclosing lambda. Only `a` is captured there.
+        assertThat(
+                rewrite(
+                        new Lambda(
+                                ImmutableList.of(new Symbol(INTEGER, "y")),
+                                new Let(new Symbol(INTEGER, "b"),
+                                        new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "a"), new Reference(INTEGER, "y"))),
+                                        new Lambda(
+                                                ImmutableList.of(new Symbol(INTEGER, "x")),
+                                                new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "b"), new Reference(INTEGER, "x")))))),
+                        allocator))
+                .isEqualTo(new Bind(
+                        ImmutableList.of(new Reference(INTEGER, "a")),
+                        new Lambda(
+                                ImmutableList.of(new Symbol(INTEGER, "a_1"), new Symbol(INTEGER, "y")),
+                                new Let(new Symbol(INTEGER, "b"),
+                                        new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "a_1"), new Reference(INTEGER, "y"))),
+                                        new Bind(
+                                                ImmutableList.of(new Reference(INTEGER, "b")),
+                                                new Lambda(
+                                                        ImmutableList.of(new Symbol(INTEGER, "b_0"), new Symbol(INTEGER, "x")),
+                                                        new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "b_0"), new Reference(INTEGER, "x")))))))));
+    }
+
+    @Test
+    public void testNestedLets()
+    {
+        SymbolAllocator allocator = new SymbolAllocator(ImmutableList.of(new Symbol(INTEGER, "a")));
+
+        // x -> let b = a + x in let c = b + x in c + c
+        // Neither binding escapes: only `a` is captured.
+        assertThat(
+                rewrite(
+                        new Lambda(
+                                ImmutableList.of(new Symbol(INTEGER, "x")),
+                                new Let(new Symbol(INTEGER, "b"),
+                                        new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "a"), new Reference(INTEGER, "x"))),
+                                        new Let(new Symbol(INTEGER, "c"),
+                                                new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "b"), new Reference(INTEGER, "x"))),
+                                                new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "c"), new Reference(INTEGER, "c")))))),
+                        allocator))
+                .isEqualTo(new Bind(
+                        ImmutableList.of(new Reference(INTEGER, "a")),
+                        new Lambda(
+                                ImmutableList.of(new Symbol(INTEGER, "a_0"), new Symbol(INTEGER, "x")),
+                                new Let(new Symbol(INTEGER, "b"),
+                                        new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "a_0"), new Reference(INTEGER, "x"))),
+                                        new Let(new Symbol(INTEGER, "c"),
+                                                new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "b"), new Reference(INTEGER, "x"))),
+                                                new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "c"), new Reference(INTEGER, "c"))))))));
+    }
+
+    @Test
+    public void testLetBoundSymbolReferencedDirectlyAndByNestedLambda()
+    {
+        SymbolAllocator allocator = new SymbolAllocator(ImmutableList.of(new Symbol(INTEGER, "a"), new Symbol(INTEGER, "b")));
+
+        // y -> let b = a + y in transform(ARRAY[b], x -> b + x)
+        // The direct reference is suppressed while the binding is in scope, and the one the nested
+        // lambda captures is removed at the Let. Neither reaches the enclosing lambda.
+        assertThat(
+                rewrite(
+                        new Lambda(
+                                ImmutableList.of(new Symbol(INTEGER, "y")),
+                                new Let(new Symbol(INTEGER, "b"),
+                                        new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "a"), new Reference(INTEGER, "y"))),
+                                        new Call(TRANSFORM, ImmutableList.of(
+                                                new Array(INTEGER, ImmutableList.of(new Reference(INTEGER, "b"))),
+                                                new Lambda(
+                                                        ImmutableList.of(new Symbol(INTEGER, "x")),
+                                                        new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "b"), new Reference(INTEGER, "x")))))))),
+                        allocator))
+                .isEqualTo(new Bind(
+                        ImmutableList.of(new Reference(INTEGER, "a")),
+                        new Lambda(
+                                ImmutableList.of(new Symbol(INTEGER, "a_1"), new Symbol(INTEGER, "y")),
+                                new Let(new Symbol(INTEGER, "b"),
+                                        new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "a_1"), new Reference(INTEGER, "y"))),
+                                        new Call(TRANSFORM, ImmutableList.of(
+                                                new Array(INTEGER, ImmutableList.of(new Reference(INTEGER, "b"))),
+                                                new Bind(
+                                                        ImmutableList.of(new Reference(INTEGER, "b")),
+                                                        new Lambda(
+                                                                ImmutableList.of(new Symbol(INTEGER, "b_0"), new Symbol(INTEGER, "x")),
+                                                                new Call(ADD_INTEGER, ImmutableList.of(new Reference(INTEGER, "b_0"), new Reference(INTEGER, "x")))))))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestExpressions.java
@@ -74,4 +74,19 @@ public class TestExpressions
         // https://github.com/trinodb/trino/issues/3411
         assertThat(assertions.query("SELECT try(k) FROM (SELECT null) t(k)")).matches("VALUES null");
     }
+
+    @Test
+    public void testTryOverLetBoundExpression()
+    {
+        // NULLIF and BETWEEN bind a non-trivial operand with a Let so it is evaluated once. Inside
+        // the lambda that TRY desugars to, that binding must not be treated as a captured symbol.
+        assertThat(assertions.query("SELECT try(nullif(trim('harsh'), ''))")).matches("VALUES CAST('harsh' AS varchar(5))");
+        assertThat(assertions.query("SELECT try(nullif(trim('  '), ''))")).matches("VALUES CAST(null AS varchar(2))");
+        assertThat(assertions.query("SELECT try(nullif(trim(x), '')) FROM (VALUES ' abc ', '   ') t(x)")).matches("VALUES CAST('abc' AS varchar(5)), null");
+
+        assertThat(assertions.query("SELECT try(trim(x) BETWEEN 'a' AND 'z') FROM (VALUES ' abc ', ' zzz ') t(x)")).matches("VALUES true, false");
+
+        // the Let-bound operand may itself fail, in which case TRY must swallow the failure
+        assertThat(assertions.query("SELECT try(nullif(x / 0, 1)) FROM (VALUES 1) t(x)")).matches("VALUES cast(null AS integer)");
+    }
 }


### PR DESCRIPTION
LambdaCaptureDesugaringRewriter treated every Reference in a lambda body as a free variable, including references to symbols bound by an enclosing Let within that same body. Such a symbol is local to the Let body, so capturing it produced a Bind over a symbol that no plan node produces, and made the rule non-idempotent: each pass captured the binding again, nesting Bind inside Bind until ExpressionTreeRewriter failed casting the inner Bind to Lambda.

NULLIF and BETWEEN lower a non-trivial operand to a Let so that it is evaluated exactly once, so any TRY over them hit this, for example:

    SELECT try(nullif(trim('harsh'), ''))

failed to plan with a ClassCastException.

Track Let bindings while rewriting and leave those references alone. The bindings are dropped when crossing a lambda boundary, where a binding from an enclosing scope genuinely is a free variable that needs to be captured, and are removed from the referenced set at the Let itself, where a binding captured by a nested lambda stops being free.

Fixes https://github.com/trinodb/trino/issues/30399

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## General
* Fix failing queries involving TRY() ({issue}`issuenumber`)
```
