### PR TITLE
Fix the Trino server process name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,13 +223,13 @@ jobs:
         run: |
           # build everything to make sure dependencies of impacted modules are present
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          $MAVEN clean install ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -pl '!:trino-docs,!:trino-server'
+          $MAVEN clean install ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -pl '!:trino-docs,!:trino-server,!:trino-server-core'
       - name: Error Prone Checks
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           # Skip checks, these are run in `maven-checks` job and e.g. checkstyle is expensive.
           $MAVEN ${MAVEN_TEST} -T 1C clean compile test-compile -DskipTests -Dair.check.skip-all=true ${MAVEN_GIB} -Dgib.buildUpstream=never -P errorprone-compiler \
-            -pl '!:trino-docs,!:trino-server'
+            -pl '!:trino-docs,!:trino-server,!:trino-server-core'
       - name: Cancel merge queue workflow
         if: ${{ failure() && github.event_name == 'merge_group' }}
         env:
@@ -257,7 +257,7 @@ jobs:
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          $MAVEN clean install ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -Dgib.logImpactedTo=gib-impacted.log -pl '!:trino-docs,!:trino-server'
+          $MAVEN clean install ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -Dgib.logImpactedTo=gib-impacted.log -pl '!:trino-docs,!:trino-server,!:trino-server-core'
       - name: Test old JDBC vs current server
         id: tests-old
         run: |
@@ -304,7 +304,7 @@ jobs:
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          $MAVEN clean install ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -pl '!:trino-docs,!:trino-server'
+          $MAVEN clean install ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -pl '!:trino-docs,!:trino-server,!:trino-server-core'
       - name: Maven Tests
         id: tests
         run: |

--- a/core/trino-server-core/pom.xml
+++ b/core/trino-server-core/pom.xml
@@ -22,7 +22,7 @@
 
         <!-- Launcher properties -->
         <main-class>io.trino.server.TrinoServer</main-class>
-        <process-name>${project.artifactId}</process-name>
+        <process-name>trino-server</process-name>
 
         <!-- Special consideration for Takari Lifecycle -->
         <!-- This works as trino-server have no sources (is just provisio packaged) -->


### PR DESCRIPTION
## Release notes

(x) Release notes are required, with the following suggested text:

```General
## Section
* Set Linux process name for Trino to be `trino-server`. ({issue}`30403`)
```
