### PR TITLE
Use SPI NodeManager worker view in StableHostAddressProvider

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/StableHostAddressProvider.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/StableHostAddressProvider.java
@@ -19,10 +19,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.airlift.slice.XxHash64;
-import io.trino.node.InternalNode;
-import io.trino.node.InternalNodeManager;
-import io.trino.node.NodeState;
 import io.trino.spi.HostAddress;
+import io.trino.spi.Node;
+import io.trino.spi.NodeManager;
 
 import java.util.Comparator;
 import java.util.List;
@@ -38,8 +37,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Maps a split's cache key to a stable list of worker host addresses using rendezvous (highest
- * random weight) hashing over a precomputed bucket table. Worker membership is refreshed lazily on
- * access, bounded by a short time window, and the table is rebuilt only when membership changes.
+ * random weight) hashing over a precomputed bucket table. Worker membership comes from
+ * {@link NodeManager#getWorkerNodes()}, is refreshed lazily on access, bounded by a short time
+ * window, and the table is rebuilt only when membership changes.
  */
 public class StableHostAddressProvider
 {
@@ -49,14 +49,14 @@ public class StableHostAddressProvider
     // hosts shift on rebuild, keeping reassignment minimal. Assumes worker count stays well below this.
     private static final int BUCKET_COUNT = 2048;
 
-    private final InternalNodeManager nodeManager;
+    private final NodeManager nodeManager;
     private final int preferredHostsCount;
 
     private volatile Snapshot snapshot = new Snapshot(ImmutableSet.of(), ImmutableList.of());
     private volatile long lastRefreshTime;
 
     @Inject
-    public StableHostAddressProvider(InternalNodeManager nodeManager, StableHostAddressProviderConfig config)
+    public StableHostAddressProvider(NodeManager nodeManager, StableHostAddressProviderConfig config)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.preferredHostsCount = config.getPreferredHostsCount();
@@ -90,8 +90,7 @@ public class StableHostAddressProvider
     synchronized void refreshSnapshot()
     {
         try {
-            Set<TrinoNode> trinoNodes = nodeManager.getNodes(NodeState.ACTIVE).stream()
-                    .filter(node -> !node.isCoordinator())
+            Set<TrinoNode> trinoNodes = nodeManager.getWorkerNodes().stream()
                     .map(TrinoNode::of)
                     .collect(toImmutableSet());
             lastRefreshTime = System.nanoTime();
@@ -142,7 +141,7 @@ public class StableHostAddressProvider
             requireNonNull(hostAndPort, "hostAndPort is null");
         }
 
-        public static TrinoNode of(InternalNode node)
+        public static TrinoNode of(Node node)
         {
             return new TrinoNode(node.getNodeIdentifier(), node.getHostAndPort(), XxHash64.hash(node.getNodeIdentifier().getBytes(UTF_8)));
         }

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -28,6 +28,7 @@ import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.http.server.HttpServerConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.trino.connector.DefaultNodeManager;
 import io.trino.cost.CostCalculator;
 import io.trino.cost.CostCalculator.EstimatedExchanges;
 import io.trino.cost.CostCalculatorUsingExchanges;
@@ -110,6 +111,8 @@ import io.trino.memory.TotalReservationOnBlockedNodesTaskLowMemoryKiller;
 import io.trino.metadata.LanguageFunctionManager;
 import io.trino.metadata.LanguageFunctionProvider;
 import io.trino.metadata.Split;
+import io.trino.node.InternalNode;
+import io.trino.node.InternalNodeManager;
 import io.trino.operator.ForScheduler;
 import io.trino.operator.OperatorStats;
 import io.trino.server.protocol.ExecutingStatementResource;
@@ -274,9 +277,8 @@ public class CoordinatorModule
         binder.bind(NodeTaskMap.class).in(Scopes.SINGLETON);
         newExporter(binder).export(NodeScheduler.class).withGeneratedName();
 
-        // consistent hashing address provider used by the scheduler to place splits that carry a cache key
+        // stable host address provider used by the scheduler to place splits that carry an affinity key
         configBinder(binder).bindConfig(StableHostAddressProviderConfig.class);
-        binder.bind(StableHostAddressProvider.class).in(Scopes.SINGLETON);
 
         // network topology
         switch (buildConfigObject(NodeSchedulerConfig.class).getNodeSchedulerPolicy()) {
@@ -449,6 +451,17 @@ public class CoordinatorModule
     public static ResourceGroupManager<?> getResourceGroupManager(@SuppressWarnings("rawtypes") ResourceGroupManager manager)
     {
         return manager;
+    }
+
+    @Provides
+    @Singleton
+    public static StableHostAddressProvider createStableHostAddressProvider(
+            InternalNode currentNode,
+            InternalNodeManager nodeManager,
+            NodeSchedulerConfig nodeSchedulerConfig,
+            StableHostAddressProviderConfig config)
+    {
+        return new StableHostAddressProvider(new DefaultNodeManager(currentNode, nodeManager, nodeSchedulerConfig.isIncludeCoordinator()), config);
     }
 
     @Provides

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -38,6 +38,7 @@ import io.trino.connector.CatalogServiceProviderModule;
 import io.trino.connector.ConnectorServicesProvider;
 import io.trino.connector.CoordinatorDynamicCatalogManager;
 import io.trino.connector.DefaultCatalogFactory;
+import io.trino.connector.DefaultNodeManager;
 import io.trino.connector.InMemoryCatalogStore;
 import io.trino.connector.LazyCatalogFactory;
 import io.trino.connector.system.AnalyzePropertiesSystemTable;
@@ -460,7 +461,7 @@ public class PlanTester
         this.pageSourceManager = new PageSourceManager(createPageSourceProviderFactory(catalogManager));
         this.pageSinkManager = new PageSinkManager(createPageSinkProvider(catalogManager));
         this.indexManager = new IndexManager(createIndexProvider(catalogManager));
-        StableHostAddressProvider stableHostAddressProvider = new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig());
+        StableHostAddressProvider stableHostAddressProvider = new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, nodeSchedulerConfig.isIncludeCoordinator()), new StableHostAddressProviderConfig());
         NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, nodeSchedulerConfig, new NodeTaskMap(finalizerService), stableHostAddressProvider));
         this.sessionPropertyManager = createSessionPropertyManager(catalogManager, taskManagerConfig, optimizerConfig);
         this.nodePartitioningManager = new NodePartitioningManager(nodeScheduler, createNodePartitioningProvider(catalogManager));

--- a/core/trino-main/src/test/java/io/trino/execution/BenchmarkNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BenchmarkNodeScheduler.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Multimap;
 import io.trino.Session;
+import io.trino.connector.DefaultNodeManager;
 import io.trino.execution.scheduler.FlatNetworkTopology;
 import io.trino.execution.scheduler.NetworkLocation;
 import io.trino.execution.scheduler.NetworkTopology;
@@ -198,7 +199,7 @@ public class BenchmarkNodeScheduler
         {
             InternalNodeManager nodeManager = TestingInternalNodeManager.createDefault();
             NodeSchedulerConfig nodeSchedulerConfig = getNodeSchedulerConfig();
-            StableHostAddressProvider stableHostAddressProvider = new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig());
+            StableHostAddressProvider stableHostAddressProvider = new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig());
             return switch (policy) {
                 case "uniform" -> new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, nodeSchedulerConfig, nodeTaskMap, stableHostAddressProvider);
                 case "topology" -> new TopologyAwareNodeSelectorFactory(new FlatNetworkTopology(), CURRENT_NODE, nodeManager, nodeSchedulerConfig, nodeTaskMap, new TopologyAwareNodeSelectorConfig(), stableHostAddressProvider);

--- a/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import io.trino.Session;
 import io.trino.SystemSessionProperties;
+import io.trino.connector.DefaultNodeManager;
 import io.trino.execution.scheduler.NetworkLocation;
 import io.trino.execution.scheduler.NetworkTopology;
 import io.trino.execution.scheduler.NodeScheduler;
@@ -117,7 +118,7 @@ public class TestNodeScheduler
                 .setMaxAdjustedPendingSplitsWeightPerTask(100)
                 .setIncludeCoordinator(false);
 
-        nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, nodeSchedulerConfig, nodeTaskMap, new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig())));
+        nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, nodeSchedulerConfig, nodeTaskMap, new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig())));
         // contents of taskMap indicate the node-task map for the current stage
         taskMap = new HashMap<>();
         nodeSelector = nodeScheduler.createNodeSelector(session);
@@ -193,7 +194,7 @@ public class TestNodeScheduler
                 nodeSchedulerConfig,
                 nodeTaskMap,
                 getNetworkTopologyConfig(),
-                new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig()));
+                new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig()));
         NodeScheduler nodeScheduler = new NodeScheduler(nodeSelectorFactory);
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session);
 
@@ -613,7 +614,7 @@ public class TestNodeScheduler
                 nodeSchedulerConfig,
                 nodeTaskMap,
                 getNetworkTopologyConfig(),
-                new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig()));
+                new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig()));
         NodeScheduler nodeScheduler = new NodeScheduler(nodeSelectorFactory);
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session);
 

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestMultiSourcePartitionedScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestMultiSourcePartitionedScheduler.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
 import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
+import io.trino.connector.DefaultNodeManager;
 import io.trino.cost.StatsAndCosts;
 import io.trino.execution.DynamicFilterConfig;
 import io.trino.execution.MockRemoteTaskFactory;
@@ -604,7 +605,7 @@ public class TestMultiSourcePartitionedScheduler
                 .setMaxSplitsPerNode(100)
                 .setMinPendingSplitsPerTask(0)
                 .setSplitsBalancingPolicy(STAGE);
-        NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, nodeSchedulerConfig, nodeTaskMap, new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig()), new Duration(0, SECONDS)));
+        NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, nodeSchedulerConfig, nodeTaskMap, new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig()), new Duration(0, SECONDS)));
         return new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(session), stage::getAllTasks);
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestScaledWriterScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestScaledWriterScheduler.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Multimap;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.opentelemetry.api.trace.Span;
+import io.trino.connector.DefaultNodeManager;
 import io.trino.cost.StatsAndCosts;
 import io.trino.execution.ExecutionFailureInfo;
 import io.trino.execution.NodeTaskMap;
@@ -222,7 +223,7 @@ public class TestScaledWriterScheduler
                 nodeManager,
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
                 new NodeTaskMap(new FinalizerService()),
-                new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig()));
+                new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, true), new StableHostAddressProviderConfig()));
     }
 
     private static TaskStatus buildTaskStatus(boolean isOutputBufferOverUtilized, long outputDataSize)

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
 import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
+import io.trino.connector.DefaultNodeManager;
 import io.trino.cost.StatsAndCosts;
 import io.trino.execution.DynamicFilterConfig;
 import io.trino.execution.MockRemoteTaskFactory;
@@ -367,7 +368,7 @@ public class TestSourcePartitionedScheduler
         assertTrinoExceptionThrownBy(() -> {
             NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
             TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault();
-            NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, new NodeSchedulerConfig().setIncludeCoordinator(false), nodeTaskMap, new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig())));
+            NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, new NodeSchedulerConfig().setIncludeCoordinator(false), nodeTaskMap, new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig())));
 
             PlanFragment plan = createFragment();
             StageExecution stage = createStageExecution(plan, nodeTaskMap);
@@ -504,7 +505,7 @@ public class TestSourcePartitionedScheduler
                 new InternalNode("other1", URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN, false),
                 new InternalNode("other2", URI.create("http://127.0.0.1:12"), NodeVersion.UNKNOWN, false),
                 new InternalNode("other3", URI.create("http://127.0.0.1:13"), NodeVersion.UNKNOWN, false));
-        NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, new NodeSchedulerConfig().setIncludeCoordinator(false), nodeTaskMap, new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig()), new Duration(0, SECONDS)));
+        NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, new NodeSchedulerConfig().setIncludeCoordinator(false), nodeTaskMap, new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig()), new Duration(0, SECONDS)));
 
         PlanFragment plan = createFragment();
         StageExecution stage = createStageExecution(plan, nodeTaskMap);
@@ -547,7 +548,7 @@ public class TestSourcePartitionedScheduler
                 new InternalNode("other1", URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN, false),
                 new InternalNode("other2", URI.create("http://127.0.0.1:12"), NodeVersion.UNKNOWN, false),
                 new InternalNode("other3", URI.create("http://127.0.0.1:13"), NodeVersion.UNKNOWN, false));
-        NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, new NodeSchedulerConfig().setIncludeCoordinator(false), nodeTaskMap, new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig()), new Duration(0, SECONDS)));
+        NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, new NodeSchedulerConfig().setIncludeCoordinator(false), nodeTaskMap, new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig()), new Duration(0, SECONDS)));
 
         PlanFragment plan = createFragment();
         StageExecution stage = createStageExecution(plan, nodeTaskMap);
@@ -587,7 +588,7 @@ public class TestSourcePartitionedScheduler
         PlanFragment plan = createFragment();
         NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
         StageExecution stage = createStageExecution(plan, nodeTaskMap);
-        NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, new NodeSchedulerConfig().setIncludeCoordinator(false), nodeTaskMap, new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig())));
+        NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, new NodeSchedulerConfig().setIncludeCoordinator(false), nodeTaskMap, new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig())));
         DynamicFilterService dynamicFilterService = new DynamicFilterService(metadata, functionManager, typeOperators, new DynamicFilterConfig());
         dynamicFilterService.registerQuery(
                 QUERY_ID,
@@ -662,7 +663,7 @@ public class TestSourcePartitionedScheduler
                 .setMaxSplitsPerNode(20)
                 .setMinPendingSplitsPerTask(0)
                 .setSplitsBalancingPolicy(splitsBalancingPolicy);
-        NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, nodeSchedulerConfig, nodeTaskMap, new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig()), new Duration(0, SECONDS)));
+        NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, nodeSchedulerConfig, nodeTaskMap, new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig()), new Duration(0, SECONDS)));
 
         SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(session), stage::getAllTasks);
         return newSourcePartitionedSchedulerAsStageScheduler(

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestStableHostAddressProvider.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestStableHostAddressProvider.java
@@ -14,6 +14,7 @@
 package io.trino.execution.scheduler;
 
 import com.google.common.collect.ImmutableSet;
+import io.trino.connector.DefaultNodeManager;
 import io.trino.node.InternalNode;
 import io.trino.node.TestingInternalNodeManager;
 import io.trino.spi.HostAddress;
@@ -22,9 +23,12 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.node.TestingInternalNodeManager.CURRENT_NODE;
 import static io.trino.spi.NodeVersion.UNKNOWN;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
@@ -92,6 +96,16 @@ public class TestStableHostAddressProvider
     }
 
     @Test
+    public void testCoordinatorIncludedOnlyWhenSchedulingOnCoordinatorEnabled()
+    {
+        TestingInternalNodeManager nodeManager = createNodeManager(5);
+        HostAddress coordinator = CURRENT_NODE.getHostAndPort();
+
+        assertThat(allHosts(createProvider(nodeManager, false))).doesNotContain(coordinator);
+        assertThat(allHosts(createProvider(nodeManager, true))).contains(coordinator);
+    }
+
+    @Test
     public void testAddingNodeReassignsFewKeys()
     {
         TestingInternalNodeManager nodeManager = createNodeManager(20);
@@ -141,9 +155,21 @@ public class TestStableHostAddressProvider
 
     private static StableHostAddressProvider createProvider(TestingInternalNodeManager nodeManager)
     {
+        return createProvider(nodeManager, false);
+    }
+
+    private static StableHostAddressProvider createProvider(TestingInternalNodeManager nodeManager, boolean includeCoordinator)
+    {
         return new StableHostAddressProvider(
-                nodeManager,
+                new DefaultNodeManager(CURRENT_NODE, nodeManager, includeCoordinator),
                 new StableHostAddressProviderConfig().setPreferredHostsCount(PREFERRED_HOSTS));
+    }
+
+    private static Set<HostAddress> allHosts(StableHostAddressProvider provider)
+    {
+        return keys().stream()
+                .flatMap(key -> provider.getHosts(key).stream())
+                .collect(toImmutableSet());
     }
 
     private static TestingInternalNodeManager createNodeManager(int nodeCount)

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestUniformNodeSelector.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestUniformNodeSelector.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import io.airlift.testing.TestingTicker;
 import io.trino.Session;
+import io.trino.connector.DefaultNodeManager;
 import io.trino.execution.MockRemoteTaskFactory;
 import io.trino.execution.NodeTaskMap;
 import io.trino.execution.RemoteTask;
@@ -99,7 +100,7 @@ public class TestUniformNodeSelector
                 .setIncludeCoordinator(false);
 
         // contents of taskMap indicate the node-task map for the current stage
-        nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, nodeSchedulerConfig, nodeTaskMap, new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig())));
+        nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(CURRENT_NODE, nodeManager, nodeSchedulerConfig, nodeTaskMap, new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig())));
         taskMap = new HashMap<>();
         nodeSelector = nodeScheduler.createNodeSelector(session);
         remoteTaskExecutor = newCachedThreadPool(daemonThreadsNamed("remoteTaskExecutor-%s"));
@@ -140,7 +141,7 @@ public class TestUniformNodeSelector
                 NodeSchedulerConfig.SplitsBalancingPolicy.STAGE,
                 false,
                 queueSizeAdjuster,
-                new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig()));
+                new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig()));
 
         for (int i = 0; i < 20; i++) {
             splits.add(new Split(TEST_CATALOG_HANDLE, TestingSplit.createRemoteSplit()));
@@ -313,7 +314,7 @@ public class TestUniformNodeSelector
                 NodeSchedulerConfig.SplitsBalancingPolicy.STAGE,
                 true,
                 new UniformNodeSelector.QueueSizeAdjuster(1000, 10000, new TestingTicker()),
-                new StableHostAddressProvider(nodeManager, new StableHostAddressProviderConfig()));
+                new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig()));
 
         Split rigidSplit = new Split(TEST_CATALOG_HANDLE, new TestingSplit(false, ImmutableList.of(node1.getHostAndPort())));
         splits.add(rigidSplit);

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestArbitraryDistributionSplitAssigner.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestArbitraryDistributionSplitAssigner.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
+import io.trino.connector.DefaultNodeManager;
 import io.trino.execution.scheduler.StableHostAddressProvider;
 import io.trino.execution.scheduler.StableHostAddressProviderConfig;
 import io.trino.metadata.Split;
@@ -48,6 +49,7 @@ import java.util.stream.IntStream;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.execution.scheduler.faulttolerant.SplitAssigner.SINGLE_SOURCE_PARTITION_ID;
+import static io.trino.node.TestingInternalNodeManager.CURRENT_NODE;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
 import static java.util.Collections.shuffle;
 import static java.util.Objects.requireNonNull;
@@ -59,7 +61,7 @@ public class TestArbitraryDistributionSplitAssigner
 
     private static final long STANDARD_SPLIT_SIZE_IN_BYTES = 1;
 
-    private static final StableHostAddressProvider CONSISTENT_HASHING_ADDRESS_PROVIDER = new StableHostAddressProvider(TestingInternalNodeManager.createDefault(), new StableHostAddressProviderConfig());
+    private static final StableHostAddressProvider CONSISTENT_HASHING_ADDRESS_PROVIDER = new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, TestingInternalNodeManager.createDefault(), false), new StableHostAddressProviderConfig());
 
     private static final PlanNodeId PARTITIONED_1 = new PlanNodeId("partitioned-1");
     private static final PlanNodeId PARTITIONED_2 = new PlanNodeId("partitioned-2");


### PR DESCRIPTION
## Description

`StableHostAddressProvider` filtered `InternalNodeManager` nodes by the coordinator flag to build its worker set, ignoring `node-scheduler.include-coordinator`. On clusters where the coordinator also runs splits, affinity keys never resolved to the coordinator. It now hashes over `NodeManager#getWorkerNodes()` (backed by a `DefaultNodeManager` that carries the config), so the worker view matches what the scheduler actually uses.

## Additional context and related issues

The provider's constructor now takes the SPI `NodeManager` instead of `InternalNodeManager`; wiring goes through a `DefaultNodeManager` built with `NodeSchedulerConfig#isIncludeCoordinator()`.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.