### PR TITLE
Preserve captures across Let bindings

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/LambdaCaptureDesugaringRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/LambdaCaptureDesugaringRewriter.java
@@ -110,12 +110,14 @@ public final class LambdaCaptureDesugaringRewriter
             Expression value = treeRewriter.rewrite(node.value(), context);
 
             // The bound symbol is local to the body and must not be treated as a captured symbol.
-            Expression body = treeRewriter.rewrite(node.body(), context.withLetBoundSymbol(node.name()));
+            Context bodyContext = context.forLetBody(node.name());
+            Expression body = treeRewriter.rewrite(node.body(), bodyContext);
 
             // Nested lambda will return the bound symbol as a capture, so we must explicitly exclude
             // it at this boundary. Otherwise, it would be propagated upward beyond the point of its
             // definition, and reported as a subexpression's free variable.
-            context.getReferencedSymbols().remove(node.name());
+            bodyContext.getReferencedSymbols().remove(node.name());
+            context.getReferencedSymbols().addAll(bodyContext.getReferencedSymbols());
 
             if (value != node.value() || body != node.body()) {
                 return new Let(node.name(), value, body);
@@ -168,9 +170,9 @@ public final class LambdaCaptureDesugaringRewriter
             return new Context(symbols, ImmutableSet.of());
         }
 
-        public Context withLetBoundSymbol(Symbol symbol)
+        public Context forLetBody(Symbol symbol)
         {
-            return new Context(referencedSymbols, ImmutableSet.<Symbol>builder()
+            return new Context(new LinkedHashSet<>(), ImmutableSet.<Symbol>builder()
                     .addAll(letBoundSymbols)
                     .add(symbol)
                     .build());

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestLambdaCaptureDesugaringRewriter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestLambdaCaptureDesugaringRewriter.java
@@ -106,6 +106,24 @@ public class TestLambdaCaptureDesugaringRewriter
     }
 
     @Test
+    public void testLetBindingDoesNotHideReferenceInValue()
+    {
+        Symbol symbol = new Symbol(INTEGER, "a");
+        SymbolAllocator allocator = new SymbolAllocator(ImmutableList.of(symbol));
+
+        assertThat(rewrite(
+                new Lambda(
+                        ImmutableList.of(),
+                        new Let(symbol, symbol.toSymbolReference(), symbol.toSymbolReference())),
+                allocator))
+                .isEqualTo(new Bind(
+                        ImmutableList.of(symbol.toSymbolReference()),
+                        new Lambda(
+                                ImmutableList.of(new Symbol(INTEGER, "a_0")),
+                                new Let(symbol, new Reference(INTEGER, "a_0"), symbol.toSymbolReference()))));
+    }
+
+    @Test
     public void testLetBoundSymbolFromEnclosingScopeIsCaptured()
     {
         SymbolAllocator allocator = new SymbolAllocator(ImmutableList.of(new Symbol(INTEGER, "a"), new Symbol(INTEGER, "b")));


### PR DESCRIPTION
## Description

A `Let` binding scopes only its body. The lambda capture rewriter currently collects references from the value and body in a shared set, then removes the bound symbol. When the value references an outer symbol with the same identity as the binding, this also removes the genuine outer capture.

Collect references from the `Let` body separately, exclude the body-local binding, and then propagate the remaining body captures to the enclosing context.

## Additional context and related issues

Follow-up to #30401, which handles shadowed symbols incorrectly.

The regression test constructs `() -> Let(a, a, a)`, where the reference in the value resolves to the outer `a`, while the reference in the body resolves to the local binding. Without this change, the outer reference is not captured.

Verified with `TestLambdaCaptureDesugaringRewriter` and the Error Prone, formatting, and Checkstyle checks. The regression test was also verified to fail without the fix.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```