### PR TITLE
Use streaming Provisio packaging

### DIFF
--- a/core/trino-server-core/src/main/provisio/trino-core.xml
+++ b/core/trino-server-core/src/main/provisio/trino-core.xml
@@ -1,6 +1,6 @@
 <runtime>
     <!-- Target -->
-    <archive name="${project.artifactId}-${project.version}.tar.gz" streaming="true" hardLinkIncludes="**/*.jar" />
+    <archive name="${project.artifactId}-${project.version}.tar.gz" streaming="true" gzipCompressionLevel="6" hardLinkIncludes="**/*.jar" />
 
     <!-- Notices -->
     <fileSet to="/">

--- a/core/trino-server-core/src/main/provisio/trino-core.xml
+++ b/core/trino-server-core/src/main/provisio/trino-core.xml
@@ -1,6 +1,6 @@
 <runtime>
     <!-- Target -->
-    <archive name="${project.artifactId}-${project.version}.tar.gz" hardLinkIncludes="**/*.jar" />
+    <archive name="${project.artifactId}-${project.version}.tar.gz" streaming="true" hardLinkIncludes="**/*.jar" />
 
     <!-- Notices -->
     <fileSet to="/">

--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -1,6 +1,6 @@
 <runtime>
     <!-- Target -->
-    <archive name="${project.artifactId}-${project.version}.tar.gz" hardLinkIncludes="**/*.jar" />
+    <archive name="${project.artifactId}-${project.version}.tar.gz" streaming="true" hardLinkIncludes="**/*.jar" />
 
    <!-- Expand on top of trino-server-core -->
     <artifactSet to="">

--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -1,6 +1,6 @@
 <runtime>
     <!-- Target -->
-    <archive name="${project.artifactId}-${project.version}.tar.gz" streaming="true" hardLinkIncludes="**/*.jar" />
+    <archive name="${project.artifactId}-${project.version}.tar.gz" streaming="true" gzipCompressionLevel="6" hardLinkIncludes="**/*.jar" />
 
    <!-- Expand on top of trino-server-core -->
     <artifactSet to="">

--- a/pom.xml
+++ b/pom.xml
@@ -2585,7 +2585,7 @@
                 <plugin>
                     <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
                     <artifactId>provisio-maven-plugin</artifactId>
-                    <version>1.1.3</version>
+                    <version>2.0.0</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
## Description

### Why

Trino currently builds each server distribution in a staging directory before writing the final TAR.GZ. This duplicates file-system work, requires several gigabytes of temporary disk space, and makes packaging the dominant cost of the final server modules.

Provisio 2.0.0 adds direct streaming assembly while preserving the existing descriptor and Maven integration. This allows Trino to avoid the staging directory without introducing Trino-specific packaging code.

### Approach

This change updates Trino from Provisio 1.1.3 to 2.0.0 and enables streaming for the core and full server distributions. It also selects gzip compression level 6, which provided a better packaging-time tradeoff while keeping the resulting archives close to the existing size.

Provisio 2.0.0, backed by Provisio Archiver 2.0.0:

- streams eligible artifacts and file sets directly into the output TAR.GZ without materializing an exploded distribution;
- uses trusted ZIP/JAR size and CRC32 metadata to emit duplicate JAR content as TAR hard links without decompressing it again;
- preserves reproducibility through deterministic source order, normalized metadata, and deterministic parallel gzip output; and
- writes transactionally, preserving an existing destination if assembly fails.

### Performance

The comparison used a common Trino base, equivalent offline Maven repositories, one unreported warm-up, and seven measured rounds in rotating order. The common reactor dependency closure and plugin artifacts were prepared before measurement. Each measured invocation ran:

```shell
./mvnw -q -o \
  -pl core/trino-server-core,core/trino-server \
  -DskipTests \
  -Dair.check.skip-all \
  -Dmaven.source.skip=true \
  clean package
```

| Variant | Median | Median absolute deviation | Combined archive size | Combined target footprint |
| --- | ---: | ---: | ---: | ---: |
| Staged Provisio | 47.13 s | 3.10 s | 1,036.87 MiB | 6.37 GiB |
| #30400 assembler, replayed on the same base | 11.01 s | 0.61 s | 1,013.69 MiB | 6.06 GiB |
| Streaming Provisio | 7.95 s | 0.47 s | 1,014.24 MiB | 1.00 GiB |

Streaming Provisio was 5.93 times faster than staged Provisio and 27.8% faster than the #30400 assembler in this comparison. It was faster in all seven measured rounds. Its combined archives were 0.054% larger than the custom assembler and 2.18% smaller than staged Provisio.

These are final two-module packaging timings after dependency and plugin preparation, not complete clean Trino reactor build times.

As a broader end-to-end check, a complete Java reactor build was also run once for each Provisio variant:

```shell
./mvnw -q -B -o clean install -DskipTests -pl '!:trino-docs'
```

| Variant | Complete reactor time |
| --- | ---: |
| Staged Provisio | 337.46 s |
| Streaming Provisio | 302.33 s |

Streaming reduced that run by 35.13 seconds, or 10.41%. `trino-docs` was excluded because its Docker-based Sphinx build could not authenticate to GHCR; all Java, plugin, and server modules were included. This was a single complete-reactor comparison, while the focused packaging results above are the controlled seven-round benchmark.

### Correctness and reproducibility

- Focused server packaging passed twice using the released Provisio 2.0.0 artifacts.
- Both gzip streams validated completely, and the TAR streams enumerated 1,092 core entries and 7,261 server entries.
- The extracted streaming archives matched staged Provisio output from the same current Trino base by path, bytes, entry kind, and mode.
- Repeated clean streaming builds produced byte-identical archives:
  - core: `eafe7e382ce3ebf966acb446a6eb642f2bab8f4c1d10df38d8918935b0743731`
  - server: `11f52c2716aabe00b503186f0910da635a8a1394c8270ec21e009e3b8d7825e0`

The controlled benchmark used Trino `9d29c8ae941`. This branch was subsequently rebased onto `b55a60601f7`, where focused packaging and correctness checks were rerun. Trino unit and integration tests were intentionally skipped for this packaging comparison.

## Additional context and related issues

This is an alternative proposal to #30400. That proposal replaces Provisio with a Trino-specific streaming assembler. This proposal retains Provisio and puts the reusable streaming implementation in Provisio Archiver and Provisio.

The Trino change itself is three lines across three files.

Related work:

- #30400
- [Provisio 2.0.0](https://repo1.maven.org/maven2/ca/vanzyl/provisio/2.0.0/)
- [Provisio Archiver 2.0.0](https://repo1.maven.org/maven2/io/takari/takari-archiver/2.0.0/)

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```