### PR TITLE
Simplify filter predicates comparing CASE/NULLIF to a constant

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -604,7 +604,7 @@ public class PlanOptimizers
                         costCalculator,
                         ImmutableSet.<Rule<?>>builder()
                                 .add(new InlineProjectIntoFilter())
-                                .add(new SimplifyFilterPredicate(metadata))
+                                .add(new SimplifyFilterPredicate(plannerContext))
                                 .addAll(columnPruningRules)
                                 .add(new InlineProjections())
                                 .addAll(new PushFilterThroughCountAggregation(plannerContext).rules()) // must run after PredicatePushDown and after TransformFilteringSemiJoinToInnerJoin

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyFilterPredicate.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyFilterPredicate.java
@@ -14,18 +14,25 @@
 package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.metadata.Metadata;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Case;
+import io.trino.sql.ir.ComparisonOperator;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.IrExpressions;
+import io.trino.sql.ir.IrVisitor;
 import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.Let;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Match;
 import io.trino.sql.ir.MatchClause;
 import io.trino.sql.ir.WhenClause;
+import io.trino.sql.ir.optimizer.IrExpressionOptimizer;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.FilterNode;
 
@@ -36,9 +43,13 @@ import java.util.Optional;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.sql.ir.Booleans.FALSE;
 import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.ir.IrExpressions.comparison;
+import static io.trino.sql.ir.IrExpressions.matchComparison;
+import static io.trino.sql.ir.IrExpressions.matchNullIf;
 import static io.trino.sql.ir.IrExpressions.not;
 import static io.trino.sql.ir.IrUtils.combineConjuncts;
 import static io.trino.sql.ir.IrUtils.extractConjuncts;
+import static io.trino.sql.ir.Logical.Operator.AND;
 import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
 import static io.trino.sql.planner.plan.Patterns.filter;
 
@@ -54,7 +65,8 @@ public class SimplifyFilterPredicate
         implements Rule<FilterNode>
 {
     private static final Pattern<FilterNode> PATTERN = filter();
-    private final Metadata metadata;
+    private final PlannerContext plannerContext;
+    private final IrExpressionOptimizer expressionOptimizer;
 
     @Override
     public Pattern<FilterNode> getPattern()
@@ -62,9 +74,10 @@ public class SimplifyFilterPredicate
         return PATTERN;
     }
 
-    public SimplifyFilterPredicate(Metadata metadata)
+    public SimplifyFilterPredicate(PlannerContext plannerContext)
     {
-        this.metadata = metadata;
+        this.plannerContext = plannerContext;
+        this.expressionOptimizer = plannerContext.getExpressionOptimizer();
     }
 
     @Override
@@ -74,22 +87,12 @@ public class SimplifyFilterPredicate
         ImmutableList.Builder<Expression> newConjuncts = ImmutableList.builder();
 
         boolean simplified = false;
+        Visitor visitor = new Visitor(plannerContext.getMetadata());
         for (Expression conjunct : conjuncts) {
-            IrExpressions.NullIf nullIf = IrExpressions.matchNullIf(conjunct);
-            Optional<Expression> simplifiedConjunct = nullIf != null ?
-                    Optional.of((Expression) Logical.and(nullIf.first(), isFalseOrNullPredicate(nullIf.second()))) :
-                    switch (conjunct) {
-                        case Case expression -> simplify(expression);
-                        case Match expression -> simplify(expression);
-                        case null, default -> Optional.empty();
-                    };
-
-            if (simplifiedConjunct.isPresent()) {
+            Expression simplifiedConjunct = visitor.process(conjunct, null);
+            newConjuncts.add(simplifiedConjunct);
+            if (conjunct != simplifiedConjunct) {
                 simplified = true;
-                newConjuncts.add(simplifiedConjunct.get());
-            }
-            else {
-                newConjuncts.add(conjunct);
             }
         }
         if (!simplified) {
@@ -97,28 +100,69 @@ public class SimplifyFilterPredicate
         }
 
         Expression predicate = combineConjuncts(newConjuncts.build());
+        predicate = expressionOptimizer.process(predicate, context.getSession(), context.getSymbolAllocator(), ImmutableMap.of()).orElse(predicate);
         if (predicate instanceof Constant constant && constant.value() == null) {
             predicate = FALSE;
         }
+
         return Result.ofPlanNode(new FilterNode(
                 node.getId(),
                 node.getSource(),
                 predicate));
     }
 
-    private Optional<Expression> simplify(Expression condition, Expression trueValue, Expression falseValue)
+    private static boolean isNotTrue(Expression expression)
+    {
+        return expression.equals(FALSE) ||
+                expression instanceof Constant constant && constant.value() == null;
+    }
+
+    private static Expression isFalseOrNullPredicate(Metadata metadata, Expression expression)
+    {
+        if (expression instanceof IsNull) {
+            return not(metadata, expression);
+        }
+        return Logical.or(new IsNull(expression), not(metadata, expression));
+    }
+
+    private static Optional<Expression> simplifyCase(Match caseExpression)
+    {
+        Optional<Expression> defaultValue = Optional.of(caseExpression.defaultValue());
+
+        if (caseExpression.operand() instanceof Constant constant && constant.value() == null) {
+            return defaultValue;
+        }
+
+        List<Expression> results = caseExpression.clauses().stream()
+                .map(MatchClause::result)
+                .collect(toImmutableList());
+        if (results.stream().allMatch(result -> result.equals(TRUE)) && defaultValue.get().equals(TRUE)) {
+            return Optional.of(TRUE);
+        }
+        if (results.stream().allMatch(SimplifyFilterPredicate::isNotTrue) && isNotTrue(defaultValue.get())) {
+            return Optional.of(FALSE);
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Expression> simplifyCase(Metadata metadata, Expression condition, Expression trueValue, Expression falseValue)
     {
         if (trueValue.equals(TRUE) && isNotTrue(falseValue)) {
             return Optional.of(condition);
         }
-        if (isNotTrue(trueValue) && falseValue.equals(TRUE)) {
-            return Optional.of(isFalseOrNullPredicate(condition));
+        if (isNotTrue(trueValue)) {
+            if (falseValue.equals(TRUE)) {
+                return Optional.of(isFalseOrNullPredicate(metadata, condition));
+            }
+            if (isNotTrue(falseValue)) {
+                return Optional.of(FALSE);
+            }
+            return Optional.of(new Logical(
+                    AND,
+                    ImmutableList.of(isFalseOrNullPredicate(metadata, condition), falseValue)));
         }
         if (falseValue.equals(trueValue) && isDeterministic(trueValue)) {
             return Optional.of(trueValue);
-        }
-        if (isNotTrue(trueValue) && isNotTrue(falseValue)) {
-            return Optional.of(FALSE);
         }
         if (condition.equals(TRUE)) {
             return Optional.of(trueValue);
@@ -129,11 +173,12 @@ public class SimplifyFilterPredicate
         return Optional.empty();
     }
 
-    private Optional<Expression> simplify(Case caseExpression)
+    private static Optional<Expression> simplifyCase(Metadata metadata, Case caseExpression)
     {
         if (caseExpression.whenClauses().size() == 1) {
             // if-like expression
-            return simplify(
+            return simplifyCase(
+                    metadata,
                     caseExpression.whenClauses().getFirst().getOperand(),
                     caseExpression.whenClauses().getFirst().getResult(),
                     caseExpression.defaultValue());
@@ -167,7 +212,7 @@ public class SimplifyFilterPredicate
                 Expression operand = whenClause.getOperand();
                 Expression result = whenClause.getResult();
                 if (isNotTrue(result)) {
-                    builder.add(isFalseOrNullPredicate(operand));
+                    builder.add(isFalseOrNullPredicate(metadata, operand));
                 }
                 else {
                     builder.add(operand);
@@ -178,7 +223,7 @@ public class SimplifyFilterPredicate
         // all results not true, and default true
         if (notTrueResultsCount == results.size() && caseExpression.defaultValue().equals(TRUE)) {
             ImmutableList.Builder<Expression> builder = ImmutableList.builder();
-            operands.forEach(operand -> builder.add(isFalseOrNullPredicate(operand)));
+            operands.forEach(operand -> builder.add(isFalseOrNullPredicate(metadata, operand)));
             return Optional.of(combineConjuncts(builder.build()));
         }
         // skip clauses with not true conditions
@@ -204,34 +249,113 @@ public class SimplifyFilterPredicate
         return Optional.empty();
     }
 
-    private static Optional<Expression> simplify(Match caseExpression)
+    /**
+     * Push a comparison against a constant down into the branches of a CASE or NULLIF operand,
+     * so that the per-branch comparisons can be folded by later simplification.
+     * Returns the original expression when no rewrite applies.
+     */
+    private static Expression simplifyCompareCase(Metadata metadata, IrExpressions.Comparison comparison)
     {
-        Optional<Expression> defaultValue = Optional.of(caseExpression.defaultValue());
+        ComparisonOperator operator = comparison.operator();
+        Expression left = comparison.left();
+        Expression right = comparison.right();
 
-        if (caseExpression.operand() instanceof Constant literal && literal.value() == null) {
-            return defaultValue;
+        // Simplify Comparison(Case, Constant)
+        if (left instanceof Case(List<WhenClause> whenClauses, Expression defaultValue) && right instanceof Constant) {
+            return new Case(
+                    whenClauses.stream()
+                            .map(whenClause -> new WhenClause(
+                                    whenClause.getOperand(),
+                                    comparison(metadata, operator, whenClause.getResult(), right)))
+                            .collect(toImmutableList()),
+                    comparison(metadata, operator, defaultValue, right));
         }
 
-        List<Expression> results = caseExpression.clauses().stream()
-                .map(MatchClause::result)
-                .collect(toImmutableList());
-        if (results.stream().allMatch(result -> result.equals(TRUE)) && defaultValue.get().equals(TRUE)) {
-            return Optional.of(TRUE);
+        // Simplify Comparison(NullIf, Constant)
+        IrExpressions.NullIf nullIf = matchNullIf(left);
+        if (nullIf != null && right instanceof Constant) {
+            return new Case(
+                    ImmutableList.of(
+                            new WhenClause(
+                                    comparison(metadata, operator, nullIf.first(), nullIf.second()),
+                                    new IsNull(right))),
+                    comparison(metadata, operator, nullIf.first(), right));
         }
-        if (results.stream().allMatch(SimplifyFilterPredicate::isNotTrue) && isNotTrue(defaultValue.get())) {
-            return Optional.of(FALSE);
-        }
-        return Optional.empty();
+
+        return null;
     }
 
-    private static boolean isNotTrue(Expression expression)
+    private static final class Visitor
+            extends IrVisitor<Expression, Void>
     {
-        return expression.equals(FALSE) ||
-                expression instanceof Constant literal && literal.value() == null;
-    }
+        private final Metadata metadata;
 
-    private Expression isFalseOrNullPredicate(Expression expression)
-    {
-        return Logical.or(new IsNull(expression), not(metadata, expression));
+        public Visitor(Metadata metadata)
+        {
+            this.metadata = metadata;
+        }
+
+        @Override
+        protected Expression visitExpression(Expression expression, Void context)
+        {
+            return expression;
+        }
+
+        @Override
+        protected Expression visitCall(Call node, Void context)
+        {
+            // A comparison against a constant is lowered to an operator Call; push it down into a
+            // CASE or NULLIF operand so the per-branch comparisons can be folded.
+            IrExpressions.Comparison comparison = matchComparison(node);
+            if (comparison != null) {
+                Expression simplified = simplifyCompareCase(metadata, comparison);
+                if (simplified != null) {
+                    return process(simplified, context);
+                }
+            }
+
+            return node;
+        }
+
+        @Override
+        protected Expression visitCase(Case node, Void context)
+        {
+            // NULLIF is lowered to an `if(first = second) then null else first` CASE: a NULLIF
+            // conjunct is true iff first is true and first is distinct from second.
+            IrExpressions.NullIf nullIf = matchNullIf(node);
+            if (nullIf != null) {
+                return Logical.and(
+                        process(nullIf.first(), context),
+                        isFalseOrNullPredicate(metadata, process(nullIf.second(), context)));
+            }
+
+            Expression defaultValue = process(node.defaultValue(), context);
+            Case caseExpression = node;
+            if (defaultValue != node.defaultValue()) {
+                caseExpression = new Case(node.whenClauses(), defaultValue);
+            }
+
+            Optional<Expression> simplified = simplifyCase(metadata, caseExpression);
+            return simplified.orElse(caseExpression);
+        }
+
+        @Override
+        protected Expression visitLet(Let node, Void context)
+        {
+            // NULLIF over a non-trivial operand is lowered to a `Let`-wrapped `if(...)` CASE.
+            IrExpressions.NullIf nullIf = matchNullIf(node);
+            if (nullIf != null) {
+                return Logical.and(
+                        process(nullIf.first(), context),
+                        isFalseOrNullPredicate(metadata, process(nullIf.second(), context)));
+            }
+            return node;
+        }
+
+        @Override
+        protected Expression visitMatch(Match node, Void context)
+        {
+            return simplifyCase(node).orElse(node);
+        }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyFilterPredicate.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyFilterPredicate.java
@@ -32,6 +32,7 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import org.junit.jupiter.api.Test;
 
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -40,7 +41,9 @@ import static io.trino.sql.ir.Booleans.NULL_BOOLEAN;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.ComparisonOperator.EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN;
+import static io.trino.sql.ir.ComparisonOperator.IDENTICAL;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN;
+import static io.trino.sql.ir.ComparisonOperator.NOT_EQUAL;
 import static io.trino.sql.ir.IrExpressions.ifExpression;
 import static io.trino.sql.ir.Logical.Operator.AND;
 import static io.trino.sql.ir.Logical.Operator.OR;
@@ -61,7 +64,7 @@ public class TestSimplifyFilterPredicate
     public void testSimplifyIfExpression()
     {
         // true result iff the condition is true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), TRUE, FALSE),
                         p.values(p.symbol("a"))))
@@ -71,7 +74,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // true result iff the condition is true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), TRUE, new Constant(BOOLEAN, null)),
                         p.values(p.symbol("a"))))
@@ -81,7 +84,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // true result iff the condition is null or false
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), FALSE, TRUE),
                         p.values(p.symbol("a"))))
@@ -91,7 +94,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // true result iff the condition is null or false
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), new Constant(BOOLEAN, null), TRUE),
                         p.values(p.symbol("a"))))
@@ -101,7 +104,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // always true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), TRUE, TRUE),
                         p.values(p.symbol("a"))))
@@ -111,7 +114,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // always false
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), FALSE, FALSE),
                         p.values(p.symbol("a"))))
@@ -121,7 +124,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // both results equal
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), comparison(GREATER_THAN, new Reference(INTEGER, "b"), new Constant(INTEGER, 0L)), comparison(GREATER_THAN, new Reference(INTEGER, "b"), new Constant(INTEGER, 0L))),
                         p.values(p.symbol("a"), p.symbol("b"))))
@@ -134,7 +137,7 @@ public class TestSimplifyFilterPredicate
         Call randomFunction = new Call(
                 tester().getMetadata().resolveBuiltinFunction("random", ImmutableList.of()),
                 ImmutableList.of());
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(
                                 new Reference(BOOLEAN, "a"),
@@ -144,7 +147,7 @@ public class TestSimplifyFilterPredicate
                 .doesNotFire();
 
         // always null (including the default) -> simplified to FALSE
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), new Constant(BOOLEAN, null)),
                         p.values(p.symbol("a"))))
@@ -154,7 +157,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // condition is true -> first branch
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(TRUE, new Reference(BOOLEAN, "a"), not(new Reference(BOOLEAN, "a"))),
                         p.values(p.symbol("a"))))
@@ -164,7 +167,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // condition is true -> second branch
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(FALSE, new Reference(BOOLEAN, "a"), not(new Reference(BOOLEAN, "a"))),
                         p.values(p.symbol("a"))))
@@ -174,7 +177,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // condition is true, no second branch -> the result is null, simplified to FALSE
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(FALSE, new Reference(BOOLEAN, "a")),
                         p.values(p.symbol("a"))))
@@ -184,7 +187,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // not known result (`b`) - cannot optimize
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), TRUE, new Reference(BOOLEAN, "b")),
                         p.values(p.symbol("a"), p.symbol("b"))))
@@ -195,7 +198,7 @@ public class TestSimplifyFilterPredicate
     public void testSimplifyNullIfExpression()
     {
         // NULLIF(x, y) returns true if and only if: x != y AND x = true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         nullIf(emptySymbolAllocator(), new Reference(BOOLEAN, "a"), new Reference(BOOLEAN, "b")),
                         p.values(p.symbol("a"), p.symbol("b"))))
@@ -212,7 +215,7 @@ public class TestSimplifyFilterPredicate
     @Test
     public void testSimplifySearchedCaseExpression()
     {
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), TRUE),
@@ -223,7 +226,7 @@ public class TestSimplifyFilterPredicate
                 .doesNotFire();
 
         // all results true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), TRUE),
@@ -237,7 +240,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // all results not true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), FALSE),
@@ -251,7 +254,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // all results not true (including default null result)
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), FALSE),
@@ -265,7 +268,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // one result true, and remaining results not true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), FALSE),
@@ -275,11 +278,11 @@ public class TestSimplifyFilterPredicate
                         p.values(p.symbol("a"))))
                 .matches(
                         filter(
-                                new Logical(AND, ImmutableList.of(new Logical(OR, ImmutableList.of(new IsNull(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))), not(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))))), new Logical(OR, ImmutableList.of(new IsNull(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))), not(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))))), comparison(GREATER_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)))),
+                                new Logical(AND, ImmutableList.of(new Logical(OR, ImmutableList.of(new IsNull(new Reference(INTEGER, "a")), not(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))))), new Logical(OR, ImmutableList.of(new IsNull(new Reference(INTEGER, "a")), not(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))))), comparison(GREATER_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)))),
                                 values("a")));
 
         // first result true, and remaining results not true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), TRUE),
@@ -293,7 +296,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // all results not true, and default true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), FALSE),
@@ -305,18 +308,18 @@ public class TestSimplifyFilterPredicate
                         filter(
                                 new Logical(AND, ImmutableList.of(
                                         new Logical(OR, ImmutableList.of(
-                                                new IsNull(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))),
+                                                new IsNull(new Reference(INTEGER, "a")),
                                                 not(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))))),
                                         new Logical(OR, ImmutableList.of(
-                                                new IsNull(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))),
+                                                new IsNull(new Reference(INTEGER, "a")),
                                                 not(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))))),
                                         new Logical(OR, ImmutableList.of(
-                                                new IsNull(comparison(GREATER_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))),
+                                                new IsNull(new Reference(INTEGER, "a")),
                                                 not(comparison(GREATER_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))))))),
                                 values("a")));
 
         // all conditions not true - return the default
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(FALSE, new Reference(BOOLEAN, "a")),
@@ -330,7 +333,7 @@ public class TestSimplifyFilterPredicate
                                 values("a", "b")));
 
         // all conditions not true, no default specified - return false
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(FALSE, new Reference(BOOLEAN, "a")),
@@ -344,7 +347,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // not true conditions preceding true condition - return the result associated with the true condition
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(FALSE, new Reference(BOOLEAN, "a")),
@@ -358,7 +361,7 @@ public class TestSimplifyFilterPredicate
                                 values("a", "b")));
 
         // remove not true condition and move the result associated with the first true condition to default
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(FALSE, new Reference(BOOLEAN, "a")),
@@ -372,7 +375,7 @@ public class TestSimplifyFilterPredicate
                                 values("a", "b")));
 
         // move the result associated with the first true condition to default
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "b"), new Constant(INTEGER, 0L)), new Reference(BOOLEAN, "a")),
@@ -390,7 +393,7 @@ public class TestSimplifyFilterPredicate
                                 values("a", "b")));
 
         // cannot remove any clause
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "b"), new Constant(INTEGER, 0L)), new Reference(BOOLEAN, "a")),
@@ -403,7 +406,7 @@ public class TestSimplifyFilterPredicate
     @Test
     public void testSimplifySimpleCaseExpression()
     {
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Match(
                                 new Reference(BOOLEAN, "a"),
@@ -415,7 +418,7 @@ public class TestSimplifyFilterPredicate
                 .doesNotFire();
 
         // comparison with null returns null - no WHEN branch matches, return default value
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Match(
                                 new Constant(BOOLEAN, null),
@@ -430,7 +433,7 @@ public class TestSimplifyFilterPredicate
                                 values("a", "b")));
 
         // comparison with null returns null - no WHEN branch matches, the result is default null, simplified to FALSE
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Match(
                                 new Constant(BOOLEAN, null),
@@ -445,7 +448,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // all results true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Match(
                                 new Reference(INTEGER, "a"),
@@ -460,7 +463,7 @@ public class TestSimplifyFilterPredicate
                                 values("a", "b")));
 
         // all results not true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Match(
                                 new Reference(INTEGER, "a"),
@@ -475,7 +478,7 @@ public class TestSimplifyFilterPredicate
                                 values("a", "b")));
 
         // all results not true (including default null result)
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Match(
                                 new Reference(INTEGER, "a"),
@@ -488,6 +491,159 @@ public class TestSimplifyFilterPredicate
                         filter(
                                 FALSE,
                                 values("a", "b")));
+    }
+
+    @Test
+    public void testSimplifyCaseCompare()
+    {
+        Expression aEqualsTo1IsIdenticalToTrue =
+                comparison(IDENTICAL, comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 1L)), TRUE);
+
+        // CASE WHEN a = 1 THEN 1 ELSE 0 END = 1
+        tester().assertThat(new SimplifyFilterPredicate(PLANNER_CONTEXT))
+                .on(p -> p.filter(
+                        comparison(
+                                EQUAL,
+                                new Case(ImmutableList.of(
+                                        new WhenClause(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L))),
+                                        new Constant(INTEGER, 0L)),
+                                new Constant(INTEGER, 1L)),
+                        p.values(p.symbol("a", INTEGER))))
+                .matches(
+                        filter(
+                                aEqualsTo1IsIdenticalToTrue,
+                                values("a")));
+
+        // CASE WHEN a = 1 THEN 1 ELSE 0 END <> 0
+        tester().assertThat(new SimplifyFilterPredicate(PLANNER_CONTEXT))
+                .on(p -> p.filter(
+                        comparison(
+                                NOT_EQUAL,
+                                new Case(
+                                        ImmutableList.of(new WhenClause(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L))),
+                                        new Constant(INTEGER, 0L)),
+                                new Constant(INTEGER, 0L)),
+                        p.values(p.symbol("a", INTEGER))))
+                .matches(
+                        filter(
+                                aEqualsTo1IsIdenticalToTrue,
+                                values("a")));
+
+        Expression aEqualsTo1NotIdenticalToTrue =
+                not(comparison(IDENTICAL, comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 1L)), TRUE));
+
+        // CASE WHEN a = 1 THEN 1 ELSE 0 END = 0
+        tester().assertThat(new SimplifyFilterPredicate(PLANNER_CONTEXT))
+                .on(p -> p.filter(
+                        comparison(
+                                EQUAL,
+                                new Case(ImmutableList.of(
+                                        new WhenClause(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L))),
+                                        new Constant(INTEGER, 0L)),
+                                new Constant(INTEGER, 0L)),
+                        p.values(p.symbol("a", INTEGER))))
+                .matches(
+                        filter(
+                                aEqualsTo1NotIdenticalToTrue,
+                                values("a")));
+
+        // CASE WHEN a = 1 THEN 1 ELSE 0 END <> 1
+        tester().assertThat(new SimplifyFilterPredicate(PLANNER_CONTEXT))
+                .on(p -> p.filter(
+                        comparison(
+                                NOT_EQUAL,
+                                new Case(
+                                        ImmutableList.of(new WhenClause(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L))),
+                                        new Constant(INTEGER, 0L)),
+                                new Constant(INTEGER, 1L)),
+                        p.values(p.symbol("a", INTEGER))))
+                .matches(
+                        filter(
+                                aEqualsTo1NotIdenticalToTrue,
+                                values("a")));
+
+        // CASE WHEN a = 1 THEN 1 WHEN a = 2 THEN 2 WHEN a = 3 THEN 3 WHEN a = 4 THEN 4 ELSE 0 END = 1
+        tester().assertThat(new SimplifyFilterPredicate(PLANNER_CONTEXT))
+                .on(p -> p.filter(
+                        comparison(
+                                EQUAL,
+                                new Case(
+                                        ImmutableList.of(
+                                                new WhenClause(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L)),
+                                                new WhenClause(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 2L)), new Constant(INTEGER, 2L)),
+                                                new WhenClause(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 3L)), new Constant(INTEGER, 3L)),
+                                                new WhenClause(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 4L)), new Constant(INTEGER, 4L))),
+                                        new Constant(INTEGER, 0L)),
+                                new Constant(INTEGER, 1L)),
+                        p.values(p.symbol("a", INTEGER))))
+                .matches(
+                        filter(
+                                comparison(
+                                        IDENTICAL,
+                                        comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 1L)),
+                                        TRUE),
+                                values("a")));
+
+        // CASE WHEN a = 1 THEN 1 WHEN a = 2 THEN 2 WHEN a = 3 THEN 3 WHEN a = 4 THEN 4 ELSE 0 END = 2
+        tester().assertThat(new SimplifyFilterPredicate(PLANNER_CONTEXT))
+                .on(p -> p.filter(
+                        comparison(
+                                EQUAL,
+                                new Case(
+                                        ImmutableList.of(
+                                                new WhenClause(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 1L)), new Constant(INTEGER, 1L)),
+                                                new WhenClause(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 2L)), new Constant(INTEGER, 2L)),
+                                                new WhenClause(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 3L)), new Constant(INTEGER, 3L)),
+                                                new WhenClause(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 4L)), new Constant(INTEGER, 4L))),
+                                        new Constant(INTEGER, 0L)),
+                                new Constant(INTEGER, 2L)),
+                        p.values(p.symbol("a", INTEGER))))
+                .matches(
+                        filter(
+                                new Logical(AND,
+                                        ImmutableList.of(
+                                                not(comparison(IDENTICAL, comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 1L)), TRUE)),
+                                                comparison(IDENTICAL, comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 2L)), TRUE))),
+                                values("a")));
+    }
+
+    @Test
+    public void testNestedCaseCompare()
+    {
+        Expression expression = comparison(
+                NOT_EQUAL,
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(new IsNull(new Reference(BIGINT, "a")), new Constant(BIGINT, 0L))),
+                        new Case(
+                                ImmutableList.of(
+                                        new WhenClause(comparison(EQUAL, new Reference(BIGINT, "a"), new Constant(BIGINT, 1001L)), new Constant(BIGINT, 1L))),
+                                new Constant(BIGINT, 0L))),
+                new Constant(BIGINT, 0L));
+
+        Expression stage1 = new Case(
+                ImmutableList.of(
+                        new WhenClause(new IsNull(new Reference(BIGINT, "a")), FALSE)),
+                comparison(
+                        IDENTICAL,
+                        comparison(EQUAL, new Reference(BIGINT, "a"), new Constant(BIGINT, 1001L)),
+                        TRUE));
+
+        Expression stage2 = new Logical(AND,
+                ImmutableList.of(
+                        not(new IsNull(new Reference(BIGINT, "a"))),
+                        comparison(
+                                IDENTICAL,
+                                comparison(EQUAL, new Reference(BIGINT, "a"), new Constant(BIGINT, 1001L)),
+                                TRUE)));
+
+        tester().assertThat(new SimplifyFilterPredicate(PLANNER_CONTEXT))
+                .on(p -> p.filter(expression, p.values(p.symbol("a", BIGINT))))
+                .matches(filter(stage1, values("a")));
+
+        tester().assertThat(new SimplifyFilterPredicate(PLANNER_CONTEXT))
+                .on(p -> p.filter(stage1, p.values(p.symbol("a", BIGINT))))
+                .matches(filter(stage2, values("a")));
     }
 
     private static Expression not(Expression expression)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Add recursive IrVisitor that pushes constant comparisons down into CASE/NULLIF branches (simplifyCompareCase), handles NULLIF lowered via Let, and runs an IrExpressionOptimizer pass over the rewritten predicate. Constructor now takes PlannerContext; update the PlanOptimizers caller and the test accordingly.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
