### PR TITLE
Remove ppc64le Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
         run: |
           BINFMT_IMAGE=docker.io/tonistiigi/binfmt:latest
           .github/bin/retry docker pull "${BINFMT_IMAGE}"
-          docker run --rm --privileged "${BINFMT_IMAGE}" --install arm64,ppc64le
+          docker run --rm --privileged "${BINFMT_IMAGE}" --install arm64
       - name: Build and Test Docker Image
         run: core/docker/build.sh
       - name: Cancel merge queue workflow

--- a/core/docker/build.sh
+++ b/core/docker/build.sh
@@ -8,7 +8,7 @@ Usage: $0 [-h] [-a <ARCHITECTURES>] [-r <VERSION>]
 Builds the Trino Docker image
 
 -h       Display help
--a       Build the specified comma-separated architectures, defaults to amd64,arm64,ppc64le
+-a       Build the specified comma-separated architectures, defaults to amd64,arm64
 -p       Use the specified server package (artifact id), for example: trino-server (default), trino-server-core
 -t       Image tag name, defaults to trino
 -r       Build the specified Trino release version, downloads all required artifacts
@@ -23,7 +23,7 @@ cd "${SCRIPT_DIR}" || exit 2
 
 SOURCE_DIR="${SCRIPT_DIR}/../.."
 
-ARCHITECTURES=(amd64 arm64 ppc64le)
+ARCHITECTURES=(amd64 arm64)
 TRINO_VERSION=
 TAG_PREFIX=trino
 SERVER_ARTIFACT=trino-server
@@ -88,8 +88,6 @@ function temurin_download_uri() {
         echo "${TEMURIN_DOWNLOAD_URL}" | sed -e "s/{release_name}/${RELEASE_NAME}/" -e "s/{arch}/aarch64/" ;;
       "amd64")
         echo "${TEMURIN_DOWNLOAD_URL}" | sed -e "s/{release_name}/${RELEASE_NAME}/" -e "s/{arch}/x64/" ;;
-      "ppc64le")
-        echo "${TEMURIN_DOWNLOAD_URL}" | sed -e "s/{release_name}/${RELEASE_NAME}/" -e "s/{arch}/ppc64le/" ;;
       *)
         echo "Unsupported architecture: ${ARCH}" >&2
         exit 1


### PR DESCRIPTION
The ppc64le image was always labeled experimental and never earned its keep:

* No test coverage. CI builds the image under QEMU emulation and runs only the smoke container test against it. Nothing else in the test suite ever executes on ppc64le, so the platform could regress silently between releases.
* No hardened base image to move to. The base images we are standardizing on are not published for ppc64le, which would leave the ppc64le image stuck on an unhardened base and pin the whole matrix to the lowest common denominator.
* Emulated multi-arch builds cost meaningful CI wall-clock time on every artifact-checks run.

Drop the architecture from the system requirements check, the Docker build script, the QEMU binfmt setup, and the product test launcher's JDK/architecture plumbing. Historical release notes are left as-is.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## General
* Remove support for ppc64le architecture. ({issue}`issuenumber`)
```
