### PR TITLE
Avoid ineffective predicate redistribution

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractCommonPredicatesExpressionRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractCommonPredicatesExpressionRewriter.java
@@ -30,6 +30,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.sql.ir.IrUtils.combinePredicates;
 import static io.trino.sql.ir.IrUtils.extractPredicates;
+import static io.trino.sql.ir.Logical.Operator.AND;
 import static io.trino.sql.ir.Logical.Operator.OR;
 import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
 import static java.util.Collections.emptySet;
@@ -74,7 +75,13 @@ public final class ExtractCommonPredicatesExpressionRewriter
 
             // Prefer AND LogicalBinaryExpression at the root if possible
             if (context.isRootNode() && simplified instanceof Logical value && value.operator() == OR) {
-                return distributeIfPossible(value);
+                Expression distributed = distributeIfPossible(value);
+                if (logical.operator() == AND && distributed instanceof Logical result && result.operator() == AND) {
+                    // Factoring a root AND only to distribute it back into an AND is ineffective
+                    // and may reorder predicates.
+                    return logical;
+                }
+                return distributed;
             }
 
             return simplified;

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -65,6 +65,7 @@ import static io.trino.sql.ir.Logical.Operator.OR;
 import static io.trino.sql.ir.TestingIr.comparison;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.sql.planner.TestingSymbolAllocator.emptySymbolAllocator;
+import static io.trino.sql.planner.iterative.rule.ExtractCommonPredicatesExpressionRewriter.extractCommonPredicates;
 import static io.trino.sql.planner.iterative.rule.SimplifyExpressions.rewrite;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -270,6 +271,18 @@ public class TestSimplifyExpressions
                         new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "A55"), new Reference(BOOLEAN, "A56"))),
                         new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "A57"), new Reference(BOOLEAN, "A58"))),
                         new Logical(AND, ImmutableList.of(new Reference(BOOLEAN, "A59"), new Reference(BOOLEAN, "A60"))))));
+    }
+
+    @Test
+    public void testExtractCommonPredicatesIsIdempotent()
+    {
+        Reference first = new Reference(BOOLEAN, "a");
+        Reference second = new Reference(BOOLEAN, "b");
+        Reference remaining = new Reference(BOOLEAN, "c");
+        Expression conjunction = new Logical(AND, ImmutableList.of(first, second));
+
+        assertExtractCommonPredicatesIsIdempotent(new Logical(OR, ImmutableList.of(conjunction, remaining)));
+        assertExtractCommonPredicatesIsIdempotent(new Logical(OR, ImmutableList.of(remaining, conjunction)));
     }
 
     @Test
@@ -533,6 +546,12 @@ public class TestSimplifyExpressions
     {
         Expression simplified = normalize(rewrite(expression, TEST_SESSION, PLANNER_CONTEXT.getMetadata(), emptySymbolAllocator(), PLANNER_CONTEXT.getExpressionOptimizer()));
         assertThat(simplified).isEqualTo(normalize(expected));
+    }
+
+    private static void assertExtractCommonPredicatesIsIdempotent(Expression expression)
+    {
+        Expression rewritten = extractCommonPredicates(expression);
+        assertThat(extractCommonPredicates(rewritten)).isEqualTo(rewritten);
     }
 
     @Test


### PR DESCRIPTION
## Description

`ExtractCommonPredicatesExpressionRewriter` can factor a root conjunction and immediately distribute it back into another conjunction. For expressions such as `OR(AND(a, b), c)`, this round trip provides no simplification but can reorder predicates, so `SimplifyExpressions` reports another change on the next optimizer iteration.

Preserve the already-normalized root conjunction when redistribution would only produce another conjunction. Factoring remains effective when it reduces the expression or when distribution is declined.

Add idempotence coverage for both operand orders. The regression test was verified to fail against the original implementation with the reported predicate reorder.

## Additional context and related issues

Fixes #30413.

Verified with the complete `TestSimplifyExpressions` test class and the `core/trino-main` Error Prone verification profile.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
