### PR TITLE
Increase task.info.max-age in tests

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
@@ -89,7 +89,7 @@ public final class StandaloneQueryRunner
                         // Purge finished-task info quickly so per-task stats are not retained, preserving memory on CI.
                         // Must stay above task.info-update-interval so the coordinator can fetch a task's final
                         // TaskInfo (incl. SpoolingOutputStats needed by fault-tolerant execution) before it is evicted.
-                        .put("task.info.max-age", "2s")
+                        .put("task.info.max-age", "10s")
                         .put("task.info-update-interval", "1s")
                         .buildOrThrow());
         serverProcessor.accept(builder);

--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -317,7 +317,7 @@ public final class DistributedQueryRunner
                 // Purge finished-task info quickly so per-task stats are not retained, preserving memory on CI.
                 // Must stay above task.info-update-interval so the coordinator can fetch a task's final
                 // TaskInfo (incl. SpoolingOutputStats needed by fault-tolerant execution) before it is evicted.
-                .put("task.info.max-age", "2s")
+                .put("task.info.max-age", "10s")
                 .put("task.info-update-interval", "1s");
         if (coordinator) {
             propertiesBuilder.put("node-scheduler.include-coordinator", "true");


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Some tests are flaky if the difference between
task.info.max-age and task.info-update-interval is too low as GC pauses or other delay make the coordinator ask for task info after it was purged.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
