### PR TITLE
Fix race between catalog metrics collection and query completion

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/CatalogTransaction.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/CatalogTransaction.java
@@ -15,6 +15,7 @@ package io.trino.metadata;
 
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.opentelemetry.api.trace.Tracer;
+import io.trino.NotInTransactionException;
 import io.trino.Session;
 import io.trino.connector.CatalogHandle;
 import io.trino.connector.informationschema.InformationSchemaMetadata;
@@ -28,7 +29,6 @@ import io.trino.tracing.TracingConnectorMetadata;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public class CatalogTransaction
@@ -65,7 +65,9 @@ public class CatalogTransaction
 
     public synchronized ConnectorMetadata getConnectorMetadata(Session session)
     {
-        checkState(!finished.get(), "Already finished");
+        if (finished.get()) {
+            throw new NotInTransactionException();
+        }
         if (connectorMetadata == null) {
             ConnectorSession connectorSession = session.toConnectorSession(catalogHandle);
             connectorMetadata = connector.getMetadata(connectorSession, transactionHandle);
@@ -76,7 +78,9 @@ public class CatalogTransaction
 
     public ConnectorTransactionHandle getTransactionHandle()
     {
-        checkState(!finished.get(), "Already finished");
+        if (finished.get()) {
+            throw new NotInTransactionException();
+        }
         return transactionHandle;
     }
 

--- a/core/trino-main/src/test/java/io/trino/transaction/TestTransactionManager.java
+++ b/core/trino-main/src/test/java/io/trino/transaction/TestTransactionManager.java
@@ -16,6 +16,9 @@ package io.trino.transaction;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
+import io.trino.NotInTransactionException;
+import io.trino.Session;
+import io.trino.metadata.Metadata;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.testing.QueryRunner;
@@ -43,6 +46,7 @@ import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
@@ -150,6 +154,31 @@ public class TestTransactionManager
             getFutureValue(transactionManager.asyncAbort(transactionId));
 
             assertThat(transactionManager.getAllTransactionInfos()).isEmpty();
+        }
+    }
+
+    @Test
+    public void testMetricsCollectionAfterTransactionFinishes()
+    {
+        try (QueryRunner queryRunner = new StandaloneQueryRunner(TEST_SESSION)) {
+            TransactionManager transactionManager = queryRunner.getTransactionManager();
+            Metadata metadata = queryRunner.getPlannerContext().getMetadata();
+
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog(TEST_CATALOG_NAME, "tpch", ImmutableMap.of());
+
+            TransactionId transactionId = transactionManager.beginTransaction(false);
+            Session session = TEST_SESSION.beginTransactionId(transactionId, transactionManager, queryRunner.getAccessControl());
+
+            // register the catalog as active in the transaction, materializing the transactional ConnectorMetadata
+            transactionManager.getOptionalCatalogMetadata(transactionId, TEST_CATALOG_NAME).orElseThrow().getMetadata(session);
+
+            getFutureValue(transactionManager.asyncCommit(transactionId));
+
+            // metrics collection races with query completion: the transaction is already finished, so
+            // getMetrics will throw NotInTransactionException that is then handled by
+            assertThatThrownBy(() -> metadata.getMetrics(session, TEST_CATALOG_NAME))
+                    .isInstanceOf(NotInTransactionException.class);
         }
     }
 


### PR DESCRIPTION
Query metrics collection reads catalog metadata metrics through the transactional ConnectorMetadata while the query transaction may be committed or aborted concurrently. When the CatalogMetadata reference was obtained before the transaction finished but used after, the finished check in CatalogTransaction.getConnectorMetadata failed with IllegalStateException ("Already finished"), which is not one of the exceptions the collection path tolerates, and was logged as an error.

Since metrics collection is best-effort by design, read the connector metadata through a non-throwing accessor and report empty metrics when the catalog transaction has already finished.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
