### PR TITLE
Fix race between spooling exchange close and memory usage update

### DIFF
--- a/core/trino-main/src/main/java/io/trino/exchange/SpoolingExchangeDataSource.java
+++ b/core/trino-main/src/main/java/io/trino/exchange/SpoolingExchangeDataSource.java
@@ -14,6 +14,7 @@
 package io.trino.exchange;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.trino.memory.context.LocalMemoryContext;
@@ -38,7 +39,8 @@ public class SpoolingExchangeDataSource
     // However since close can be called at any moment this variable has to be accessed in a safe way (avoiding "check-then-use").
     private ExchangeSource exchangeSource;
     private final LocalMemoryContext memoryContext;
-    private volatile boolean closed;
+    @GuardedBy("this")
+    private boolean closed;
 
     public SpoolingExchangeDataSource(ExchangeSource exchangeSource, LocalMemoryContext memoryContext)
     {
@@ -62,14 +64,19 @@ public class SpoolingExchangeDataSource
         }
 
         Slice data = exchangeSource.read();
-        memoryContext.setBytes(exchangeSource.getMemoryUsage());
-
-        // If the data source has been closed in a meantime reset memory usage back to 0
-        if (closed) {
-            memoryContext.setBytes(0);
-        }
-
+        updateMemoryUsage(exchangeSource.getMemoryUsage());
         return data;
+    }
+
+    private synchronized void updateMemoryUsage(long bytes)
+    {
+        // This data source is shared between all ExchangeOperator instances of a pipeline while the
+        // memory context belongs to the operator that created it. Once close() completes, that operator
+        // may already be destroyed together with its memory context, so the memory usage must not be
+        // updated anymore. Synchronizing with close() guarantees no update can slip in after it returns.
+        if (!closed) {
+            memoryContext.setBytes(bytes);
+        }
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/exchange/TestSpoolingExchangeDataSource.java
+++ b/core/trino-main/src/test/java/io/trino/exchange/TestSpoolingExchangeDataSource.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.exchange;
+
+import io.airlift.slice.Slice;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.memory.context.LocalMemoryContext;
+import io.trino.spi.exchange.ExchangeSource;
+import io.trino.spi.exchange.ExchangeSourceHandle;
+import io.trino.spi.exchange.ExchangeSourceOutputSelector;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSpoolingExchangeDataSource
+{
+    private static final Slice PAGE = utf8Slice("page");
+
+    @Test
+    public void testPollPageUpdatesMemoryUsage()
+    {
+        LocalMemoryContext memoryContext = newSimpleAggregatedMemoryContext().newLocalMemoryContext("test");
+        SpoolingExchangeDataSource dataSource = new SpoolingExchangeDataSource(new TestingExchangeSource(PAGE, 123, () -> {}), memoryContext);
+
+        assertThat(dataSource.pollPage()).isEqualTo(PAGE);
+        assertThat(memoryContext.getBytes()).isEqualTo(123);
+
+        dataSource.close();
+        assertThat(memoryContext.getBytes()).isEqualTo(0);
+    }
+
+    @Test
+    public void testCloseDuringPollPage()
+    {
+        AggregatedMemoryContext operatorMemoryContext = newSimpleAggregatedMemoryContext().newAggregatedMemoryContext();
+        LocalMemoryContext memoryContext = operatorMemoryContext.newLocalMemoryContext("test");
+        AtomicReference<SpoolingExchangeDataSource> dataSource = new AtomicReference<>();
+        // Simulate another driver closing the shared data source and destroying the memory context
+        // of the operator owning it while pollPage is reading from the exchange source
+        TestingExchangeSource exchangeSource = new TestingExchangeSource(PAGE, 123, () -> {
+            dataSource.get().close();
+            operatorMemoryContext.close();
+        });
+        dataSource.set(new SpoolingExchangeDataSource(exchangeSource, memoryContext));
+
+        assertThat(dataSource.get().pollPage()).isEqualTo(PAGE);
+        assertThat(memoryContext.getBytes()).isEqualTo(0);
+    }
+
+    private static class TestingExchangeSource
+            implements ExchangeSource
+    {
+        private final Slice data;
+        private final long memoryUsage;
+        private final Runnable onRead;
+
+        public TestingExchangeSource(Slice data, long memoryUsage, Runnable onRead)
+        {
+            this.data = requireNonNull(data, "data is null");
+            this.memoryUsage = memoryUsage;
+            this.onRead = requireNonNull(onRead, "onRead is null");
+        }
+
+        @Override
+        public void addSourceHandles(List<ExchangeSourceHandle> handles) {}
+
+        @Override
+        public void noMoreSourceHandles() {}
+
+        @Override
+        public void setOutputSelector(ExchangeSourceOutputSelector selector) {}
+
+        @Override
+        public CompletableFuture<Void> isBlocked()
+        {
+            return NOT_BLOCKED;
+        }
+
+        @Override
+        public boolean isFinished()
+        {
+            return false;
+        }
+
+        @Override
+        public Slice read()
+        {
+            onRead.run();
+            return data;
+        }
+
+        @Override
+        public long getMemoryUsage()
+        {
+            return memoryUsage;
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
SpoolingExchangeDataSource is shared by all ExchangeOperator instances of a pipeline but tracks memory in the context of the operator that created it. When that operator was closed and destroyed while another driver was inside pollPage, the memory usage update hit an already closed memory context and failed the task with GENERIC_INTERNAL_ERROR. Skip the update once the data source is closed, synchronizing with close to guarantee no update can happen after it completes.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
