### PR TITLE
Expose iceberg maintenance procedures on materialized view

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -126,6 +126,10 @@ statement
         RENAME TO to=qualifiedName                                     #renameMaterializedView
     | ALTER MATERIALIZED VIEW qualifiedName
         SET PROPERTIES propertyAssignments                             #setMaterializedViewProperties
+    | ALTER MATERIALIZED VIEW qualifiedName
+        EXECUTE procedureName=identifier
+        ('(' (argument (',' argument)*)? ')')?
+        (WHERE where=booleanExpression)?                               #materializedViewExecute
     | DROP VIEW (IF EXISTS)? qualifiedName                             #dropView
     | ALTER VIEW from=qualifiedName RENAME TO to=qualifiedName         #renameView
     | ALTER VIEW viewName=qualifiedName REFRESH                        #refreshView

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -121,6 +121,12 @@ public interface Metadata
             String procedureName,
             Map<String, Object> executeProperties);
 
+    Optional<TableExecuteHandle> getMaterializedViewTableHandleForExecute(
+            Session session,
+            TableHandle tableHandle,
+            String procedureName,
+            Map<String, Object> executeProperties);
+
     Set<ColumnHandle> getColumnHandlesForTableExecute(Session session, TableExecuteHandle tableExecuteHandle);
 
     Optional<TableLayout> getLayoutForTableExecute(Session session, TableExecuteHandle tableExecuteHandle);

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -364,6 +364,33 @@ public final class MetadataManager
     }
 
     @Override
+    public Optional<TableExecuteHandle> getMaterializedViewTableHandleForExecute(Session session, TableHandle tableHandle, String procedure, Map<String, Object> executeProperties)
+    {
+        requireNonNull(session, "session is null");
+        requireNonNull(tableHandle, "tableHandle is null");
+        requireNonNull(procedure, "procedure is null");
+        requireNonNull(executeProperties, "executeProperties is null");
+
+        CatalogHandle catalogHandle = tableHandle.catalogHandle();
+        CatalogMetadata catalogMetadata = getCatalogMetadata(session, catalogHandle);
+        ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
+
+        Optional<ConnectorTableExecuteHandle> executeHandle = metadata.getMaterializedViewTableHandleForExecute(
+                session.toConnectorSession(catalogHandle),
+                new InjectedConnectorAccessControl(accessControl, session.toSecurityContext(), catalogHandle.getCatalogName().toString()),
+                tableHandle.connectorHandle(),
+                procedure,
+                executeProperties,
+                getRetryPolicy(session).getRetryMode());
+
+        return executeHandle.map(handle -> new TableExecuteHandle(
+                catalogHandle,
+                tableHandle.transaction(),
+                tableHandle.connectorHandle(),
+                handle));
+    }
+
+    @Override
     public Set<ColumnHandle> getColumnHandlesForTableExecute(Session session, TableExecuteHandle tableExecuteHandle)
     {
         CatalogHandle catalogHandle = tableExecuteHandle.catalogHandle();

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -275,6 +275,8 @@ public class Analysis
     private final Multimap<NodeRef<Expression>, Field> fieldLineage = ArrayListMultimap.create();
 
     private Optional<TableExecuteHandle> tableExecuteHandle = Optional.empty();
+    // table the execute handle targets; for a materialized view this is its storage table
+    private Optional<Table> tableExecuteTable = Optional.empty();
 
     // names of tables and aliased relations. All names are resolved case-insensitive.
     private final Map<NodeRef<Relation>, QualifiedName> relationNames = new LinkedHashMap<>();
@@ -1498,6 +1500,18 @@ public class Analysis
     public Optional<TableExecuteHandle> getTableExecuteHandle()
     {
         return tableExecuteHandle;
+    }
+
+    public void setTableExecuteTable(Table table)
+    {
+        requireNonNull(table, "table is null");
+        checkState(this.tableExecuteTable.isEmpty(), "tableExecuteTable already set");
+        this.tableExecuteTable = Optional.of(table);
+    }
+
+    public Table getTableExecuteTable()
+    {
+        return tableExecuteTable.orElseThrow(() -> new IllegalStateException("tableExecuteTable not set"));
     }
 
     public void setTableFunctionAnalysis(TableFunctionInvocation node, TableFunctionInvocationAnalysis analysis)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -195,6 +195,7 @@ import io.trino.sql.tree.Lateral;
 import io.trino.sql.tree.Limit;
 import io.trino.sql.tree.Literal;
 import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.MeasureDefinition;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.MergeCase;
@@ -1278,13 +1279,71 @@ class StatementAnalyzer
                     tableName,
                     procedureName);
 
+            return analyzeTableExecute(
+                    node,
+                    "ALTER TABLE EXECUTE",
+                    "table",
+                    table,
+                    tableName,
+                    tableHandle,
+                    procedureName,
+                    node.getArguments(),
+                    node.getWhere(),
+                    tableName,
+                    scope);
+        }
+
+        @Override
+        protected Scope visitMaterializedViewExecute(MaterializedViewExecute node, Optional<Scope> scope)
+        {
+            QualifiedObjectName name = createQualifiedObjectName(session, node, node.getName());
+            MaterializedViewDefinition view = metadata.getMaterializedView(session, name)
+                    .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, node, "Materialized view '%s' does not exist", name));
+            String procedureName = node.getProcedureName().getCanonicalValue();
+
+            accessControl.checkCanExecuteTableProcedure(session.toSecurityContext(), name, procedureName);
+
+            QualifiedName storageName = getMaterializedViewStorageTableName(view)
+                    .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, node, "Storage table for materialized view '%s' does not exist", name));
+            QualifiedObjectName storageTableName = createQualifiedObjectName(session, node, storageName);
+            checkStorageTableNotRedirected(storageTableName);
+            TableHandle storageTableHandle = metadata.getTableHandle(session, storageTableName)
+                    .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, node, "Table '%s' does not exist", storageTableName));
+
+            return analyzeTableExecute(
+                    node,
+                    "ALTER MATERIALIZED VIEW EXECUTE",
+                    "materialized view",
+                    new Table(storageName),
+                    storageTableName,
+                    storageTableHandle,
+                    procedureName,
+                    node.getArguments(),
+                    node.getWhere(),
+                    name,
+                    scope);
+        }
+
+        private Scope analyzeTableExecute(
+                Node node,
+                String updateType,
+                String targetNoun,
+                Table table,
+                QualifiedObjectName tableName,
+                TableHandle tableHandle,
+                String procedureName,
+                List<CallArgument> arguments,
+                Optional<Expression> where,
+                QualifiedObjectName updateTargetName,
+                Optional<Scope> scope)
+        {
             if (!accessControl.getRowFilters(session.toSecurityContext(), tableName).isEmpty()) {
-                throw semanticException(NOT_SUPPORTED, node, "ALTER TABLE EXECUTE is not supported for table with row filter");
+                throw semanticException(NOT_SUPPORTED, node, "%s is not supported for %s with row filter", updateType, targetNoun);
             }
 
             TableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle);
             if (!accessControl.getColumnMasks(session.toSecurityContext(), tableName, tableMetadata.columns().stream().map(ColumnMetadata::getColumnSchema).collect(toImmutableList())).isEmpty()) {
-                throw semanticException(NOT_SUPPORTED, node, "ALTER TABLE EXECUTE is not supported for table with column masks");
+                throw semanticException(NOT_SUPPORTED, node, "%s is not supported for %s with column masks", updateType, targetNoun);
             }
 
             Scope tableScope = analyze(table);
@@ -1294,19 +1353,19 @@ class StatementAnalyzer
             TableProcedureMetadata procedureMetadata = tableProceduresRegistry.resolve(catalogHandle, procedureName);
 
             // analyze WHERE
-            if (!procedureMetadata.getExecutionMode().supportsFilter() && node.getWhere().isPresent()) {
+            if (!procedureMetadata.getExecutionMode().supportsFilter() && where.isPresent()) {
                 throw semanticException(NOT_SUPPORTED, node, "WHERE not supported for procedure %s", procedureName);
             }
-            node.getWhere().ifPresent(where -> analyzeWhere(node, tableScope, where));
+            where.ifPresent(whereExpression -> analyzeWhere(node, tableScope, whereExpression));
 
             // analyze arguments
 
-            List<Property> arguments = processTableExecuteArguments(node, procedureMetadata, scope);
+            List<Property> properties = processTableExecuteArguments(node, arguments, procedureMetadata, scope);
             Map<String, Object> tableProperties = tableProceduresPropertyManager.getProperties(
                     catalogName,
                     catalogHandle,
                     procedureName,
-                    arguments,
+                    properties,
                     session,
                     plannerContext,
                     accessControl,
@@ -1322,16 +1381,16 @@ class StatementAnalyzer
 
             analysis.setTableExecuteReadsData(procedureMetadata.getExecutionMode().isReadsData());
             analysis.setTableExecuteHandle(executeHandle);
+            analysis.setTableExecuteTable(table);
 
-            analysis.setUpdateType("ALTER TABLE EXECUTE");
-            analysis.setUpdateTarget(executeHandle.catalogHandle().getVersion(), tableName, Optional.of(table), Optional.empty());
+            analysis.setUpdateType(updateType);
+            analysis.setUpdateTarget(executeHandle.catalogHandle().getVersion(), updateTargetName, Optional.of(table), Optional.empty());
 
             return createAndAssignScope(node, scope, Field.newUnqualified("metric_name", VARCHAR), Field.newUnqualified("metric_value", BIGINT));
         }
 
-        private List<Property> processTableExecuteArguments(TableExecute node, TableProcedureMetadata procedureMetadata, Optional<Scope> scope)
+        private List<Property> processTableExecuteArguments(Node node, List<CallArgument> arguments, TableProcedureMetadata procedureMetadata, Optional<Scope> scope)
         {
-            List<CallArgument> arguments = node.getArguments();
             Predicate<CallArgument> hasName = argument -> argument.getName().isPresent();
             boolean anyNamed = arguments.stream().anyMatch(hasName);
             boolean allNamed = arguments.stream().allMatch(hasName);

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1353,7 +1353,7 @@ class StatementAnalyzer
             Scope tableScope;
             if (materializedView.isPresent()) {
                 analysis.addEmptyColumnReferencesForTable(accessControl, session.getIdentity(), target.updateTargetName(), getBranchName(target.table()));
-                tableScope = createScopeForMaterializedView(target.table(), target.updateTargetName(), scope, materializedView.get(), Optional.of(tableHandle));
+                tableScope = createScopeForMaterializedViewStorageTableExecute(target.table(), target.updateTargetName(), scope, tableHandle);
             }
             else {
                 tableScope = analyze(target.table());
@@ -1382,13 +1382,19 @@ class StatementAnalyzer
                     accessControl,
                     analysis.getParameters());
 
-            TableExecuteHandle executeHandle =
+            TableExecuteHandle executeHandle = materializedView.isPresent() ?
+                    metadata.getMaterializedViewTableHandleForExecute(
+                            session,
+                            tableHandle,
+                            procedureName,
+                            tableProperties)
+                    .orElseThrow(() -> semanticException(NOT_SUPPORTED, node, "Procedure '%s' cannot be executed on table '%s'", procedureName, target.tableName())) :
                     metadata.getTableHandleForExecute(
-                                    session,
-                                    tableHandle,
-                                    procedureName,
-                                    tableProperties)
-                            .orElseThrow(() -> semanticException(NOT_SUPPORTED, node, "Procedure '%s' cannot be executed on table '%s'", procedureName, target.tableName()));
+                            session,
+                            tableHandle,
+                            procedureName,
+                            tableProperties)
+                    .orElseThrow(() -> semanticException(NOT_SUPPORTED, node, "Procedure '%s' cannot be executed on materialized view '%s'", procedureName, target.tableName()));
 
             analysis.setTableExecuteReadsData(procedureMetadata.getExecutionMode().isReadsData());
             analysis.setTableExecuteHandle(executeHandle);
@@ -2708,6 +2714,21 @@ class StatementAnalyzer
                     view.getColumns(),
                     freshStorageTable,
                     true);
+        }
+
+        private Scope createScopeForMaterializedViewStorageTableExecute(Table table, QualifiedObjectName viewName, Optional<Scope> scope, TableHandle storageTable)
+        {
+            TableSchema tableSchema = metadata.getTableSchema(session, storageTable);
+            Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, storageTable);
+            List<Field> outputFields = analyzeTableOutputFields(table, viewName, tableSchema, columnHandles);
+
+            Scope accessControlScope = Scope.builder()
+                    .withRelationType(RelationId.anonymous(), new RelationType(outputFields))
+                    .build();
+            analyzeFiltersAndMasks(table, viewName, new RelationType(outputFields), accessControlScope);
+            analysis.registerTable(table, Optional.of(storageTable), viewName, getBranchName(table), session.getIdentity().getUser(), accessControlScope, Optional.empty());
+
+            return createAndAssignScope(table, scope, outputFields);
         }
 
         private Scope createScopeForView(Table table, QualifiedObjectName name, Optional<Scope> scope, ViewDefinition view)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1283,13 +1283,12 @@ class StatementAnalyzer
                     node,
                     "ALTER TABLE EXECUTE",
                     "table",
-                    table,
-                    tableName,
+                    new ExecuteTarget(table, tableName, tableName),
                     tableHandle,
                     procedureName,
                     node.getArguments(),
                     node.getWhere(),
-                    tableName,
+                    Optional.empty(),
                     scope);
         }
 
@@ -1314,41 +1313,53 @@ class StatementAnalyzer
                     node,
                     "ALTER MATERIALIZED VIEW EXECUTE",
                     "materialized view",
-                    new Table(storageName),
-                    storageTableName,
+                    new ExecuteTarget(node.getTable(), storageTableName, name),
                     storageTableHandle,
                     procedureName,
                     node.getArguments(),
                     node.getWhere(),
-                    name,
+                    Optional.of(view),
                     scope);
         }
+
+        // table: the table node to analyze for scope/authorization purposes; tableName: its name, used to resolve
+        // the catalog and procedure; updateTargetName: the name authorization (SELECT, row filters, column masks)
+        // is checked against, which for ALTER MATERIALIZED VIEW EXECUTE is the materialized view rather than its
+        // storage table. Grouped into a record so the two QualifiedObjectName fields can't be transposed at a
+        // call site.
+        private record ExecuteTarget(Table table, QualifiedObjectName tableName, QualifiedObjectName updateTargetName) {}
 
         private Scope analyzeTableExecute(
                 Node node,
                 String updateType,
                 String targetNoun,
-                Table table,
-                QualifiedObjectName tableName,
+                ExecuteTarget target,
                 TableHandle tableHandle,
                 String procedureName,
                 List<CallArgument> arguments,
                 Optional<Expression> where,
-                QualifiedObjectName updateTargetName,
+                Optional<MaterializedViewDefinition> materializedView,
                 Optional<Scope> scope)
         {
-            if (!accessControl.getRowFilters(session.toSecurityContext(), tableName).isEmpty()) {
+            if (!accessControl.getRowFilters(session.toSecurityContext(), target.updateTargetName()).isEmpty()) {
                 throw semanticException(NOT_SUPPORTED, node, "%s is not supported for %s with row filter", updateType, targetNoun);
             }
 
             TableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle);
-            if (!accessControl.getColumnMasks(session.toSecurityContext(), tableName, tableMetadata.columns().stream().map(ColumnMetadata::getColumnSchema).collect(toImmutableList())).isEmpty()) {
+            if (!accessControl.getColumnMasks(session.toSecurityContext(), target.updateTargetName(), tableMetadata.columns().stream().map(ColumnMetadata::getColumnSchema).collect(toImmutableList())).isEmpty()) {
                 throw semanticException(NOT_SUPPORTED, node, "%s is not supported for %s with column masks", updateType, targetNoun);
             }
 
-            Scope tableScope = analyze(table);
+            Scope tableScope;
+            if (materializedView.isPresent()) {
+                analysis.addEmptyColumnReferencesForTable(accessControl, session.getIdentity(), target.updateTargetName(), getBranchName(target.table()));
+                tableScope = createScopeForMaterializedView(target.table(), target.updateTargetName(), scope, materializedView.get(), Optional.of(tableHandle));
+            }
+            else {
+                tableScope = analyze(target.table());
+            }
 
-            String catalogName = tableName.catalogName();
+            String catalogName = target.tableName().catalogName();
             CatalogHandle catalogHandle = getRequiredCatalogHandle(metadata, session, node, catalogName);
             TableProcedureMetadata procedureMetadata = tableProceduresRegistry.resolve(catalogHandle, procedureName);
 
@@ -1377,14 +1388,14 @@ class StatementAnalyzer
                                     tableHandle,
                                     procedureName,
                                     tableProperties)
-                            .orElseThrow(() -> semanticException(NOT_SUPPORTED, node, "Procedure '%s' cannot be executed on table '%s'", procedureName, tableName));
+                            .orElseThrow(() -> semanticException(NOT_SUPPORTED, node, "Procedure '%s' cannot be executed on table '%s'", procedureName, target.tableName()));
 
             analysis.setTableExecuteReadsData(procedureMetadata.getExecutionMode().isReadsData());
             analysis.setTableExecuteHandle(executeHandle);
-            analysis.setTableExecuteTable(table);
+            analysis.setTableExecuteTable(target.table());
 
             analysis.setUpdateType(updateType);
-            analysis.setUpdateTarget(executeHandle.catalogHandle().getVersion(), updateTargetName, Optional.of(table), Optional.empty());
+            analysis.setUpdateTarget(executeHandle.catalogHandle().getVersion(), target.updateTargetName(), Optional.of(target.table()), Optional.empty());
 
             return createAndAssignScope(node, scope, Field.newUnqualified("metric_name", VARCHAR), Field.newUnqualified("metric_value", BIGINT));
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -109,6 +109,7 @@ import io.trino.sql.tree.Delete;
 import io.trino.sql.tree.ExplainAnalyze;
 import io.trino.sql.tree.Insert;
 import io.trino.sql.tree.LambdaArgumentDeclaration;
+import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.Query;
@@ -390,8 +391,8 @@ public class LogicalPlanner
         if (statement instanceof ExplainAnalyze explainAnalyze) {
             return createExplainAnalyzePlan(analysis, explainAnalyze);
         }
-        if (statement instanceof TableExecute tableExecute) {
-            return createTableExecutePlan(analysis, tableExecute);
+        if (statement instanceof TableExecute || statement instanceof MaterializedViewExecute) {
+            return createTableExecutePlan(analysis, statement);
         }
         throw new TrinoException(NOT_SUPPORTED, "Unsupported statement type " + statement.getClass().getSimpleName());
     }
@@ -1064,9 +1065,15 @@ public class LogicalPlanner
         return result;
     }
 
-    private RelationPlan createTableExecutePlan(Analysis analysis, TableExecute statement)
+    private RelationPlan createTableExecutePlan(Analysis analysis, Statement statement)
     {
-        Table table = statement.getTable();
+        Optional<io.trino.sql.tree.Expression> where = switch (statement) {
+            case TableExecute tableExecute -> tableExecute.getWhere();
+            case MaterializedViewExecute materializedViewExecute -> materializedViewExecute.getWhere();
+            default -> throw new IllegalArgumentException("Unexpected statement: " + statement);
+        };
+
+        Table table = analysis.getTableExecuteTable();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, table.getName());
         TableExecuteHandle executeHandle = analysis.getTableExecuteHandle().orElseThrow();
 
@@ -1083,9 +1090,9 @@ public class LogicalPlanner
         TableHandle tableHandle = analysis.getTableHandle(table);
         RelationPlan tableScanPlan = createRelationPlan(analysis, table);
         PlanBuilder sourcePlanBuilder = newPlanBuilder(tableScanPlan, analysis, ImmutableMap.of(), ImmutableMap.of(), session, plannerContext, symbolAllocator);
-        if (statement.getWhere().isPresent()) {
+        if (where.isPresent()) {
             SubqueryPlanner subqueryPlanner = new SubqueryPlanner(analysis, symbolAllocator, idAllocator, buildLambdaDeclarationToSymbolMap(analysis, symbolAllocator), plannerContext, Optional.empty(), session, ImmutableMap.of());
-            io.trino.sql.tree.Expression whereExpression = statement.getWhere().get();
+            io.trino.sql.tree.Expression whereExpression = where.get();
             sourcePlanBuilder = subqueryPlanner.handleSubqueries(sourcePlanBuilder, whereExpression, analysis.getSubqueries(statement));
             sourcePlanBuilder = sourcePlanBuilder.withNewRoot(new FilterNode(idAllocator.getNextId(), sourcePlanBuilder.getRoot(), sourcePlanBuilder.rewrite(whereExpression)));
         }

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -156,6 +156,15 @@ public class TracingConnectorMetadata
     }
 
     @Override
+    public Optional<ConnectorTableExecuteHandle> getMaterializedViewTableHandleForExecute(ConnectorSession session, ConnectorAccessControl accessControl, ConnectorTableHandle tableHandle, String procedureName, Map<String, Object> executeProperties, RetryMode retryMode)
+    {
+        Span span = startSpan("getMaterializedViewTableHandleForExecute", tableHandle);
+        try (var _ = scopedSpan(span)) {
+            return delegate.getMaterializedViewTableHandleForExecute(session, accessControl, tableHandle, procedureName, executeProperties, retryMode);
+        }
+    }
+
+    @Override
     public Set<ColumnHandle> getColumnHandlesForTableExecute(ConnectorSession connectorSession, ConnectorTableHandle tableHandle, ConnectorTableExecuteHandle connectorTableExecuteHandle)
     {
         Span span = startSpan("getColumnHandlesForTableExecute", tableHandle);

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -216,6 +216,16 @@ public class TracingMetadata
     }
 
     @Override
+    public Optional<TableExecuteHandle> getMaterializedViewTableHandleForExecute(Session session, TableHandle tableHandle, String procedureName, Map<String, Object> executeProperties)
+    {
+        Span span = startSpan("getMaterializedViewTableHandleForExecute", tableHandle)
+                .setAttribute(TrinoAttributes.PROCEDURE, procedureName);
+        try (var _ = scopedSpan(span)) {
+            return delegate.getMaterializedViewTableHandleForExecute(session, tableHandle, procedureName, executeProperties);
+        }
+    }
+
+    @Override
     public Set<ColumnHandle> getColumnHandlesForTableExecute(Session session, TableExecuteHandle tableExecuteHandle)
     {
         Span span = startSpan("getColumnHandlesForTableExecute", tableExecuteHandle);

--- a/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
@@ -105,6 +105,7 @@ import io.trino.sql.tree.FastForwardBranch;
 import io.trino.sql.tree.Grant;
 import io.trino.sql.tree.GrantRoles;
 import io.trino.sql.tree.Insert;
+import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.Prepare;
 import io.trino.sql.tree.Query;
@@ -198,6 +199,7 @@ public final class StatementUtils
             .add(basicStatement(ShowBranches.class, DESCRIBE))
             // Table Procedure
             .add(basicStatement(TableExecute.class, ALTER_TABLE_EXECUTE))
+            .add(basicStatement(MaterializedViewExecute.class, ALTER_TABLE_EXECUTE))
             // DML
             .add(basicStatement(CreateTableAsSelect.class, INSERT))
             .add(basicStatement(RefreshMaterializedView.class, INSERT))

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -158,6 +158,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public Optional<TableExecuteHandle> getMaterializedViewTableHandleForExecute(Session session, TableHandle tableHandle, String procedureName, Map<String, Object> executeProperties)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Set<ColumnHandle> getColumnHandlesForTableExecute(Session session, TableExecuteHandle tableExecuteHandle)
     {
         throw new UnsupportedOperationException();

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -96,6 +96,7 @@ import io.trino.sql.tree.LeaveStatement;
 import io.trino.sql.tree.LikeClause;
 import io.trino.sql.tree.Limit;
 import io.trino.sql.tree.LoopStatement;
+import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.MergeCase;
 import io.trino.sql.tree.MergeDelete;
@@ -1918,20 +1919,31 @@ public final class SqlFormatter
         @Override
         protected Void visitTableExecute(TableExecute node, Integer indent)
         {
-            builder.append("ALTER TABLE ");
-            builder.append(formatName(node.getTable().getName()));
+            return formatExecute(indent, "ALTER TABLE ", node.getTable().getName(), node.getProcedureName(), node.getArguments(), node.getWhere());
+        }
+
+        @Override
+        protected Void visitMaterializedViewExecute(MaterializedViewExecute node, Integer indent)
+        {
+            return formatExecute(indent, "ALTER MATERIALIZED VIEW ", node.getName(), node.getProcedureName(), node.getArguments(), node.getWhere());
+        }
+
+        private Void formatExecute(Integer indent, String keyword, QualifiedName name, Identifier procedureName, List<CallArgument> arguments, Optional<Expression> where)
+        {
+            builder.append(keyword);
+            builder.append(formatName(name));
             builder.append(" EXECUTE ");
-            builder.append(formatName(node.getProcedureName()));
-            if (!node.getArguments().isEmpty()) {
+            builder.append(formatName(procedureName));
+            if (!arguments.isEmpty()) {
                 builder.append("(");
-                formatCallArguments(indent, node.getArguments());
+                formatCallArguments(indent, arguments);
                 builder.append(")");
             }
-            node.getWhere().ifPresent(where -> builder
+            where.ifPresent(whereExpression -> builder
                     .append("\n")
                     .append(indentString(indent))
                     .append("WHERE ")
-                    .append(formatExpression(where)));
+                    .append(formatExpression(whereExpression)));
             return null;
         }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -185,6 +185,7 @@ import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.LoopStatement;
 import io.trino.sql.tree.MatchPredicate;
+import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.MeasureDefinition;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.MergeCase;
@@ -974,6 +975,22 @@ class AstBuilder
         return new TableExecute(
                 getLocation(context),
                 new Table(getLocation(context.TABLE()), getQualifiedName(context.tableName)),
+                (Identifier) visit(context.procedureName),
+                arguments,
+                visitIfPresent(context.booleanExpression(), Expression.class));
+    }
+
+    @Override
+    public Node visitMaterializedViewExecute(SqlBaseParser.MaterializedViewExecuteContext context)
+    {
+        List<CallArgument> arguments = ImmutableList.of();
+        if (context.argument() != null) {
+            arguments = visit(context.argument(), CallArgument.class);
+        }
+
+        return new MaterializedViewExecute(
+                getLocation(context),
+                new Table(getQualifiedName(context.qualifiedName())),
                 (Identifier) visit(context.procedureName),
                 arguments,
                 visitIfPresent(context.booleanExpression(), Expression.class));

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -812,6 +812,11 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitMaterializedViewExecute(MaterializedViewExecute node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
     protected R visitAnalyze(Analyze node, C context)
     {
         return visitStatement(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/MaterializedViewExecute.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/MaterializedViewExecute.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class MaterializedViewExecute
+        extends Statement
+{
+    private final Table table;
+    private final Identifier procedureName;
+    private final List<CallArgument> arguments;
+    private final Optional<Expression> where;
+
+    public MaterializedViewExecute(
+            NodeLocation location,
+            Table table,
+            Identifier procedureName,
+            List<CallArgument> arguments,
+            Optional<Expression> where)
+    {
+        super(location);
+        this.table = requireNonNull(table, "table is null");
+        this.procedureName = requireNonNull(procedureName, "procedureName is null");
+        this.arguments = requireNonNull(arguments, "arguments is null");
+        this.where = requireNonNull(where, "where is null");
+    }
+
+    public Table getTable()
+    {
+        return table;
+    }
+
+    public QualifiedName getName()
+    {
+        return table.getName();
+    }
+
+    public Identifier getProcedureName()
+    {
+        return procedureName;
+    }
+
+    public List<CallArgument> getArguments()
+    {
+        return arguments;
+    }
+
+    public Optional<Expression> getWhere()
+    {
+        return where;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitMaterializedViewExecute(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        ImmutableList.Builder<Node> nodes = ImmutableList.builder();
+        nodes.addAll(arguments);
+        where.ifPresent(nodes::add);
+        return nodes.build();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(table, procedureName, arguments, where);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MaterializedViewExecute that = (MaterializedViewExecute) o;
+        return Objects.equals(table, that.table) &&
+                Objects.equals(procedureName, that.procedureName) &&
+                Objects.equals(arguments, that.arguments) &&
+                Objects.equals(where, that.where);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("table", table)
+                .add("procedureName", procedureName)
+                .add("arguments", arguments)
+                .add("where", where)
+                .toString();
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -18,9 +18,11 @@ import io.trino.sql.tree.AddColumn;
 import io.trino.sql.tree.AllColumns;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.CallArgument;
 import io.trino.sql.tree.ColumnDefinition;
 import io.trino.sql.tree.ColumnPosition;
 import io.trino.sql.tree.Comment;
+import io.trino.sql.tree.ComparisonPredicate;
 import io.trino.sql.tree.CreateBranch;
 import io.trino.sql.tree.CreateCatalog;
 import io.trino.sql.tree.CreateMaterializedView;
@@ -37,9 +39,11 @@ import io.trino.sql.tree.GenericDataType;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.Insert;
 import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.MergeDelete;
 import io.trino.sql.tree.NodeLocation;
+import io.trino.sql.tree.Predicated;
 import io.trino.sql.tree.Property;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Query;
@@ -495,6 +499,41 @@ public class TestSqlFormatter
                         FROM
                           test_base
                         """);
+    }
+
+    @Test
+    public void testMaterializedViewExecute()
+    {
+        Table mv = new Table(QualifiedName.of("test_mv"));
+        Identifier procedure = new Identifier("optimize", false);
+
+        assertThat(formatSql(
+                new MaterializedViewExecute(new NodeLocation(1, 1), mv, procedure, ImmutableList.of(), Optional.empty())))
+                .isEqualTo("ALTER MATERIALIZED VIEW test_mv EXECUTE optimize");
+
+        assertThat(formatSql(
+                new MaterializedViewExecute(
+                        new NodeLocation(1, 1),
+                        mv,
+                        procedure,
+                        ImmutableList.of(new CallArgument(new NodeLocation(1, 1), Optional.of(new Identifier("file_size_threshold", false)), new StringLiteral("10MB"))),
+                        Optional.empty())))
+                .isEqualTo("ALTER MATERIALIZED VIEW test_mv EXECUTE optimize(file_size_threshold => '10MB')");
+
+        assertThat(formatSql(
+                new MaterializedViewExecute(
+                        new NodeLocation(1, 1),
+                        mv,
+                        procedure,
+                        ImmutableList.of(),
+                        Optional.of(new Predicated(
+                                new NodeLocation(1, 1),
+                                new Identifier("age", false),
+                                new ComparisonPredicate(new NodeLocation(1, 1), ComparisonPredicate.Operator.GREATER_THAN, new LongLiteral("17")))))))
+                .isEqualTo(
+                        """
+                        ALTER MATERIALIZED VIEW test_mv EXECUTE optimize
+                        WHERE (age > 17)""");
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -136,6 +136,7 @@ import io.trino.sql.tree.Literal;
 import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.MatchPredicate;
+import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.MeasureDefinition;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.MergeDelete;
@@ -5115,6 +5116,29 @@ public class TestSqlParser
                                         location(1, 50),
                                         new Identifier(location(1, 46), "age", false),
                                         new ComparisonPredicate(location(1, 50), ComparisonPredicate.Operator.GREATER_THAN, new LongLiteral(location(1, 52), "17"))))));
+    }
+
+    @Test
+    public void testMaterializedViewExecute()
+    {
+        Table mv = new Table(QualifiedName.of(ImmutableList.of(new Identifier(location(1, 25), "foo", false))));
+        Identifier procedure = new Identifier(location(1, 37), "bar", false);
+
+        assertThat(statement("ALTER MATERIALIZED VIEW foo EXECUTE bar"))
+                .isEqualTo(new MaterializedViewExecute(location(1, 1), mv, procedure, ImmutableList.of(), Optional.empty()));
+        assertThat(statement("ALTER MATERIALIZED VIEW foo EXECUTE bar(bah => 1, wuh => 'clap') WHERE age > 17")).isEqualTo(
+                new MaterializedViewExecute(
+                        location(1, 1),
+                        mv,
+                        procedure,
+                        ImmutableList.of(
+                                new CallArgument(location(1, 41), Optional.of(new Identifier(location(1, 41), "bah", false)), new LongLiteral(location(1, 48), "1")),
+                                new CallArgument(location(1, 51), Optional.of(new Identifier(location(1, 51), "wuh", false)), new StringLiteral(location(1, 58), "clap"))),
+                        Optional.of(
+                                new Predicated(
+                                        location(1, 76),
+                                        new Identifier(location(1, 72), "age", false),
+                                        new ComparisonPredicate(location(1, 76), ComparisonPredicate.Operator.GREATER_THAN, new LongLiteral(location(1, 78), "17"))))));
     }
 
     @Test

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -536,6 +536,12 @@
                                     <code>java.method.addedToInterface</code>
                                     <new>method boolean io.trino.spi.spool.SpoolingManager::isRecoverableException(java.io.IOException)</new>
                                 </item>
+                                <!-- Added getMaterializedViewTableHandleForExecute for ALTER MATERIALIZED VIEW EXECUTE; default throws NOT_SUPPORTED -->
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.addedToInterface</code>
+                                    <new>method java.util.Optional&lt;io.trino.spi.connector.ConnectorTableExecuteHandle&gt; io.trino.spi.connector.ConnectorMetadata::getMaterializedViewTableHandleForExecute(io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorAccessControl, io.trino.spi.connector.ConnectorTableHandle, java.lang.String, java.util.Map&lt;java.lang.String, java.lang.Object&gt;, io.trino.spi.connector.RetryMode)</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -140,6 +140,24 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Variant of {@link #getTableHandleForExecute} used when the procedure is invoked through the engine's
+     * materialized view execute syntax (naming the materialized view rather than {@code tableHandle}'s underlying
+     * table directly). Connectors that restrict procedures on materialized view storage can override this to apply
+     * those restrictions regardless of how the underlying storage table happens to be named. The default ignores
+     * {@code isMaterializedViewExecute} and behaves exactly like the base method.
+     */
+    default Optional<ConnectorTableExecuteHandle> getMaterializedViewTableHandleForExecute(
+            ConnectorSession session,
+            ConnectorAccessControl accessControl,
+            ConnectorTableHandle tableHandle,
+            String procedureName,
+            Map<String, Object> executeProperties,
+            RetryMode retryMode)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "This connector does not support materialized view procedures");
+    }
+
+    /**
      * Returns source table columns required to execute a table procedure.
      * <p>
      * Connectors may override this to return the exact source-column set needed for the procedure.

--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -2222,6 +2222,19 @@ The Iceberg connector supports the {ref}`WHEN STALE <mv-when-stale>` clause in
 {doc}`/sql/create-materialized-view` to control the behavior when a materialized
 view is stale. 
 
+You can perform physical maintenance of the storage table with {ref}`ALTER
+MATERIALIZED VIEW EXECUTE <alter-materialized-view-execute>`. Only the
+`optimize`, `optimize_manifests`, `expire_snapshots`, and `remove_orphan_files`
+procedures are supported; other procedures are rejected because they would
+desynchronize the storage table from the materialized view. Running a
+procedure requires the privilege to execute that procedure against the
+materialized view, and preserves the metadata used to determine freshness, so
+a subsequent `REFRESH MATERIALIZED VIEW` can still be incremental:
+
+```
+ALTER MATERIALIZED VIEW mv_name EXECUTE optimize
+```
+
 Dropping a materialized view with {doc}`/sql/drop-materialized-view` removes
 the definition and the storage table.
 

--- a/docs/src/main/sphinx/sql/alter-materialized-view.md
+++ b/docs/src/main/sphinx/sql/alter-materialized-view.md
@@ -6,6 +6,8 @@
 ALTER MATERIALIZED VIEW [ IF EXISTS ] name RENAME TO new_name
 ALTER MATERIALIZED VIEW name SET PROPERTIES property_name = expression [, ...]
 ALTER MATERIALIZED VIEW name SET AUTHORIZATION ( user | USER user | ROLE role )
+ALTER MATERIALIZED VIEW name EXECUTE command [ ( parameter => expression [, ... ] ) ]
+    [ WHERE expression ]
 ```
 
 ## Description
@@ -30,6 +32,35 @@ reverts its value back to the default in that materialized view.
 
 Support for `ALTER MATERIALIZED VIEW SET PROPERTIES` varies between
 connectors. Refer to the connector documentation for more details.
+
+(alter-materialized-view-execute)=
+### EXECUTE
+
+The `ALTER MATERIALIZED VIEW EXECUTE` statement followed by a `command` and
+`parameters` modifies the materialized view or its underlying storage
+according to the specified command and parameters.
+
+You can use the `=>` operator for passing named parameter values. The left side
+is the name of the parameter, the right side is the value being passed.
+
+Executable commands are contributed by connectors, such as the `optimize`
+command provided by the[Iceberg](iceberg-alter-table-execute) connector. For example, a user observing
+many small files in the storage of a often incrementally refreshed materialized view
+called `test_mv` in the `test` schema of the `example` catalog,
+can use the `optimize` command to merge all files below the `file_size_threshold` value.
+The result is fewer, but larger files, which typically results in higher query performance
+on the data in the files:
+
+```
+ALTER MATERIALIZED VIEW example.test.test_mv EXECUTE optimize(file_size_threshold => '16MB')
+```
+
+Running a command against a materialized view requires the privilege to
+execute that command against the view itself, not against its underlying
+storage table.
+
+Support for `ALTER MATERIALIZED VIEW EXECUTE` varies between connectors.
+Refer to the connector documentation for more details.
 
 ## Examples
 
@@ -69,6 +100,12 @@ Change owner of materialized view `people` to user `alice`:
 
 ```
 ALTER MATERIALIZED VIEW people SET AUTHORIZATION alice
+```
+
+Merge small files in the storage of materialized view `people`:
+
+```
+ALTER MATERIALIZED VIEW people EXECUTE optimize(file_size_threshold => '16MB')
 ```
 
 ## See also

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -213,6 +213,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public Optional<ConnectorTableExecuteHandle> getMaterializedViewTableHandleForExecute(ConnectorSession session, ConnectorAccessControl accessControl, ConnectorTableHandle tableHandle, String procedureName, Map<String, Object> executeProperties, RetryMode retryMode)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getMaterializedViewTableHandleForExecute(session, accessControl, tableHandle, procedureName, executeProperties, retryMode);
+        }
+    }
+
+    @Override
     public Map<String, Long> executeTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle)
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewSummary.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewSummary.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotUpdate;
+
+import java.util.List;
+import java.util.Map;
+
+public final class IcebergMaterializedViewSummary
+{
+    // Snapshot summary properties tracking the tables/functions a materialized view depends on, and its snapshot ids.
+    public static final String DEPENDS_ON_TABLES = "dependsOnTables";
+    public static final String DEPENDS_ON_TABLE_FUNCTIONS = "dependsOnTableFunctions";
+    public static final String DEPENDS_ON_NON_DETERMINISTIC_FUNCTIONS = "dependsOnNonDeterministicFunctions";
+    // Value should be ISO-8601 formatted time instant
+    public static final String TRINO_QUERY_START_TIME = "trino-query-start-time";
+
+    private static final List<String> DEPENDENCY_SUMMARY_PROPERTIES = ImmutableList.of(
+            DEPENDS_ON_TABLES,
+            DEPENDS_ON_TABLE_FUNCTIONS,
+            DEPENDS_ON_NON_DETERMINISTIC_FUNCTIONS,
+            TRINO_QUERY_START_TIME);
+
+    private IcebergMaterializedViewSummary() {}
+
+    /**
+     * Carries forward the materialized view dependency summary properties from the given snapshot onto the
+     * given snapshot update. Maintenance operations that commit a new snapshot on a materialized view storage table
+     * (OPTIMIZE, optimize_manifests) would otherwise drop these properties, which would
+     * break freshness computation and demote the next incremental refresh to a full refresh. This is a no-op for
+     * ordinary tables, which do not carry these properties.
+     * <p>
+     * Callers should pass the same snapshot the maintenance operation validated/scanned against, rather than
+     * re-reading the table's current snapshot, so the copied summary stays consistent with what was actually
+     * rewritten.
+     */
+    public static void carryForwardMaterializedViewDependencies(Snapshot snapshot, SnapshotUpdate<?> snapshotUpdate)
+    {
+        Map<String, String> summary = snapshot.summary();
+        for (String key : DEPENDENCY_SUMMARY_PROPERTIES) {
+            String value = summary.get(key);
+            if (value != null) {
+                snapshotUpdate.set(key, value);
+            }
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -901,7 +901,7 @@ public class IcebergMetadata
         SchemaTableName baseName = new SchemaTableName(tableName.getSchemaName(), name);
         try {
             return getMaterializedView(session, baseName)
-                    .flatMap(_ -> catalog.getMaterializedViewStorageTable(session, baseName))
+                    .map(definition -> loadMaterializedViewStorageTable(session, baseName, definition))
                     .or(() -> Optional.of(catalog.loadTable(session, baseName)));
         }
         catch (TableNotFoundException e) {
@@ -911,6 +911,24 @@ public class IcebergMetadata
             // avoid dealing with non Iceberg tables
             return Optional.empty();
         }
+    }
+
+    private BaseTable loadMaterializedViewStorageTable(ConnectorSession session, SchemaTableName materializedViewName, ConnectorMaterializedViewDefinition definition)
+    {
+        SchemaTableName storageTableName = getMaterializedViewStorageTableName(materializedViewName, definition);
+        // With iceberg.materialized-views.hide-storage-table disabled the storage table is a regular, separately-named Iceberg table.
+        if (!isMaterializedViewStorage(storageTableName.getTableName())) {
+            return catalog.loadTable(session, storageTableName);
+        }
+        return catalog.getMaterializedViewStorageTable(session, materializedViewName)
+                .orElseThrow(() -> new TrinoException(TABLE_NOT_FOUND, "Storage table metadata not found for materialized view " + materializedViewName));
+    }
+
+    private static SchemaTableName getMaterializedViewStorageTableName(SchemaTableName materializedViewName, ConnectorMaterializedViewDefinition materializedViewDefinition)
+    {
+        return materializedViewDefinition.getStorageTable()
+                .map(CatalogSchemaTableName::getSchemaTableName)
+                .orElseThrow(() -> new IllegalStateException("Storage table missing in definition of materialized view " + materializedViewName));
     }
 
     private Optional<SystemTable> getRawSystemTable(ConnectorSession session, SchemaTableName tableName)
@@ -1770,7 +1788,41 @@ public class IcebergMetadata
             Map<String, Object> executeProperties,
             RetryMode retryMode)
     {
-        IcebergTableHandle tableHandle = (IcebergTableHandle) connectorTableHandle;
+        return internalGetTableHandleForExecute(
+                session,
+                accessControl,
+                (IcebergTableHandle) connectorTableHandle,
+                procedureName,
+                executeProperties,
+                false);
+    }
+
+    @Override
+    public Optional<ConnectorTableExecuteHandle> getMaterializedViewTableHandleForExecute(
+            ConnectorSession session,
+            ConnectorAccessControl accessControl,
+            ConnectorTableHandle connectorTableHandle,
+            String procedureName,
+            Map<String, Object> executeProperties,
+            RetryMode retryMode)
+    {
+        return internalGetTableHandleForExecute(
+                session,
+                accessControl,
+                (IcebergTableHandle) connectorTableHandle,
+                procedureName,
+                executeProperties,
+                true);
+    }
+
+    private Optional<ConnectorTableExecuteHandle> internalGetTableHandleForExecute(
+            ConnectorSession session,
+            ConnectorAccessControl accessControl,
+            IcebergTableHandle tableHandle,
+            String procedureName,
+            Map<String, Object> executeProperties,
+            boolean isMaterializedViewExecute)
+    {
         checkArgument(tableHandle.getTableType() == DATA, "Cannot execute table procedure %s on non-DATA table: %s", procedureName, tableHandle.getTableType());
         Table icebergTable = catalog.loadTable(session, tableHandle.getSchemaTableName());
         if (tableHandle.getSnapshotId().isPresent() && (tableHandle.getSnapshotId().orElseThrow() != icebergTable.currentSnapshot().snapshotId())) {
@@ -1785,7 +1837,8 @@ public class IcebergMetadata
             throw new IllegalArgumentException("Unknown procedure '" + procedureName + "'");
         }
 
-        if (isMaterializedViewStorage(tableHandle.getSchemaTableName().getTableName()) && !MATERIALIZED_VIEW_STORAGE_ALLOWED_PROCEDURES.contains(procedureId)) {
+        boolean isExecutedOnMaterializedViewStorageTable = isMaterializedViewStorage(tableHandle.getSchemaTableName().getTableName()) || isMaterializedViewExecute;
+        if (isExecutedOnMaterializedViewStorageTable && !MATERIALIZED_VIEW_STORAGE_ALLOWED_PROCEDURES.contains(procedureId)) {
             throw new TrinoException(NOT_SUPPORTED, "Table procedure %s is not supported on a materialized view storage table".formatted(procedureName));
         }
 
@@ -4178,9 +4231,7 @@ public class IcebergMetadata
             return new MaterializedViewFreshness(STALE, Optional.empty());
         }
 
-        SchemaTableName storageTableName = materializedViewDefinition.get().getStorageTable()
-                .map(CatalogSchemaTableName::getSchemaTableName)
-                .orElseThrow(() -> new IllegalStateException("Storage table missing in definition of materialized view " + materializedViewName));
+        SchemaTableName storageTableName = getMaterializedViewStorageTableName(materializedViewName, materializedViewDefinition.get());
 
         Table icebergTable = catalog.loadTable(session, storageTableName);
         Optional<Snapshot> currentSnapshot = Optional.ofNullable(icebergTable.currentSnapshot());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -299,6 +299,11 @@ import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_MISSING_METADATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_UNSUPPORTED_VIEW_DIALECT;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.DEPENDS_ON_NON_DETERMINISTIC_FUNCTIONS;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.DEPENDS_ON_TABLES;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.DEPENDS_ON_TABLE_FUNCTIONS;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.TRINO_QUERY_START_TIME;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.carryForwardMaterializedViewDependencies;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.FILE_MODIFIED_TIME;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.FILE_PATH;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.LAST_UPDATED_SEQUENCE_NUMBER;
@@ -496,12 +501,14 @@ public class IcebergMetadata
 
     public static final int GET_METADATA_BATCH_SIZE = 1000;
     private static final MapSplitter MAP_SPLITTER = Splitter.on(",").trimResults().omitEmptyStrings().withKeyValueSeparator("=");
-
-    private static final String DEPENDS_ON_TABLES = "dependsOnTables";
-    private static final String DEPENDS_ON_TABLE_FUNCTIONS = "dependsOnTableFunctions";
-    private static final String DEPENDS_ON_NON_DETERMINISTIC_FUNCTIONS = "dependsOnNonDeterministicFunctions";
-    // Value should be ISO-8601 formatted time instant
-    private static final String TRINO_QUERY_START_TIME = "trino-query-start-time";
+    // Any procedure added here that commits a NEW snapshot must call
+    // IcebergMaterializedViewSummary.carryForwardMaterializedViewDependencies before committing, otherwise the
+    // materialized view's dependency summary is dropped and the next refresh is demoted from incremental to full.
+    private static final Set<IcebergTableProcedureId> MATERIALIZED_VIEW_STORAGE_ALLOWED_PROCEDURES = Sets.immutableEnumSet(
+            OPTIMIZE,
+            OPTIMIZE_MANIFESTS,
+            EXPIRE_SNAPSHOTS,
+            REMOVE_ORPHAN_FILES);
 
     private final CatalogName catalogName;
     private final TypeManager typeManager;
@@ -1778,6 +1785,10 @@ public class IcebergMetadata
             throw new IllegalArgumentException("Unknown procedure '" + procedureName + "'");
         }
 
+        if (isMaterializedViewStorage(tableHandle.getSchemaTableName().getTableName()) && !MATERIALIZED_VIEW_STORAGE_ALLOWED_PROCEDURES.contains(procedureId)) {
+            throw new TrinoException(NOT_SUPPORTED, "Table procedure %s is not supported on a materialized view storage table".formatted(procedureName));
+        }
+
         return switch (procedureId) {
             case OPTIMIZE -> getTableHandleForOptimize(tableHandle, icebergTable, executeProperties);
             case OPTIMIZE_MANIFESTS -> getTableHandleForOptimizeManifests(session, tableHandle);
@@ -2191,6 +2202,7 @@ public class IcebergMetadata
         rewriteFiles.dataSequenceNumber(snapshot.sequenceNumber());
         rewriteFiles.validateFromSnapshot(snapshot.snapshotId());
         rewriteFiles.scanManifestsWith(icebergScanExecutor);
+        carryForwardMaterializedViewDependencies(snapshot, rewriteFiles);
         commitUpdate(rewriteFiles, session, "optimize");
 
         long newSnapshotId = icebergTable.currentSnapshot().snapshotId();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/OptimizeManifests.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/OptimizeManifests.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RewriteManifests;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.metrics.CommitMetricsResult;
@@ -50,6 +51,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.carryForwardMaterializedViewDependencies;
 import static io.trino.plugin.iceberg.IcebergUtil.loadDataManifestsFromSnapshot;
 import static java.lang.Math.toIntExact;
 import static org.apache.iceberg.IcebergManifestUtils.liveEntries;
@@ -65,7 +67,8 @@ public final class OptimizeManifests
     public static Map<String, Long> optimizeManifests(BaseTable table, ExecutorService icebergScanExecutor)
     {
         // org.apache.iceberg.BaseRewriteManifests currently rewrites only data manifests
-        List<ManifestFile> manifests = loadDataManifestsFromSnapshot(table, table.currentSnapshot());
+        Snapshot snapshot = table.currentSnapshot();
+        List<ManifestFile> manifests = loadDataManifestsFromSnapshot(table, snapshot);
         if (manifests.isEmpty()) {
             return ImmutableMap.of();
         }
@@ -106,8 +109,9 @@ public final class OptimizeManifests
                     }
                     return clusteredPartitionValues.get(value);
                 })
-                .scanManifestsWith(icebergScanExecutor)
-                .commit();
+                .scanManifestsWith(icebergScanExecutor);
+        carryForwardMaterializedViewDependencies(snapshot, rewriteManifests);
+        rewriteManifests.commit();
 
         CommitReport report = reporter.commitReport();
         if (report == null) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -5758,7 +5758,7 @@ public abstract class BaseIcebergConnectorTest
     public void testOptimize()
             throws Exception
     {
-        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion < IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
+        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion <= IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
             String tableName = "test_optimize_" + randomNameSuffix();
             assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar) WITH (format_version = " + formatVersion + ")");
 
@@ -5888,7 +5888,7 @@ public abstract class BaseIcebergConnectorTest
     public void testOptimizeForPartitionedTable()
             throws IOException
     {
-        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion < IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
+        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion <= IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
             // This test will have its own session to make sure partitioning is indeed forced and is not a result
             // of session configuration
             Session session = testSessionBuilder()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -5816,6 +5816,75 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testOptimizeMaterializedView()
+            throws Exception
+    {
+        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion <= IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
+            String tableName = "test_optimize_" + randomNameSuffix();
+            assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar) WITH (format_version = " + formatVersion + ")");
+            String mvName = "test_optimize_mv_" + randomNameSuffix();
+            assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " WITH (format_version = " + formatVersion + ")" + " AS SELECT * FROM " + tableName);
+
+            // DistributedQueryRunner sets node-scheduler.include-coordinator by default, so include coordinator
+            int workerCount = getQueryRunner().getNodeCount();
+
+            // optimize an empty storage table
+            assertQuerySucceeds(withSingleWriterPerTask(getSession()), "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE");
+            assertThat(getSnapshotIds(mvName)).isEmpty();
+
+            assertUpdate("INSERT INTO " + tableName + " VALUES (11, 'eleven')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (12, 'zwölf')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (13, 'trzynaście')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (14, 'quatorze')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (15, 'пʼятнадцять')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+            List<String> initialFiles = getActiveFiles(mvName);
+            assertThat(initialFiles)
+                    .hasSize(5)
+                    // Verify we have sufficiently many test rows with respect to worker count.
+                    .hasSizeGreaterThan(workerCount);
+
+            // For optimize we need to set task_min_writer_count to 1, otherwise it will create more than one file.
+            assertUpdate(
+                    withSingleWriterPerTask(getSession()),
+                    "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE",
+                    "VALUES ('rewritten_data_files_count', 5), ('removed_delete_files_count', 0), ('added_data_files_count', 1)");
+            assertThat(query("SELECT sum(key), listagg(value, ' ') WITHIN GROUP (ORDER BY key) FROM " + mvName))
+                    .matches("VALUES (BIGINT '65', VARCHAR 'eleven zwölf trzynaście quatorze пʼятнадцять')");
+            List<String> updatedFiles = getActiveFiles(mvName);
+            assertThat(updatedFiles)
+                    .hasSizeBetween(1, workerCount)
+                    .doesNotContainAnyElementsOf(initialFiles);
+            // No files should be removed (this is expire_snapshots's job, when it exists)
+            assertThat(getAllDataFilesFromMvStorageTableDirectory(mvName))
+                    .containsExactlyInAnyOrderElementsOf(concat(initialFiles, updatedFiles));
+
+            // optimize with low retention threshold, nothing should change
+            // For optimize we need to set task_min_writer_count to 1, otherwise it will create more than one file.
+            computeActual(withSingleWriterPerTask(getSession()), "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE (file_size_threshold => '33B')");
+            assertThat(query("SELECT sum(key), listagg(value, ' ') WITHIN GROUP (ORDER BY key) FROM " + mvName))
+                    .matches("VALUES (BIGINT '65', VARCHAR 'eleven zwölf trzynaście quatorze пʼятнадцять')");
+            assertThat(getActiveFiles(mvName)).isEqualTo(updatedFiles);
+            assertThat(getAllDataFilesFromMvStorageTableDirectory(mvName))
+                    .containsExactlyInAnyOrderElementsOf(concat(initialFiles, updatedFiles));
+
+            // optimize with delimited procedure name
+            assertQueryFails("ALTER MATERIALIZED VIEW " + mvName + " EXECUTE \"optimize\"", "Table procedure not registered: optimize");
+            assertUpdate("ALTER MATERIALIZED VIEW " + mvName + " EXECUTE \"OPTIMIZE\"");
+            // optimize with delimited parameter name (and procedure name)
+            assertUpdate("ALTER MATERIALIZED VIEW " + mvName + " EXECUTE \"OPTIMIZE\" (\"file_size_threshold\" => '33B')"); // TODO (https://github.com/trinodb/trino/issues/11326) this should fail
+            assertUpdate("ALTER MATERIALIZED VIEW " + mvName + " EXECUTE \"OPTIMIZE\" (\"FILE_SIZE_THRESHOLD\" => '33B')");
+            assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
     public void testOptimizeForPartitionedTable()
             throws IOException
     {
@@ -6222,20 +6291,36 @@ public abstract class BaseIcebergConnectorTest
 
     protected String getTableLocation(String tableName)
     {
+        return getLocationFromShowCreate("SHOW CREATE TABLE " + tableName);
+    }
+
+    protected String getMvStorageTableLocation(String mvName)
+    {
+        return getLocationFromShowCreate("SHOW CREATE MATERIALIZED VIEW " + mvName);
+    }
+
+    private String getLocationFromShowCreate(String showCreateStatement)
+    {
         Pattern locationPattern = Pattern.compile(".*location = '(.*?)'.*", Pattern.DOTALL);
-        Matcher m = locationPattern.matcher((String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue());
+        Matcher m = locationPattern.matcher((String) computeActual(showCreateStatement).getOnlyValue());
         if (m.find()) {
             String location = m.group(1);
             verify(!m.find(), "Unexpected second match");
             return location;
         }
-        throw new IllegalStateException("Location not found in SHOW CREATE TABLE result");
+        throw new IllegalStateException("Location not found in " + showCreateStatement + " result");
     }
 
     protected List<String> getAllDataFilesFromTableDirectory(String tableName)
             throws IOException
     {
         return listFiles(getIcebergTableDataPath(getTableLocation(tableName)));
+    }
+
+    protected List<String> getAllDataFilesFromMvStorageTableDirectory(String mvName)
+            throws IOException
+    {
+        return listFiles(getIcebergTableDataPath(getMvStorageTableLocation(mvName)));
     }
 
     @Test
@@ -6940,6 +7025,42 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testExpireSnapshotsMaterializedView()
+            throws Exception
+    {
+        String tableName = "test_expiring_snapshots_" + randomNameSuffix();
+        String mvName = "test_expiring_snapshots_mv_" + randomNameSuffix();
+        Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
+        assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer)");
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + tableName);
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2)", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        assertThat(query("SELECT sum(value), listagg(key, ' ') WITHIN GROUP (ORDER BY key) FROM " + mvName))
+                .matches("VALUES (BIGINT '3', VARCHAR 'one two')");
+
+        List<Long> initialSnapshots = getSnapshotIds(mvName);
+        String tableLocation = getMvStorageTableLocation(mvName);
+        List<String> initialFiles = getAllMetadataFilesFromTableDirectory(tableLocation);
+        assertQuerySucceeds(sessionWithShortRetentionUnlocked, "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')");
+
+        assertThat(query("SELECT sum(value), listagg(key, ' ') WITHIN GROUP (ORDER BY key) FROM " + mvName))
+                .matches("VALUES (BIGINT '3', VARCHAR 'one two')");
+        List<String> updatedFiles = getAllMetadataFilesFromTableDirectory(tableLocation);
+        List<Long> updatedSnapshots = getSnapshotIds(mvName);
+        // MV refresh writes no per-snapshot Puffin .stats file (unlike a plain INSERT), so EXPIRE_SNAPSHOTS
+        // reclaims only manifest lists here — one fewer file than the plain-table case in testExpireSnapshots.
+        assertThat(updatedFiles).hasSize(initialFiles.size() - 1);
+        assertThat(updatedSnapshots.size()).isLessThan(initialSnapshots.size());
+        assertThat(updatedSnapshots).hasSize(1);
+        assertThat(initialSnapshots).containsAll(updatedSnapshots);
+    }
+
+    @Test
     public void testExpireSnapshotsPartitionedTable()
             throws Exception
     {
@@ -7192,6 +7313,44 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testRemoveOrphanFilesMaterializedView()
+            throws Exception
+    {
+        String tableName = "test_deleting_orphan_files_unnecessary_files" + randomNameSuffix();
+        String mvName = "test_deleting_orphan_files_unnecessary_files_mv_" + randomNameSuffix();
+        Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
+        assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer)");
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + tableName);
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2), ('three', 3)", 2);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 2);
+        assertUpdate("DELETE FROM " + tableName + " WHERE key = 'two'", 1);
+        // performs full refresh as there has been a DELETE, so refresh goes through whole table (2 rows)
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 2);
+        String location = getMvStorageTableLocation(mvName);
+        String orphanFile1 = getIcebergTableDataPath(location) + "/invalidData1." + format;
+        String orphanFile2 = getIcebergTableDataPath(location) + "/invalidData2." + format;
+        int orphanFile1Bytes = 123;
+        int orphanFile2Bytes = 456;
+        int totalOrphanBytes = orphanFile1Bytes + orphanFile2Bytes;
+        createFile(orphanFile1, new byte[orphanFile1Bytes]);
+        createFile(orphanFile2, new byte[orphanFile2Bytes]);
+        List<String> initialDataFiles = getAllDataFilesFromMvStorageTableDirectory(mvName);
+        assertThat(initialDataFiles).contains(orphanFile1, orphanFile2);
+
+        assertUpdate(
+                sessionWithShortRetentionUnlocked,
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')",
+                "VALUES ('processed_manifests_count', 5), ('active_files_count', 17), ('scanned_files_count', 19), ('deleted_files_count', 2), ('deleted_bytes', " + totalOrphanBytes + ")");
+        assertQuery("SELECT * FROM " + tableName, "VALUES ('one', 1), ('three', 3)");
+
+        List<String> updatedDataFiles = getAllDataFilesFromMvStorageTableDirectory(mvName);
+        assertThat(updatedDataFiles.size()).isLessThan(initialDataFiles.size());
+        assertThat(updatedDataFiles).doesNotContain(orphanFile1, orphanFile2);
+    }
+
+    @Test
     public void testIfRemoveOrphanFilesCleansUnnecessaryDataFilesInPartitionedTable()
             throws Exception
     {
@@ -7267,7 +7426,7 @@ public abstract class BaseIcebergConnectorTest
         List<String> prunedMetadataFiles = getAllMetadataFilesFromTableDirectory(tableDirectory);
         List<Long> prunedSnapshots = getSnapshotIds(tableName);
         assertThat(prunedMetadataFiles).as("prunedMetadataFiles")
-                .hasSize(initialMetadataFiles.size() - 2);
+                .hasSizeLessThan(initialMetadataFiles.size());
         assertThat(prunedSnapshots).as("prunedSnapshots")
                 .hasSizeLessThan(initialSnapshots.size())
                 .hasSize(1);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -1112,24 +1112,59 @@ public abstract class BaseIcebergMaterializedViewTest
     @Test
     public void testUnsafeProcedureRejectedOnMaterializedView()
     {
+        testUnsafeProcedureRejectedOnMaterializedView(getSession());
+    }
+
+    @Test
+    public void testUnsafeProcedureRejectedOnMaterializedViewWithVisibleStorageTable()
+    {
+        // With iceberg.materialized-views.hide-storage-table disabled, the storage table is a plain
+        // "st_<uuid>"-named table rather than "<mv>$materialized_view_storage", so the connector cannot
+        // recognize it as materialized view storage by name alone; the engine must still signal that the
+        // procedure was reached through ALTER MATERIALIZED VIEW EXECUTE. iceberg_legacy_mv is set up (sharing
+        // the same underlying storage as the default catalog) exactly for this case.
+        testUnsafeProcedureRejectedOnMaterializedView(Session.builder(getSession())
+                .setCatalog("iceberg_legacy_mv")
+                .build());
+    }
+
+    private void testUnsafeProcedureRejectedOnMaterializedView(Session session)
+    {
         String mvName = "test_unsafe_procedure_mv_" + randomNameSuffix();
-        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM base_table1");
-        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 6);
+        assertUpdate(session, "CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM base_table1");
+        assertUpdate(session, "REFRESH MATERIALIZED VIEW " + mvName, 6);
 
         // Procedures that would change the storage table's logical contents or desync it from the materialized view
         // are rejected; only physical maintenance is allowed.
         assertQueryFails(
+                session,
                 "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE DROP_EXTENDED_STATS",
                 "Table procedure DROP_EXTENDED_STATS is not supported on a materialized view storage table");
 
-        long snapshotId = (long) computeScalar("SELECT snapshot_id FROM \"" + mvName + "$snapshots\" ORDER BY committed_at LIMIT 1");
+        long snapshotId = (long) computeScalar(session, "SELECT snapshot_id FROM \"" + mvName + "$snapshots\" ORDER BY committed_at LIMIT 1");
         assertQueryFails(
+                session,
                 "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE ROLLBACK_TO_SNAPSHOT(" + snapshotId + ")",
                 "Table procedure ROLLBACK_TO_SNAPSHOT is not supported on a materialized view storage table");
 
         assertQueryFails(
+                session,
                 "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE ADD_FILES_FROM_TABLE(schema_name => CURRENT_SCHEMA, table_name => 'base_table1')",
                 "Table procedure ADD_FILES_FROM_TABLE is not supported on a materialized view storage table");
+
+        assertUpdate(session, "DROP MATERIALIZED VIEW " + mvName);
+    }
+
+    @Test
+    public void testUnallowedProcedureRejectedOnHiddenStorageTableByName()
+    {
+        String mvName = "test_unsafe_procedure_storage_" + randomNameSuffix();
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM base_table1");
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 6);
+
+        assertQueryFails(
+                "ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE DROP_EXTENDED_STATS",
+                "Table procedure DROP_EXTENDED_STATS is not supported on a materialized view storage table");
 
         assertUpdate("DROP MATERIALIZED VIEW " + mvName);
     }
@@ -1167,6 +1202,41 @@ public abstract class BaseIcebergMaterializedViewTest
 
         assertUpdate("DROP MATERIALIZED VIEW " + mvName);
         assertUpdate("DROP TABLE " + sourceTable);
+    }
+
+    @Test
+    public void testOptimizeMaterializedViewWithVisibleStorageTable()
+    {
+        // With iceberg.materialized-views.hide-storage-table disabled the storage table is a plain "st_<uuid>" table
+        // rather than "<mv>$materialized_view_storage". OPTIMIZE must still compact it through ALTER MATERIALIZED VIEW
+        // EXECUTE; format version 3 additionally exercises the row-lineage columns the storage-table scan must expose.
+        Session session = Session.builder(getSession())
+                .setCatalog("iceberg_legacy_mv")
+                .setSystemProperty("task_min_writer_count", "1")
+                .build();
+        String sourceTable = "test_optimize_legacy_src_" + randomNameSuffix();
+        String mvName = "test_optimize_legacy_mv_" + randomNameSuffix();
+        assertUpdate(session, "CREATE TABLE " + sourceTable + " (key integer, value varchar) WITH (format_version = 3)");
+        assertUpdate(session, "CREATE MATERIALIZED VIEW " + mvName + " WITH (format_version = 3) AS SELECT * FROM " + sourceTable);
+
+        // Populate across several refreshes so the storage table ends up with multiple data files.
+        assertUpdate(session, "INSERT INTO " + sourceTable + " VALUES (1, 'a')", 1);
+        assertUpdate(session, "REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertUpdate(session, "INSERT INTO " + sourceTable + " VALUES (2, 'b')", 1);
+        assertUpdate(session, "REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertUpdate(session, "INSERT INTO " + sourceTable + " VALUES (3, 'c')", 1);
+        assertUpdate(session, "REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertThat((long) computeScalar(session, "SELECT count(*) FROM \"" + mvName + "$files\"")).isGreaterThan(1L);
+
+        assertQuerySucceeds(session, "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE");
+
+        // The storage table is compacted to a single file and its contents are preserved.
+        assertThat((long) computeScalar(session, "SELECT count(*) FROM \"" + mvName + "$files\"")).isEqualTo(1L);
+        assertThat(query(session, "SELECT * FROM " + mvName))
+                .matches("VALUES (1, CAST('a' AS varchar)), (2, CAST('b' AS varchar)), (3, CAST('c' AS varchar))");
+
+        assertUpdate(session, "DROP MATERIALIZED VIEW " + mvName);
+        assertUpdate(session, "DROP TABLE " + sourceTable);
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -78,6 +78,7 @@ import static io.trino.spi.function.table.TableFunctionProcessorState.Processed.
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.testing.MaterializedResult.DEFAULT_PRECISION;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.DROP_MATERIALIZED_VIEW;
+import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.EXECUTE_TABLE_PROCEDURE;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.REFRESH_MATERIALIZED_VIEW;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.RENAME_MATERIALIZED_VIEW;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
@@ -1070,6 +1071,233 @@ public abstract class BaseIcebergMaterializedViewTest
 
         assertUpdate("DROP MATERIALIZED VIEW " + mvName);
         assertUpdate("DROP TABLE base_table1_mv_copy");
+    }
+
+    @Test
+    public void testMaterializedViewMaintenanceAuthorizedByExecuteTableProcedurePrivilege()
+    {
+        String catalog = getSession().getCatalog().orElseThrow();
+        String schema = getSession().getSchema().orElseThrow();
+        String mvName = "test_optimize_ac_mv_" + randomNameSuffix();
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM base_table1");
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 6);
+
+        // Maintenance is authorized as execute-table-procedure on the materialized view itself.
+        assertAccessDenied(
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE",
+                "Cannot execute table procedure OPTIMIZE on " + catalog + "\\." + schema + "\\." + mvName,
+                privilege(format("%s.%s.%s.OPTIMIZE", catalog, schema, mvName), EXECUTE_TABLE_PROCEDURE));
+
+        // It is NOT gated by the refresh privilege: a maintenance runner should not need the ability
+        // to fully recompute and overwrite the view's contents.
+        assertAccessAllowed(
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE",
+                privilege(mvName, REFRESH_MATERIALIZED_VIEW));
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+    }
+
+    @Test
+    public void testUnsafeProcedureRejectedOnMaterializedView()
+    {
+        String mvName = "test_unsafe_procedure_mv_" + randomNameSuffix();
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM base_table1");
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 6);
+
+        // Procedures that would change the storage table's logical contents or desync it from the materialized view
+        // are rejected; only physical maintenance is allowed.
+        assertQueryFails(
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE DROP_EXTENDED_STATS",
+                "Table procedure DROP_EXTENDED_STATS is not supported on a materialized view storage table");
+
+        long snapshotId = (long) computeScalar("SELECT snapshot_id FROM \"" + mvName + "$snapshots\" ORDER BY committed_at LIMIT 1");
+        assertQueryFails(
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE ROLLBACK_TO_SNAPSHOT(" + snapshotId + ")",
+                "Table procedure ROLLBACK_TO_SNAPSHOT is not supported on a materialized view storage table");
+
+        assertQueryFails(
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE ADD_FILES_FROM_TABLE(schema_name => CURRENT_SCHEMA, table_name => 'base_table1')",
+                "Table procedure ADD_FILES_FROM_TABLE is not supported on a materialized view storage table");
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+    }
+
+    @Test
+    public void testMaterializedViewOptimizePreservesDependencyMetadata()
+    {
+        String sourceTable = "test_optimize_preserve_src_" + randomNameSuffix();
+        String mvName = "test_optimize_preserve_mv_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + sourceTable + " (id BIGINT)");
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 1, 2, 3", 3);
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + sourceTable);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 3);
+
+        // Baseline: a refresh after a single-row insert is incremental (only the delta is written).
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 4", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        // OPTIMIZE the storage table between refreshes.
+        assertUpdate("ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE");
+
+        // The dependency metadata survives the optimize snapshot.
+        assertThat((String) computeScalar(
+                "SELECT element_at(summary, 'dependsOnTables') FROM \"" + mvName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1"))
+                .isNotNull()
+                .contains(sourceTable);
+
+        // OPTIMIZE with no source change must not make the MV stale.
+        assertFreshness(mvName, "FRESH");
+
+        // The next refresh stays incremental: only the new delta row is written, not a full re-scan.
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 5", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertThat(computeScalar("SELECT count(*) FROM " + mvName)).isEqualTo(5L);
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        assertUpdate("DROP TABLE " + sourceTable);
+    }
+
+    @Test
+    public void testExecuteOnMissingMaterializedView()
+    {
+        String mvName = "non_existent_mv_" + randomNameSuffix();
+        assertQueryFails(
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE",
+                "line 1:1: Materialized view '.*\\." + mvName + "' does not exist");
+    }
+
+    @Test
+    public void testExecuteOnTable()
+    {
+        String tableName = "test_execute_on_table_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (id BIGINT)");
+
+        // ALTER MATERIALIZED VIEW EXECUTE resolves its target purely as a materialized view; a plain table
+        // named the same way is reported as a missing materialized view, exactly like a nonexistent name.
+        assertQueryFails(
+                "ALTER MATERIALIZED VIEW " + tableName + " EXECUTE OPTIMIZE",
+                "line 1:1: Materialized view '.*\\." + tableName + "' does not exist");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testExecuteOnView()
+    {
+        String viewName = "test_execute_on_view_" + randomNameSuffix();
+        assertUpdate("CREATE VIEW " + viewName + " AS SELECT * FROM base_table1");
+
+        assertQueryFails(
+                "ALTER MATERIALIZED VIEW " + viewName + " EXECUTE OPTIMIZE",
+                "line 1:1: Materialized view '.*\\." + viewName + "' does not exist");
+
+        assertUpdate("DROP VIEW " + viewName);
+    }
+
+    @Test
+    public void testMaterializedViewExecuteOptimizeWithWhere()
+    {
+        String sourceTable = "test_optimize_where_src_" + randomNameSuffix();
+        String mvName = "test_optimize_where_mv_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + sourceTable + " (id BIGINT, part BIGINT)");
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES (1, 1)", 1);
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES (2, 2)", 1);
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " WITH (partitioning = ARRAY['part']) AS SELECT * FROM " + sourceTable);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 2);
+
+        // A second incremental refresh appends a second file to both partitions.
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES (3, 1)", 1);
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES (4, 2)", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 2);
+
+        String storageTable = "\"" + mvName + "$materialized_view_storage\"";
+        assertThat((long) computeScalar("SELECT count(DISTINCT \"$path\") FROM " + storageTable + " WHERE part = 1"))
+                .isGreaterThanOrEqualTo(2);
+        long filesInPart2Before = (long) computeScalar("SELECT count(DISTINCT \"$path\") FROM " + storageTable + " WHERE part = 2");
+        assertThat(filesInPart2Before).isEqualTo(2L);
+
+        assertUpdate("ALTER MATERIALIZED VIEW " + mvName + " EXECUTE optimize WHERE part = 1");
+
+        // Only the matching partition is coalesced into a single file; the other partition is untouched.
+        assertThat((long) computeScalar("SELECT count(DISTINCT \"$path\") FROM " + storageTable + " WHERE part = 1"))
+                .isEqualTo(1);
+        assertThat((long) computeScalar("SELECT count(DISTINCT \"$path\") FROM " + storageTable + " WHERE part = 2"))
+                .isEqualTo(filesInPart2Before);
+
+        assertThat((long) computeScalar("SELECT count(*) FROM " + mvName)).isEqualTo(4L);
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        assertUpdate("DROP TABLE " + sourceTable);
+    }
+
+    @Test
+    public void testMaterializedViewExpireSnapshotsPreservesDependencyMetadata()
+    {
+        String sourceTable = "test_expire_preserve_src_" + randomNameSuffix();
+        String mvName = "test_expire_preserve_mv_" + randomNameSuffix();
+        Session shortRetentionSession = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "expire_snapshots_min_retention", "0s")
+                .build();
+        assertUpdate("CREATE TABLE " + sourceTable + " (id BIGINT)");
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 1, 2, 3", 3);
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + sourceTable);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 3);
+
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 4", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        assertUpdate(shortRetentionSession, "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')");
+
+        // EXPIRE_SNAPSHOTS commits no new snapshot; the dependency metadata stays on the retained current snapshot.
+        String dependencyMetadataAfterExpire = (String) computeScalar(
+                "SELECT element_at(summary, 'dependsOnTables') FROM \"" + mvName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1");
+        assertThat(dependencyMetadataAfterExpire)
+                .isNotNull()
+                .contains(sourceTable);
+
+        assertFreshness(mvName, "FRESH");
+
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 5", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertThat(computeScalar("SELECT count(*) FROM " + mvName)).isEqualTo(5L);
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        assertUpdate("DROP TABLE " + sourceTable);
+    }
+
+    @Test
+    public void testMaterializedViewRemoveOrphanFilesPreservesDependencyMetadata()
+    {
+        String sourceTable = "test_remove_orphan_preserve_src_" + randomNameSuffix();
+        String mvName = "test_remove_orphan_preserve_mv_" + randomNameSuffix();
+        Session shortRetentionSession = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "remove_orphan_files_min_retention", "0s")
+                .build();
+        assertUpdate("CREATE TABLE " + sourceTable + " (id BIGINT)");
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 1, 2, 3", 3);
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + sourceTable);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 3);
+
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 4", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        assertUpdate(shortRetentionSession, "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')");
+
+        // REMOVE_ORPHAN_FILES only deletes unreferenced files; the dependency metadata stays on the untouched current snapshot.
+        String dependencyMetadataAfterRemoveOrphans = (String) computeScalar(
+                "SELECT element_at(summary, 'dependsOnTables') FROM \"" + mvName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1");
+        assertThat(dependencyMetadataAfterRemoveOrphans)
+                .isNotNull()
+                .contains(sourceTable);
+
+        assertFreshness(mvName, "FRESH");
+
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 5", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertThat(computeScalar("SELECT count(*) FROM " + mvName)).isEqualTo(5L);
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        assertUpdate("DROP TABLE " + sourceTable);
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -1094,6 +1094,18 @@ public abstract class BaseIcebergMaterializedViewTest
                 "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE",
                 privilege(mvName, REFRESH_MATERIALIZED_VIEW));
 
+        // SELECT is checked against the materialized view's own name, matching the privilege required to read
+        // it, not against its (possibly hidden) storage table.
+        assertAccessDenied(
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE",
+                "Cannot select from columns .*",
+                privilege(mvName, SELECT_COLUMN));
+
+        // A grant or deny on the storage table's own synthetic name is irrelevant to this statement.
+        assertAccessAllowed(
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE",
+                privilege(mvName + "$materialized_view_storage", SELECT_COLUMN));
+
         assertUpdate("DROP MATERIALIZED VIEW " + mvName);
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergOptimizeManifestsProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergOptimizeManifestsProcedure.java
@@ -129,6 +129,54 @@ final class TestIcebergOptimizeManifestsProcedure
     }
 
     @Test
+    void testOptimizeManifestsOnMaterializedView()
+    {
+        try (TestTable table = newTrinoTable("test_optimize_manifests_on_mv_storage_table", "(x int)")) {
+            String mvName = "test_optimize_manifests_mv_" + randomNameSuffix();
+            assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + table.getName());
+
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 1", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 2", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+            Set<String> manifestFiles = manifestFiles(mvName);
+            assertThat(manifestFiles).hasSize(2);
+
+            // The two data manifests are combined into one.
+            assertUpdate(
+                    "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE optimize_manifests",
+                    "VALUES " +
+                            "('rewritten_manifests_count', 2), " +
+                            "('added_manifests_count', 1), " +
+                            "('kept_manifests_count', 0), " +
+                            "('processed_manifest_entries_count', 2)");
+            Set<String> optimizedManifestFiles = manifestFiles(mvName);
+            assertThat(optimizedManifestFiles).hasSize(1);
+            assertThat(Sets.intersection(optimizedManifestFiles, manifestFiles)).isEmpty();
+
+            assertThat(query("SELECT * FROM " + mvName))
+                    .matches("VALUES 1, 2");
+
+            String dependencyMetadataAfterOptimizeManifests = (String) computeScalar(
+                    "SELECT element_at(summary, 'dependsOnTables') FROM \"" + mvName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1");
+            assertThat(dependencyMetadataAfterOptimizeManifests)
+                    .isNotNull()
+                    .contains(table.getName());
+
+            assertThat((String) computeScalar("SELECT freshness FROM system.metadata.materialized_views WHERE catalog_name = CURRENT_CATALOG AND schema_name = CURRENT_SCHEMA AND name = '" + mvName + "'"))
+                    .isEqualTo("FRESH");
+
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 3", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertThat(query("SELECT * FROM " + mvName))
+                    .matches("VALUES 1, 2, 3");
+
+            assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        }
+    }
+
+    @Test
     void testSplitManifests()
     {
         try (TestTable table = newTrinoTable("test_optimize_manifests", "(x int)")) {

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseMetadata.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseMetadata.java
@@ -188,6 +188,12 @@ public class LakehouseMetadata
     }
 
     @Override
+    public Optional<ConnectorTableExecuteHandle> getMaterializedViewTableHandleForExecute(ConnectorSession session, ConnectorAccessControl accessControl, ConnectorTableHandle tableHandle, String procedureName, Map<String, Object> executeProperties, RetryMode retryMode)
+    {
+        return forHandle(tableHandle).getMaterializedViewTableHandleForExecute(session, accessControl, tableHandle, procedureName, executeProperties, retryMode);
+    }
+
+    @Override
     public Set<ColumnHandle> getColumnHandlesForTableExecute(ConnectorSession connectorSession, ConnectorTableHandle tableHandle, ConnectorTableExecuteHandle connectorTableExecuteHandle)
     {
         return forHandle(tableHandle).getColumnHandlesForTableExecute(connectorSession, tableHandle, connectorTableExecuteHandle);

--- a/testing/trino-testing/src/main/java/io/trino/testing/QueryAssertions.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/QueryAssertions.java
@@ -341,7 +341,11 @@ public final class QueryAssertions
         List<MaterializedRow> actualRows = actualResults.getMaterializedRows();
         List<MaterializedRow> expectedRows = expectedResults.getMaterializedRows();
 
-        if (compareUpdate && !actualResults.getUpdateType().equals(Optional.of("ALTER TABLE EXECUTE"))) {
+        // ALTER TABLE EXECUTE and ALTER MATERIALIZED VIEW EXECUTE both return procedure metrics as rows
+        // (metric_name, metric_value), not a single scalar update count, so they are compared as ordinary rows below.
+        boolean isTableExecute = actualResults.getUpdateType().equals(Optional.of("ALTER TABLE EXECUTE")) ||
+                actualResults.getUpdateType().equals(Optional.of("ALTER MATERIALIZED VIEW EXECUTE"));
+        if (compareUpdate && !isTableExecute) {
             if (actualResults.getUpdateType().isEmpty()) {
                 fail("update type not present for query " + queryId + ": \n" + actual);
             }


### PR DESCRIPTION
## Description

Alternative approach of: https://github.com/trinodb/trino/pull/30335
Instead of exposing `ALTER TABLE <MV>$materialized_view_storage EXECUTE` use `ALTER MATERIALIZED VIEW <MV> EXECUTE`

Decided to open separate PR as revert and adding this approach there would be a mess.

Additional context:
**This PR aims to address the problem of lacking capabilities to manage storage table of iceberg materialized views.**

Connector checks against allow-listed procedure names, that are guaranteed to keep the MV storage table in consistent state and retain any custom properties, carried by the MV implementation, on the snapshots.

## Additional context and related issues

Follow-up of: https://github.com/trinodb/trino/pull/30218

Completes: https://github.com/trinodb/trino/issues/21797

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
##General
* Add support for `ALTER MATERIALIZED VIEW ... EXECUTE` syntax

##Iceberg connector                                                                                                                                                                                                 
* Add support for running `OPTIMIZE`, `OPTIMIZE_MANIFESTS`, `EXPIRE_SNAPSHOTS`, `REMOVE_ORPHAN_FILES` on materialized view storage table through `ALTER MATERIALIZED VIEW ... EXECUTE`

