### PR TITLE
Reduce coordinator memory usage for Iceberg writes with many files

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
@@ -27,7 +27,7 @@ public record CommitTaskData(
         IcebergFileFormat fileFormat,
         long fileSizeInBytes,
         MetricsWrapper metrics,
-        String partitionSpecJson,
+        int partitionSpecId,
         Optional<String> partitionDataJson,
         FileContent content,
         Optional<String> referencedDataFile,
@@ -40,7 +40,6 @@ public record CommitTaskData(
         requireNonNull(path, "path is null");
         requireNonNull(fileFormat, "fileFormat is null");
         requireNonNull(metrics, "metrics is null");
-        requireNonNull(partitionSpecJson, "partitionSpecJson is null");
         requireNonNull(partitionDataJson, "partitionDataJson is null");
         requireNonNull(content, "content is null");
         requireNonNull(referencedDataFile, "referencedDataFile is null");

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMergeSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMergeSink.java
@@ -33,7 +33,6 @@ import io.trino.spi.type.VarcharType;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.io.LocationProvider;
 
@@ -173,7 +172,7 @@ public class IcebergMergeSink
                         fileFormat,
                         0, // size of the v2 delete file
                         new MetricsWrapper(new Metrics(deletionVector.cardinality())),
-                        PartitionSpecParser.toJson(partitionSpec),
+                        partitionSpec.specId(),
                         partitionData.map(PartitionData::toJson),
                         FileContent.POSITION_DELETES,
                         Optional.of(dataFilePath.toStringUtf8()),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1693,12 +1693,7 @@ public class IcebergMetadata
             Collection<Slice> fragments,
             Collection<ComputedStatistics> computedStatistics)
     {
-        List<CommitTaskData> commitTasks = fragments.stream()
-                .map(Slice::getInput)
-                .map(commitTaskCodec::fromJson)
-                .collect(toImmutableList());
-
-        if (commitTasks.isEmpty()) {
+        if (fragments.isEmpty()) {
             transaction = null;
             return Optional.empty();
         }
@@ -1709,7 +1704,9 @@ public class IcebergMetadata
         AppendFiles appendFiles = isMergeManifestsOnWrite(session) ? transaction.newAppend() : transaction.newFastAppend();
         Map<Integer, SortOrder> sortOrders = icebergTable.sortOrders();
         PartitionSpec partitionSpec = icebergTable.spec();
-        for (CommitTaskData task : commitTasks) {
+        // Commit tasks are deserialized and converted one at a time to bound coordinator memory for writes producing many files
+        for (Slice fragment : fragments) {
+            CommitTaskData task = commitTaskCodec.fromJson(fragment.getInput());
             DataFiles.Builder builder = DataFiles.builder(partitionSpec)
                     .withPath(task.path())
                     .withFileSizeInBytes(task.fileSizeInBytes())
@@ -2155,15 +2152,11 @@ public class IcebergMetadata
         Set<DataFile> scannedDataFiles = scannedDataFilesBuilder.build();
         Set<DeleteFile> fullyAppliedDeleteFiles = scannedDeleteFilesBuilder.build();
 
-        List<CommitTaskData> commitTasks = fragments.stream()
-                .map(Slice::getInput)
-                .map(commitTaskCodec::fromJson)
-                .collect(toImmutableList());
-
         Set<DataFile> newFiles = new HashSet<>();
         Map<Integer, SortOrder> sortOrders = icebergTable.sortOrders();
         PartitionSpec partitionSpec = icebergTable.spec();
-        for (CommitTaskData task : commitTasks) {
+        for (Slice fragment : fragments) {
+            CommitTaskData task = commitTaskCodec.fromJson(fragment.getInput());
             DataFiles.Builder builder = DataFiles.builder(partitionSpec)
                     .withPath(task.path())
                     .withFileSizeInBytes(task.fileSizeInBytes())
@@ -3339,12 +3332,7 @@ public class IcebergMetadata
     {
         Table icebergTable = transaction.table();
 
-        List<CommitTaskData> commitTasks = fragments.stream()
-                .map(Slice::getInput)
-                .map(commitTaskCodec::fromJson)
-                .collect(toImmutableList());
-
-        if (commitTasks.isEmpty()) {
+        if (fragments.isEmpty()) {
             // Avoid recording "empty" write operation
             transaction = null;
             return;
@@ -3357,14 +3345,6 @@ public class IcebergMetadata
         if (baseSnapshotId.isPresent()) {
             rowDelta.validateFromSnapshot(icebergTable.snapshot(baseSnapshotId.getAsLong()).snapshotId());
         }
-        TupleDomain<IcebergColumnHandle> dataColumnPredicate = table.getEnforcedPredicate().filter((column, _) -> !isMetadataColumnId(column.getId()));
-        TupleDomain<IcebergColumnHandle> effectivePredicate = dataColumnPredicate.intersect(table.getUnenforcedPredicate());
-        effectivePredicate = effectivePredicate.intersect(extractTupleDomainsFromCommitTasks(table, icebergTable, commitTasks, typeManager));
-        effectivePredicate = effectivePredicate.filter((_, domain) -> isConvertibleToIcebergExpression(domain));
-
-        if (!effectivePredicate.isAll()) {
-            rowDelta.conflictDetectionFilter(toIcebergExpression(effectivePredicate));
-        }
         IsolationLevel isolationLevel = IsolationLevel.fromName(icebergTable.properties().getOrDefault(DELETE_ISOLATION_LEVEL, DELETE_ISOLATION_LEVEL_DEFAULT));
         if (isolationLevel == IsolationLevel.SERIALIZABLE) {
             rowDelta.validateNoConflictingDataFiles();
@@ -3375,108 +3355,122 @@ public class IcebergMetadata
         rowDelta.validateNoConflictingDeleteFiles();
         rowDelta.scanManifestsWith(icebergScanExecutor);
 
-        List<CommitTaskData> dataTasks = new ArrayList<>();
-        List<CommitTaskData> deleteTasks = new ArrayList<>();
+        int formatVersion = table.getFormatVersion();
+        Map<Integer, SortOrder> sortOrders = icebergTable.sortOrders();
+        CommitTaskDomainCollector domainCollector = new CommitTaskDomainCollector(icebergTable, typeManager);
+        ImmutableList.Builder<String> referencedDataFiles = ImmutableList.builder();
+        List<DeletionVectorInfo> deletionVectorInfos = new ArrayList<>();
+        boolean hasDeleteTasks = false;
 
-        for (CommitTaskData task : commitTasks) {
+        // Commit tasks are deserialized and converted one at a time to bound coordinator memory for writes producing many files
+        for (Slice fragment : fragments) {
+            CommitTaskData task = commitTaskCodec.fromJson(fragment.getInput());
+            PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, task.partitionSpecJson());
+            domainCollector.add(task, partitionSpec);
             switch (task.content()) {
-                case DATA -> dataTasks.add(task);
-                case POSITION_DELETES -> deleteTasks.add(task);
+                case DATA -> {
+                    DataFiles.Builder builder = DataFiles.builder(partitionSpec)
+                            .withPath(task.path())
+                            .withFormat(task.fileFormat().toIceberg())
+                            .withFileSizeInBytes(task.fileSizeInBytes())
+                            .withMetrics(task.metrics().metrics())
+                            .withSortOrder(sortOrders.get(task.sortOrderId()));
+                    task.fileSplitOffsets().ifPresent(builder::withSplitOffsets);
+
+                    if (partitionSpec.isPartitioned()) {
+                        String partitionDataJson = task.partitionDataJson()
+                                .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
+                        builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionSpec));
+                    }
+                    rowDelta.addRows(builder.build());
+                }
+                case POSITION_DELETES -> {
+                    if (formatVersion < 2) {
+                        throw new TrinoException(ICEBERG_BAD_DATA, "Position delete files are not supported for Iceberg format version < 2");
+                    }
+                    hasDeleteTasks = true;
+                    task.referencedDataFile().ifPresent(referencedDataFiles::add);
+                    if (formatVersion == 2) {
+                        FileMetadata.Builder deleteBuilder = FileMetadata.deleteFileBuilder(partitionSpec)
+                                .withPath(task.path())
+                                .withFormat(task.fileFormat().toIceberg())
+                                .ofPositionDeletes()
+                                .withFileSizeInBytes(task.fileSizeInBytes())
+                                .withMetrics(task.metrics().metrics());
+                        task.fileSplitOffsets().ifPresent(deleteBuilder::withSplitOffsets);
+                        if (partitionSpec.isPartitioned()) {
+                            deleteBuilder.withPartition(PartitionData.fromJson(
+                                    task.partitionDataJson().orElseThrow(() -> new VerifyException("No partition data for partitioned table")),
+                                    partitionSpec));
+                        }
+
+                        rowDelta.addDeletes(deleteBuilder.build());
+                    }
+                    else {
+                        // v3 delete: deletion vector for updated files are merged with any existing delection vectors or legacy position delete files.
+                        Optional<PartitionData> partitionData = partitionSpec.isPartitioned()
+                                ? Optional.of(PartitionData.fromJson(
+                                task.partitionDataJson().orElseThrow(() -> new VerifyException("No partition data for partitioned table")),
+                                partitionSpec))
+                                : Optional.empty();
+                        deletionVectorInfos.add(new DeletionVectorInfo(
+                                task.referencedDataFile().orElseThrow(() -> new VerifyException("v3 POSITION_DELETES task missing referencedDataFile")),
+                                task.serializedDeletionVector()
+                                        .map(Slices::wrappedBuffer)
+                                        .orElseThrow(() -> new VerifyException("v3 POSITION_DELETES task missing serializedDeletionVector")),
+                                partitionSpec,
+                                partitionData));
+                    }
+                }
                 case EQUALITY_DELETES, DATA_MANIFEST, DELETE_MANIFEST -> throw new UnsupportedOperationException("Unsupported task content: " + task.content());
             }
         }
 
-        Map<Integer, SortOrder> sortOrders = icebergTable.sortOrders();
-        for (CommitTaskData task : dataTasks) {
-            PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, task.partitionSpecJson());
-            DataFiles.Builder builder = DataFiles.builder(partitionSpec)
-                    .withPath(task.path())
-                    .withFormat(task.fileFormat().toIceberg())
-                    .withFileSizeInBytes(task.fileSizeInBytes())
-                    .withMetrics(task.metrics().metrics())
-                    .withSortOrder(sortOrders.get(task.sortOrderId()));
-            task.fileSplitOffsets().ifPresent(builder::withSplitOffsets);
+        TupleDomain<IcebergColumnHandle> dataColumnPredicate = table.getEnforcedPredicate().filter((column, _) -> !isMetadataColumnId(column.getId()));
+        TupleDomain<IcebergColumnHandle> effectivePredicate = dataColumnPredicate.intersect(table.getUnenforcedPredicate());
+        effectivePredicate = effectivePredicate.intersect(domainCollector.domains());
+        effectivePredicate = effectivePredicate.filter((_, domain) -> isConvertibleToIcebergExpression(domain));
 
-            if (partitionSpec.isPartitioned()) {
-                String partitionDataJson = task.partitionDataJson()
-                        .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
-                builder.withPartition(PartitionData.fromJson(partitionDataJson, partitionSpec));
-            }
-            rowDelta.addRows(builder.build());
+        if (!effectivePredicate.isAll()) {
+            rowDelta.conflictDetectionFilter(toIcebergExpression(effectivePredicate));
         }
 
-        if (deleteTasks.isEmpty()) {
-            commitUpdateAndTransaction(rowDelta, session, transaction, "write");
-            return;
+        if (hasDeleteTasks) {
+            rowDelta.validateDataFilesExist(referencedDataFiles.build());
         }
-
-        if (table.getFormatVersion() < 2) {
-            throw new TrinoException(ICEBERG_BAD_DATA, "Position delete files are not supported for Iceberg format version < 2");
+        if (!deletionVectorInfos.isEmpty()) {
+            deletionVectorWriter.writeDeletionVectors(session, icebergTable, table, deletionVectorInfos, rowDelta);
         }
-
-        rowDelta.validateDataFilesExist(deleteTasks.stream()
-                .map(CommitTaskData::referencedDataFile)
-                .flatMap(Optional::stream)
-                .toList());
-
-        if (table.getFormatVersion() == 2) {
-            for (CommitTaskData task : deleteTasks) {
-                PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, task.partitionSpecJson());
-                FileMetadata.Builder deleteBuilder = FileMetadata.deleteFileBuilder(partitionSpec)
-                        .withPath(task.path())
-                        .withFormat(task.fileFormat().toIceberg())
-                        .ofPositionDeletes()
-                        .withFileSizeInBytes(task.fileSizeInBytes())
-                        .withMetrics(task.metrics().metrics());
-                task.fileSplitOffsets().ifPresent(deleteBuilder::withSplitOffsets);
-                if (partitionSpec.isPartitioned()) {
-                    deleteBuilder.withPartition(PartitionData.fromJson(
-                            task.partitionDataJson().orElseThrow(() -> new VerifyException("No partition data for partitioned table")),
-                            partitionSpec));
-                }
-
-                rowDelta.addDeletes(deleteBuilder.build());
-            }
-            commitUpdateAndTransaction(rowDelta, session, transaction, "write");
-            return;
-        }
-
-        // v3 delete: deletion vector for updated files are merged with any existing delection vectors or legacy position delete files.
-        List<DeletionVectorInfo> deletionVectorInfos = deleteTasks.stream()
-                .map(task -> {
-                    PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, task.partitionSpecJson());
-                    Optional<PartitionData> partitionData = partitionSpec.isPartitioned()
-                            ? Optional.of(PartitionData.fromJson(
-                            task.partitionDataJson().orElseThrow(() -> new VerifyException("No partition data for partitioned table")),
-                            partitionSpec))
-                            : Optional.empty();
-                    return new DeletionVectorInfo(
-                            task.referencedDataFile().orElseThrow(() -> new VerifyException("v3 POSITION_DELETES task missing referencedDataFile")),
-                            task.serializedDeletionVector()
-                                    .map(Slices::wrappedBuffer)
-                                    .orElseThrow(() -> new VerifyException("v3 POSITION_DELETES task missing serializedDeletionVector")),
-                            partitionSpec,
-                            partitionData);
-                })
-                .toList();
-
-        deletionVectorWriter.writeDeletionVectors(session, icebergTable, table, deletionVectorInfos, rowDelta);
-
         commitUpdateAndTransaction(rowDelta, session, transaction, "write");
     }
 
-    static TupleDomain<IcebergColumnHandle> extractTupleDomainsFromCommitTasks(IcebergTableHandle table, Table icebergTable, List<CommitTaskData> commitTasks, TypeManager typeManager)
+    /**
+     * Collects identity partition value domains from commit tasks for the row-level conflict detection filter.
+     */
+    static class CommitTaskDomainCollector
     {
-        Set<IcebergColumnHandle> partitionColumns = new HashSet<>(getProjectedColumns(icebergTable.schema(), typeManager, identityPartitionColumnsInAllSpecs(icebergTable)));
-        PartitionSpec partitionSpec = icebergTable.spec();
-        Schema schema = SchemaParser.fromJson(table.getTableSchemaJson());
-        Map<IcebergColumnHandle, List<Domain>> domainsFromTasks = new HashMap<>();
-        for (CommitTaskData commitTask : commitTasks) {
-            PartitionSpec taskPartitionSpec = PartitionSpecParser.fromJson(schema, commitTask.partitionSpecJson());
+        private final PartitionSpec partitionSpec;
+        private final Set<IcebergColumnHandle> partitionColumns;
+        private final Map<IcebergColumnHandle, Set<Domain>> domainsFromTasks = new HashMap<>();
+        private boolean allTasksMatchTableSpec = true;
+
+        CommitTaskDomainCollector(Table icebergTable, TypeManager typeManager)
+        {
+            this.partitionSpec = icebergTable.spec();
+            this.partitionColumns = ImmutableSet.copyOf(getProjectedColumns(icebergTable.schema(), typeManager, identityPartitionColumnsInAllSpecs(icebergTable)));
+        }
+
+        void add(CommitTaskData commitTask, PartitionSpec taskPartitionSpec)
+        {
+            if (!allTasksMatchTableSpec) {
+                return;
+            }
             if (commitTask.partitionDataJson().isEmpty() || taskPartitionSpec.isUnpartitioned() || !taskPartitionSpec.equals(partitionSpec)) {
                 // We should not produce any specific domains if there are no partitions or current partitions does not match task partitions for any of tasks
                 // As each partition value narrows down conflict scope we should produce values from all commit tasks or not at all, to avoid partial information
-                return TupleDomain.all();
+                allTasksMatchTableSpec = false;
+                domainsFromTasks.clear();
+                return;
             }
 
             PartitionData partitionData = PartitionData.fromJson(commitTask.partitionDataJson().get(), partitionSpec);
@@ -3487,13 +3481,20 @@ public class IcebergMetadata
                 IcebergColumnHandle columnHandle = (IcebergColumnHandle) entry.getKey();
                 NullableValue value = entry.getValue();
                 Domain newDomain = value.isNull() ? Domain.onlyNull(columnHandle.getType()) : Domain.singleValue(columnHandle.getType(), value.getValue());
-                domainsFromTasks.computeIfAbsent(columnHandle, _ -> new ArrayList<>()).add(newDomain);
+                domainsFromTasks.computeIfAbsent(columnHandle, _ -> new HashSet<>()).add(newDomain);
             }
         }
-        return withColumnDomains(domainsFromTasks.entrySet().stream()
-                .collect(toImmutableMap(
-                        Entry::getKey,
-                        entry -> Domain.union(entry.getValue()))));
+
+        TupleDomain<IcebergColumnHandle> domains()
+        {
+            if (!allTasksMatchTableSpec) {
+                return TupleDomain.all();
+            }
+            return withColumnDomains(domainsFromTasks.entrySet().stream()
+                    .collect(toImmutableMap(
+                            Entry::getKey,
+                            entry -> Domain.union(ImmutableList.copyOf(entry.getValue())))));
+        }
     }
 
     @Override
@@ -4043,15 +4044,11 @@ public class IcebergMetadata
             log.info("Performing incremental MV refresh for storage table: %s", table.name());
         }
 
-        List<CommitTaskData> commitTasks = fragments.stream()
-                .map(Slice::getInput)
-                .map(commitTaskCodec::fromJson)
-                .collect(toImmutableList());
-
         AppendFiles appendFiles = isMergeManifestsOnWrite(session) ? transaction.newAppend() : transaction.newFastAppend();
         Map<Integer, SortOrder> sortOrders = icebergTable.sortOrders();
         PartitionSpec partitionSpec = icebergTable.spec();
-        for (CommitTaskData task : commitTasks) {
+        for (Slice fragment : fragments) {
+            CommitTaskData task = commitTaskCodec.fromJson(fragment.getInput());
             DataFiles.Builder builder = DataFiles.builder(partitionSpec)
                     .withPath(task.path())
                     .withFileSizeInBytes(task.fileSizeInBytes())

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -3338,8 +3338,6 @@ public class IcebergMetadata
             return;
         }
 
-        Schema schema = SchemaParser.fromJson(table.getTableSchemaJson());
-
         RowDelta rowDelta = transaction.newRowDelta();
         OptionalLong baseSnapshotId = table.getSnapshotId();
         if (baseSnapshotId.isPresent()) {
@@ -3357,6 +3355,7 @@ public class IcebergMetadata
 
         int formatVersion = table.getFormatVersion();
         Map<Integer, SortOrder> sortOrders = icebergTable.sortOrders();
+        Map<Integer, PartitionSpec> partitionSpecs = icebergTable.specs();
         CommitTaskDomainCollector domainCollector = new CommitTaskDomainCollector(icebergTable, typeManager);
         ImmutableList.Builder<String> referencedDataFiles = ImmutableList.builder();
         List<DeletionVectorInfo> deletionVectorInfos = new ArrayList<>();
@@ -3365,7 +3364,7 @@ public class IcebergMetadata
         // Commit tasks are deserialized and converted one at a time to bound coordinator memory for writes producing many files
         for (Slice fragment : fragments) {
             CommitTaskData task = commitTaskCodec.fromJson(fragment.getInput());
-            PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, task.partitionSpecJson());
+            PartitionSpec partitionSpec = verifyNotNull(partitionSpecs.get(task.partitionSpecId()), "No partition spec found for id %s", task.partitionSpecId());
             domainCollector.add(task, partitionSpec);
             switch (task.content()) {
                 case DATA -> {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -53,7 +53,6 @@ import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.transforms.Transform;
@@ -601,7 +600,7 @@ public class IcebergPageSink
                 fileFormat,
                 writer.getWrittenBytes(),
                 new MetricsWrapper(writer.getFileMetrics().metrics()),
-                PartitionSpecParser.toJson(partitionSpec),
+                partitionSpec.specId(),
                 writeContext.getPartitionData().map(PartitionData::toJson),
                 DATA,
                 Optional.empty(),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/PositionDeleteWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/PositionDeleteWriter.java
@@ -28,7 +28,6 @@ import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.connector.ConnectorSession;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.io.LocationProvider;
 
@@ -87,7 +86,7 @@ public class PositionDeleteWriter
                 fileFormat,
                 writer.getWrittenBytes(),
                 new MetricsWrapper(writer.getFileMetrics().metrics()),
-                PartitionSpecParser.toJson(partitionSpec),
+                partitionSpec.specId(),
                 partition.map(PartitionData::toJson),
                 FileContent.POSITION_DELETES,
                 Optional.of(dataFilePath),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestFileBasedConflictDetection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestFileBasedConflictDetection.java
@@ -15,7 +15,6 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.RowType;
@@ -23,7 +22,6 @@ import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.hadoop.HadoopTables;
@@ -33,16 +31,14 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.OptionalLong;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.iceberg.ColumnIdentity.TypeCategory.PRIMITIVE;
 import static io.trino.plugin.iceberg.ColumnIdentity.TypeCategory.STRUCT;
-import static io.trino.plugin.iceberg.IcebergMetadata.extractTupleDomainsFromCommitTasks;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static org.apache.iceberg.FileContent.DATA;
 import static org.apache.iceberg.FileContent.POSITION_DELETES;
 import static org.apache.iceberg.types.Types.NestedField.optional;
@@ -81,7 +77,7 @@ class TestFileBasedConflictDetection
         Table icebergTable = createIcebergTable(partitionSpec);
 
         List<CommitTaskData> commitTasks = getCommitTaskDataForUpdate(partitionSpec, Optional.empty());
-        TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomainsFromCommitTasks(getIcebergTableHandle(partitionSpec), icebergTable, commitTasks, null);
+        TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomains(icebergTable, commitTasks);
         assertThat(icebergColumnHandleTupleDomain.getDomains().orElseThrow()).isEmpty();
 
         dropIcebergTable(icebergTable);
@@ -101,7 +97,7 @@ class TestFileBasedConflictDetection
                 """;
         Map<IcebergColumnHandle, Domain> expectedDomains = Map.of(COLUMN_2_HANDLE, Domain.singleValue(INTEGER, 40L));
         List<CommitTaskData> commitTasks = getCommitTaskDataForUpdate(partitionSpec, Optional.of(partitionDataJson));
-        TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomainsFromCommitTasks(getIcebergTableHandle(partitionSpec), icebergTable, commitTasks, null);
+        TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomains(icebergTable, commitTasks);
         assertThat(icebergColumnHandleTupleDomain.getDomains().orElseThrow()).isEqualTo(expectedDomains);
 
         dropIcebergTable(icebergTable);
@@ -128,7 +124,7 @@ class TestFileBasedConflictDetection
         List<CommitTaskData> commitTasks = Stream.concat(
                 getCommitTaskDataForUpdate(partitionSpec, Optional.of(partitionDataJson1)).stream(),
                 getCommitTaskDataForUpdate(partitionSpec, Optional.of(partitionDataJson2)).stream()).collect(toImmutableList());
-        TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomainsFromCommitTasks(getIcebergTableHandle(partitionSpec), icebergTable, commitTasks, null);
+        TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomains(icebergTable, commitTasks);
         assertThat(icebergColumnHandleTupleDomain.getDomains().orElseThrow()).isEqualTo(expectedDomains);
 
         dropIcebergTable(icebergTable);
@@ -148,7 +144,7 @@ class TestFileBasedConflictDetection
                 """;
         Map<IcebergColumnHandle, Domain> expectedDomains = Map.of(CHILD_COLUMN_HANDLE, Domain.singleValue(INTEGER, 40L));
         List<CommitTaskData> commitTasks = getCommitTaskDataForUpdate(partitionSpec, Optional.of(partitionDataJson));
-        TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomainsFromCommitTasks(getIcebergTableHandle(partitionSpec), icebergTable, commitTasks, null);
+        TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomains(icebergTable, commitTasks);
         assertThat(icebergColumnHandleTupleDomain.getDomains().orElseThrow()).isEqualTo(expectedDomains);
 
         dropIcebergTable(icebergTable);
@@ -169,7 +165,7 @@ class TestFileBasedConflictDetection
                 """;
         Map<IcebergColumnHandle, Domain> expectedDomains = Map.of(COLUMN_2_HANDLE, Domain.singleValue(INTEGER, 40L), COLUMN_1_HANDLE, Domain.singleValue(INTEGER, 12L));
         List<CommitTaskData> commitTasks = getCommitTaskDataForUpdate(partitionSpec, Optional.of(partitionDataJson));
-        TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomainsFromCommitTasks(getIcebergTableHandle(partitionSpec), icebergTable, commitTasks, null);
+        TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomains(icebergTable, commitTasks);
         assertThat(icebergColumnHandleTupleDomain.getDomains().orElseThrow()).isEqualTo(expectedDomains);
 
         dropIcebergTable(icebergTable);
@@ -190,7 +186,7 @@ class TestFileBasedConflictDetection
                 """;
         Map<IcebergColumnHandle, Domain> expectedDomains = Map.of(COLUMN_2_HANDLE, Domain.singleValue(INTEGER, 40L), COLUMN_1_HANDLE, Domain.onlyNull(INTEGER));
         List<CommitTaskData> commitTasks = getCommitTaskDataForUpdate(partitionSpec, Optional.of(partitionDataJson));
-        TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomainsFromCommitTasks(getIcebergTableHandle(partitionSpec), icebergTable, commitTasks, null);
+        TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomains(icebergTable, commitTasks);
         assertThat(icebergColumnHandleTupleDomain.getDomains().orElseThrow()).isEqualTo(expectedDomains);
 
         dropIcebergTable(icebergTable);
@@ -236,7 +232,7 @@ class TestFileBasedConflictDetection
                 Optional.empty(),
                 SortOrder.unsorted().orderId(),
                 Optional.empty());
-        TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomainsFromCommitTasks(getIcebergTableHandle(currentPartitionSpec), icebergTable, List.of(commitTaskData1, commitTaskData2), null);
+        TupleDomain<IcebergColumnHandle> icebergColumnHandleTupleDomain = extractTupleDomains(icebergTable, List.of(commitTaskData1, commitTaskData2));
         assertThat(icebergColumnHandleTupleDomain.getDomains().orElseThrow()).isEmpty();
 
         dropIcebergTable(icebergTable);
@@ -273,30 +269,13 @@ class TestFileBasedConflictDetection
         return List.of(commitTaskData1, commitTaskData2);
     }
 
-    private static IcebergTableHandle getIcebergTableHandle(PartitionSpec partitionSpec)
+    private static TupleDomain<IcebergColumnHandle> extractTupleDomains(Table icebergTable, List<CommitTaskData> commitTasks)
     {
-        String partitionSpecJson = PartitionSpecParser.toJson(partitionSpec);
-        return new IcebergTableHandle(
-                "schemaName",
-                "tableName",
-                TableType.DATA,
-                OptionalLong.empty(),
-                SchemaParser.toJson(TABLE_SCHEMA),
-                OptionalInt.of(partitionSpec.specId()),
-                ImmutableMap.of(partitionSpec.specId(), partitionSpecJson),
-                1,
-                TupleDomain.all(),
-                TupleDomain.all(),
-                OptionalLong.empty(),
-                ImmutableSet.of(),
-                Optional.empty(),
-                "dummy_table_location",
-                ImmutableMap.of(),
-                Optional.empty(),
-                false,
-                Optional.empty(),
-                ImmutableSet.of(),
-                Optional.of(false));
+        IcebergMetadata.CommitTaskDomainCollector domainCollector = new IcebergMetadata.CommitTaskDomainCollector(icebergTable, TESTING_TYPE_MANAGER);
+        for (CommitTaskData task : commitTasks) {
+            domainCollector.add(task, PartitionSpecParser.fromJson(TABLE_SCHEMA, task.partitionSpecJson()));
+        }
+        return domainCollector.domains();
     }
 
     private static Table createIcebergTable(PartitionSpec partitionSpec)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestFileBasedConflictDetection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestFileBasedConflictDetection.java
@@ -20,7 +20,6 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.RowType;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
@@ -198,10 +197,11 @@ class TestFileBasedConflictDetection
         PartitionSpec previousPartitionSpec = PartitionSpec.builderFor(TABLE_SCHEMA)
                 .identity(COLUMN_1_NAME)
                 .build();
-        PartitionSpec currentPartitionSpec = PartitionSpec.builderFor(TABLE_SCHEMA)
-                .identity(COLUMN_2_NAME)
-                .build();
-        Table icebergTable = createIcebergTable(currentPartitionSpec);
+        Table icebergTable = createIcebergTable(previousPartitionSpec);
+        icebergTable.updateSpec()
+                .removeField(COLUMN_1_NAME)
+                .addField(COLUMN_2_NAME)
+                .commit();
 
         String partitionDataJson =
                 """
@@ -212,7 +212,7 @@ class TestFileBasedConflictDetection
                 IcebergFileFormat.PARQUET,
                 0,
                 new MetricsWrapper(new Metrics()),
-                PartitionSpecParser.toJson(currentPartitionSpec),
+                icebergTable.spec().specId(),
                 Optional.of(partitionDataJson),
                 DATA,
                 Optional.empty(),
@@ -225,7 +225,7 @@ class TestFileBasedConflictDetection
                 IcebergFileFormat.PARQUET,
                 0,
                 new MetricsWrapper(new Metrics()),
-                PartitionSpecParser.toJson(previousPartitionSpec),
+                previousPartitionSpec.specId(),
                 Optional.of(partitionDataJson),
                 POSITION_DELETES,
                 Optional.empty(),
@@ -246,7 +246,7 @@ class TestFileBasedConflictDetection
                 IcebergFileFormat.PARQUET,
                 0,
                 new MetricsWrapper(new Metrics()),
-                PartitionSpecParser.toJson(partitionSpec),
+                partitionSpec.specId(),
                 partitionDataJson,
                 DATA,
                 Optional.empty(),
@@ -258,7 +258,7 @@ class TestFileBasedConflictDetection
                 IcebergFileFormat.PARQUET,
                 0,
                 new MetricsWrapper(new Metrics()),
-                PartitionSpecParser.toJson(partitionSpec),
+                partitionSpec.specId(),
                 partitionDataJson,
                 POSITION_DELETES,
                 Optional.empty(),
@@ -273,7 +273,7 @@ class TestFileBasedConflictDetection
     {
         IcebergMetadata.CommitTaskDomainCollector domainCollector = new IcebergMetadata.CommitTaskDomainCollector(icebergTable, TESTING_TYPE_MANAGER);
         for (CommitTaskData task : commitTasks) {
-            domainCollector.add(task, PartitionSpecParser.fromJson(TABLE_SCHEMA, task.partitionSpecJson()));
+            domainCollector.add(task, icebergTable.specs().get(task.partitionSpecId()));
         }
         return domainCollector.domains();
     }
@@ -284,7 +284,7 @@ class TestFileBasedConflictDetection
                 TABLE_SCHEMA,
                 partitionSpec,
                 SortOrder.unsorted(),
-                ImmutableMap.of("write.format.default", "ORC"),
+                ImmutableMap.of("write.format.default", "ORC", "format-version", "2"),
                 "table_location" + randomNameSuffix());
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -261,6 +261,19 @@ public class TestIcebergV2
     }
 
     @Test
+    public void testPositionDeletesAfterPartitionSpecEvolution()
+    {
+        try (TestTable table = newTrinoTable("test_position_deletes_after_partition_evolution_", "WITH (partitioning = ARRAY['regionkey']) AS SELECT * FROM tpch.tiny.nation")) {
+            assertUpdate("ALTER TABLE " + table.getName() + " SET PROPERTIES partitioning = ARRAY['bucket(name, 4)']");
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (25, 'ATLANTIS', 0, 'mythical')", 1);
+            // Deletes rows from data files written under both the previous and the current partition spec
+            assertUpdate("DELETE FROM " + table.getName() + " WHERE name LIKE 'A%'", 3);
+            assertQuery("SELECT count(*) FROM " + table.getName(), "VALUES 23");
+            assertQuery("SELECT count(*) FROM \"" + table.getName() + "$files\" WHERE content = " + POSITION_DELETES.id(), "VALUES 3");
+        }
+    }
+
+    @Test
     public void testV2TableWithPositionDelete()
             throws Exception
     {


### PR DESCRIPTION
## Description

Lowers coordinator peak memory for Iceberg write commits that produce a large number of files, in two steps:

1. Process commit task fragments one at a time in `finishWrite`, `finishInsert`, `finishOptimize` and `finishRefreshMaterializedView` instead of first materializing the full `List<CommitTaskData>`. Identity partition domains for the conflict detection filter are collected incrementally by the new `CommitTaskDomainCollector`.
2. Ship the partition spec ID in commit task fragments instead of the full serialized partition spec JSON, which was repeated in every per-file fragment. The coordinator resolves the spec from table metadata, which also removes the per-task spec JSON parsing.

## Additional context and related issues

A heap dump from a row-level DELETE touching ~3.5 million data files showed the coordinator OOM with 15 GB retained by the materialized `CommitTaskData` list on a 22 GB heap, on top of ~7 GB of raw fragments. The fragments themselves still accumulate in `TableFinishOperator` before the connector sees them, so this does not remove the O(files) floor, but it eliminates the largest term and shrinks the per-fragment payload.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Reduce coordinator memory usage when committing queries that write a large number of files. ({issue}`issuenumber`)
```
