### PR TITLE
Show only denied columns in Ranger error message

### DIFF
--- a/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java
+++ b/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java
@@ -46,11 +46,13 @@ import java.io.File;
 import java.net.URL;
 import java.security.Principal;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -102,6 +104,7 @@ import static io.trino.spi.security.AccessDeniedException.denyRenameSchema;
 import static io.trino.spi.security.AccessDeniedException.denyRenameTable;
 import static io.trino.spi.security.AccessDeniedException.denyRenameView;
 import static io.trino.spi.security.AccessDeniedException.denySelectColumns;
+import static io.trino.spi.security.AccessDeniedException.denySelectTable;
 import static io.trino.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static io.trino.spi.security.AccessDeniedException.denySetMaterializedViewProperties;
 import static io.trino.spi.security.AccessDeniedException.denySetSchemaAuthorization;
@@ -518,9 +521,23 @@ public class RangerSystemAccessControl
     @Override
     public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
     {
+        List<RangerTrinoResource> errorResources = new ArrayList<>();
         for (RangerTrinoResource resource : RangerTrinoResource.forColumns(table.getCatalogName(), table.getSchemaTableName().getSchemaName(), table.getSchemaTableName().getTableName(), columns)) {
             if (!hasPermission(resource, context, SELECT, "SelectFromColumns")) {
-                denySelectColumns(table.getSchemaTableName().getTableName(), columns);
+                errorResources.add(resource);
+            }
+        }
+        if (!errorResources.isEmpty()) {
+            List<String> errorColumns = errorResources.stream()
+                    .map(resource -> resource.getAsMap().get(RangerTrinoResource.KEY_COLUMN))
+                    .filter(Objects::nonNull)
+                    .map(Object::toString)
+                    .toList();
+            if (errorColumns.isEmpty()) {
+                denySelectTable(table.getSchemaTableName().getTableName());
+            }
+            else {
+                denySelectColumns(table.getSchemaTableName().getTableName(), errorColumns);
             }
         }
     }

--- a/plugin/trino-ranger/src/test/java/io/trino/plugin/ranger/TestRangerSystemAccessControl.java
+++ b/plugin/trino-ranger/src/test/java/io/trino/plugin/ranger/TestRangerSystemAccessControl.java
@@ -64,6 +64,7 @@ final class TestRangerSystemAccessControl
     private static final CatalogSchemaRoutineName FUNC_ALICE_SCH1_FUNC1 = new CatalogSchemaRoutineName(CATALOG_ALICE, "sch1", "func1");
     private static final CatalogSchemaName SCHEMA_USER_BOB = new CatalogSchemaName(CATALOG_USER_HOME, "bob_schema");
     private static final CatalogSchemaTableName TABLE_USER_BOB_TBL1 = new CatalogSchemaTableName(CATALOG_USER_HOME, SCHEMA_USER_BOB.getSchemaName(), "tbl1");
+    private static final CatalogSchemaTableName TABLE_USER_SCH1_TBL1 = new CatalogSchemaTableName(CATALOG_USER_HOME, "sch1", "tbl1");
 
     @BeforeAll
     public static void setUpBeforeClass()
@@ -222,7 +223,10 @@ final class TestRangerSystemAccessControl
         assertThatThrownBy(() -> accessControlManager.checkCanRenameColumn(context(BOB), TABLE_ALICE_SCH1_TBL1)).isInstanceOf(AccessDeniedException.class);
         assertThatThrownBy(() -> accessControlManager.checkCanSetColumnComment(context(BOB), TABLE_ALICE_SCH1_TBL1)).isInstanceOf(AccessDeniedException.class);
         assertThatThrownBy(() -> accessControlManager.checkCanShowColumns(context(BOB), TABLE_ALICE_SCH1_TBL1)).isInstanceOf(AccessDeniedException.class);
-        assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(context(BOB), TABLE_ALICE_SCH1_TBL1, Optional.empty(), ImmutableSet.of())).isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(context(BOB), TABLE_ALICE_SCH1_TBL1, Optional.empty(), ImmutableSet.of())).isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("Cannot select from table tbl1");
+        assertThatThrownBy(() -> accessControlManager.checkCanSelectFromColumns(context(BOB), TABLE_USER_SCH1_TBL1, ImmutableSet.of("id", "name", "time"))).isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("Cannot select from columns [id, name] in table or view tbl1");
         assertThatThrownBy(() -> accessControlManager.checkCanUpdateTableColumns(context(BOB), TABLE_ALICE_SCH1_TBL1, Optional.empty(), Collections.emptySet())).isInstanceOf(AccessDeniedException.class);
     }
 

--- a/plugin/trino-ranger/src/test/resources/trino-policies.json
+++ b/plugin/trino-ranger/src/test/resources/trino-policies.json
@@ -300,6 +300,23 @@
       "policyItems": [
         { "accesses": [ { "type": "select" }, { "type": "insert" }, { "type": "create" }, { "type": "drop" }, { "type": "alter" }, { "type": "show" }, { "type": "grant" }, { "type": "revoke" } ], "users": [ "{USER}" ] }
       ]
+    },
+    {
+      "id":             30,
+      "service":        "dev_trino",
+      "serviceType":    "trino",
+      "name":           "allow access at column-level",
+      "policyType":     0,
+      "policyPriority": 0,
+      "resources": {
+        "catalog": { "values": [ "user-catalog" ] },
+        "schema":  { "values": [ "sch1" ] },
+        "table":   { "values": [ "tbl1" ] },
+        "column":  { "values": [ "time" ] }
+      },
+      "policyItems": [
+        { "accesses": [ { "type": "select" } ], "users": [ "bob" ] }
+      ]
     }
   ]
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
When selecting from columns is denied, the current error message contains all requested columns:
```
Cannot select from columns [id, name, time] in table or view tbl1
```
With this change, the error message will only contains denied columns:
```
Cannot select from columns [id, name] in table or view tbl1
```
or 
```
Cannot select from table tbl1
```
if the table itself is not allowed to select.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- https://github.com/trinodb/trino/issues/28602


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Ranger plugin
* Improve Ranger error message to only show denied columns when select from columns is not allowed ({issue}`30435`)
```
