### PR TITLE
Add cache to ldap group provider (issue #29134)

### DIFF
--- a/docs/src/main/sphinx/security/group-mapping.md
+++ b/docs/src/main/sphinx/security/group-mapping.md
@@ -173,6 +173,23 @@ directly from a user attribute. This requires the following property:
   - Group membership attribute in user documents. For example, `memberOf`.
 :::
 
+### Caching provider results
+
+The LDAP group provider caches group membership results to reduce the number of required
+LDAP queries. This may help to reduce the time Trino takes to start queries when latency to the LDAP server is high or when the LDAP server is slow to respond. It may also help to reduce the load on the LDAP server when many queries are started in a short period of time. The cache is configured with the following properties:
+
+:::{list-table} Provider cache configuration
+:widths: 40, 60
+:header-rows: 1
+
+* - Property name
+  - Description
+* - `ldap.group-cache-ttl`
+  - Time-to-live for the group membership cache. For example, `10m`.
+* - `ldap.group-cache-size`
+  - Maximum number of entries in the group membership cache. Defaults to `1000`.
+:::
+
 ### Example configurations
 
 The following configuration is an example for an OpenLDAP (search-based)

--- a/plugin/trino-ldap-group-provider/pom.xml
+++ b/plugin/trino-ldap-group-provider/pom.xml
@@ -41,6 +41,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-cache</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProvider.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapFilteringGroupProvider.java
@@ -13,9 +13,12 @@
  */
 package io.trino.plugin.ldapgroup;
 
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
+import io.trino.cache.EvictableCacheBuilder;
 import io.trino.plugin.base.ldap.LdapClient;
 import io.trino.plugin.base.ldap.LdapQuery;
 import io.trino.spi.security.GroupProvider;
@@ -24,6 +27,7 @@ import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.SearchResult;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.Set;
 
@@ -42,6 +46,7 @@ public class LdapFilteringGroupProvider
     private final String groupBaseDN;
     private final String groupsNameAttribute;
     private final String combinedGroupSearchFilter;
+    private final LoadingCache<String, Set<String>> groupsCache;
 
     @Inject
     public LdapFilteringGroupProvider(
@@ -61,6 +66,12 @@ public class LdapFilteringGroupProvider
         combinedGroupSearchFilter = filteringConfig.getLdapGroupsSearchFilter()
                 .map(filter -> String.format("(&(%s)(%s={0}))", filter, groupsSearchMemberAttribute))
                 .orElse(String.format("(%s={0})", groupsSearchMemberAttribute));
+
+        groupsCache = EvictableCacheBuilder.newBuilder()
+                .expireAfterWrite(Duration.ofMillis(config.getLdapGroupCacheTtl().toMillis()))
+                .maximumSize(config.getLdapGroupCacheSize())
+                .shareResultsAndFailuresEvenIfDisabled()
+                .build(CacheLoader.from(this::loadGroups));
     }
 
     /**
@@ -68,11 +79,23 @@ public class LdapFilteringGroupProvider
      * Filters groups by user membership AND filter expression {@link LdapFilteringGroupProviderConfig#getLdapGroupsSearchFilter()}.
      * If {@link LdapGroupProviderConfig#getLdapGroupsNameAttribute()} is missing from group document, fallback on full name.
      * Swallows LDAP exceptions.
+     * Results are cached per user based on the configured cache TTL.
      *
      * @return Names of groups that the user is a member of
      */
     @Override
     public Set<String> getGroups(String user)
+    {
+        return groupsCache.getUnchecked(user);
+    }
+
+    /**
+     * Loads groups from LDAP for the specified user.
+     * Swallows LDAP exceptions.
+     *
+     * @return Names of groups that the user is a member of
+     */
+    private Set<String> loadGroups(String user)
     {
         Optional<String> userDistinguishedName;
         try {

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupProviderConfig.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupProviderConfig.java
@@ -16,7 +16,11 @@ package io.trino.plugin.ldapgroup;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
 import jakarta.validation.constraints.NotNull;
+
+import java.util.concurrent.TimeUnit;
 
 public class LdapGroupProviderConfig
 {
@@ -26,6 +30,8 @@ public class LdapGroupProviderConfig
     private String ldapUserSearchFilter = "(uid={0})";
     private String ldapGroupsNameAttribute = "cn";
     private boolean ldapUseGroupFilter;
+    private Duration ldapGroupCacheTtl = new Duration(0, TimeUnit.SECONDS);
+    private int ldapGroupCacheSize = 1000;
 
     @NotNull
     public String getLdapAdminUser()
@@ -108,6 +114,34 @@ public class LdapGroupProviderConfig
     public LdapGroupProviderConfig setLdapUseGroupFilter(boolean ldapUseGroupFilter)
     {
         this.ldapUseGroupFilter = ldapUseGroupFilter;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("0ms")
+    public Duration getLdapGroupCacheTtl()
+    {
+        return ldapGroupCacheTtl;
+    }
+
+    @Config("ldap.group-cache-ttl")
+    @ConfigDescription("Duration to cache groups retrieved from LDAP. Set to 0 to disable caching, default value is 0s (disabled)")
+    public LdapGroupProviderConfig setLdapGroupCacheTtl(Duration ldapGroupCacheTtl)
+    {
+        this.ldapGroupCacheTtl = ldapGroupCacheTtl;
+        return this;
+    }
+
+    public int getLdapGroupCacheSize()
+    {
+        return ldapGroupCacheSize;
+    }
+
+    @Config("ldap.group-cache-size")
+    @ConfigDescription("Maximum number of entries in the group membership cache, default value is 1000")
+    public LdapGroupProviderConfig setLdapGroupCacheSize(int ldapGroupCacheSize)
+    {
+        this.ldapGroupCacheSize = ldapGroupCacheSize;
         return this;
     }
 }

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapSingleQueryGroupProvider.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapSingleQueryGroupProvider.java
@@ -13,10 +13,13 @@
  */
 package io.trino.plugin.ldapgroup;
 
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
+import io.trino.cache.EvictableCacheBuilder;
 import io.trino.plugin.base.ldap.LdapClient;
 import io.trino.plugin.base.ldap.LdapQuery;
 import io.trino.spi.security.GroupProvider;
@@ -27,6 +30,7 @@ import javax.naming.directory.SearchResult;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -46,6 +50,7 @@ public class LdapSingleQueryGroupProvider
     private final String groupsNameAttribute;
     private final String userSearchFilter;
     private final String userMemberOfAttribute;
+    private final LoadingCache<String, Set<String>> groupsCache;
 
     @Inject
     public LdapSingleQueryGroupProvider(LdapClient ldapClient, LdapGroupProviderConfig config, LdapSingleQueryGroupProviderConfig singleQueryGroupProviderConfig)
@@ -57,6 +62,12 @@ public class LdapSingleQueryGroupProvider
         this.groupsNameAttribute = config.getLdapGroupsNameAttribute();
         this.userSearchFilter = config.getLdapUserSearchFilter();
         this.userMemberOfAttribute = singleQueryGroupProviderConfig.getLdapUserMemberOfAttribute();
+
+        groupsCache = EvictableCacheBuilder.newBuilder()
+                .expireAfterWrite(Duration.ofMillis(config.getLdapGroupCacheTtl().toMillis()))
+                .maximumSize(config.getLdapGroupCacheSize())
+                .shareResultsAndFailuresEvenIfDisabled()
+                .build(CacheLoader.from(this::loadGroups));
     }
 
     /**
@@ -66,6 +77,7 @@ public class LdapSingleQueryGroupProvider
      * If the requested group attribute is missing from the LDAP document, it will be ignored
      * (i.e., the function will not error).
      * Swallows all LDAP exceptions.
+     * Results are cached per user based on the configured cache TTL.
      *
      * @param user Username of user, used with filter expression {@link LdapGroupProviderConfig#getLdapUserSearchFilter()}.
      * @return The relative domain name of all the values of attribute
@@ -73,6 +85,18 @@ public class LdapSingleQueryGroupProvider
      */
     @Override
     public Set<String> getGroups(String user)
+    {
+        return groupsCache.getUnchecked(user);
+    }
+
+    /**
+     * Loads groups from LDAP for the specified user.
+     * Swallows all LDAP exceptions.
+     *
+     * @return The relative domain name of all the values of attribute
+     *         {@link LdapSingleQueryGroupProviderConfig#getLdapUserMemberOfAttribute()}.
+     */
+    private Set<String> loadGroups(String user)
     {
         try {
             return ldapClient.executeLdapQuery(

--- a/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapGroupProviderConfig.java
+++ b/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapGroupProviderConfig.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.ldapgroup;
 
+import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -32,7 +33,9 @@ class TestLdapGroupProviderConfig
                 .setLdapUserBaseDN(null)
                 .setLdapUserSearchFilter("(uid={0})")
                 .setLdapGroupsNameAttribute("cn")
-                .setLdapUseGroupFilter(false));
+                .setLdapUseGroupFilter(false)
+                .setLdapGroupCacheTtl(Duration.valueOf("0m"))
+                .setLdapGroupCacheSize(1000));
     }
 
     @Test
@@ -44,7 +47,9 @@ class TestLdapGroupProviderConfig
                 "ldap.user-base-dn", "dc=trino,dc=io",
                 "ldap.user-search-filter", "(accountName={0})",
                 "ldap.group-name-attribute", "groupName",
-                "ldap.use-group-filter", "true");
+                "ldap.use-group-filter", "true",
+                "ldap.group-cache-ttl", "10m",
+                "ldap.group-cache-size", "100");
 
         LdapGroupProviderConfig expected = new LdapGroupProviderConfig()
                 .setLdapAdminUser("cn=admin,dc=trino,dc=io")
@@ -52,7 +57,9 @@ class TestLdapGroupProviderConfig
                 .setLdapUserBaseDN("dc=trino,dc=io")
                 .setLdapUserSearchFilter("(accountName={0})")
                 .setLdapGroupsNameAttribute("groupName")
-                .setLdapUseGroupFilter(true);
+                .setLdapUseGroupFilter(true)
+                .setLdapGroupCacheTtl(Duration.valueOf("10m"))
+                .setLdapGroupCacheSize(100);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapGroupProviderIntegration.java
+++ b/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapGroupProviderIntegration.java
@@ -36,6 +36,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -265,6 +266,60 @@ public class TestLdapGroupProviderIntegration
         });
 
         latch.await();
+    }
+
+    @Test
+    public void testGroupsCacheWithTtl()
+    {
+        for (ConfigBuilder configBuilder : CONFIG_BUILDERS) {
+            // Test with cache enabled (10 minute TTL)
+            Map<String, String> config = configBuilder.apply(new HashMap<>(baseConfig));
+            config.put("ldap.group-cache-ttl", "10m");
+            GroupProvider groupsProvider = factory.create(config);
+
+            // First call - should query LDAP
+            long start = System.nanoTime();
+            Set<String> groups1 = groupsProvider.getGroups("alicea");
+            long firstCallTime = System.nanoTime() - start;
+            assertThat(groups1).containsExactlyInAnyOrder("clients", "qualityAssurance", "developers");
+
+            // Second call - should be cached (much faster)
+            start = System.nanoTime();
+            Set<String> groups2 = groupsProvider.getGroups("alicea");
+            long cachedCallTime = System.nanoTime() - start;
+            assertThat(groups2).isEqualTo(groups1);
+
+            // Cached call should be significantly faster (at least 10x faster as a rough heuristic)
+            // Note: This is a heuristic test - actual performance may vary
+            assertThat(cachedCallTime).isLessThan(firstCallTime / 10);
+        }
+    }
+
+    @Test
+    public void testGroupsCacheExpiration()
+            throws InterruptedException
+    {
+        for (ConfigBuilder configBuilder : CONFIG_BUILDERS) {
+            // Test with very short cache TTL (100ms)
+            Map<String, String> config = configBuilder.apply(new HashMap<>(baseConfig));
+            config.put("ldap.group-cache-ttl", "100ms");
+            GroupProvider groupsProvider = factory.create(config);
+
+            // First call
+            Set<String> groups1 = groupsProvider.getGroups("alicea");
+            assertThat(groups1).containsExactlyInAnyOrder("clients", "qualityAssurance", "developers");
+
+            // Immediate second call should be cached
+            Set<String> groups2 = groupsProvider.getGroups("alicea");
+            assertThat(groups2).isEqualTo(groups1);
+
+            // Wait for cache to expire
+            MILLISECONDS.sleep(150);
+
+            // Call after expiration should query LDAP again (result should still be correct)
+            Set<String> groups3 = groupsProvider.getGroups("alicea");
+            assertThat(groups3).containsExactlyInAnyOrder("clients", "qualityAssurance", "developers");
+        }
     }
 
     @FunctionalInterface


### PR DESCRIPTION
** This is a replacement PR for https://github.com/trinodb/trino/pull/29143 **
## Description

This PR adds caching to the  ldap group provider,

## Additional context and related issues

Using the ldap group provider, means every Trino query will result into connection to ldap server and ldap search query. This adds multiple seconds of delay to each query. This is very annoying when using Trino interactively. 

This PR adds caching to the  ldap group provider, and a configuration option for setting the cache TTL.

- Fixes #29134

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Added caching for the LDAP group provider configuration, adds options `ldap.group-cache-ttl` and `ldap.group-cache-size`  ({issue}`29134 `)
```