### PR TITLE
Extract per-column domains from row comparisons

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -25,6 +25,7 @@ import io.trino.metadata.OperatorNotFoundException;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.TrinoException;
+import io.trino.spi.block.SqlRow;
 import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.spi.predicate.DiscreteValues;
 import io.trino.spi.predicate.Domain;
@@ -35,6 +36,7 @@ import io.trino.spi.predicate.SortedRangeSet;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.CharType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import io.trino.sql.InterpretedFunctionInvoker;
@@ -54,6 +56,7 @@ import io.trino.sql.ir.IsNull;
 import io.trino.sql.ir.Let;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.Row;
 import io.trino.type.LikeFunctions;
 import io.trino.type.LikePattern;
 import io.trino.type.TypeCoercion;
@@ -90,6 +93,7 @@ import static io.trino.spi.predicate.TupleDomain.strictUnion;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.TypeUtils.isFloatingPointNaN;
+import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.spi.type.TypeUtils.typeHasNaN;
 import static io.trino.sql.ir.Booleans.FALSE;
 import static io.trino.sql.ir.Booleans.TRUE;
@@ -435,6 +439,11 @@ public final class DomainTranslator
 
         private ExtractionResult processComparison(Comparison node, Expression originalExpression, Boolean complement)
         {
+            Optional<Expression> decomposedRowComparison = tryDecomposeRowComparison(node, complement);
+            if (decomposedRowComparison.isPresent()) {
+                return process(decomposedRowComparison.get(), complement);
+            }
+
             Optional<NormalizedSimpleComparison> optionalNormalized = toNormalizedSimpleComparison(node);
             if (optionalNormalized.isEmpty()) {
                 return visitExpression(originalExpression, complement);
@@ -496,6 +505,74 @@ public final class DomainTranslator
                 return visitExpression(originalExpression, complement);
             }
             return visitExpression(originalExpression, complement);
+        }
+
+        /**
+         * Decompose a row comparison into per-field comparisons, e.g. {@code ROW(a, b) = ROW(1, 2)}
+         * into {@code a = 1 AND b = 2}. The two forms are equivalent, including their handling of
+         * NULL field values, and the per-field form allows extracting single-column domains, e.g.
+         * for multi-column IN predicates over partition keys.
+         * <p>
+         * This is only valid because both operands are known to be non-null rows, which is what
+         * {@link #rowComparisonFields} buys by accepting only a {@link Row} constructor and a
+         * {@link Constant} holding an {@link SqlRow}. A row constructor never evaluates to NULL, and a
+         * NULL row constant is rejected. The precondition matters for {@code IDENTICAL}, because
+         * {@link RowType}'s identical operator special-cases a NULL row before going field-wise, so
+         * {@code NULL IDENTICAL ROW(1, 2)} is FALSE while the field-wise form would be unknown.
+         */
+        private Optional<Expression> tryDecomposeRowComparison(Comparison node, boolean complement)
+        {
+            ComparisonOperator operator = node.operator();
+            if (operator != EQUAL && operator != NOT_EQUAL && operator != IDENTICAL) {
+                // ordering comparisons on rows are lexicographic and cannot be decomposed field-wise
+                return Optional.empty();
+            }
+
+            Optional<List<Expression>> optionalLeftFields = rowComparisonFields(node.left());
+            Optional<List<Expression>> optionalRightFields = rowComparisonFields(node.right());
+            if (optionalLeftFields.isEmpty() || optionalRightFields.isEmpty()) {
+                return Optional.empty();
+            }
+            List<Expression> leftFields = optionalLeftFields.get();
+            List<Expression> rightFields = optionalRightFields.get();
+            if (leftFields.isEmpty() || leftFields.size() != rightFields.size()) {
+                return Optional.empty();
+            }
+
+            // NOT_EQUAL decomposes into a disjunction, and extracting the complement of EQUAL or IDENTICAL
+            // effectively does the same. A disjunction over more than one field column-wise unions to ALL, so
+            // decomposing would replace the comparison with a larger equivalent expression and derive nothing.
+            boolean conjunctive = (operator == NOT_EQUAL) == complement;
+            if (!conjunctive && leftFields.size() > 1) {
+                return Optional.empty();
+            }
+
+            ImmutableList.Builder<Expression> fieldComparisons = ImmutableList.builder();
+            for (int field = 0; field < leftFields.size(); field++) {
+                fieldComparisons.add(comparison(plannerContext.getMetadata(), operator, leftFields.get(field), rightFields.get(field)));
+            }
+            if (operator == NOT_EQUAL) {
+                // rows are not equal when any field pair is not equal
+                return Optional.of(or(fieldComparisons.build()));
+            }
+            return Optional.of(and(fieldComparisons.build()));
+        }
+
+        private static Optional<List<Expression>> rowComparisonFields(Expression expression)
+        {
+            if (expression instanceof Row row) {
+                return Optional.of(row.items());
+            }
+            if (expression instanceof Constant constant && constant.type() instanceof RowType rowType && constant.value() instanceof SqlRow sqlRow) {
+                ImmutableList.Builder<Expression> fields = ImmutableList.builder();
+                List<RowType.Field> rowFields = rowType.getFields();
+                for (int field = 0; field < rowFields.size(); field++) {
+                    Type fieldType = rowFields.get(field).getType();
+                    fields.add(new Constant(fieldType, readNativeValue(fieldType, sqlRow.getRawFieldBlock(field), sqlRow.getRawIndex())));
+                }
+                return Optional.of(fields.build());
+            }
+            return Optional.empty();
         }
 
         /**
@@ -867,10 +944,14 @@ public final class DomainTranslator
             for (Expression expression : node.valueList()) {
                 disjuncts.add(comparison(plannerContext.getMetadata(), EQUAL, node.value(), expression));
             }
-            ExtractionResult extractionResult = process(or(disjuncts.build()), complement);
+            Expression expansion = or(disjuncts.build());
+            ExtractionResult extractionResult = process(expansion, complement);
 
-            // preserve original IN predicate as remaining predicate
-            if (extractionResult.tupleDomain.isAll()) {
+            // Preserve the original IN predicate as the remaining predicate, to avoid replacing it with the
+            // (potentially large) expansion into a disjunction. This is sound because the extracted domain is a
+            // necessary condition of the IN predicate, so "domain AND node" is equivalent to "node". A residual
+            // that is not the expansion is tighter than the original predicate, and is kept as is.
+            if (extractionResult.tupleDomain.isAll() || extractionResult.remainingExpression.equals(complementIfNecessary(expansion, complement))) {
                 Expression originalPredicate = node;
                 if (complement) {
                     originalPredicate = not(plannerContext.getMetadata(), originalPredicate);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
@@ -23,6 +23,7 @@ import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.Decimals;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Cast;
@@ -34,6 +35,7 @@ import io.trino.sql.ir.IrExpressions;
 import io.trino.sql.ir.IsNull;
 import io.trino.sql.ir.Let;
 import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.Row;
 import io.trino.sql.ir.TestingIr;
 import io.trino.sql.planner.DomainTranslator.ExtractionResult;
 import io.trino.type.LikePattern;
@@ -91,6 +93,7 @@ import static io.trino.type.ColorType.COLOR;
 import static io.trino.type.LikeFunctions.LIKE_FUNCTION_NAME;
 import static io.trino.type.LikeFunctions.LIKE_PATTERN_FUNCTION_NAME;
 import static io.trino.type.Reals.toReal;
+import static io.trino.util.StructuralTestUtil.sqlRowOf;
 import static java.lang.String.format;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TWO;
@@ -1050,6 +1053,140 @@ public class TestDomainTranslator
                 VARCHAR,
                 utf8Slice("first"),
                 utf8Slice("second"));
+    }
+
+    @Test
+    public void testRowComparison()
+    {
+        RowType rowType = RowType.anonymous(ImmutableList.of(BIGINT, DOUBLE));
+        Expression row = new Row(ImmutableList.of(C_BIGINT.toSymbolReference(), C_DOUBLE.toSymbolReference()));
+        Expression rowConstant = new Constant(rowType, sqlRowOf(rowType, 1L, 10.0));
+        TupleDomain<Symbol> expectedDomain = tupleDomain(ImmutableMap.of(
+                C_BIGINT, Domain.singleValue(BIGINT, 1L),
+                C_DOUBLE, Domain.singleValue(DOUBLE, 10.0)));
+
+        // row equality with a folded row constant decomposes into per-field domains
+        assertPredicateTranslates(comparison(EQUAL, row, rowConstant), expectedDomain);
+
+        // flipped sides
+        assertPredicateTranslates(comparison(EQUAL, rowConstant, row), expectedDomain);
+
+        // row equality with a row constructor of constants
+        assertPredicateTranslates(
+                comparison(EQUAL, row, new Row(ImmutableList.of(bigintLiteral(1L), doubleLiteral(10.0)))),
+                expectedDomain);
+
+        // IDENTICAL decomposes the same way when no field is NULL
+        assertPredicateTranslates(comparison(IDENTICAL, row, rowConstant), expectedDomain);
+
+        // IDENTICAL is null-safe per field, so a NULL field constrains that column to NULL rather than to nothing
+        assertPredicateTranslates(
+                comparison(IDENTICAL, row, new Constant(rowType, sqlRowOf(rowType, 1L, null))),
+                tupleDomain(ImmutableMap.of(
+                        C_BIGINT, Domain.singleValue(BIGINT, 1L),
+                        C_DOUBLE, Domain.onlyNull(DOUBLE))));
+
+        // EQUAL against a NULL field evaluates to NULL rather than FALSE, which filters out every row all the same
+        assertPredicateIsAlwaysFalse(comparison(EQUAL, row, new Constant(rowType, sqlRowOf(rowType, 1L, null))));
+
+        // an entirely NULL row constant is not decomposable, because a comparison against a NULL row is not field-wise
+        assertUnsupportedPredicate(comparison(EQUAL, row, new Constant(rowType, null)));
+
+        // a field that cannot be translated is left in the remaining predicate, while the others still derive domains
+        Expression unprocessable = unprocessableExpression1(C_BIGINT_1);
+        assertPredicateTranslates(
+                comparison(
+                        EQUAL,
+                        new Row(ImmutableList.of(C_BIGINT.toSymbolReference(), unprocessable)),
+                        new Row(ImmutableList.of(bigintLiteral(1L), TRUE))),
+                tupleDomain(C_BIGINT, Domain.singleValue(BIGINT, 1L)),
+                comparison(EQUAL, unprocessable, TRUE));
+
+        // IDENTICAL against NaN has no Domain representation, so that field falls back to the remaining predicate
+        assertPredicateTranslates(
+                comparison(IDENTICAL, row, new Constant(rowType, sqlRowOf(rowType, 1L, Double.NaN))),
+                tupleDomain(C_BIGINT, Domain.singleValue(BIGINT, 1L)),
+                comparison(IDENTICAL, C_DOUBLE.toSymbolReference(), doubleLiteral(Double.NaN)));
+
+        // EQUAL against NaN never matches
+        assertPredicateIsAlwaysFalse(comparison(EQUAL, row, new Constant(rowType, sqlRowOf(rowType, 1L, Double.NaN))));
+
+        // a nested row field is read back as a row constant and yields a row-typed domain for that column
+        RowType nestedRowType = RowType.anonymous(ImmutableList.of(BIGINT, rowType));
+        Symbol nestedSymbol = new Symbol(rowType, "c_row");
+        assertPredicateTranslates(
+                comparison(
+                        EQUAL,
+                        new Row(ImmutableList.of(C_BIGINT.toSymbolReference(), nestedSymbol.toSymbolReference())),
+                        new Constant(nestedRowType, sqlRowOf(nestedRowType, 1L, sqlRowOf(rowType, 2L, 3.0)))),
+                tupleDomain(
+                        C_BIGINT,
+                        Domain.singleValue(BIGINT, 1L),
+                        nestedSymbol,
+                        Domain.singleValue(rowType, sqlRowOf(rowType, 2L, 3.0))));
+
+        // a cast around the row constructor is not decomposed
+        assertUnsupportedPredicate(comparison(EQUAL, cast(row, rowType), rowConstant));
+
+        // negating a multi-field row comparison decomposes into a disjunction over distinct columns, which unions to
+        // ALL. Decomposing would only inflate the predicate, so the compact form is kept instead
+        assertUnsupportedPredicate(comparison(NOT_EQUAL, row, rowConstant));
+        assertUnsupportedPredicate(not(comparison(EQUAL, row, rowConstant)));
+        assertUnsupportedPredicate(not(comparison(IDENTICAL, row, rowConstant)));
+
+        // a single-field row has nothing to union, so its negation still derives a domain
+        RowType singleFieldRowType = RowType.anonymous(ImmutableList.of(BIGINT));
+        Expression singleFieldRow = new Row(ImmutableList.of(C_BIGINT.toSymbolReference()));
+        assertPredicateTranslates(
+                comparison(NOT_EQUAL, singleFieldRow, new Constant(singleFieldRowType, sqlRowOf(singleFieldRowType, 1L))),
+                tupleDomain(C_BIGINT, Domain.create(ValueSet.ofRanges(Range.lessThan(BIGINT, 1L), Range.greaterThan(BIGINT, 1L)), false)));
+
+        // ordering comparisons on rows are lexicographic and are not decomposed
+        assertUnsupportedPredicate(comparison(GREATER_THAN, row, rowConstant));
+    }
+
+    @Test
+    public void testRowInPredicate()
+    {
+        RowType rowType = RowType.anonymous(ImmutableList.of(BIGINT, DOUBLE));
+        Expression row = new Row(ImmutableList.of(C_BIGINT.toSymbolReference(), C_DOUBLE.toSymbolReference()));
+        Expression firstTuple = new Constant(rowType, sqlRowOf(rowType, 1L, 10.0));
+        Expression secondTuple = new Constant(rowType, sqlRowOf(rowType, 3L, 30.0));
+
+        // multi-tuple IN derives per-column domains while keeping the original predicate as a filter
+        assertPredicateDerives(
+                new In(row, ImmutableList.of(firstTuple, secondTuple)),
+                tupleDomain(ImmutableMap.of(
+                        C_BIGINT, Domain.multipleValues(BIGINT, ImmutableList.of(1L, 3L)),
+                        C_DOUBLE, Domain.multipleValues(DOUBLE, ImmutableList.of(10.0, 30.0)))));
+
+        // single-tuple IN is equivalent to row equality and translates exactly
+        assertPredicateTranslates(
+                new In(row, ImmutableList.of(firstTuple)),
+                tupleDomain(ImmutableMap.of(
+                        C_BIGINT, Domain.singleValue(BIGINT, 1L),
+                        C_DOUBLE, Domain.singleValue(DOUBLE, 10.0))));
+
+        // a tuple containing a NULL field can never match, and does not widen the domains. The
+        // remaining tuple translates exactly, so no remaining predicate is needed
+        assertPredicateTranslates(
+                new In(row, ImmutableList.of(new Constant(rowType, sqlRowOf(rowType, 1L, null)), secondTuple)),
+                tupleDomain(ImmutableMap.of(
+                        C_BIGINT, Domain.singleValue(BIGINT, 3L),
+                        C_DOUBLE, Domain.singleValue(DOUBLE, 30.0))));
+
+        // when every tuple leaves the same remaining predicate, that tighter predicate is kept instead of the IN
+        Expression unprocessable = unprocessableExpression1(C_BIGINT_1);
+        assertPredicateTranslates(
+                new In(new Row(ImmutableList.of(C_BIGINT.toSymbolReference(), unprocessable)),
+                        ImmutableList.of(
+                                new Row(ImmutableList.of(bigintLiteral(1L), TRUE)),
+                                new Row(ImmutableList.of(bigintLiteral(3L), TRUE)))),
+                tupleDomain(C_BIGINT, Domain.multipleValues(BIGINT, ImmutableList.of(1L, 3L))),
+                comparison(EQUAL, unprocessable, TRUE));
+
+        // NOT IN produces no single-column domains, and keeps the compact form rather than the expansion
+        assertUnsupportedPredicate(not(new In(row, ImmutableList.of(firstTuple, secondTuple))));
     }
 
     private void testInPredicate(Symbol symbol, Symbol symbol2, Type type, Object one, Object two)


### PR DESCRIPTION
Decompose ROW(a, b) = ROW(1, 2) into per-field comparisons in DomainTranslator, so multi-column row IN predicates yield single-column domains for partition pruning.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
