### PR TITLE
Switch web UI Dependabot ecosystem from npm to bun

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
     ignore:
       # TODO remove once https://github.com/jline/jline3/issues/1879 has been addressed
       - dependency-name: "org.jline:jline-*"
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/core/trino-web-ui/src/main/resources/webapp"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
The web UI migrated from npm to bun, replacing package-lock.json with bun.lock. Dependabot's npm ecosystem only recognizes npm/yarn/pnpm lockfiles, so it stopped producing dependency updates for the webapp. Bun is a distinct package-ecosystem value (supported for bun.lock
>= v1.1.39), so declare it accordingly.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
