### PR TITLE
Use Floci for GCS REST credential refresh tests

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -563,6 +563,24 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-credentials</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <scope>test</scope>

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogStorageCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogStorageCredentialsRefresh.java
@@ -13,19 +13,17 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.BucketInfo;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.gcs.GcsFileSystemConfig;
 import io.trino.filesystem.gcs.GcsFileSystemFactory;
-import io.trino.filesystem.gcs.GcsServiceAccountAuth;
-import io.trino.filesystem.gcs.GcsServiceAccountAuthConfig;
 import io.trino.filesystem.gcs.GcsStorageFactory;
+import io.trino.testing.containers.FlociGcp;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.gcp.gcs.GCSFileIO;
@@ -36,18 +34,15 @@ import org.apache.iceberg.rest.credentials.ImmutableCredential;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.Base64;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static io.trino.testing.containers.FlociGcp.FLOCI_GCP_PROJECT_ID;
 import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
 
 final class TestIcebergGcsRestCatalogStorageCredentialsRefresh
@@ -55,24 +50,12 @@ final class TestIcebergGcsRestCatalogStorageCredentialsRefresh
 {
     private static final Logger LOG = Logger.get(TestIcebergGcsRestCatalogStorageCredentialsRefresh.class);
 
-    private final String gcpCredentialKey = requiredNonEmptySystemProperty("testing.gcp-credentials-key");
-    private final String gcpStorageBucket = requiredNonEmptySystemProperty("testing.gcp-storage-bucket");
+    private final String gcpStorageBucket = "test-iceberg-gcs-storage-credentials-refresh-" + randomNameSuffix();
 
-    private String oauthToken;
-    private long tokenExpiresAtMs;
-    private String gcpProjectId;
+    private final String oauthToken = "test-oauth-token";
+    private final long tokenExpiresAtMs = sessionTokenExpirationTime.get().toEpochMilli();
+    private FlociGcp flociGcp;
     private TrinoFileSystem fileSystem;
-
-    @BeforeAll
-    public void initFileSystem()
-            throws Exception
-    {
-        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
-        GcsFileSystemConfig config = new GcsFileSystemConfig();
-        GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig().setJsonKey(new String(jsonKeyBytes, UTF_8));
-        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new GcsServiceAccountAuth(authConfig));
-        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
-    }
 
     @AfterAll
     public void removeTestData()
@@ -84,8 +67,7 @@ final class TestIcebergGcsRestCatalogStorageCredentialsRefresh
             fileSystem.deleteDirectory(Location.of(warehouseLocation));
         }
         catch (IOException e) {
-            // The GCS bucket should be configured to expire objects automatically. Clean up issues do not need to fail the test.
-            LOG.warn(e, "Failed to clean up GCS test directory: %s", warehouseLocation);
+            LOG.warn(e, "Failed to clean up Floci test directory: %s", warehouseLocation);
         }
     }
 
@@ -93,18 +75,17 @@ final class TestIcebergGcsRestCatalogStorageCredentialsRefresh
     protected String setupStorageAndGetWarehouseLocation()
             throws Exception
     {
-        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
-        String gcpCredentials = new String(jsonKeyBytes, UTF_8);
+        flociGcp = closeAfterClass(new FlociGcp());
+        flociGcp.start();
 
-        GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(jsonKeyBytes))
-                .createScoped("https://www.googleapis.com/auth/cloud-platform");
-        AccessToken accessToken = credentials.refreshAccessToken();
-        oauthToken = accessToken.getTokenValue();
-        tokenExpiresAtMs = accessToken.getExpirationTime().getTime();
-
-        JsonMapper mapper = new JsonMapper();
-        JsonNode jsonKey = mapper.readTree(gcpCredentials);
-        gcpProjectId = jsonKey.get("project_id").asText();
+        GcsFileSystemConfig config = new GcsFileSystemConfig()
+                .setEndpoint(Optional.of(flociGcp.getEndpoint().toString()))
+                .setProjectId(FLOCI_GCP_PROJECT_ID);
+        GcsStorageFactory storageFactory = new GcsStorageFactory(
+                config,
+                (builder, _) -> builder.setCredentials(GoogleCredentials.create(new AccessToken(oauthToken, null))));
+        storageFactory.create(SESSION.getIdentity()).create(BucketInfo.of(gcpStorageBucket));
+        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
 
         return "gs://%s/gcs-storage-creds-rest-refresh-test-%s/".formatted(gcpStorageBucket, randomNameSuffix());
     }
@@ -114,7 +95,8 @@ final class TestIcebergGcsRestCatalogStorageCredentialsRefresh
     {
         return ImmutableMap.<String, String>builder()
                 .put(FILE_IO_IMPL, GCSFileIO.class.getName())
-                .put(GCPProperties.GCS_PROJECT_ID, gcpProjectId)
+                .put(GCPProperties.GCS_PROJECT_ID, FLOCI_GCP_PROJECT_ID)
+                .put(GCPProperties.GCS_SERVICE_HOST, flociGcp.getEndpoint().toString())
                 .put(GCPProperties.GCS_OAUTH2_TOKEN, oauthToken)
                 .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(tokenExpiresAtMs))
                 .buildOrThrow();
@@ -182,6 +164,8 @@ final class TestIcebergGcsRestCatalogStorageCredentialsRefresh
         return ImmutableMap.<String, String>builder()
                 .put("fs.gcs.enabled", "true")
                 .put("gcs.auth-type", "APPLICATION_DEFAULT")
+                .put("gcs.endpoint", flociGcp.getEndpoint().toString())
+                .put("gcs.project-id", FLOCI_GCP_PROJECT_ID)
                 .buildOrThrow();
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java
@@ -13,34 +13,29 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.BucketInfo;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.gcs.GcsFileSystemConfig;
 import io.trino.filesystem.gcs.GcsFileSystemFactory;
-import io.trino.filesystem.gcs.GcsServiceAccountAuth;
-import io.trino.filesystem.gcs.GcsServiceAccountAuthConfig;
 import io.trino.filesystem.gcs.GcsStorageFactory;
+import io.trino.testing.containers.FlociGcp;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.gcp.gcs.GCSFileIO;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.Base64;
 import java.util.Map;
+import java.util.Optional;
 
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static io.trino.testing.containers.FlociGcp.FLOCI_GCP_PROJECT_ID;
 import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
 
 final class TestIcebergGcsRestCatalogVendedCredentialsRefresh
@@ -48,29 +43,12 @@ final class TestIcebergGcsRestCatalogVendedCredentialsRefresh
 {
     private static final Logger LOG = Logger.get(TestIcebergGcsRestCatalogVendedCredentialsRefresh.class);
 
-    private final String gcpCredentialKey = requiredNonEmptySystemProperty("testing.gcp-credentials-key");
-    private final String gcpStorageBucket = requiredNonEmptySystemProperty("testing.gcp-storage-bucket");
+    private final String gcpStorageBucket = "test-iceberg-gcs-vended-credentials-refresh-" + randomNameSuffix();
 
-    private String oauthToken;
-    private long tokenExpiresAtMs;
-    private String gcpProjectId;
+    private final String oauthToken = "test-oauth-token";
+    private final long tokenExpiresAtMs = sessionTokenExpirationTime.get().toEpochMilli();
+    private FlociGcp flociGcp;
     private TrinoFileSystem fileSystem;
-
-    @BeforeAll
-    public void initFileSystem()
-    {
-        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
-        GcsFileSystemConfig config = new GcsFileSystemConfig();
-        GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig().setJsonKey(new String(jsonKeyBytes, UTF_8));
-        GcsStorageFactory storageFactory;
-        try {
-            storageFactory = new GcsStorageFactory(config, new GcsServiceAccountAuth(authConfig));
-        }
-        catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
-    }
 
     @AfterAll
     public void removeTestData()
@@ -82,8 +60,7 @@ final class TestIcebergGcsRestCatalogVendedCredentialsRefresh
             fileSystem.deleteDirectory(Location.of(warehouseLocation));
         }
         catch (IOException e) {
-            // The GCS bucket should be configured to expire objects automatically. Clean up issues do not need to fail the test.
-            LOG.warn(e, "Failed to clean up GCS test directory: %s", warehouseLocation);
+            LOG.warn(e, "Failed to clean up Floci test directory: %s", warehouseLocation);
         }
     }
 
@@ -91,18 +68,17 @@ final class TestIcebergGcsRestCatalogVendedCredentialsRefresh
     protected String setupStorageAndGetWarehouseLocation()
             throws Exception
     {
-        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
-        String gcpCredentials = new String(jsonKeyBytes, UTF_8);
+        flociGcp = closeAfterClass(new FlociGcp());
+        flociGcp.start();
 
-        GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(jsonKeyBytes))
-                .createScoped("https://www.googleapis.com/auth/cloud-platform");
-        AccessToken accessToken = credentials.refreshAccessToken();
-        oauthToken = accessToken.getTokenValue();
-        tokenExpiresAtMs = accessToken.getExpirationTime().getTime();
-
-        JsonMapper mapper = new JsonMapper();
-        JsonNode jsonKey = mapper.readTree(gcpCredentials);
-        gcpProjectId = jsonKey.get("project_id").asText();
+        GcsFileSystemConfig config = new GcsFileSystemConfig()
+                .setEndpoint(Optional.of(flociGcp.getEndpoint().toString()))
+                .setProjectId(FLOCI_GCP_PROJECT_ID);
+        GcsStorageFactory storageFactory = new GcsStorageFactory(
+                config,
+                (builder, _) -> builder.setCredentials(GoogleCredentials.create(new AccessToken(oauthToken, null))));
+        storageFactory.create(SESSION.getIdentity()).create(BucketInfo.of(gcpStorageBucket));
+        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
 
         return "gs://%s/gcs-vending-rest-refresh-test-%s/".formatted(gcpStorageBucket, randomNameSuffix());
     }
@@ -112,7 +88,8 @@ final class TestIcebergGcsRestCatalogVendedCredentialsRefresh
     {
         return ImmutableMap.<String, String>builder()
                 .put(FILE_IO_IMPL, GCSFileIO.class.getName())
-                .put(GCPProperties.GCS_PROJECT_ID, gcpProjectId)
+                .put(GCPProperties.GCS_PROJECT_ID, FLOCI_GCP_PROJECT_ID)
+                .put(GCPProperties.GCS_SERVICE_HOST, flociGcp.getEndpoint().toString())
                 .put(GCPProperties.GCS_OAUTH2_TOKEN, oauthToken)
                 .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(tokenExpiresAtMs))
                 .buildOrThrow();
@@ -161,6 +138,8 @@ final class TestIcebergGcsRestCatalogVendedCredentialsRefresh
         return ImmutableMap.<String, String>builder()
                 .put("fs.gcs.enabled", "true")
                 .put("gcs.auth-type", "APPLICATION_DEFAULT")
+                .put("gcs.endpoint", flociGcp.getEndpoint().toString())
+                .put("gcs.project-id", FLOCI_GCP_PROJECT_ID)
                 .buildOrThrow();
     }
 }


### PR DESCRIPTION
## Description

Converts Iceberg REST catalog credential refresh tests to use [Floci](https://floci.io)-backed GCS storage.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.