### PR TITLE
Use Floci for GCS REST vending smoke test

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -563,6 +563,24 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-credentials</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <scope>test</scope>

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java
@@ -13,17 +13,14 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.BucketInfo;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.gcs.GcsFileSystemConfig;
 import io.trino.filesystem.gcs.GcsFileSystemFactory;
-import io.trino.filesystem.gcs.GcsServiceAccountAuth;
-import io.trino.filesystem.gcs.GcsServiceAccountAuthConfig;
 import io.trino.filesystem.gcs.GcsStorageFactory;
 import io.trino.plugin.iceberg.BaseIcebergConnectorSmokeTest;
 import io.trino.plugin.iceberg.IcebergConfig;
@@ -31,6 +28,7 @@ import io.trino.plugin.iceberg.IcebergQueryRunner;
 import io.trino.testing.QueryFailedException;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
+import io.trino.testing.containers.FlociGcp;
 import io.trino.testing.containers.IcebergGcsRestCatalogBackendContainer;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
@@ -41,19 +39,18 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Network;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Base64;
+import java.util.Optional;
 
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkOrcFileSorting;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
+import static io.trino.testing.containers.FlociGcp.FLOCI_GCP_PROJECT_ID;
 import static java.lang.String.format;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.iceberg.FileFormat.PARQUET;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -61,18 +58,18 @@ final class TestIcebergGcsVendingRestCatalogConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {
     private static final Logger LOG = Logger.get(TestIcebergGcsVendingRestCatalogConnectorSmokeTest.class);
+    private static final String OAUTH_TOKEN = "test-oauth-token";
 
-    private final String gcpCredentialKey;
-    private final String warehouseLocation;
+    private final String bucketName = "test-iceberg-gcs-vending-rest-" + randomNameSuffix();
 
+    private String warehouseLocation;
+    private FlociGcp flociGcp;
+    private GcsFileSystemFactory flociFileSystemFactory;
     private IcebergGcsRestCatalogBackendContainer restCatalog;
 
     public TestIcebergGcsVendingRestCatalogConnectorSmokeTest()
     {
         super(new IcebergConfig().getFileFormat().toIceberg());
-        gcpCredentialKey = requiredNonEmptySystemProperty("testing.gcp-credentials-key");
-        String gcpStorageBucket = requiredNonEmptySystemProperty("testing.gcp-storage-bucket");
-        warehouseLocation = "gs://%s/gcs-vending-rest-test-%s/".formatted(gcpStorageBucket, randomNameSuffix());
     }
 
     @Override
@@ -90,22 +87,26 @@ final class TestIcebergGcsVendingRestCatalogConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
-        String gcpCredentials = new String(jsonKeyBytes, UTF_8);
+        Network network = closeAfterClass(Network.newNetwork());
+        flociGcp = closeAfterClass(new FlociGcp().withNetwork(network));
+        flociGcp.start();
 
-        GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(jsonKeyBytes))
-                .createScoped("https://www.googleapis.com/auth/cloud-platform");
-        AccessToken accessToken = credentials.refreshAccessToken();
-
-        JsonMapper mapper = new JsonMapper();
-        JsonNode jsonKey = mapper.readTree(gcpCredentials);
-        String gcpProjectId = jsonKey.get("project_id").asText();
+        warehouseLocation = "gs://%s/gcs-vending-rest-test-%s/".formatted(bucketName, randomNameSuffix());
+        GcsFileSystemConfig config = new GcsFileSystemConfig()
+                .setEndpoint(Optional.of(flociGcp.getEndpoint().toString()))
+                .setProjectId(FLOCI_GCP_PROJECT_ID);
+        GcsStorageFactory storageFactory = new GcsStorageFactory(
+                config,
+                (builder, _) -> builder.setCredentials(GoogleCredentials.create(new AccessToken(OAUTH_TOKEN, null))));
+        storageFactory.create(SESSION.getIdentity()).create(BucketInfo.of(bucketName));
+        flociFileSystemFactory = new GcsFileSystemFactory(config, storageFactory);
 
         restCatalog = closeAfterClass(new IcebergGcsRestCatalogBackendContainer(
+                Optional.of(network),
                 warehouseLocation,
-                gcpProjectId,
-                accessToken.getTokenValue(),
-                accessToken.getExpirationTime().getTime()));
+                FLOCI_GCP_PROJECT_ID,
+                flociGcp.getContainerEndpoint().toString(),
+                OAUTH_TOKEN));
         restCatalog.start();
 
         return IcebergQueryRunner.builder()
@@ -118,6 +119,8 @@ final class TestIcebergGcsVendingRestCatalogConnectorSmokeTest
                                 .put("iceberg.writer-sort-buffer-size", "1MB")
                                 .put("fs.gcs.enabled", "true")
                                 .put("gcs.auth-type", "APPLICATION_DEFAULT")
+                                .put("gcs.endpoint", flociGcp.getEndpoint().toString())
+                                .put("gcs.project-id", FLOCI_GCP_PROJECT_ID)
                                 .buildOrThrow())
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
@@ -127,17 +130,7 @@ final class TestIcebergGcsVendingRestCatalogConnectorSmokeTest
     @BeforeAll
     public void initFileSystem()
     {
-        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
-        GcsFileSystemConfig config = new GcsFileSystemConfig();
-        GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig().setJsonKey(new String(jsonKeyBytes, UTF_8));
-        GcsStorageFactory storageFactory;
-        try {
-            storageFactory = new GcsStorageFactory(config, new GcsServiceAccountAuth(authConfig));
-        }
-        catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
+        fileSystem = flociFileSystemFactory.create(SESSION);
     }
 
     @AfterAll
@@ -150,8 +143,7 @@ final class TestIcebergGcsVendingRestCatalogConnectorSmokeTest
             fileSystem.deleteDirectory(Location.of(warehouseLocation));
         }
         catch (IOException e) {
-            // The GCS bucket should be configured to expire objects automatically. Clean up issues do not need to fail the test.
-            LOG.warn(e, "Failed to clean up GCS test directory: %s", warehouseLocation);
+            LOG.warn(e, "Failed to clean up Floci test directory: %s", warehouseLocation);
         }
     }
 

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/FlociGcp.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/FlociGcp.java
@@ -25,17 +25,24 @@ public final class FlociGcp
     public static final String FLOCI_GCP_IMAGE = "floci/floci-gcp:0.3.0";
     public static final String FLOCI_GCP_PROJECT_ID = "floci-local";
 
+    private static final String FLOCI_GCP_NETWORK_ALIAS = "floci-gcp";
     private static final int FLOCI_GCP_PORT = 4588;
 
     public FlociGcp()
     {
         super(DockerImageName.parse(FLOCI_GCP_IMAGE));
         addExposedPort(FLOCI_GCP_PORT);
+        withNetworkAliases(FLOCI_GCP_NETWORK_ALIAS);
         waitingFor(Wait.forLogMessage(".*=== floci-gcp Ready ===.*\\n", 1));
     }
 
     public URI getEndpoint()
     {
         return URI.create("http://%s:%s".formatted(getHost(), getMappedPort(FLOCI_GCP_PORT)));
+    }
+
+    public URI getContainerEndpoint()
+    {
+        return URI.create("http://%s:%s".formatted(FLOCI_GCP_NETWORK_ALIAS, FLOCI_GCP_PORT));
     }
 }

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/IcebergGcsRestCatalogBackendContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/IcebergGcsRestCatalogBackendContainer.java
@@ -15,6 +15,7 @@ package io.trino.testing.containers;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.testcontainers.containers.Network;
 
 import java.util.Optional;
 
@@ -22,10 +23,11 @@ public class IcebergGcsRestCatalogBackendContainer
         extends BaseTestContainer
 {
     public IcebergGcsRestCatalogBackendContainer(
+            Optional<Network> network,
             String warehouseLocation,
             String gcpProjectId,
-            String accessToken,
-            long accessTokenExpiresAt)
+            String gcpServiceHost,
+            String accessToken)
     {
         super("apache/iceberg-rest-fixture:1.10.1",
                 "iceberg-rest",
@@ -36,9 +38,9 @@ public class IcebergGcsRestCatalogBackendContainer
                         "CATALOG_WAREHOUSE", warehouseLocation,
                         "CATALOG_IO__IMPL", "org.apache.iceberg.gcp.gcs.GCSFileIO",
                         "CATALOG_GCS_PROJECT__ID", gcpProjectId,
-                        "CATALOG_GCS_OAUTH2_TOKEN", accessToken,
-                        "CATALOG_GCS_OAUTH2_TOKEN_EXPIRES_AT", Long.toString(accessTokenExpiresAt)),
-                Optional.empty(),
+                        "CATALOG_GCS_SERVICE_HOST", gcpServiceHost,
+                        "CATALOG_GCS_OAUTH2_TOKEN", accessToken),
+                network,
                 5);
     }
 


### PR DESCRIPTION
## Description

Converts the Iceberg GCS REST vending smoke test to use [Floci](https://floci.io)-backed GCS storage.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.