### PR TITLE
Use Floci for Delta Lake GCS smoke test

### DIFF
--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -273,6 +273,52 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-credentials</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-core</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>listenablefuture</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud.bigdataoss</groupId>
+            <artifactId>gcs-connector</artifactId>
+            <version>hadoop3-2.2.24</version>
+            <classifier>shaded</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <scope>test</scope>
@@ -355,6 +401,12 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-filesystem-azure</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem-gcs</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
+import com.google.inject.Module;
 import io.airlift.concurrent.MoreFutures;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -66,6 +67,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.collect.Sets.union;
+import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
 import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.trino.plugin.base.util.Closables.closeAllSuppress;
@@ -161,6 +163,16 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
 
     protected abstract void deleteFile(String filePath);
 
+    protected Module additionalDeltaLakeModule()
+    {
+        return EMPTY_MODULE;
+    }
+
+    protected Module additionalHiveModule()
+    {
+        return EMPTY_MODULE;
+    }
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
@@ -203,7 +215,9 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                 registerTableFromResources(table.tableName(), table.resourcePath(), queryRunner);
             });
 
-            queryRunner.installPlugin(new TestingHivePlugin(queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data")));
+            queryRunner.installPlugin(new TestingHivePlugin(
+                    queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data"),
+                    additionalHiveModule()));
 
             queryRunner.createCatalog(
                     "hive",
@@ -235,6 +249,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                         .putAll(deltaStorageConfiguration())
                         .buildOrThrow())
                 .addDeltaProperty("fs.hadoop.enabled", "true")
+                .setAdditionalModule(additionalDeltaLakeModule())
                 .setSchemaLocation(getLocationForTable(bucketName, SCHEMA))
                 .build();
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -16,6 +16,7 @@ package io.trino.plugin.deltalake;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.inject.Module;
 import io.airlift.log.Level;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.deltalake.DeltaLakeConnectorFactory.CONNECTOR_NAME;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
@@ -75,6 +77,7 @@ public final class DeltaLakeQueryRunner
         private ImmutableMap.Builder<String, String> deltaProperties = ImmutableMap.builder();
         private Optional<String> schemaLocation = Optional.empty();
         private List<TpchTable<?>> initialTables = ImmutableList.of();
+        private Module additionalModule = EMPTY_MODULE;
 
         protected Builder(String schemaName)
         {
@@ -145,6 +148,13 @@ public final class DeltaLakeQueryRunner
             return this;
         }
 
+        @CanIgnoreReturnValue
+        public Builder setAdditionalModule(Module additionalModule)
+        {
+            this.additionalModule = requireNonNull(additionalModule, "additionalModule is null");
+            return this;
+        }
+
         @Override
         public DistributedQueryRunner build()
                 throws Exception
@@ -154,7 +164,10 @@ public final class DeltaLakeQueryRunner
                 queryRunner.installPlugin(new TpchPlugin());
                 queryRunner.createCatalog("tpch", "tpch");
 
-                queryRunner.installPlugin(new TestingDeltaLakePlugin(queryRunner.getCoordinator().getBaseDataDir().resolve("delta_lake_data")));
+                queryRunner.installPlugin(new TestingDeltaLakePlugin(
+                        queryRunner.getCoordinator().getBaseDataDir().resolve("delta_lake_data"),
+                        Optional::empty,
+                        additionalModule));
 
                 Map<String, String> deltaProperties = new HashMap<>(this.deltaProperties.buildOrThrow());
                 if (!deltaProperties.containsKey("hive.metastore") && !deltaProperties.containsKey("hive.metastore.uri")) {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeGcsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeGcsConnectorSmokeTest.java
@@ -13,22 +13,36 @@
  */
 package io.trino.plugin.deltalake;
 
+import com.google.cloud.NoCredentials;
+import com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem;
+import com.google.cloud.storage.BucketInfo;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.google.common.reflect.ClassPath;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
 import io.airlift.log.Logger;
 import io.trino.filesystem.FileIterator;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.TrinoOutputFile;
+import io.trino.filesystem.gcs.GcsAuth;
+import io.trino.filesystem.gcs.GcsFileSystemConfig;
+import io.trino.filesystem.gcs.GcsFileSystemFactory;
+import io.trino.filesystem.gcs.GcsStorageFactory;
 import io.trino.plugin.hive.containers.HiveHadoop;
 import io.trino.spi.security.ConnectorIdentity;
 import io.trino.testing.QueryRunner;
+import io.trino.testing.containers.FlociGcp;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
+import org.testcontainers.containers.Network;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -37,15 +51,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.inject.multibindings.MapBinder.newMapBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.plugin.deltalake.TestingDeltaLakeUtils.getConnectorService;
 import static io.trino.plugin.hive.containers.HiveHadoop.HIVE3_IMAGE;
-import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
+import static io.trino.testing.containers.FlociGcp.FLOCI_GCP_PROJECT_ID;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.regex.Matcher.quoteReplacement;
@@ -53,12 +69,6 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 import static org.testcontainers.containers.Network.newNetwork;
 
-/**
- * This test requires these variables to connect to GCS:
- * - gcp-storage-bucket: The name of the bucket to store tables in. The bucket must already exist.
- * - gcp-credentials-key: A base64 encoded copy of the JSON authentication file for the service account used to connect to GCP.
- *   For example, `cat service-account-key.json | base64`
- */
 @TestInstance(PER_CLASS)
 @Execution(SAME_THREAD)
 public class TestDeltaLakeGcsConnectorSmokeTest
@@ -66,33 +76,27 @@ public class TestDeltaLakeGcsConnectorSmokeTest
 {
     private static final Logger LOG = Logger.get(TestDeltaLakeGcsConnectorSmokeTest.class);
     private static final FileAttribute<?> READ_ONLY_PERMISSIONS = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--"));
+    private static final String HADOOP_GCS_CONNECTOR = "/usr/hdp/3.1.0.0-78/hadoop-mapreduce/gcs-connector-1.9.10.3.1.0.0-78-shaded.jar";
+    private static final String TEZ_GCS_CONNECTOR = "/usr/hdp/3.1.0.0-78/tez/lib/gcs-connector-1.9.10.3.1.0.0-78-shaded.jar";
 
-    private final String gcpStorageBucket;
-    private final String gcpCredentialKey;
-
-    private Path gcpCredentialsFile;
-    private String gcpCredentials;
+    private FlociGcp flociGcp;
+    private Network network;
     private TrinoFileSystem fileSystem;
-
-    public TestDeltaLakeGcsConnectorSmokeTest()
-    {
-        this.gcpStorageBucket = requiredNonEmptySystemProperty("testing.gcp-storage-bucket");
-        this.gcpCredentialKey = requiredNonEmptySystemProperty("testing.gcp-credentials-key");
-    }
 
     @Override
     protected void environmentSetup()
     {
-        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
-        gcpCredentials = new String(jsonKeyBytes, UTF_8);
-        try {
-            this.gcpCredentialsFile = Files.createTempFile("gcp-credentials", ".json", READ_ONLY_PERMISSIONS);
-            gcpCredentialsFile.toFile().deleteOnExit();
-            Files.write(gcpCredentialsFile, jsonKeyBytes);
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        network = closeAfterClass(newNetwork());
+        flociGcp = closeAfterClass(new FlociGcp().withNetwork(network));
+        flociGcp.start();
+
+        GcsFileSystemConfig config = new GcsFileSystemConfig()
+                .setEndpoint(Optional.of(flociGcp.getEndpoint().toString()))
+                .setProjectId(FLOCI_GCP_PROJECT_ID);
+        GcsStorageFactory storageFactory = new GcsStorageFactory(
+                config,
+                (builder, _) -> builder.setCredentials(NoCredentials.getInstance()));
+        storageFactory.create(ConnectorIdentity.ofUser("test")).create(BucketInfo.of(bucketName));
     }
 
     @AfterAll
@@ -114,41 +118,78 @@ public class TestDeltaLakeGcsConnectorSmokeTest
     protected HiveHadoop createHiveHadoop()
             throws Exception
     {
-        String gcpSpecificCoreSiteXmlContent = Resources.toString(Resources.getResource("io/trino/plugin/deltalake/hdp3.1-core-site.xml.gcs-template"), UTF_8)
-                .replace("%GCP_CREDENTIALS_FILE_PATH%", "/etc/hadoop/conf/gcp-credentials.json");
+        Path containerCoreSite = createCoreSite(flociGcp.getContainerEndpoint().toString());
 
-        Path hadoopCoreSiteXmlTempFile = Files.createTempFile("core-site", ".xml", READ_ONLY_PERMISSIONS);
-        hadoopCoreSiteXmlTempFile.toFile().deleteOnExit();
-        Files.writeString(hadoopCoreSiteXmlTempFile, gcpSpecificCoreSiteXmlContent);
-
+        String gcsConnector = Path.of(GoogleHadoopFileSystem.class.getProtectionDomain().getCodeSource().getLocation().toURI())
+                .toAbsolutePath()
+                .toString();
         HiveHadoop hiveHadoop = HiveHadoop.builder()
                 .withImage(HIVE3_IMAGE)
-                .withNetwork(closeAfterClass(newNetwork()))
+                .withNetwork(network)
                 .withFilesToMount(ImmutableMap.of(
-                        "/etc/hadoop/conf/core-site.xml", hadoopCoreSiteXmlTempFile.normalize().toAbsolutePath().toString(),
-                        "/etc/hadoop/conf/gcp-credentials.json", gcpCredentialsFile.toAbsolutePath().toString()))
+                        "/etc/hadoop/conf/core-site.xml", containerCoreSite.normalize().toAbsolutePath().toString(),
+                        HADOOP_GCS_CONNECTOR, gcsConnector,
+                        TEZ_GCS_CONNECTOR, gcsConnector))
                 .build();
         hiveHadoop.start();
         return hiveHadoop; // closed by superclass
     }
 
+    private static Path createCoreSite(String endpoint)
+            throws IOException
+    {
+        String content = Resources.toString(Resources.getResource("io/trino/plugin/deltalake/hdp3.1-core-site.xml.gcs-template"), UTF_8)
+                .replace("%GCS_ENDPOINT%", endpoint + "/")
+                .replace("%GCP_PROJECT_ID%", FLOCI_GCP_PROJECT_ID);
+        Path coreSite = Files.createTempFile("core-site", ".xml", READ_ONLY_PERMISSIONS);
+        coreSite.toFile().deleteOnExit();
+        Files.writeString(coreSite, content);
+        return coreSite;
+    }
+
     @Override
     protected Map<String, String> hiveStorageConfiguration()
     {
-        return ImmutableMap.<String, String>builder()
-                .put("fs.gcs.enabled", "true")
-                .put("gcs.json-key", gcpCredentials)
-                .buildOrThrow();
+        return ImmutableMap.of(
+                "gcs.endpoint", flociGcp.getEndpoint().toString(),
+                "gcs.project-id", FLOCI_GCP_PROJECT_ID);
     }
 
     @Override
     protected Map<String, String> deltaStorageConfiguration()
     {
         return ImmutableMap.<String, String>builder()
-                .putAll(hiveStorageConfiguration())
+                .put("gcs.endpoint", flociGcp.getEndpoint().toString())
+                .put("gcs.project-id", FLOCI_GCP_PROJECT_ID)
                 // TODO why not unique table locations? (This is here since 52bf6680c1b25516f6e8e64f82ada089abc0c9d3.)
                 .put("delta.unique-table-location", "false")
                 .buildOrThrow();
+    }
+
+    @Override
+    protected Module additionalDeltaLakeModule()
+    {
+        return gcsModule();
+    }
+
+    @Override
+    protected Module additionalHiveModule()
+    {
+        return gcsModule();
+    }
+
+    private static Module gcsModule()
+    {
+        return binder -> {
+            configBinder(binder).bindConfig(GcsFileSystemConfig.class);
+            binder.bind(GcsAuth.class)
+                    .toInstance((builder, _) -> builder.setCredentials(NoCredentials.getInstance()));
+            binder.bind(GcsStorageFactory.class).in(Scopes.SINGLETON);
+            binder.bind(GcsFileSystemFactory.class).in(Scopes.SINGLETON);
+            newMapBinder(binder, String.class, TrinoFileSystemFactory.class)
+                    .addBinding("gs")
+                    .to(GcsFileSystemFactory.class);
+        };
     }
 
     @Override
@@ -198,6 +239,31 @@ public class TestDeltaLakeGcsConnectorSmokeTest
                 .collect(toImmutableList());
     }
 
+    @Test
+    @Override
+    @Disabled("Floci GCP does not preserve URI-encoded object names")
+    public void testPathUriDecoding() {}
+
+    @Test
+    @Override
+    @Disabled("Floci GCP does not preserve URI-encoded object names")
+    public void testPathUriEncoding() {}
+
+    @Test
+    @Override
+    @Disabled("Floci GCP does not preserve URI-encoded object names")
+    public void testVacuumWithWhiteSpace() {}
+
+    @RepeatedTest(3)
+    @Override
+    @Disabled("Floci GCP does not atomically enforce object preconditions")
+    public void testConcurrentInsertsReconciliationForBlindInserts() {}
+
+    @RepeatedTest(3)
+    @Override
+    @Disabled("Floci GCP does not atomically enforce object preconditions")
+    public void testConcurrentDeletePushdownReconciliation() {}
+
     private List<String> listAllFilesRecursive(String directory)
     {
         ImmutableList.Builder<String> locations = ImmutableList.builder();
@@ -230,6 +296,6 @@ public class TestDeltaLakeGcsConnectorSmokeTest
     @Override
     protected String bucketUrl()
     {
-        return format("gs://%s/%s/", gcpStorageBucket, bucketName);
+        return format("gs://%s/%s/", bucketName, bucketName);
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestingDeltaLakePlugin.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestingDeltaLakePlugin.java
@@ -30,7 +30,9 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
+import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.configuration.ConfigurationAwareModule.combine;
 import static io.trino.plugin.deltalake.DeltaLakeConnectorFactory.createConnector;
 import static java.util.Objects.requireNonNull;
 
@@ -40,18 +42,25 @@ public class TestingDeltaLakePlugin
     private final LocalFileSystemFactory localFileSystemFactory;
     private final TestingLocalTransactionLogSynchronizer localTransactionLogSynchronizer;
     private final Supplier<Optional<Module>> metastoreModule;
+    private final Module additionalModule;
 
     public TestingDeltaLakePlugin(Path localFileSystemRootPath)
     {
-        this(localFileSystemRootPath, Optional::empty);
+        this(localFileSystemRootPath, Optional::empty, EMPTY_MODULE);
     }
 
     public TestingDeltaLakePlugin(Path localFileSystemRootPath, Supplier<Optional<Module>> metastoreModule)
+    {
+        this(localFileSystemRootPath, metastoreModule, EMPTY_MODULE);
+    }
+
+    public TestingDeltaLakePlugin(Path localFileSystemRootPath, Supplier<Optional<Module>> metastoreModule, Module additionalModule)
     {
         localFileSystemRootPath.toFile().mkdirs();
         localFileSystemFactory = new LocalFileSystemFactory(localFileSystemRootPath);
         localTransactionLogSynchronizer = new TestingLocalTransactionLogSynchronizer(new DefaultDeltaLakeFileSystemFactory(localFileSystemFactory, new NoOpTableCredentialsProvider()));
         this.metastoreModule = requireNonNull(metastoreModule, "metastoreModule is null");
+        this.additionalModule = requireNonNull(additionalModule, "additionalModule is null");
     }
 
     @Override
@@ -73,16 +82,18 @@ public class TestingDeltaLakePlugin
                         config,
                         context,
                         metastoreModule.get(),
-                        binder -> {
-                            binder.install(new TestingDeltaLakeExtensionsModule());
-                            newMapBinder(binder, String.class, TrinoFileSystemFactory.class)
-                                    .addBinding("local").toInstance(localFileSystemFactory);
-                            newMapBinder(binder, String.class, TransactionLogSynchronizer.class)
-                                    .addBinding("local").toInstance(localTransactionLogSynchronizer);
-                            configBinder(binder).bindConfigDefaults(
-                                    FileHiveMetastoreConfig.class,
-                                    metastoreConfig -> metastoreConfig.setCatalogDirectory("local:///" + catalogName));
-                        });
+                        combine(
+                                binder -> {
+                                    binder.install(new TestingDeltaLakeExtensionsModule());
+                                    newMapBinder(binder, String.class, TrinoFileSystemFactory.class)
+                                            .addBinding("local").toInstance(localFileSystemFactory);
+                                    newMapBinder(binder, String.class, TransactionLogSynchronizer.class)
+                                            .addBinding("local").toInstance(localTransactionLogSynchronizer);
+                                    configBinder(binder).bindConfigDefaults(
+                                            FileHiveMetastoreConfig.class,
+                                            metastoreConfig -> metastoreConfig.setCatalogDirectory("local:///" + catalogName));
+                                },
+                                additionalModule));
             }
         });
     }

--- a/plugin/trino-delta-lake/src/test/resources/io/trino/plugin/deltalake/hdp3.1-core-site.xml.gcs-template
+++ b/plugin/trino-delta-lake/src/test/resources/io/trino/plugin/deltalake/hdp3.1-core-site.xml.gcs-template
@@ -42,25 +42,20 @@
     </property>
 
     <property>
-      <name>google.cloud.auth.service.account.enable</name>
-      <value>true</value>
-      <description>
-        Whether to use a service account for GCS authorizaiton. If an email and
-        keyfile are provided (see google.cloud.auth.service.account.email and
-        google.cloud.auth.service.account.keyfile), then that service account
-        willl be used. Otherwise the connector will look to see if it running on
-        a GCE VM with some level of GCS access in it's service account scope, and
-        use that service account.
-      </description>
+      <name>fs.gs.auth.service.account.enable</name>
+      <value>false</value>
     </property>
-
     <property>
-      <name>google.cloud.auth.service.account.json.keyfile</name>
-      <value>%GCP_CREDENTIALS_FILE_PATH%</value>
-      <description>
-        The JSON key file of the service account used for GCS
-        access when google.cloud.auth.service.account.enable is true.
-      </description>
+      <name>fs.gs.auth.null.enable</name>
+      <value>true</value>
+    </property>
+    <property>
+      <name>fs.gs.project.id</name>
+      <value>%GCP_PROJECT_ID%</value>
+    </property>
+    <property>
+      <name>fs.gs.storage.root.url</name>
+      <value>%GCS_ENDPOINT%</value>
     </property>
 
     <!-- OOZIE proxy user setting -->

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingHiveConnectorFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingHiveConnectorFactory.java
@@ -31,7 +31,9 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
+import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.configuration.ConfigurationAwareModule.combine;
 import static io.trino.plugin.hive.HiveConnectorFactory.createConnector;
 import static java.util.Objects.requireNonNull;
 
@@ -42,10 +44,11 @@ public class TestingHiveConnectorFactory
     private final boolean metastoreImpersonationEnabled;
     private final Path localFileSystemRootPath;
     private final Optional<DecryptionKeyRetriever> decryptionKeyRetriever;
+    private final Module additionalModule;
 
     public TestingHiveConnectorFactory(Path localFileSystemRootPath)
     {
-        this(localFileSystemRootPath, Optional.empty(), false, Optional.empty());
+        this(localFileSystemRootPath, Optional.empty(), false, Optional.empty(), EMPTY_MODULE);
     }
 
     @Deprecated
@@ -55,12 +58,23 @@ public class TestingHiveConnectorFactory
             boolean metastoreImpersonationEnabled,
             Optional<DecryptionKeyRetriever> decryptionKeyRetriever)
     {
+        this(localFileSystemRootPath, metastore, metastoreImpersonationEnabled, decryptionKeyRetriever, EMPTY_MODULE);
+    }
+
+    public TestingHiveConnectorFactory(
+            Path localFileSystemRootPath,
+            Optional<HiveMetastore> metastore,
+            boolean metastoreImpersonationEnabled,
+            Optional<DecryptionKeyRetriever> decryptionKeyRetriever,
+            Module additionalModule)
+    {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.metastoreImpersonationEnabled = metastoreImpersonationEnabled;
         var rootPath = localFileSystemRootPath.toFile();
         var _ = rootPath.mkdirs();
         this.localFileSystemRootPath = localFileSystemRootPath;
         this.decryptionKeyRetriever = requireNonNull(decryptionKeyRetriever, "decryptionKeyRetriever is null");
+        this.additionalModule = requireNonNull(additionalModule, "additionalModule is null");
     }
 
     @Override
@@ -78,19 +92,21 @@ public class TestingHiveConnectorFactory
         if (metastore.isEmpty() && !config.containsKey("hive.metastore")) {
             configBuilder.put("hive.metastore", "file");
         }
-        Supplier<Module> module = () -> binder -> {
-            newMapBinder(binder, String.class, TrinoFileSystemFactory.class)
-                    .addBinding("local").toInstance(new LocalFileSystemFactory(localFileSystemRootPath));
-            configBinder(binder).bindConfigDefaults(
-                    FileHiveMetastoreConfig.class,
-                    metastoreConfig -> metastoreConfig.setCatalogDirectory("local:///" + catalogName));
+        Supplier<Module> module = () -> combine(
+                binder -> {
+                    newMapBinder(binder, String.class, TrinoFileSystemFactory.class)
+                            .addBinding("local").toInstance(new LocalFileSystemFactory(localFileSystemRootPath));
+                    configBinder(binder).bindConfigDefaults(
+                            FileHiveMetastoreConfig.class,
+                            metastoreConfig -> metastoreConfig.setCatalogDirectory("local:///" + catalogName));
 
-            decryptionKeyRetriever.ifPresent(retriever -> {
-                Multibinder<DecryptionKeyRetriever> retrieverBinder =
-                        Multibinder.newSetBinder(binder, DecryptionKeyRetriever.class);
-                retrieverBinder.addBinding().toInstance(retriever);
-            });
-        };
+                    decryptionKeyRetriever.ifPresent(retriever -> {
+                        Multibinder<DecryptionKeyRetriever> retrieverBinder =
+                                Multibinder.newSetBinder(binder, DecryptionKeyRetriever.class);
+                        retrieverBinder.addBinding().toInstance(retriever);
+                    });
+                },
+                additionalModule);
         return createConnector(catalogName, configBuilder.buildOrThrow(), context, module, metastore, metastoreImpersonationEnabled, Optional.empty());
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingHivePlugin.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingHivePlugin.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Module;
 import io.trino.metastore.HiveMetastore;
 import io.trino.parquet.crypto.DecryptionKeyRetriever;
 import io.trino.spi.Plugin;
@@ -22,6 +23,7 @@ import io.trino.spi.connector.ConnectorFactory;
 import java.nio.file.Path;
 import java.util.Optional;
 
+import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static java.util.Objects.requireNonNull;
 
 public class TestingHivePlugin
@@ -31,16 +33,22 @@ public class TestingHivePlugin
     private final Optional<HiveMetastore> metastore;
     private final boolean metastoreImpersonationEnabled;
     private final Optional<DecryptionKeyRetriever> decryptionKeyRetriever;
+    private final Module additionalModule;
 
     public TestingHivePlugin(Path localFileSystemRootPath)
     {
-        this(localFileSystemRootPath, Optional.empty(), false, Optional.empty());
+        this(localFileSystemRootPath, Optional.empty(), false, Optional.empty(), EMPTY_MODULE);
+    }
+
+    public TestingHivePlugin(Path localFileSystemRootPath, Module additionalModule)
+    {
+        this(localFileSystemRootPath, Optional.empty(), false, Optional.empty(), additionalModule);
     }
 
     @Deprecated
     public TestingHivePlugin(Path localFileSystemRootPath, HiveMetastore metastore)
     {
-        this(localFileSystemRootPath, Optional.of(metastore), false, Optional.empty());
+        this(localFileSystemRootPath, Optional.of(metastore), false, Optional.empty(), EMPTY_MODULE);
     }
 
     @Deprecated
@@ -50,15 +58,26 @@ public class TestingHivePlugin
             boolean metastoreImpersonationEnabled,
             Optional<DecryptionKeyRetriever> decryptionKeyRetriever)
     {
+        this(localFileSystemRootPath, metastore, metastoreImpersonationEnabled, decryptionKeyRetriever, EMPTY_MODULE);
+    }
+
+    public TestingHivePlugin(
+            Path localFileSystemRootPath,
+            Optional<HiveMetastore> metastore,
+            boolean metastoreImpersonationEnabled,
+            Optional<DecryptionKeyRetriever> decryptionKeyRetriever,
+            Module additionalModule)
+    {
         this.localFileSystemRootPath = requireNonNull(localFileSystemRootPath, "localFileSystemRootPath is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.metastoreImpersonationEnabled = metastoreImpersonationEnabled;
         this.decryptionKeyRetriever = requireNonNull(decryptionKeyRetriever, "decryptionKeyRetriever is null");
+        this.additionalModule = requireNonNull(additionalModule, "additionalModule is null");
     }
 
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new TestingHiveConnectorFactory(localFileSystemRootPath, metastore, metastoreImpersonationEnabled, decryptionKeyRetriever));
+        return ImmutableList.of(new TestingHiveConnectorFactory(localFileSystemRootPath, metastore, metastoreImpersonationEnabled, decryptionKeyRetriever, additionalModule));
     }
 }

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/FlociGcp.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/FlociGcp.java
@@ -25,17 +25,24 @@ public final class FlociGcp
     public static final String FLOCI_GCP_IMAGE = "floci/floci-gcp:0.3.0";
     public static final String FLOCI_GCP_PROJECT_ID = "floci-local";
 
+    private static final String FLOCI_GCP_NETWORK_ALIAS = "floci-gcp";
     private static final int FLOCI_GCP_PORT = 4588;
 
     public FlociGcp()
     {
         super(DockerImageName.parse(FLOCI_GCP_IMAGE));
         addExposedPort(FLOCI_GCP_PORT);
+        withNetworkAliases(FLOCI_GCP_NETWORK_ALIAS);
         waitingFor(Wait.forLogMessage(".*=== floci-gcp Ready ===.*\\n", 1));
     }
 
     public URI getEndpoint()
     {
         return URI.create("http://%s:%s".formatted(getHost(), getMappedPort(FLOCI_GCP_PORT)));
+    }
+
+    public URI getContainerEndpoint()
+    {
+        return URI.create("http://%s:%s".formatted(FLOCI_GCP_NETWORK_ALIAS, FLOCI_GCP_PORT));
     }
 }


### PR DESCRIPTION
## Description

Converts the Delta Lake GCS smoke test to use [Floci](https://floci.io)-backed GCS storage.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.