### PR TITLE
Use Floci for GCS REST tests

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -959,7 +959,6 @@
                                 <exclude>**/TestIcebergS3TablesConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergBigLakeMetastoreConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergGcsConnectorSmokeTest.java</exclude>
-                                <exclude>**/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergAbfsVendingRestCatalogConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergAzureRestCatalogVendedCredentialsRefresh.java</exclude>
                                 <exclude>**/TestIcebergAbfsConnectorSmokeTest.java</exclude>
@@ -1020,7 +1019,6 @@
                                 <include>**/TestIcebergS3TablesConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergBigLakeMetastoreConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergGcsConnectorSmokeTest.java</include>
-                                <include>**/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergAbfsVendingRestCatalogConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergAzureRestCatalogVendedCredentialsRefresh.java</include>
                                 <include>**/TestIcebergAbfsConnectorSmokeTest.java</include>

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -960,8 +960,6 @@
                                 <exclude>**/TestIcebergBigLakeMetastoreConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergGcsConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java</exclude>
-                                <exclude>**/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java</exclude>
-                                <exclude>**/TestIcebergGcsRestCatalogStorageCredentialsRefresh.java</exclude>
                                 <exclude>**/TestIcebergAbfsVendingRestCatalogConnectorSmokeTest.java</exclude>
                                 <exclude>**/TestIcebergAzureRestCatalogVendedCredentialsRefresh.java</exclude>
                                 <exclude>**/TestIcebergAbfsConnectorSmokeTest.java</exclude>
@@ -1023,8 +1021,6 @@
                                 <include>**/TestIcebergBigLakeMetastoreConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergGcsConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java</include>
-                                <include>**/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java</include>
-                                <include>**/TestIcebergGcsRestCatalogStorageCredentialsRefresh.java</include>
                                 <include>**/TestIcebergAbfsVendingRestCatalogConnectorSmokeTest.java</include>
                                 <include>**/TestIcebergAzureRestCatalogVendedCredentialsRefresh.java</include>
                                 <include>**/TestIcebergAbfsConnectorSmokeTest.java</include>

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogStorageCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogStorageCredentialsRefresh.java
@@ -13,19 +13,8 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.google.auth.oauth2.AccessToken;
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.log.Logger;
-import io.trino.filesystem.Location;
-import io.trino.filesystem.TrinoFileSystem;
-import io.trino.filesystem.gcs.GcsFileSystemConfig;
-import io.trino.filesystem.gcs.GcsFileSystemFactory;
-import io.trino.filesystem.gcs.GcsServiceAccountAuth;
-import io.trino.filesystem.gcs.GcsServiceAccountAuthConfig;
-import io.trino.filesystem.gcs.GcsStorageFactory;
+import io.trino.testing.containers.FlociGcp;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.gcp.gcs.GCSFileIO;
@@ -35,76 +24,30 @@ import org.apache.iceberg.rest.RESTResponse;
 import org.apache.iceberg.rest.credentials.ImmutableCredential;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Base64;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static io.trino.testing.containers.FlociGcp.FLOCI_GCP_PROJECT_ID;
 import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
 
 final class TestIcebergGcsRestCatalogStorageCredentialsRefresh
         extends AbstractTestIcebergRestCatalogVendedCredentialsRefresh
 {
-    private static final Logger LOG = Logger.get(TestIcebergGcsRestCatalogStorageCredentialsRefresh.class);
+    private final String gcpStorageBucket = "test-iceberg-gcs-storage-credentials-refresh-" + randomNameSuffix();
 
-    private final String gcpCredentialKey = requiredNonEmptySystemProperty("testing.gcp-credentials-key");
-    private final String gcpStorageBucket = requiredNonEmptySystemProperty("testing.gcp-storage-bucket");
-
-    private String oauthToken;
-    private long tokenExpiresAtMs;
-    private String gcpProjectId;
-    private TrinoFileSystem fileSystem;
-
-    @BeforeAll
-    public void initFileSystem()
-            throws Exception
-    {
-        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
-        GcsFileSystemConfig config = new GcsFileSystemConfig();
-        GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig().setJsonKey(new String(jsonKeyBytes, UTF_8));
-        GcsStorageFactory storageFactory = new GcsStorageFactory(config, new GcsServiceAccountAuth(authConfig));
-        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
-    }
-
-    @AfterAll
-    public void removeTestData()
-    {
-        if (fileSystem == null) {
-            return;
-        }
-        try {
-            fileSystem.deleteDirectory(Location.of(warehouseLocation));
-        }
-        catch (IOException e) {
-            // The GCS bucket should be configured to expire objects automatically. Clean up issues do not need to fail the test.
-            LOG.warn(e, "Failed to clean up GCS test directory: %s", warehouseLocation);
-        }
-    }
+    private final String oauthToken = "test-oauth-token";
+    private final long tokenExpiresAtMs = sessionTokenExpirationTime.get().toEpochMilli();
+    private FlociGcp flociGcp;
 
     @Override
     protected String setupStorageAndGetWarehouseLocation()
             throws Exception
     {
-        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
-        String gcpCredentials = new String(jsonKeyBytes, UTF_8);
-
-        GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(jsonKeyBytes))
-                .createScoped("https://www.googleapis.com/auth/cloud-platform");
-        AccessToken accessToken = credentials.refreshAccessToken();
-        oauthToken = accessToken.getTokenValue();
-        tokenExpiresAtMs = accessToken.getExpirationTime().getTime();
-
-        JsonMapper mapper = new JsonMapper();
-        JsonNode jsonKey = mapper.readTree(gcpCredentials);
-        gcpProjectId = jsonKey.get("project_id").asText();
+        flociGcp = closeAfterClass(new FlociGcp());
+        flociGcp.start();
+        flociGcp.createBucket(gcpStorageBucket);
 
         return "gs://%s/gcs-storage-creds-rest-refresh-test-%s/".formatted(gcpStorageBucket, randomNameSuffix());
     }
@@ -114,7 +57,8 @@ final class TestIcebergGcsRestCatalogStorageCredentialsRefresh
     {
         return ImmutableMap.<String, String>builder()
                 .put(FILE_IO_IMPL, GCSFileIO.class.getName())
-                .put(GCPProperties.GCS_PROJECT_ID, gcpProjectId)
+                .put(GCPProperties.GCS_PROJECT_ID, FLOCI_GCP_PROJECT_ID)
+                .put(GCPProperties.GCS_SERVICE_HOST, flociGcp.getEndpoint().toString())
                 .put(GCPProperties.GCS_OAUTH2_TOKEN, oauthToken)
                 .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(tokenExpiresAtMs))
                 .buildOrThrow();
@@ -182,6 +126,8 @@ final class TestIcebergGcsRestCatalogStorageCredentialsRefresh
         return ImmutableMap.<String, String>builder()
                 .put("fs.gcs.enabled", "true")
                 .put("gcs.auth-type", "APPLICATION_DEFAULT")
+                .put("gcs.endpoint", flociGcp.getEndpoint().toString())
+                .put("gcs.project-id", FLOCI_GCP_PROJECT_ID)
                 .buildOrThrow();
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsRestCatalogVendedCredentialsRefresh.java
@@ -13,96 +13,34 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.google.auth.oauth2.AccessToken;
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.log.Logger;
-import io.trino.filesystem.Location;
-import io.trino.filesystem.TrinoFileSystem;
-import io.trino.filesystem.gcs.GcsFileSystemConfig;
-import io.trino.filesystem.gcs.GcsFileSystemFactory;
-import io.trino.filesystem.gcs.GcsServiceAccountAuth;
-import io.trino.filesystem.gcs.GcsServiceAccountAuthConfig;
-import io.trino.filesystem.gcs.GcsStorageFactory;
+import io.trino.testing.containers.FlociGcp;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.gcp.gcs.GCSFileIO;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Base64;
 import java.util.Map;
 
-import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static io.trino.testing.containers.FlociGcp.FLOCI_GCP_PROJECT_ID;
 import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
 
 final class TestIcebergGcsRestCatalogVendedCredentialsRefresh
         extends AbstractTestIcebergRestCatalogVendedCredentialsRefresh
 {
-    private static final Logger LOG = Logger.get(TestIcebergGcsRestCatalogVendedCredentialsRefresh.class);
+    private final String gcpStorageBucket = "test-iceberg-gcs-vended-credentials-refresh-" + randomNameSuffix();
 
-    private final String gcpCredentialKey = requiredNonEmptySystemProperty("testing.gcp-credentials-key");
-    private final String gcpStorageBucket = requiredNonEmptySystemProperty("testing.gcp-storage-bucket");
-
-    private String oauthToken;
-    private long tokenExpiresAtMs;
-    private String gcpProjectId;
-    private TrinoFileSystem fileSystem;
-
-    @BeforeAll
-    public void initFileSystem()
-    {
-        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
-        GcsFileSystemConfig config = new GcsFileSystemConfig();
-        GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig().setJsonKey(new String(jsonKeyBytes, UTF_8));
-        GcsStorageFactory storageFactory;
-        try {
-            storageFactory = new GcsStorageFactory(config, new GcsServiceAccountAuth(authConfig));
-        }
-        catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
-    }
-
-    @AfterAll
-    public void removeTestData()
-    {
-        if (fileSystem == null) {
-            return;
-        }
-        try {
-            fileSystem.deleteDirectory(Location.of(warehouseLocation));
-        }
-        catch (IOException e) {
-            // The GCS bucket should be configured to expire objects automatically. Clean up issues do not need to fail the test.
-            LOG.warn(e, "Failed to clean up GCS test directory: %s", warehouseLocation);
-        }
-    }
+    private final String oauthToken = "test-oauth-token";
+    private final long tokenExpiresAtMs = sessionTokenExpirationTime.get().toEpochMilli();
+    private FlociGcp flociGcp;
 
     @Override
     protected String setupStorageAndGetWarehouseLocation()
             throws Exception
     {
-        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
-        String gcpCredentials = new String(jsonKeyBytes, UTF_8);
-
-        GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(jsonKeyBytes))
-                .createScoped("https://www.googleapis.com/auth/cloud-platform");
-        AccessToken accessToken = credentials.refreshAccessToken();
-        oauthToken = accessToken.getTokenValue();
-        tokenExpiresAtMs = accessToken.getExpirationTime().getTime();
-
-        JsonMapper mapper = new JsonMapper();
-        JsonNode jsonKey = mapper.readTree(gcpCredentials);
-        gcpProjectId = jsonKey.get("project_id").asText();
+        flociGcp = closeAfterClass(new FlociGcp());
+        flociGcp.start();
+        flociGcp.createBucket(gcpStorageBucket);
 
         return "gs://%s/gcs-vending-rest-refresh-test-%s/".formatted(gcpStorageBucket, randomNameSuffix());
     }
@@ -112,7 +50,8 @@ final class TestIcebergGcsRestCatalogVendedCredentialsRefresh
     {
         return ImmutableMap.<String, String>builder()
                 .put(FILE_IO_IMPL, GCSFileIO.class.getName())
-                .put(GCPProperties.GCS_PROJECT_ID, gcpProjectId)
+                .put(GCPProperties.GCS_PROJECT_ID, FLOCI_GCP_PROJECT_ID)
+                .put(GCPProperties.GCS_SERVICE_HOST, flociGcp.getEndpoint().toString())
                 .put(GCPProperties.GCS_OAUTH2_TOKEN, oauthToken)
                 .put(GCPProperties.GCS_OAUTH2_TOKEN_EXPIRES_AT, Long.toString(tokenExpiresAtMs))
                 .buildOrThrow();
@@ -161,6 +100,8 @@ final class TestIcebergGcsRestCatalogVendedCredentialsRefresh
         return ImmutableMap.<String, String>builder()
                 .put("fs.gcs.enabled", "true")
                 .put("gcs.auth-type", "APPLICATION_DEFAULT")
+                .put("gcs.endpoint", flociGcp.getEndpoint().toString())
+                .put("gcs.project-id", FLOCI_GCP_PROJECT_ID)
                 .buildOrThrow();
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergGcsVendingRestCatalogConnectorSmokeTest.java
@@ -13,63 +13,55 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.google.auth.oauth2.AccessToken;
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.log.Logger;
 import io.trino.filesystem.Location;
-import io.trino.filesystem.gcs.GcsFileSystemConfig;
-import io.trino.filesystem.gcs.GcsFileSystemFactory;
-import io.trino.filesystem.gcs.GcsServiceAccountAuth;
-import io.trino.filesystem.gcs.GcsServiceAccountAuthConfig;
-import io.trino.filesystem.gcs.GcsStorageFactory;
+import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.iceberg.BaseIcebergConnectorSmokeTest;
 import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.spi.security.ConnectorIdentity;
 import io.trino.testing.QueryFailedException;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
+import io.trino.testing.containers.FlociGcp;
 import io.trino.testing.containers.IcebergGcsRestCatalogBackendContainer;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.RESTSessionCatalog;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Network;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Base64;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 
+import static io.trino.filesystem.gcs.GcsFileSystemConstants.EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getConnectorService;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
+import static io.trino.testing.containers.FlociGcp.FLOCI_GCP_PROJECT_ID;
 import static java.lang.String.format;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class TestIcebergGcsVendingRestCatalogConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {
-    private static final Logger LOG = Logger.get(TestIcebergGcsVendingRestCatalogConnectorSmokeTest.class);
+    private static final String OAUTH_TOKEN = "test-oauth-token";
 
-    private final String gcpCredentialKey;
-    private final String warehouseLocation;
+    private final String bucketName = "test-iceberg-gcs-vending-rest-" + randomNameSuffix();
 
+    private String warehouseLocation;
     private IcebergGcsRestCatalogBackendContainer restCatalog;
 
     public TestIcebergGcsVendingRestCatalogConnectorSmokeTest()
     {
         super(new IcebergConfig().getFileFormat().toIceberg());
-        gcpCredentialKey = requiredNonEmptySystemProperty("testing.gcp-credentials-key");
-        String gcpStorageBucket = requiredNonEmptySystemProperty("testing.gcp-storage-bucket");
-        warehouseLocation = "gs://%s/gcs-vending-rest-test-%s/".formatted(gcpStorageBucket, randomNameSuffix());
     }
 
     @Override
@@ -87,22 +79,19 @@ final class TestIcebergGcsVendingRestCatalogConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
-        String gcpCredentials = new String(jsonKeyBytes, UTF_8);
+        Network network = closeAfterClass(Network.newNetwork());
+        FlociGcp flociGcp = closeAfterClass(new FlociGcp().withNetwork(network));
+        flociGcp.start();
+        flociGcp.createBucket(bucketName);
 
-        GoogleCredentials credentials = GoogleCredentials.fromStream(new ByteArrayInputStream(jsonKeyBytes))
-                .createScoped("https://www.googleapis.com/auth/cloud-platform");
-        AccessToken accessToken = credentials.refreshAccessToken();
-
-        JsonMapper mapper = new JsonMapper();
-        JsonNode jsonKey = mapper.readTree(gcpCredentials);
-        String gcpProjectId = jsonKey.get("project_id").asText();
-
+        warehouseLocation = "gs://%s/gcs-vending-rest-test-%s/".formatted(bucketName, randomNameSuffix());
         restCatalog = closeAfterClass(new IcebergGcsRestCatalogBackendContainer(
+                Optional.of(network),
                 warehouseLocation,
-                gcpProjectId,
-                accessToken.getTokenValue(),
-                accessToken.getExpirationTime().getTime()));
+                FLOCI_GCP_PROJECT_ID,
+                flociGcp.getContainerEndpoint().toString(),
+                OAUTH_TOKEN,
+                Instant.now().plus(1, ChronoUnit.HOURS).toEpochMilli()));
         restCatalog.start();
 
         return IcebergQueryRunner.builder()
@@ -115,6 +104,8 @@ final class TestIcebergGcsVendingRestCatalogConnectorSmokeTest
                                 .put("iceberg.writer-sort-buffer-size", "1MB")
                                 .put("fs.gcs.enabled", "true")
                                 .put("gcs.auth-type", "APPLICATION_DEFAULT")
+                                .put("gcs.endpoint", flociGcp.getEndpoint().toString())
+                                .put("gcs.project-id", FLOCI_GCP_PROJECT_ID)
                                 .buildOrThrow())
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
@@ -124,32 +115,10 @@ final class TestIcebergGcsVendingRestCatalogConnectorSmokeTest
     @BeforeAll
     public void initFileSystem()
     {
-        byte[] jsonKeyBytes = Base64.getDecoder().decode(gcpCredentialKey);
-        GcsFileSystemConfig config = new GcsFileSystemConfig();
-        GcsServiceAccountAuthConfig authConfig = new GcsServiceAccountAuthConfig().setJsonKey(new String(jsonKeyBytes, UTF_8));
-        GcsStorageFactory storageFactory;
-        try {
-            storageFactory = new GcsStorageFactory(config, new GcsServiceAccountAuth(authConfig));
-        }
-        catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        fileSystem = new GcsFileSystemFactory(config, storageFactory).create(SESSION);
-    }
-
-    @AfterAll
-    public void removeTestData()
-    {
-        if (fileSystem == null) {
-            return;
-        }
-        try {
-            fileSystem.deleteDirectory(Location.of(warehouseLocation));
-        }
-        catch (IOException e) {
-            // The GCS bucket should be configured to expire objects automatically. Clean up issues do not need to fail the test.
-            LOG.warn(e, "Failed to clean up GCS test directory: %s", warehouseLocation);
-        }
+        fileSystem = getConnectorService(getQueryRunner(), TrinoFileSystemFactory.class)
+                .create(ConnectorIdentity.forUser(SESSION.getUser())
+                        .withExtraCredentials(ImmutableMap.of(EXTRA_CREDENTIALS_GCS_OAUTH_TOKEN_PROPERTY, OAUTH_TOKEN))
+                        .build());
     }
 
     @Test

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/FlociGcp.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/FlociGcp.java
@@ -17,7 +17,15 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static java.net.http.HttpRequest.BodyPublishers.ofString;
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
 
 public final class FlociGcp
         extends GenericContainer<FlociGcp>
@@ -31,11 +39,33 @@ public final class FlociGcp
     {
         super(DockerImageName.parse(FLOCI_GCP_IMAGE));
         addExposedPort(FLOCI_GCP_PORT);
-        waitingFor(Wait.forLogMessage(".*=== floci-gcp Ready ===.*\\n", 1));
+        waitingFor(Wait.forHttp("/_floci-gcp/init").forPort(FLOCI_GCP_PORT));
     }
 
     public URI getEndpoint()
     {
         return URI.create("http://%s:%s".formatted(getHost(), getMappedPort(FLOCI_GCP_PORT)));
+    }
+
+    public void createBucket(String bucketName)
+    {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(getEndpoint().resolve("/storage/v1/b?project=" + FLOCI_GCP_PROJECT_ID))
+                .header("Content-Type", "application/json")
+                .POST(ofString("{\"name\":\"%s\"}".formatted(bucketName)))
+                .build();
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpResponse<String> response = client.send(request, ofString());
+            if (response.statusCode() != 200) {
+                throw new RuntimeException("Failed to create bucket (HTTP %s): %s".formatted(response.statusCode(), response.body()));
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/FlociGcp.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/FlociGcp.java
@@ -33,18 +33,25 @@ public final class FlociGcp
     public static final String FLOCI_GCP_IMAGE = "floci/floci-gcp:0.3.0";
     public static final String FLOCI_GCP_PROJECT_ID = "floci-local";
 
+    private static final String FLOCI_GCP_NETWORK_ALIAS = "floci-gcp";
     private static final int FLOCI_GCP_PORT = 4588;
 
     public FlociGcp()
     {
         super(DockerImageName.parse(FLOCI_GCP_IMAGE));
         addExposedPort(FLOCI_GCP_PORT);
+        withNetworkAliases(FLOCI_GCP_NETWORK_ALIAS);
         waitingFor(Wait.forHttp("/_floci-gcp/init").forPort(FLOCI_GCP_PORT));
     }
 
     public URI getEndpoint()
     {
         return URI.create("http://%s:%s".formatted(getHost(), getMappedPort(FLOCI_GCP_PORT)));
+    }
+
+    public URI getContainerEndpoint()
+    {
+        return URI.create("http://%s:%s".formatted(FLOCI_GCP_NETWORK_ALIAS, FLOCI_GCP_PORT));
     }
 
     public void createBucket(String bucketName)

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/IcebergGcsRestCatalogBackendContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/IcebergGcsRestCatalogBackendContainer.java
@@ -15,6 +15,7 @@ package io.trino.testing.containers;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.testcontainers.containers.Network;
 
 import java.util.Optional;
 
@@ -22,8 +23,10 @@ public class IcebergGcsRestCatalogBackendContainer
         extends BaseTestContainer
 {
     public IcebergGcsRestCatalogBackendContainer(
+            Optional<Network> network,
             String warehouseLocation,
             String gcpProjectId,
+            String gcpServiceHost,
             String accessToken,
             long accessTokenExpiresAt)
     {
@@ -36,9 +39,10 @@ public class IcebergGcsRestCatalogBackendContainer
                         "CATALOG_WAREHOUSE", warehouseLocation,
                         "CATALOG_IO__IMPL", "org.apache.iceberg.gcp.gcs.GCSFileIO",
                         "CATALOG_GCS_PROJECT__ID", gcpProjectId,
+                        "CATALOG_GCS_SERVICE_HOST", gcpServiceHost,
                         "CATALOG_GCS_OAUTH2_TOKEN", accessToken,
                         "CATALOG_GCS_OAUTH2_TOKEN_EXPIRES_AT", Long.toString(accessTokenExpiresAt)),
-                Optional.empty(),
+                network,
                 5);
     }
 


### PR DESCRIPTION
## Description

Converts GCS REST credential refresh and vending tests to use [Floci](https://floci.io)-backed GCS storage.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
