### PR TITLE
Add support for location schema property in BigQuery

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.md
+++ b/docs/src/main/sphinx/connector/bigquery.md
@@ -499,6 +499,19 @@ the following features:
 ```{include} sql-delete-limitation.fragment
 ```
 
+### Schema properties
+
+The connector supports setting the location of a schema when it is created with
+the {doc}`/sql/create-schema` statement and the `location` schema property. The
+value must be a [BigQuery dataset location](https://cloud.google.com/bigquery/docs/locations),
+for example `US`, `EU`, or `asia-northeast1`. When the property is omitted,
+BigQuery applies its own default location.
+
+```sql
+CREATE SCHEMA example.example_schema
+WITH (location = 'asia-northeast1');
+```
+
 ### Wildcard table
 
 The connector provides support to query multiple tables using a concise

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnector.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnector.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.bootstrap.LifeCycleManager;
@@ -47,6 +48,7 @@ public class BigQueryConnector
     private final Set<ConnectorTableFunction> connectorTableFunctions;
     private final Set<Procedure> procedures;
     private final List<PropertyMetadata<?>> sessionProperties;
+    private final List<PropertyMetadata<?>> schemaProperties;
 
     @Inject
     public BigQueryConnector(
@@ -57,7 +59,8 @@ public class BigQueryConnector
             BigQueryPageSinkProvider pageSinkProvider,
             Set<ConnectorTableFunction> connectorTableFunctions,
             Set<Procedure> procedures,
-            Set<SessionPropertiesProvider> sessionPropertiesProviders)
+            Set<SessionPropertiesProvider> sessionPropertiesProviders,
+            BigQuerySchemaProperties schemaProperties)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
@@ -69,6 +72,7 @@ public class BigQueryConnector
         this.sessionProperties = sessionPropertiesProviders.stream()
                 .flatMap(sessionPropertiesProvider -> sessionPropertiesProvider.getSessionProperties().stream())
                 .collect(toImmutableList());
+        this.schemaProperties = ImmutableList.copyOf(requireNonNull(schemaProperties, "schemaProperties is null").schemaProperties());
     }
 
     @Override
@@ -129,6 +133,12 @@ public class BigQueryConnector
     public List<PropertyMetadata<?>> getSessionProperties()
     {
         return sessionProperties;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSchemaProperties()
+    {
+        return schemaProperties;
     }
 
     @Override

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
@@ -83,6 +83,7 @@ public class BigQueryConnectorModule
             binder.bind(BigQueryPageSourceProvider.class).in(Scopes.SINGLETON);
             binder.bind(BigQueryPageSinkProvider.class).in(Scopes.SINGLETON);
             binder.bind(ViewMaterializationCache.class).in(Scopes.SINGLETON);
+            binder.bind(BigQuerySchemaProperties.class).in(Scopes.SINGLETON);
             configBinder(binder).bindConfig(BigQueryConfig.class);
             configBinder(binder).bindConfig(BigQueryRpcConfig.class);
             newOptionalBinder(binder, BigQueryArrowBufferAllocator.class);

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryErrorCode.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryErrorCode.java
@@ -34,6 +34,7 @@ public enum BigQueryErrorCode
     BIGQUERY_BAD_WRITE(8, EXTERNAL),
     BIGQUERY_LISTING_TABLE_ERROR(9, EXTERNAL),
     BIGQUERY_CREATE_READ_SESSION_ERROR(10, EXTERNAL),
+    BIGQUERY_CREATE_SCHEMA(11, EXTERNAL),
     /**/;
 
     private final ErrorCode errorCode;

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -132,11 +132,13 @@ import static io.trino.plugin.base.TemporaryTables.generateTemporaryTableName;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.replaceWithNewVariables;
 import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_BAD_WRITE;
+import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_CREATE_SCHEMA;
 import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_FAILED_TO_EXECUTE_QUERY;
 import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_LISTING_TABLE_ERROR;
 import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_UNSUPPORTED_OPERATION;
 import static io.trino.plugin.bigquery.BigQueryPseudoColumn.PARTITION_DATE;
 import static io.trino.plugin.bigquery.BigQueryPseudoColumn.PARTITION_TIME;
+import static io.trino.plugin.bigquery.BigQuerySchemaProperties.LOCATION_PROPERTY;
 import static io.trino.plugin.bigquery.BigQuerySessionProperties.isProjectionPushdownEnabled;
 import static io.trino.plugin.bigquery.BigQuerySessionProperties.isSkipViewMaterialization;
 import static io.trino.plugin.bigquery.BigQueryTableHandle.BigQueryPartitionType.INGESTION;
@@ -152,6 +154,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 import static java.util.function.Function.identity;
 
 public class BigQueryMetadata
@@ -508,9 +511,14 @@ public class BigQueryMetadata
     public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, TrinoPrincipal owner)
     {
         BigQueryClient client = bigQueryClientFactory.create(session);
-        checkArgument(properties.isEmpty(), "Can't have properties for schema creation");
-        DatasetInfo datasetInfo = DatasetInfo.newBuilder(client.toDatasetId(schemaName)).build();
-        client.createSchema(datasetInfo);
+        DatasetInfo.Builder datasetInfo = DatasetInfo.newBuilder(client.toDatasetId(schemaName));
+        BigQuerySchemaProperties.location(properties).ifPresent(datasetInfo::setLocation);
+        try {
+            client.createSchema(datasetInfo.build());
+        }
+        catch (BigQueryException e) {
+            throw new TrinoException(BIGQUERY_CREATE_SCHEMA, "Failed to create schema. " + requireNonNullElse(e.getMessage(), e), e);
+        }
     }
 
     @Override
@@ -520,6 +528,24 @@ public class BigQueryMetadata
         DatasetId localDatasetId = client.toDatasetId(schemaName);
         String remoteSchemaName = getRemoteSchemaName(client, localDatasetId.getProject(), localDatasetId.getDataset());
         client.dropSchema(DatasetId.of(localDatasetId.getProject(), remoteSchemaName), cascade);
+    }
+
+    @Override
+    public Map<String, Object> getSchemaProperties(ConnectorSession session, String schemaName)
+    {
+        BigQueryClient client = bigQueryClientFactory.create(session);
+        DatasetId localDatasetId = client.toDatasetId(schemaName);
+        String remoteSchemaName = getRemoteSchemaName(client, localDatasetId.getProject(), localDatasetId.getDataset());
+        DatasetInfo dataset = client.getDataset(DatasetId.of(localDatasetId.getProject(), remoteSchemaName));
+        if (dataset == null) {
+            throw new SchemaNotFoundException(schemaName);
+        }
+
+        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+        if (dataset.getLocation() != null) {
+            properties.put(LOCATION_PROPERTY, dataset.getLocation());
+        }
+        return properties.buildOrThrow();
     }
 
     private void setRollback(Runnable action)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySchemaProperties.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySchemaProperties.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.session.PropertyMetadata.stringProperty;
+
+public final class BigQuerySchemaProperties
+{
+    public static final String LOCATION_PROPERTY = "location";
+
+    private final List<PropertyMetadata<?>> schemaProperties;
+
+    @Inject
+    public BigQuerySchemaProperties()
+    {
+        schemaProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .add(stringProperty(
+                        LOCATION_PROPERTY,
+                        "BigQuery dataset location, e.g. US, EU, asia-northeast1. Defaults to the BigQuery API's default (US) when unset.",
+                        null,
+                        false))
+                .build();
+    }
+
+    public List<PropertyMetadata<?>> schemaProperties()
+    {
+        return schemaProperties;
+    }
+
+    public static Optional<String> location(Map<String, Object> schemaProperties)
+    {
+        return Optional.ofNullable((String) schemaProperties.get(LOCATION_PROPERTY));
+    }
+}

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -128,6 +128,46 @@ public abstract class BaseBigQueryConnectorTest
     }
 
     @Test
+    @Override // BigQuery connector exposes location property
+    public void testShowCreateSchema()
+    {
+        String schemaName = getSession().getSchema().orElseThrow();
+        assertThat((String) computeScalar("SHOW CREATE SCHEMA " + schemaName))
+                .isEqualTo(
+                        """
+                        CREATE SCHEMA %s.%s
+                        WITH (
+                           location = 'US'
+                        )""".formatted(getSession().getCatalog().orElseThrow(), schemaName));
+    }
+
+    @Test
+    public void testCreateSchemaWithLocation()
+    {
+        String schemaName = "test_schema_with_location_" + randomNameSuffix();
+        try {
+            assertUpdate("CREATE SCHEMA " + schemaName + " WITH (location = 'us-east1')");
+            assertThat((String) computeScalar("SHOW CREATE SCHEMA " + schemaName))
+                    .contains("location = 'us-east1'");
+        }
+        finally {
+            assertUpdate("DROP SCHEMA IF EXISTS " + schemaName);
+        }
+    }
+
+    @Test
+    public void testCreateSchemaWithInvalidLocation()
+    {
+        String schemaName = "test_schema_with_invalid_location_" + randomNameSuffix();
+        try {
+            assertQueryFails("CREATE SCHEMA " + schemaName + " WITH (location = 'invalid-location')", "Failed to create schema.*");
+        }
+        finally {
+            assertUpdate("DROP SCHEMA IF EXISTS " + schemaName);
+        }
+    }
+
+    @Test
     @Disabled // Disable this test because this test is slow and BigQuery connector doesn't support sample pushdown
     @Override
     public void testTableSampleBernoulli() {}


### PR DESCRIPTION
## Description

- Fixes #30366

## Release notes

```markdown
## BigQuery
* Add support for `location` schema property. ({issue}`30366`)
```
