### PR TITLE
Fix Oracle NUMBER column with zero precision mapping to NUMBER type

### DIFF
--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -557,6 +557,10 @@ public class OracleClient
                     // Map decimal(p, s) with s>p, to decimal(s, s).
                     int precision = max(columnSize + max(-scale, 0), scale);
                     scale = max(scale, 0);
+                    if (precision == 0) {
+                        // Oracle JDBC reports precision=0 for certain NUMBER expressions (e.g. COUNT(*) in passthrough queries)
+                        yield Optional.of(numberColumnMapping());
+                    }
                     if (precision <= Decimals.MAX_PRECISION) {
                         yield Optional.of(decimalColumnMapping(createDecimalType(precision, scale), UNNECESSARY));
                     }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
@@ -454,6 +454,23 @@ public abstract class BaseOracleConnectorTest
                 .failure().hasMessageContaining("Query not supported: ResultSetMetaData not available for query: some wrong syntax");
     }
 
+    @Test
+    public void testNativeQueryMaterializedViewNumberZeroPrecision()
+    {
+        // Oracle JDBC reports precision=0 for COUNT(*) result columns in passthrough queries,
+        // unlike regular NUMBER columns in table metadata which use 127 as the "unspecified" sentinel.
+        // Without the fix this would throw "DECIMAL precision must be in range [1, 38]: 0".
+        String viewName = getUser() + ".test_mv_num_" + randomNameSuffix();
+        onRemoteDatabase().execute("CREATE MATERIALIZED VIEW " + viewName + " BUILD IMMEDIATE AS SELECT COUNT(*) AS col FROM dual");
+        try {
+            assertThat(query("SELECT * FROM TABLE(system.query(query => 'SELECT count(*) FROM " + viewName + "'))"))
+                    .matches("VALUES NUMBER '1'");
+        }
+        finally {
+            onRemoteDatabase().execute("DROP MATERIALIZED VIEW " + viewName);
+        }
+    }
+
     @Override
     protected TestTable simpleTable()
     {

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleClient.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleClient.java
@@ -17,10 +17,12 @@ import io.trino.plugin.base.mapping.DefaultIdentifierMapping;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.DefaultQueryBuilder;
 import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.WriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
 import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.NumberType;
 import io.trino.spi.type.Type;
 import io.trino.testing.TestingConnectorSession;
 import oracle.jdbc.OracleTypes;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Optional;
 
 import static com.google.common.reflect.Reflection.newProxy;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -88,6 +91,24 @@ public class TestOracleClient
         testTypedNullWriteMapping(TIMESTAMP_NANOS, "TO_TIMESTAMP(?, 'SYYYY-MM-DD HH24:MI:SS.FF9')", Types.VARCHAR);
         testTypedNullWriteMapping(TIMESTAMP_TZ_MILLIS, "?", OracleTypes.TIMESTAMPTZ);
         testTypedNullWriteMapping(DATE, "TO_DATE(?, 'SYYYY-MM-DD')", Types.VARCHAR);
+    }
+
+    @Test
+    public void testNumberColumnWithZeroPrecisionMapsToNumberType()
+    {
+        // Oracle JDBC can return columnSize=0, decimalDigits=0 for NUMBER columns in stored views
+        // and materialized views. This must not throw "DECIMAL precision must be in range [1, 38]: 0".
+        JdbcTypeHandle typeHandle = new JdbcTypeHandle(
+                OracleTypes.NUMBER,
+                Optional.of("NUMBER"),
+                Optional.of(0),
+                Optional.of(0),
+                Optional.empty(),
+                Optional.empty());
+        assertThat(CLIENT.toColumnMapping(SESSION, null, typeHandle))
+                .isPresent()
+                .get()
+                .satisfies(mapping -> assertThat(mapping.getType()).isEqualTo(NumberType.NUMBER));
     }
 
     private void testTypedNullWriteMapping(Type type, String bindExpression, int nullJdbcType)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Oracle JDBC can return `columnSize=0, decimalDigits=0` for `NUMBER` columns                                                                                                                                                                                                                                       
when column types are read via `ResultSetMetaData` (stored view analysis,                                                                                                                                                                                                                                         
`system.query()` passthrough). Previously this caused:                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                    
DECIMAL precision must be in range [1, 38]: 0                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                    
because the computed `precision=0` fell through to `createDecpalType(0, 0)`.                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                    
The fix handles `precision == 0` explicitly by mapping to `NumberType.NUMBER`                                                                                                                                                                                                                                     


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

**To reproduce:** create an Oracle materialized view with an aggregate `NUMBER`                                                                                                                                                                                                                                   
  column and query it via `system.query()`:                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                    
```sql
  -- Oracle side                                                                                                                                                                                                                                                                                                    
  CREATE MATERIALIZED VIEW mv_test BUILD IMMEDIATE AS                                                                                                                                                                                                                                                               
  SELECT COUNT(*) AS record_count FROM dual;                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  -- Trino (fails before fix, succeeds after)                                                                                                                                                                                                                                                                       
  SELECT * FROM TABLE(oracle.system.query(query => 'SELECT COUNT(*) AS record_count FROM mv_test'));    
```                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                    
  COUNT(*) has no declared precision, so Oracle JDBC's ResultSetMetaData.getPrecision()                                                                                                                                                                                                                             
  returns 0, which triggered the crash.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:
  * Fix failure when querying Oracle stored views or materialized views containing                                                                                                                                                                                                                                  
    untyped `NUMBER` columns that report zero precision via JDBC metadata. 

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
