### PR TITLE
Skip zero-duration output buffer utilization samples

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBufferMemoryManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBufferMemoryManager.java
@@ -54,7 +54,7 @@ final class OutputBufferMemoryManager
     // guarded by "this" for updates
     private volatile ListenableFuture<Void> blockedOnMemory = NOT_BLOCKED;
 
-    private final Ticker ticker = Ticker.systemTicker();
+    private final Ticker ticker;
 
     private final AtomicBoolean blockOnFull = new AtomicBoolean(true);
 
@@ -70,11 +70,18 @@ final class OutputBufferMemoryManager
 
     public OutputBufferMemoryManager(long maxBufferedBytes, Lazy<LocalMemoryContext> memoryContextSupplier, Executor notificationExecutor)
     {
+        this(maxBufferedBytes, memoryContextSupplier, notificationExecutor, Ticker.systemTicker());
+    }
+
+    @VisibleForTesting
+    OutputBufferMemoryManager(long maxBufferedBytes, Lazy<LocalMemoryContext> memoryContextSupplier, Executor notificationExecutor, Ticker ticker)
+    {
         requireNonNull(memoryContextSupplier, "memoryContextSupplier is null");
         checkArgument(maxBufferedBytes > 0, "maxBufferedBytes must be > 0");
         this.maxBufferedBytes = maxBufferedBytes;
         this.memoryContextSupplier = requireNonNull(memoryContextSupplier, "memoryContextSupplier is null");
         this.notificationExecutor = requireNonNull(notificationExecutor, "notificationExecutor is null");
+        this.ticker = requireNonNull(ticker, "ticker is null");
         this.lastBufferUtilizationRecordTime = ticker.read();
         this.lastBufferUtilization = 0;
     }
@@ -137,8 +144,12 @@ final class OutputBufferMemoryManager
     private synchronized void recordBufferUtilization(long currentBufferedBytes)
     {
         long recordTime = ticker.read();
-        bufferUtilization.add(lastBufferUtilization, (double) recordTime - this.lastBufferUtilizationRecordTime);
-        lastBufferUtilizationRecordTime = recordTime;
+        long elapsed = recordTime - lastBufferUtilizationRecordTime;
+        // TDigest rejects non-positive weights
+        if (elapsed > 0) {
+            bufferUtilization.add(lastBufferUtilization, elapsed);
+            lastBufferUtilizationRecordTime = recordTime;
+        }
         lastBufferUtilization = getUtilization(currentBufferedBytes);
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestOutputBufferMemoryManager.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestOutputBufferMemoryManager.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.buffer;
+
+import com.google.common.base.Ticker;
+import io.airlift.stats.TDigest;
+import io.airlift.testing.TestingTicker;
+import io.trino.plugin.base.util.Lazy;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestOutputBufferMemoryManager
+{
+    private static final long MAX_BUFFERED_BYTES = 1024;
+
+    @Test
+    void testUtilizationHistogramWithStalledTicker()
+    {
+        // a ticker that never advances yields zero-duration samples, which must not reach the TDigest
+        OutputBufferMemoryManager memoryManager = createMemoryManager(new TestingTicker());
+
+        memoryManager.updateMemoryUsage(512);
+        memoryManager.updateMemoryUsage(-512);
+        memoryManager.close();
+
+        assertThat(memoryManager.getUtilizationHistogram().getCount()).isEqualTo(0);
+    }
+
+    @Test
+    void testUtilizationHistogramWithAdvancingTicker()
+    {
+        TestingTicker ticker = new TestingTicker();
+        OutputBufferMemoryManager memoryManager = createMemoryManager(ticker);
+
+        ticker.increment(1, NANOSECONDS);
+        memoryManager.updateMemoryUsage(MAX_BUFFERED_BYTES);
+        ticker.increment(1, NANOSECONDS);
+        memoryManager.updateMemoryUsage(-MAX_BUFFERED_BYTES);
+        ticker.increment(1, NANOSECONDS);
+
+        // one sample per recording: the initial empty buffer, the full buffer, and the empty buffer again
+        TDigest histogram = memoryManager.getUtilizationHistogram();
+        assertThat(histogram.getCount()).isEqualTo(3);
+        assertThat(histogram.getMin()).isEqualTo(0.0);
+        assertThat(histogram.getMax()).isEqualTo(1.0);
+    }
+
+    private static OutputBufferMemoryManager createMemoryManager(Ticker ticker)
+    {
+        return new OutputBufferMemoryManager(
+                MAX_BUFFERED_BYTES,
+                Lazy.from(() -> newSimpleAggregatedMemoryContext().newLocalMemoryContext(TestOutputBufferMemoryManager.class.getSimpleName())),
+                directExecutor(),
+                ticker);
+    }
+}


### PR DESCRIPTION
Buffer utilization samples are weighted by the nanos elapsed since the previous recording. Two recordings can observe the same ticker value, which used to be silently accepted by TDigest but now fails with "weight must be positive: 0.0" since the weight validation was added in airlift. This aborts OutputBufferMemoryManager.close() before the memory context is closed, leaking the buffer memory reservation.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
