### PR TITLE
Remove branch-scoped local repository guidance from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,21 +33,6 @@ Fastest full build and install:
 
 It skips tests, Javadoc, and the airbase checks — run `./mvnw validate` before opening a PR.
 
-## Working in a git worktree
-
-Builds share `~/.m2/repository`, so parallel agents in different worktrees overwrite each other's
-installed SNAPSHOTs and end up building against the wrong branch. `-DbranchScopedLocalRepo.enabled=true`
-keeps installed artifacts separate per branch:
-
-```bash
-./mvnw install -DskipTests -DbranchScopedLocalRepo.enabled=true
-```
-
-Off by default, and it only isolates builds that pass it — put the flag on the command line of
-every Maven command in that worktree, starting with a full `install`. When the work is finished,
-delete `~/.m2/repository/installed/<branch>/`. See
-[Branch-scoped local repository](.github/DEVELOPMENT.md#branch-scoped-local-repository).
-
 ## Java formatting
 
 Run `mvnd airstyle:format` after Java edits — the `airstyle-maven-plugin` (`io.airlift:airstyle-maven-plugin`)


### PR DESCRIPTION
The "Working in a git worktree" section of `CLAUDE.md` recommended `-DbranchScopedLocalRepo.enabled=true` for parallel worktree builds. That guidance reflects developer-specific tooling and workflows rather than something that belongs in the shared project instructions, so this removes it.

The flag itself and its full explanation remain documented in `.github/DEVELOPMENT.md`, which is still referenced from its own table of contents — nothing is left dangling.