### PR TITLE
Use virtual threads for split execution

### DIFF
--- a/core/docker/default/etc/jvm.config
+++ b/core/docker/default/etc/jvm.config
@@ -12,3 +12,4 @@
 -XX:PerBytecodeRecompilationCutoff=10000
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
+--enable-native-access=ALL-UNNAMED

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -14,6 +14,7 @@
     <description>Trino - Engine</description>
 
     <properties>
+        <air.test.jvm.additional-arguments>${air.test.jvm.additional-arguments.default} --enable-native-access=ALL-UNNAMED</air.test.jvm.additional-arguments>
         <!-- TODO enable @GuardedBy checks in trino-main -->
         <trino.error-prone.guarded-by>WARN</trino.error-prone.guarded-by>
     </properties>
@@ -173,6 +174,11 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>vthreadtime</artifactId>
         </dependency>
 
         <dependency>

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -14,6 +14,7 @@
     <description>Trino - Engine</description>
 
     <properties>
+        <air.test.jvm.additional-arguments>${air.test.jvm.additional-arguments.default} --enable-native-access=ALL-UNNAMED</air.test.jvm.additional-arguments>
         <!-- TODO enable @GuardedBy checks in trino-main -->
         <trino.error-prone.guarded-by>WARN</trino.error-prone.guarded-by>
     </properties>
@@ -177,6 +178,11 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>vthreadtime</artifactId>
         </dependency>
 
         <dependency>

--- a/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
@@ -55,6 +55,7 @@ public class TaskManagerConfig
     public static final int MAX_WRITER_COUNT = 64;
 
     private boolean threadPerDriverSchedulerEnabled = true;
+    private boolean threadPerDriverSchedulerVirtualThreadsEnabled = true;
     private boolean perOperatorCpuTimerEnabled = true;
     private boolean taskCpuTimerEnabled = true;
     private DataSize maxPartialAggregationMemoryUsage = DataSize.of(16, Unit.MEGABYTE);
@@ -124,6 +125,19 @@ public class TaskManagerConfig
     public boolean isThreadPerDriverSchedulerEnabled()
     {
         return threadPerDriverSchedulerEnabled;
+    }
+
+    @Config("experimental.thread-per-driver-scheduler-virtual-threads-enabled")
+    @ConfigDescription("Use virtual threads for split processing with the thread-per-driver scheduler")
+    public TaskManagerConfig setThreadPerDriverSchedulerVirtualThreadsEnabled(boolean enabled)
+    {
+        this.threadPerDriverSchedulerVirtualThreadsEnabled = enabled;
+        return this;
+    }
+
+    public boolean isThreadPerDriverSchedulerVirtualThreadsEnabled()
+    {
+        return threadPerDriverSchedulerVirtualThreadsEnabled;
     }
 
     @MinDuration("1ms")

--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/SplitProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/SplitProcessor.java
@@ -13,11 +13,9 @@
  */
 package io.trino.execution.executor.dedicated;
 
-import com.google.common.base.Ticker;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.concurrent.SetThreadName;
 import io.airlift.log.Logger;
-import io.airlift.stats.CpuTimer;
 import io.airlift.units.Duration;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
@@ -27,12 +25,12 @@ import io.trino.execution.SplitRunner;
 import io.trino.execution.TaskId;
 import io.trino.execution.executor.scheduler.Schedulable;
 import io.trino.execution.executor.scheduler.SchedulerContext;
+import io.trino.operator.ThreadExecutionTimer;
 import io.trino.tracing.TrinoAttributes;
 
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 class SplitProcessor
         implements Schedulable
@@ -57,6 +55,13 @@ class SplitProcessor
     @Override
     public void run(SchedulerContext context)
     {
+        try (ThreadExecutionTimer timer = ThreadExecutionTimer.start()) {
+            process(context, timer);
+        }
+    }
+
+    private void process(SchedulerContext context, ThreadExecutionTimer timer)
+    {
         Span splitSpan = tracer.spanBuilder("split")
                 .setParent(Context.current().with(split.getPipelineSpan()))
                 .setAttribute(TrinoAttributes.QUERY_ID, taskId.queryId().toString())
@@ -68,20 +73,19 @@ class SplitProcessor
 
         Span processSpan = newSpan(splitSpan, null);
 
-        CpuTimer timer = new CpuTimer(Ticker.systemTicker(), false);
+        long wallStart = System.nanoTime();
         long previousCpuNanos = 0;
         long previousScheduledNanos = 0;
         try (SetThreadName _ = new SetThreadName("SplitRunner-" + taskId + "-" + splitId)) {
             while (!split.isFinished()) {
                 try (var ignored2 = processSpan.makeCurrent()) {
                     ListenableFuture<Void> blocked = split.processFor(SPLIT_RUN_QUANTA);
-                    CpuTimer.CpuDuration elapsed = timer.elapsedTime();
 
-                    long scheduledNanos = elapsed.wall().roundTo(NANOSECONDS);
+                    long scheduledNanos = System.nanoTime() - wallStart;
                     processSpan.setAttribute(TrinoAttributes.SPLIT_SCHEDULED_TIME_NANOS, scheduledNanos - previousScheduledNanos);
                     previousScheduledNanos = scheduledNanos;
 
-                    long cpuNanos = elapsed.cpu().roundTo(NANOSECONDS);
+                    long cpuNanos = timer.elapsedNanos();
                     processSpan.setAttribute(TrinoAttributes.SPLIT_CPU_TIME_NANOS, cpuNanos - previousCpuNanos);
                     previousCpuNanos = cpuNanos;
 
@@ -115,7 +119,7 @@ class SplitProcessor
                 processSpan.end();
             }
 
-            splitSpan.setAttribute(TrinoAttributes.SPLIT_CPU_TIME_NANOS, timer.elapsedTime().cpu().roundTo(NANOSECONDS));
+            splitSpan.setAttribute(TrinoAttributes.SPLIT_CPU_TIME_NANOS, timer.elapsedNanos());
             splitSpan.setAttribute(TrinoAttributes.SPLIT_SCHEDULED_TIME_NANOS, context.getScheduledNanos());
             splitSpan.setAttribute(TrinoAttributes.SPLIT_BLOCK_TIME_NANOS, context.getBlockedNanos());
             splitSpan.setAttribute(TrinoAttributes.SPLIT_WAIT_TIME_NANOS, context.getWaitNanos());

--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
@@ -87,7 +87,11 @@ public class ThreadPerDriverTaskExecutor
     {
         this(tracer,
                 versionEmbedder,
-                new FairScheduler(config.getMaxWorkerThreads(), "SplitRunner-%d", Ticker.systemTicker()),
+                new FairScheduler(
+                        config.getMaxWorkerThreads(),
+                        "SplitRunner-%d",
+                        Ticker.systemTicker(),
+                        config.isThreadPerDriverSchedulerVirtualThreadsEnabled()),
                 config.getMinDriversPerTask(),
                 config.getMaxDriversPerTask(),
                 config.getMinDrivers());

--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
@@ -96,7 +96,11 @@ public class ThreadPerDriverTaskExecutor
     {
         this(tracer,
                 versionEmbedder,
-                new FairScheduler(config.getMaxWorkerThreads(), "SplitRunner-%d", Ticker.systemTicker()),
+                new FairScheduler(
+                        config.getMaxWorkerThreads(),
+                        "SplitRunner-%d",
+                        Ticker.systemTicker(),
+                        config.isThreadPerDriverSchedulerVirtualThreadsEnabled()),
                 config.getMinDriversPerTask(),
                 config.getMaxDriversPerTask(),
                 config.getMinDrivers());

--- a/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/FairScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/FairScheduler.java
@@ -34,7 +34,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.concurrent.Threads.virtualThreadsNamed;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newThreadPerTaskExecutor;
 
 /**
  * <h2>Implementation nodes</h2>
@@ -70,6 +72,11 @@ public final class FairScheduler
 
     public FairScheduler(int maxConcurrentTasks, String threadNameFormat, Ticker ticker)
     {
+        this(maxConcurrentTasks, threadNameFormat, ticker, false);
+    }
+
+    public FairScheduler(int maxConcurrentTasks, String threadNameFormat, Ticker ticker, boolean virtualThreadsEnabled)
+    {
         this.ticker = requireNonNull(ticker, "ticker is null");
 
         concurrencyControl = new Reservation<>(maxConcurrentTasks);
@@ -77,9 +84,18 @@ public final class FairScheduler
         schedulerExecutor = Executors.newCachedThreadPool(daemonThreadsNamed("fair-scheduler-%d"));
         schedulerExecutorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) schedulerExecutor);
 
-        executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(), daemonThreadsNamed(threadNameFormat));
-        executorMBean = new ThreadPoolExecutorMBean(executor);
-        taskExecutor = MoreExecutors.listeningDecorator(executor);
+        ExecutorService executorService;
+        if (virtualThreadsEnabled) {
+            executor = null;
+            executorMBean = null;
+            executorService = newThreadPerTaskExecutor(virtualThreadsNamed(threadNameFormat));
+        }
+        else {
+            executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(), daemonThreadsNamed(threadNameFormat));
+            executorMBean = new ThreadPoolExecutorMBean(executor);
+            executorService = executor;
+        }
+        taskExecutor = MoreExecutors.listeningDecorator(executorService);
     }
 
     public static FairScheduler newInstance(int maxConcurrentTasks)
@@ -311,10 +327,12 @@ public final class FairScheduler
         StringBuilder builder = new StringBuilder();
         builder.append(queue);
 
-        builder.append("Task executor: pool=%s, active=%s, queue=%s\n".formatted(
-                executor.getPoolSize(),
-                executor.getActiveCount(),
-                executor.getQueue().size()));
+        if (executor != null) {
+            builder.append("Task executor: pool=%s, active=%s, queue=%s\n".formatted(
+                    executor.getPoolSize(),
+                    executor.getActiveCount(),
+                    executor.getQueue().size()));
+        }
 
         builder.append("Concurrency control: slots=%s, available=%s\n".formatted(
                 concurrencyControl.totalSlots(),

--- a/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/FairScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/FairScheduler.java
@@ -37,7 +37,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.concurrent.Threads.virtualThreadsNamed;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newThreadPerTaskExecutor;
 
 /**
  * <h2>Implementation nodes</h2>
@@ -77,11 +79,21 @@ public final class FairScheduler
 
     public FairScheduler(int maxConcurrentTasks, String threadNameFormat, Ticker ticker)
     {
-        this(maxConcurrentTasks, daemonThreadsNamed(threadNameFormat), ticker);
+        this(maxConcurrentTasks, threadNameFormat, ticker, false);
+    }
+
+    public FairScheduler(int maxConcurrentTasks, String threadNameFormat, Ticker ticker, boolean virtualThreadsEnabled)
+    {
+        this(maxConcurrentTasks, threadFactory(threadNameFormat, virtualThreadsEnabled), virtualThreadsEnabled, ticker);
     }
 
     @VisibleForTesting
     public FairScheduler(int maxConcurrentTasks, ThreadFactory threadFactory, Ticker ticker)
+    {
+        this(maxConcurrentTasks, threadFactory, false, ticker);
+    }
+
+    private FairScheduler(int maxConcurrentTasks, ThreadFactory threadFactory, boolean virtualThreadsEnabled, Ticker ticker)
     {
         this.ticker = requireNonNull(ticker, "ticker is null");
 
@@ -90,9 +102,26 @@ public final class FairScheduler
         schedulerExecutor = Executors.newCachedThreadPool(daemonThreadsNamed("fair-scheduler-%d"));
         schedulerExecutorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) schedulerExecutor);
 
-        executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(), threadFactory);
-        executorMBean = new ThreadPoolExecutorMBean(executor);
-        taskExecutor = MoreExecutors.listeningDecorator(executor);
+        ExecutorService executorService;
+        if (virtualThreadsEnabled) {
+            executor = null;
+            executorMBean = null;
+            executorService = newThreadPerTaskExecutor(threadFactory);
+        }
+        else {
+            executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(), threadFactory);
+            executorMBean = new ThreadPoolExecutorMBean(executor);
+            executorService = executor;
+        }
+        taskExecutor = MoreExecutors.listeningDecorator(executorService);
+    }
+
+    private static ThreadFactory threadFactory(String threadNameFormat, boolean virtualThreadsEnabled)
+    {
+        if (virtualThreadsEnabled) {
+            return virtualThreadsNamed(threadNameFormat);
+        }
+        return daemonThreadsNamed(threadNameFormat);
     }
 
     public static FairScheduler newInstance(int maxConcurrentTasks)
@@ -342,10 +371,12 @@ public final class FairScheduler
         StringBuilder builder = new StringBuilder();
         builder.append(queue);
 
-        builder.append("Task executor: pool=%s, active=%s, queue=%s\n".formatted(
-                executor.getPoolSize(),
-                executor.getActiveCount(),
-                executor.getQueue().size()));
+        if (executor != null) {
+            builder.append("Task executor: pool=%s, active=%s, queue=%s\n".formatted(
+                    executor.getPoolSize(),
+                    executor.getActiveCount(),
+                    executor.getQueue().size()));
+        }
 
         builder.append("Concurrency control: slots=%s, available=%s\n".formatted(
                 concurrencyControl.totalSlots(),

--- a/core/trino-main/src/main/java/io/trino/operator/OperationTimer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperationTimer.java
@@ -14,11 +14,10 @@
 package io.trino.operator;
 
 import com.google.errorprone.annotations.ThreadSafe;
+import io.airlift.vthreadtime.VirtualThreadTime;
 import io.trino.annotation.NotThreadSafe;
 import jakarta.annotation.Nullable;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.ThreadMXBean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -30,10 +29,11 @@ import static java.util.Objects.requireNonNull;
 @NotThreadSafe
 class OperationTimer
 {
-    private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
-
     private final boolean trackOverallCpuTime;
     private final boolean trackOperationCpuTime;
+    private final boolean virtualThread;
+    @Nullable
+    private final VirtualThreadTime virtualThreadTime;
 
     private final long wallStart;
     private final long cpuStart;
@@ -53,6 +53,9 @@ class OperationTimer
         this.trackOverallCpuTime = trackOverallCpuTime;
         this.trackOperationCpuTime = trackOperationCpuTime;
         checkArgument(trackOverallCpuTime || !trackOperationCpuTime, "tracking operation cpu time without tracking overall cpu time is not supported");
+
+        virtualThread = trackOverallCpuTime && Thread.currentThread().isVirtual();
+        virtualThreadTime = virtualThread ? ThreadExecutionTimer.currentVirtualThreadTime() : null;
 
         wallStart = System.nanoTime();
         cpuStart = trackOverallCpuTime ? currentThreadCpuTime() : 0;
@@ -89,9 +92,15 @@ class OperationTimer
         overallTiming.record(nanosBetween(wallStart, wallEnd), nanosBetween(cpuStart, cpuEnd));
     }
 
-    private static long currentThreadCpuTime()
+    private long currentThreadCpuTime()
     {
-        return THREAD_MX_BEAN.getCurrentThreadCpuTime();
+        if (!virtualThread) {
+            return ThreadExecutionTimer.currentPlatformThreadTimeNanos();
+        }
+        if (virtualThreadTime == null) {
+            return 0;
+        }
+        return virtualThreadTime.mountedTimeNanos();
     }
 
     private static long nanosBetween(long start, long end)

--- a/core/trino-main/src/main/java/io/trino/operator/ThreadExecutionTimer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ThreadExecutionTimer.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.airlift.vthreadtime.VirtualThreadTime;
+import jakarta.annotation.Nullable;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.max;
+
+public final class ThreadExecutionTimer
+        implements AutoCloseable
+{
+    private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
+    private static final ThreadLocal<VirtualThreadTime> VIRTUAL_THREAD_TIME = new ThreadLocal<>();
+
+    private final boolean virtualThread;
+    private final long startNanos;
+    @Nullable
+    private final VirtualThreadTime virtualThreadTime;
+
+    private boolean closed;
+
+    private ThreadExecutionTimer(boolean virtualThread, long startNanos, @Nullable VirtualThreadTime virtualThreadTime)
+    {
+        this.virtualThread = virtualThread;
+        this.startNanos = startNanos;
+        this.virtualThreadTime = virtualThreadTime;
+    }
+
+    public static ThreadExecutionTimer start()
+    {
+        if (!Thread.currentThread().isVirtual()) {
+            return new ThreadExecutionTimer(false, currentPlatformThreadTimeNanos(), null);
+        }
+
+        if (!VirtualThreadTime.isSupported()) {
+            return new ThreadExecutionTimer(true, 0, null);
+        }
+
+        checkState(VIRTUAL_THREAD_TIME.get() == null, "Virtual thread execution timing is already active");
+        VirtualThreadTime virtualThreadTime = VirtualThreadTime.register();
+        VIRTUAL_THREAD_TIME.set(virtualThreadTime);
+        return new ThreadExecutionTimer(true, virtualThreadTime.mountedTimeNanos(), virtualThreadTime);
+    }
+
+    public long elapsedNanos()
+    {
+        checkState(!closed, "Timer is closed");
+        return max(0, currentTimeNanos() - startNanos);
+    }
+
+    @Nullable
+    static VirtualThreadTime currentVirtualThreadTime()
+    {
+        return VIRTUAL_THREAD_TIME.get();
+    }
+
+    static long currentPlatformThreadTimeNanos()
+    {
+        return THREAD_MX_BEAN.getCurrentThreadCpuTime();
+    }
+
+    @Override
+    public void close()
+    {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        if (virtualThreadTime != null) {
+            checkState(VIRTUAL_THREAD_TIME.get() == virtualThreadTime, "Virtual thread execution timer is not active");
+            VIRTUAL_THREAD_TIME.remove();
+            virtualThreadTime.close();
+        }
+    }
+
+    private long currentTimeNanos()
+    {
+        if (!virtualThread) {
+            return currentPlatformThreadTimeNanos();
+        }
+        if (virtualThreadTime == null) {
+            return 0;
+        }
+        return virtualThreadTime.mountedTimeNanos();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManagerVirtualThreadPerDriver.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManagerVirtualThreadPerDriver.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.base.Ticker;
+import io.airlift.tracing.Tracing;
+import io.trino.execution.executor.TaskExecutor;
+import io.trino.execution.executor.dedicated.ThreadPerDriverTaskExecutor;
+import io.trino.execution.executor.scheduler.FairScheduler;
+
+import static io.trino.util.EmbedVersion.testingVersionEmbedder;
+
+public class TestSqlTaskManagerVirtualThreadPerDriver
+        extends BaseTestSqlTaskManager
+{
+    @Override
+    protected TaskExecutor createTaskExecutor()
+    {
+        return new ThreadPerDriverTaskExecutor(
+                Tracing.noopTracer(),
+                testingVersionEmbedder(),
+                new FairScheduler(8, "Runner-%d", Ticker.systemTicker(), true),
+                1,
+                Integer.MAX_VALUE,
+                8);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
@@ -40,6 +40,7 @@ public class TestTaskManagerConfig
     {
         assertRecordedDefaults(recordDefaults(TaskManagerConfig.class)
                 .setThreadPerDriverSchedulerEnabled(true)
+                .setThreadPerDriverSchedulerVirtualThreadsEnabled(true)
                 .setInitialSplitsPerNode(Runtime.getRuntime().availableProcessors() * 2)
                 .setSplitConcurrencyAdjustmentInterval(new Duration(100, TimeUnit.MILLISECONDS))
                 .setStatusRefreshMaxWait(new Duration(1, TimeUnit.SECONDS))
@@ -86,6 +87,7 @@ public class TestTaskManagerConfig
         int maxWriterCount = DEFAULT_MAX_WRITER_COUNT == 32 ? 16 : 32;
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("experimental.thread-per-driver-scheduler-enabled", "false")
+                .put("experimental.thread-per-driver-scheduler-virtual-threads-enabled", "false")
                 .put("task.initial-splits-per-node", "1")
                 .put("task.split-concurrency-adjustment-interval", "3s")
                 .put("task.status-refresh-max-wait", "2s")
@@ -127,6 +129,7 @@ public class TestTaskManagerConfig
 
         TaskManagerConfig expected = new TaskManagerConfig()
                 .setThreadPerDriverSchedulerEnabled(false)
+                .setThreadPerDriverSchedulerVirtualThreadsEnabled(false)
                 .setInitialSplitsPerNode(1)
                 .setSplitConcurrencyAdjustmentInterval(new Duration(3, TimeUnit.SECONDS))
                 .setStatusRefreshMaxWait(new Duration(2, TimeUnit.SECONDS))

--- a/core/trino-main/src/test/java/io/trino/execution/executor/dedicated/TestThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/dedicated/TestThreadPerDriverTaskExecutor.java
@@ -28,6 +28,10 @@ import io.trino.execution.executor.TaskHandle;
 import io.trino.execution.executor.scheduler.FairScheduler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.testing.TestingMBeanServer;
 
 import java.util.List;
 import java.util.OptionalInt;
@@ -45,12 +49,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestThreadPerDriverTaskExecutor
 {
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     @Timeout(10)
-    public void testCancellationWhileProcessing()
+    public void testCancellationWhileProcessing(boolean virtualThreadsEnabled)
             throws ExecutionException, InterruptedException
     {
-        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(new TaskManagerConfig(), noopTracer(), testingVersionEmbedder());
+        TaskManagerConfig config = new TaskManagerConfig()
+                .setThreadPerDriverSchedulerVirtualThreadsEnabled(virtualThreadsEnabled);
+        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(config, noopTracer(), testingVersionEmbedder());
+        new MBeanExporter(new TestingMBeanServer()).export("test:name=TaskExecutor", executor);
+        if (virtualThreadsEnabled) {
+            assertThat(executor.getTaskExecutor()).isNull();
+        }
+        else {
+            assertThat(executor.getTaskExecutor()).isNotNull();
+        }
         executor.start();
         try {
             TaskId taskId = new TaskId(new StageId("query", 1), 1, 1);
@@ -59,6 +73,7 @@ public class TestThreadPerDriverTaskExecutor
             CountDownLatch started = new CountDownLatch(1);
 
             SplitRunner split = new TestingSplitRunner(ImmutableList.of(_ -> {
+                assertThat(Thread.currentThread().isVirtual()).isEqualTo(virtualThreadsEnabled);
                 started.countDown();
                 try {
                     Thread.currentThread().join();

--- a/core/trino-main/src/test/java/io/trino/execution/executor/dedicated/TestThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/dedicated/TestThreadPerDriverTaskExecutor.java
@@ -30,6 +30,10 @@ import io.trino.execution.executor.TaskHandle;
 import io.trino.execution.executor.scheduler.FairScheduler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.testing.TestingMBeanServer;
 
 import java.util.List;
 import java.util.OptionalInt;
@@ -382,12 +386,22 @@ public class TestThreadPerDriverTaskExecutor
         assertThat(runs.get()).isEqualTo(2);
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
     @Timeout(10)
-    public void testCancellationWhileProcessing()
+    public void testCancellationWhileProcessing(boolean virtualThreadsEnabled)
             throws ExecutionException, InterruptedException
     {
-        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(new TaskManagerConfig(), noopTracer(), testingVersionEmbedder());
+        TaskManagerConfig config = new TaskManagerConfig()
+                .setThreadPerDriverSchedulerVirtualThreadsEnabled(virtualThreadsEnabled);
+        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(config, noopTracer(), testingVersionEmbedder());
+        new MBeanExporter(new TestingMBeanServer()).export("test:name=TaskExecutor", executor);
+        if (virtualThreadsEnabled) {
+            assertThat(executor.getTaskExecutor()).isNull();
+        }
+        else {
+            assertThat(executor.getTaskExecutor()).isNotNull();
+        }
         executor.start();
         try {
             TaskId taskId = new TaskId(new StageId("query", 1), 1, 1);
@@ -396,6 +410,7 @@ public class TestThreadPerDriverTaskExecutor
             CountDownLatch started = new CountDownLatch(1);
 
             SplitRunner split = new TestingSplitRunner(ImmutableList.of(_ -> {
+                assertThat(Thread.currentThread().isVirtual()).isEqualTo(virtualThreadsEnabled);
                 started.countDown();
                 try {
                     Thread.currentThread().join();

--- a/core/trino-main/src/test/java/io/trino/operator/TestThreadExecutionTimer.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestThreadExecutionTimer.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.airlift.vthreadtime.VirtualThreadTime;
+import io.trino.operator.OperationTimer.OperationTiming;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class TestThreadExecutionTimer
+{
+    @Test
+    public void testVirtualThreadMountedTime()
+            throws InterruptedException
+    {
+        assumeTrue(VirtualThreadTime.isSupported());
+
+        AtomicReference<Measurement> result = new AtomicReference<>();
+        Thread thread = Thread.ofVirtual().start(() -> {
+            try (ThreadExecutionTimer timer = ThreadExecutionTimer.start()) {
+                long wallStart = System.nanoTime();
+                OperationTimer operationTimer = new OperationTimer(true, true);
+                OperationTiming operationTiming = new OperationTiming();
+                OperationTiming overallTiming = new OperationTiming();
+
+                spin(Duration.ofMillis(20));
+                operationTimer.recordOperationComplete(operationTiming);
+                LockSupport.parkNanos(Duration.ofMillis(100).toNanos());
+                spin(Duration.ofMillis(20));
+                operationTimer.recordOperationComplete(operationTiming);
+                operationTimer.end(overallTiming);
+
+                result.set(new Measurement(
+                        System.nanoTime() - wallStart,
+                        timer.elapsedNanos(),
+                        overallTiming.getWallNanos(),
+                        overallTiming.getCpuNanos(),
+                        operationTiming.getCpuNanos()));
+            }
+        });
+        thread.join();
+
+        Measurement measurement = result.get();
+        assertThat(measurement.mountedNanos()).isGreaterThan(Duration.ofMillis(10).toNanos());
+        assertThat(measurement.wallNanos() - measurement.mountedNanos()).isGreaterThan(Duration.ofMillis(50).toNanos());
+        assertThat(measurement.operationWallNanos()).isGreaterThan(measurement.operationCpuNanos());
+        assertThat(measurement.operationCpuNanos()).isGreaterThan(Duration.ofMillis(10).toNanos());
+        assertThat(measurement.operatorCpuNanos()).isGreaterThan(Duration.ofMillis(10).toNanos());
+        assertThat(measurement.operationCpuNanos()).isLessThanOrEqualTo(measurement.mountedNanos());
+    }
+
+    private static void spin(Duration duration)
+    {
+        long end = System.nanoTime() + duration.toNanos();
+        while (System.nanoTime() < end) {
+            Thread.onSpinWait();
+        }
+    }
+
+    private record Measurement(
+            long wallNanos,
+            long mountedNanos,
+            long operationWallNanos,
+            long operationCpuNanos,
+            long operatorCpuNanos) {}
+}

--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -139,6 +139,7 @@ The following provides a good starting point for creating `etc/jvm.config`:
 -Djdk.attach.allowAttachSelf=true
 -Djdk.nio.maxCachedBufferSize=2000000
 --add-modules=jdk.incubator.vector
+--enable-native-access=ALL-UNNAMED
 ```
 
 You must adjust the value for the memory used by Trino, specified with `-Xmx`

--- a/pom.xml
+++ b/pom.xml
@@ -626,6 +626,12 @@
             </dependency>
 
             <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>vthreadtime</artifactId>
+                <version>1.0</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.airlift.discovery</groupId>
                 <artifactId>discovery-server</artifactId>
                 <version>1.37</version>

--- a/pom.xml
+++ b/pom.xml
@@ -639,6 +639,12 @@
             </dependency>
 
             <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>vthreadtime</artifactId>
+                <version>1.0</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.airlift.discovery</groupId>
                 <artifactId>discovery-server</artifactId>
                 <version>1.37</version>


### PR DESCRIPTION
## Description

Use virtual threads by default for split execution with the thread-per-driver scheduler. This changes only the threads that execute drivers; the scheduler control thread continues to use a platform thread.

Keep a temporary kill switch so deployments can restore the existing platform-thread executor by setting `experimental.thread-per-driver-scheduler-virtual-threads-enabled` to `false`. The platform-thread executor continues to expose its pool-specific JMX statistics.

For platform threads, driver and operator CPU statistics continue to report thread CPU time. For virtual threads, these statistics report mounted time: the time the virtual thread is mounted on a carrier and able to execute. Time spent unmounted while sleeping, parking, or waiting for I/O is excluded. This preserves the execution-time accounting that these statistics are intended to provide.

## Additional context and related issues

Virtual-thread mounted time is provided by [`io.airlift:vthreadtime`](https://github.com/airlift/vthreadtime). Its documentation describes the measurement semantics, runtime overhead, supported platforms, and native-access requirements.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve scalability under high concurrency by using virtual threads for split execution. Restore platform-thread split execution by setting `experimental.thread-per-driver-scheduler-virtual-threads-enabled` to `false`. ({issue}`30477`)
```