### PR TITLE
Improve FileBaseAccessControl error message to show only denied columns

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/CatalogTableAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/CatalogTableAccessControlRule.java
@@ -79,6 +79,11 @@ public class CatalogTableAccessControlRule
         return tableAccessControlRule.canSelectColumns(columnNames);
     }
 
+    public Set<String> getDeniedColumns(Set<String> columnNames)
+    {
+        return tableAccessControlRule.getDeniedColumns(columnNames);
+    }
+
     public Optional<ViewExpression> getColumnMask(String catalog, String schema, String column)
     {
         return tableAccessControlRule.getColumnMask(catalog, schema, column);

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -92,6 +92,7 @@ import static io.trino.spi.security.AccessDeniedException.denyRevokeRoles;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeSchemaPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeTableBranchPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
+import static io.trino.spi.security.AccessDeniedException.denySelectColumns;
 import static io.trino.spi.security.AccessDeniedException.denySelectTable;
 import static io.trino.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static io.trino.spi.security.AccessDeniedException.denySetEntityAuthorization;
@@ -387,13 +388,21 @@ public class FileBasedAccessControl
         }
 
         ConnectorIdentity identity = context.getIdentity();
-        boolean allowed = tableRules.stream()
-                .filter(rule -> rule.matches(identity.getUser(), identity.getEnabledSystemRoles(), identity.getGroups(), tableName))
-                .map(rule -> rule.canSelectColumns(columnNames))
+        TableAccessControlRule rule = tableRules.stream()
+                .filter(tableRule -> tableRule.matches(identity.getUser(), identity.getEnabledSystemRoles(), identity.getGroups(), tableName))
                 .findFirst()
-                .orElse(false);
-        if (!allowed) {
+                .orElse(null);
+        if (rule == null) {
             denySelectTable(tableName.toString(), branch);
+        }
+        if (!rule.canSelectColumns(columnNames)) {
+            Set<String> deniedColumns = rule.getDeniedColumns(columnNames);
+            if (deniedColumns.isEmpty()) {
+                denySelectTable(tableName.toString(), branch);
+            }
+            else {
+                denySelectColumns(tableName.toString(), deniedColumns, branch.orElse(null));
+            }
         }
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -106,6 +106,7 @@ import static io.trino.spi.security.AccessDeniedException.denyRenameView;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeRoles;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeSchemaPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
+import static io.trino.spi.security.AccessDeniedException.denySelectColumns;
 import static io.trino.spi.security.AccessDeniedException.denySelectTable;
 import static io.trino.spi.security.AccessDeniedException.denySetCatalogSessionProperty;
 import static io.trino.spi.security.AccessDeniedException.denySetEntityAuthorization;
@@ -669,13 +670,21 @@ public class FileBasedSystemAccessControl
         }
 
         Identity identity = context.getIdentity();
-        boolean allowed = tableRules.stream()
-                .filter(rule -> rule.matches(identity.getUser(), identity.getEnabledRoles(), identity.getGroups(), table))
-                .map(rule -> rule.canSelectColumns(columns))
+        CatalogTableAccessControlRule rule = tableRules.stream()
+                .filter(tableRule -> tableRule.matches(identity.getUser(), identity.getEnabledRoles(), identity.getGroups(), table))
                 .findFirst()
-                .orElse(false);
-        if (!allowed) {
+                .orElse(null);
+        if (rule == null) {
             denySelectTable(table.toString(), branch);
+        }
+        if (!rule.canSelectColumns(columns)) {
+            Set<String> deniedColumns = rule.getDeniedColumns(columns);
+            if (deniedColumns.isEmpty()) {
+                denySelectTable(table.toString(), branch);
+            }
+            else {
+                denySelectColumns(table.toString(), deniedColumns, branch.orElse(null));
+            }
         }
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/TableAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/TableAccessControlRule.java
@@ -102,6 +102,14 @@ public class TableAccessControlRule
         return (privileges.contains(SELECT) || privileges.contains(GRANT_SELECT)) && restrictedColumns.stream().noneMatch(columnNames::contains);
     }
 
+    public Set<String> getDeniedColumns(Set<String> columnNames)
+    {
+        if (!privileges.contains(SELECT) && !privileges.contains(GRANT_SELECT)) {
+            return columnNames;
+        }
+        return restrictedColumns.stream().filter(columnNames::contains).collect(toImmutableSet());
+    }
+
     public Optional<ViewExpression> getColumnMask(String catalog, String schema, String column)
     {
         return Optional.ofNullable(columnConstraints.get(column)).flatMap(constraint ->

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedConnectorAccessControlTest.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedConnectorAccessControlTest.java
@@ -356,8 +356,9 @@ public abstract class BaseFileBasedConnectorAccessControlTest
         assertDenied(() -> accessControl.checkCanAlterColumn(BOB, bobTable));
         assertDenied(() -> accessControl.checkCanSetTableProperties(BOB, bobTable, ImmutableMap.of()));
         assertDenied(() -> accessControl.checkCanInsertIntoTable(BOB, testTable, Optional.empty()));
-        assertDenied(() -> accessControl.checkCanSelectFromColumns(ADMIN, new SchemaTableName("secret", "secret"), Optional.empty(), ImmutableSet.of()));
-        assertDenied(() -> accessControl.checkCanSelectFromColumns(JOE, new SchemaTableName("secret", "secret"), Optional.empty(), ImmutableSet.of()));
+        assertDenied(() -> accessControl.checkCanSelectFromColumns(ADMIN, new SchemaTableName("secret", "secret"), Optional.empty(), ImmutableSet.of()), "Cannot select from table secret.secret");
+        assertDenied(() -> accessControl.checkCanSelectFromColumns(JOE, new SchemaTableName("secret", "secret"), Optional.empty(), ImmutableSet.of()), "Cannot select from table secret.secret");
+        assertDenied(() -> accessControl.checkCanSelectFromColumns(CHARLIE, bobTable, Optional.empty(), ImmutableSet.of("private", "public")), "Cannot select from columns [private] in table or view bobschema.bobtable");
         assertDenied(() -> accessControl.checkCanCreateViewWithSelectFromColumns(JOE, bobTable, ImmutableSet.of()));
         assertDenied(() -> accessControl.checkCanRenameView(BOB, new SchemaTableName("bobschema", "bobview"), new SchemaTableName("bobschema", "newbobview")));
         assertDenied(() -> accessControl.checkCanRenameView(ALICE, aliceTable, new SchemaTableName("bobschema", "newalicetable")));
@@ -900,6 +901,13 @@ public abstract class BaseFileBasedConnectorAccessControlTest
                 .isInstanceOf(AccessDeniedException.class)
                 // TODO test expected message precisely, as in TestFileBasedSystemAccessControl
                 .hasMessageStartingWith("Access Denied");
+    }
+
+    private static void assertDenied(ThrowingRunnable runnable, String expectedMessage)
+    {
+        assertThatThrownBy(runnable::run)
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("Access Denied: " + expectedMessage);
     }
 
     interface ThrowingRunnable

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
@@ -106,6 +106,7 @@ public abstract class BaseFileBasedSystemAccessControlTest
 
     private static final String SHOWN_TABLES_ACCESS_DENIED_MESSAGE = "Cannot show tables of .*";
     private static final String SELECT_TABLE_ACCESS_DENIED_MESSAGE = "Cannot select from table .*";
+    private static final String SELECT_COLUMNS_ACCESS_DENIED_MESSAGE = "Cannot select from columns \\[%s\\] in table or view %s";
     private static final String SHOW_COLUMNS_ACCESS_DENIED_MESSAGE = "Cannot show columns of table .*";
     private static final String ADD_COLUMNS_ACCESS_DENIED_MESSAGE = "Cannot add a column to table .*";
     private static final String DROP_COLUMNS_ACCESS_DENIED_MESSAGE = "Cannot drop a column from table .*";
@@ -461,7 +462,7 @@ public abstract class BaseFileBasedSystemAccessControlTest
                         new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"),
                         Optional.empty(),
                         ImmutableSet.of("bobcolumn", "private")),
-                SELECT_TABLE_ACCESS_DENIED_MESSAGE);
+                SELECT_COLUMNS_ACCESS_DENIED_MESSAGE.formatted("private", "some-catalog.bobschema.bobcolumns"));
         accessControl.checkCanSelectFromColumns(JOE, new CatalogSchemaTableName("some-catalog", "bobschema", "bobcolumns"), Optional.empty(), ImmutableSet.of());
 
         assertAccessDenied(

--- a/lib/trino-plugin-toolkit/src/test/resources/table.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/table.json
@@ -35,6 +35,12 @@
       "group": "guests",
       "schema": "bobschema",
       "table": "bobtable",
+      "columns" : [
+        {
+          "name": "private",
+          "allow": false
+        }
+      ],
       "privileges": ["SELECT", "INSERT"]
     },
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Improve FileBaseAccessControl error message to show only denied columns when select from columns is not allowed.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- https://github.com/trinodb/trino/issues/28602


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Security
* Improve file based access control error message to only show denied columns when select from columns is not allowed ({issue}`30479`)
```
