### PR TITLE
Fix Iceberg $partitions for columns named after reserved words

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/PartitionsView.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/PartitionsView.java
@@ -15,7 +15,6 @@ package io.trino.plugin.iceberg.system;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import io.trino.plugin.iceberg.IcebergUtil;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.ConnectorViewDefinition.ViewColumn;
 import io.trino.spi.type.RowType;
@@ -98,9 +97,9 @@ public final class PartitionsView
                 """.formatted(
                         hasPartitionColumn ? "partition," : "",
                         hasDataColumn ? ", " + dataAggregationSql : "",
-                        IcebergUtil.quotedName(catalogName),
-                        IcebergUtil.quotedName(schemaName),
-                        IcebergUtil.quotedName(tableName + "$files"),
+                        quoted(catalogName),
+                        quoted(schemaName),
+                        quoted(tableName + "$files"),
                         hasPartitionColumn ? "GROUP BY 1" : "");
 
         return new ConnectorViewDefinition(
@@ -148,7 +147,13 @@ public final class PartitionsView
     private static String buildColumnRowType(String columnName, String trinoTypeDisplayName)
     {
         return "%s ROW(min %2$s, max %2$s, null_count BIGINT, nan_count BIGINT)"
-                .formatted(IcebergUtil.quotedName(columnName), trinoTypeDisplayName);
+                .formatted(quoted(columnName), trinoTypeDisplayName);
+    }
+
+    // identifiers embedded in the generated view SQL are always quoted, since a bare reserved word (e.g. a column named "group") would not parse
+    private static String quoted(String name)
+    {
+        return '"' + name.replace("\"", "\"\"") + '"';
     }
 
     private static Optional<RowType> getMetricsColumnType(TypeManager typeManager, List<NestedField> columns)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -241,6 +241,20 @@ public abstract class BaseIcebergSystemTables
     }
 
     @Test
+    public void testPartitionsTableWithReservedKeywordColumnName()
+    {
+        try (TestTable table = newTrinoTable(
+                "test_partitions_reserved_keyword",
+                "(\"group\" varchar, \"order\" bigint, _date date) WITH (partitioning = ARRAY['_date'])")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES ('a', 1, DATE '2024-01-01'), ('b', 2, DATE '2024-01-02')", 2);
+
+            assertQuery(
+                    "SELECT partition._date, record_count, data.\"group\".min, data.\"order\".max FROM \"" + table.getName() + "$partitions\"",
+                    "VALUES (DATE '2024-01-01', 1, 'a', 1), (DATE '2024-01-02', 1, 'b', 2)");
+        }
+    }
+
+    @Test
     public void testPartitionsTableOnDropColumn()
     {
         MaterializedResult resultAfterDrop = computeActual("SELECT * from test_schema.\"test_table_drop_column$partitions\"");


### PR DESCRIPTION
## Description

Querying the `$partitions` metadata table fails with `INVALID_VIEW` when the base table has a column whose name is a SQL reserved word (e.g. `group`, `order`):

```sql
CREATE TABLE iceberg.tmp.test_reserved ("group" varchar, "order" bigint, _date date)
WITH (partitioning = ARRAY['_date']);

SELECT * FROM iceberg.tmp."test_reserved$partitions";
-- Failed parsing stored view 'iceberg.tmp."test_reserved$partitions"':
--   mismatched input 'group'. Expecting: <identifier>, <type>
```

### Full stack trace
```
io.trino.spi.TrinoException: line 12:18: Failed parsing stored view 'iceberg.tmp."test_reserved$partitions"': line 61:861: mismatched input 'group'. Expecting: <identifier>, <type>
	at io.trino.sql.analyzer.SemanticExceptions.semanticException(SemanticExceptions.java:58)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.parseView(StatementAnalyzer.java:5732)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.createScopeForView(StatementAnalyzer.java:2750)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.createScopeForView(StatementAnalyzer.java:2686)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:2415)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:550)
	at io.trino.sql.tree.Table.accept(Table.java:70)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:574)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.analyzeFrom(StatementAnalyzer.java:5632)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:3518)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:550)
	at io.trino.sql.tree.QuerySpecification.accept(QuerySpecification.java:155)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:574)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:582)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:1629)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:550)
	at io.trino.sql.tree.Query.accept(Query.java:130)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:574)
	at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:529)
	at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:518)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:98)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:87)
	at io.trino.execution.SqlQueryExecution.analyze(SqlQueryExecution.java:297)
	at io.trino.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:231)
	at io.trino.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:957)
	at io.trino.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:163)
	at io.trino.$gen.Trino_483_15_g70a8b85____20260727_060826_2.call(Unknown Source)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: io.trino.sql.parser.ParsingException: line 61:861: mismatched input 'group'. Expecting: <identifier>, <type>
	at io.trino.sql.parser.ErrorHandler.syntaxError(ErrorHandler.java:117)
	at org.antlr.v4.runtime.ProxyErrorListener.syntaxError(ProxyErrorListener.java:41)
	at org.antlr.v4.runtime.Parser.notifyErrorListeners(Parser.java:544)
	at org.antlr.v4.runtime.DefaultErrorStrategy.reportNoViableAlternative(DefaultErrorStrategy.java:310)
	at org.antlr.v4.runtime.DefaultErrorStrategy.reportError(DefaultErrorStrategy.java:136)
	at io.trino.grammar.sql.SqlBaseParser.selectItem(SqlBaseParser.java:9498)
	at io.trino.grammar.sql.SqlBaseParser.querySpecification(SqlBaseParser.java:8500)
	at io.trino.grammar.sql.SqlBaseParser.queryPrimary(SqlBaseParser.java:8188)
	at io.trino.grammar.sql.SqlBaseParser.queryTerm(SqlBaseParser.java:7968)
	at io.trino.grammar.sql.SqlBaseParser.queryNoWith(SqlBaseParser.java:7560)
	at io.trino.grammar.sql.SqlBaseParser.query(SqlBaseParser.java:6667)
	at io.trino.grammar.sql.SqlBaseParser.rootQuery(SqlBaseParser.java:6471)
	at io.trino.grammar.sql.SqlBaseParser.rootQueryWithSession(SqlBaseParser.java:6555)
	at io.trino.grammar.sql.SqlBaseParser.statement(SqlBaseParser.java:3259)
	at io.trino.grammar.sql.SqlBaseParser.singleStatement(SqlBaseParser.java:367)
	at io.trino.sql.parser.SqlParser.invokeParser(SqlParser.java:173)
	at io.trino.sql.parser.SqlParser.invokeParser(SqlParser.java:141)
	at io.trino.sql.parser.SqlParser.createStatement(SqlParser.java:106)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.parseView(StatementAnalyzer.java:5729)
	... 34 more
Caused by: org.antlr.v4.runtime.NoViableAltException: undefined
	at org.antlr.v4.runtime.atn.ParserATNSimulator.noViableAlt(ParserATNSimulator.java:2014)
	at org.antlr.v4.runtime.atn.ParserATNSimulator.execATN(ParserATNSimulator.java:445)
	at org.antlr.v4.runtime.atn.ParserATNSimulator.adaptivePredict(ParserATNSimulator.java:371)
	at io.trino.grammar.sql.SqlBaseParser.selectItem(SqlBaseParser.java:9433)
	... 47 more
```

Since `$partitions` was reimplemented as a view over `$files` (#28997, released in 482), the connector generates view SQL and the engine parses it. The generated SQL quotes identifiers with `IcebergUtil.quotedName()`, which leaves simple lower-case names (`[a-z][a-z0-9]*`) unquoted. When such a name is a reserved word, it ends up unquoted in the `CAST(ROW(...) AS ROW(<column> ROW(min ..., max ..., ...)))` type of the `data` column and the view fails to parse. The catalog, schema, and table names interpolated into the `FROM` clause are exposed to the same hazard (e.g. a schema named `order`).

This change quotes all identifiers embedded in the generated view SQL unconditionally, matching how the engine formats identifiers in SQL it produces. `IcebergUtil.quotedName()` is left untouched, since its other callers use it for display names (`BaseTable` naming across the catalog implementations), not for parseable SQL.

## Additional context and related issues

- Regression introduced by #28997 (482). Before 482, `$partitions` was a `SystemTable` and no SQL text was generated, so reserved-word column names worked fine.
- This is the second regression from that rewrite: #30311 (wide tables failing with `MethodTooLargeException`) was confirmed in https://github.com/trinodb/trino/issues/30311#issuecomment-5012744820 to be caused by #28997 as well, and was fixed by #30279 (483).
- Added a regression test to `BaseIcebergSystemTables` covering reserved-word column names in both the `data` metrics row type and the aggregation results (runs for Parquet and ORC).

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Fix failure when querying the `$partitions` metadata table on tables with
  columns named after SQL reserved words.
```

cc/ @tbaeg @martint @raunaqmorarka 
