### PR TITLE
Fix Iceberg metadata tables for dropped partition fields

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/SystemTableUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/SystemTableUtil.java
@@ -72,8 +72,15 @@ public final class SystemTableUtil
     {
         Map<Integer, PartitionField> result = new LinkedHashMap<>();
         for (PartitionField partitionField : visiblePartitionFields) {
-            // Use last occurrence of partition field in case of duplicates
-            result.put(partitionField.fieldId(), partitionField);
+            // Use last occurrence of partition field in case of duplicates, except for the void placeholder that
+            // a dropped partition field can leave behind under the same field id, which reports the source type
+            // as its result type
+            result.merge(partitionField.fieldId(), partitionField, (existing, duplicate) -> {
+                if (duplicate.transform().isVoid()) {
+                    return existing;
+                }
+                return duplicate;
+            });
         }
         return result.values().stream().collect(toImmutableList());
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/util/TestSystemTableUtil.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/util/TestSystemTableUtil.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.iceberg.system.IcebergPartitionColumn;
+import io.trino.spi.type.RowType;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.trino.plugin.iceberg.util.SystemTableUtil.getAllPartitionFields;
+import static io.trino.plugin.iceberg.util.SystemTableUtil.getPartitionColumnType;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSystemTableUtil
+{
+    private static final Schema SCHEMA = new Schema(
+            Types.NestedField.optional(1, "event_time", Types.TimestampType.withoutZone()),
+            Types.NestedField.optional(2, "value", Types.IntegerType.get()));
+
+    @Test
+    public void testPartitionColumnTypeIgnoresVoidPlaceholderOfDroppedField()
+    {
+        // a void placeholder reuses the field id of the dropped field and reports the source type as its result type
+        PartitionSpec dayPartitioned = parseSpec(
+                """
+                {"spec-id": 0, "fields": [
+                    {"name": "event_time_day", "transform": "day", "source-id": 1, "field-id": 1000}]}
+                """);
+        PartitionSpec hourPartitioned = parseSpec(
+                """
+                {"spec-id": 1, "fields": [
+                    {"name": "event_time_day", "transform": "void", "source-id": 1, "field-id": 1000},
+                    {"name": "event_time_hour", "transform": "hour", "source-id": 1, "field-id": 1001}]}
+                """);
+
+        List<PartitionField> partitionFields = getAllPartitionFields(SCHEMA, ImmutableMap.of(0, dayPartitioned, 1, hourPartitioned));
+        IcebergPartitionColumn partitionColumn = getPartitionColumnType(TESTING_TYPE_MANAGER, partitionFields, SCHEMA).orElseThrow();
+
+        assertThat(partitionColumn.rowType()).isEqualTo(RowType.from(ImmutableList.of(
+                RowType.field("event_time_day", DATE),
+                RowType.field("event_time_hour", INTEGER))));
+        assertThat(partitionColumn.fieldIds()).containsExactly(1000, 1001);
+    }
+
+    private static PartitionSpec parseSpec(String json)
+    {
+        return PartitionSpecParser.fromJson(SCHEMA, json);
+    }
+}


### PR DESCRIPTION
## Description

Reading `$files`, `$partitions`, `$entries` or `$all_entries` fails with `Wrong class, expected java.lang.Long, but was java.lang.Integer` when a partition field was dropped.

Dropping a partition field can leave a `void` transform placeholder that reuses the field id of the dropped field, and `VoidTransform.getResultType` returns the source type. `getAllPartitionFields` dedupes by field id keeping the last occurrence, so the placeholder wins and the partition row type expects the source type instead of the transform result type. A `void` duplicate no longer displaces a non-void field with the same field id, matching `org.apache.iceberg.Partitioning.buildPartitionProjectionType`.

## Additional context and related issues

Fixes #30247.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Fix query failure when reading the `$files`, `$partitions`, `$entries` or `$all_entries` metadata table of a table with a dropped partition field. ({issue}`30247`)
```
