### PR TITLE
Use list of requests in ranger system access control checkCanSelectFromColumns method

### DIFF
--- a/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java
+++ b/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java
@@ -48,17 +48,17 @@ import java.net.URL;
 import java.security.Principal;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.ranger.RangerTrinoAccessType.ALTER;
 import static io.trino.plugin.ranger.RangerTrinoAccessType.CREATE;
 import static io.trino.plugin.ranger.RangerTrinoAccessType.DELETE;
@@ -207,7 +207,9 @@ public class RangerSystemAccessControl
             return queryOwners;
         }
 
-        return queryOwners.stream().filter(not(toExclude::contains)).collect(Collectors.toList());
+        return queryOwners.stream()
+                .filter(not(toExclude::contains))
+                .collect(toImmutableList());
     }
 
     @Override
@@ -287,7 +289,9 @@ public class RangerSystemAccessControl
             return catalogs;
         }
 
-        return catalogs.stream().filter(not(toExclude::contains)).collect(Collectors.toSet());
+        return catalogs.stream()
+                .filter(not(toExclude::contains))
+                .collect(toImmutableSet());
     }
 
     @Override
@@ -348,7 +352,9 @@ public class RangerSystemAccessControl
             return schemaNames;
         }
 
-        return schemaNames.stream().filter(not(toExclude::contains)).collect(Collectors.toSet());
+        return schemaNames.stream()
+                .filter(not(toExclude::contains))
+                .collect(toImmutableSet());
     }
 
     @Override
@@ -467,7 +473,9 @@ public class RangerSystemAccessControl
             return tableNames;
         }
 
-        return tableNames.stream().filter(not(toExclude::contains)).collect(Collectors.toSet());
+        return tableNames.stream()
+                .filter(not(toExclude::contains))
+                .collect(toImmutableSet());
     }
 
     @Override
@@ -524,21 +532,21 @@ public class RangerSystemAccessControl
         Collection<RangerAccessRequest> requests = RangerTrinoResource.forColumns(table.getCatalogName(), table.getSchemaTableName().getSchemaName(), table.getSchemaTableName().getTableName(), columns)
                 .stream()
                 .map(resource -> createAccessRequest(resource, context, SELECT, "SelectFromColumns"))
-                .collect(Collectors.toList());
+                .collect(toImmutableList());
 
         List<RangerAccessResource> errorResources = rangerPlugin.isAccessAllowed(requests)
                 .stream()
                 .filter(request -> !request.getIsAllowed())
                 .map(RangerAccessResult::getAccessRequest)
                 .map(RangerAccessRequest::getResource)
-                .toList();
+                .collect(toImmutableList());
 
         if (!errorResources.isEmpty()) {
             List<String> errorColumns = errorResources.stream()
                     .map(resource -> resource.getAsMap().get(RangerTrinoResource.KEY_COLUMN))
                     .filter(Objects::nonNull)
                     .map(Object::toString)
-                    .toList();
+                    .collect(toImmutableList());
             if (errorColumns.isEmpty()) {
                 denySelectTable(table.getSchemaTableName().getTableName());
             }
@@ -577,7 +585,9 @@ public class RangerSystemAccessControl
             return columns;
         }
 
-        return columns.stream().filter(not(toExclude::contains)).collect(Collectors.toSet());
+        return columns.stream()
+                .filter(not(toExclude::contains))
+                .collect(toImmutableSet());
     }
 
     @Override
@@ -801,7 +811,9 @@ public class RangerSystemAccessControl
             return functionNames;
         }
         else {
-            return functionNames.stream().filter(not(toExclude::contains)).collect(Collectors.toSet());
+            return functionNames.stream()
+                    .filter(not(toExclude::contains))
+                    .collect(toImmutableSet());
         }
     }
 
@@ -811,7 +823,7 @@ public class RangerSystemAccessControl
         RangerAccessResult result = getRowFilterResult(createAccessRequest(createTableResource(tableName), context, SELECT, "getRowFilters"));
 
         if (!isRowFilterEnabled(result)) {
-            return Collections.emptyList();
+            return ImmutableList.of();
         }
 
         String filter = result.getFilterExpr();

--- a/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java
+++ b/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java
@@ -39,6 +39,7 @@ import org.apache.ranger.plugin.audit.RangerDefaultAuditHandler;
 import org.apache.ranger.plugin.model.RangerPolicy;
 import org.apache.ranger.plugin.model.RangerServiceDef;
 import org.apache.ranger.plugin.policyengine.RangerAccessRequest;
+import org.apache.ranger.plugin.policyengine.RangerAccessResource;
 import org.apache.ranger.plugin.policyengine.RangerAccessResult;
 import org.apache.ranger.plugin.service.RangerBasePlugin;
 
@@ -46,7 +47,6 @@ import java.io.File;
 import java.net.URL;
 import java.security.Principal;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -521,12 +521,18 @@ public class RangerSystemAccessControl
     @Override
     public void checkCanSelectFromColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
     {
-        List<RangerTrinoResource> errorResources = new ArrayList<>();
-        for (RangerTrinoResource resource : RangerTrinoResource.forColumns(table.getCatalogName(), table.getSchemaTableName().getSchemaName(), table.getSchemaTableName().getTableName(), columns)) {
-            if (!hasPermission(resource, context, SELECT, "SelectFromColumns")) {
-                errorResources.add(resource);
-            }
-        }
+        Collection<RangerAccessRequest> requests = RangerTrinoResource.forColumns(table.getCatalogName(), table.getSchemaTableName().getSchemaName(), table.getSchemaTableName().getTableName(), columns)
+                .stream()
+                .map(resource -> createAccessRequest(resource, context, SELECT, "SelectFromColumns"))
+                .collect(Collectors.toList());
+
+        List<RangerAccessResource> errorResources = rangerPlugin.isAccessAllowed(requests)
+                .stream()
+                .filter(request -> !request.getIsAllowed())
+                .map(RangerAccessResult::getAccessRequest)
+                .map(RangerAccessRequest::getResource)
+                .toList();
+
         if (!errorResources.isEmpty()) {
             List<String> errorColumns = errorResources.stream()
                     .map(resource -> resource.getAsMap().get(RangerTrinoResource.KEY_COLUMN))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Use a list of requests api in ranger plugin during checkCanSelectFromColumns that will help reduce number of audit logs for each columns later.

Today number of audit entries in trino-ranger plugin is proportional to the number of columns in a table. Using the list api will ensure ranger plugin updated with custom audit handler for trino generating a consolidated audit entry.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Ranger plugin
* Improve Ranger audit columns' access check to use batch api
```
