### PR TITLE
Suggest similar column names on COLUMN_NOT_FOUND

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -15,12 +15,14 @@ package io.trino.sql.analyzer;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import io.airlift.slice.Slice;
 import io.trino.Session;
@@ -29,6 +31,7 @@ import io.trino.metadata.CatalogFunctionMetadata;
 import io.trino.metadata.FunctionResolver;
 import io.trino.metadata.LanguageFunctionAnalysisException;
 import io.trino.metadata.OperatorNotFoundException;
+import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.security.AccessControl;
 import io.trino.spi.ErrorCode;
@@ -190,12 +193,14 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -727,6 +732,40 @@ public class ExpressionAnalyzer
         return jsonOutputFunctions;
     }
 
+    private Set<Field> extractAccessibleFields(List<Field> fields)
+    {
+        ImmutableSet.Builder<Field> allowed = ImmutableSet.builder();
+
+        ListMultimap<QualifiedObjectName, Field> fieldsByTable = ArrayListMultimap.create();
+        for (Field field : fields) {
+            if (field.getOriginTable().isPresent() && field.getOriginColumnName().isPresent()) {
+                fieldsByTable.put(field.getOriginTable().get(), field);
+            }
+            else {
+                // Fields with no origin table (aliases, derived columns) are always allowed
+                allowed.add(field);
+            }
+        }
+
+        for (Entry<QualifiedObjectName, Collection<Field>> entry : fieldsByTable.asMap().entrySet()) {
+            QualifiedObjectName table = entry.getKey();
+            Collection<Field> tableFields = entry.getValue();
+            Set<String> accessibleColumns = accessControl.filterColumns(
+                            session.toSecurityContext(),
+                            table.catalogName(),
+                            ImmutableMap.of(
+                                    table.asSchemaTableName(), tableFields.stream()
+                                            .map(field -> field.getOriginColumnName().orElseThrow())
+                                            .collect(toImmutableSet())))
+                    .getOrDefault(table.asSchemaTableName(), ImmutableSet.of());
+            allowed.addAll(tableFields.stream()
+                    .filter(field -> accessibleColumns.contains(field.getOriginColumnName().orElseThrow()))
+                    .collect(toImmutableList()));
+        }
+
+        return allowed.build();
+    }
+
     private class Visitor
             extends AstVisitor<Type, Context>
     {
@@ -822,7 +861,11 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitIdentifier(Identifier node, Context context)
         {
-            ResolvedField resolvedField = context.getScope().resolveField(node, QualifiedName.of(node.getValue()));
+            Scope scope = context.getScope();
+
+            // Lazy extraction to avoid unnecessary work
+            Supplier<Set<Field>> accessibleFields = () -> extractAccessibleFields(scope.collectSuggestionFields());
+            ResolvedField resolvedField = scope.resolveField(node, QualifiedName.of(node.getValue()), accessibleFields);
 
             if (context.isPatternRecognition()) {
                 labels.put(NodeRef.of(node), Optional.empty());
@@ -3663,7 +3706,7 @@ public class ExpressionAnalyzer
                 fieldToLambdaArgumentDeclaration.putAll(context.getFieldToLambdaArgumentDeclaration());
             }
             for (LambdaArgumentDeclaration lambdaArgument : lambdaArguments) {
-                ResolvedField resolvedField = lambdaScope.resolveField(lambdaArgument, QualifiedName.of(lambdaArgument.getName().getValue()));
+                ResolvedField resolvedField = lambdaScope.resolveField(lambdaArgument, QualifiedName.of(lambdaArgument.getName().getValue()), ImmutableSet::of);
                 fieldToLambdaArgumentDeclaration.put(FieldId.from(resolvedField), lambdaArgument);
             }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Scope.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Scope.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.analyzer;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.Immutable;
 import io.trino.spi.type.RowType;
@@ -25,10 +26,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.spi.StandardErrorCode.AMBIGUOUS_NAME;
 import static io.trino.sql.analyzer.ExpressionTreeUtils.asQualifiedName;
@@ -37,6 +41,10 @@ import static io.trino.sql.analyzer.Scope.BasisType.TABLE;
 import static io.trino.sql.analyzer.SemanticExceptions.ambiguousAttributeException;
 import static io.trino.sql.analyzer.SemanticExceptions.missingAttributeException;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static io.trino.util.JaroWinkler.similarity;
+import static java.util.Comparator.comparingDouble;
+import static java.util.Locale.ENGLISH;
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -222,9 +230,19 @@ public class Scope
         return findLocally(scope -> scope.getRelationId().equals(other.getRelationId())).isPresent();
     }
 
-    public ResolvedField resolveField(Expression expression, QualifiedName name)
+    public ResolvedField resolveField(Expression expression, QualifiedName name, Supplier<Set<Field>> accessibleFields)
     {
-        return tryResolveField(expression, name).orElseThrow(() -> missingAttributeException(expression, name));
+        return tryResolveField(expression, name).orElseThrow(() -> missingAttributeException(expression, name, trySuggestFieldNames(name, accessibleFields)));
+    }
+
+    private Optional<String> trySuggestFieldNames(QualifiedName name, Supplier<Set<Field>> accessibleFields)
+    {
+        try {
+            return suggestFieldNames(name.getSuffix(), accessibleFields.get());
+        }
+        catch (RuntimeException _) {
+            return Optional.empty();
+        }
     }
 
     public Optional<ResolvedField> tryResolveField(Expression expression)
@@ -265,6 +283,55 @@ public class Scope
             return parent.get().resolveField(node, name, local);
         }
         return Optional.empty();
+    }
+
+    List<Field> collectSuggestionFields()
+    {
+        ImmutableList.Builder<Field> fields = ImmutableList.builder();
+        Scope scope = this;
+        while (scope != null) {
+            scope.relation.getVisibleFields().stream()
+                    .filter(field -> field.getName().isPresent())
+                    .forEach(fields::add);
+            scope = scope.parent.orElse(null);
+        }
+        return fields.build();
+    }
+
+    private Optional<String> suggestFieldNames(String columnName, Set<Field> accessibleFields)
+    {
+        if (accessibleFields.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String lowercaseName = columnName.toLowerCase(ROOT);
+
+        List<String> suggestions = accessibleFields.stream()
+                .map(Field::getName)
+                .filter(Optional::isPresent)
+                .map(Optional::orElseThrow)
+                .distinct()
+                .map(candidate -> new Match(candidate, similarity(candidate.toLowerCase(ENGLISH), lowercaseName)))
+                .filter(match -> match.similarity() > 0.85)
+                .sorted(comparingDouble(Match::similarity).reversed())
+                .limit(3)
+                .map(Match::candidate)
+                .collect(toImmutableList());
+
+        return switch (suggestions.size()) {
+            case 0 -> Optional.empty();
+            case 1 -> Optional.of(quote(suggestions.getFirst()));
+            case 2 -> Optional.of(quote(suggestions.getFirst()) + " or " + quote(suggestions.get(1)));
+            default -> Optional.of(quote(suggestions.getFirst()) + ", " + quote(suggestions.get(1)) + " or " + quote(suggestions.get(2)));
+        };
+    }
+
+    private record Match(String candidate, double similarity)
+    {
+        public Match
+        {
+            requireNonNull(candidate, "candidate is null");
+        }
     }
 
     public ResolvedField getField(int index)
@@ -421,5 +488,10 @@ public class Scope
     {
         TABLE,
         FIELD,
+    }
+
+    private static String quote(String name)
+    {
+        return "'" + name.replace("'", "''") + "'";
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/SemanticExceptions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/SemanticExceptions.java
@@ -20,6 +20,8 @@ import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Node;
 import io.trino.sql.tree.QualifiedName;
 
+import java.util.Optional;
+
 import static io.trino.spi.StandardErrorCode.AMBIGUOUS_NAME;
 import static io.trino.spi.StandardErrorCode.COLUMN_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.INVALID_COLUMN_REFERENCE;
@@ -33,6 +35,11 @@ public final class SemanticExceptions
     public static TrinoException missingAttributeException(Expression node, QualifiedName name)
     {
         throw semanticException(COLUMN_NOT_FOUND, node, "Column '%s' cannot be resolved", name);
+    }
+
+    public static TrinoException missingAttributeException(Expression node, QualifiedName name, Optional<String> suggestion)
+    {
+        throw semanticException(COLUMN_NOT_FOUND, node, "Column '%s' cannot be resolved%s", name, suggestion.map(". Did you mean %s?"::formatted).orElse(""));
     }
 
     public static TrinoException invalidReferenceException(Expression node, QualifiedName name)

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -415,6 +415,35 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testColumnNotFoundSuggestion()
+    {
+        // typo — one close match
+        assertFails("SELECT firs_name FROM (VALUES 1) t(first_name)")
+                .hasErrorCode(COLUMN_NOT_FOUND)
+                .hasMessage("line 1:8: Column 'firs_name' cannot be resolved. Did you mean 'first_name'?");
+
+        // typo — two close matches
+        assertFails("SELECT first_nme FROM (VALUES (1, 2)) t(first_name, first_line)")
+                .hasErrorCode(COLUMN_NOT_FOUND)
+                .hasMessage("line 1:8: Column 'first_nme' cannot be resolved. Did you mean 'first_name' or 'first_line'?");
+
+        // typo — three close matches, capped at 3
+        assertFails("SELECT first_nme FROM (VALUES (1, 2, 3, 4)) t(first_name, first_line, first_lime, first_nine)")
+                .hasErrorCode(COLUMN_NOT_FOUND)
+                .hasMessageMatching("line 1:8: Column 'first_nme' cannot be resolved\\. Did you mean 'first_n.+', 'first_.+' or 'first_.+'\\?");
+
+        // no close match — no suggestion appended
+        assertFails("SELECT xyz FROM (VALUES 1) t(first_name)")
+                .hasErrorCode(COLUMN_NOT_FOUND)
+                .hasMessage("line 1:8: Column 'xyz' cannot be resolved");
+
+        // suggestion from outer scope of a correlated subquery
+        assertFails("SELECT (SELECT first_nme FROM (VALUES 1) t(x)) FROM (VALUES 1) u(first_name)")
+                .hasErrorCode(COLUMN_NOT_FOUND)
+                .hasMessage("line 1:16: Column 'first_nme' cannot be resolved. Did you mean 'first_name'?");
+    }
+
+    @Test
     public void testHavingReferencesOutputAlias()
     {
         assertFails("SELECT sum(a) x FROM t1 HAVING x > 5")
@@ -7403,7 +7432,7 @@ public class TestAnalyzer
 
         assertFails("SELECT column FROM TABLE(system.two_arguments_function('a', 1)) table_alias(column_alias)")
                 .hasErrorCode(COLUMN_NOT_FOUND)
-                .hasMessage("line 1:8: Column 'column' cannot be resolved");
+                .hasMessageStartingWith("line 1:8: Column 'column' cannot be resolved");
 
         assertFails("SELECT column FROM TABLE(system.two_arguments_function('a', 1)) table_alias(col1, col2, col3)")
                 .hasErrorCode(MISMATCHED_COLUMN_ALIASES)

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestScope.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestScope.java
@@ -20,7 +20,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static io.trino.spi.StandardErrorCode.COLUMN_NOT_FOUND;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestScope
@@ -72,6 +74,19 @@ public class TestScope
         assertThat(inner.tryResolveField(c4)).isEmpty();
 
         assertThat(inner.getOuterQueryParent()).isEqualTo(Optional.of(outer));
+    }
+
+    @Test
+    public void testSuggestionFailureDoesNotMaskColumnNotFound()
+    {
+        Field firstName = Field.newQualified(QualifiedName.of("table", "first_name"), Optional.of("first_name"), BIGINT, false, Optional.empty(), Optional.empty(), Optional.empty(), false);
+        Scope scope = Scope.builder().withRelationType(RelationId.anonymous(), new RelationType(firstName)).build();
+
+        assertTrinoExceptionThrownBy(() -> scope.resolveField(name("firs_name"), QualifiedName.of("firs_name"), () -> {
+            throw new RuntimeException("access control failure");
+        }))
+                .hasErrorCode(COLUMN_NOT_FOUND)
+                .hasMessage("Column 'firs_name' cannot be resolved");
     }
 
     private static Expression name(String first, String... parts)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
@@ -354,6 +354,23 @@ public class TestFilterInaccessibleColumns
                 .failure().hasMessage("Access Denied: Cannot select from columns [name] in table or view test_catalog.tiny.nation");
     }
 
+    @Test
+    public void testColumnNotFoundSuggestionRespectsAccessControl()
+    {
+        accessControl.reset();
+
+        // Without any restriction, a typo in a column name produces a suggestion
+        assertThat(assertions.query("SELECT coment FROM nation"))
+                .failure()
+                .hasMessage("line 1:8: Column 'coment' cannot be resolved. Did you mean 'comment'?");
+
+        // When SELECT on 'comment' is denied, the suggestion is suppressed
+        accessControl.deny(privilege(USER, "nation.comment", SELECT_COLUMN));
+        assertThat(assertions.query("SELECT coment FROM nation"))
+                .failure()
+                .hasMessage("line 1:8: Column 'coment' cannot be resolved");
+    }
+
     private Session user(String user)
     {
         return Session.builder(assertions.getDefaultSession())

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -958,7 +958,7 @@ public abstract class AbstractTestEngineOnlyQueries
     {
         assertQueryFails(
                 "SELECT * FROM lineitem l JOIN (SELECT orderkey_1, custkey FROM orders) o on l.orderkey = o.orderkey_1",
-                "line 1:39: Column 'orderkey_1' cannot be resolved");
+                "line 1:39: Column 'orderkey_1' cannot be resolved.*");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

When a bare column reference cannot be resolved during SQL analysis, the error message now includes a "Did you mean...?" suggestion if any visible field in scope (including outer query scopes) has a Jaro-Winkler similarity above 0.85 with the unresolved name.

Examples:
  Column 'firs_name' cannot be resolved. Did you mean 'first_name'?
  Column 'column' cannot be resolved. Did you mean 'column_alias'?

* Fixes #18649

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The suggestion is generated in Scope.suggestSimilarFieldNames, which reuses the existing JaroWinkler utility already used for session property suggestions. Only the Scope.resolveField path (bare identifier and correlated subquery lookups) is covered. Qualified-name dereferences and MATCH_RECOGNIZE label paths in ExpressionAnalyzer are unaffected.

Suggestions are filtered through access control: Columns from a base table are suggested only if the current user has SELECT permission on all candidate fields from that table. Fields with no traceable origin table (aliases, derived columns) are suggested unconditionally.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
