### PR TITLE
Support more expression for column default values

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -95,7 +95,8 @@ statement
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
         DROP COLUMN (IF EXISTS)? column=qualifiedName                  #dropColumn
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
-        ALTER COLUMN columnName=qualifiedName SET DEFAULT literal      #setDefaultValue
+        ALTER COLUMN columnName=qualifiedName
+        SET DEFAULT defaultOption                                      #setDefaultValue
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
         ALTER COLUMN columnName=qualifiedName DROP DEFAULT             #dropDefaultValue
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
@@ -254,7 +255,56 @@ tableElement
     ;
 
 columnDefinition
-    : qualifiedName type (DEFAULT literal)? (NOT NULL)? (COMMENT string)? (WITH properties)?
+    : qualifiedName type (DEFAULT defaultOption)? (NOT NULL)? (COMMENT string)? (WITH properties)?
+    ;
+
+defaultOption
+    : literal
+    | currentDate
+    | currentTime
+    | currentTimestamp
+    | localTime
+    | localTimestamp
+    | currentUser
+    | currentCatalog
+    | currentSchema
+    | currentPath
+    ;
+
+currentDate
+    : CURRENT_DATE
+    ;
+
+currentTime
+    : CURRENT_TIME ('(' precision=INTEGER_VALUE ')')?
+    ;
+
+currentTimestamp
+    : CURRENT_TIMESTAMP ('(' precision=INTEGER_VALUE ')')?
+    ;
+
+localTime
+    : LOCALTIME ('(' precision=INTEGER_VALUE ')')?
+    ;
+
+localTimestamp
+    : LOCALTIMESTAMP ('(' precision=INTEGER_VALUE ')')?
+    ;
+
+currentUser
+    : CURRENT_USER
+    ;
+
+currentCatalog
+    : CURRENT_CATALOG
+    ;
+
+currentSchema
+    : CURRENT_SCHEMA
+    ;
+
+currentPath
+    : CURRENT_PATH
     ;
 
 likeClause
@@ -665,15 +715,15 @@ primaryExpression
     | identifier                                                                          #columnReference
     | base=primaryExpression '.' fieldName=identifier                                     #dereference
     | base=primaryExpression '.' stringField=string                                       #stringLiteralDereference
-    | name=CURRENT_DATE                                                                   #currentDate
-    | name=CURRENT_TIME ('(' precision=INTEGER_VALUE ')')?                                #currentTime
-    | name=CURRENT_TIMESTAMP ('(' precision=INTEGER_VALUE ')')?                           #currentTimestamp
-    | name=LOCALTIME ('(' precision=INTEGER_VALUE ')')?                                   #localTime
-    | name=LOCALTIMESTAMP ('(' precision=INTEGER_VALUE ')')?                              #localTimestamp
-    | name=CURRENT_USER                                                                   #currentUser
-    | name=CURRENT_CATALOG                                                                #currentCatalog
-    | name=CURRENT_SCHEMA                                                                 #currentSchema
-    | name=CURRENT_PATH                                                                   #currentPath
+    | currentDate                                                                         #currentDates
+    | currentTime                                                                         #currentTimes
+    | currentTimestamp                                                                    #currentTimestamps
+    | localTime                                                                           #localTimes
+    | localTimestamp                                                                      #localTimestamps
+    | currentUser                                                                         #currentUsers
+    | currentCatalog                                                                      #currentCatalogs
+    | currentSchema                                                                       #currentSchemas
+    | currentPath                                                                         #currentPaths
     | TRIM '(' (trimsSpecification? trimChar=valueExpression? FROM)?
         trimSource=valueExpression ')'                                                    #trim
     | TRIM '(' trimSource=valueExpression ',' trimChar=valueExpression ')'                #trim

--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -95,7 +95,8 @@ statement
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
         DROP COLUMN (IF EXISTS)? column=qualifiedName                  #dropColumn
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
-        ALTER COLUMN columnName=qualifiedName SET DEFAULT literal      #setDefaultValue
+        ALTER COLUMN columnName=qualifiedName
+        SET DEFAULT defaultOption                                      #setDefaultValue
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
         ALTER COLUMN columnName=qualifiedName DROP DEFAULT             #dropDefaultValue
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
@@ -250,7 +251,56 @@ tableElement
     ;
 
 columnDefinition
-    : qualifiedName type (DEFAULT literal)? (NOT NULL)? (COMMENT string)? (WITH properties)?
+    : qualifiedName type (DEFAULT defaultOption)? (NOT NULL)? (COMMENT string)? (WITH properties)?
+    ;
+
+defaultOption
+    : literal
+    | currentDate
+    | currentTime
+    | currentTimestamp
+    | localTime
+    | localTimestamp
+    | currentUser
+    | currentCatalog
+    | currentSchema
+    | currentPath
+    ;
+
+currentDate
+    : CURRENT_DATE
+    ;
+
+currentTime
+    : CURRENT_TIME ('(' precision=INTEGER_VALUE ')')?
+    ;
+
+currentTimestamp
+    : CURRENT_TIMESTAMP ('(' precision=INTEGER_VALUE ')')?
+    ;
+
+localTime
+    : LOCALTIME ('(' precision=INTEGER_VALUE ')')?
+    ;
+
+localTimestamp
+    : LOCALTIMESTAMP ('(' precision=INTEGER_VALUE ')')?
+    ;
+
+currentUser
+    : CURRENT_USER
+    ;
+
+currentCatalog
+    : CURRENT_CATALOG
+    ;
+
+currentSchema
+    : CURRENT_SCHEMA
+    ;
+
+currentPath
+    : CURRENT_PATH
     ;
 
 likeClause
@@ -661,15 +711,15 @@ primaryExpression
     | identifier                                                                          #columnReference
     | base=primaryExpression '.' fieldName=identifier                                     #dereference
     | base=primaryExpression '.' stringField=string                                       #stringLiteralDereference
-    | name=CURRENT_DATE                                                                   #currentDate
-    | name=CURRENT_TIME ('(' precision=INTEGER_VALUE ')')?                                #currentTime
-    | name=CURRENT_TIMESTAMP ('(' precision=INTEGER_VALUE ')')?                           #currentTimestamp
-    | name=LOCALTIME ('(' precision=INTEGER_VALUE ')')?                                   #localTime
-    | name=LOCALTIMESTAMP ('(' precision=INTEGER_VALUE ')')?                              #localTimestamp
-    | name=CURRENT_USER                                                                   #currentUser
-    | name=CURRENT_CATALOG                                                                #currentCatalog
-    | name=CURRENT_SCHEMA                                                                 #currentSchema
-    | name=CURRENT_PATH                                                                   #currentPath
+    | currentDate                                                                         #currentDates
+    | currentTime                                                                         #currentTimes
+    | currentTimestamp                                                                    #currentTimestamps
+    | localTime                                                                           #localTimes
+    | localTimestamp                                                                      #localTimestamps
+    | currentUser                                                                         #currentUsers
+    | currentCatalog                                                                      #currentCatalogs
+    | currentSchema                                                                       #currentSchemas
+    | currentPath                                                                         #currentPaths
     | TRIM '(' (trimsSpecification? trimChar=valueExpression? FROM)?
         trimSource=valueExpression ')'                                                    #trim
     | TRIM '(' trimSource=valueExpression ',' trimChar=valueExpression ')'                #trim

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -5049,24 +5049,51 @@ public class ExpressionAnalyzer
             Map<NodeRef<Parameter>, Expression> parameters,
             WarningCollector warningCollector,
             Type columnType,
-            Expression defaultLiteral)
+            Expression expression)
     {
-        if (!(defaultLiteral instanceof Literal literal)) {
-            throw new IllegalArgumentException("Unsupported default expression: " + defaultLiteral);
-        }
+        validateDefaultExpression(expression, columnType);
 
         try {
             ExpressionAnalyzer constantAnalyzer = createConstantAnalyzer(plannerContext, accessControl, session, parameters, warningCollector);
-            Type literalType = constantAnalyzer.analyze(literal, Scope.create());
-            Object value = evaluateConstant(literal, literalType, parameters, plannerContext, session, accessControl);
+            Type expressionType = constantAnalyzer.analyze(expression, Scope.create());
 
-            if (!literalType.equals(columnType)) {
-                checkDefaultColumnValue(session, plannerContext, value, columnType, literalType);
+            Object value = evaluateConstant(expression, expressionType, parameters, plannerContext, session, accessControl);
+            if (!expressionType.equals(columnType)) {
+                checkDefaultColumnValue(session, plannerContext, value, columnType, expressionType);
             }
         }
         catch (RuntimeException e) {
-            throw semanticException(INVALID_DEFAULT_COLUMN_VALUE, literal, e, "'%s' is not a valid %s literal", literal, columnType.getDisplayName().toUpperCase(ENGLISH));
+            throw semanticException(INVALID_DEFAULT_COLUMN_VALUE, expression, e, "'%s' is not a valid %s literal", expression, columnType.getDisplayName().toUpperCase(ENGLISH));
         }
+    }
+
+    public static void validateDefaultExpression(Expression expression, Type columnType)
+    {
+        if (expression instanceof Literal ||
+                expression instanceof CurrentDate ||
+                expression instanceof CurrentTime ||
+                expression instanceof CurrentTimestamp ||
+                expression instanceof LocalTime ||
+                expression instanceof LocalTimestamp) {
+            return;
+        }
+        if (expression instanceof CurrentUser || expression instanceof CurrentCatalog || expression instanceof CurrentSchema) {
+            // The length shall be at least 128 characters, as required by the SQL standard
+            if ((columnType instanceof VarcharType varcharType && !varcharType.isUnbounded() && varcharType.getBoundedLength() < 128) ||
+                    (columnType instanceof CharType charType && charType.getLength() < 128)) {
+                throw new TrinoException(INVALID_DEFAULT_COLUMN_VALUE, "CURRENT_USER, CURRENT_CATALOG, CURRENT_SCHEMA requires at least 128 length");
+            }
+            return;
+        }
+        if (expression instanceof CurrentPath) {
+            // The length shall be at least 1031 characters, as required by the SQL standard
+            if ((columnType instanceof VarcharType varcharType && !varcharType.isUnbounded() && varcharType.getBoundedLength() < 1031) ||
+                    (columnType instanceof CharType charType && charType.getLength() < 1031)) {
+                throw new TrinoException(INVALID_DEFAULT_COLUMN_VALUE, "CURRENT_PATH requires at least 1031 length");
+            }
+            return;
+        }
+        throw new IllegalArgumentException("Unsupported default expression: " + expression);
     }
 
     private static void checkDefaultColumnValue(Session session, PlannerContext plannerContext, Object value, Type type, Type literalType)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -5098,24 +5098,51 @@ public class ExpressionAnalyzer
             Map<NodeRef<Parameter>, Expression> parameters,
             WarningCollector warningCollector,
             Type columnType,
-            Expression defaultLiteral)
+            Expression expression)
     {
-        if (!(defaultLiteral instanceof Literal literal)) {
-            throw new IllegalArgumentException("Unsupported default expression: " + defaultLiteral);
-        }
+        validateDefaultExpression(expression, columnType);
 
         try {
             ExpressionAnalyzer constantAnalyzer = createConstantAnalyzer(plannerContext, accessControl, session, parameters, warningCollector);
-            Type literalType = constantAnalyzer.analyze(literal, Scope.create());
-            Object value = evaluateConstant(literal, literalType, parameters, plannerContext, session, accessControl);
+            Type expressionType = constantAnalyzer.analyze(expression, Scope.create());
 
-            if (!literalType.equals(columnType)) {
-                checkDefaultColumnValue(session, plannerContext, value, columnType, literalType);
+            Object value = evaluateConstant(expression, expressionType, parameters, plannerContext, session, accessControl);
+            if (!expressionType.equals(columnType)) {
+                checkDefaultColumnValue(session, plannerContext, value, columnType, expressionType);
             }
         }
         catch (RuntimeException e) {
-            throw semanticException(INVALID_DEFAULT_COLUMN_VALUE, literal, e, "'%s' is not a valid %s literal", literal, columnType.getDisplayName().toUpperCase(ENGLISH));
+            throw semanticException(INVALID_DEFAULT_COLUMN_VALUE, expression, e, "'%s' is not a valid %s literal", expression, columnType.getDisplayName().toUpperCase(ENGLISH));
         }
+    }
+
+    public static void validateDefaultExpression(Expression expression, Type columnType)
+    {
+        if (expression instanceof Literal ||
+                expression instanceof CurrentDate ||
+                expression instanceof CurrentTime ||
+                expression instanceof CurrentTimestamp ||
+                expression instanceof LocalTime ||
+                expression instanceof LocalTimestamp) {
+            return;
+        }
+        if (expression instanceof CurrentUser || expression instanceof CurrentCatalog || expression instanceof CurrentSchema) {
+            // The length shall be at least 128 characters, as required by the SQL standard
+            if ((columnType instanceof VarcharType varcharType && !varcharType.isUnbounded() && varcharType.getBoundedLength() < 128) ||
+                    (columnType instanceof CharType charType && charType.getLength() < 128)) {
+                throw new TrinoException(INVALID_DEFAULT_COLUMN_VALUE, "CURRENT_USER, CURRENT_CATALOG, CURRENT_SCHEMA requires at least 128 length");
+            }
+            return;
+        }
+        if (expression instanceof CurrentPath) {
+            // The length shall be at least 1031 characters, as required by the SQL standard
+            if ((columnType instanceof VarcharType varcharType && !varcharType.isUnbounded() && varcharType.getBoundedLength() < 1031) ||
+                    (columnType instanceof CharType charType && charType.getLength() < 1031)) {
+                throw new TrinoException(INVALID_DEFAULT_COLUMN_VALUE, "CURRENT_PATH requires at least 1031 length");
+            }
+            return;
+        }
+        throw new IllegalArgumentException("Unsupported default expression: " + expression);
     }
 
     private static void checkDefaultColumnValue(Session session, PlannerContext plannerContext, Object value, Type type, Type literalType)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -193,7 +193,6 @@ import io.trino.sql.tree.JsonTableColumnDefinition;
 import io.trino.sql.tree.JsonTableSpecificPlan;
 import io.trino.sql.tree.Lateral;
 import io.trino.sql.tree.Limit;
-import io.trino.sql.tree.Literal;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.MeasureDefinition;
 import io.trino.sql.tree.Merge;
@@ -415,6 +414,7 @@ import static io.trino.sql.analyzer.DeterminismEvaluator.isDeterministic;
 import static io.trino.sql.analyzer.ExpressionAnalyzer.analyzeJsonQueryExpression;
 import static io.trino.sql.analyzer.ExpressionAnalyzer.analyzeJsonValueExpression;
 import static io.trino.sql.analyzer.ExpressionAnalyzer.createConstantAnalyzer;
+import static io.trino.sql.analyzer.ExpressionAnalyzer.validateDefaultExpression;
 import static io.trino.sql.analyzer.ExpressionTreeUtils.asQualifiedName;
 import static io.trino.sql.analyzer.ExpressionTreeUtils.extractAggregateFunctions;
 import static io.trino.sql.analyzer.ExpressionTreeUtils.extractExpressions;
@@ -2547,9 +2547,7 @@ class StatementAnalyzer
                         throw new TrinoException(INVALID_DEFAULT_COLUMN_VALUE, extractLocation(table), format("Invalid default column value for '%s.%s': %s", table.getName(), columnMetadata.getName(), e.getErrorMessage()), e);
                     }
 
-                    if (!(expression instanceof Literal)) {
-                        throw new TrinoException(NOT_SUPPORTED, extractLocation(table), format("Default column value supports only literals '%s.%s': %s", table.getName(), columnMetadata.getName(), expression), null);
-                    }
+                    validateDefaultExpression(expression, columnMetadata.getType());
                     analyzeExpression(expression, scope);
                     analysis.addDefaultColumnValue(table, columnHandle, expression);
                 });

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -193,7 +193,6 @@ import io.trino.sql.tree.JsonTableColumnDefinition;
 import io.trino.sql.tree.JsonTableSpecificPlan;
 import io.trino.sql.tree.Lateral;
 import io.trino.sql.tree.Limit;
-import io.trino.sql.tree.Literal;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.MeasureDefinition;
@@ -418,6 +417,7 @@ import static io.trino.sql.analyzer.DeterminismEvaluator.isDeterministic;
 import static io.trino.sql.analyzer.ExpressionAnalyzer.analyzeJsonQueryExpression;
 import static io.trino.sql.analyzer.ExpressionAnalyzer.analyzeJsonValueExpression;
 import static io.trino.sql.analyzer.ExpressionAnalyzer.createConstantAnalyzer;
+import static io.trino.sql.analyzer.ExpressionAnalyzer.validateDefaultExpression;
 import static io.trino.sql.analyzer.ExpressionTreeUtils.asQualifiedName;
 import static io.trino.sql.analyzer.ExpressionTreeUtils.extractAggregateFunctions;
 import static io.trino.sql.analyzer.ExpressionTreeUtils.extractExpressions;
@@ -2608,9 +2608,7 @@ class StatementAnalyzer
                         throw new TrinoException(INVALID_DEFAULT_COLUMN_VALUE, extractLocation(table), format("Invalid default column value for '%s.%s': %s", table.getName(), columnMetadata.getName(), e.getErrorMessage()), e);
                     }
 
-                    if (!(expression instanceof Literal)) {
-                        throw new TrinoException(NOT_SUPPORTED, extractLocation(table), format("Default column value supports only literals '%s.%s': %s", table.getName(), columnMetadata.getName(), expression), null);
-                    }
+                    validateDefaultExpression(expression, columnMetadata.getType());
                     analyzeExpression(expression, scope);
                     analysis.addDefaultColumnValue(table, columnHandle, expression);
                 });

--- a/core/trino-main/src/test/java/io/trino/util/TestColumnDefaultOptions.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestColumnDefaultOptions.java
@@ -18,10 +18,19 @@ import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.CurrentCatalog;
+import io.trino.sql.tree.CurrentDate;
+import io.trino.sql.tree.CurrentPath;
+import io.trino.sql.tree.CurrentSchema;
+import io.trino.sql.tree.CurrentTime;
+import io.trino.sql.tree.CurrentTimestamp;
+import io.trino.sql.tree.CurrentUser;
 import io.trino.sql.tree.DecimalLiteral;
 import io.trino.sql.tree.DoubleLiteral;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.GenericLiteral;
+import io.trino.sql.tree.LocalTime;
+import io.trino.sql.tree.LocalTimestamp;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.NullLiteral;
@@ -29,6 +38,7 @@ import io.trino.sql.tree.StringLiteral;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.spi.StandardErrorCode.INVALID_DEFAULT_COLUMN_VALUE;
@@ -42,6 +52,7 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeType.createTimeType;
+import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
 import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static io.trino.spi.type.TinyintType.TINYINT;
@@ -54,6 +65,10 @@ import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExcept
 final class TestColumnDefaultOptions
 {
     private static final NodeLocation LOCATION = new NodeLocation(1, 1);
+    private static final CurrentUser CURRENT_USER = new CurrentUser(LOCATION);
+    private static final CurrentCatalog CURRENT_CATALOG = new CurrentCatalog(LOCATION);
+    private static final CurrentSchema CURRENT_SCHEMA = new CurrentSchema(LOCATION);
+    private static final CurrentPath CURRENT_PATH = new CurrentPath(LOCATION);
 
     private final PlannerContext plannerContext;
 
@@ -328,6 +343,107 @@ final class TestColumnDefaultOptions
         assertInvalidDefaultColumnValue(createTimestampWithTimeZoneType(9), new GenericLiteral(LOCATION, "TIMESTAMP", "1970-01-01 00:00:00.9999999995 UTC"), "Value too large");
     }
 
+    @Test
+    void testCurrentDate()
+    {
+        assertDefaultColumnValue(DATE, new CurrentDate(LOCATION));
+
+        assertInvalidValueExpression(INTEGER, new CurrentDate(LOCATION), "line 1:1: 'current_date' is not a valid INTEGER literal");
+    }
+
+    @Test
+    void testCurrentTime()
+    {
+        assertDefaultColumnValue(createTimeWithTimeZoneType(3), new CurrentTime(LOCATION, Optional.empty()));
+        assertDefaultColumnValue(createTimeWithTimeZoneType(0), new CurrentTime(LOCATION, Optional.of(0)));
+        assertDefaultColumnValue(createTimeWithTimeZoneType(6), new CurrentTime(LOCATION, Optional.of(6)));
+
+        assertInvalidValueExpression(INTEGER, new CurrentTime(LOCATION, Optional.empty()), "line 1:1: 'current_time' is not a valid INTEGER literal");
+    }
+
+    @Test
+    void testCurrentTimestamp()
+    {
+        assertDefaultColumnValue(createTimestampWithTimeZoneType(3), new CurrentTimestamp(LOCATION, Optional.empty()));
+        assertDefaultColumnValue(createTimestampWithTimeZoneType(0), new CurrentTimestamp(LOCATION, Optional.of(0)));
+        assertDefaultColumnValue(createTimestampWithTimeZoneType(6), new CurrentTimestamp(LOCATION, Optional.of(6)));
+
+        assertInvalidValueExpression(INTEGER, new CurrentTimestamp(LOCATION, Optional.empty()), "line 1:1: 'current_timestamp' is not a valid INTEGER literal");
+    }
+
+    @Test
+    void testLocalTime()
+    {
+        assertDefaultColumnValue(createTimeType(3), new LocalTime(LOCATION));
+        assertDefaultColumnValue(createTimeType(0), new LocalTime(LOCATION, 0));
+        assertDefaultColumnValue(createTimeType(6), new LocalTime(LOCATION, 6));
+
+        assertInvalidValueExpression(INTEGER, new LocalTime(LOCATION), "line 1:1: 'localtime' is not a valid INTEGER literal");
+    }
+
+    @Test
+    void testLocalTimestamp()
+    {
+        assertDefaultColumnValue(createTimestampType(3), new LocalTimestamp(LOCATION));
+        assertDefaultColumnValue(createTimestampType(0), new LocalTimestamp(LOCATION, 0));
+        assertDefaultColumnValue(createTimestampType(6), new LocalTimestamp(LOCATION, 6));
+
+        assertInvalidValueExpression(INTEGER, new LocalTimestamp(LOCATION), "line 1:1: 'localtimestamp' is not a valid INTEGER literal");
+    }
+
+    @Test
+    void testCurrentUser()
+    {
+        assertDefaultColumnValue(VARCHAR, CURRENT_USER);
+        assertDefaultColumnValue(createVarcharType(128), CURRENT_USER);
+        assertDefaultColumnValue(createVarcharType(256), CURRENT_USER);
+        assertDefaultColumnValue(createCharType(128), CURRENT_USER);
+
+        assertInvalidValueExpression(createVarcharType(127), CURRENT_USER, "CURRENT_USER, CURRENT_CATALOG, CURRENT_SCHEMA requires at least 128 length");
+        assertInvalidValueExpression(createCharType(127), CURRENT_USER, "CURRENT_USER, CURRENT_CATALOG, CURRENT_SCHEMA requires at least 128 length");
+
+        assertInvalidValueExpression(INTEGER, CURRENT_USER, "line 1:1: 'CURRENT_USER' is not a valid INTEGER literal");
+    }
+
+    @Test
+    void testCurrentCatalog()
+    {
+        assertDefaultColumnValue(VARCHAR, CURRENT_CATALOG);
+        assertDefaultColumnValue(createVarcharType(128), CURRENT_CATALOG);
+        assertDefaultColumnValue(createCharType(128), CURRENT_CATALOG);
+
+        assertInvalidValueExpression(createVarcharType(127), CURRENT_CATALOG, "CURRENT_USER, CURRENT_CATALOG, CURRENT_SCHEMA requires at least 128 length");
+        assertInvalidValueExpression(createCharType(127), CURRENT_CATALOG, "CURRENT_USER, CURRENT_CATALOG, CURRENT_SCHEMA requires at least 128 length");
+
+        assertInvalidValueExpression(INTEGER, CURRENT_CATALOG, "line 1:1: 'CURRENT_CATALOG' is not a valid INTEGER literal");
+    }
+
+    @Test
+    void testCurrentSchema()
+    {
+        assertDefaultColumnValue(VARCHAR, CURRENT_SCHEMA);
+        assertDefaultColumnValue(createVarcharType(128), CURRENT_SCHEMA);
+        assertDefaultColumnValue(createCharType(128), CURRENT_SCHEMA);
+
+        assertInvalidValueExpression(createVarcharType(127), CURRENT_SCHEMA, "CURRENT_USER, CURRENT_CATALOG, CURRENT_SCHEMA requires at least 128 length");
+        assertInvalidValueExpression(createCharType(127), CURRENT_SCHEMA, "CURRENT_USER, CURRENT_CATALOG, CURRENT_SCHEMA requires at least 128 length");
+
+        assertInvalidValueExpression(INTEGER, CURRENT_SCHEMA, "line 1:1: 'CURRENT_SCHEMA' is not a valid INTEGER literal");
+    }
+
+    @Test
+    void testCurrentPath()
+    {
+        assertDefaultColumnValue(VARCHAR, CURRENT_PATH);
+        assertDefaultColumnValue(createVarcharType(1031), CURRENT_PATH);
+        assertDefaultColumnValue(createCharType(1031), CURRENT_PATH);
+
+        assertInvalidValueExpression(createVarcharType(1030), CURRENT_PATH, "CURRENT_PATH requires at least 1031 length");
+        assertInvalidValueExpression(createCharType(1030), CURRENT_PATH, "CURRENT_PATH requires at least 1031 length");
+
+        assertInvalidValueExpression(INTEGER, CURRENT_PATH, "line 1:1: 'CURRENT_PATH' is not a valid INTEGER literal");
+    }
+
     private void assertDefaultColumnValue(Type columnType, Expression expression)
     {
         analyzeDefaultColumnValue(TEST_SESSION, plannerContext, new AllowAllAccessControl(), Map.of(), WarningCollector.NOOP, columnType, expression);
@@ -339,5 +455,12 @@ final class TestColumnDefaultOptions
                 .hasErrorCode(INVALID_DEFAULT_COLUMN_VALUE)
                 .hasMessageMatching("line 1:1: .* is not a valid .* literal")
                 .hasStackTraceContaining(stackTrace);
+    }
+
+    private void assertInvalidValueExpression(Type columnType, Expression expression, String message)
+    {
+        assertTrinoExceptionThrownBy(() -> analyzeDefaultColumnValue(TEST_SESSION, plannerContext, new AllowAllAccessControl(), Map.of(), WarningCollector.NOOP, columnType, expression))
+                .hasErrorCode(INVALID_DEFAULT_COLUMN_VALUE)
+                .hasMessageMatching(message);
     }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -918,7 +918,7 @@ class AstBuilder
                 getLocation(context),
                 getQualifiedName(context.tableName),
                 getQualifiedName(context.columnName),
-                (Expression) visit(context.literal()),
+                (Expression) visit(context.defaultOption()),
                 context.EXISTS() != null);
     }
 
@@ -3424,10 +3424,17 @@ class AstBuilder
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
                 (DataType) visit(context.type()),
-                visitIfPresent(context.literal(), Expression.class),
+                visitIfPresent(context.defaultOption(), Expression.class),
                 nullable,
                 properties,
                 comment);
+    }
+
+    @Override
+    public Node visitDefaultOption(SqlBaseParser.DefaultOptionContext context)
+    {
+        checkArgument(context.getChildCount() == 1, "Default option context must have one child");
+        return visit(context.getChild(0));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -917,7 +917,7 @@ class AstBuilder
                 getLocation(context),
                 getQualifiedName(context.tableName),
                 getQualifiedName(context.columnName),
-                (Expression) visit(context.literal()),
+                (Expression) visit(context.defaultOption()),
                 context.EXISTS() != null);
     }
 
@@ -3407,10 +3407,17 @@ class AstBuilder
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
                 (DataType) visit(context.type()),
-                visitIfPresent(context.literal(), Expression.class),
+                visitIfPresent(context.defaultOption(), Expression.class),
                 nullable,
                 properties,
                 comment);
+    }
+
+    @Override
+    public Node visitDefaultOption(SqlBaseParser.DefaultOptionContext context)
+    {
+        checkArgument(context.getChildCount() == 1, "Default option context must have one child");
+        return visit(context.getChild(0));
     }
 
     @Override

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -28,6 +28,13 @@ import io.trino.sql.tree.CreateMaterializedView.WhenStaleBehavior;
 import io.trino.sql.tree.CreateTable;
 import io.trino.sql.tree.CreateTableAsSelect;
 import io.trino.sql.tree.CreateView;
+import io.trino.sql.tree.CurrentCatalog;
+import io.trino.sql.tree.CurrentDate;
+import io.trino.sql.tree.CurrentPath;
+import io.trino.sql.tree.CurrentSchema;
+import io.trino.sql.tree.CurrentTime;
+import io.trino.sql.tree.CurrentTimestamp;
+import io.trino.sql.tree.CurrentUser;
 import io.trino.sql.tree.Delete;
 import io.trino.sql.tree.DropBranch;
 import io.trino.sql.tree.DropDefaultValue;
@@ -36,6 +43,8 @@ import io.trino.sql.tree.FastForwardBranch;
 import io.trino.sql.tree.GenericDataType;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.Insert;
+import io.trino.sql.tree.LocalTime;
+import io.trino.sql.tree.LocalTimestamp;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.MergeDelete;
@@ -326,6 +335,187 @@ public class TestSqlFormatter
                            col VARCHAR NOT NULL WITH (abc = 'test', xyz = DEFAULT)
                         )\
                         """);
+
+        // Create a table with column default values
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "DATE", false), ImmutableList.of()),
+                                Optional.of(new CurrentDate(new NodeLocation(1, 1))),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col DATE DEFAULT current_date
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "TIME", false), ImmutableList.of()),
+                                Optional.of(new CurrentTime(new NodeLocation(1, 1), Optional.empty())),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col TIME DEFAULT current_time
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "TIMESTAMP", false), ImmutableList.of()),
+                                Optional.of(new CurrentTimestamp(new NodeLocation(1, 1), Optional.empty())),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col TIMESTAMP DEFAULT current_timestamp
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "TIME", false), ImmutableList.of()),
+                                Optional.of(new LocalTime(new NodeLocation(1, 1))),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col TIME DEFAULT localtime
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "TIMESTAMP", false), ImmutableList.of()),
+                                Optional.of(new LocalTimestamp(new NodeLocation(1, 1))),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col TIMESTAMP DEFAULT localtimestamp
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "VARCHAR", false), ImmutableList.of()),
+                                Optional.of(new CurrentUser(new NodeLocation(1, 1))),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col VARCHAR DEFAULT CURRENT_USER
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "VARCHAR", false), ImmutableList.of()),
+                                Optional.of(new CurrentCatalog(new NodeLocation(1, 1))),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col VARCHAR DEFAULT CURRENT_CATALOG
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "VARCHAR", false), ImmutableList.of()),
+                                Optional.of(new CurrentSchema(new NodeLocation(1, 1))),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col VARCHAR DEFAULT CURRENT_SCHEMA
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "VARCHAR", false), ImmutableList.of()),
+                                Optional.of(new CurrentPath(new NodeLocation(1, 1))),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col VARCHAR DEFAULT CURRENT_PATH
+                        )""");
     }
 
     @Test
@@ -594,6 +784,96 @@ public class TestSqlFormatter
                 new LongLiteral(new NodeLocation(1, 56), "123"),
                 true)))
                 .isEqualTo("ALTER TABLE IF EXISTS foo.t ALTER COLUMN b SET DEFAULT 123");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 23), "foo", false),
+                        new Identifier(new NodeLocation(1, 27), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 42), "b", false))),
+                new CurrentDate(new NodeLocation(1, 56)),
+                true)))
+                .isEqualTo("ALTER TABLE IF EXISTS foo.t ALTER COLUMN b SET DEFAULT current_date");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new CurrentTime(new NodeLocation(1, 46), Optional.empty()),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT current_time");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new CurrentTimestamp(new NodeLocation(1, 46), Optional.empty()),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT current_timestamp");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new LocalTime(new NodeLocation(1, 46)),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT localtime");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new LocalTimestamp(new NodeLocation(1, 46)),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT localtimestamp");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new CurrentUser(new NodeLocation(1, 46)),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT CURRENT_USER");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new CurrentCatalog(new NodeLocation(1, 46)),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT CURRENT_CATALOG");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new CurrentSchema(new NodeLocation(1, 46)),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT CURRENT_SCHEMA");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new CurrentPath(new NodeLocation(1, 46)),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT CURRENT_PATH");
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -30,6 +30,13 @@ import io.trino.sql.tree.CreateMaterializedView.WhenStaleBehavior;
 import io.trino.sql.tree.CreateTable;
 import io.trino.sql.tree.CreateTableAsSelect;
 import io.trino.sql.tree.CreateView;
+import io.trino.sql.tree.CurrentCatalog;
+import io.trino.sql.tree.CurrentDate;
+import io.trino.sql.tree.CurrentPath;
+import io.trino.sql.tree.CurrentSchema;
+import io.trino.sql.tree.CurrentTime;
+import io.trino.sql.tree.CurrentTimestamp;
+import io.trino.sql.tree.CurrentUser;
 import io.trino.sql.tree.Delete;
 import io.trino.sql.tree.DropBranch;
 import io.trino.sql.tree.DropDefaultValue;
@@ -38,6 +45,8 @@ import io.trino.sql.tree.FastForwardBranch;
 import io.trino.sql.tree.GenericDataType;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.Insert;
+import io.trino.sql.tree.LocalTime;
+import io.trino.sql.tree.LocalTimestamp;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.Merge;
@@ -330,6 +339,187 @@ public class TestSqlFormatter
                            col VARCHAR NOT NULL WITH (abc = 'test', xyz = DEFAULT)
                         )\
                         """);
+
+        // Create a table with column default values
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "DATE", false), ImmutableList.of()),
+                                Optional.of(new CurrentDate(new NodeLocation(1, 1))),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col DATE DEFAULT current_date
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "TIME", false), ImmutableList.of()),
+                                Optional.of(new CurrentTime(new NodeLocation(1, 1), Optional.empty())),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col TIME DEFAULT current_time
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "TIMESTAMP", false), ImmutableList.of()),
+                                Optional.of(new CurrentTimestamp(new NodeLocation(1, 1), Optional.empty())),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col TIMESTAMP DEFAULT current_timestamp
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "TIME", false), ImmutableList.of()),
+                                Optional.of(new LocalTime(new NodeLocation(1, 1))),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col TIME DEFAULT localtime
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "TIMESTAMP", false), ImmutableList.of()),
+                                Optional.of(new LocalTimestamp(new NodeLocation(1, 1))),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col TIMESTAMP DEFAULT localtimestamp
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "VARCHAR", false), ImmutableList.of()),
+                                Optional.of(new CurrentUser(new NodeLocation(1, 1))),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col VARCHAR DEFAULT CURRENT_USER
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "VARCHAR", false), ImmutableList.of()),
+                                Optional.of(new CurrentCatalog(new NodeLocation(1, 1))),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col VARCHAR DEFAULT CURRENT_CATALOG
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "VARCHAR", false), ImmutableList.of()),
+                                Optional.of(new CurrentSchema(new NodeLocation(1, 1))),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col VARCHAR DEFAULT CURRENT_SCHEMA
+                        )""");
+
+        assertThat(formatSql(
+                new CreateTable(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier(new NodeLocation(1, 1), "VARCHAR", false), ImmutableList.of()),
+                                Optional.of(new CurrentPath(new NodeLocation(1, 1))),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo(
+                        """
+                        CREATE TABLE test (
+                           col VARCHAR DEFAULT CURRENT_PATH
+                        )""");
     }
 
     @Test
@@ -633,6 +823,96 @@ public class TestSqlFormatter
                 new LongLiteral(new NodeLocation(1, 56), "123"),
                 true)))
                 .isEqualTo("ALTER TABLE IF EXISTS foo.t ALTER COLUMN b SET DEFAULT 123");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 23), "foo", false),
+                        new Identifier(new NodeLocation(1, 27), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 42), "b", false))),
+                new CurrentDate(new NodeLocation(1, 56)),
+                true)))
+                .isEqualTo("ALTER TABLE IF EXISTS foo.t ALTER COLUMN b SET DEFAULT current_date");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new CurrentTime(new NodeLocation(1, 46), Optional.empty()),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT current_time");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new CurrentTimestamp(new NodeLocation(1, 46), Optional.empty()),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT current_timestamp");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new LocalTime(new NodeLocation(1, 46)),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT localtime");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new LocalTimestamp(new NodeLocation(1, 46)),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT localtimestamp");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new CurrentUser(new NodeLocation(1, 46)),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT CURRENT_USER");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new CurrentCatalog(new NodeLocation(1, 46)),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT CURRENT_CATALOG");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new CurrentSchema(new NodeLocation(1, 46)),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT CURRENT_SCHEMA");
+
+        assertThat(formatSql(new SetDefaultValue(
+                new NodeLocation(1, 1),
+                QualifiedName.of(ImmutableList.of(
+                        new Identifier(new NodeLocation(1, 13), "foo", false),
+                        new Identifier(new NodeLocation(1, 17), "t", false))),
+                QualifiedName.of(ImmutableList.of(new Identifier(new NodeLocation(1, 32), "a", false))),
+                new CurrentPath(new NodeLocation(1, 46)),
+                false)))
+                .isEqualTo("ALTER TABLE foo.t ALTER COLUMN a SET DEFAULT CURRENT_PATH");
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -3539,9 +3539,9 @@ public class TestSqlParser
                         ImmutableList.of(),
                         Optional.empty()));
 
-        assertThatThrownBy(() -> SQL_PARSER.createStatement("CREATE TABLE foo (a VARCHAR DEFAULT CURRENT_USER)"))
+        assertThatThrownBy(() -> SQL_PARSER.createStatement("CREATE TABLE foo (a VARCHAR DEFAULT upper('trino'))"))
                 .isInstanceOf(ParsingException.class)
-                .hasMessageMatching("line 1:37: mismatched input 'CURRENT_USER'.*");
+                .hasMessage("line 1:42: mismatched input '('. Expecting: <string>");
     }
 
     @Test
@@ -5210,9 +5210,9 @@ public class TestSqlParser
                         false,
                         false));
 
-        assertThatThrownBy(() -> SQL_PARSER.createStatement("ALTER TABLE foo.t ADD COLUMN c varchar DEFAULT CURRENT_USER"))
+        assertThatThrownBy(() -> SQL_PARSER.createStatement("ALTER TABLE foo.t ADD COLUMN c varchar DEFAULT upper('trino')"))
                 .isInstanceOf(ParsingException.class)
-                .hasMessageMatching("line 1:48: mismatched input 'CURRENT_USER'.*");
+                .hasMessage("line 1:53: mismatched input '('. Expecting: <string>");
 
         assertThat(statement("ALTER TABLE foo.t ADD COLUMN d double NOT NULL"))
                 .isEqualTo(new AddColumn(

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -3540,9 +3540,9 @@ public class TestSqlParser
                         ImmutableList.of(),
                         Optional.empty()));
 
-        assertThatThrownBy(() -> SQL_PARSER.createStatement("CREATE TABLE foo (a VARCHAR DEFAULT CURRENT_USER)"))
+        assertThatThrownBy(() -> SQL_PARSER.createStatement("CREATE TABLE foo (a VARCHAR DEFAULT upper('trino'))"))
                 .isInstanceOf(ParsingException.class)
-                .hasMessageMatching("line 1:37: mismatched input 'CURRENT_USER'.*");
+                .hasMessage("line 1:42: mismatched input '('. Expecting: <string>");
     }
 
     @Test
@@ -5234,9 +5234,9 @@ public class TestSqlParser
                         false,
                         false));
 
-        assertThatThrownBy(() -> SQL_PARSER.createStatement("ALTER TABLE foo.t ADD COLUMN c varchar DEFAULT CURRENT_USER"))
+        assertThatThrownBy(() -> SQL_PARSER.createStatement("ALTER TABLE foo.t ADD COLUMN c varchar DEFAULT upper('trino')"))
                 .isInstanceOf(ParsingException.class)
-                .hasMessageMatching("line 1:48: mismatched input 'CURRENT_USER'.*");
+                .hasMessage("line 1:53: mismatched input '('. Expecting: <string>");
 
         assertThat(statement("ALTER TABLE foo.t ADD COLUMN d double NOT NULL"))
                 .isEqualTo(new AddColumn(

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryDefaultColumnValue.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryDefaultColumnValue.java
@@ -195,11 +195,94 @@ public class TestMemoryDefaultColumnValue
     }
 
     @Test
+    void testCurrentDate()
+    {
+        assertNonNullDefaultValue("DATE", "CURRENT_DATE");
+    }
+
+    @Test
+    void testCurrentTime()
+    {
+        assertNonNullDefaultValue("TIME(3) WITH TIME ZONE", "CURRENT_TIME");
+        assertNonNullDefaultValue("TIME(0) WITH TIME ZONE", "CURRENT_TIME(0)");
+        assertNonNullDefaultValue("TIME(6) WITH TIME ZONE", "CURRENT_TIME(6)");
+    }
+
+    @Test
+    void testCurrentTimestamp()
+    {
+        assertNonNullDefaultValue("TIMESTAMP(3) WITH TIME ZONE", "CURRENT_TIMESTAMP");
+        assertNonNullDefaultValue("TIMESTAMP(0) WITH TIME ZONE", "CURRENT_TIMESTAMP(0)");
+        assertNonNullDefaultValue("TIMESTAMP(6) WITH TIME ZONE", "CURRENT_TIMESTAMP(6)");
+    }
+
+    @Test
+    void testLocalTime()
+    {
+        assertNonNullDefaultValue("TIME(3)", "LOCALTIME");
+        assertNonNullDefaultValue("TIME(0)", "LOCALTIME(0)");
+        assertNonNullDefaultValue("TIME(6)", "LOCALTIME(6)");
+    }
+
+    @Test
+    void testLocalTimestamp()
+    {
+        assertNonNullDefaultValue("TIMESTAMP(3)", "LOCALTIMESTAMP");
+        assertNonNullDefaultValue("TIMESTAMP(0)", "LOCALTIMESTAMP(0)");
+        assertNonNullDefaultValue("TIMESTAMP(6)", "LOCALTIMESTAMP(6)");
+    }
+
+    @Test
+    void testCurrentUser()
+    {
+        assertDefaultValue("VARCHAR", "CURRENT_USER", "CURRENT_USER");
+    }
+
+    @Test
+    void testCurrentCatalog()
+    {
+        assertDefaultValue("VARCHAR", "CURRENT_CATALOG", "CURRENT_CATALOG");
+    }
+
+    @Test
+    void testCurrentSchema()
+    {
+        assertDefaultValue("VARCHAR", "CURRENT_SCHEMA", "CURRENT_SCHEMA");
+    }
+
+    @Test
+    void testCurrentPath()
+    {
+        assertDefaultValue("VARCHAR", "CURRENT_PATH", "CURRENT_PATH");
+    }
+
+    @Test
     void testInformationSchema()
     {
         try (TestTable table = newTrinoTable("test_default_value", "(id int, data int DEFAULT 123)")) {
             assertThat((String) computeScalar("SELECT column_default FROM information_schema.columns WHERE table_name = '" + table.getName() + "' AND column_name = 'data'"))
                     .isEqualTo("123");
+        }
+    }
+
+    private void assertNonNullDefaultValue(@Language("SQL") String columnType, @Language("SQL") String defaultValue)
+    {
+        try (TestTable table = newTrinoTable("test_default_value", "(id int, data " + columnType + " DEFAULT " + defaultValue + ")")) {
+            assertUpdate("INSERT INTO " + table.getName() + " (id) VALUES (1)", 1);
+            assertThat(query("SELECT data IS NOT NULL FROM " + table.getName()))
+                    .matches("VALUES true");
+        }
+
+        try (TestTable table = newTrinoTable("test_default_value", "(id int, data " + columnType + ")")) {
+            assertUpdate("ALTER TABLE " + table.getName() + " ALTER COLUMN data SET DEFAULT " + defaultValue);
+            assertUpdate("INSERT INTO " + table.getName() + " (id) VALUES (1)", 1);
+            assertThat(query("SELECT data IS NOT NULL FROM " + table.getName()))
+                    .matches("VALUES true");
+
+            assertUpdate("ALTER TABLE " + table.getName() + " ALTER COLUMN data DROP DEFAULT");
+            assertUpdate("INSERT INTO " + table.getName() + " (id) VALUES (2)", 1);
+            assertThat(query("SELECT data IS NOT NULL FROM " + table.getName() + " WHERE id = 2"))
+                    .matches("VALUES false");
         }
     }
 


### PR DESCRIPTION
## Description

SQL standard supports more expressions for column defaults: 

```g4
<default clause> ::=
  DEFAULT <default option> 
```

```g4
<default option> ::=
    <literal> 
  | <datetime value function> 
  | USER
  | CURRENT_USER
  | CURRENT_ROLE
  | SESSION_USER
  | SYSTEM_USER
  | CURRENT_CATALOG
  | CURRENT_SCHEMA
  | CURRENT_PATH
  | <implicitly typed value specification> 
```

```g4
<datetime value function> ::=
    <current date value function> 
  | <current time value function> 
  | <current timestamp value function> 
  | <current local time value function> 
  | <current local timestamp value function> 
```

This PR adds support for CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, LOCALTIME, LOCALTIMESTAMP, CURRENT_USER, CURRENT_CATALOG, CURRENT_SCHEMA, CURRENT_PATH. 

SQL standard has special rules for some expressions:
> If CURRENT_USER, CURRENT_ROLE, SESSION_USER, SYSTEM_USER, CURRENT_CATALOG, or CURRENT_SCHEMA is specified, then the subject data type shall be character string with character set SQL_IDENTIFIER. If the length of the subject data type is fixed, then its length shall not be less than 128 characters. If the length of the subject data type is variable, then its maximum length shall not be less than 128 characters.

> If CURRENT_PATH is specified, then the subject data type shall be character string with character set SQL_IDENTIFIER. If the length of the subject data type is fixed, then its length shall not be less than 1031 characters. If the length of the subject data type is variable, then its maximum length shall not be less than 1031 characters.

## Release notes

```markdown
## General, Memory
* Add support more expression for column default values. ({issue}`30495`)
```
