### PR TITLE
Fix table_changes for partition values requiring URI encoding

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesSplitSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesSplitSource.java
@@ -29,6 +29,7 @@ import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.DynamicFilterSnapshot;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -153,7 +154,18 @@ public class TableChangesSplitSource
             String entryPath,
             Map<String, Optional<String>> canonicalPartitionValues)
     {
-        String path = Locations.appendPath(tableLocation, entryPath);
+        // Paths in add/cdc entries are RFC 2396 URIs and may be absolute for shallow-cloned
+        // tables, so decode them the same way the table scan does in
+        // DeltaLakeSplitManager.buildSplitPath. Appending the raw entry made the reader request
+        // percent-encoded object keys for partition values that require encoding.
+        URI uri = URI.create(entryPath);
+        String path;
+        if (uri.isAbsolute()) {
+            path = uri.getScheme() + ":" + uri.getSchemeSpecificPart();
+        }
+        else {
+            path = Locations.appendPath(tableLocation, uri.getPath());
+        }
         return new TableChangesSplit(
                 path,
                 length,

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -3226,6 +3226,27 @@ public class TestDeltaLakeConnectorTest
     }
 
     @Test
+    public void testReadCdfChangesOnPartitionValueRequiringEncoding()
+    {
+        String tableName = "test_cdf_partition_value_requiring_encoding_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (page_url VARCHAR, domain VARCHAR) " +
+                "WITH (change_data_feed_enabled = true, partitioned_by = ARRAY['domain'])");
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('url1', 'do main')", 1);
+        assertUpdate("UPDATE " + tableName + " SET page_url = 'url2' WHERE domain = 'do main'", 1);
+
+        assertTableChangesQuery(
+                "SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + tableName + "'))",
+                """
+                VALUES
+                    ('url1', 'do main', 'insert', BIGINT '1'),
+                    ('url1', 'do main', 'update_preimage', BIGINT '2'),
+                    ('url2', 'do main', 'update_postimage', BIGINT '2')
+                """);
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
     public void testCdfWithNameMappingModeOnTableWithColumnDropped()
     {
         testCdfWithMappingModeOnTableWithColumnDropped(ColumnMappingMode.NAME);


### PR DESCRIPTION
## Description

`table_changes` fails to read change data for any file stored under a partition value that requires URI encoding (a space, `#`, `%`, and so on).

Paths in `add` and `cdc` entries are RFC 2396 URIs, so a partition value of `do main` is written to the transaction log as `domain=do%20main/...`. `DeltaLakeSplitManager.buildSplitPath` decodes those paths for the table scan, but `TableChangesSplitSource.mapToDeltaLakeTableChangesSplit` appended the raw entry path to the table location, so the reader requested an object key that literally contained `%20`, and the query failed with a file-not-found error even though the table scan reads the same file fine.

This decodes the entry path the same way `buildSplitPath` does, including the absolute-path case for shallow-cloned tables. Both the `add` and `cdc` branches go through this method, so inserts and updates are both covered.

Reproduction:

```sql
CREATE TABLE test_encoding (page_url varchar, domain varchar)
WITH (change_data_feed_enabled = true, partitioned_by = ARRAY['domain']);

INSERT INTO test_encoding VALUES ('url1', 'do main');

SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, 'test_encoding'));
-- before: fails opening .../domain=do%20main/part-....parquet
```

## Additional context and related issues

Added a regression test next to the existing partitioned change-data-feed tests.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake connector
* Fix `table_changes` failing to read change data for partition values that require URI encoding, such as values containing a space. ({issue}`ISSUE`)
```
