### PR TITLE
Fix wrong results when unwrapping precision-reducing timestamp casts

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampToTimestampCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampToTimestampCast.java
@@ -13,18 +13,22 @@
  */
 package io.trino.operator.scalar.timestamp;
 
+import io.trino.spi.TrinoException;
 import io.trino.spi.function.LiteralParameter;
 import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.LongTimestamp;
 
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.TimestampType.MAX_PRECISION;
 import static io.trino.spi.type.TimestampType.MAX_SHORT_PRECISION;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.round;
+import static io.trino.spi.type.Timestamps.roundExact;
 import static io.trino.type.DateTimes.roundToNearest;
+import static java.lang.Math.incrementExact;
 
 @ScalarOperator(CAST)
 public final class TimestampToTimestampCast
@@ -44,7 +48,7 @@ public final class TimestampToTimestampCast
             return epochMicros;
         }
 
-        return round(epochMicros, (int) (MAX_SHORT_PRECISION - targetPrecision));
+        return roundEpochMicrosExact(epochMicros, (int) (MAX_SHORT_PRECISION - targetPrecision));
     }
 
     @LiteralParameters({"sourcePrecision", "targetPrecision"})
@@ -62,11 +66,11 @@ public final class TimestampToTimestampCast
     {
         long epochMicros = value.getEpochMicros();
         if (targetPrecision < MAX_SHORT_PRECISION) {
-            return round(epochMicros, (int) (MAX_SHORT_PRECISION - targetPrecision));
+            return roundEpochMicrosExact(epochMicros, (int) (MAX_SHORT_PRECISION - targetPrecision));
         }
 
         if (roundToNearest(value.getPicosOfMicro(), PICOSECONDS_PER_MICROSECOND) == PICOSECONDS_PER_MICROSECOND) {
-            epochMicros++;
+            epochMicros = incrementEpochMicrosExact(epochMicros);
         }
 
         return epochMicros;
@@ -81,9 +85,29 @@ public final class TimestampToTimestampCast
         long epochMicros = value.getEpochMicros();
         int picosOfMicro = (int) round(value.getPicosOfMicro(), (int) (MAX_PRECISION - targetPrecision));
         if (picosOfMicro == PICOSECONDS_PER_MICROSECOND) {
-            epochMicros++;
+            epochMicros = incrementEpochMicrosExact(epochMicros);
             picosOfMicro = 0;
         }
         return new LongTimestamp(epochMicros, picosOfMicro);
+    }
+
+    private static long roundEpochMicrosExact(long epochMicros, int magnitude)
+    {
+        try {
+            return roundExact(epochMicros, magnitude);
+        }
+        catch (ArithmeticException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Out of range for timestamp: " + epochMicros + " microseconds", e);
+        }
+    }
+
+    private static long incrementEpochMicrosExact(long epochMicros)
+    {
+        try {
+            return incrementExact(epochMicros);
+        }
+        catch (ArithmeticException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Out of range for timestamp: " + epochMicros + " microseconds", e);
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampToTimestampWithTimeZoneCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampToTimestampWithTimeZoneCast.java
@@ -27,10 +27,12 @@ import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.round;
+import static io.trino.spi.type.Timestamps.roundExact;
 import static io.trino.type.DateTimes.getMicrosOfMilli;
 import static io.trino.type.DateTimes.roundToNearest;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 import static io.trino.util.DateTimeZoneIndex.getChronology;
+import static java.lang.Math.incrementExact;
 
 @ScalarOperator(CAST)
 public final class TimestampToTimestampWithTimeZoneCast
@@ -44,7 +46,7 @@ public final class TimestampToTimestampWithTimeZoneCast
             ConnectorSession session,
             @SqlType("timestamp(sourcePrecision)") long timestamp)
     {
-        long epochMillis = scaleEpochMicrosToMillis(round(timestamp, 3));
+        long epochMillis = scaleEpochMicrosToMillis(roundEpochMicrosExact(timestamp, 3));
         epochMillis = round(epochMillis, (int) (3 - targetPrecision));
         return toShort(session, epochMillis);
     }
@@ -56,7 +58,7 @@ public final class TimestampToTimestampWithTimeZoneCast
             ConnectorSession session,
             @SqlType("timestamp(sourcePrecision)") LongTimestamp timestamp)
     {
-        long epochMillis = scaleEpochMicrosToMillis(round(timestamp.getEpochMicros(), (int) (6 - targetPrecision)));
+        long epochMillis = scaleEpochMicrosToMillis(roundEpochMicrosExact(timestamp.getEpochMicros(), (int) (6 - targetPrecision)));
         return toShort(session, epochMillis);
     }
 
@@ -69,7 +71,7 @@ public final class TimestampToTimestampWithTimeZoneCast
             @SqlType("timestamp(sourcePrecision)") long epochMicros)
     {
         if (sourcePrecision > targetPrecision) {
-            epochMicros = round(epochMicros, (int) (6 - targetPrecision));
+            epochMicros = roundEpochMicrosExact(epochMicros, (int) (6 - targetPrecision));
         }
 
         return toLong(session, epochMicros, 0);
@@ -91,20 +93,44 @@ public final class TimestampToTimestampWithTimeZoneCast
         int picosOfMicro = timestamp.getPicosOfMicro();
 
         if (targetPrecision < 6) {
-            epochMicros = round(epochMicros, (int) (6 - targetPrecision));
+            epochMicros = roundEpochMicrosExact(epochMicros, (int) (6 - targetPrecision));
             picosOfMicro = 0;
         }
         else if (targetPrecision == 6) {
             if (roundToNearest(picosOfMicro, PICOSECONDS_PER_MICROSECOND) == PICOSECONDS_PER_MICROSECOND) {
-                epochMicros++;
+                epochMicros = incrementEpochMicrosExact(epochMicros);
             }
             picosOfMicro = 0;
         }
         else {
             picosOfMicro = (int) round(picosOfMicro, (int) (12 - targetPrecision));
+            if (picosOfMicro == PICOSECONDS_PER_MICROSECOND) {
+                epochMicros = incrementEpochMicrosExact(epochMicros);
+                picosOfMicro = 0;
+            }
         }
 
         return toLong(session, epochMicros, picosOfMicro);
+    }
+
+    private static long roundEpochMicrosExact(long epochMicros, int magnitude)
+    {
+        try {
+            return roundExact(epochMicros, magnitude);
+        }
+        catch (ArithmeticException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Out of range for timestamp with time zone: " + epochMicros + " microseconds", e);
+        }
+    }
+
+    private static long incrementEpochMicrosExact(long epochMicros)
+    {
+        try {
+            return incrementExact(epochMicros);
+        }
+        catch (ArithmeticException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Out of range for timestamp with time zone: " + epochMicros + " microseconds", e);
+        }
     }
 
     private static long toShort(ConnectorSession session, long epochMillis)
@@ -119,7 +145,7 @@ public final class TimestampToTimestampWithTimeZoneCast
             return packDateTimeWithZone(epochMillis, session.getTimeZoneKey());
         }
         catch (IllegalArgumentException e) {
-            throw new TrinoException(INVALID_CAST_ARGUMENT, "Out of range for timestamp with time zone: " + epochMillis, e);
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Out of range for timestamp with time zone: " + epochMillis + " milliseconds", e);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/TimestampWithTimeZoneToTimestampCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/TimestampWithTimeZoneToTimestampCast.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.scalar.timestamptz;
 
+import io.trino.spi.TrinoException;
 import io.trino.spi.function.LiteralParameter;
 import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarOperator;
@@ -20,16 +21,19 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.type.LongTimestamp;
 import io.trino.spi.type.LongTimestampWithTimeZone;
 
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.OperatorType.CAST;
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.DateTimeEncoding.unpackZoneKey;
 import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.round;
-import static io.trino.type.DateTimes.roundToNearest;
+import static io.trino.spi.type.Timestamps.roundExact;
 import static io.trino.type.DateTimes.scaleEpochMillisToMicros;
 import static io.trino.type.DateTimes.toEpochMicros;
 import static io.trino.util.DateTimeZoneIndex.getChronology;
+import static java.lang.Math.incrementExact;
 
 @ScalarOperator(CAST)
 public final class TimestampWithTimeZoneToTimestampCast
@@ -61,19 +65,23 @@ public final class TimestampWithTimeZoneToTimestampCast
                 .convertUTCToLocal(timestamp.getEpochMillis());
         int picosOfMilli = timestamp.getPicosOfMilli();
 
+        // Round in the (millis, picos of milli) domain before converting to micros, so that a value
+        // whose rounded result is representable does not overflow the conversion
+        if (targetPrecision < 3) {
+            // The positive sub-millisecond fraction cannot affect rounding at a grain of 10ms or more
+            epochMillis = roundEpochMillisExact(epochMillis, (int) (3 - targetPrecision));
+            picosOfMilli = 0;
+        }
+        else {
+            picosOfMilli = (int) round(picosOfMilli, (int) (12 - targetPrecision));
+            if (picosOfMilli == PICOSECONDS_PER_MILLISECOND) {
+                epochMillis = incrementEpochMillisExact(epochMillis);
+                picosOfMilli = 0;
+            }
+        }
+
         // Convert to micros
-        long epochMicros = toEpochMicros(epochMillis, picosOfMilli);
-        int picosOfMicro = picosOfMilli % PICOSECONDS_PER_MICROSECOND;
-
-        // Round
-        if (targetPrecision < 6) {
-            epochMicros = round(epochMicros, (int) (6 - targetPrecision));
-        }
-        else if (roundToNearest(picosOfMicro, PICOSECONDS_PER_MICROSECOND) == PICOSECONDS_PER_MICROSECOND) {
-            epochMicros++;
-        }
-
-        return epochMicros;
+        return toEpochMicrosExact(epochMillis, picosOfMilli);
     }
 
     @LiteralParameters({"sourcePrecision", "targetPrecision"})
@@ -99,17 +107,46 @@ public final class TimestampWithTimeZoneToTimestampCast
                 .convertUTCToLocal(timestamp.getEpochMillis());
         int picosOfMilli = timestamp.getPicosOfMilli();
 
-        // Convert to micros
-        long epochMicros = toEpochMicros(epochMillis, picosOfMilli);
-        int picosOfMicro = picosOfMilli % PICOSECONDS_PER_MICROSECOND;
-
-        // Round
-        picosOfMicro = (int) round(picosOfMicro, (int) (12 - targetPrecision));
-        if (picosOfMicro == PICOSECONDS_PER_MICROSECOND) {
-            epochMicros++;
-            picosOfMicro = 0;
+        // Round in the (millis, picos of milli) domain before converting to micros, so that a value
+        // whose rounded result is representable does not overflow the conversion
+        picosOfMilli = (int) round(picosOfMilli, (int) (12 - targetPrecision));
+        if (picosOfMilli == PICOSECONDS_PER_MILLISECOND) {
+            epochMillis = incrementEpochMillisExact(epochMillis);
+            picosOfMilli = 0;
         }
 
-        return new LongTimestamp(epochMicros, picosOfMicro);
+        // Convert to micros
+        long epochMicros = toEpochMicrosExact(epochMillis, picosOfMilli);
+        return new LongTimestamp(epochMicros, picosOfMilli % PICOSECONDS_PER_MICROSECOND);
+    }
+
+    private static long roundEpochMillisExact(long epochMillis, int magnitude)
+    {
+        try {
+            return roundExact(epochMillis, magnitude);
+        }
+        catch (ArithmeticException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Out of range for timestamp: " + epochMillis + " milliseconds", e);
+        }
+    }
+
+    private static long incrementEpochMillisExact(long epochMillis)
+    {
+        try {
+            return incrementExact(epochMillis);
+        }
+        catch (ArithmeticException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Out of range for timestamp: " + epochMillis + " milliseconds", e);
+        }
+    }
+
+    private static long toEpochMicrosExact(long epochMillis, int picosOfMilli)
+    {
+        try {
+            return toEpochMicros(epochMillis, picosOfMilli);
+        }
+        catch (ArithmeticException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, "Out of range for timestamp: " + epochMillis + " milliseconds", e);
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
@@ -657,7 +657,12 @@ public class UnwrapCastInComparison
                     // Cast from DATE to TIMESTAMP WITH TIME ZONE is not monotonic when there is a forward DST change in the session zone
                     return isTimestampToTimestampWithTimeZoneInjectiveAt(session.getTimeZoneKey().getZoneId(), getInstantWithTruncation(timestampWithTimeZoneType, value));
                 }
-                if (source instanceof TimestampType) {
+                if (source instanceof TimestampType timestampType) {
+                    // A precision-reducing cast rounds, so it maps multiple TIMESTAMP values to the same TIMESTAMP WITH TIME ZONE value
+                    if (timestampType.getPrecision() > timestampWithTimeZoneType.getPrecision()) {
+                        return false;
+                    }
+
                     // Cast from TIMESTAMP WITH TIME ZONE to TIMESTAMP and back to TIMESTAMP WITH TIME ZONE does not round trip, unless the value's zone is equal to session zone
                     if (!getTimeZone(timestampWithTimeZoneType, value).equals(session.getTimeZoneKey())) {
                         return false;

--- a/core/trino-main/src/main/java/io/trino/type/DateTimes.java
+++ b/core/trino-main/src/main/java/io/trino/type/DateTimes.java
@@ -55,6 +55,7 @@ import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.round;
 import static io.trino.spi.type.Timestamps.roundDiv;
+import static java.lang.Math.addExact;
 import static java.lang.Math.floorMod;
 import static java.lang.Math.min;
 import static java.lang.Math.multiplyExact;
@@ -287,7 +288,7 @@ public final class DateTimes
 
     public static long toEpochMicros(long epochMillis, int picosOfMilli)
     {
-        return scaleEpochMillisToMicros(epochMillis) + picosOfMilli / 1_000_000;
+        return addExact(scaleEpochMillisToMicros(epochMillis), picosOfMilli / PICOSECONDS_PER_MICROSECOND);
     }
 
     public static long roundToNearest(long value, long bound)
@@ -600,8 +601,19 @@ public final class DateTimes
 
         ZoneId zoneId = ZoneId.of(timezone);
         long epochSecond = toEpochSecond(year, month, day, hour, minute, second, zoneId);
+        TimeZoneKey timeZoneKey = getTimeZoneKey(timezone);
+        long fractionInPicos = rescale(Long.parseLong(fraction), fraction.length(), 12);
 
-        return LongTimestampWithTimeZone.fromEpochSecondsAndFraction(epochSecond, rescale(Long.parseLong(fraction), fraction.length(), 12), getTimeZoneKey(timezone));
+        try {
+            // The engine representation packs epochMillis together with the zone key, so values whose
+            // epochMillis does not fit the packed encoding are not representable
+            DateTimeEncoding.packDateTimeWithZone(addExact(multiplyExact(epochSecond, (long) MILLISECONDS_PER_SECOND), fractionInPicos / PICOSECONDS_PER_MILLISECOND), timeZoneKey);
+        }
+        catch (ArithmeticException | IllegalArgumentException e) {
+            throw new IllegalArgumentException(format("TIMESTAMP WITH TIME ZONE '%s' is out of range", value), e);
+        }
+
+        return LongTimestampWithTimeZone.fromEpochSecondsAndFraction(epochSecond, fractionInPicos, timeZoneKey);
     }
 
     private static long toEpochSecond(String year, String month, String day, String hour, String minute, String second, ZoneId zoneId)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
@@ -1475,17 +1475,46 @@ public class TestTimestamp
 
         assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.555555555555' AS TIMESTAMP(11) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:56.55555555556 Pacific/Apia'");
 
+        // source > target, round up carries into the next microsecond
+        assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.9999999995' AS TIMESTAMP(9) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:57.000000000 Pacific/Apia'");
+        assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.999999999999' AS TIMESTAMP(9) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:57.000000000 Pacific/Apia'");
+        assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.9999995' AS TIMESTAMP(6) WITH TIME ZONE)")).matches("TIMESTAMP '2020-05-01 12:34:57.000000 Pacific/Apia'");
+
         // 5-digit year in the future
         assertThat(assertions.expression("CAST(TIMESTAMP '12001-05-01 12:34:56' AS TIMESTAMP(0) WITH TIME ZONE)")).matches("TIMESTAMP '12001-05-01 12:34:56 Pacific/Apia'");
 
         // 5-digit year in the past
         assertThat(assertions.expression("CAST(TIMESTAMP '-12001-05-01 12:34:56' AS TIMESTAMP(0) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56 Pacific/Apia'");
 
+        // Rounding towards the negative side of zero
+        assertThat(assertions.expression("CAST(TIMESTAMP '1969-12-31 23:59:59.5555' AS TIMESTAMP(3) WITH TIME ZONE)")).matches("TIMESTAMP '1969-12-31 23:59:59.556 Pacific/Apia'");
+        assertThat(assertions.expression("CAST(TIMESTAMP '1969-12-31 23:59:59.5554' AS TIMESTAMP(3) WITH TIME ZONE)")).matches("TIMESTAMP '1969-12-31 23:59:59.555 Pacific/Apia'");
+
         // Overflow
         assertThatThrownBy(assertions.expression("CAST(TIMESTAMP '123001-05-01 12:34:56' AS TIMESTAMP WITH TIME ZONE)")::evaluate)
-                .hasMessage("Out of range for timestamp with time zone: 3819379822496000");
+                .hasMessage("Out of range for timestamp with time zone: 3819379822496000 milliseconds");
         assertThatThrownBy(assertions.expression("CAST(TIMESTAMP '-123001-05-01 12:34:56' AS TIMESTAMP WITH TIME ZONE)")::evaluate)
-                .hasMessage("Out of range for timestamp with time zone: -3943693439888000");
+                .hasMessage("Out of range for timestamp with time zone: -3943693439888000 milliseconds");
+
+        // Rounding the maximum timestamp value up must not silently overflow (https://github.com/trinodb/trino/issues/30496)
+        assertThatThrownBy(assertions.expression("CAST(TIMESTAMP '+294247-01-10 04:00:54.775807999' AS TIMESTAMP(6) WITH TIME ZONE)")::evaluate)
+                .hasMessage("Out of range for timestamp with time zone: 9223372036854775807 microseconds");
+        assertThatThrownBy(assertions.expression("CAST(TIMESTAMP '+294247-01-10 04:00:54.775807' AS TIMESTAMP(5) WITH TIME ZONE)")::evaluate)
+                .hasMessage("Out of range for timestamp with time zone: 9223372036854775807 microseconds");
+        assertThatThrownBy(assertions.expression("CAST(TIMESTAMP '+294247-01-10 04:00:54.775807999' AS TIMESTAMP(3) WITH TIME ZONE)")::evaluate)
+                .hasMessage("Out of range for timestamp with time zone: 9223372036854775807 microseconds");
+        assertThatThrownBy(assertions.expression("CAST(TIMESTAMP '+294247-01-10 04:00:54.775807' AS TIMESTAMP(3) WITH TIME ZONE)")::evaluate)
+                .hasMessage("Out of range for timestamp with time zone: 9223372036854775807 microseconds");
+        assertThatThrownBy(assertions.expression("CAST(TIMESTAMP '+294247-01-10 04:00:54.775807999999' AS TIMESTAMP(9) WITH TIME ZONE)")::evaluate)
+                .hasMessage("Out of range for timestamp with time zone: 9223372036854775807 microseconds");
+
+        // Rounding near the range limits succeeds when the rounded value is still representable. The negative
+        // limit cannot overflow: no literal earlier than -290308-12-21 19:59:06 parses, and every parseable
+        // value rounds to a representable result. Values this far from the epoch cannot be materialized as
+        // TIMESTAMP WITH TIME ZONE output, so cast back to TIMESTAMP to observe the result.
+        assertThat(assertions.expression("CAST(CAST(TIMESTAMP '+294247-01-10 04:00:54.775807999' AS TIMESTAMP(4) WITH TIME ZONE) AS TIMESTAMP(4))")).matches("TIMESTAMP '+294247-01-10 04:00:54.7758'");
+        assertThat(assertions.expression("CAST(CAST(TIMESTAMP '+294247-01-10 04:00:54.775807' AS TIMESTAMP(4) WITH TIME ZONE) AS TIMESTAMP(4))")).matches("TIMESTAMP '+294247-01-10 04:00:54.7758'");
+        assertThat(assertions.expression("CAST(CAST(TIMESTAMP '-290308-12-21 19:59:06.000001' AS TIMESTAMP(4) WITH TIME ZONE) AS TIMESTAMP(4))")).matches("TIMESTAMP '-290308-12-21 19:59:06.0000'");
     }
 
     @Test
@@ -2009,6 +2038,28 @@ public class TestTimestamp
         assertThat(assertions.expression("CAST(CAST(TIMESTAMP '2020-05-10 12:34:56.555555' AS TIMESTAMP(3)) AS TIMESTAMP(6))")).matches("TIMESTAMP '2020-05-10 12:34:56.556000'");
         assertThat(assertions.expression("CAST(CAST(TIMESTAMP '2020-05-10 12:34:56.555555' AS TIMESTAMP(6)) AS TIMESTAMP(6))")).matches("TIMESTAMP '2020-05-10 12:34:56.555555'");
         assertThat(assertions.expression("CAST(CAST(TIMESTAMP '2020-05-10 12:34:56.555' AS TIMESTAMP(0)) AS TIMESTAMP(3))")).matches("TIMESTAMP '2020-05-10 12:34:57.000'");
+    }
+
+    @Test
+    public void testPrecisionReducingCastNearRangeLimits()
+    {
+        // Rounding the maximum timestamp value up must not silently overflow (https://github.com/trinodb/trino/issues/30496)
+        assertThatThrownBy(assertions.expression("CAST(TIMESTAMP '+294247-01-10 04:00:54.775807' AS TIMESTAMP(3))")::evaluate)
+                .hasMessage("Out of range for timestamp: 9223372036854775807 microseconds");
+        assertThatThrownBy(assertions.expression("CAST(TIMESTAMP '+294247-01-10 04:00:54.775807999' AS TIMESTAMP(6))")::evaluate)
+                .hasMessage("Out of range for timestamp: 9223372036854775807 microseconds");
+        assertThatThrownBy(assertions.expression("CAST(TIMESTAMP '+294247-01-10 04:00:54.775807999999' AS TIMESTAMP(9))")::evaluate)
+                .hasMessage("Out of range for timestamp: 9223372036854775807 microseconds");
+
+        // Rounding succeeds when the rounded value is still representable. The negative limit cannot overflow:
+        // no literal earlier than -290308-12-21 19:59:06 parses, and every parseable value rounds to a
+        // representable result.
+        assertThat(assertions.expression("CAST(TIMESTAMP '+294247-01-10 04:00:54.775807' AS TIMESTAMP(4))")).matches("TIMESTAMP '+294247-01-10 04:00:54.7758'");
+        assertThat(assertions.expression("CAST(TIMESTAMP '-290308-12-21 19:59:06.000001' AS TIMESTAMP(4))")).matches("TIMESTAMP '-290308-12-21 19:59:06.0000'");
+
+        // Rounding towards the negative side of zero
+        assertThat(assertions.expression("CAST(TIMESTAMP '1969-12-31 23:59:59.5555' AS TIMESTAMP(3))")).matches("TIMESTAMP '1969-12-31 23:59:59.556'");
+        assertThat(assertions.expression("CAST(TIMESTAMP '1969-12-31 23:59:59.5554' AS TIMESTAMP(3))")).matches("TIMESTAMP '1969-12-31 23:59:59.555'");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
@@ -444,6 +444,25 @@ public class TestTimestampWithTimeZone
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '-123001-01-02 03:04:05.321 Europe/Berlin' is not a valid TIMESTAMP literal");
 
+        // Long precision literals outside the packed epochMillis range are rejected as well (https://github.com/trinodb/trino/issues/30496)
+        assertTrinoExceptionThrownBy(assertions.expression("TIMESTAMP '+73326-09-11 20:14:45.2480 UTC'")::evaluate)
+                .hasErrorCode(INVALID_LITERAL)
+                .hasMessage("line 1:12: '+73326-09-11 20:14:45.2480 UTC' is not a valid TIMESTAMP literal");
+        assertTrinoExceptionThrownBy(assertions.expression("TIMESTAMP '-69387-04-22 03:45:14.7510 UTC'")::evaluate)
+                .hasErrorCode(INVALID_LITERAL)
+                .hasMessage("line 1:12: '-69387-04-22 03:45:14.7510 UTC' is not a valid TIMESTAMP literal");
+        assertTrinoExceptionThrownBy(assertions.expression("TIMESTAMP '+294247-01-10 04:00:54.775999999999 UTC'")::evaluate)
+                .hasErrorCode(INVALID_LITERAL)
+                .hasMessage("line 1:12: '+294247-01-10 04:00:54.775999999999 UTC' is not a valid TIMESTAMP literal");
+
+        // The range limits themselves are valid
+        assertThat(assertions.expression("TIMESTAMP '+73326-09-11 20:14:45.2470 UTC'"))
+                .hasType(createTimestampWithTimeZoneType(4))
+                .isEqualTo(timestampWithTimeZone(4, 73326, 9, 11, 20, 14, 45, 247_000_000_000L, getTimeZoneKey("UTC")));
+        assertThat(assertions.expression("TIMESTAMP '-69387-04-22 03:45:14.7520 UTC'"))
+                .hasType(createTimestampWithTimeZoneType(4))
+                .isEqualTo(timestampWithTimeZone(4, -69387, 4, 22, 3, 45, 14, 752_000_000_000L, getTimeZoneKey("UTC")));
+
         // missing space after day
         assertTrinoExceptionThrownBy(assertions.expression("TIMESTAMP '2020-13-01-12'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
@@ -1761,6 +1780,12 @@ public class TestTimestampWithTimeZone
         assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.9999999995 Asia/Kathmandu' AS TIMESTAMP(9))")).matches("TIMESTAMP '2020-05-01 12:34:57.000000000'");
         assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.99999999995 Asia/Kathmandu' AS TIMESTAMP(10))")).matches("TIMESTAMP '2020-05-01 12:34:57.0000000000'");
         assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.999999999995 Asia/Kathmandu' AS TIMESTAMP(11))")).matches("TIMESTAMP '2020-05-01 12:34:57.00000000000'");
+
+        // Rounding at the range limits of TIMESTAMP WITH TIME ZONE, which lie well within the TIMESTAMP
+        // range (https://github.com/trinodb/trino/issues/30496)
+        assertThat(assertions.expression("CAST(TIMESTAMP '+73326-09-11 20:14:45.2470 UTC' AS TIMESTAMP(0))")).matches("TIMESTAMP '+73326-09-11 20:14:45'");
+        assertThat(assertions.expression("CAST(TIMESTAMP '+73326-09-11 20:14:45.2470 UTC' AS TIMESTAMP(9))")).matches("TIMESTAMP '+73326-09-11 20:14:45.247000000'");
+        assertThat(assertions.expression("CAST(TIMESTAMP '-69387-04-22 03:45:14.7520 UTC' AS TIMESTAMP(3))")).matches("TIMESTAMP '-69387-04-22 03:45:14.752'");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapCastInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapCastInComparison.java
@@ -52,6 +52,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
@@ -632,6 +633,28 @@ public class TestUnwrapCastInComparison
         // maximum precision
         testUnwrap(warsawSession, "timestamp(12)", "a > TIMESTAMP '2020-10-26 11:02:18.123456789321 UTC'", comparison(GREATER_THAN, new Reference(createTimestampType(12), "a"), new Constant(createTimestampType(12), DateTimes.parseTimestamp(12, "2020-10-26 12:02:18.123456789321"))));
         testUnwrap(losAngelesSession, "timestamp(12)", "a > TIMESTAMP '2020-10-26 11:02:18.123456789321 UTC'", comparison(GREATER_THAN, new Reference(createTimestampType(12), "a"), new Constant(createTimestampType(12), DateTimes.parseTimestamp(12, "2020-10-26 04:02:18.123456789321"))));
+
+        // A precision-reducing cast rounds, so it is not injective and must not be unwrapped (https://github.com/trinodb/trino/issues/30496)
+        testUnwrap(
+                warsawSession,
+                "timestamp(9)",
+                "CAST(a AS timestamp(6) with time zone) > TIMESTAMP '2026-07-25 00:00:00 UTC'",
+                comparison(GREATER_THAN, new Cast(new Reference(createTimestampType(9), "a"), createTimestampWithTimeZoneType(6)), new Constant(createTimestampWithTimeZoneType(6), DateTimes.parseTimestampWithTimeZone(6, "2026-07-25 00:00:00.000000 UTC"))));
+        testUnwrap(
+                warsawSession,
+                "timestamp(9)",
+                "CAST(a AS timestamp(6) with time zone) = TIMESTAMP '2026-07-25 00:00:00 UTC'",
+                comparison(EQUAL, new Cast(new Reference(createTimestampType(9), "a"), createTimestampWithTimeZoneType(6)), new Constant(createTimestampWithTimeZoneType(6), DateTimes.parseTimestampWithTimeZone(6, "2026-07-25 00:00:00.000000 UTC"))));
+        testUnwrap(
+                warsawSession,
+                "timestamp(9)",
+                "CAST(a AS timestamp(6) with time zone) < TIMESTAMP '2026-07-25 00:00:00 UTC'",
+                comparison(LESS_THAN, new Cast(new Reference(createTimestampType(9), "a"), createTimestampWithTimeZoneType(6)), new Constant(createTimestampWithTimeZoneType(6), DateTimes.parseTimestampWithTimeZone(6, "2026-07-25 00:00:00.000000 UTC"))));
+        testUnwrap(
+                warsawSession,
+                "timestamp(6)",
+                "CAST(a AS timestamp(4) with time zone) > TIMESTAMP '2026-07-25 00:00:00 UTC'",
+                comparison(GREATER_THAN, new Cast(new Reference(createTimestampType(6), "a"), createTimestampWithTimeZoneType(4)), new Constant(createTimestampWithTimeZoneType(4), DateTimes.parseTimestampWithTimeZone(4, "2026-07-25 00:00:00.0000 UTC"))));
 
         // DST forward -- Warsaw changed clock 1h forward on 2020-03-29T01:00 UTC (2020-03-29T02:00 local time)
         // Note that in given session input TIMESTAMP values  2020-03-29 02:31 and 2020-03-29 03:31 produce the same value 2020-03-29 01:31 UTC (conversion is not monotonic)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestUnwrapCastInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestUnwrapCastInComparison.java
@@ -397,6 +397,21 @@ public class TestUnwrapCastInComparison
             validate(session, operator, "timestamp(12)", "TIMESTAMP '2020-07-03 01:23:45.123456789123'", "timestamp(12) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
         }
 
+        // Precision-reducing casts round, so they are not injective and must not be unwrapped (https://github.com/trinodb/trino/issues/30496)
+        // 2026-07-25 00:00:00 UTC is 2026-07-25 13:00:00 in Pacific/Apia; the sub-microsecond values round onto the literal
+        for (String operator : COMPARISON_OPERATORS) {
+            validate(session, operator, "timestamp(9)", "TIMESTAMP '2026-07-26 03:00:00'", "timestamp(6) with time zone", "TIMESTAMP '2026-07-25 00:00:00 UTC'");
+            validate(session, operator, "timestamp(9)", "TIMESTAMP '2026-07-25 13:00:00.000000400'", "timestamp(6) with time zone", "TIMESTAMP '2026-07-25 00:00:00 UTC'");
+            validate(session, operator, "timestamp(9)", "TIMESTAMP '2026-07-25 13:00:00.000000500'", "timestamp(6) with time zone", "TIMESTAMP '2026-07-25 00:00:00 UTC'");
+            validate(session, operator, "timestamp(12)", "TIMESTAMP '2026-07-25 13:00:00.000000000123'", "timestamp(6) with time zone", "TIMESTAMP '2026-07-25 00:00:00 UTC'");
+            validate(session, operator, "timestamp(6)", "TIMESTAMP '2026-07-25 13:00:00.000040'", "timestamp(4) with time zone", "TIMESTAMP '2026-07-25 00:00:00 UTC'");
+            validate(session, operator, "timestamp(6)", "TIMESTAMP '2026-07-25 13:00:00.400000'", "timestamp(0) with time zone", "TIMESTAMP '2026-07-25 00:00:00 UTC'");
+        }
+
+        validateBetween(session, "timestamp(9)", "TIMESTAMP '2026-07-25 13:00:00.000000400'", "timestamp(6) with time zone", "TIMESTAMP '2026-07-25 00:00:00 UTC'", "TIMESTAMP '2026-07-26 00:00:00 UTC'");
+        validateBetween(session, "timestamp(9)", "TIMESTAMP '2026-07-25 13:00:00.000000500'", "timestamp(6) with time zone", "TIMESTAMP '2026-07-24 00:00:00 UTC'", "TIMESTAMP '2026-07-25 00:00:00 UTC'");
+        validateBetween(session, "timestamp(6)", "TIMESTAMP '2026-07-25 13:00:00.000040'", "timestamp(4) with time zone", "TIMESTAMP '2026-07-25 00:00:00 UTC'", "TIMESTAMP '2026-07-26 00:00:00 UTC'");
+
         validateBetween(session, "timestamp(3)", "TIMESTAMP '2020-07-03 01:23:45.123'", "timestamp(3) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");
         validateBetween(session, "timestamp(3)", "TIMESTAMP '2020-07-03 01:23:45.123'", "timestamp(3) with time zone", "TIMESTAMP '2020-07-03 01:23:45 UTC'", "TIMESTAMP '2020-07-03 01:23:45 UTC'");
         validateBetween(session, "timestamp(6)", "TIMESTAMP '2020-07-03 01:23:45.123456'", "timestamp(6) with time zone", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'", "TIMESTAMP '2020-07-03 01:23:45 Europe/Warsaw'");

--- a/core/trino-spi/src/main/java/io/trino/spi/type/SqlTimestamp.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SqlTimestamp.java
@@ -21,6 +21,7 @@ import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.spi.type.Timestamps.POWERS_OF_TEN;
 import static io.trino.spi.type.Timestamps.formatTimestamp;
 import static io.trino.spi.type.Timestamps.round;
 import static io.trino.spi.type.Timestamps.roundDiv;
@@ -58,7 +59,8 @@ public final class SqlTimestamp
             if (picosOfMicro != 0) {
                 throw new IllegalArgumentException(format("Expected picosOfMicro to be 0 for precision %s: %s", precision, picosOfMicro));
             }
-            if (round(epochMicros, 6 - precision) != epochMicros) {
+            // Check divisibility directly: round() wraps around near the range limits and would reject valid values
+            if (epochMicros % POWERS_OF_TEN[6 - precision] != 0) {
                 throw new IllegalArgumentException(format("Expected 0s for digits beyond precision %s: epochMicros = %s", precision, epochMicros));
             }
         }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/Timestamps.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/Timestamps.java
@@ -75,6 +75,30 @@ public class Timestamps
     }
 
     /**
+     * Like {@link #round(long, int)}, but fails with {@link ArithmeticException} when the rounded
+     * value does not fit in a long, instead of silently wrapping around.
+     */
+    public static long roundExact(long value, int magnitude)
+    {
+        long factor = POWERS_OF_TEN[magnitude];
+        if (factor == 1) {
+            return value;
+        }
+
+        // Round the quotient rather than the value so that only results that truly exceed the long
+        // range overflow. Ties round half-up toward positive infinity, matching round().
+        long quotient = value / factor;
+        long remainder = value % factor;
+        if (remainder * 2 >= factor) {
+            quotient = Math.incrementExact(quotient);
+        }
+        else if (-remainder * 2 > factor) {
+            quotient = Math.decrementExact(quotient);
+        }
+        return Math.multiplyExact(quotient, factor);
+    }
+
+    /**
      * Rescales a value of the given precision to another precision by adding 0s or truncating.
      */
     static long rescale(long value, int fromPrecision, int toPrecision)

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestTimestamps.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestTimestamps.java
@@ -15,12 +15,42 @@ package io.trino.spi.type;
 
 import org.junit.jupiter.api.Test;
 
+import static io.trino.spi.type.Timestamps.round;
 import static io.trino.spi.type.Timestamps.roundDiv;
+import static io.trino.spi.type.Timestamps.roundExact;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class TestTimestamps
 {
+    @Test
+    public void testRoundExact()
+    {
+        // agrees with round() wherever round() does not overflow
+        for (int magnitude = 0; magnitude <= 6; magnitude++) {
+            for (long value : new long[] {0, 1, -1, 499, 500, 501, -499, -500, -501, 999999, -999999, 44444, -55556, 1234567890123L, -1234567890123L}) {
+                assertThat(roundExact(value, magnitude))
+                        .as("value %s, magnitude %s", value, magnitude)
+                        .isEqualTo(round(value, magnitude));
+            }
+        }
+
+        // ties round half-up toward positive infinity
+        assertThat(roundExact(150, 2)).isEqualTo(200);
+        assertThat(roundExact(-150, 2)).isEqualTo(-100);
+        assertThat(roundExact(-151, 2)).isEqualTo(-200);
+
+        // rounding near the long range limits succeeds when the result is representable
+        assertThat(roundExact(Long.MAX_VALUE, 2)).isEqualTo(9223372036854775800L);
+        assertThat(roundExact(Long.MIN_VALUE, 2)).isEqualTo(-9223372036854775800L);
+
+        // rounding fails instead of wrapping when the result exceeds the long range
+        assertThatThrownBy(() -> roundExact(Long.MAX_VALUE, 1)).isExactlyInstanceOf(ArithmeticException.class);
+        assertThatThrownBy(() -> roundExact(Long.MAX_VALUE, 3)).isExactlyInstanceOf(ArithmeticException.class);
+        assertThatThrownBy(() -> roundExact(Long.MIN_VALUE, 1)).isExactlyInstanceOf(ArithmeticException.class);
+        assertThatThrownBy(() -> roundExact(Long.MIN_VALUE, 3)).isExactlyInstanceOf(ArithmeticException.class);
+    }
+
     @Test
     public void testRoundDiv()
     {


### PR DESCRIPTION
A cast from timestamp(p) to timestamp(q < p) with time zone rounds and is not injective, so UnwrapCastInComparison must not unwrap it. The rule also probed the range of the source type by casting its max value, which silently overflowed epochMicros and folded filters to constant results. The cast now fails with INVALID_CAST_ARGUMENT on overflow and carries sub-microsecond rounding into epochMicros.

Fixes https://github.com/trinodb/trino/issues/30496

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

() This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix wrong results when unwrapping precision-reducing timestamp casts ({issue}`30496`)
* Fail precision-reducing casts of `timestamp` values near the type's range limits with `INVALID_CAST_ARGUMENT` instead of returning wrong values ({issue}`30496`)
* Reject `TIMESTAMP WITH TIME ZONE` literals outside the representable range of the type instead of returning wrong results or failing queries later ({issue}`30496`)
```


