### PR TITLE
Fix querying $files and $partitions of Iceberg table without snapshots

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/files/FilesTableSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/files/FilesTableSplitSource.java
@@ -19,6 +19,7 @@ import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.DynamicFilterSnapshot;
 import io.trino.spi.type.Type;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.io.FileIO;
@@ -71,16 +72,20 @@ public final class FilesTableSplitSource
         snapshotId.ifPresent(scan::useSnapshot);
         List<ConnectorSplit> splits = new ArrayList<>();
 
-        try (FileIO fileIO = icebergTable.io()) {
-            for (ManifestFile manifestFile : scan.snapshot().allManifests(fileIO)) {
-                splits.add(new FilesTableSplit(
-                        TrinoManifestFile.from(manifestFile),
-                        schemaJson,
-                        metadataSchemaJson,
-                        partitionSpecsByIdJson,
-                        partitionColumnType,
-                        boundsColumnType,
-                        Optional.ofNullable(icebergTable.properties().get(ENCRYPTION_TABLE_KEY))));
+        // A table with no snapshot has no manifests to scan
+        Snapshot snapshot = scan.snapshot();
+        if (snapshot != null) {
+            try (FileIO fileIO = icebergTable.io()) {
+                for (ManifestFile manifestFile : snapshot.allManifests(fileIO)) {
+                    splits.add(new FilesTableSplit(
+                            TrinoManifestFile.from(manifestFile),
+                            schemaJson,
+                            metadataSchemaJson,
+                            partitionSpecsByIdJson,
+                            partitionColumnType,
+                            boundsColumnType,
+                            Optional.ofNullable(icebergTable.properties().get(ENCRYPTION_TABLE_KEY))));
+                }
             }
         }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -17,6 +17,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.metastore.HiveMetastore;
+import io.trino.plugin.iceberg.catalog.TrinoCatalog;
+import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.type.ArrayType;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
@@ -29,8 +31,12 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Types;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -49,8 +55,10 @@ import java.util.stream.IntStream;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
+import static io.trino.plugin.iceberg.IcebergTestUtils.SESSION;
 import static io.trino.plugin.iceberg.IcebergTestUtils.getFileSystemFactory;
 import static io.trino.plugin.iceberg.IcebergTestUtils.getHiveMetastore;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getTrinoCatalog;
 import static io.trino.plugin.iceberg.util.EqualityDeleteUtils.writeEqualityDeleteForTable;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.testing.MaterializedResult.DEFAULT_PRECISION;
@@ -71,6 +79,7 @@ public abstract class BaseIcebergSystemTables
     private final IcebergFileFormat format;
     private HiveMetastore metastore;
     private TrinoFileSystemFactory fileSystemFactory;
+    private TrinoCatalog catalog;
 
     protected BaseIcebergSystemTables(IcebergFileFormat format)
     {
@@ -86,6 +95,7 @@ public abstract class BaseIcebergSystemTables
                 .build();
         metastore = getHiveMetastore(queryRunner);
         fileSystemFactory = getFileSystemFactory(queryRunner);
+        catalog = getTrinoCatalog(metastore, fileSystemFactory, "iceberg");
         return queryRunner;
     }
 
@@ -270,6 +280,37 @@ public abstract class BaseIcebergSystemTables
     public void testFilesTableOnDropColumn()
     {
         assertQuery("SELECT sum(record_count) FROM test_schema.\"test_table_drop_column$files\"", "VALUES 6");
+    }
+
+    @Test
+    public void testFilesAndPartitionsTableWithoutSnapshot()
+    {
+        SchemaTableName tableName = new SchemaTableName("test_schema", "test_table_without_snapshot");
+        createTableWithoutSnapshot(tableName);
+        try {
+            assertThat(computeActual("SELECT * FROM test_schema.\"test_table_without_snapshot$files\"").getRowCount()).isEqualTo(0);
+            assertThat(computeActual("SELECT * FROM test_schema.\"test_table_without_snapshot$partitions\"").getRowCount()).isEqualTo(0);
+        }
+        finally {
+            catalog.dropTable(SESSION, tableName);
+        }
+    }
+
+    // Create the table with the Iceberg API so that it has no snapshot (Trino CREATE TABLE would add an empty one)
+    private void createTableWithoutSnapshot(SchemaTableName tableName)
+    {
+        Schema schema = new Schema(
+                Types.NestedField.optional(1, "_bigint", Types.LongType.get()),
+                Types.NestedField.optional(2, "_date", Types.DateType.get()));
+        catalog.newCreateTableTransaction(
+                        SESSION,
+                        tableName,
+                        schema,
+                        PartitionSpec.builderFor(schema).identity("_date").build(),
+                        SortOrder.unsorted(),
+                        Optional.ofNullable(catalog.defaultTableLocation(SESSION, tableName)),
+                        ImmutableMap.of())
+                .commitTransaction();
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -55,6 +55,7 @@ import java.util.stream.IntStream;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
+import static io.trino.plugin.iceberg.IcebergTableName.tableNameWithType;
 import static io.trino.plugin.iceberg.IcebergTestUtils.SESSION;
 import static io.trino.plugin.iceberg.IcebergTestUtils.getFileSystemFactory;
 import static io.trino.plugin.iceberg.IcebergTestUtils.getHiveMetastore;
@@ -70,6 +71,7 @@ import static java.util.stream.Collectors.joining;
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_PATH;
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_POS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
@@ -290,6 +292,27 @@ public abstract class BaseIcebergSystemTables
         try {
             assertThat(computeActual("SELECT * FROM test_schema.\"test_table_without_snapshot$files\"").getRowCount()).isEqualTo(0);
             assertThat(computeActual("SELECT * FROM test_schema.\"test_table_without_snapshot$partitions\"").getRowCount()).isEqualTo(0);
+        }
+        finally {
+            catalog.dropTable(SESSION, tableName);
+        }
+    }
+
+    @Test
+    public void testMetadataTablesWithoutSnapshot()
+    {
+        SchemaTableName tableName = new SchemaTableName("test_schema", "test_metadata_tables_without_snapshot");
+        createTableWithoutSnapshot(tableName);
+        try {
+            for (TableType tableType : TableType.values()) {
+                if (tableType == TableType.DATA || tableType == TableType.MATERIALIZED_VIEW_STORAGE) {
+                    continue;
+                }
+                String metadataTable = tableNameWithType(tableName.getTableName(), tableType);
+                assertThatCode(() -> computeActual("SELECT * FROM test_schema.\"" + metadataTable + "\""))
+                        .describedAs(tableType.name())
+                        .doesNotThrowAnyException();
+            }
         }
         finally {
             catalog.dropTable(SESSION, tableName);


### PR DESCRIPTION
## Description

Fix a `NullPointerException` when querying the `$files` or `$partitions` metadata table of an Iceberg table that has no snapshot (for example, a table created but never written to).

`FilesTableSplitSource` produces one split per manifest by calling`TableScan.snapshot().allManifests(...)`. When the table has no snapshot, `TableScan.snapshot()` returns `null` and the query fails with:
```
type=INTERNAL_ERROR,
name=GENERIC_INTERNAL_ERROR, 
message="Cannot invoke "org.apache.iceberg.Snapshot.allManifests(org.apache.iceberg.io.FileIO)" because the return value of "org.apache.iceberg.TableScan.snapshot()" is null"
```

This change guards the null snapshot and returns no splits, yielding an empty result instead of failing. `$partitions` is a view over `$files`, so the single guard covers both metadata tables.

## Additional context and related issues

The `$files` and `$partitions` metadata tables originally ran on a single coordinator, where the no-snapshot case returned an empty result. They were later made distributed through split sources — `$files` in #25677 and `$partitions` in #26737 — and the new `FilesTableSplitSource` did not carry over the null-snapshot guard, introducing this regression.

## Release notes
( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```
## Iceberg connector
* Fix query failure when reading the `$files` or `$partitions` metadata table of a table that has no snapshots. ({issue}`<PR-number>`)
```

cc/ @tbaeg @raunaqmorarka 