### PR TITLE
Add support for default column values in PostgreSql connector

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -338,6 +338,7 @@ public abstract class BaseJdbcClient
                 boolean nullable = (resultSet.getInt("NULLABLE") != columnNoNulls);
                 // Note: some databases (e.g. SQL Server) do not return column remarks/comment here.
                 Optional<String> comment = Optional.ofNullable(emptyToNull(resultSet.getString("REMARKS")));
+                Optional<String> defaultValue = getColumnDefaultValue(resultSet, typeHandle);
                 // skip unsupported column types
                 columnMapping.ifPresent(mapping -> columns.add(JdbcColumnHandle.builder()
                         .setColumnName(columnName)
@@ -345,6 +346,7 @@ public abstract class BaseJdbcClient
                         .setColumnType(mapping.getType())
                         .setNullable(nullable)
                         .setComment(comment)
+                        .setDefaultValue(defaultValue)
                         .build()));
                 if (columnMapping.isEmpty()) {
                     UnsupportedTypeHandling unsupportedTypeHandling = getUnsupportedTypeHandling(session);
@@ -365,6 +367,12 @@ public abstract class BaseJdbcClient
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
         }
+    }
+
+    protected Optional<String> getColumnDefaultValue(ResultSet resultSet, JdbcTypeHandle typeHandle)
+            throws SQLException
+    {
+        return Optional.empty();
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -132,11 +132,11 @@ public class DefaultJdbcMetadata
     private static final String SYNTHETIC_COLUMN_NAME_PREFIX = "_pfgnrtd_";
     private static final String DELETE_ROW_ID = "_trino_artificial_column_handle_for_delete_row_id_";
 
-    private final JdbcClient jdbcClient;
     private final TimestampTimeZoneDomain timestampTimeZoneDomain;
     private final boolean precalculateStatisticsForPushdown;
     private final Set<JdbcQueryEventListener> jdbcQueryEventListeners;
 
+    protected final JdbcClient jdbcClient;
     protected final List<Runnable> rollbackActions = new ArrayList<>();
 
     public DefaultJdbcMetadata(

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
@@ -41,11 +41,12 @@ public final class JdbcColumnHandle
     private final Type columnType;
     private final boolean nullable;
     private final Optional<String> comment;
+    private final Optional<String> defaultValue;
 
     // All and only required fields
     public JdbcColumnHandle(String columnName, JdbcTypeHandle jdbcTypeHandle, Type columnType)
     {
-        this(columnName, jdbcTypeHandle, columnType, true, Optional.empty());
+        this(columnName, jdbcTypeHandle, columnType, true, Optional.empty(), Optional.empty());
     }
 
     /**
@@ -58,13 +59,15 @@ public final class JdbcColumnHandle
             @JsonProperty("jdbcTypeHandle") JdbcTypeHandle jdbcTypeHandle,
             @JsonProperty("columnType") Type columnType,
             @JsonProperty("nullable") boolean nullable,
-            @JsonProperty("comment") Optional<String> comment)
+            @JsonProperty("comment") Optional<String> comment,
+            @JsonProperty("defaultValue") Optional<String> defaultValue)
     {
         this.columnName = requireNonNull(columnName, "columnName is null");
         this.jdbcTypeHandle = requireNonNull(jdbcTypeHandle, "jdbcTypeHandle is null");
         this.columnType = requireNonNull(columnType, "columnType is null");
         this.nullable = nullable;
         this.comment = requireNonNull(comment, "comment is null");
+        this.defaultValue = requireNonNull(defaultValue, "defaultValue is null");
     }
 
     @JsonProperty
@@ -97,6 +100,12 @@ public final class JdbcColumnHandle
         return comment;
     }
 
+    @JsonProperty
+    public Optional<String> getDefaultValue()
+    {
+        return defaultValue;
+    }
+
     public ColumnMetadata getColumnMetadata()
     {
         return ColumnMetadata.builder()
@@ -104,6 +113,7 @@ public final class JdbcColumnHandle
                 .setType(columnType)
                 .setNullable(nullable)
                 .setComment(comment)
+                .setDefaultValue(defaultValue)
                 .build();
     }
 
@@ -152,6 +162,7 @@ public final class JdbcColumnHandle
                 + sizeOf(nullable)
                 + estimatedSizeOf(columnName)
                 + sizeOf(comment, SizeOf::estimatedSizeOf)
+                + sizeOf(defaultValue, SizeOf::estimatedSizeOf)
                 + jdbcTypeHandle.getRetainedSizeInBytes();
     }
 
@@ -172,6 +183,7 @@ public final class JdbcColumnHandle
         private Type columnType;
         private boolean nullable = true;
         private Optional<String> comment = Optional.empty();
+        private Optional<String> defaultValue = Optional.empty();
 
         public Builder() {}
 
@@ -182,6 +194,7 @@ public final class JdbcColumnHandle
             this.columnType = handle.getColumnType();
             this.nullable = handle.isNullable();
             this.comment = handle.getComment();
+            this.defaultValue = handle.getDefaultValue();
         }
 
         public Builder setColumnName(String columnName)
@@ -214,6 +227,12 @@ public final class JdbcColumnHandle
             return this;
         }
 
+        public Builder setDefaultValue(Optional<String> defaultValue)
+        {
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
         public JdbcColumnHandle build()
         {
             return new JdbcColumnHandle(
@@ -221,7 +240,8 @@ public final class JdbcColumnHandle
                     jdbcTypeHandle,
                     columnType,
                     nullable,
-                    comment);
+                    comment,
+                    defaultValue);
         }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -164,6 +164,8 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_ADD_COLUMN;
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_DEFAULT_COLUMN_VALUE;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -299,6 +301,33 @@ public abstract class BaseIcebergConnectorTest
             case SUPPORTS_DEFAULT_COLUMN_VALUE -> formatVersion >= 3;
             default -> super.hasBehavior(connectorBehavior);
         };
+    }
+
+    @Test
+    @Override // Overriden because with Iceberg default value is used when inserting a new column.
+    public void testAddDefaultColumn()
+    {
+        skipTestUnless(hasBehavior(SUPPORTS_ADD_COLUMN) && hasBehavior(SUPPORTS_DEFAULT_COLUMN_VALUE));
+
+        try (TestTable table = newTrinoTable("test_default_value", "(w int)")) {
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN x int DEFAULT 123");
+            assertUpdate("INSERT INTO " + table.getName() + "(w) VALUES 1", 1);
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .skippingTypesCheck()
+                    .matches("VALUES (1, 123)");
+
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN y varchar DEFAULT 'default varchar'");
+            assertUpdate("INSERT INTO " + table.getName() + "(w) VALUES 2", 1);
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .skippingTypesCheck()
+                    .matches("VALUES (1, 123, 'default varchar'), (2, 123, 'default varchar')");
+
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN z char(15) DEFAULT 'default char'");
+            assertUpdate("INSERT INTO " + table.getName() + "(w) VALUES 3", 1);
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .skippingTypesCheck()
+                    .matches("VALUES (1, 123, 'default varchar', 'default char'), (2, 123, 'default varchar', 'default char'), (3, 123, 'default varchar', 'default char')");
+        }
     }
 
     @Test

--- a/plugin/trino-postgresql/pom.xml
+++ b/plugin/trino-postgresql/pom.xml
@@ -28,6 +28,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>
 

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -89,6 +89,7 @@ import io.trino.spi.block.MapBlock;
 import io.trino.spi.block.SqlMap;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.JoinCondition;
@@ -155,6 +156,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.emptyToNull;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -501,6 +503,7 @@ public class PostgreSqlClient
                             Optional.empty());
                     Optional<ColumnMapping> columnMapping = toColumnMapping(session, connection, typeHandle);
                     log.debug("Mapping data type of '%s' column '%s': %s mapped to %s", schemaTableName, columnName, typeHandle, columnMapping);
+                    Optional<String> defaultValue = getColumnDefaultValue(resultSet, typeHandle);
                     // skip unsupported column types
                     if (columnMapping.isPresent()) {
                         boolean nullable = (resultSet.getInt("NULLABLE") != columnNoNulls);
@@ -510,6 +513,7 @@ public class PostgreSqlClient
                                 .setJdbcTypeHandle(typeHandle)
                                 .setColumnType(columnMapping.get().getType())
                                 .setNullable(nullable)
+                                .setDefaultValue(defaultValue)
                                 .setComment(comment)
                                 .build());
                     }
@@ -533,6 +537,55 @@ public class PostgreSqlClient
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
         }
+    }
+
+    @Override
+    protected Optional<String> getColumnDefaultValue(ResultSet resultSet, JdbcTypeHandle typeHandle)
+            throws SQLException
+    {
+        String value = emptyToNull(resultSet.getString("COLUMN_DEF"));
+        return switch (typeHandle.jdbcType()) {
+            case Types.VARCHAR -> {
+                if (value != null && value.startsWith("'") && value.endsWith("'::character varying")) {
+                    yield Optional.of(value.substring(0, value.length() - 19));
+                }
+                yield Optional.empty();
+            }
+            case Types.CHAR -> {
+                if (value != null && value.startsWith("'") && value.endsWith("'::bpchar")) {
+                    yield Optional.of(value.substring(0, value.length() - 8));
+                }
+                yield Optional.empty();
+            }
+            case Types.SMALLINT, Types.INTEGER, Types.BIGINT -> {
+                if (value != null && value.matches("-?\\d+")) {
+                    yield Optional.of(value);
+                }
+                yield Optional.empty();
+            }
+            default -> Optional.empty();
+        };
+    }
+
+    @Override
+    protected String getColumnDefinitionSql(ConnectorSession session, ColumnMetadata column, String columnName)
+    {
+        if (column.getComment().isPresent()) {
+            throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating tables with column comment");
+        }
+        StringBuilder sb = new StringBuilder()
+                .append(quoted(columnName))
+                .append(" ")
+                .append(toWriteMapping(session, column.getType()).getDataType());
+        if (!column.isNullable()) {
+            sb.append(" NOT NULL");
+        }
+        Optional<String> defaultValue = column.getDefaultValue();
+        if (defaultValue.isPresent()) {
+            sb.append(" DEFAULT ");
+            sb.append(defaultValue.get());
+        }
+        return sb.toString();
     }
 
     @Override

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClientModule.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClientModule.java
@@ -20,6 +20,7 @@ import io.trino.plugin.jdbc.DecimalModule;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcJoinPushdownSupportModule;
+import io.trino.plugin.jdbc.JdbcMetadataFactory;
 import io.trino.plugin.jdbc.JdbcStatisticsConfig;
 import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.TimestampTimeZoneDomain;
@@ -39,6 +40,8 @@ public class PostgreSqlClientModule
     public void setup(Binder binder)
     {
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(PostgreSqlClient.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, JdbcMetadataFactory.class).setBinding().to(PostgreSqlMetadataFactory.class).in(Scopes.SINGLETON);
+        binder.bind(PostgreSqlConnector.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, TimestampTimeZoneDomain.class).setBinding().toInstance(TimestampTimeZoneDomain.UTC_ONLY);
         configBinder(binder).bindConfig(PostgreSqlConfig.class);
         configBinder(binder).bindConfig(JdbcStatisticsConfig.class);

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConnector.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConnector.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.postgresql;
+
+import com.google.inject.Inject;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.plugin.jdbc.JdbcConnector;
+import io.trino.plugin.jdbc.JdbcTransactionManager;
+import io.trino.plugin.jdbc.TablePropertiesProvider;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorCapabilities;
+import io.trino.spi.connector.ConnectorPageSinkProvider;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.function.table.ConnectorTableFunction;
+import io.trino.spi.procedure.Procedure;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.Sets.immutableEnumSet;
+import static io.trino.spi.connector.ConnectorCapabilities.DEFAULT_COLUMN_VALUE;
+import static io.trino.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
+
+public class PostgreSqlConnector
+        extends JdbcConnector
+{
+    @Inject
+    public PostgreSqlConnector(
+            LifeCycleManager lifeCycleManager,
+            ConnectorSplitManager jdbcSplitManager,
+            ConnectorPageSourceProvider jdbcPageSourceProvider,
+            ConnectorPageSinkProvider jdbcPageSinkProvider,
+            Optional<ConnectorAccessControl> accessControl,
+            Set<Procedure> procedures,
+            Set<ConnectorTableFunction> connectorTableFunctions,
+            Set<SessionPropertiesProvider> sessionProperties,
+            Set<TablePropertiesProvider> tableProperties,
+            JdbcTransactionManager transactionManager)
+    {
+        super(lifeCycleManager, jdbcSplitManager, jdbcPageSourceProvider, jdbcPageSinkProvider, accessControl, procedures, connectorTableFunctions, sessionProperties, tableProperties, transactionManager);
+    }
+
+    @Override
+    public Set<ConnectorCapabilities> getCapabilities()
+    {
+        return immutableEnumSet(
+                DEFAULT_COLUMN_VALUE,
+                NOT_NULL_COLUMN_CONSTRAINT);
+    }
+}

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConnectorFactory.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlConnectorFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.postgresql;
+
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import io.airlift.bootstrap.Bootstrap;
+import io.trino.plugin.base.ConnectorContextModule;
+import io.trino.plugin.jdbc.JdbcModule;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
+import static java.util.Objects.requireNonNull;
+
+public class PostgreSqlConnectorFactory
+        implements ConnectorFactory
+{
+    private final String name;
+    private final Supplier<Module> module;
+
+    public PostgreSqlConnectorFactory(String name, Supplier<Module> module)
+    {
+        checkArgument(!isNullOrEmpty(name), "name is null or empty");
+        this.name = name;
+        this.module = requireNonNull(module, "module is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return name;
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
+    {
+        requireNonNull(requiredConfig, "requiredConfig is null");
+        checkStrictSpiVersionMatch(context, this);
+
+        // A plugin is not required to use Guice; it is just very convenient
+        Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.catalog." + catalogName,
+                new ConnectorContextModule(catalogName, context),
+                new JdbcModule(),
+                module.get());
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .disableSystemProperties()
+                .setRequiredConfigurationProperties(requiredConfig)
+                .initialize();
+
+        return injector.getInstance(PostgreSqlConnector.class);
+    }
+}

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlMetadata.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlMetadata.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.postgresql;
+
+import io.trino.plugin.jdbc.DefaultJdbcMetadata;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcQueryEventListener;
+import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.TimestampTimeZoneDomain;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.type.Type;
+
+import java.util.Set;
+
+import static io.trino.plugin.jdbc.BaseJdbcClient.varcharLiteral;
+import static java.lang.String.format;
+
+public class PostgreSqlMetadata
+        extends DefaultJdbcMetadata
+{
+    public PostgreSqlMetadata(JdbcClient jdbcClient, TimestampTimeZoneDomain timestampTimeZoneDomain, Set<JdbcQueryEventListener> jdbcQueryEventListeners)
+    {
+        super(jdbcClient, timestampTimeZoneDomain, true, jdbcQueryEventListeners);
+    }
+
+    @Override
+    public void setDefaultValue(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle, String defaultValue)
+    {
+        JdbcTableHandle table = (JdbcTableHandle) tableHandle;
+        JdbcColumnHandle column = (JdbcColumnHandle) columnHandle;
+        jdbcClient.execute(session, format(
+                "ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s",
+                jdbcClient.quoted(table.asPlainTable().getRemoteTableName()),
+                jdbcClient.quoted(column.getColumnName()),
+                getDefaultValue(column.getColumnType(), defaultValue)));
+    }
+
+    @Override
+    public void dropDefaultValue(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        JdbcTableHandle table = (JdbcTableHandle) tableHandle;
+        JdbcColumnHandle column = (JdbcColumnHandle) columnHandle;
+        jdbcClient.execute(session, format(
+                "ALTER TABLE %s ALTER COLUMN %s DROP DEFAULT",
+                jdbcClient.quoted(table.asPlainTable().getRemoteTableName()),
+                jdbcClient.quoted(column.getColumnName())));
+    }
+
+    private String getDefaultValue(Type columnType, String defaultValue)
+    {
+        return switch (columnType.getBaseName()) {
+            case "varchar", "char" -> varcharLiteral(defaultValue);
+            default -> defaultValue;
+        };
+    }
+}

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlMetadataFactory.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlMetadataFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.postgresql;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import io.trino.plugin.base.cache.identity.IdentityCacheMapping;
+import io.trino.plugin.jdbc.DefaultJdbcMetadataFactory;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcMetadata;
+import io.trino.plugin.jdbc.JdbcQueryEventListener;
+import io.trino.plugin.jdbc.TimestampTimeZoneDomain;
+
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class PostgreSqlMetadataFactory
+        extends DefaultJdbcMetadataFactory
+{
+    private final TimestampTimeZoneDomain timestampTimeZoneDomain;
+    private final Set<JdbcQueryEventListener> jdbcQueryEventListeners;
+
+    @Inject
+    public PostgreSqlMetadataFactory(JdbcClient jdbcClient, TimestampTimeZoneDomain timestampTimeZoneDomain, Set<JdbcQueryEventListener> jdbcQueryEventListeners, IdentityCacheMapping identityCacheMapping)
+    {
+        super(jdbcClient, timestampTimeZoneDomain, jdbcQueryEventListeners, identityCacheMapping);
+        this.timestampTimeZoneDomain = requireNonNull(timestampTimeZoneDomain, "timestampTimeZoneDomain is null");
+        this.jdbcQueryEventListeners = ImmutableSet.copyOf(jdbcQueryEventListeners);
+    }
+
+    @Override
+    protected JdbcMetadata create(JdbcClient transactionCachingJdbcClient)
+    {
+        return new PostgreSqlMetadata(transactionCachingJdbcClient, timestampTimeZoneDomain, jdbcQueryEventListeners);
+    }
+}

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlPlugin.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlPlugin.java
@@ -13,15 +13,37 @@
  */
 package io.trino.plugin.postgresql;
 
-import io.trino.plugin.jdbc.JdbcPlugin;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Module;
+import io.trino.plugin.jdbc.ExtraCredentialsBasedIdentityCacheMappingModule;
+import io.trino.plugin.jdbc.credential.CredentialProviderModule;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.ConnectorFactory;
+
+import java.util.function.Supplier;
 
 import static io.airlift.configuration.ConfigurationAwareModule.combine;
 
 public class PostgreSqlPlugin
-        extends JdbcPlugin
+        implements Plugin
 {
+    private final String name;
+    private final Supplier<Module> module;
+
     public PostgreSqlPlugin()
     {
-        super("postgresql", () -> combine(new PostgreSqlClientModule(), new PostgreSqlConnectionFactoryModule()));
+        this.name = "postgresql";
+        this.module = () -> combine(new PostgreSqlClientModule(), new PostgreSqlConnectionFactoryModule());
+    }
+
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableList.of(new PostgreSqlConnectorFactory(
+                name,
+                () -> combine(
+                        new CredentialProviderModule(),
+                        new ExtraCredentialsBasedIdentityCacheMappingModule(),
+                        module.get())));
     }
 }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -74,7 +74,9 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_ADD_COLUMN;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_AGGREGATION_PUSHDOWN;
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_DEFAULT_COLUMN_VALUE;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_JOIN_PUSHDOWN_WITH_FULL_JOIN;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_LIMIT_PUSHDOWN;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_EQUALITY;
@@ -86,6 +88,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @see TestPostgreSqlConnectorSmokeTest
@@ -123,6 +126,7 @@ public class TestPostgreSqlConnectorTest
             // Arrays are supported conditionally. Check the defaults.
             case SUPPORTS_ARRAY -> new PostgreSqlConfig().getArrayMapping() != PostgreSqlConfig.ArrayMapping.DISABLED;
             case SUPPORTS_CANCELLATION,
+                 SUPPORTS_DEFAULT_COLUMN_VALUE,
                  SUPPORTS_JOIN_PUSHDOWN,
                  SUPPORTS_TOPN_PUSHDOWN_WITH_VARCHAR -> true;
             case SUPPORTS_ADD_COLUMN_WITH_COMMENT,
@@ -271,6 +275,76 @@ public class TestPostgreSqlConnectorTest
     protected void verifyAddNotNullColumnToNonEmptyTableFailurePermissible(Throwable e)
     {
         assertThat(e).hasMessageMatching("ERROR: column \".*\" contains null values");
+    }
+
+    @Test
+    @Override // Overriden because exception is throw during table creation and not after insert
+    public void testInsertDefaultNullIntoNotNullColumn()
+    {
+        assertThatThrownBy(super::testInsertDefaultNullIntoNotNullColumn)
+                .hasMessageMatching("(?s).*Expecting message:.*ERROR: null value in column \"y\" violates not-null constraint.*");
+    }
+
+    @Test
+    public void testExecuteCreateTableWithDefaultColumn()
+    {
+        skipTestUnless(hasBehavior(SUPPORTS_DEFAULT_COLUMN_VALUE));
+
+        String tableName = "test_default_value" + randomNameSuffix();
+        String schemaTableName = getSession().getSchema().orElseThrow() + "." + tableName;
+        assertUpdate("CALL system.execute('CREATE TABLE " + schemaTableName + " (x INT, y VARCHAR DEFAULT ''hello || word'')')");
+        assertUpdate("INSERT INTO " + schemaTableName + "(x) VALUES 1", 1);
+        assertThat(query("SELECT * FROM " + schemaTableName))
+                .skippingTypesCheck()
+                .matches("VALUES (1, 'hello || word')");
+        assertUpdate("ALTER TABLE " + schemaTableName + " ALTER COLUMN y DROP DEFAULT");
+        assertUpdate("DROP TABLE " + schemaTableName);
+
+        assertUpdate("CALL system.execute('CREATE TABLE " + schemaTableName + " (x INT, y VARCHAR DEFAULT ''hello'''' || ''''word'')')");
+        assertUpdate("INSERT INTO " + schemaTableName + "(x) VALUES 1", 1);
+        assertThat(query("SELECT * FROM " + schemaTableName))
+                .skippingTypesCheck()
+                .matches("VALUES (1, 'hello'' || ''word')");
+        assertUpdate("ALTER TABLE " + schemaTableName + " ALTER COLUMN y DROP DEFAULT");
+        assertUpdate("DROP TABLE " + schemaTableName);
+
+        // FIXME: Concatenation when assigning a default value works when executing table creation, but this default value cannot be dropped by Trino.
+        //        This is a limitation stemming from the underlying pgjdbc driver. See: https://github.com/pgjdbc/pgjdbc/issues/4333
+        assertUpdate("CALL system.execute('CREATE TABLE " + schemaTableName + " (x INT, y VARCHAR DEFAULT ''hello'' || ''word'')')");
+        assertUpdate("INSERT INTO " + schemaTableName + "(x) VALUES 1", 1);
+        assertThat(query("SELECT * FROM " + schemaTableName))
+                .skippingTypesCheck()
+                .matches("VALUES (1, 'helloword')");
+        assertQueryFails("ALTER TABLE " + schemaTableName + " ALTER COLUMN y DROP DEFAULT", "line 1:1: Column 'y' does not have a default value");
+        assertUpdate("CALL system.execute('ALTER TABLE " + schemaTableName + " ALTER COLUMN y DROP DEFAULT')");
+        assertUpdate("DROP TABLE " + schemaTableName);
+    }
+
+    @Test
+    @Override // Overriden because with PostgreSql default value is used when inserting a new column.
+    public void testAddDefaultColumn()
+    {
+        skipTestUnless(hasBehavior(SUPPORTS_ADD_COLUMN) && hasBehavior(SUPPORTS_DEFAULT_COLUMN_VALUE));
+
+        try (TestTable table = newTrinoTable("test_default_value", "(w int)")) {
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN x int DEFAULT 123");
+            assertUpdate("INSERT INTO " + table.getName() + "(w) VALUES 1", 1);
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .skippingTypesCheck()
+                    .matches("VALUES (1, 123)");
+
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN y varchar DEFAULT 'default varchar'");
+            assertUpdate("INSERT INTO " + table.getName() + "(w) VALUES 2", 1);
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .skippingTypesCheck()
+                    .matches("VALUES (1, 123, 'default varchar'), (2, 123, 'default varchar')");
+
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN z char(15) DEFAULT 'default char'");
+            assertUpdate("INSERT INTO " + table.getName() + "(w) VALUES 3", 1);
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .skippingTypesCheck()
+                    .matches("VALUES (1, 123, 'default varchar', 'default char   '), (2, 123, 'default varchar', 'default char   '), (3, 123, 'default varchar', 'default char   ')");
+        }
     }
 
     @Test

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -2757,12 +2757,24 @@ public abstract class BaseConnectorTest
     {
         skipTestUnless(hasBehavior(SUPPORTS_ADD_COLUMN) && hasBehavior(SUPPORTS_DEFAULT_COLUMN_VALUE));
 
-        try (TestTable table = newTrinoTable("test_default_value", "(x int)")) {
-            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN y int DEFAULT 123");
-            assertUpdate("INSERT INTO " + table.getName() + "(x) VALUES 1", 1);
+        try (TestTable table = newTrinoTable("test_default_value", "(w int)")) {
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN x int DEFAULT 123");
+            assertUpdate("INSERT INTO " + table.getName() + "(w) VALUES 1", 1);
             assertThat(query("SELECT * FROM " + table.getName()))
                     .skippingTypesCheck()
                     .matches("VALUES (1, 123)");
+
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN y varchar DEFAULT 'default varchar'");
+            assertUpdate("INSERT INTO " + table.getName() + "(w) VALUES 2", 1);
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .skippingTypesCheck()
+                    .matches("VALUES (1, 123, null), (2, 123, 'default varchar')");
+
+            assertUpdate("ALTER TABLE " + table.getName() + " ADD COLUMN z char(15) DEFAULT 'default char'");
+            assertUpdate("INSERT INTO " + table.getName() + "(w) VALUES 3", 1);
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .skippingTypesCheck()
+                    .matches("VALUES (1, 123, null, null), (2, 123, 'default varchar', null), (3, 123, 'default varchar', 'default char   ')");
         }
     }
 


### PR DESCRIPTION
## Description

Currently, it is not possible to implement a connector that supports default column value management, because the default value is never read, and is therefore absent from the metadata of the columns making up a table.

As [requested](https://github.com/trinodb/trino/pull/30507#pullrequestreview-4813924998) by @ebyhr, the PostgreSQL connector has been migrated to ensure proper operation.

Pending the resolution of [issue#4333](https://github.com/pgjdbc/pgjdbc/issues/4333) by pgjdbc, only assigned default values ​​meeting the following criteria will be fully supported:
- no use of operator during assignment (ie: concatenation...).
- applied to `java.sql.Types` columns: `VARCHAR`, `CHAR`, `SMALLINT`, `INTEGER` and `BIGINT`.

In short: it works as before if these criteria are not met.

## Additional context and related issues

This PR is supposed to resolve issue #30503.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Add support for default column values in PostgreSql connector. ({issue}`30503`)
```
