### PR TITLE
Keep repeated non-deterministic conjuncts in Case conjunct extraction

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/ExtractCommonConjunctFromCase.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/ExtractCommonConjunctFromCase.java
@@ -14,8 +14,6 @@
 package io.trino.sql.ir.optimizer.rule;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import io.trino.Session;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Case;
@@ -107,6 +105,9 @@ public class ExtractCommonConjunctFromCase
 
     private static Expression removeConjuncts(Expression expression, Set<Expression> removed)
     {
-        return combineConjuncts(Sets.difference(ImmutableSet.copyOf(extractConjuncts(expression)), removed));
+        // Repeated non-deterministic conjuncts are semantically distinct, so every occurrence must survive
+        return combineConjuncts(extractConjuncts(expression).stream()
+                .filter(conjunct -> !removed.contains(conjunct))
+                .collect(toImmutableList()));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestExtractCommonConjunctFromCase.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestExtractCommonConjunctFromCase.java
@@ -87,6 +87,59 @@ final class TestExtractCommonConjunctFromCase
     }
 
     @Test
+    void preservesRepeatedNonDeterministicConjunctInBranch()
+    {
+        assertThat(optimize(new Case(
+                ImmutableList.of(new WhenClause(CONDITION, new Logical(AND, ImmutableList.of(SHARED, NON_DETERMINISTIC, NON_DETERMINISTIC)))),
+                SHARED)))
+                .isEqualTo(Optional.of(new Logical(AND, ImmutableList.of(
+                        SHARED,
+                        new Case(
+                                ImmutableList.of(new WhenClause(CONDITION, new Logical(AND, ImmutableList.of(NON_DETERMINISTIC, NON_DETERMINISTIC)))),
+                                TRUE)))));
+    }
+
+    @Test
+    void removesEveryOccurrenceOfExtractedConjunct()
+    {
+        assertThat(optimize(new Case(
+                ImmutableList.of(new WhenClause(CONDITION, new Logical(AND, ImmutableList.of(SHARED, SHARED, OTHER)))),
+                SHARED)))
+                .isEqualTo(Optional.of(new Logical(AND, ImmutableList.of(
+                        SHARED,
+                        new Case(
+                                ImmutableList.of(new WhenClause(CONDITION, OTHER)),
+                                TRUE)))));
+    }
+
+    @Test
+    void extractsEveryCommonConjunct()
+    {
+        assertThat(optimize(new Case(
+                ImmutableList.of(new WhenClause(CONDITION, new Logical(AND, ImmutableList.of(SHARED, OTHER, THIRD)))),
+                Logical.and(THIRD, SHARED))))
+                .isEqualTo(Optional.of(new Logical(AND, ImmutableList.of(
+                        SHARED,
+                        THIRD,
+                        new Case(
+                                ImmutableList.of(new WhenClause(CONDITION, OTHER)),
+                                TRUE)))));
+    }
+
+    @Test
+    void leavesFailingConjunctInBranchWhenAnotherConjunctIsExtracted()
+    {
+        assertThat(optimize(new Case(
+                ImmutableList.of(new WhenClause(CONDITION, Logical.and(SHARED, MAY_FAIL))),
+                Logical.and(SHARED, MAY_FAIL))))
+                .isEqualTo(Optional.of(new Logical(AND, ImmutableList.of(
+                        SHARED,
+                        new Case(
+                                ImmutableList.of(new WhenClause(CONDITION, MAY_FAIL)),
+                                MAY_FAIL)))));
+    }
+
+    @Test
     void doesNotFireWhenNoConjunctIsCommonToAllBranches()
     {
         assertThat(optimize(new Case(


### PR DESCRIPTION
## Description

`ExtractCommonConjunctFromCase` removed the extracted conjuncts from each branch with `Sets.difference(ImmutableSet.copyOf(extractConjuncts(...)), removed)`, which also collapsed repeated conjuncts within a branch. Repeated non-deterministic conjuncts are semantically distinct, which is why `combineConjuncts` exempts them from deduplication, so `IF(c, random() = 0.5 AND random() = 0.5, ...)` was rewritten with a single `random() = 0.5` and changed results.

Filter the conjuncts as a list instead, leaving deduplication to `combineConjuncts`.

## Additional context and related issues

The rule was added in #30288 and released in 483.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix incorrect results for `CASE` expressions with a repeated non-deterministic condition in a single branch. ({issue}`30509`)
```
