### PR TITLE
Fix CTAS WITH NO DATA for some connectors

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -50,6 +50,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.SaveMode;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.statistics.TableStatistics;
@@ -353,6 +354,22 @@ public class LogicalPlanner
             Symbol symbol = symbolAllocator.newSymbol("rows", BIGINT);
             PlanNode source = new ValuesNode(idAllocator.getNextId(), ImmutableList.of(symbol), ImmutableList.of(new Row(ImmutableList.of(new Constant(BIGINT, 0L)))));
             return new OutputNode(idAllocator.getNextId(), source, ImmutableList.of("rows"), ImmutableList.of(symbol));
+        }
+        if (statement instanceof CreateTableAsSelect) {
+            Analysis.Create create = analysis.getCreate().orElseThrow();
+            if (!create.isCreateTableAsSelectWithData()) {
+                // WITH NO DATA is a pure DDL operation: create the empty table via createTable() and
+                // never invoke the data-write path (beginCreateTable). This lets connectors that support
+                // creating table structures but not writing data (e.g. Iceberg-over-Snowflake, #3172)
+                // handle WITH NO DATA, and subjects the statement to the same validations as CREATE TABLE.
+                QualifiedObjectName destination = create.getDestination().orElseThrow();
+                ConnectorTableMetadata tableMetadata = create.getMetadata().orElseThrow();
+                SaveMode saveMode = create.isReplace() ? SaveMode.REPLACE : SaveMode.FAIL;
+                metadata.createTable(session, destination.catalogName(), tableMetadata, saveMode);
+                Symbol symbol = symbolAllocator.newSymbol("rows", BIGINT);
+                PlanNode source = new ValuesNode(idAllocator.getNextId(), ImmutableList.of(symbol), ImmutableList.of(new Row(ImmutableList.of(new Constant(BIGINT, 0L)))));
+                return new OutputNode(idAllocator.getNextId(), source, ImmutableList.of("rows"), ImmutableList.of(symbol));
+            }
         }
         return createOutputPlan(planStatementWithoutOutput(analysis, statement), analysis);
     }

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -23,6 +23,8 @@ import io.trino.connector.MockConnectorFactory.ApplyProjection;
 import io.trino.connector.MockConnectorFactory.ApplyTableFunction;
 import io.trino.connector.MockConnectorFactory.ApplyTableScanRedirect;
 import io.trino.connector.MockConnectorFactory.ApplyTopN;
+import io.trino.connector.MockConnectorFactory.BeginCreateTable;
+import io.trino.connector.MockConnectorFactory.CreateTable;
 import io.trino.connector.MockConnectorFactory.ListRoleGrants;
 import io.trino.spi.Page;
 import io.trino.spi.RefreshType;
@@ -170,6 +172,8 @@ public class MockConnector
     private final BiFunction<ConnectorSession, SchemaTableName, Optional<CatalogSchemaTableName>> redirectTable;
     private final BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorTableLayout>> getInsertLayout;
     private final BiFunction<ConnectorSession, ConnectorTableMetadata, Optional<ConnectorTableLayout>> getNewTableLayout;
+    private final MockConnectorFactory.CreateTable createTable;
+    private final MockConnectorFactory.BeginCreateTable beginCreateTable;
     private final BiFunction<ConnectorSession, Type, Optional<Type>> getSupportedType;
     private final BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties;
     private final BiFunction<ConnectorSession, SchemaTablePrefix, List<GrantInfo>> listTablePrivileges;
@@ -227,6 +231,8 @@ public class MockConnector
             BiFunction<ConnectorSession, SchemaTableName, Optional<CatalogSchemaTableName>> redirectTable,
             BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorTableLayout>> getInsertLayout,
             BiFunction<ConnectorSession, ConnectorTableMetadata, Optional<ConnectorTableLayout>> getNewTableLayout,
+            CreateTable createTable,
+            BeginCreateTable beginCreateTable,
             BiFunction<ConnectorSession, Type, Optional<Type>> getSupportedType,
             BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties,
             BiFunction<ConnectorSession, SchemaTablePrefix, List<GrantInfo>> listTablePrivileges,
@@ -283,6 +289,8 @@ public class MockConnector
         this.redirectTable = requireNonNull(redirectTable, "redirectTable is null");
         this.getInsertLayout = requireNonNull(getInsertLayout, "getInsertLayout is null");
         this.getNewTableLayout = requireNonNull(getNewTableLayout, "getNewTableLayout is null");
+        this.createTable = requireNonNull(createTable, "createTable is null");
+        this.beginCreateTable = requireNonNull(beginCreateTable, "beginCreateTable is null");
         this.getSupportedType = requireNonNull(getSupportedType, "getSupportedType is null");
         this.getTableProperties = requireNonNull(getTableProperties, "getTableProperties is null");
         this.listTablePrivileges = requireNonNull(listTablePrivileges, "listTablePrivileges is null");
@@ -643,7 +651,10 @@ public class MockConnector
         }
 
         @Override
-        public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, SaveMode saveMode) {}
+        public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, SaveMode saveMode)
+        {
+            createTable.apply(session, tableMetadata, saveMode);
+        }
 
         @Override
         public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle) {}
@@ -852,7 +863,7 @@ public class MockConnector
         @Override
         public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorTableLayout> layout, RetryMode retryMode, boolean replace)
         {
-            return new MockConnectorOutputTableHandle(tableMetadata.getTable());
+            return beginCreateTable.apply(session, tableMetadata, layout, retryMode, replace);
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -29,6 +29,7 @@ import io.trino.spi.connector.ConnectorFactory;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
+import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableExecuteHandle;
@@ -45,6 +46,8 @@ import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationColumnsMetadata;
+import io.trino.spi.connector.RetryMode;
+import io.trino.spi.connector.SaveMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SortItem;
@@ -125,6 +128,8 @@ public class MockConnectorFactory
     private final BiFunction<ConnectorSession, SchemaTableName, Optional<CatalogSchemaTableName>> redirectTable;
     private final BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorTableLayout>> getInsertLayout;
     private final BiFunction<ConnectorSession, ConnectorTableMetadata, Optional<ConnectorTableLayout>> getNewTableLayout;
+    private final CreateTable createTable;
+    private final BeginCreateTable beginCreateTable;
     private final BiFunction<ConnectorSession, Type, Optional<Type>> getSupportedType;
     private final BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties;
     private final BiFunction<ConnectorSession, SchemaTablePrefix, List<GrantInfo>> listTablePrivileges;
@@ -186,6 +191,8 @@ public class MockConnectorFactory
             BiFunction<ConnectorSession, SchemaTableName, Optional<CatalogSchemaTableName>> redirectTable,
             BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorTableLayout>> getInsertLayout,
             BiFunction<ConnectorSession, ConnectorTableMetadata, Optional<ConnectorTableLayout>> getNewTableLayout,
+            CreateTable createTable,
+            BeginCreateTable beginCreateTable,
             BiFunction<ConnectorSession, Type, Optional<Type>> getSupportedType,
             BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties,
             BiFunction<ConnectorSession, SchemaTablePrefix, List<GrantInfo>> listTablePrivileges,
@@ -243,6 +250,8 @@ public class MockConnectorFactory
         this.redirectTable = requireNonNull(redirectTable, "redirectTable is null");
         this.getInsertLayout = requireNonNull(getInsertLayout, "getInsertLayout is null");
         this.getNewTableLayout = requireNonNull(getNewTableLayout, "getNewTableLayout is null");
+        this.createTable = requireNonNull(createTable, "createTable is null");
+        this.beginCreateTable = requireNonNull(beginCreateTable, "beginCreateTable is null");
         this.getSupportedType = requireNonNull(getSupportedType, "getSupportedType is null");
         this.getTableProperties = requireNonNull(getTableProperties, "getTableProperties is null");
         this.listTablePrivileges = requireNonNull(listTablePrivileges, "listTablePrivileges is null");
@@ -310,6 +319,8 @@ public class MockConnectorFactory
                 redirectTable,
                 getInsertLayout,
                 getNewTableLayout,
+                createTable,
+                beginCreateTable,
                 getSupportedType,
                 getTableProperties,
                 listTablePrivileges,
@@ -370,6 +381,18 @@ public class MockConnectorFactory
                 ConnectorTableHandle handle,
                 List<ConnectorExpression> projections,
                 Map<String, ColumnHandle> assignments);
+    }
+
+    @FunctionalInterface
+    public interface CreateTable
+    {
+        void apply(ConnectorSession session, ConnectorTableMetadata tableMetadata, SaveMode saveMode);
+    }
+
+    @FunctionalInterface
+    public interface BeginCreateTable
+    {
+        ConnectorOutputTableHandle apply(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorTableLayout> layout, RetryMode retryMode, boolean replace);
     }
 
     @FunctionalInterface
@@ -461,6 +484,8 @@ public class MockConnectorFactory
         private ApplyJoin applyJoin = (_, _, _, _, _, _, _, _) -> Optional.empty();
         private BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorTableLayout>> getInsertLayout = defaultGetInsertLayout();
         private BiFunction<ConnectorSession, ConnectorTableMetadata, Optional<ConnectorTableLayout>> getNewTableLayout = defaultGetNewTableLayout();
+        private CreateTable createTable = (_, _, _) -> {};
+        private BeginCreateTable beginCreateTable = (_, tableMetadata, _, _, _) -> new MockConnectorOutputTableHandle(tableMetadata.getTable());
         private BiFunction<ConnectorSession, Type, Optional<Type>> getSupportedType = (_, _) -> Optional.empty();
         private BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties = defaultGetTableProperties();
         private BiFunction<ConnectorSession, SchemaTablePrefix, List<GrantInfo>> listTablePrivileges = defaultListTablePrivileges();
@@ -689,6 +714,18 @@ public class MockConnectorFactory
             return this;
         }
 
+        public Builder withCreateTable(CreateTable createTable)
+        {
+            this.createTable = requireNonNull(createTable, "createTable is null");
+            return this;
+        }
+
+        public Builder withBeginCreateTable(BeginCreateTable beginCreateTable)
+        {
+            this.beginCreateTable = requireNonNull(beginCreateTable, "beginCreateTable is null");
+            return this;
+        }
+
         public Builder withGetSupportedType(BiFunction<ConnectorSession, Type, Optional<Type>> getSupportedType)
         {
             this.getSupportedType = requireNonNull(getSupportedType, "getSupportedType is null");
@@ -908,6 +945,8 @@ public class MockConnectorFactory
                     redirectTable,
                     getInsertLayout,
                     getNewTableLayout,
+                    createTable,
+                    beginCreateTable,
                     getSupportedType,
                     getTableProperties,
                     listTablePrivileges,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -8361,17 +8361,59 @@ public abstract class BaseHiveConnectorTest
     @Test
     public void testCtasFailsWithAvroSchemaUrl()
     {
+        // WITH NO DATA is a pure DDL operation that goes through createTable(), which validates the
+        // avro_schema_url property against the (default ORC) storage format rather than rejecting CTAS.
         @Language("SQL") String ctasSqlWithoutData = "CREATE TABLE create_avro\n" +
                 "WITH (avro_schema_url = 'dummy_schema')\n" +
                 "AS SELECT 'dummy_value' as dummy_col WITH NO DATA";
 
-        assertQueryFails(ctasSqlWithoutData, "CREATE TABLE AS not supported when Avro schema url is set");
+        assertQueryFails(ctasSqlWithoutData, "Cannot specify avro_schema_url table property for storage format: ORC");
 
+        // WITH DATA goes through beginCreateTable(), which rejects CTAS when an Avro schema url is set.
         @Language("SQL") String ctasSql = "CREATE TABLE create_avro\n" +
                 "WITH (avro_schema_url = 'dummy_schema')\n" +
                 "AS SELECT * FROM (VALUES('a')) t (a)";
 
         assertQueryFails(ctasSql, "CREATE TABLE AS not supported when Avro schema url is set");
+    }
+
+    @Test
+    public void testCtasWithNoDataSucceedsWithAvroSchemaUrl()
+            throws Exception
+    {
+        String tableName = "test_ctas_no_data_avro_schema_url_" + randomNameSuffix();
+        TrinoFileSystem fileSystem = getTrinoFileSystem();
+        Location tempDir = Location.of("local:///temp_" + UUID.randomUUID());
+        fileSystem.createDirectory(tempDir);
+        String schema =
+                """
+                {
+                    "namespace": "io.trino.test",
+                    "name": "testNoData",
+                    "type": "record",
+                    "fields": [
+                       { "name":"dummy_col", "type":"string" }
+                    ]
+                }\
+                """;
+        Location schemaFile = tempDir.appendPath("test_no_data_schema.avsc");
+        try (OutputStream out = fileSystem.newOutputFile(schemaFile).create()) {
+            out.write(schema.getBytes(UTF_8));
+        }
+
+        try {
+            assertUpdate(
+                    format("CREATE TABLE %s WITH (avro_schema_url = '%s', format = 'AVRO') " +
+                                    "AS SELECT 'dummy' AS dummy_col WITH NO DATA",
+                            tableName,
+                            schemaFile),
+                    0);
+            assertQuery("SELECT count(*) FROM " + tableName, "VALUES 0");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+            fileSystem.deleteDirectory(tempDir);
+        }
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestCreateTableAsSelectWithNoData.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestCreateTableAsSelectWithNoData.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorPlugin;
+import io.trino.spi.TrinoException;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.StandaloneQueryRunner;
+import org.junit.jupiter.api.Test;
+
+import java.util.OptionalLong;
+
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestCreateTableAsSelectWithNoData
+        extends AbstractTestQueryFramework
+{
+    private static final String CATALOG = "mock";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        QueryRunner queryRunner = new StandaloneQueryRunner(testSessionBuilder()
+                .setCatalog(CATALOG)
+                .setSchema("default")
+                .build());
+        queryRunner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
+                .withName(CATALOG)
+                // Report the destination table as not yet existing so CREATE TABLE AS SELECT proceeds.
+                .withGetTableHandle((_, _) -> null)
+                // Simulates a connector that supports creating empty table structures (createTable, the
+                // default no-op) but not writing data (beginCreateTable).
+                .withBeginCreateTable((_, _, _, _, _) -> {
+                    throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating tables with data");
+                })
+                .build()));
+        queryRunner.createCatalog(CATALOG, CATALOG, ImmutableMap.of());
+        return queryRunner;
+    }
+
+    @Test
+    void testCtasWithNoDataSucceeds()
+    {
+        assertThat(getQueryRunner().execute("CREATE TABLE test_no_data AS SELECT * FROM (VALUES (1, 'a'), (2, 'b')) t(id, name) WITH NO DATA").getUpdateCount())
+                .isEqualTo(OptionalLong.of(0));
+    }
+
+    @Test
+    void testCtasWithDataFails()
+    {
+        assertTrinoExceptionThrownBy(() -> getQueryRunner().execute("CREATE TABLE test_with_data AS SELECT * FROM (VALUES (1, 'a'), (2, 'b')) t(id, name)"))
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessage("This connector does not support creating tables with data");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Connectors that support creating tables but not creating tables with data fail on CREATE TABLE AS SELECT WITH NO DATA statements with "This connector does not support creating tables with data" error messages. This change allows those connectors to execute CTAS WITH NO DATA statements without throwing that confusing error message.

* Fixes #3172

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Previously, the engine routed WITH NO DATA through the data-write path (beginCreateTable + a zero-row write), so connectors that implement createTable but not beginCreateTable would fail with the misleading error message (although it seems no such connectors currently exist). 

WITH NO DATA is now treated as a pure DDL operation and creates the empty table via createTable(), subject to the same validations as a plain CREATE TABLE. beginCreateTable() is never invoked.

One behavior change: connector CTAS-write validations that live only in beginCreateTable no longer apply to WITH NO DATA; the empty-table validations apply instead. For example, Hive's avro_schema_url + WITH NO DATA case still fails, but now reports the property/format error rather than the CTAS-specific one.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

