### PR TITLE
Support RSA private key authentication in Snowflake connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -676,6 +676,8 @@ jobs:
           SNOWFLAKE_URL: ${{ vars.SNOWFLAKE_URL }}
           SNOWFLAKE_USER: ${{ vars.SNOWFLAKE_USER }}
           SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          SNOWFLAKE_PRIVATE_KEY: ${{ secrets.SNOWFLAKE_PRIVATE_KEY }}
+          SNOWFLAKE_PRIVATE_KEY_PASSWORD: ${{ secrets.SNOWFLAKE_PRIVATE_KEY_PASSWORD }}
           SNOWFLAKE_DATABASE: ${{ vars.SNOWFLAKE_DATABASE }}
           SNOWFLAKE_ROLE: ${{ vars.SNOWFLAKE_ROLE }}
           SNOWFLAKE_WAREHOUSE: ${{ vars.SNOWFLAKE_WAREHOUSE }}
@@ -685,6 +687,8 @@ jobs:
             -Dsnowflake.test.server.url="${SNOWFLAKE_URL}" \
             -Dsnowflake.test.server.user="${SNOWFLAKE_USER}" \
             -Dsnowflake.test.server.password="${SNOWFLAKE_PASSWORD}" \
+            -Dsnowflake.test.server.private-key="${SNOWFLAKE_PRIVATE_KEY}" \
+            -Dsnowflake.test.server.private-key-password="${SNOWFLAKE_PRIVATE_KEY_PASSWORD}" \
             -Dsnowflake.test.server.database="${SNOWFLAKE_DATABASE}" \
             -Dsnowflake.test.server.role="${SNOWFLAKE_ROLE}" \
             -Dsnowflake.test.server.warehouse="${SNOWFLAKE_WAREHOUSE}"

--- a/docs/src/main/sphinx/connector/snowflake.md
+++ b/docs/src/main/sphinx/connector/snowflake.md
@@ -26,12 +26,19 @@ connection properties as appropriate for your setup:
 connector.name=snowflake
 connection-url=jdbc:snowflake://<account>.snowflakecomputing.com
 connection-user=root
-connection-password=secret
+snowflake.connection-private-key=private-key-content
 snowflake.account=account
 snowflake.database=database
 snowflake.role=role
 snowflake.warehouse=warehouse
 ```
+
+:::{note}
+The `snowflake.connection-private-key` property accepts a Base64-encoded RSA private key
+in PKCS#8 format. If the private key is encrypted, also set
+`snowflake.connection-private-key-password` to the password used to decrypt it.
+Alternatively, you can use `connection-password` for password-based authentication.
+:::
 
 The Snowflake connector uses Apache Arrow as the serialization format when
 reading from Snowflake. Add the following required, additional JVM argument

--- a/plugin/trino-snowflake/pom.xml
+++ b/plugin/trino-snowflake/pom.xml
@@ -230,6 +230,7 @@
                             <excludes>
                                 <exclude>**/TestSnowflakeConnectorTest.java</exclude>
                                 <exclude>**/TestSnowflakeTypeMapping.java</exclude>
+                                <exclude>**/TestSnowflakeWithPrivateKeyConnectorSmokeTest.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -252,6 +253,7 @@
                             <includes>
                                 <include>**/TestSnowflakeConnectorTest.java</include>
                                 <include>**/TestSnowflakeTypeMapping.java</include>
+                                <include>**/TestSnowflakeWithPrivateKeyConnectorSmokeTest.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/SnowflakeClientModule.java
+++ b/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/SnowflakeClientModule.java
@@ -72,6 +72,8 @@ public class SnowflakeClientModule
         snowflakeConfig.getDatabase().ifPresent(database -> properties.setProperty("db", database));
         snowflakeConfig.getRole().ifPresent(role -> properties.setProperty("role", role));
         snowflakeConfig.getWarehouse().ifPresent(warehouse -> properties.setProperty("warehouse", warehouse));
+        snowflakeConfig.getPrivateKey().ifPresent(privateKey -> properties.setProperty("private_key_base64", privateKey));
+        snowflakeConfig.getPrivateKeyPassword().ifPresent(privateKeyPassword -> properties.setProperty("private_key_pwd", privateKeyPassword));
 
         setOutputProperties(properties);
 

--- a/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/SnowflakeConfig.java
+++ b/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/SnowflakeConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.snowflake;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
 
 import java.util.Optional;
@@ -25,6 +26,8 @@ public class SnowflakeConfig
     private String role;
     private String warehouse;
     private String httpProxy;
+    private String privateKey;
+    private String privateKeyPassword;
 
     public Optional<String> getAccount()
     {
@@ -84,6 +87,34 @@ public class SnowflakeConfig
     public SnowflakeConfig setHttpProxy(String httpProxy)
     {
         this.httpProxy = httpProxy;
+        return this;
+    }
+
+    public Optional<String> getPrivateKey()
+    {
+        return Optional.ofNullable(privateKey);
+    }
+
+    @Config("snowflake.connection-private-key")
+    @ConfigDescription("Base64-encoded PKCS#8 RSA private key for key-pair authentication")
+    @ConfigSecuritySensitive
+    public SnowflakeConfig setPrivateKey(String privateKey)
+    {
+        this.privateKey = privateKey;
+        return this;
+    }
+
+    public Optional<String> getPrivateKeyPassword()
+    {
+        return Optional.ofNullable(privateKeyPassword);
+    }
+
+    @Config("snowflake.connection-private-key-password")
+    @ConfigDescription("Password to decrypt an encrypted private key")
+    @ConfigSecuritySensitive
+    public SnowflakeConfig setPrivateKeyPassword(String privateKeyPassword)
+    {
+        this.privateKeyPassword = privateKeyPassword;
         return this;
     }
 }

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/SnowflakeQueryRunner.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/SnowflakeQueryRunner.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
+import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.Objects.requireNonNull;
 
@@ -48,7 +49,6 @@ public final class SnowflakeQueryRunner
         Builder builder = new Builder()
                 .addConnectorProperty("connection-url", TestingSnowflakeServer.TEST_URL)
                 .addConnectorProperty("connection-user", TestingSnowflakeServer.TEST_USER)
-                .addConnectorProperty("connection-password", TestingSnowflakeServer.TEST_PASSWORD)
                 .addConnectorProperty("snowflake.database", TestingSnowflakeServer.TEST_DATABASE)
                 .addConnectorProperty("snowflake.warehouse", TestingSnowflakeServer.TEST_WAREHOUSE);
         TestingSnowflakeServer.TEST_ROLE.ifPresent(role -> builder.addConnectorProperty("snowflake.role", role));
@@ -111,6 +111,7 @@ public final class SnowflakeQueryRunner
             throws Exception
     {
         DistributedQueryRunner queryRunner = builder()
+                .addConnectorProperty("connection-password", requiredNonEmptySystemProperty("snowflake.test.server.password"))
                 .addCoordinatorProperty("http-server.http.port", "8080")
                 .build();
 

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConfig.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConfig.java
@@ -32,7 +32,9 @@ public class TestSnowflakeConfig
                 .setDatabase(null)
                 .setRole(null)
                 .setWarehouse(null)
-                .setHttpProxy(null));
+                .setHttpProxy(null)
+                .setPrivateKey(null)
+                .setPrivateKeyPassword(null));
     }
 
     @Test
@@ -44,6 +46,8 @@ public class TestSnowflakeConfig
                 .put("snowflake.role", "MYROLE")
                 .put("snowflake.warehouse", "MYWAREHOUSE")
                 .put("snowflake.http-proxy", "MYPROXY")
+                .put("snowflake.connection-private-key", "MYPRIVATEKEY")
+                .put("snowflake.connection-private-key-password", "MYPASSWORD")
                 .buildOrThrow();
 
         SnowflakeConfig expected = new SnowflakeConfig()
@@ -51,7 +55,9 @@ public class TestSnowflakeConfig
                 .setDatabase("MYDATABASE")
                 .setRole("MYROLE")
                 .setWarehouse("MYWAREHOUSE")
-                .setHttpProxy("MYPROXY");
+                .setHttpProxy("MYPROXY")
+                .setPrivateKey("MYPRIVATEKEY")
+                .setPrivateKeyPassword("MYPASSWORD");
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConnectorTest.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConnectorTest.java
@@ -35,6 +35,7 @@ import static io.trino.spi.connector.ConnectorMetadata.MODIFYING_ROWS_MESSAGE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -52,6 +53,7 @@ public class TestSnowflakeConnectorTest
             throws Exception
     {
         return SnowflakeQueryRunner.builder()
+                .addConnectorProperty("connection-password", requiredNonEmptySystemProperty("snowflake.test.server.password"))
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();
     }

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakePlugin.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakePlugin.java
@@ -30,4 +30,31 @@ public class TestSnowflakePlugin
         ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
         factory.create("test", ImmutableMap.of("connection-url", "jdbc:snowflake://test"), new TestingConnectorContext()).shutdown();
     }
+
+    @Test
+    public void testCreateConnectorWithPrivateKey()
+    {
+        Plugin plugin = new SnowflakePlugin();
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        factory.create(
+                "test",
+                ImmutableMap.of(
+                        "connection-url", "jdbc:snowflake://test",
+                        "snowflake.connection-private-key", "dummy-private-key"),
+                new TestingConnectorContext()).shutdown();
+    }
+
+    @Test
+    public void testCreateConnectorWithEncryptedPrivateKey()
+    {
+        Plugin plugin = new SnowflakePlugin();
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        factory.create(
+                "test",
+                ImmutableMap.of(
+                        "connection-url", "jdbc:snowflake://test",
+                        "snowflake.connection-private-key", "dummy-private-key",
+                        "snowflake.connection-private-key-password", "dummy-password"),
+                new TestingConnectorContext()).shutdown();
+    }
 }

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeTypeMapping.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeTypeMapping.java
@@ -47,6 +47,7 @@ import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
 import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 import static java.time.ZoneOffset.UTC;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -76,6 +77,7 @@ public class TestSnowflakeTypeMapping
             throws Exception
     {
         return SnowflakeQueryRunner.builder()
+                .addConnectorProperty("connection-password", requiredNonEmptySystemProperty("snowflake.test.server.password"))
                 .addConnectorProperty("jdbc-types-mapped-to-varchar", "ARRAY")
                 .build();
     }

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeWithPrivateKeyConnectorSmokeTest.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeWithPrivateKeyConnectorSmokeTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.snowflake;
+
+import io.trino.plugin.jdbc.BaseJdbcConnectorSmokeTest;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+
+import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
+
+public class TestSnowflakeWithPrivateKeyConnectorSmokeTest
+        extends BaseJdbcConnectorSmokeTest
+{
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return switch (connectorBehavior) {
+            case SUPPORTS_ADD_COLUMN_WITH_COMMENT,
+                 SUPPORTS_ADD_COLUMN_WITH_POSITION,
+                 SUPPORTS_ARRAY,
+                 SUPPORTS_COMMENT_ON_COLUMN,
+                 SUPPORTS_CREATE_TABLE_WITH_COLUMN_COMMENT,
+                 SUPPORTS_MAP_TYPE,
+                 SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_EQUALITY,
+                 SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY,
+                 SUPPORTS_PREDICATE_EXPRESSION_PUSHDOWN,
+                 SUPPORTS_ROW_TYPE,
+                 SUPPORTS_SET_COLUMN_TYPE,
+                 SUPPORTS_MERGE,
+                 SUPPORTS_ROW_LEVEL_UPDATE -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        SnowflakeQueryRunner.Builder builder = SnowflakeQueryRunner.builder()
+                .addConnectorProperty("snowflake.connection-private-key", requiredNonEmptySystemProperty("snowflake.test.server.private-key"));
+        TestingSnowflakeServer.TEST_PRIVATE_KEY_PASSWORD.ifPresent(password -> builder.addConnectorProperty("snowflake.connection-private-key-password", password));
+        return builder
+                .setInitialTables(REQUIRED_TPCH_TABLES)
+                .build();
+    }
+}

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestingSnowflakeServer.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestingSnowflakeServer.java
@@ -22,7 +22,9 @@ import java.sql.Statement;
 import java.util.Optional;
 import java.util.Properties;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.snowflake.SnowflakeClientModule.setOutputProperties;
+import static io.trino.testing.TestingProperties.optionalSystemProperty;
 import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 
 public final class TestingSnowflakeServer
@@ -31,7 +33,9 @@ public final class TestingSnowflakeServer
 
     public static final String TEST_URL = requiredNonEmptySystemProperty("snowflake.test.server.url");
     public static final String TEST_USER = requiredNonEmptySystemProperty("snowflake.test.server.user");
-    public static final String TEST_PASSWORD = requiredNonEmptySystemProperty("snowflake.test.server.password");
+    public static final Optional<String> TEST_PASSWORD = optionalSystemProperty("snowflake.test.server.password");
+    public static final Optional<String> TEST_PRIVATE_KEY = optionalSystemProperty("snowflake.test.server.private-key");
+    public static final Optional<String> TEST_PRIVATE_KEY_PASSWORD = optionalSystemProperty("snowflake.test.server.private-key-password");
     public static final String TEST_DATABASE = requiredNonEmptySystemProperty("snowflake.test.server.database");
     public static final String TEST_WAREHOUSE = requiredNonEmptySystemProperty("snowflake.test.server.warehouse");
     public static final Optional<String> TEST_ROLE = Optional.ofNullable(System.getProperty("snowflake.test.server.role"));
@@ -57,7 +61,16 @@ public final class TestingSnowflakeServer
     {
         Properties properties = new Properties();
         properties.setProperty("user", TEST_USER);
-        properties.setProperty("password", TEST_PASSWORD);
+        checkArgument(
+                TEST_PRIVATE_KEY.isPresent() || TEST_PASSWORD.isPresent(),
+                "At least one of the private key or password must be set");
+        if (TEST_PRIVATE_KEY.isPresent()) {
+            properties.setProperty("private_key_base64", TEST_PRIVATE_KEY.get());
+            TEST_PRIVATE_KEY_PASSWORD.ifPresent(password -> properties.setProperty("private_key_pwd", password));
+        }
+        else {
+            properties.setProperty("password", TEST_PASSWORD.get());
+        }
         properties.setProperty("db", TEST_DATABASE);
         properties.setProperty("schema", TEST_SCHEMA);
         properties.setProperty("warehouse", TEST_WAREHOUSE);

--- a/testing/trino-testing-services/src/main/java/io/trino/testing/TestingProperties.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testing/TestingProperties.java
@@ -20,6 +20,7 @@ import com.google.common.io.Resources;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.Optional;
 import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -69,5 +70,10 @@ public final class TestingProperties
         String value = System.getProperty(propertyName);
         checkArgument(!isNullOrEmpty(value), "System property %s must be non-empty", propertyName);
         return value;
+    }
+
+    public static Optional<String> optionalSystemProperty(String propertyName)
+    {
+        return Optional.ofNullable(System.getProperty(propertyName));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
* Adds support for key-pair authentication in the Snowflake connector through the `snowflake.connection-private-key` property, which accepts a Base64-encoded PKCS#8 RSA private key.
* Adds an optional `snowflake.connection-private-key-password` property so encrypted private keys are supported.
* The key material is passed through to the Snowflake JDBC driver (`private_key_base64` and `private_key_pwd`), which parses and decrypts it. Both encrypted and unencrypted keys are supported without any key handling in the connector.
* Users can configure key-pair authentication directly in the catalog instead of relying on file-based approaches.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
* Fixes #26514
* Provides a more secure and convenient alternative to using JDBC URL parameters with file paths and passwords.
* Particularly useful for dynamic catalog creation, where file system dependencies are harder to manage.
* Supersedes #26519, which parsed the private key inside the connector and supported unencrypted keys only. This PR delegates parsing and decryption to the driver, which adds encrypted-key support and removes the custom key-handling code. #26519 can be closed in favor of this one.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(&#x2713;) Release notes are required, with the following suggested text:

```markdown
## Snowflake connector
* Add support for key-pair authentication with the `snowflake.connection-private-key` and `snowflake.connection-private-key-password` catalog properties. (#26514)
```
