### PR TITLE
Remove testHiddenPathColumn from BaseIcebergConnectorSmokeTest

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -119,19 +119,6 @@ public abstract class BaseIcebergConnectorSmokeTest
                         "\\)");
     }
 
-    @Test
-    public void testHiddenPathColumn()
-    {
-        try (TestTable table = newTrinoTable("hidden_file_path", "(a int, b VARCHAR)", ImmutableList.of("(1, 'a')"))) {
-            String filePath = (String) computeScalar(format("SELECT file_path FROM \"%s$files\"", table.getName()));
-
-            assertQuery("SELECT DISTINCT \"$path\" FROM " + table.getName(), "VALUES " + "'" + filePath + "'");
-
-            // Check whether the "$path" hidden column is correctly evaluated in the filter expression
-            assertQuery(format("SELECT a FROM %s WHERE \"$path\" = '%s'", table.getName(), filePath), "VALUES 1");
-        }
-    }
-
     // Repeat test with invocationCount for better test coverage, since the tested aspect is inherently non-deterministic.
     @RepeatedTest(4)
     @Timeout(120)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergUnityRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergUnityRestCatalogConnectorSmokeTest.java
@@ -225,13 +225,6 @@ final class TestIcebergUnityRestCatalogConnectorSmokeTest
 
     @Test
     @Override
-    public void testHiddenPathColumn()
-    {
-        testFailsDueToReadOnlyCatalog(super::testHiddenPathColumn);
-    }
-
-    @Test
-    @Override
     public void testRowLevelDelete()
     {
         testFailsDueToReadOnlyCatalog(super::testRowLevelDelete);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/snowflake/TestIcebergSnowflakeCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/snowflake/TestIcebergSnowflakeCatalogConnectorSmokeTest.java
@@ -252,14 +252,6 @@ public class TestIcebergSnowflakeCatalogConnectorSmokeTest
 
     @Test
     @Override
-    public void testHiddenPathColumn()
-    {
-        assertThatThrownBy(super::testHiddenPathColumn)
-                .hasMessageContaining("Snowflake managed Iceberg tables do not support modifications");
-    }
-
-    @Test
-    @Override
     public void testDeleteRowsConcurrently()
     {
         assertThatThrownBy(super::testDeleteRowsConcurrently)


### PR DESCRIPTION
## Description

The BaseIcebergConnectorTest covers the functionality. Since the logic
is agnostic to the catalog implementation, there's no need to run the
test with BaseIcebergConnectorSmokeTest.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.