### PR TITLE
Fix Oracle NUMBER zero columnSize check

### DIFF
--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -190,6 +190,8 @@ public class OracleClient
     public static final int ORACLE_CHAR_MAX_CHARS = ORACLE_CHAR_MAX_BYTES / MAX_BYTES_PER_CHAR;
 
     private static final int PRECISION_OF_UNSPECIFIED_NUMBER = 127;
+    // Oracle JDBC reports columnSize=0 for NUMBER expressions (e.g. COUNT(*), SUM(), EXTRACT(...)) in passthrough queries
+    private static final int EXPRESSION_NUMBER_COLUMN_SIZE = 0;
 
     private static final int TRINO_BIGINT_TYPE = 832_424_001;
 
@@ -551,16 +553,12 @@ public class OracleClient
             case OracleTypes.NUMBER -> {
                 int columnSize = typeHandle.requiredColumnSize();
                 int decimalDigits = typeHandle.requiredDecimalDigits();
-                if (columnSize != PRECISION_OF_UNSPECIFIED_NUMBER) {
+                if (columnSize != PRECISION_OF_UNSPECIFIED_NUMBER && columnSize != EXPRESSION_NUMBER_COLUMN_SIZE) {
                     int scale = decimalDigits;
                     // Map decimal(p, -s) (negative scale) to decimal(p+s, 0).
                     // Map decimal(p, s) with s>p, to decimal(s, s).
                     int precision = max(columnSize + max(-scale, 0), scale);
                     scale = max(scale, 0);
-                    if (precision == 0) {
-                        // Oracle JDBC reports precision=0 for certain NUMBER expressions (e.g. COUNT(*) in passthrough queries)
-                        yield Optional.of(numberColumnMapping());
-                    }
                     if (precision <= Decimals.MAX_PRECISION) {
                         yield Optional.of(decimalColumnMapping(createDecimalType(precision, scale), UNNECESSARY));
                     }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
@@ -25,6 +25,7 @@ import io.trino.testing.sql.TestTable;
 import io.trino.testing.sql.TestView;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -468,6 +469,39 @@ public abstract class BaseOracleConnectorTest
         }
         finally {
             onRemoteDatabase().execute("DROP MATERIALIZED VIEW " + viewName);
+        }
+    }
+
+    @Test
+    public void testNativeQueryStoredViewExtractYearNumberZeroPrecision()
+    {
+        // EXTRACT(YEAR FROM date) returns NUMBER with columnSize=0, decimalDigits=0 via Oracle JDBC.
+        // Without the fix this would throw "DECIMAL precision must be in range [1, 38]: 0".
+        try (TestView view = new TestView(onRemoteDatabase(), getUser() + ".test_view_yr", "SELECT EXTRACT(YEAR FROM SYSDATE) AS yr FROM dual")) {
+            assertThat(query("SELECT yr FROM TABLE(system.query(query => 'SELECT yr FROM " + view.getName() + "'))"))
+                    .matches("VALUES NUMBER '" + LocalDate.now().getYear() + "'");
+        }
+    }
+
+    @Test
+    public void testNativeQueryStoredViewCountNumberZeroPrecision()
+    {
+        // COUNT(*) in a stored Oracle view returns NUMBER with columnSize=0, decimalDigits=0 via Oracle JDBC.
+        // Without the fix this would throw "DECIMAL precision must be in range [1, 38]: 0".
+        try (TestView view = new TestView(onRemoteDatabase(), getUser() + ".test_view_cnt", "SELECT COUNT(*) AS cnt FROM dual")) {
+            assertThat(query("SELECT cnt FROM TABLE(system.query(query => 'SELECT cnt FROM " + view.getName() + "'))"))
+                    .matches("VALUES NUMBER '1'");
+        }
+    }
+
+    @Test
+    public void testNativeQueryStoredViewSumNumberZeroPrecision()
+    {
+        // SUM() in a stored Oracle view returns NUMBER with columnSize=0, decimalDigits=0 via Oracle JDBC.
+        // Without the fix this would throw "DECIMAL precision must be in range [1, 38]: 0".
+        try (TestView view = new TestView(onRemoteDatabase(), getUser() + ".test_view_sum", "SELECT SUM(1) AS total FROM dual")) {
+            assertThat(query("SELECT total FROM TABLE(system.query(query => 'SELECT total FROM " + view.getName() + "'))"))
+                    .matches("VALUES NUMBER '1'");
         }
     }
 

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleClient.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleClient.java
@@ -66,7 +66,9 @@ public class TestOracleClient
             new DefaultIdentifierMapping(),
             RemoteQueryModifier.NONE);
 
-    private static final ConnectorSession SESSION = TestingConnectorSession.SESSION;
+    private static final ConnectorSession SESSION = TestingConnectorSession.builder()
+            .setPropertyMetadata(new OracleSessionProperties(new OracleConfig()).getSessionProperties())
+            .build();
 
     @Test
     public void testTypedNullWriteMapping()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->

## Description                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
Oracle JDBC reports `columnSize=0, decimalDigits=0` for computed `NUMBER`                                                                                                                                                                                                                                         
expressions — such as `COUNT(*)`, `SUM()`, and `EXTRACT(YEAR FROM …)` — when                                                                                                                                                                                                                                      
those expressions appear as columns in stored views or materialized views                                                                                                                                                                                                                                         
accessed via the `system.query()` passthrough. Querying such views previously                                                                                                                                                                                                                                     
threw:                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                    
DECIMAL precision must be in range [1, 38]: 0                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                    
The root cause was that the zero-precision guard in `OracleClient.toColumnMapping`                                                                                                                                                                                                                                
was placed **after** the scale arithmetic, checking the derived `precision`                                                                                                                                                                                                                                       
value. This worked correctly but was fragile — the guard is moved to                                                                                                                                                                                                                                              
**before** the arithmetic, checking the raw JDBC values directly:                                                                                                                                                                                                                                                 
`columnSize == 0 && decimalDigits == 0`. The two conditions are semantically                                                                                                                                                                                                                                      
equivalent; the new form is also consistent with the                                                                                                                                                                                                                                                              
  `columnSize != PRECISION_OF_UNSPECIFIED_NUMBER` guard immediately above it.                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                    
## Additional context and related issues                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                    
Affected query pattern:                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                    
```sql                                                                                                                                                                                                                                                                                                            
SELECT year(as_of_date)                                                                                                                                                                                                                                                                                           
FROM TABLE(oracle.system.query(query => 'SELECT * FROM schema.stored_view'))                                                                                                                                                                                                                                      
```                                                                                                                                                                                                                                                                                                                    
where stored_view exposes a column defined as EXTRACT(YEAR FROM some_date),                                                                                                                                                                                                                                       
COUNT(*), or SUM(expr). The connector reads JDBC metadata for the view                                                                                                                                                                                                                                            
column and encounters columnSize=0, decimalDigits=0, which was not handled                                                                                                                                                                                                                                        
before the arithmetic reached createDecimalType.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

## Oracle connector                                                                                                                                                                                                                                                                                               
  * Fix error when querying stored views that expose computed `NUMBER` columns                                                                                                                                                                                                                                      
    (such as `COUNT(*)`, `SUM()`, or `EXTRACT(YEAR FROM …)`) via the                                                                                                                                                                                                                                                
    `system.query()` passthrough. 

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
