### PR TITLE
Multiple SQL queries use same connection

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -652,12 +652,12 @@ public abstract class BaseJdbcClient
     }
 
     @Override
-    public Connection getConnection(ConnectorSession session)
+    public Connection getConnection(ConnectorSession session, boolean readOnly)
             throws SQLException
     {
         Connection connection = connectionFactory.openConnection(session);
         try {
-            connection.setReadOnly(true);
+            connection.setReadOnly(readOnly);
         }
         catch (SQLException e) {
             connection.close();
@@ -1632,7 +1632,8 @@ public abstract class BaseJdbcClient
         }
     }
 
-    protected void execute(ConnectorSession session, Connection connection, String query)
+    @Override
+    public void execute(ConnectorSession session, Connection connection, String query)
             throws SQLException
     {
         try (Statement statement = connection.createStatement()) {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -281,6 +281,13 @@ public class CachingJdbcClient
     }
 
     @Override
+    public void execute(ConnectorSession session, Connection connection, String query)
+            throws SQLException
+    {
+        delegate.execute(session, connection, query);
+    }
+
+    @Override
     public void abortReadConnection(Connection connection, ResultSet resultSet)
             throws SQLException
     {
@@ -475,6 +482,13 @@ public class CachingJdbcClient
             throws SQLException
     {
         return delegate.getConnection(session);
+    }
+
+    @Override
+    public Connection getConnection(ConnectorSession session, boolean readOnly)
+            throws SQLException
+    {
+        return delegate.getConnection(session, readOnly);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -205,6 +205,13 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
+    public void execute(ConnectorSession session, Connection connection, String query)
+            throws SQLException
+    {
+        delegate().execute(session, connection, query);
+    }
+
+    @Override
     public void abortReadConnection(Connection connection, ResultSet resultSet)
             throws SQLException
     {
@@ -340,6 +347,13 @@ public abstract class ForwardingJdbcClient
             throws SQLException
     {
         return delegate().getConnection(session);
+    }
+
+    @Override
+    public Connection getConnection(ConnectorSession session, boolean readOnly)
+            throws SQLException
+    {
+        return delegate().getConnection(session, readOnly);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -122,6 +122,9 @@ public interface JdbcClient
 
     void execute(ConnectorSession session, String query);
 
+    void execute(ConnectorSession session, Connection connection, String query)
+            throws SQLException;
+
     default void abortReadConnection(Connection connection, ResultSet resultSet)
             throws SQLException
     {
@@ -243,7 +246,13 @@ public interface JdbcClient
 
     String buildInsertSql(JdbcOutputTableHandle handle, List<WriteFunction> columnWriters);
 
-    Connection getConnection(ConnectorSession session)
+    default Connection getConnection(ConnectorSession session)
+            throws SQLException
+    {
+        return getConnection(session, true);
+    }
+
+    Connection getConnection(ConnectorSession session, boolean readOnly)
             throws SQLException;
 
     Connection getConnection(ConnectorSession session, JdbcOutputTableHandle handle)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RetryingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RetryingJdbcClient.java
@@ -211,6 +211,13 @@ public class RetryingJdbcClient
     }
 
     @Override
+    public void execute(ConnectorSession session, Connection connection, String query)
+            throws SQLException
+    {
+        retry(policy, () -> delegate.execute(session, connection, query));
+    }
+
+    @Override
     public void abortReadConnection(Connection connection, ResultSet resultSet)
             throws SQLException
     {
@@ -455,6 +462,14 @@ public class RetryingJdbcClient
     {
         // retry already implemented by RetryingConnectionFactory
         return delegate.getConnection(session);
+    }
+
+    @Override
+    public Connection getConnection(ConnectorSession session, boolean readOnly)
+            throws SQLException
+    {
+        // retry already implemented by RetryingConnectionFactory
+        return delegate.getConnection(session, readOnly);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -228,6 +228,13 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
+    public void execute(ConnectorSession session, Connection connection, String query)
+            throws SQLException
+    {
+        stats.getExecute().wrap(() -> delegate().execute(session, connection, query));
+    }
+
+    @Override
     public void abortReadConnection(Connection connection, ResultSet resultSet)
             throws SQLException
     {
@@ -430,6 +437,13 @@ public final class StatisticsAwareJdbcClient
             throws SQLException
     {
         return stats.getGetConnection().wrap(() -> delegate().getConnection(session));
+    }
+
+    @Override
+    public Connection getConnection(ConnectorSession session, boolean readOnly)
+            throws SQLException
+    {
+        return stats.getGetConnection().wrap(() -> delegate().getConnection(session, readOnly));
     }
 
     @Override

--- a/plugin/trino-duckdb/src/main/java/io/trino/plugin/duckdb/DuckDbClient.java
+++ b/plugin/trino-duckdb/src/main/java/io/trino/plugin/duckdb/DuckDbClient.java
@@ -104,7 +104,7 @@ public final class DuckDbClient
     }
 
     @Override
-    public Connection getConnection(ConnectorSession session)
+    public Connection getConnection(ConnectorSession session, boolean readOnly)
             throws SQLException
     {
         // The method calls Connection.setReadOnly method, but DuckDB does not support changing read-only status on connection level


### PR DESCRIPTION
## Description

Regarding JDBC connectors, and for performance reasons, it is important to be able to execute multiple SQL queries using the same `java.sql.Connection`.

As @ebyhr pointed out to me, **it is still necessary to open a statement for each queries** in order to support retries after an error.

This fix is ​​intended to achieve that.

## Additional context and related issues

This PR is supposed to resolve issue #30520.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix JDBC connectors must be capable of executing multiple SQL queries using the same connection. ({issue}`30520`)
```
