### PR TITLE
Document configuration for S3-compatible storage systems

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-s3.md
+++ b/docs/src/main/sphinx/object-storage/file-system-s3.md
@@ -109,6 +109,26 @@ support:
     for all requests sent to S3. Defaults to `Trino`.
 :::
 
+(fs-s3-compatible)=
+## S3-compatible storage systems
+
+In addition to [Amazon S3](https://aws.amazon.com/s3/), the native S3 support
+works with any S3-compatible object storage system. Point Trino at a compatible
+system by setting `s3.endpoint` to its service URL, together with `s3.region`
+and, if the system requires it, `s3.path-style-access`:
+
+```properties
+fs.s3.enabled=true
+s3.endpoint=https://storage.example.com
+s3.region=us-east-1
+s3.path-style-access=true
+```
+
+Replace the placeholder endpoint and region with the values for your storage
+system. Commonly used S3-compatible providers include Amazon S3, Backblaze B2,
+Cloudflare R2, and MinIO. As noted above, only Amazon S3 and MinIO are tested
+for compatibility, so validate other systems against your own workload.
+
 ## Authentication
 
 Use the following properties to configure the authentication to S3 with access


### PR DESCRIPTION
## Description

Add an `S3-compatible storage systems` section to the S3 file system page. The introduction already states that compatible systems are supported, but the page had no guidance about which properties to set for them.

The new section shows the minimal catalog properties for pointing Trino at a non-AWS endpoint (`s3.endpoint`, `s3.region`, and `s3.path-style-access`), names commonly used S3-compatible providers, and repeats the existing caveat that only Amazon S3 and MinIO are tested for compatibility.

## Additional context and related issues

Docs only, no behavior change. The example uses a placeholder endpoint and region, and the section gets an `fs-s3-compatible` anchor so other pages can cross-reference it.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
