### PR TITLE
Improve query sorting on progress in web ui by using endTime on finished and failed queries

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp/src/components/QueryList.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/QueryList.tsx
@@ -61,16 +61,15 @@ const ACTIVE_QUERY_STATES = [
 
 const SORT_TYPE = {
     PROGRESS: (queryInfo: QueryInfo) => {
-        let value = 0
         const index = ACTIVE_QUERY_STATES.findIndex((state) => state === queryInfo.state)
         if (index !== -1) {
-            value = (ACTIVE_QUERY_STATES.length - index) * 1e15
+            return (
+                (ACTIVE_QUERY_STATES.length - index) * 1e15 +
+                (100 - (queryInfo.queryStats.progressPercentage ?? 100)) * 1e12 +
+                Date.parse(queryInfo.queryStats.createTime)
+            )
         }
-        return (
-            value +
-            (100 - (queryInfo.queryStats.progressPercentage ?? 100)) * 1e12 +
-            Date.parse(queryInfo.queryStats.createTime)
-        )
+        return Date.parse(queryInfo.queryStats.endTime)
     },
     CREATED: (queryInfo: QueryInfo) => Date.parse(queryInfo.queryStats.createTime),
     ELAPSED: (queryInfo: QueryInfo) => parseDuration(queryInfo.queryStats.elapsedTime),


### PR DESCRIPTION
## Description
The new "sorting by progress" in the web ui should use the `endTime` for done queries (failed, finished) and it should omit the progressPercentage as a failed query might still have percentage stuck on < 100 causing it to rank higher than finished queries.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
## General
* Improve query sorting on progress in web ui by using endTime on finished and failed queries 
```
