### PR TITLE
Remove error translations that can never happen in CompilerUtils

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/CompilerUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/CompilerUtils.java
@@ -19,8 +19,6 @@ import io.airlift.bytecode.DynamicClassLoader;
 import io.airlift.bytecode.MethodDefinition;
 import io.airlift.bytecode.ParameterizedType;
 import io.airlift.log.Logger;
-import io.trino.spi.TrinoException;
-import org.objectweb.asm.MethodTooLargeException;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -43,7 +41,6 @@ import static io.airlift.bytecode.HiddenClassGenerator.hiddenClassGenerator;
 import static io.airlift.bytecode.ParameterizedType.type;
 import static io.airlift.bytecode.ParameterizedType.typeFromJavaClassName;
 import static io.airlift.bytecode.expression.BytecodeExpressions.invokeStatic;
-import static io.trino.spi.StandardErrorCode.QUERY_EXCEEDED_COMPILER_LIMIT;
 import static java.time.ZoneOffset.UTC;
 
 public final class CompilerUtils
@@ -135,15 +132,11 @@ public final class CompilerUtils
     public static <T> Class<? extends T> defineClass(ClassDefinition classDefinition, Class<T> superType, DynamicClassLoader classLoader)
     {
         log.debug("Defining class: %s", classDefinition.getName());
-        try {
-            return classGenerator(classLoader)
-                    .omitDebugInfo(DUMP_CLASSES_DIRECTORY.isEmpty())
-                    .dumpClassFilesTo(DUMP_CLASSES_DIRECTORY)
-                    .defineClass(classDefinition, superType);
-        }
-        catch (MethodTooLargeException e) {
-            throw new TrinoException(QUERY_EXCEEDED_COMPILER_LIMIT, "Query exceeded maximum method size.", e);
-        }
+
+        return classGenerator(classLoader)
+                .omitDebugInfo(DUMP_CLASSES_DIRECTORY.isEmpty())
+                .dumpClassFilesTo(DUMP_CLASSES_DIRECTORY)
+                .defineClass(classDefinition, superType);
     }
 
     /**
@@ -175,15 +168,11 @@ public final class CompilerUtils
     private static <T> Class<? extends T> defineHiddenClass(ClassDefinition classDefinition, Class<T> superType, Lookup lookup, List<Object> classData)
     {
         log.debug("Defining hidden class: %s", classDefinition.getName());
-        try {
-            // production servers never inspect SourceFile, LineNumberTable, or LocalVariableTable
-            return hiddenClassGenerator(lookup)
-                    .omitDebugInfo(DUMP_CLASSES_DIRECTORY.isEmpty())
-                    .dumpClassFilesTo(DUMP_CLASSES_DIRECTORY)
-                    .defineHiddenClass(classDefinition, superType, Optional.of(ImmutableList.copyOf(classData)));
-        }
-        catch (MethodTooLargeException e) {
-            throw new TrinoException(QUERY_EXCEEDED_COMPILER_LIMIT, "Query exceeded maximum method size.", e);
-        }
+
+        // production servers never inspect SourceFile, LineNumberTable, or LocalVariableTable
+        return hiddenClassGenerator(lookup)
+                .omitDebugInfo(DUMP_CLASSES_DIRECTORY.isEmpty())
+                .dumpClassFilesTo(DUMP_CLASSES_DIRECTORY)
+                .defineHiddenClass(classDefinition, superType, Optional.of(ImmutableList.copyOf(classData)));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
`MethodTooLargeException` could happen in `ByteCodeGenerator.generateByteCode()`. However, it's caught and wrapped inside the method:
https://github.com/airlift/bytecode/blob/bafeaa8cf4d2e45d85d0af074ee51cafae4e2ed7/src/main/java/io/airlift/bytecode/ByteCodeGenerator.java#L123-L125

Therefore, it can never fall into the catch blocks in `CompilerUtils`.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
The catch block was originally introduced in https://github.com/trinodb/trino/pull/24536. However, I think it has never worked. Instead, the following PRs would handle `MethodTooLargeException`.

- https://github.com/trinodb/trino/pull/23662
- https://github.com/trinodb/trino/pull/30529


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
