### PR TITLE
Use RLE for single-entry dictionaries

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
@@ -248,7 +248,11 @@ public class FlatGroupByHash
         int positionCount = blocks[0].getPositionCount();
         long cardinality = 1;
         for (int channel = 0; channel < groupByChannelCount; channel++) {
-            if (!(blocks[channel] instanceof DictionaryBlock dictionaryBlock)) {
+            Block block = blocks[channel];
+            if (block instanceof RunLengthEncodedBlock) {
+                continue;
+            }
+            if (!(block instanceof DictionaryBlock dictionaryBlock)) {
                 return false;
             }
             cardinality = multiplyExact(cardinality, dictionaryBlock.getDictionary().getPositionCount());
@@ -727,6 +731,10 @@ public class FlatGroupByHash
         int maxCardinality = 1;
         for (int channel = 0; channel < groupByChannelCount; channel++) {
             Block block = blocks[channel];
+            // RLE is equivalent to a dictionary with cardinality one and id zero.
+            if (block instanceof RunLengthEncodedBlock) {
+                continue;
+            }
             verify(block instanceof DictionaryBlock, "Only dictionary blocks are supported");
             DictionaryBlock dictionaryBlock = (DictionaryBlock) block;
             int dictionarySize = dictionaryBlock.getDictionary().getPositionCount();

--- a/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
@@ -496,8 +496,12 @@ public final class BlockAssertions
     public static Block createStringDictionaryBlock(int start, int length)
     {
         checkArgument(length > 5, "block must have more than 5 entries");
+        return createStringDictionaryBlock(start, length, length / 5);
+    }
 
-        int dictionarySize = length / 5;
+    public static Block createStringDictionaryBlock(int start, int length, int dictionarySize)
+    {
+        checkArgument(dictionarySize > 0, "dictionarySize must be greater than 0");
         BlockBuilder builder = VARCHAR.createBlockBuilder(null, dictionarySize);
         for (int i = start; i < start + dictionarySize; i++) {
             VARCHAR.writeString(builder, String.valueOf(i));

--- a/core/trino-main/src/test/java/io/trino/block/TestDictionaryBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestDictionaryBlock.java
@@ -20,6 +20,7 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.DictionaryId;
 import io.trino.spi.block.IntArrayBlock;
+import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.block.ValueBlock;
 import io.trino.spi.block.VariableWidthBlock;
 import io.trino.spi.block.VariableWidthBlockBuilder;
@@ -62,6 +63,29 @@ public class TestDictionaryBlock
     }
 
     @Test
+    public void testConstructionSingleEntryDictionary()
+    {
+        Slice[] expectedValues = createExpectedValues(1);
+        Block dictionary = createSlicesBlock(expectedValues);
+        Block block = DictionaryBlock.create(5, dictionary, new int[5]);
+
+        assertThat(block).isInstanceOf(RunLengthEncodedBlock.class);
+        assertThat(((RunLengthEncodedBlock) block).getValue()).isSameAs(dictionary);
+        assertBlock(block, new Slice[] {
+                expectedValues[0], expectedValues[0], expectedValues[0], expectedValues[0], expectedValues[0],
+        });
+    }
+
+    @Test
+    public void testConstructionSingleNullEntryDictionary()
+    {
+        Block block = DictionaryBlock.create(5, createSlicesBlock(new Slice[] {null}), new int[5]);
+
+        assertThat(block).isInstanceOf(RunLengthEncodedBlock.class);
+        assertBlock(block, new Slice[] {null, null, null, null, null});
+    }
+
+    @Test
     public void testConstructionUnnestDictionary()
     {
         Slice[] expectedValues = createExpectedValues(10);
@@ -87,13 +111,15 @@ public class TestDictionaryBlock
     }
 
     @Test
-    public void testCopyRegionCreatesCompactBlock()
+    public void testCopyRegionWithUniqueValues()
     {
         Slice[] expectedValues = createExpectedValues(10);
         DictionaryBlock dictionaryBlock = createDictionaryBlock(expectedValues, 100);
 
-        DictionaryBlock copyRegionDictionaryBlock = (DictionaryBlock) dictionaryBlock.copyRegion(1, 3);
-        assertThat(copyRegionDictionaryBlock.isCompact()).isTrue();
+        Block copyRegionBlock = dictionaryBlock.copyRegion(1, 3);
+
+        assertThat(copyRegionBlock).isInstanceOf(VariableWidthBlock.class);
+        assertBlock(copyRegionBlock, new Slice[] {expectedValues[1], expectedValues[2], expectedValues[3]});
     }
 
     @Test
@@ -104,11 +130,10 @@ public class TestDictionaryBlock
         DictionaryBlock dictionaryBlock = createDictionaryBlock(expectedValues, 100);
 
         int[] positionsToCopy = {0, 10, 20, 30, 40};
-        DictionaryBlock copiedBlock = (DictionaryBlock) dictionaryBlock.copyPositions(positionsToCopy, 0, positionsToCopy.length);
+        Block copiedBlock = dictionaryBlock.copyPositions(positionsToCopy, 0, positionsToCopy.length);
 
-        assertThat(copiedBlock.getDictionary().getPositionCount()).isEqualTo(1);
+        assertThat(copiedBlock).isInstanceOf(RunLengthEncodedBlock.class);
         assertThat(copiedBlock.getPositionCount()).isEqualTo(positionsToCopy.length);
-        assertBlock(copiedBlock.getDictionary(), new Slice[] {firstExpectedValue});
         assertBlock(copiedBlock, new Slice[] {
                 firstExpectedValue, firstExpectedValue, firstExpectedValue, firstExpectedValue, firstExpectedValue,
         });
@@ -123,6 +148,7 @@ public class TestDictionaryBlock
 
         DictionaryBlock copiedBlock = (DictionaryBlock) dictionaryBlock.copyPositions(positionsToCopy, 0, positionsToCopy.length);
 
+        assertThat(copiedBlock.isCompact()).isTrue();
         assertThat(copiedBlock.getDictionary().getPositionCount()).isEqualTo(2);
         assertThat(copiedBlock.getPositionCount()).isEqualTo(positionsToCopy.length);
 
@@ -137,24 +163,24 @@ public class TestDictionaryBlock
         DictionaryBlock dictionaryBlock = createDictionaryBlock(expectedValues, 100);
         int[] positionsToCopy = {52, 52, 52};
 
-        DictionaryBlock copiedBlock = (DictionaryBlock) dictionaryBlock.copyPositions(positionsToCopy, 0, positionsToCopy.length);
+        Block copiedBlock = dictionaryBlock.copyPositions(positionsToCopy, 0, positionsToCopy.length);
 
-        assertThat(copiedBlock.getDictionary().getPositionCount()).isEqualTo(1);
+        assertThat(copiedBlock).isInstanceOf(RunLengthEncodedBlock.class);
         assertThat(copiedBlock.getPositionCount()).isEqualTo(positionsToCopy.length);
 
-        assertBlock(copiedBlock.getDictionary(), new Slice[] {expectedValues[2]});
-        assertDictionaryIds(copiedBlock, 0, 0, 0);
+        assertBlock(copiedBlock, new Slice[] {expectedValues[2], expectedValues[2], expectedValues[2]});
     }
 
     @Test
     public void testCopyPositionsNoCompaction()
     {
-        Slice[] expectedValues = createExpectedValues(1);
+        Slice[] expectedValues = createExpectedValues(2);
         DictionaryBlock dictionaryBlock = createDictionaryBlock(expectedValues, 100);
 
-        int[] positionsToCopy = {0, 2, 4, 5};
+        int[] positionsToCopy = {0, 1, 2, 3};
         DictionaryBlock copiedBlock = (DictionaryBlock) dictionaryBlock.copyPositions(positionsToCopy, 0, positionsToCopy.length);
 
+        assertThat(copiedBlock.isCompact()).isTrue();
         assertThat(copiedBlock.getPositionCount()).isEqualTo(positionsToCopy.length);
         assertBlock(copiedBlock.getDictionary(), expectedValues);
     }
@@ -166,7 +192,9 @@ public class TestDictionaryBlock
         DictionaryBlock dictionaryBlock = createDictionaryBlockWithUnreferencedKeys(expectedValues, 10);
 
         assertThat(dictionaryBlock.isCompact()).isEqualTo(false);
-        DictionaryBlock compactBlock = dictionaryBlock.compact();
+        Block compactedBlock = dictionaryBlock.compact();
+        assertThat(compactedBlock).isInstanceOf(DictionaryBlock.class);
+        DictionaryBlock compactBlock = (DictionaryBlock) compactedBlock;
         assertThat(dictionaryBlock.getDictionarySourceId())
                 .isNotEqualTo(compactBlock.getDictionarySourceId());
 
@@ -175,8 +203,7 @@ public class TestDictionaryBlock
         assertDictionaryIds(compactBlock, 0, 1, 1, 2, 2, 0, 1, 1, 2, 2);
         assertThat(compactBlock.isCompact()).isEqualTo(true);
 
-        DictionaryBlock reCompactedBlock = compactBlock.compact();
-        assertThat(reCompactedBlock.getDictionarySourceId()).isEqualTo(compactBlock.getDictionarySourceId());
+        assertThat(compactBlock.compact()).isSameAs(compactBlock);
     }
 
     @Test
@@ -184,15 +211,53 @@ public class TestDictionaryBlock
     {
         Slice[] expectedValues = createExpectedValues(5);
         DictionaryBlock dictionaryBlock = createDictionaryBlock(expectedValues, 10);
-        DictionaryBlock compactBlock = dictionaryBlock.compact();
+        Block compactBlock = dictionaryBlock.compact();
 
         // When there is nothing to compact, we return the same block
-        assertThat(compactBlock.getDictionary()).isEqualTo(dictionaryBlock.getDictionary());
-        assertThat(compactBlock.getPositionCount()).isEqualTo(dictionaryBlock.getPositionCount());
-        for (int position = 0; position < compactBlock.getPositionCount(); position++) {
-            assertThat(compactBlock.getId(position)).isEqualTo(dictionaryBlock.getId(position));
-        }
-        assertThat(compactBlock.isCompact()).isEqualTo(true);
+        assertThat(compactBlock).isSameAs(dictionaryBlock);
+    }
+
+    @Test
+    public void testCompactIdentityDictionary()
+    {
+        Block dictionary = createSlicesBlock(createExpectedValues(5));
+        DictionaryBlock dictionaryBlock = (DictionaryBlock) DictionaryBlock.create(5, dictionary, new int[] {0, 1, 2, 3, 4});
+
+        assertThat(dictionaryBlock.compact()).isSameAs(dictionary);
+    }
+
+    @Test
+    public void testCompactIdentityGetPositions()
+    {
+        Block dictionary = createSlicesBlock(createExpectedValues(5));
+        DictionaryBlock dictionaryBlock = (DictionaryBlock) DictionaryBlock.create(5, dictionary, new int[] {0, 1, 2, 3, 4});
+
+        DictionaryBlock selectedBlock = (DictionaryBlock) dictionaryBlock.getPositions(new int[] {0, 1, 2, 3, 4}, 0, 5);
+
+        assertThat(selectedBlock.compact()).isSameAs(dictionary);
+    }
+
+    @Test
+    public void testCompactCopyWithAppendedNull()
+    {
+        Block dictionary = createSlicesBlock(createExpectedValues(5));
+        DictionaryBlock dictionaryBlock = (DictionaryBlock) DictionaryBlock.create(5, dictionary, new int[] {0, 1, 2, 3, 4});
+
+        DictionaryBlock blockWithNull = (DictionaryBlock) dictionaryBlock.copyWithAppendedNull();
+
+        assertThat(blockWithNull.compact()).isSameAs(blockWithNull.getDictionary());
+    }
+
+    @Test
+    public void testCompactUniqueEntries()
+    {
+        Slice[] expectedValues = createExpectedValues(10);
+        DictionaryBlock dictionaryBlock = (DictionaryBlock) DictionaryBlock.create(4, createSlicesBlock(expectedValues), new int[] {1, 3, 5, 7});
+
+        Block compactBlock = dictionaryBlock.compact();
+
+        assertThat(compactBlock).isInstanceOf(VariableWidthBlock.class);
+        assertBlock(compactBlock, new Slice[] {expectedValues[1], expectedValues[3], expectedValues[5], expectedValues[7]});
     }
 
     @Test
@@ -256,8 +321,7 @@ public class TestDictionaryBlock
     @Test
     public void testCompactGetPositions()
     {
-        DictionaryBlock block = (DictionaryBlock) DictionaryBlock.create(6, createSlicesBlock(createExpectedValues(10)), new int[] {0, 1, 2, 3, 4, 5});
-        block = block.compact();
+        DictionaryBlock block = (DictionaryBlock) DictionaryBlock.create(6, createSlicesBlock(createExpectedValues(6)), new int[] {0, 1, 2, 3, 4, 5});
 
         // 3, 3, 4, 5, 2, 0, 1, 1
         block = (DictionaryBlock) block.getPositions(new int[] {3, 3, 4, 5, 2, 0, 1, 1}, 0, 7);
@@ -271,7 +335,7 @@ public class TestDictionaryBlock
         block = (DictionaryBlock) block.getPositions(new int[] {0, 2, 0, 2, 0}, 0, 5);
         assertThat(block.isCompact()).isFalse();
 
-        block = block.compact();
+        block = (DictionaryBlock) block.compact();
         // 3, 4, 4, 4
         block = (DictionaryBlock) block.getPositions(new int[] {0, 1, 1, 1}, 0, 4);
         assertThat(block.isCompact()).isTrue();
@@ -280,19 +344,14 @@ public class TestDictionaryBlock
         block = (DictionaryBlock) block.getPositions(new int[] {1, 1, 1, 1}, 0, 4);
         assertThat(block.isCompact()).isFalse();
 
-        block = block.compact();
-        // 4
-        block = (DictionaryBlock) block.getPositions(new int[] {0}, 0, 1);
-        assertThat(block.isCompact()).isTrue();
+        assertThat(block.getPositions(new int[] {0}, 0, 1)).isInstanceOf(VariableWidthBlock.class);
+        assertThat(block.getPositions(new int[] {}, 0, 0)).isInstanceOf(VariableWidthBlock.class);
 
-        // empty
-        block = (DictionaryBlock) block.getPositions(new int[] {}, 0, 0);
-        assertThat(block.isCompact()).isFalse();
-
-        block = block.compact();
-        // empty
-        block = (DictionaryBlock) block.getPositions(new int[] {}, 0, 0);
-        assertThat(block.isCompact()).isTrue();
+        Block compactBlock = block.compact();
+        assertThat(compactBlock).isInstanceOf(RunLengthEncodedBlock.class);
+        assertBlock(compactBlock, new Slice[] {
+                createExpectedValue(4), createExpectedValue(4), createExpectedValue(4), createExpectedValue(4),
+        });
     }
 
     @Test
@@ -324,7 +383,8 @@ public class TestDictionaryBlock
         double averageEntrySize = dictionary.getSizeInBytes() / (double) entryCount;
 
         int[] allIds = IntStream.range(0, entryCount).toArray();
-        assertThat(DictionaryBlock.create(allIds.length, dictionary, allIds).getSizeInBytes()).isEqualTo(dictionary.getSizeInBytes() + (Integer.BYTES * (long) entryCount));
+        Block dictionaryBlock = DictionaryBlock.create(allIds.length, dictionary, allIds);
+        assertThat(dictionaryBlock.getSizeInBytes()).isEqualTo(dictionary.getSizeInBytes() + (Integer.BYTES * (long) entryCount));
 
         int firstHalfLength = entryCount / 2;
         int secondHalfLength = entryCount - firstHalfLength;
@@ -333,8 +393,10 @@ public class TestDictionaryBlock
 
         assertThat(DictionaryBlock.create(firstHalfIds.length, dictionary, firstHalfIds).getSizeInBytes()).isEqualTo((long) (averageEntrySize * firstHalfLength) + (Integer.BYTES * (long) firstHalfLength));
         assertThat(DictionaryBlock.create(secondHalfIds.length, dictionary, secondHalfIds).getSizeInBytes()).isEqualTo((long) (averageEntrySize * secondHalfLength) + (Integer.BYTES * (long) secondHalfLength));
-        assertThat(DictionaryBlock.create(allIds.length, dictionary, allIds).getRegionSizeInBytes(0, firstHalfLength)).isEqualTo((long) (averageEntrySize * firstHalfLength) + (Integer.BYTES * (long) firstHalfLength));
-        assertThat(DictionaryBlock.create(allIds.length, dictionary, allIds).getRegionSizeInBytes(firstHalfLength, secondHalfLength)).isEqualTo((long) (averageEntrySize * secondHalfLength) + (Integer.BYTES * (long) secondHalfLength));
+        assertThat(dictionaryBlock.getRegionSizeInBytes(0, firstHalfLength)).isEqualTo((long) (averageEntrySize * firstHalfLength) + (Integer.BYTES * (long) firstHalfLength));
+        assertThat(dictionaryBlock.getRegionSizeInBytes(firstHalfLength, secondHalfLength)).isEqualTo((long) (averageEntrySize * secondHalfLength) + (Integer.BYTES * (long) secondHalfLength));
+        assertThat(dictionaryBlock.getRegionSizeInBytes(0, 0)).isEqualTo(dictionaryBlock.getRegion(0, 0).getSizeInBytes());
+        assertThat(dictionaryBlock.getRegionSizeInBytes(1, 1)).isEqualTo(dictionaryBlock.getRegion(1, 1).getSizeInBytes());
     }
 
     private static DictionaryBlock createDictionaryBlockWithUnreferencedKeys(Slice[] expectedValues, int positionCount)

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupByHash.java
@@ -524,14 +524,15 @@ public class TestGroupByHash
     {
         GroupByHash groupByHash = createGroupByHash(
                 TEST_SESSION,
-                ImmutableList.of(BIGINT, BIGINT),
+                ImmutableList.of(BIGINT, BIGINT, BIGINT),
                 false,
                 100,
                 new FlatHashStrategyCompiler(new TypeOperators(), new NullSafeHashCompiler(new TypeOperators())),
                 NOOP);
         Block firstBlock = BlockAssertions.createLongDictionaryBlock(0, 1000, 10);
         Block secondBlock = BlockAssertions.createLongDictionaryBlock(0, 1000, 10);
-        Page page = new Page(firstBlock, secondBlock);
+        Block rleBlock = BlockAssertions.createRepeatedValuesBlock(0, 1000);
+        Page page = new Page(firstBlock, secondBlock, rleBlock);
 
         Work<?> work = groupByHash.addPage(page);
         assertThat(work).isInstanceOf(FlatGroupByHash.AddLowCardinalityDictionaryPageWork.class);
@@ -540,7 +541,7 @@ public class TestGroupByHash
 
         firstBlock = BlockAssertions.createLongDictionaryBlock(10, 1000, 5);
         secondBlock = BlockAssertions.createLongDictionaryBlock(10, 1000, 7);
-        page = new Page(firstBlock, secondBlock);
+        page = new Page(firstBlock, secondBlock, rleBlock);
 
         groupByHash.addPage(page).process();
         assertThat(groupByHash.getGroupCount()).isEqualTo(45); // Old 10 groups and 35 new
@@ -549,7 +550,7 @@ public class TestGroupByHash
     @Test
     public void testLowCardinalityDictionariesGetGroupIds()
     {
-        // Compare group ids results from page with dictionaries only (processed via low cardinality work) and the same page processed normally
+        // Compare group ids results from page with dictionaries and RLE (processed via low cardinality work) and the same page processed normally
         GroupByHash groupByHash = createGroupByHash(
                 TEST_SESSION,
                 ImmutableList.of(BIGINT, BIGINT, BIGINT, BIGINT, BIGINT),
@@ -560,24 +561,26 @@ public class TestGroupByHash
 
         GroupByHash lowCardinalityGroupByHash = createGroupByHash(
                 TEST_SESSION,
-                ImmutableList.of(BIGINT, BIGINT, BIGINT, BIGINT),
+                ImmutableList.of(BIGINT, BIGINT, BIGINT, BIGINT, BIGINT),
                 false,
                 100,
                 new FlatHashStrategyCompiler(new TypeOperators(), new NullSafeHashCompiler(new TypeOperators())),
                 NOOP);
-        Block sameValueBlock = BlockAssertions.createLongRepeatBlock(0, 100);
-        Block block1 = BlockAssertions.createLongDictionaryBlock(0, 100, 1);
+        Block rleBlock = BlockAssertions.createRepeatedValuesBlock(0, 100);
+        Block flatSameValueBlock = new LongArrayBlock(100, Optional.empty(), new long[100]);
+        Block block1 = BlockAssertions.createLongDictionaryBlock(0, 100, 2);
         Block block2 = BlockAssertions.createLongDictionaryBlock(0, 100, 2);
-        Block block3 = BlockAssertions.createLongDictionaryBlock(0, 100, 3);
-        Block block4 = BlockAssertions.createLongDictionaryBlock(0, 100, 4);
-        // Combining block 2 and 4 will result in only 4 distinct values since 2 and 4 are not coprime
+        Block block3 = BlockAssertions.createLongDictionaryBlock(0, 100, 2);
+        Block block4 = BlockAssertions.createLongDictionaryBlock(0, 100, 3);
+        // The 24 possible dictionary combinations are within the low cardinality threshold
 
-        Page lowCardinalityPage = new Page(block1, block2, block3, block4);
-        Page page = new Page(block1, block2, block3, block4, sameValueBlock); // sameValueBlock will prevent low cardinality optimization to fire
+        Page lowCardinalityPage = new Page(block1, block2, block3, block4, rleBlock);
+        Page page = new Page(block1, block2, block3, block4, flatSameValueBlock);
 
         Work<int[]> lowCardinalityWork = lowCardinalityGroupByHash.getGroupIds(lowCardinalityPage);
         assertThat(lowCardinalityWork).isInstanceOf(FlatGroupByHash.GetLowCardinalityDictionaryGroupIdsWork.class);
         Work<int[]> work = groupByHash.getGroupIds(page);
+        assertThat(work).isInstanceOf(FlatGroupByHash.GetNonDictionaryGroupIdsWork.class);
 
         lowCardinalityWork.process();
         work.process();
@@ -627,13 +630,13 @@ public class TestGroupByHash
     public void testProperWorkTypesSelected()
     {
         Block bigintBlock = createLongsBlock(1, 2, 3, 4, 5, 6, 7, 8);
-        Block bigintDictionaryBlock = BlockAssertions.createLongDictionaryBlock(0, 8);
+        Block bigintDictionaryBlock = BlockAssertions.createLongDictionaryBlock(0, 16, 2);
         Block bigintRleBlock = BlockAssertions.createRepeatedValuesBlock(42, 8);
         Block varcharBlock = BlockAssertions.createStringsBlock("1", "2", "3", "4", "5", "6", "7", "8");
-        Block varcharDictionaryBlock = BlockAssertions.createStringDictionaryBlock(1, 8);
+        Block varcharDictionaryBlock = BlockAssertions.createStringDictionaryBlock(1, 16, 2);
         Block varcharRleBlock = RunLengthEncodedBlock.create(new VariableWidthBlock(1, Slices.EMPTY_SLICE, new int[] {0, 1}, Optional.empty()), 8);
-        Block bigintBigDictionaryBlock = BlockAssertions.createLongDictionaryBlock(1, 8, 1000);
-        Block bigintSingletonDictionaryBlock = BlockAssertions.createLongDictionaryBlock(1, 500000, 1);
+        Block bigintBigDictionaryBlock = BlockAssertions.createLongDictionaryBlock(1, 16, 1000);
+        Block bigintSmallDictionaryBlock = BlockAssertions.createLongDictionaryBlock(1, 500000, 2);
         Block bigintHugeDictionaryBlock = BlockAssertions.createLongDictionaryBlock(1, 500000, 66000); // Above Short.MAX_VALUE
 
         Page singleBigintPage = new Page(bigintBlock);
@@ -651,11 +654,13 @@ public class TestGroupByHash
 
         Page lowCardinalityDictionaryPage = new Page(bigintDictionaryBlock, varcharDictionaryBlock);
         assertGroupByHashWork(lowCardinalityDictionaryPage, ImmutableList.of(BIGINT, VARCHAR), FlatGroupByHash.GetLowCardinalityDictionaryGroupIdsWork.class);
+        Page lowCardinalityDictionaryAndRlePage = new Page(BlockAssertions.createRepeatedValuesBlock(42, 16), varcharDictionaryBlock);
+        assertGroupByHashWork(lowCardinalityDictionaryAndRlePage, ImmutableList.of(BIGINT, VARCHAR), FlatGroupByHash.GetLowCardinalityDictionaryGroupIdsWork.class);
         Page highCardinalityDictionaryPage = new Page(bigintDictionaryBlock, bigintBigDictionaryBlock);
         assertGroupByHashWork(highCardinalityDictionaryPage, ImmutableList.of(BIGINT, VARCHAR), FlatGroupByHash.GetNonDictionaryGroupIdsWork.class);
 
         // Cardinality above Short.MAX_VALUE
-        Page lowCardinalityHugeDictionaryPage = new Page(bigintSingletonDictionaryBlock, bigintHugeDictionaryBlock);
+        Page lowCardinalityHugeDictionaryPage = new Page(bigintSmallDictionaryBlock, bigintHugeDictionaryBlock);
         assertGroupByHashWork(lowCardinalityHugeDictionaryPage, ImmutableList.of(BIGINT, BIGINT), FlatGroupByHash.GetNonDictionaryGroupIdsWork.class);
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPagePartitioner.java
@@ -508,17 +508,18 @@ public class TestPagePartitioner
     }
 
     @Test
-    public void testOutputForOneValueDictionaryBlock()
+    public void testOutputForSingleEntryDictionary()
     {
-        testOutputForOneValueDictionaryBlock(PartitioningMode.ROW_WISE);
-        testOutputForOneValueDictionaryBlock(PartitioningMode.COLUMNAR);
+        testOutputForSingleEntryDictionary(PartitioningMode.ROW_WISE);
+        testOutputForSingleEntryDictionary(PartitioningMode.COLUMNAR);
     }
 
-    private void testOutputForOneValueDictionaryBlock(PartitioningMode partitioningMode)
+    private void testOutputForSingleEntryDictionary(PartitioningMode partitioningMode)
     {
         TestOutputBuffer outputBuffer = new TestOutputBuffer();
         PagePartitioner multiPartitionPartitioner = pagePartitioner(outputBuffer, BIGINT).build();
         Page page = new Page(DictionaryBlock.create(4, createLongsBlock(0), new int[] {0, 0, 0, 0}));
+        assertThat(page.getBlock(0)).isInstanceOf(RunLengthEncodedBlock.class);
 
         processPages(multiPartitionPartitioner, partitioningMode, page);
 

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
@@ -16,6 +16,7 @@ package io.trino.operator.output;
 import io.airlift.slice.Slices;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.block.ValueBlock;
@@ -27,7 +28,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.trino.block.BlockAssertions.createRandomBlockForType;
-import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.Math.toIntExact;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -138,8 +138,11 @@ public class TestPositionsAppenderPageBuilder
                 List.of(VARCHAR),
                 new PositionsAppenderFactory(new BlockTypeOperators()));
 
-        Block valueBlock = writeNativeValue(VARCHAR, Slices.utf8Slice("test"));
-        Block dictionaryBlock = DictionaryBlock.create(10, valueBlock, new int[10]);
+        BlockBuilder dictionaryBuilder = VARCHAR.createBlockBuilder(null, 2);
+        VARCHAR.writeString(dictionaryBuilder, "first");
+        VARCHAR.writeString(dictionaryBuilder, "second");
+        Block valueBlock = dictionaryBuilder.build();
+        Block dictionaryBlock = DictionaryBlock.create(10, valueBlock, new int[] {0, 1, 0, 1, 0, 1, 0, 1, 0, 1});
         Page inputPage = new Page(dictionaryBlock);
 
         pageBuilder.appendToOutputPartition(inputPage, IntArrayList.wrap(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageFilter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageFilter.java
@@ -87,7 +87,9 @@ public class TestDictionaryAwarePageFilter
         testFilter(createDictionaryBlock(20, 0), LongArrayBlock.class);
 
         // match all
-        testFilter(DictionaryBlock.create(100, createLongSequenceBlock(4, 5), new int[100]), LongArrayBlock.class);
+        int[] ids = new int[100];
+        Arrays.setAll(ids, index -> index % 2);
+        testFilter(DictionaryBlock.create(100, createLongsBlock(4, 7), ids), LongArrayBlock.class);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestDictionaryAwareColumnarFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestDictionaryAwareColumnarFilter.java
@@ -117,7 +117,9 @@ public class TestDictionaryAwareColumnarFilter
         testFilter(createDictionaryBlock(20, 0), LongArrayBlock.class);
 
         // match all
-        testFilter(DictionaryBlock.create(100, createLongSequenceBlock(4, 5), new int[100]), LongArrayBlock.class);
+        int[] ids = new int[100];
+        Arrays.setAll(ids, index -> index % 2);
+        testFilter(DictionaryBlock.create(100, createLongsBlock(4, 7), ids), LongArrayBlock.class);
     }
 
     @Test

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -231,6 +231,18 @@
                                 </item>
                                 <!-- Backwards incompatible changes since the previous release -->
                                 <item>
+                                    <code>java.method.returnTypeChanged</code>
+                                    <old>method io.trino.spi.block.DictionaryBlock io.trino.spi.block.DictionaryBlock::compact()</old>
+                                    <new>method io.trino.spi.block.Block io.trino.spi.block.DictionaryBlock::compact()</new>
+                                    <justification>Dictionary compaction can produce a simpler block representation.</justification>
+                                </item>
+                                <item>
+                                    <code>java.method.returnTypeTypeParametersChanged</code>
+                                    <old>method java.util.List&lt;io.trino.spi.block.DictionaryBlock&gt; io.trino.spi.block.DictionaryBlock::compactRelatedBlocks(java.util.List&lt;io.trino.spi.block.DictionaryBlock&gt;)</old>
+                                    <new>method java.util.List&lt;? extends io.trino.spi.block.Block&gt; io.trino.spi.block.DictionaryBlock::compactRelatedBlocks(java.util.List&lt;io.trino.spi.block.DictionaryBlock&gt;)</new>
+                                    <justification>Related dictionary compaction can produce simpler block representations.</justification>
+                                </item>
+                                <item>
                                     <code>java.method.visibilityIncreased</code>
                                     <old>method int io.trino.spi.block.ArrayBlock::getOffsetBase()</old>
                                 </item>

--- a/core/trino-spi/src/main/java/io/trino/spi/Page.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Page.java
@@ -186,7 +186,7 @@ public final class Page
 
         Map<DictionaryId, DictionaryBlockIndexes> dictionaryBlocks = getRelatedDictionaryBlocks();
         for (DictionaryBlockIndexes blockIndexes : dictionaryBlocks.values()) {
-            List<DictionaryBlock> compactBlocks = DictionaryBlock.compactRelatedBlocks(blockIndexes.getBlocks());
+            List<? extends Block> compactBlocks = DictionaryBlock.compactRelatedBlocks(blockIndexes.getBlocks());
             List<Integer> indexes = blockIndexes.getIndexes();
             for (int i = 0; i < compactBlocks.size(); i++) {
                 blocks[indexes.get(i)] = compactBlocks.get(i);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -28,11 +28,29 @@ import static io.trino.spi.block.DictionaryId.randomDictionaryId;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
+/**
+ * A dictionary block maps each position to a position in an underlying dictionary.
+ * <p>
+ * A dictionary block and its underlying dictionary both contain at least two positions.
+ * <p>
+ * Methods returning {@link Block} may return a simpler equivalent representation:
+ * <ul>
+ * <li>empty and single-position results are returned directly from the dictionary;</li>
+ * <li>multi-position results backed by a single-entry or run-length encoded dictionary are
+ * represented as a {@link RunLengthEncodedBlock};</li>
+ * <li>compacted identity mappings are returned directly as the underlying value block; and</li>
+ * <li>nested dictionaries are flattened to a single dictionary layer.</li>
+ * </ul>
+ * Callers should not assume the returned block is a {@link DictionaryBlock}.
+ */
 public final class DictionaryBlock
         implements Block
 {
     private static final int INSTANCE_SIZE = instanceSize(DictionaryBlock.class) + instanceSize(DictionaryId.class);
     private static final int NULL_NOT_FOUND = -1;
+    private static final byte SEQUENTIAL_IDS_UNCHECKED = 0;
+    private static final byte SEQUENTIAL_IDS = 1;
+    private static final byte NON_SEQUENTIAL_IDS = 2;
 
     private final int positionCount;
     private final ValueBlock dictionary;
@@ -41,8 +59,10 @@ public final class DictionaryBlock
     private final long retainedSizeInBytes;
     private volatile long sizeInBytes = -1;
     private volatile int uniqueIds = -1;
-    // isSequentialIds is only valid when uniqueIds is computed
-    private volatile boolean isSequentialIds;
+    // SEQUENTIAL_IDS_UNCHECKED means the ids have not been inspected. The computed states are valid
+    // independently from uniqueIds because some construction paths know only one fact. countUniqueIds
+    // publishes uniqueIds before the computed sequential state.
+    private volatile byte sequentialIdsState = SEQUENTIAL_IDS_UNCHECKED;
     private final DictionaryId dictionarySourceId;
     private final boolean mayHaveNull;
 
@@ -61,11 +81,8 @@ public final class DictionaryBlock
 
     static Block createInternal(int idsOffset, int positionCount, Block dictionary, int[] ids, DictionaryId dictionarySourceId)
     {
-        if (positionCount == 0) {
-            return dictionary.copyRegion(0, 0);
-        }
-        if (positionCount == 1) {
-            return dictionary.getRegion(ids[idsOffset], 1);
+        if (dictionary instanceof ValueBlock valueBlock) {
+            return createInternal(idsOffset, positionCount, valueBlock, ids, false, SEQUENTIAL_IDS_UNCHECKED, dictionarySourceId);
         }
 
         // if dictionary is an RLE then this can just be a new RLE
@@ -73,25 +90,44 @@ public final class DictionaryBlock
             return RunLengthEncodedBlock.create(rle.getValue(), positionCount);
         }
 
-        if (dictionary instanceof ValueBlock valueBlock) {
-            return new DictionaryBlock(idsOffset, positionCount, valueBlock, ids, false, false, dictionarySourceId);
-        }
-
         // unwrap dictionary in dictionary
         int[] newIds = new int[positionCount];
         for (int position = 0; position < positionCount; position++) {
             newIds[position] = dictionary.getUnderlyingValuePosition(ids[idsOffset + position]);
         }
-        return new DictionaryBlock(0, positionCount, dictionary.getUnderlyingValueBlock(), newIds, false, false, randomDictionaryId());
+        return createInternal(0, positionCount, dictionary.getUnderlyingValueBlock(), newIds, false, SEQUENTIAL_IDS_UNCHECKED, randomDictionaryId());
     }
 
-    private DictionaryBlock(int idsOffset, int positionCount, ValueBlock dictionary, int[] ids, boolean dictionaryIsCompacted, boolean isSequentialIds, DictionaryId dictionarySourceId)
+    private static Block createInternal(int idsOffset, int positionCount, ValueBlock dictionary, int[] ids, boolean dictionaryIsCompacted, byte sequentialIdsState, DictionaryId dictionarySourceId)
+    {
+        if (positionCount == 0) {
+            return dictionary.copyRegion(0, 0);
+        }
+        if (positionCount == 1) {
+            return dictionary.getRegion(ids[idsOffset], 1);
+        }
+
+        // A dictionary with a single entry contains the same value at every position.
+        if (dictionary.getPositionCount() == 1) {
+            return RunLengthEncodedBlock.create(dictionary, positionCount);
+        }
+
+        return new DictionaryBlock(idsOffset, positionCount, dictionary, ids, dictionaryIsCompacted, sequentialIdsState, dictionarySourceId);
+    }
+
+    private DictionaryBlock(int idsOffset, int positionCount, ValueBlock dictionary, int[] ids, boolean dictionaryIsCompacted, byte sequentialIdsState, DictionaryId dictionarySourceId)
     {
         requireNonNull(dictionary, "dictionary is null");
         requireNonNull(ids, "ids is null");
 
         if (positionCount < 0) {
             throw new IllegalArgumentException("positionCount is negative");
+        }
+        if (positionCount < 2) {
+            throw new IllegalArgumentException("positionCount must be at least 2");
+        }
+        if (dictionary.getPositionCount() < 2) {
+            throw new IllegalArgumentException("dictionary must have at least 2 positions");
         }
 
         this.idsOffset = idsOffset;
@@ -104,16 +140,13 @@ public final class DictionaryBlock
         this.ids = ids;
         this.dictionarySourceId = requireNonNull(dictionarySourceId, "dictionarySourceId is null");
         this.retainedSizeInBytes = INSTANCE_SIZE + sizeOf(ids);
-        this.mayHaveNull = positionCount > 0 && dictionary.mayHaveNull();
+        this.mayHaveNull = dictionary.mayHaveNull();
 
         if (dictionaryIsCompacted) {
             this.uniqueIds = dictionary.getPositionCount();
         }
 
-        if (isSequentialIds && !dictionaryIsCompacted) {
-            throw new IllegalArgumentException("sequential ids flag is only valid for compacted dictionary");
-        }
-        this.isSequentialIds = isSequentialIds;
+        this.sequentialIdsState = sequentialIdsState;
     }
 
     public int[] getRawIds()
@@ -155,23 +188,22 @@ public final class DictionaryBlock
     {
         int uniqueIds = 0;
         boolean[] used = new boolean[dictionary.getPositionCount()];
-        // nested dictionaries are assumed not to have sequential ids
-        boolean isSequentialIds = true;
+        boolean sequentialIds = true;
         int previousPosition = -1;
         for (int i = 0; i < positionCount; i++) {
             int position = ids[idsOffset + i];
             // Avoid branching
             uniqueIds += used[position] ? 0 : 1;
             used[position] = true;
-            if (isSequentialIds) {
+            if (sequentialIds) {
                 // this branch is predictable and will switch paths at most once while looping
-                isSequentialIds = previousPosition < position;
+                sequentialIds = previousPosition < position;
                 previousPosition = position;
             }
         }
 
         this.uniqueIds = uniqueIds;
-        this.isSequentialIds = isSequentialIds;
+        this.sequentialIdsState = sequentialIds ? SEQUENTIAL_IDS : NON_SEQUENTIAL_IDS;
     }
 
     @Override
@@ -181,6 +213,13 @@ public final class DictionaryBlock
             // Calculation of getRegionSizeInBytes is expensive in this class.
             // On the other hand, getSizeInBytes result is cached.
             return getSizeInBytes();
+        }
+
+        if (length == 0) {
+            return 0;
+        }
+        if (length == 1) {
+            return dictionary.getRegionSizeInBytes(getId(positionOffset), 1);
         }
 
         double averageEntrySize = dictionary.getSizeInBytes() / (double) dictionary.getPositionCount();
@@ -241,13 +280,13 @@ public final class DictionaryBlock
             // discovered that all positions are unique, so return the unwrapped underlying dictionary directly
             return compactDictionary;
         }
-        return new DictionaryBlock(
+        return createInternal(
                 0,
                 length,
                 compactDictionary,
                 newIds,
                 true, // new dictionary is compact
-                false,
+                NON_SEQUENTIAL_IDS,
                 randomDictionaryId());
     }
 
@@ -260,7 +299,7 @@ public final class DictionaryBlock
             return this;
         }
 
-        return new DictionaryBlock(idsOffset + positionOffset, length, dictionary, ids, false, false, dictionarySourceId);
+        return createInternal(idsOffset + positionOffset, length, dictionary, ids, false, SEQUENTIAL_IDS_UNCHECKED, dictionarySourceId);
     }
 
     @Override
@@ -274,7 +313,7 @@ public final class DictionaryBlock
         }
         // Avoid repeated volatile reads to the uniqueIds field
         int uniqueIds = this.uniqueIds;
-        if (length <= 1 || (uniqueIds == dictionary.getPositionCount() && isSequentialIds)) {
+        if (length <= 1 || (uniqueIds == dictionary.getPositionCount() && sequentialIdsState == SEQUENTIAL_IDS)) {
             // copy the contiguous range directly via copyRegion
             return dictionary.copyRegion(getId(position), length);
         }
@@ -287,20 +326,21 @@ public final class DictionaryBlock
         if (newIds == ids) {
             return this;
         }
-        return new DictionaryBlock(
+        DictionaryBlock result = (DictionaryBlock) createInternal(
                 0,
                 length,
                 dictionary,
                 newIds,
                 false,
-                false,
-                randomDictionaryId()).compact();
+                SEQUENTIAL_IDS_UNCHECKED,
+                randomDictionaryId());
+        return result.compact();
     }
 
     @Override
     public boolean mayHaveNull()
     {
-        return mayHaveNull && dictionary.mayHaveNull();
+        return mayHaveNull;
     }
 
     @Override
@@ -328,20 +368,30 @@ public final class DictionaryBlock
         boolean isCompact = length >= dictionary.getPositionCount() && isCompact();
         boolean[] usedIds = isCompact ? new boolean[dictionary.getPositionCount()] : null;
         int uniqueIds = 0;
+        boolean sequentialIds = true;
+        int previousId = -1;
         for (int i = 0; i < length; i++) {
             int id = getId(positions[offset + i]);
             newIds[i] = id;
             if (usedIds != null) {
                 uniqueIds += usedIds[id] ? 0 : 1;
                 usedIds[id] = true;
+                if (sequentialIds) {
+                    sequentialIds = previousId < id;
+                    previousId = id;
+                }
             }
         }
         // All positions must have been referenced in order to be compact
         isCompact &= (usedIds != null && usedIds.length == uniqueIds);
-        DictionaryBlock result = new DictionaryBlock(0, newIds.length, dictionary, newIds, isCompact, false, getDictionarySourceId());
-        if (usedIds != null && !isCompact) {
+        byte sequentialIdsState = SEQUENTIAL_IDS_UNCHECKED;
+        if (isCompact) {
+            sequentialIdsState = sequentialIds ? SEQUENTIAL_IDS : NON_SEQUENTIAL_IDS;
+        }
+        Block result = createInternal(0, newIds.length, dictionary, newIds, isCompact, sequentialIdsState, getDictionarySourceId());
+        if (result instanceof DictionaryBlock dictionaryBlock && usedIds != null && !isCompact) {
             // resulting dictionary is not compact, but we know the number of unique ids and which positions are used
-            result.uniqueIds = uniqueIds;
+            dictionaryBlock.uniqueIds = uniqueIds;
         }
         return result;
     }
@@ -373,7 +423,12 @@ public final class DictionaryBlock
             newIds[idsOffset + positionCount] = nullIndex;
         }
 
-        return new DictionaryBlock(idsOffset, positionCount + 1, newDictionary, newIds, isCompact(), false, getDictionarySourceId());
+        boolean compact = isCompact();
+        byte sequentialIdsState = SEQUENTIAL_IDS_UNCHECKED;
+        if (compact) {
+            sequentialIdsState = nullIndex == NULL_NOT_FOUND ? this.sequentialIdsState : NON_SEQUENTIAL_IDS;
+        }
+        return new DictionaryBlock(idsOffset, positionCount + 1, newDictionary, newIds, compact, sequentialIdsState, getDictionarySourceId());
     }
 
     @Override
@@ -409,7 +464,8 @@ public final class DictionaryBlock
         }
 
         if (newDictionary instanceof ValueBlock valueBlock) {
-            return new DictionaryBlock(idsOffset, positionCount, valueBlock, ids, isCompact(), false, dictionarySourceId);
+            boolean compact = isCompact();
+            return new DictionaryBlock(idsOffset, positionCount, valueBlock, ids, compact, sequentialIdsState, dictionarySourceId);
         }
         if (newDictionary instanceof RunLengthEncodedBlock rle) {
             return RunLengthEncodedBlock.create(rle.getValue(), positionCount);
@@ -420,16 +476,18 @@ public final class DictionaryBlock
         for (int position = 0; position < positionCount; position++) {
             newIds[position] = newDictionary.getUnderlyingValuePosition(getIdUnchecked(position));
         }
-        return new DictionaryBlock(0, positionCount, newDictionary.getUnderlyingValueBlock(), newIds, false, false, randomDictionaryId());
+        return new DictionaryBlock(0, positionCount, newDictionary.getUnderlyingValueBlock(), newIds, false, SEQUENTIAL_IDS_UNCHECKED, randomDictionaryId());
     }
 
     boolean isSequentialIds()
     {
-        if (uniqueIds == -1) {
+        byte sequentialIdsState = this.sequentialIdsState;
+        if (sequentialIdsState == SEQUENTIAL_IDS_UNCHECKED) {
             countUniqueIds();
+            sequentialIdsState = this.sequentialIdsState;
         }
 
-        return isSequentialIds;
+        return sequentialIdsState == SEQUENTIAL_IDS;
     }
 
     int getUniqueIds()
@@ -465,9 +523,12 @@ public final class DictionaryBlock
         return uniqueIds == dictionary.getPositionCount();
     }
 
-    public DictionaryBlock compact()
+    public Block compact()
     {
         if (isCompact()) {
+            if (isSequentialIds()) {
+                return dictionary;
+            }
             return this;
         }
 
@@ -492,27 +553,20 @@ public final class DictionaryBlock
             return this;
         }
 
-        // compact the dictionary
-        int[] newIds = new int[positionCount];
-        for (int i = 0; i < positionCount; i++) {
-            int newId = remapIndex[getId(i)];
-            if (newId == -1) {
-                throw new IllegalStateException("reference to a non-existent key");
-            }
-            newIds[i] = newId;
-        }
         try {
             ValueBlock compactDictionary = dictionary.copyPositions(dictionaryPositionsToCopy.elements(), 0, dictionaryPositionsToCopy.size());
-            return new DictionaryBlock(
+            if (dictionaryPositionsToCopy.size() == positionCount) {
+                return compactDictionary;
+            }
+
+            int[] newIds = getNewIds(positionCount, this, remapIndex);
+            return createInternal(
                     0,
                     positionCount,
                     compactDictionary,
                     newIds,
                     true,
-                    // Copied dictionary positions match ids sequence. Therefore new
-                    // compact dictionary block has sequential ids only if single position
-                    // is not used more than once.
-                    uniqueIds == positionCount,
+                    NON_SEQUENTIAL_IDS,
                     randomDictionaryId());
         }
         catch (UnsupportedOperationException e) {
@@ -525,9 +579,15 @@ public final class DictionaryBlock
      * Compact the dictionary down to only the used positions for a set of
      * blocks that have been projected from the same dictionary.
      */
-    public static List<DictionaryBlock> compactRelatedBlocks(List<DictionaryBlock> blocks)
+    public static List<? extends Block> compactRelatedBlocks(List<DictionaryBlock> blocks)
     {
         DictionaryBlock firstDictionaryBlock = blocks.get(0);
+        for (DictionaryBlock dictionaryBlock : blocks) {
+            if (!firstDictionaryBlock.getDictionarySourceId().equals(dictionaryBlock.getDictionarySourceId())) {
+                throw new IllegalArgumentException("dictionarySourceIds must be the same");
+            }
+        }
+
         Block dictionary = firstDictionaryBlock.getDictionary();
 
         int positionCount = firstDictionaryBlock.getPositionCount();
@@ -550,35 +610,44 @@ public final class DictionaryBlock
 
         // entire dictionary is referenced
         if (numberOfIndexes == dictionarySize) {
+            if (numberOfIndexes == positionCount && firstDictionaryBlock.isSequentialIds()) {
+                List<Block> outputBlocks = new ArrayList<>(blocks.size());
+                for (DictionaryBlock dictionaryBlock : blocks) {
+                    outputBlocks.add(dictionaryBlock.getDictionary());
+                }
+                return outputBlocks;
+            }
             return blocks;
         }
 
         // compact the dictionaries
-        int[] newIds = getNewIds(positionCount, firstDictionaryBlock, remapIndex);
-        List<DictionaryBlock> outputDictionaryBlocks = new ArrayList<>(blocks.size());
+        boolean isIdentity = numberOfIndexes == positionCount;
+        int[] newIds = isIdentity ? null : getNewIds(positionCount, firstDictionaryBlock, remapIndex);
+        List<Block> outputBlocks = new ArrayList<>(blocks.size());
         DictionaryId newDictionaryId = randomDictionaryId();
         for (DictionaryBlock dictionaryBlock : blocks) {
-            if (!firstDictionaryBlock.getDictionarySourceId().equals(dictionaryBlock.getDictionarySourceId())) {
-                throw new IllegalArgumentException("dictionarySourceIds must be the same");
-            }
-
             try {
                 ValueBlock compactDictionary = dictionaryBlock.getDictionary().copyPositions(dictionaryPositionsToCopy, 0, numberOfIndexes);
-                outputDictionaryBlocks.add(new DictionaryBlock(
-                        0,
-                        positionCount,
-                        compactDictionary,
-                        newIds,
-                        true,
-                        false,
-                        newDictionaryId));
+                if (isIdentity) {
+                    outputBlocks.add(compactDictionary);
+                }
+                else {
+                    outputBlocks.add(createInternal(
+                            0,
+                            positionCount,
+                            compactDictionary,
+                            newIds,
+                            true,
+                            NON_SEQUENTIAL_IDS,
+                            newDictionaryId));
+                }
             }
             catch (UnsupportedOperationException e) {
                 // ignore if copy positions is not supported for the dictionary
-                outputDictionaryBlocks.add(dictionaryBlock);
+                outputBlocks.add(dictionaryBlock);
             }
         }
-        return outputDictionaryBlocks;
+        return outputBlocks;
     }
 
     private static int[] getNewIds(int positionCount, DictionaryBlock dictionaryBlock, int[] remapIndex)

--- a/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
@@ -13,13 +13,19 @@
  */
 package io.trino.spi;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.DictionaryId;
+import io.trino.spi.block.LongArrayBlock;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.block.VariableWidthBlock;
 import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verifyNotNull;
@@ -84,11 +90,7 @@ final class TestPage
         Block commonSourceIdBlock1 = createProjectedDictionaryBlock(positionCount, dictionary1, commonDictionaryIds, commonSourceId);
 
         // second dictionary block is "length(firstColumn)"
-        BlockBuilder dictionary2 = BIGINT.createFixedSizeBlockBuilder(dictionary1.getPositionCount());
-        for (Slice expectedValue : dictionaryValues1) {
-            BIGINT.writeLong(dictionary2, expectedValue.length());
-        }
-        Block commonSourceIdBlock2 = createProjectedDictionaryBlock(positionCount, dictionary2.build(), commonDictionaryIds, commonSourceId);
+        Block commonSourceIdBlock2 = createProjectedDictionaryBlock(positionCount, createLengthsBlock(dictionaryValues1), commonDictionaryIds, commonSourceId);
 
         // Create block with a different source id, dictionary size, used
         int otherDictionaryUsedPositions = 30;
@@ -113,6 +115,94 @@ final class TestPage
 
         assertThat(((DictionaryBlock) page.getBlock(0)).getDictionarySourceId())
                 .isEqualTo(((DictionaryBlock) page.getBlock(2)).getDictionarySourceId());
+    }
+
+    @Test
+    public void testCompactSingleEntryRelatedDictionaryBlocks()
+    {
+        int positionCount = 100;
+        DictionaryId commonSourceId = randomDictionaryId();
+        int[] dictionaryIds = new int[positionCount];
+
+        Slice[] dictionaryValues = createExpectedValues(1000);
+        int dictionaryPosition = 723;
+        Arrays.fill(dictionaryIds, dictionaryPosition);
+        Block dictionary1 = createSlicesBlock(dictionaryValues);
+        Block dictionaryBlock1 = createProjectedDictionaryBlock(positionCount, dictionary1, dictionaryIds, commonSourceId);
+
+        Block dictionaryBlock2 = createProjectedDictionaryBlock(positionCount, createLengthsBlock(dictionaryValues), dictionaryIds, commonSourceId);
+
+        Page page = new Page(dictionaryBlock1, dictionaryBlock2);
+        page.compact();
+
+        assertThat(page.getBlock(0)).isInstanceOf(RunLengthEncodedBlock.class);
+        assertThat(page.getBlock(1)).isInstanceOf(RunLengthEncodedBlock.class);
+        assertThat(VARBINARY.getSlice(page.getBlock(0), 0)).isEqualTo(dictionaryValues[dictionaryPosition]);
+        assertThat(BIGINT.getLong(page.getBlock(1), 0)).isEqualTo(dictionaryValues[dictionaryPosition].length());
+    }
+
+    @Test
+    public void testCompactIdentityRelatedDictionaryBlocks()
+    {
+        int positionCount = 100;
+        DictionaryId commonSourceId = randomDictionaryId();
+        int[] dictionaryIds = new int[positionCount];
+        Arrays.setAll(dictionaryIds, position -> position);
+
+        Slice[] dictionaryValues = createExpectedValues(positionCount);
+        Block dictionary1 = createSlicesBlock(dictionaryValues);
+        Block dictionary2 = createLengthsBlock(dictionaryValues);
+        Block dictionaryBlock1 = createProjectedDictionaryBlock(positionCount, dictionary1, dictionaryIds, commonSourceId);
+        Block dictionaryBlock2 = createProjectedDictionaryBlock(positionCount, dictionary2, dictionaryIds, commonSourceId);
+
+        Page page = new Page(dictionaryBlock1, dictionaryBlock2);
+        page.compact();
+
+        assertThat(page.getBlock(0)).isSameAs(dictionary1);
+        assertThat(page.getBlock(1)).isSameAs(dictionary2);
+    }
+
+    @Test
+    public void testCompactIdentityRelatedDictionaryBlocksWithDifferentSources()
+    {
+        int positionCount = 2;
+        Slice[] dictionaryValues = createExpectedValues(positionCount);
+        Block dictionary = createSlicesBlock(dictionaryValues);
+        DictionaryBlock firstBlock = (DictionaryBlock) createProjectedDictionaryBlock(
+                positionCount,
+                dictionary,
+                new int[] {0, 1},
+                randomDictionaryId());
+        DictionaryBlock secondBlock = (DictionaryBlock) createProjectedDictionaryBlock(
+                positionCount,
+                dictionary,
+                new int[] {1, 0},
+                randomDictionaryId());
+
+        assertThatThrownBy(() -> DictionaryBlock.compactRelatedBlocks(ImmutableList.of(firstBlock, secondBlock)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("dictionarySourceIds must be the same");
+    }
+
+    @Test
+    public void testCompactUniqueRelatedDictionaryBlocks()
+    {
+        int positionCount = 100;
+        DictionaryId commonSourceId = randomDictionaryId();
+        int[] dictionaryIds = new int[positionCount];
+        Arrays.setAll(dictionaryIds, position -> position * 2);
+
+        Slice[] dictionaryValues = createExpectedValues(positionCount * 2);
+        Block dictionaryBlock1 = createProjectedDictionaryBlock(positionCount, createSlicesBlock(dictionaryValues), dictionaryIds, commonSourceId);
+        Block dictionaryBlock2 = createProjectedDictionaryBlock(positionCount, createLengthsBlock(dictionaryValues), dictionaryIds, commonSourceId);
+
+        Page page = new Page(dictionaryBlock1, dictionaryBlock2);
+        page.compact();
+
+        assertThat(page.getBlock(0)).isInstanceOf(VariableWidthBlock.class);
+        assertThat(page.getBlock(1)).isInstanceOf(LongArrayBlock.class);
+        assertThat(VARBINARY.getSlice(page.getBlock(0), 50)).isEqualTo(dictionaryValues[100]);
+        assertThat(BIGINT.getLong(page.getBlock(1), 50)).isEqualTo(dictionaryValues[100].length());
     }
 
     @Test
@@ -172,6 +262,15 @@ final class TestPage
         for (Slice value : values) {
             verifyNotNull(value);
             VARBINARY.writeSlice(builder, value);
+        }
+        return builder.build();
+    }
+
+    private static Block createLengthsBlock(Slice[] values)
+    {
+        BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(values.length);
+        for (Slice value : values) {
+            BIGINT.writeLong(builder, value.length());
         }
         return builder.build();
     }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataWriterWithoutTypeManager.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataWriterWithoutTypeManager.java
@@ -133,7 +133,7 @@ public class TestAvroPageDataWriterWithoutTypeManager
                         expectedRLERow, 2),
                 DictionaryBlock.create(
                         2,
-                        expectedDictionaryRow,
+                        expectedDictionaryRow.copyWithAppendedNull(),
                         new int[] {0, 0}));
 
         Location testLocation = createLocalTempLocation();

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/AbstractColumnReaderTest.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/AbstractColumnReaderTest.java
@@ -89,7 +89,7 @@ public abstract class AbstractColumnReaderTest
         Block actual = reader.readPrimitive().getBlock();
         assertThat(actual.mayHaveNull()).isFalse();
         if (shouldProduceDictionaryForType(field.getType())) {
-            assertThat(actual).isInstanceOf(DictionaryBlock.class);
+            assertThat(actual).isInstanceOf(RunLengthEncodedBlock.class);
         }
         format.assertBlock(values, actual);
     }
@@ -160,7 +160,7 @@ public abstract class AbstractColumnReaderTest
         reader.prepareNextRead(2);
         Block actual = reader.readPrimitive().getBlock();
         if (shouldProduceDictionaryForType(field.getType())) {
-            assertThat(actual).isInstanceOf(DictionaryBlock.class);
+            assertThat(actual).isInstanceOf(RunLengthEncodedBlock.class);
             assertThat(actual.mayHaveNull()).isFalse();
         }
         format.assertBlock(values, actual);


### PR DESCRIPTION
## Why
- A dictionary with one physical entry can only represent a repeated value, but retaining it as a dictionary adds an IDs vector, indirection, and retained memory without preserving information.
- Allowing these degenerate blocks to escape forces every downstream consumer to handle a representation that can be expressed more directly.
- Compaction can also discover identity mappings whose simplest representation is the underlying value block.

## Approach
- Establish the class-level policy that operations returning `Block` may return a simpler representation.
- Centralize dictionary creation so empty and single-position results, single-entry dictionaries, and RLE dictionaries are canonicalized consistently.
- Let compaction return `Block` and simplify single-entry, RLE, and identity results while preserving dictionary behavior otherwise.
