### PR TITLE
Fix Parquet predicate on a type-mismatched column

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -54,6 +54,7 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.joda.time.DateTimeZone;
 
 import java.io.Serializable;
@@ -267,6 +268,12 @@ public class TupleDomainParquetPredicate
                 continue;
             }
 
+            // decided once for the column, which also skips the range expansion below when the filter cannot match
+            Optional<BloomFilterHasher> hasher = bloomFilterHasher(effectivePredicateDomain.getType(), column.getPrimitiveType());
+            if (hasher.isEmpty()) {
+                continue;
+            }
+
             Optional<Collection<Object>> discreteValues = extractDiscreteValues(domainCompactionThreshold, effectivePredicateDomain.getValues());
             // values are not discrete, so bloom filter isn't helpful
             if (discreteValues.isEmpty()) {
@@ -278,7 +285,8 @@ public class TupleDomainParquetPredicate
                 continue;
             }
             BloomFilter bloomFilter = bloomFilterOptional.get();
-            if (discreteValues.get().stream().noneMatch(value -> checkInBloomFilter(bloomFilter, value, effectivePredicateDomain.getType()))) {
+            BloomFilterHasher columnHasher = hasher.orElseThrow();
+            if (discreteValues.get().stream().noneMatch(value -> bloomFilter.findHash(columnHasher.hash(bloomFilter, value)))) {
                 return false;
             }
         }
@@ -738,37 +746,64 @@ public class TupleDomainParquetPredicate
     }
 
     /**
-     * Check if the predicateValue might be in the bloomfilter
-     *
-     * @param bloomFilter parquet bloomfilter.
-     * @param predicateValue effective discrete predicate value.
-     * @param sqlType Type that contains information about the type schema from connector's metadata
-     * @return true if the predicateValue might be in the bloomfilter, false if the predicateValue absolutely is not in the bloomfilter
+     * How a predicate value has to be hashed to be looked up in the bloom filter of this column, or empty when the
+     * filter cannot answer for this column at all and has to be ignored rather than trusted.
+     * <p>
+     * parquet-mr builds a filter by hashing each value at the physical width of the column, so a lookup performed as a
+     * type of a different width never finds a value which is present. Binary values are hashed by their bytes alone,
+     * which makes the two byte array physical types interchangeable, but only where the reader hands those same bytes
+     * back, as it does not for a bounded varchar or for a decimal annotated column read as text.
      */
     @VisibleForTesting
-    public static boolean checkInBloomFilter(BloomFilter bloomFilter, Object predicateValue, Type sqlType)
+    public static Optional<BloomFilterHasher> bloomFilterHasher(Type sqlType, PrimitiveType parquetType)
     {
+        PrimitiveTypeName primitiveType = parquetType.getPrimitiveTypeName();
+
         // TODO: Support TIMESTAMP, CHAR and DECIMAL
         if (sqlType == TINYINT || sqlType == SMALLINT || sqlType == INTEGER || sqlType == DATE) {
-            return bloomFilter.findHash(bloomFilter.hash(toIntExact(((Number) predicateValue).longValue())));
+            if (primitiveType != PrimitiveTypeName.INT32) {
+                return Optional.empty();
+            }
+            return Optional.of((bloomFilter, value) -> bloomFilter.hash(toIntExact(((Number) value).longValue())));
         }
         if (sqlType == BIGINT) {
-            return bloomFilter.findHash(bloomFilter.hash(((Number) predicateValue).longValue()));
+            if (primitiveType != INT64) {
+                return Optional.empty();
+            }
+            return Optional.of((bloomFilter, value) -> bloomFilter.hash(((Number) value).longValue()));
         }
-        else if (sqlType == DOUBLE) {
-            return bloomFilter.findHash(bloomFilter.hash(((Double) predicateValue).doubleValue()));
+        if (sqlType == DOUBLE) {
+            if (primitiveType != PrimitiveTypeName.DOUBLE) {
+                return Optional.empty();
+            }
+            return Optional.of((bloomFilter, value) -> bloomFilter.hash(((Double) value).doubleValue()));
         }
-        else if (sqlType == REAL) {
-            return bloomFilter.findHash(bloomFilter.hash(intBitsToFloat(toIntExact(((Number) predicateValue).longValue()))));
+        if (sqlType == REAL) {
+            if (primitiveType != FLOAT) {
+                return Optional.empty();
+            }
+            return Optional.of((bloomFilter, value) -> bloomFilter.hash(intBitsToFloat(toIntExact(((Number) value).longValue()))));
         }
-        else if (sqlType instanceof VarcharType || sqlType instanceof VarbinaryType) {
-            return bloomFilter.findHash(bloomFilter.hash(Binary.fromConstantByteBuffer(((Slice) predicateValue).toByteBuffer())));
-        }
-        else if (sqlType instanceof UuidType) {
-            return bloomFilter.findHash(bloomFilter.hash(Binary.fromConstantByteArray(((Slice) predicateValue).getBytes())));
+        // The filter hashed what the writer stored, so a byte array column only answers where the reader hands those
+        // same bytes back, which is the condition its statistics are usable under as well. A char is none of the
+        // three types below and falls through to the empty result
+        if (sqlType instanceof VarcharType || sqlType instanceof VarbinaryType || sqlType instanceof UuidType) {
+            if (!canNarrowDomain(sqlType, parquetType)) {
+                return Optional.empty();
+            }
+            return Optional.of((bloomFilter, value) -> bloomFilter.hash(Binary.fromConstantByteBuffer(((Slice) value).toByteBuffer())));
         }
 
-        return true;
+        return Optional.empty();
+    }
+
+    /**
+     * Hashes one predicate value the way the bloom filter of a particular column was built.
+     */
+    @FunctionalInterface
+    public interface BloomFilterHasher
+    {
+        long hash(BloomFilter bloomFilter, Object predicateValue);
     }
 
     private static Optional<Collection<Object>> extractDiscreteValues(int domainCompactionThreshold, ValueSet valueSet)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -376,10 +376,6 @@ public class TupleDomainParquetPredicate
         if (type instanceof VarcharType && parquetType.getLogicalTypeAnnotation() instanceof DecimalLogicalTypeAnnotation) {
             return false;
         }
-        // The double branch decodes a Double, so a float column is left alone until those bounds are widened
-        if (DOUBLE.equals(type) && parquetType.getPrimitiveTypeName() == FLOAT) {
-            return false;
-        }
         return true;
     }
 
@@ -476,10 +472,12 @@ public class TupleDomainParquetPredicate
         if (type.equals(DOUBLE)) {
             SortedRangeSet.Builder rangesBuilder = SortedRangeSet.builder(type, minimums.size());
             for (int i = 0; i < minimums.size(); i++) {
-                Double min = (Double) minimums.get(i);
-                Double max = (Double) maximums.get(i);
+                // ColumnReaderFactory widens a float column to double, and every float has an exact double, so these
+                // bounds are the values the reader itself produces
+                double min = ((Number) minimums.get(i)).doubleValue();
+                double max = ((Number) maximums.get(i)).doubleValue();
 
-                if (min.isNaN() || max.isNaN()) {
+                if (Double.isNaN(min) || Double.isNaN(max)) {
                     return Domain.create(ValueSet.all(type), hasNullValue);
                 }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -68,6 +68,7 @@ import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static io.trino.parquet.ParquetMetadataConverter.isMinMaxStatsSupported;
 import static io.trino.parquet.ParquetTimestampUtils.decodeInt64Timestamp;
 import static io.trino.parquet.ParquetTimestampUtils.decodeInt96Timestamp;
@@ -85,8 +86,10 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.Varchars.byteCount;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
@@ -356,9 +359,9 @@ public class TupleDomainParquetPredicate
      * Statistics, column indexes and dictionaries are decoded according to the physical type of the column in the file,
      * while the domain being narrowed carries the type from the table schema, and schema evolution makes the two
      * disagree. A bound is usable only when the reader can produce the column at all, which
-     * {@link ColumnReaderFactory#isSupported} decides, when the reader produces the stored value unchanged, and when
-     * the statistics of the physical type arrive as the Java value the branch which builds the domain reads them as.
-     * The conversions below are readable but fail one of the other two.
+     * {@link ColumnReaderFactory#isSupported} decides, when what the reader produces is ordered the same way as what
+     * the file stores, and when the statistics of the physical type arrive as the Java value the branch which builds
+     * the domain reads them as. The conversions below are readable but fail one of the other two.
      */
     private static boolean canNarrowDomain(Type type, PrimitiveType parquetType)
     {
@@ -376,15 +379,37 @@ public class TupleDomainParquetPredicate
         if (isIntegralType(type) && primitiveType != INT32 && primitiveType != INT64) {
             return false;
         }
-        // The reader truncates a bounded varchar to its length, and pads and trims a char, so a bound built from the
-        // stored bytes can sit above a value the reader goes on to produce
-        if (type instanceof VarcharType varcharType && !varcharType.isUnbounded()) {
-            return false;
-        }
+        // Trino orders a char as if the shorter value were padded with spaces, while the reader trims the trailing
+        // spaces off the stored bytes, so a bound taken from those bytes is not a bound in the order the domain uses
         if (type instanceof CharType) {
             return false;
         }
         return true;
+    }
+
+    /**
+     * The lowest value the reader can produce for a column whose stored values are at or above {@code minimum}.
+     * <p>
+     * The reader cuts a bounded varchar down to its length, counting the bytes which are not UTF-8 continuation
+     * bytes, so the bound is the longest prefix of the minimum that nothing readable sorts below: its first
+     * {@code n - 1} code points followed by the leading byte of the {@code n}th. A stored value which agrees with
+     * the minimum that far scans those bytes identically and so cannot be cut any shorter, and one which differs
+     * inside them differs upwards on a byte the reader keeps. Cutting the {@code n}th code point off whole would
+     * not hold, since through a {@code varchar(1)} a minimum of {@code C3 A9} is cut to itself while a larger
+     * {@code C3 C3 A9} is cut to {@code C3}.
+     */
+    private static Slice readableLowerBound(Slice minimum, VarcharType varcharType)
+    {
+        if (varcharType.isUnbounded()) {
+            return minimum;
+        }
+        int boundedLength = varcharType.getBoundedLength();
+        if (boundedLength == 0) {
+            // the reader produces nothing but the empty slice, which no varchar sorts below
+            return EMPTY_SLICE;
+        }
+        int precedingLength = byteCount(minimum, 0, minimum.length(), boundedLength - 1);
+        return minimum.slice(0, min(precedingLength + 1, minimum.length()));
     }
 
     /**
@@ -502,12 +527,12 @@ public class TupleDomainParquetPredicate
             return Domain.create(rangesBuilder.build(), hasNullValue);
         }
 
-        if (type instanceof VarcharType) {
+        if (type instanceof VarcharType varcharType) {
             SortedRangeSet.Builder rangesBuilder = SortedRangeSet.builder(type, minimums.size());
             for (int i = 0; i < minimums.size(); i++) {
-                Slice min = (Slice) minimums.get(i);
-                Slice max = (Slice) maximums.get(i);
-                rangesBuilder.addRangeInclusive(min, max);
+                // the stored maximum bounds what the reader produces as it stands, since the reader only ever cuts a
+                // prefix off a bounded varchar and a prefix never sorts above the value it was cut from
+                rangesBuilder.addRangeInclusive(readableLowerBound((Slice) minimums.get(i), varcharType), (Slice) maximums.get(i));
             }
             return Domain.create(rangesBuilder.build(), hasNullValue);
         }
@@ -766,7 +791,7 @@ public class TupleDomainParquetPredicate
      * parquet-mr builds a filter by hashing each value at the physical width of the column, so a lookup performed as a
      * type of a different width never finds a value which is present. Binary values are hashed by their bytes alone,
      * which makes the two byte array physical types interchangeable, but only where the reader hands those same bytes
-     * back, as it does not for a bounded varchar or for a decimal annotated column read as text.
+     * back, as it does not for a bounded varchar or a char.
      */
     @VisibleForTesting
     public static Optional<BloomFilterHasher> bloomFilterHasher(Type sqlType, PrimitiveType parquetType)
@@ -798,11 +823,12 @@ public class TupleDomainParquetPredicate
             }
             return Optional.of((bloomFilter, value) -> bloomFilter.hash(intBitsToFloat(toIntExact(((Number) value).longValue()))));
         }
-        // The filter hashed what the writer stored, so a byte array column only answers where the reader hands those
-        // same bytes back, which is the condition its statistics are usable under as well. A char is none of the
-        // three types below and falls through to the empty result
+        // The filter hashed whole values, so a byte array column only answers where the reader hands those same bytes
+        // back, which a bounded varchar is cut too short for. Note that this is stronger than the condition the
+        // statistics of the same column are usable under, which needs only the order to survive the read. A char is
+        // none of the three types below and falls through to the empty result
         if (sqlType instanceof VarcharType || sqlType instanceof VarbinaryType || sqlType instanceof UuidType) {
-            if (!canNarrowDomain(sqlType, parquetType)) {
+            if (!isSupported(sqlType, parquetType) || (sqlType instanceof VarcharType varcharType && !varcharType.isUnbounded())) {
                 return Optional.empty();
             }
             return Optional.of((bloomFilter, value) -> bloomFilter.hash(Binary.fromConstantByteBuffer(((Slice) value).toByteBuffer())));

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -28,6 +28,7 @@ import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.SortedRangeSet;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalConversions;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
@@ -72,6 +73,7 @@ import static io.trino.parquet.ParquetTimestampUtils.decodeInt96Timestamp;
 import static io.trino.parquet.ParquetTypeUtils.getShortDecimalValue;
 import static io.trino.parquet.predicate.PredicateUtils.isStatisticsOverflow;
 import static io.trino.parquet.reader.ColumnReaderFactory.isDecimalRescaled;
+import static io.trino.parquet.reader.ColumnReaderFactory.isSupported;
 import static io.trino.plugin.base.type.TrinoTimestampEncoderFactory.createTimestampEncoder;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -88,6 +90,7 @@ import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
 
@@ -136,6 +139,11 @@ public class TupleDomainParquetPredicate
             if (effectivePredicateDomain == null) {
                 continue;
             }
+            // Page stats and the dictionary decode a column whose type does not match no differently from the
+            // row-group statistics, so neither can narrow its domain and neither is worth reading
+            if (!canNarrowDomain(effectivePredicateDomain.getType(), column.getPrimitiveType())) {
+                continue;
+            }
 
             Statistics<?> columnStatistics = statistics.get(column);
             if (columnStatistics == null || columnStatistics.isEmpty()) {
@@ -160,9 +168,10 @@ public class TupleDomainParquetPredicate
             }
             // If the predicate domain on a column includes the entire domain from column row-group statistics,
             // then more granular statistics from page stats or dictionary for this column will not help to eliminate the row-group.
-            if (!effectivePredicateDomain.contains(domain)) {
-                candidateColumns.add(column);
+            if (effectivePredicateDomain.contains(domain)) {
+                continue;
             }
+            candidateColumns.add(column);
         }
         return Optional.of(candidateColumns.build());
     }
@@ -333,6 +342,40 @@ public class TupleDomainParquetPredicate
     }
 
     /**
+     * Whether a domain may be narrowed from the statistics of this column.
+     * <p>
+     * Statistics, column indexes and dictionaries are decoded according to the physical type of the column in the file,
+     * while the domain being narrowed carries the type from the table schema, and schema evolution makes the two
+     * disagree. A bound is usable only when the reader can produce the column at all, which
+     * {@link ColumnReaderFactory#isSupported} decides, and when it produces the stored value unchanged, which the
+     * conversions below do not.
+     */
+    private static boolean canNarrowDomain(Type type, PrimitiveType parquetType)
+    {
+        if (!isSupported(type, parquetType)) {
+            return false;
+        }
+        // The reader truncates a bounded varchar to its length, and pads and trims a char, so a bound built from the
+        // stored bytes can sit above a value the reader goes on to produce
+        if (type instanceof VarcharType varcharType && !varcharType.isUnbounded()) {
+            return false;
+        }
+        if (type instanceof CharType) {
+            return false;
+        }
+        // A decimal annotated column read as varchar is rendered as text rather than as the two's complement bytes the
+        // statistics hold, and the two orderings are unrelated
+        if (type instanceof VarcharType && parquetType.getLogicalTypeAnnotation() instanceof DecimalLogicalTypeAnnotation) {
+            return false;
+        }
+        // The double branch decodes a Double, so a float column is left alone until those bounds are widened
+        if (DOUBLE.equals(type) && parquetType.getPrimitiveTypeName() == FLOAT) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Get a domain for the ranges defined by each pair of elements from {@code minimums} and {@code maximums}.
      * Both arrays must have the same length.
      */
@@ -345,6 +388,10 @@ public class TupleDomainParquetPredicate
             DateTimeZone timeZone)
     {
         checkArgument(minimums.size() == maximums.size(), "Expected minimums and maximums to have the same size");
+
+        if (!canNarrowDomain(type, column.getPrimitiveType())) {
+            return Domain.create(ValueSet.all(type), hasNullValue);
+        }
 
         if (type.equals(BOOLEAN)) {
             boolean hasTrueValues = minimums.stream().anyMatch(value -> (boolean) value) || maximums.stream().anyMatch(value -> (boolean) value);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -384,11 +384,6 @@ public class TupleDomainParquetPredicate
         if (type instanceof CharType) {
             return false;
         }
-        // A decimal annotated column read as varchar is rendered as text rather than as the two's complement bytes the
-        // statistics hold, and the two orderings are unrelated
-        if (type instanceof VarcharType && parquetType.getLogicalTypeAnnotation() instanceof DecimalLogicalTypeAnnotation) {
-            return false;
-        }
         return true;
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -92,6 +92,7 @@ import static java.lang.String.format;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.util.Objects.requireNonNull;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
 
@@ -355,12 +356,24 @@ public class TupleDomainParquetPredicate
      * Statistics, column indexes and dictionaries are decoded according to the physical type of the column in the file,
      * while the domain being narrowed carries the type from the table schema, and schema evolution makes the two
      * disagree. A bound is usable only when the reader can produce the column at all, which
-     * {@link ColumnReaderFactory#isSupported} decides, and when it produces the stored value unchanged, which the
-     * conversions below do not.
+     * {@link ColumnReaderFactory#isSupported} decides, when the reader produces the stored value unchanged, and when
+     * the statistics of the physical type arrive as the Java value the branch which builds the domain reads them as.
+     * The conversions below are readable but fail one of the other two.
      */
     private static boolean canNarrowDomain(Type type, PrimitiveType parquetType)
     {
         if (!isSupported(type, parquetType)) {
+            return false;
+        }
+        PrimitiveTypeName primitiveType = parquetType.getPrimitiveTypeName();
+        // RealType is an integer type, so isSupported takes a real over an integral column, where the reader
+        // reinterprets the stored integer as float bits instead of reading the value it holds
+        if (type.equals(REAL) && primitiveType != FLOAT) {
+            return false;
+        }
+        // A zero scale short decimal is read as an integer whatever it is stored in, but a byte array holds its
+        // statistics as two's complement bytes rather than as a number, which the integral branch does not read
+        if (isIntegralType(type) && primitiveType != INT32 && primitiveType != INT64) {
             return false;
         }
         // The reader truncates a bounded varchar to its length, and pads and trims a char, so a bound built from the
@@ -377,6 +390,14 @@ public class TupleDomainParquetPredicate
             return false;
         }
         return true;
+    }
+
+    /**
+     * The types whose bounds are read through {@link #asLong}, which accepts a boxed integer and nothing else.
+     */
+    private static boolean isIntegralType(Type type)
+    {
+        return type.equals(BIGINT) || type.equals(INTEGER) || type.equals(DATE) || type.equals(SMALLINT) || type.equals(TINYINT);
     }
 
     /**
@@ -413,7 +434,7 @@ public class TupleDomainParquetPredicate
             throw new VerifyException("Impossible boolean statistics");
         }
 
-        if (type.equals(BIGINT) || type.equals(INTEGER) || type.equals(DATE) || type.equals(SMALLINT) || type.equals(TINYINT)) {
+        if (isIntegralType(type)) {
             SortedRangeSet.Builder rangesBuilder = SortedRangeSet.builder(type, minimums.size());
             for (int i = 0; i < minimums.size(); i++) {
                 long min = asLong(minimums.get(i));
@@ -759,7 +780,7 @@ public class TupleDomainParquetPredicate
 
         // TODO: Support TIMESTAMP, CHAR and DECIMAL
         if (sqlType == TINYINT || sqlType == SMALLINT || sqlType == INTEGER || sqlType == DATE) {
-            if (primitiveType != PrimitiveTypeName.INT32) {
+            if (primitiveType != INT32) {
                 return Optional.empty();
             }
             return Optional.of((bloomFilter, value) -> bloomFilter.hash(toIntExact(((Number) value).longValue())));

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -300,8 +300,10 @@ public final class ColumnReaderFactory
                 && (annotation instanceof TimestampLogicalTypeAnnotation || annotation instanceof TimeLogicalTypeAnnotation)) {
             return true;
         }
-        // DATE and REAL are integer types as well, and TIME and BIGINT are long types, so the three branches above
-        // have to stay ahead of this one, which a date over INT64 and a real over an integral column reach
+        // DATE and REAL are integer types, and TIME and BIGINT are long types, so the three branches above have to
+        // stay ahead of this one. A date over INT64 and a real over an integral column reach here, where create()
+        // reads the real through the integer decoder, as the raw bits of the stored integer rather than as the value
+        // it holds
         if ((TINYINT.equals(type) || SMALLINT.equals(type) || type instanceof AbstractIntType || type instanceof AbstractLongType)
                 && isIntegerOrDecimalPrimitive(primitiveType)) {
             return isZeroScaleShortDecimalAnnotation(annotation) || isIntegerAnnotationAndPrimitive(annotation, primitiveType);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -43,6 +43,7 @@ import org.apache.parquet.schema.LogicalTypeAnnotation.LogicalTypeAnnotationVisi
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.joda.time.DateTimeZone;
 
@@ -100,8 +101,13 @@ public final class ColumnReaderFactory
     public ColumnReader create(PrimitiveField field, AggregatedMemoryContext aggregatedMemoryContext)
     {
         Type type = field.getType();
-        PrimitiveTypeName primitiveType = field.getDescriptor().getPrimitiveType().getPrimitiveTypeName();
-        LogicalTypeAnnotation annotation = field.getDescriptor().getPrimitiveType().getLogicalTypeAnnotation();
+        PrimitiveType parquetType = field.getDescriptor().getPrimitiveType();
+        if (!isSupported(type, parquetType)) {
+            throw unsupportedException(type, field);
+        }
+
+        PrimitiveTypeName primitiveType = parquetType.getPrimitiveTypeName();
+        LogicalTypeAnnotation annotation = parquetType.getLogicalTypeAnnotation();
         LocalMemoryContext memoryContext = aggregatedMemoryContext.newLocalMemoryContext(ColumnReader.class.getSimpleName());
         ValueDecoders valueDecoders = new ValueDecoders(field, vectorizedDecodingEnabled);
         if (BOOLEAN.equals(type) && primitiveType == PrimitiveTypeName.BOOLEAN) {
@@ -111,32 +117,20 @@ public final class ColumnReaderFactory
             if (isZeroScaleShortDecimalAnnotation(annotation)) {
                 return createColumnReader(field, valueDecoders::getShortDecimalToByteDecoder, BYTE_ADAPTER, memoryContext);
             }
-            if (!isIntegerAnnotationAndPrimitive(annotation, primitiveType)) {
-                throw unsupportedException(type, field);
-            }
             return createColumnReader(field, valueDecoders::getByteDecoder, BYTE_ADAPTER, memoryContext);
         }
         if (SMALLINT.equals(type) && isIntegerOrDecimalPrimitive(primitiveType)) {
             if (isZeroScaleShortDecimalAnnotation(annotation)) {
                 return createColumnReader(field, valueDecoders::getShortDecimalToShortDecoder, SHORT_ADAPTER, memoryContext);
             }
-            if (!isIntegerAnnotationAndPrimitive(annotation, primitiveType)) {
-                throw unsupportedException(type, field);
-            }
             return createColumnReader(field, valueDecoders::getShortDecoder, SHORT_ADAPTER, memoryContext);
         }
         if (DATE.equals(type) && primitiveType == INT32) {
-            if (isIntegerAnnotation(annotation) || annotation instanceof DateLogicalTypeAnnotation) {
-                return createColumnReader(field, valueDecoders::getIntDecoder, INT_ADAPTER, memoryContext);
-            }
-            throw unsupportedException(type, field);
+            return createColumnReader(field, valueDecoders::getIntDecoder, INT_ADAPTER, memoryContext);
         }
         if (type instanceof AbstractIntType && isIntegerOrDecimalPrimitive(primitiveType)) {
             if (isZeroScaleShortDecimalAnnotation(annotation)) {
                 return createColumnReader(field, valueDecoders::getShortDecimalToIntDecoder, INT_ADAPTER, memoryContext);
-            }
-            if (!isIntegerAnnotationAndPrimitive(annotation, primitiveType)) {
-                throw unsupportedException(type, field);
             }
             return createColumnReader(field, valueDecoders::getIntDecoder, INT_ADAPTER, memoryContext);
         }
@@ -159,9 +153,6 @@ public final class ColumnReaderFactory
         if (type instanceof AbstractLongType && isIntegerOrDecimalPrimitive(primitiveType)) {
             if (isZeroScaleShortDecimalAnnotation(annotation)) {
                 return createColumnReader(field, valueDecoders::getShortDecimalDecoder, LONG_ADAPTER, memoryContext);
-            }
-            if (!isIntegerAnnotationAndPrimitive(annotation, primitiveType)) {
-                throw unsupportedException(type, field);
             }
             if (primitiveType == INT32) {
                 return createColumnReader(field, valueDecoders::getInt32ToLongDecoder, LONG_ADAPTER, memoryContext);
@@ -269,19 +260,91 @@ public final class ColumnReaderFactory
             return createColumnReader(field, valueDecoders::getBinaryDecoder, BINARY_ADAPTER, memoryContext);
         }
         if ((VARBINARY.equals(type) || VARCHAR.equals(type)) && primitiveType == FIXED_LEN_BYTE_ARRAY) {
-            if (annotation instanceof DecimalLogicalTypeAnnotation) {
-                throw unsupportedException(type, field);
-            }
             return createColumnReader(field, valueDecoders::getFixedWidthBinaryDecoder, BINARY_ADAPTER, memoryContext);
         }
         if (UUID.equals(type) && primitiveType == FIXED_LEN_BYTE_ARRAY) {
             // Iceberg 0.11.1 writes UUID as FIXED_LEN_BYTE_ARRAY without logical type annotation (see https://github.com/apache/iceberg/pull/2913)
             // To support such files, we bet on the logical type to be UUID based on the Trino UUID type check.
-            if (annotation == null || isLogicalUuid(annotation)) {
-                return createColumnReader(field, valueDecoders::getUuidDecoder, INT128_ADAPTER, memoryContext);
-            }
+            return createColumnReader(field, valueDecoders::getUuidDecoder, INT128_ADAPTER, memoryContext);
         }
         throw unsupportedException(type, field);
+    }
+
+    /**
+     * Whether {@link #create} can build a reader for this Trino type over this Parquet column.
+     * <p>
+     * Callers which need to know whether a column is readable before a reader exists, such as statistics based pruning
+     * in the Parquet predicate, ask here instead of restating the rules, so that the two cannot drift apart. What
+     * holds the two together is {@code TestColumnReaderFactory.testIsSupportedAgreesWithCreate}, which walks every
+     * combination of the two, rather than the branches below standing in the same order as those of {@link #create}.
+     */
+    public static boolean isSupported(Type type, PrimitiveType parquetType)
+    {
+        PrimitiveTypeName primitiveType = parquetType.getPrimitiveTypeName();
+        LogicalTypeAnnotation annotation = parquetType.getLogicalTypeAnnotation();
+
+        if (BOOLEAN.equals(type) && primitiveType == PrimitiveTypeName.BOOLEAN) {
+            return true;
+        }
+        if (DATE.equals(type) && primitiveType == INT32) {
+            return isIntegerAnnotation(annotation) || annotation instanceof DateLogicalTypeAnnotation;
+        }
+        if (type instanceof TimeType) {
+            if (!(annotation instanceof TimeLogicalTypeAnnotation timeAnnotation)) {
+                return false;
+            }
+            return (primitiveType == INT64 && timeAnnotation.getUnit() == MICROS)
+                    || (primitiveType == INT32 && timeAnnotation.getUnit() == MILLIS);
+        }
+        if (BIGINT.equals(type) && primitiveType == INT64
+                && (annotation instanceof TimestampLogicalTypeAnnotation || annotation instanceof TimeLogicalTypeAnnotation)) {
+            return true;
+        }
+        // DATE and REAL are integer types as well, and TIME and BIGINT are long types, so the three branches above
+        // have to stay ahead of this one, which a date over INT64 and a real over an integral column reach
+        if ((TINYINT.equals(type) || SMALLINT.equals(type) || type instanceof AbstractIntType || type instanceof AbstractLongType)
+                && isIntegerOrDecimalPrimitive(primitiveType)) {
+            return isZeroScaleShortDecimalAnnotation(annotation) || isIntegerAnnotationAndPrimitive(annotation, primitiveType);
+        }
+        if (REAL.equals(type) && primitiveType == FLOAT) {
+            return true;
+        }
+        if (DOUBLE.equals(type)) {
+            return primitiveType == PrimitiveTypeName.DOUBLE || primitiveType == FLOAT;
+        }
+        if (type instanceof TimestampType && primitiveType == INT96) {
+            return true;
+        }
+        if (type instanceof TimestampWithTimeZoneType && primitiveType == INT96) {
+            return true;
+        }
+        if (type instanceof TimestampType && primitiveType == INT64) {
+            return annotation instanceof TimestampLogicalTypeAnnotation;
+        }
+        if (type instanceof TimestampWithTimeZoneType timestampWithTimeZoneType && primitiveType == INT64) {
+            if (!(annotation instanceof TimestampLogicalTypeAnnotation timestampAnnotation)) {
+                return false;
+            }
+            // there is no millisecond decoder for a long timestamp with time zone
+            return timestampWithTimeZoneType.isShort() || timestampAnnotation.getUnit() != MILLIS;
+        }
+        if (type instanceof DecimalType decimalType && decimalType.isShort() && isIntegerOrDecimalPrimitive(primitiveType)) {
+            return (primitiveType == INT32 && isIntegerAnnotation(annotation)) || annotation instanceof DecimalLogicalTypeAnnotation;
+        }
+        if (type instanceof DecimalType decimalType && !decimalType.isShort() && isIntegerOrDecimalPrimitive(primitiveType)) {
+            return annotation instanceof DecimalLogicalTypeAnnotation;
+        }
+        // covers the bounded varchar, char and plain binary readers, which all take a variable width type over BINARY
+        if (type instanceof AbstractVariableWidthType && primitiveType == BINARY) {
+            return true;
+        }
+        if ((VARBINARY.equals(type) || VARCHAR.equals(type)) && primitiveType == FIXED_LEN_BYTE_ARRAY) {
+            return !(annotation instanceof DecimalLogicalTypeAnnotation);
+        }
+        if (UUID.equals(type) && primitiveType == FIXED_LEN_BYTE_ARRAY) {
+            return annotation == null || isLogicalUuid(annotation);
+        }
+        return false;
     }
 
     private <T> ColumnReader createColumnReader(

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ColumnReaderFactory.java
@@ -338,7 +338,9 @@ public final class ColumnReaderFactory
         }
         // covers the bounded varchar, char and plain binary readers, which all take a variable width type over BINARY
         if (type instanceof AbstractVariableWidthType && primitiveType == BINARY) {
-            return true;
+            // a decimal annotated column holds a number in its bytes, which these readers would hand back as text,
+            // so it is refused here just as it is on the fixed length branch below
+            return !(annotation instanceof DecimalLogicalTypeAnnotation);
         }
         if ((VARBINARY.equals(type) || VARCHAR.equals(type)) && primitiveType == FIXED_LEN_BYTE_ARRAY) {
             return !(annotation instanceof DecimalLogicalTypeAnnotation);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
@@ -508,6 +508,37 @@ public class TestTupleDomainParquetPredicate
     }
 
     @Test
+    public void testDoubleWithFloatColumn()
+            throws Exception
+    {
+        // A column widened from real to double keeps its physical float statistics in every file written before the
+        // change, and ColumnReaderFactory widens the column itself, so those bounds are what the reader will produce
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(FLOAT, "FloatColumn");
+
+        float minimum = 4.3f;
+        float maximum = 40.3f;
+
+        assertThat(getDomain(columnDescriptor, DOUBLE, 10, floatColumnStats(minimum, maximum), ID, UTC))
+                .isEqualTo(create(ValueSet.ofRanges(range(DOUBLE, (double) minimum, true, (double) maximum, true)), false));
+
+        assertThat(getDomain(DOUBLE, floatDictionaryDescriptor(minimum)))
+                .isEqualTo(create(ValueSet.ofRanges(range(DOUBLE, (double) minimum, true, (double) minimum, true)), true));
+
+        ColumnIndex columnIndex = ColumnIndexBuilder.build(
+                Types.required(FLOAT).named("test_float"),
+                BoundaryOrder.UNORDERED,
+                asList(false),
+                asList(0L),
+                toFloatByteBufferList(minimum),
+                toFloatByteBufferList(maximum));
+        assertThat(getDomain(DOUBLE, 200, columnIndex, ID, columnDescriptor, UTC))
+                .isEqualTo(create(ValueSet.ofRanges(range(DOUBLE, (double) minimum, true, (double) maximum, true)), false));
+
+        // a NaN bound is as unusable here as it is on a physical double column
+        assertThat(getDomain(columnDescriptor, DOUBLE, 10, floatColumnStats(NaN, NaN), ID, UTC)).isEqualTo(notNull(DOUBLE));
+    }
+
+    @Test
     public void testDictionaryTypeMismatchLeavesDomainUnnarrowed()
             throws Exception
     {
@@ -562,6 +593,8 @@ public class TestTupleDomainParquetPredicate
                 // ColumnReaderFactory reads a fixed length byte array verbatim for an unbounded varchar, and both byte
                 // array physical types hold the statistics as raw bytes
                 Arguments.of(FIXED_LEN_BYTE_ARRAY, null, createUnboundedVarcharType(), true),
+                // the reader widens a float column to double, so its bounds are usable as double bounds
+                Arguments.of(FLOAT, null, DOUBLE, true),
 
                 // the reader refuses the column outright
                 Arguments.of(INT32, null, BOOLEAN, false),
@@ -587,9 +620,7 @@ public class TestTupleDomainParquetPredicate
                 // the reader accepts the column but does not produce the stored value
                 Arguments.of(BINARY, null, createVarcharType(3), false),
                 Arguments.of(BINARY, null, createCharType(3), false),
-                Arguments.of(BINARY, decimalType(2, 10), createUnboundedVarcharType(), false),
-                // widening float bounds to double is a separate change
-                Arguments.of(FLOAT, null, DOUBLE, false));
+                Arguments.of(BINARY, decimalType(2, 10), createUnboundedVarcharType(), false));
     }
 
     /**
@@ -622,6 +653,7 @@ public class TestTupleDomainParquetPredicate
                 // hashed at a different width, so a lookup would miss every value which is present
                 Arguments.of(INT32, null, BIGINT, false),
                 Arguments.of(INT64, null, INTEGER, false),
+                // note the contrast with the statistics above: the bounds widen exactly, but a hash does not
                 Arguments.of(FLOAT, null, DOUBLE, false),
                 Arguments.of(PrimitiveTypeName.DOUBLE, null, REAL, false),
 
@@ -1099,6 +1131,15 @@ public class TestTupleDomainParquetPredicate
         return new LongTimestamp(
                 start.atZone(ZoneOffset.UTC).toInstant().getEpochSecond() * MICROSECONDS_PER_SECOND + start.getLong(MICRO_OF_SECOND),
                 toIntExact(round((start.getNano() % PICOSECONDS_PER_NANOSECOND) * (long) PICOSECONDS_PER_NANOSECOND, toIntExact(TimestampType.MAX_PRECISION - precision))));
+    }
+
+    private static List<ByteBuffer> toFloatByteBufferList(Float... values)
+    {
+        List<ByteBuffer> buffers = new ArrayList<>(values.length);
+        for (Float value : values) {
+            buffers.add(ByteBuffer.wrap(BytesUtils.intToBytes(Float.floatToIntBits(value))));
+        }
+        return buffers;
     }
 
     private static List<ByteBuffer> toByteBufferList(Long... values)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
@@ -73,6 +73,7 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.parquet.ParquetEncoding.PLAIN_DICTIONARY;
 import static io.trino.parquet.ParquetTimestampUtils.JULIAN_EPOCH_OFFSET_DAYS;
 import static io.trino.parquet.ParquetTypeUtils.paddingBigInteger;
+import static io.trino.parquet.predicate.TupleDomainParquetPredicate.bloomFilterHasher;
 import static io.trino.parquet.predicate.TupleDomainParquetPredicate.getDomain;
 import static io.trino.spi.predicate.Domain.all;
 import static io.trino.spi.predicate.Domain.create;
@@ -589,6 +590,49 @@ public class TestTupleDomainParquetPredicate
                 Arguments.of(BINARY, decimalType(2, 10), createUnboundedVarcharType(), false),
                 // widening float bounds to double is a separate change
                 Arguments.of(FLOAT, null, DOUBLE, false));
+    }
+
+    /**
+     * A bloom filter is built by hashing each value at the physical width of the column, so it can only be consulted
+     * where the predicate value hashes to the same thing the writer hashed.
+     */
+    @ParameterizedTest
+    @MethodSource("bloomFilterTypeCombinations")
+    public void testBloomFilterIsConsultedOnlyAtTheHashedWidth(PrimitiveTypeName physicalType, LogicalTypeAnnotation annotation, Type type, boolean consulted)
+    {
+        PrimitiveType parquetType = createColumnDescriptor(physicalType, annotation, "TestColumn").getPrimitiveType();
+
+        assertThat(bloomFilterHasher(type, parquetType)).matches(hasher -> hasher.isPresent() == consulted);
+    }
+
+    private static Stream<Arguments> bloomFilterTypeCombinations()
+    {
+        return Stream.of(
+                Arguments.of(INT32, null, INTEGER, true),
+                Arguments.of(INT32, null, TINYINT, true),
+                Arguments.of(INT32, dateType(), DATE, true),
+                Arguments.of(INT64, null, BIGINT, true),
+                Arguments.of(PrimitiveTypeName.DOUBLE, null, DOUBLE, true),
+                Arguments.of(FLOAT, null, REAL, true),
+                Arguments.of(BINARY, null, createUnboundedVarcharType(), true),
+                Arguments.of(BINARY, null, VARBINARY, true),
+                Arguments.of(FIXED_LEN_BYTE_ARRAY, null, VARBINARY, true),
+                Arguments.of(FIXED_LEN_BYTE_ARRAY, uuidType(), UUID, true),
+
+                // hashed at a different width, so a lookup would miss every value which is present
+                Arguments.of(INT32, null, BIGINT, false),
+                Arguments.of(INT64, null, INTEGER, false),
+                Arguments.of(FLOAT, null, DOUBLE, false),
+                Arguments.of(PrimitiveTypeName.DOUBLE, null, REAL, false),
+
+                // ColumnReaderFactory refuses a decimal annotated fixed length byte array for these, so the filter
+                // holds bytes the reader never produces
+                Arguments.of(FIXED_LEN_BYTE_ARRAY, decimalType(2, 20), VARBINARY, false),
+                Arguments.of(FIXED_LEN_BYTE_ARRAY, decimalType(2, 20), UUID, false),
+
+                // the reader does not hand these bytes back unchanged
+                Arguments.of(BINARY, null, createVarcharType(3), false),
+                Arguments.of(BINARY, decimalType(2, 10), createUnboundedVarcharType(), false));
     }
 
     private static Statistics<?> statisticsFor(PrimitiveTypeName physicalType)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
@@ -21,6 +21,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.parquet.predicate.DictionaryDescriptor;
 import io.trino.parquet.predicate.TupleDomainParquetPredicate;
+import io.trino.parquet.predicate.TupleDomainParquetPredicate.BloomFilterHasher;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
@@ -40,9 +41,12 @@ import org.apache.parquet.column.statistics.FloatStatistics;
 import org.apache.parquet.column.statistics.IntStatistics;
 import org.apache.parquet.column.statistics.LongStatistics;
 import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.column.values.bloomfilter.BlockSplitBloomFilter;
+import org.apache.parquet.column.values.bloomfilter.BloomFilter;
 import org.apache.parquet.internal.column.columnindex.BoundaryOrder;
 import org.apache.parquet.internal.column.columnindex.ColumnIndex;
 import org.apache.parquet.internal.column.columnindex.ColumnIndexBuilder;
+import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
 import org.apache.parquet.schema.PrimitiveType;
@@ -61,6 +65,8 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -103,6 +109,7 @@ import static io.trino.spi.type.UuidType.UUID;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.spi.type.Varchars.truncateToLength;
 import static java.lang.Float.NaN;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Math.toIntExact;
@@ -114,6 +121,7 @@ import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.uuidType;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
@@ -466,6 +474,159 @@ public class TestTupleDomainParquetPredicate
                 .withMessage("Malformed Parquet file. Corrupted statistics for column \"[] required binary StringColumn\": [min: 0x7461636F, max: 0x6170706C65, num_nulls: 0] [testFile]");
     }
 
+    /**
+     * The reader cuts a bounded varchar down to its length, so the bounds it can be held to are not the stored ones.
+     * The stored maximum still bounds it, since a prefix never sorts above the value it was cut from, while the
+     * minimum is cut back to the longest prefix of itself that nothing readable sorts below.
+     */
+    @Test
+    public void testBoundedVarcharStatistics()
+            throws ParquetCorruptionException
+    {
+        ColumnDescriptor column = createColumnDescriptor(BINARY, stringType(), "StringColumn");
+
+        VarcharType threeCodePoints = createVarcharType(3);
+        assertThat(getDomain(column, threeCodePoints, 10, stringColumnStats("apple", "taco"), ID, UTC))
+                .isEqualTo(create(ValueSet.ofRanges(range(threeCodePoints, utf8Slice("app"), true, utf8Slice("taco"), true)), false));
+        // "tacos" sits inside the stored bounds and is read back as "tac", which the range still admits
+        assertThat(getDomain(column, threeCodePoints, 10, stringColumnStats("apple", "taco"), ID, UTC).includesNullableValue(utf8Slice("tac")))
+                .isTrue();
+
+        // the cut is by code point and not by byte, and it keeps the leading byte of the code point it cuts at, so
+        // 中国 bounds at E4 rather than at 中
+        VarcharType oneCodePoint = createVarcharType(1);
+        assertThat(getDomain(column, oneCodePoint, 10, stringColumnStats("中国", "美利坚"), ID, UTC))
+                .isEqualTo(create(ValueSet.ofRanges(range(oneCodePoint, Slices.wrappedBuffer((byte) 0xE4), true, utf8Slice("美利坚"), true)), false));
+
+        // C3 C3 A9 sorts above the minimum, can sit in the same row group, and is read back as C3, which a minimum
+        // cut to a whole code point would have put outside the range
+        Slice codePointMinimum = Slices.wrappedBuffer((byte) 0xC3, (byte) 0xA9);
+        Slice codePointMaximum = Slices.wrappedBuffer((byte) 0xC3, (byte) 0xC3, (byte) 0xA9);
+        assertThat(getDomain(column, oneCodePoint, 10, binaryColumnStats(codePointMinimum, codePointMaximum), ID, UTC)
+                .includesNullableValue(Slices.wrappedBuffer((byte) 0xC3)))
+                .isTrue();
+
+        // the STRING annotation does not promise the bytes are UTF-8, and the cut no longer needs it to, since it
+        // stops at the leading byte rather than scanning past it
+        Slice invalidMinimum = Slices.wrappedBuffer((byte) 0xC7, (byte) 0x8F, (byte) 0x91, (byte) 0x4F, (byte) 0x85);
+        Slice invalidMaximum = Slices.wrappedBuffer((byte) 0xC7, (byte) 0xC8, (byte) 0x93, (byte) 0x0A);
+        assertThat(getDomain(column, oneCodePoint, 10, binaryColumnStats(invalidMinimum, invalidMaximum), ID, UTC))
+                .isEqualTo(create(ValueSet.ofRanges(range(oneCodePoint, Slices.wrappedBuffer((byte) 0xC7), true, invalidMaximum, true)), false));
+
+        // 42 C0 C9 C2 41 lies between these bounds and is read back as 42, which a minimum cut to 42 AA A3 81 would
+        // have put outside the range
+        Slice shortenedMinimum = Slices.wrappedBuffer((byte) 0x42, (byte) 0xAA, (byte) 0xA3, (byte) 0x81);
+        Slice shortenedMaximum = Slices.wrappedBuffer((byte) 0xC3, (byte) 0xC4, (byte) 0x97, (byte) 0x41);
+        assertThat(getDomain(column, oneCodePoint, 10, binaryColumnStats(shortenedMinimum, shortenedMaximum), ID, UTC)
+                .includesNullableValue(Slices.wrappedBuffer((byte) 0x42)))
+                .isTrue();
+
+        // the minimum is guarded where it is used, so an unannotated column is bounded exactly the same way
+        ColumnDescriptor unannotated = createColumnDescriptor(BINARY, "StringColumn");
+        assertThat(getDomain(unannotated, threeCodePoints, 10, stringColumnStats("apple", "taco"), ID, UTC))
+                .isEqualTo(create(ValueSet.ofRanges(range(threeCodePoints, utf8Slice("app"), true, utf8Slice("taco"), true)), false));
+    }
+
+    /**
+     * The reason the minimum is cut at all: no value the reader can produce out of a row group sorts below the low
+     * bound built from that row group's minimum, and the bounds never come out inverted. Swept over every byte string
+     * the interesting UTF-8 shapes can spell, rather than over the cases review happened to think of.
+     */
+    @Test
+    public void testBoundedVarcharLowerBoundHoldsForEveryReadableValue()
+    {
+        ColumnDescriptor column = createColumnDescriptor(BINARY, stringType(), "StringColumn");
+        List<byte[]> storedValues = byteStringsUpToLength(4);
+        ImmutableList.Builder<String> violations = ImmutableList.builder();
+
+        for (int boundedLength = 1; boundedLength <= 3; boundedLength++) {
+            VarcharType varcharType = createVarcharType(boundedLength);
+            for (byte[] minimum : storedValues) {
+                for (byte[] stored : storedValues) {
+                    if (Arrays.compareUnsigned(minimum, stored) > 0) {
+                        continue;
+                    }
+                    Slice readValue = truncateToLength(Slices.wrappedBuffer(stored), varcharType);
+                    Domain domain;
+                    try {
+                        domain = getDomain(column, varcharType, 10, binaryColumnStats(Slices.wrappedBuffer(minimum), Slices.wrappedBuffer(stored)), ID, UTC);
+                    }
+                    catch (ParquetCorruptionException _) {
+                        violations.add(describeBound(boundedLength, minimum, stored, "builds an inverted range"));
+                        continue;
+                    }
+                    if (!domain.includesNullableValue(readValue)) {
+                        violations.add(describeBound(boundedLength, minimum, stored, "excludes " + HexFormat.of().formatHex(readValue.getBytes())));
+                    }
+                }
+            }
+        }
+
+        assertThat(violations.build()).isEmpty();
+    }
+
+    private static String describeBound(int boundedLength, byte[] minimum, byte[] stored, String failure)
+    {
+        return "varchar(%s) over [%s, %s] %s".formatted(boundedLength, HexFormat.of().formatHex(minimum), HexFormat.of().formatHex(stored), failure);
+    }
+
+    /**
+     * Every byte string up to {@code maxLength} bytes long over an ASCII byte, a UTF-8 continuation byte, and the
+     * leading bytes of a two and a three byte code point, which is every shape the cut can behave differently on.
+     */
+    private static List<byte[]> byteStringsUpToLength(int maxLength)
+    {
+        byte[] alphabet = {(byte) 0x41, (byte) 0x80, (byte) 0xC3, (byte) 0xE4};
+        ImmutableList.Builder<byte[]> allValues = ImmutableList.builder();
+        List<byte[]> shorterValues = ImmutableList.of(new byte[0]);
+        for (int length = 1; length <= maxLength; length++) {
+            ImmutableList.Builder<byte[]> currentValues = ImmutableList.builder();
+            for (byte[] prefix : shorterValues) {
+                for (byte symbol : alphabet) {
+                    byte[] value = Arrays.copyOf(prefix, length);
+                    value[length - 1] = symbol;
+                    currentValues.add(value);
+                }
+            }
+            shorterValues = currentValues.build();
+            allValues.addAll(shorterValues);
+        }
+        return allValues.build();
+    }
+
+    /**
+     * The uuid values reach the bloom filter through the same branch as varchar and varbinary, wrapped in a
+     * {@link Binary} over the buffer of the slice rather than over a copy of its bytes. parquet-mr hashes the two
+     * identically, including for a slice held at an offset inside a larger buffer.
+     */
+    @Test
+    public void testUuidBloomFilterHashesTheStoredBytes()
+    {
+        PrimitiveType uuidColumn = createColumnDescriptor(FIXED_LEN_BYTE_ARRAY, uuidType(), "UuidColumn").getPrimitiveType();
+        byte[] uuidBytes = new byte[16];
+        for (int i = 0; i < uuidBytes.length; i++) {
+            uuidBytes[i] = (byte) (7 * i + 1);
+        }
+        BloomFilter bloomFilter = new BlockSplitBloomFilter(1024, 1024);
+        bloomFilter.insertHash(bloomFilter.hash(Binary.fromConstantByteArray(uuidBytes)));
+
+        byte[] backingBuffer = new byte[uuidBytes.length + 8];
+        System.arraycopy(uuidBytes, 0, backingBuffer, 5, uuidBytes.length);
+        Slice heldAtAnOffset = Slices.wrappedBuffer(backingBuffer, 5, uuidBytes.length);
+
+        BloomFilterHasher hasher = bloomFilterHasher(UUID, uuidColumn).orElseThrow();
+        assertThat(bloomFilter.findHash(hasher.hash(bloomFilter, heldAtAnOffset))).isTrue();
+    }
+
+    private static BinaryStatistics binaryColumnStats(Slice minimum, Slice maximum)
+    {
+        return (BinaryStatistics) Statistics.getBuilderForReading(Types.optional(BINARY).named("StringColumn"))
+                .withMin(minimum.getBytes())
+                .withMax(maximum.getBytes())
+                .withNumNulls(0)
+                .build();
+    }
+
     private static BinaryStatistics stringColumnStats(String minimum, String maximum)
     {
         return (BinaryStatistics) Statistics.getBuilderForReading(Types.optional(BINARY).named("StringColumn"))
@@ -588,6 +749,10 @@ public class TestTupleDomainParquetPredicate
                 Arguments.of(FLOAT, null, REAL, true),
                 Arguments.of(PrimitiveTypeName.DOUBLE, null, DOUBLE, true),
                 Arguments.of(BINARY, null, createUnboundedVarcharType(), true),
+                // the reader cuts a bounded varchar down to its length and the low bound is cut with it, which is
+                // guarded where the bound is built rather than here
+                Arguments.of(BINARY, stringType(), createVarcharType(3), true),
+                Arguments.of(BINARY, null, createVarcharType(3), true),
                 Arguments.of(BINARY, decimalType(2, 10), createDecimalType(10, 2), true),
                 Arguments.of(INT96, null, createTimestampType(3), true),
                 // ColumnReaderFactory reads a fixed length byte array verbatim for an unbounded varchar, and both byte
@@ -622,8 +787,8 @@ public class TestTupleDomainParquetPredicate
                 Arguments.of(FIXED_LEN_BYTE_ARRAY, uuidType(), UUID, false),
 
                 // the reader accepts the column but does not produce the stored value
-                Arguments.of(BINARY, null, createVarcharType(3), false),
                 Arguments.of(BINARY, null, createCharType(3), false),
+                Arguments.of(BINARY, stringType(), createCharType(3), false),
                 // RealType is an integer type, so the reader takes a real over an integral column and reinterprets
                 // the stored integer as float bits
                 Arguments.of(INT32, null, REAL, false),
@@ -675,8 +840,9 @@ public class TestTupleDomainParquetPredicate
                 Arguments.of(FIXED_LEN_BYTE_ARRAY, decimalType(2, 20), VARBINARY, false),
                 Arguments.of(FIXED_LEN_BYTE_ARRAY, decimalType(2, 20), UUID, false),
 
-                // the reader does not hand these bytes back unchanged
+                // the reader does not hand these bytes back unchanged, whatever their statistics can be narrowed to
                 Arguments.of(BINARY, null, createVarcharType(3), false),
+                Arguments.of(BINARY, stringType(), createVarcharType(3), false),
                 Arguments.of(BINARY, decimalType(2, 10), createUnboundedVarcharType(), false));
     }
 
@@ -844,14 +1010,31 @@ public class TestTupleDomainParquetPredicate
         assertThat(parquetPredicate.getIndexLookupCandidates(ImmutableMap.of(column, 2L), ImmutableMap.of(column, stats), ID))
                 .isEqualTo(Optional.of(ImmutableList.of(column)));
 
-        // The reader truncates a bounded varchar to its length while the statistics hold the untruncated bytes, so the
-        // column is worth no further inspection either
-        TupleDomainParquetPredicate boundedPredicate = new TupleDomainParquetPredicate(
-                getEffectivePredicate(column, createVarcharType(255), utf8Slice(value)),
-                singletonList(column),
-                UTC);
-        assertThat(boundedPredicate.getIndexLookupCandidates(ImmutableMap.of(column, 2L), ImmutableMap.of(column, stats), ID))
-                .isEqualTo(Optional.of(ImmutableList.of()));
+        // "Test" is read back as "Te" through a varchar(2), and the bounds are truncated with it, so a predicate on
+        // "Te" keeps the row group while one on "Ta" eliminates it
+        ColumnDescriptor utf8Column = createColumnDescriptor(BINARY, stringType(), "VarcharColumn");
+        Statistics<?> utf8Stats = Statistics.getBuilderForReading(utf8Column.getPrimitiveType())
+                .withMin(value.getBytes(UTF_8))
+                .withMax(value.getBytes(UTF_8))
+                .withNumNulls(1L)
+                .build();
+        Map<ColumnDescriptor, Long> utf8ValueCounts = ImmutableMap.of(utf8Column, 2L);
+        Map<ColumnDescriptor, Statistics<?>> utf8Statistics = ImmutableMap.of(utf8Column, utf8Stats);
+        assertThat(new TupleDomainParquetPredicate(getEffectivePredicate(utf8Column, createVarcharType(2), utf8Slice("Te")), singletonList(utf8Column), UTC)
+                .getIndexLookupCandidates(utf8ValueCounts, utf8Statistics, ID))
+                .isEqualTo(Optional.of(ImmutableList.of(utf8Column)));
+        assertThat(new TupleDomainParquetPredicate(getEffectivePredicate(utf8Column, createVarcharType(2), utf8Slice("Ta")), singletonList(utf8Column), UTC)
+                .getIndexLookupCandidates(utf8ValueCounts, utf8Statistics, ID))
+                .isEmpty();
+
+        // the low bound is guarded where it is built rather than by the annotation, so an unannotated column is held
+        // to the same bounds
+        assertThat(new TupleDomainParquetPredicate(getEffectivePredicate(column, createVarcharType(2), utf8Slice("Te")), singletonList(column), UTC)
+                .getIndexLookupCandidates(ImmutableMap.of(column, 2L), ImmutableMap.of(column, stats), ID))
+                .isEqualTo(Optional.of(ImmutableList.of(column)));
+        assertThat(new TupleDomainParquetPredicate(getEffectivePredicate(column, createVarcharType(2), utf8Slice("Ta")), singletonList(column), UTC)
+                .getIndexLookupCandidates(ImmutableMap.of(column, 2L), ImmutableMap.of(column, stats), ID))
+                .isEmpty();
     }
 
     @Test

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
@@ -49,6 +49,9 @@ import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Types;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
@@ -61,6 +64,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.log.Level.ERROR;
@@ -79,6 +83,7 @@ import static io.trino.spi.predicate.Range.range;
 import static io.trino.spi.predicate.TupleDomain.withColumnDomains;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -93,6 +98,8 @@ import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.spi.type.Timestamps.round;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.UuidType.UUID;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.lang.Float.NaN;
@@ -104,7 +111,9 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.uuidType;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
@@ -251,7 +260,7 @@ public class TestTupleDomainParquetPredicate
     public void testShortDecimalWithInt64()
             throws Exception
     {
-        ColumnDescriptor columnDescriptor = createColumnDescriptor(INT64, "ShortDecimalColumn");
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(INT64, decimalType(2, 5), "ShortDecimalColumn");
         Type type = createDecimalType(5, 2);
         assertThat(getDomain(columnDescriptor, type, 0, null, ID, UTC)).isEqualTo(all(type));
 
@@ -263,7 +272,7 @@ public class TestTupleDomainParquetPredicate
         // fail on corrupted statistics
         assertThatExceptionOfType(ParquetCorruptionException.class)
                 .isThrownBy(() -> getDomain(columnDescriptor, type, 10, longColumnStats(100L, 10L), ID, UTC))
-                .withMessage("Malformed Parquet file. Corrupted statistics for column \"[] required int64 ShortDecimalColumn\": [min: 100, max: 10, num_nulls: 0] [testFile]");
+                .withMessage("Malformed Parquet file. Corrupted statistics for column \"[] required int64 ShortDecimalColumn (DECIMAL(5,2))\": [min: 100, max: 10, num_nulls: 0] [testFile]");
     }
 
     @Test
@@ -326,7 +335,7 @@ public class TestTupleDomainParquetPredicate
     public void testLongDecimal()
             throws Exception
     {
-        ColumnDescriptor columnDescriptor = createColumnDescriptor(FIXED_LEN_BYTE_ARRAY, "LongDecimalColumn");
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(FIXED_LEN_BYTE_ARRAY, decimalType(5, 20), "LongDecimalColumn");
         DecimalType type = createDecimalType(20, 5);
         BigInteger maximum = new BigInteger("12345678901234512345");
 
@@ -343,14 +352,14 @@ public class TestTupleDomainParquetPredicate
         // fail on corrupted statistics
         assertThatExceptionOfType(ParquetCorruptionException.class)
                 .isThrownBy(() -> getDomain(columnDescriptor, type, 10, binaryColumnStats(100L, 10L), ID, UTC))
-                .withMessage("Malformed Parquet file. Corrupted statistics for column \"[] required fixed_len_byte_array(0) LongDecimalColumn\": [min: 0x00000000000000000000000000000064, max: 0x0000000000000000000000000000000A, num_nulls: 0] [testFile]");
+                .withMessage("Malformed Parquet file. Corrupted statistics for column \"[] required fixed_len_byte_array(0) LongDecimalColumn (DECIMAL(20,5))\": [min: 0x00000000000000000000000000000064, max: 0x0000000000000000000000000000000A, num_nulls: 0] [testFile]");
     }
 
     @Test
     public void testLongDecimalWithNoScale()
             throws Exception
     {
-        ColumnDescriptor columnDescriptor = createColumnDescriptor(FIXED_LEN_BYTE_ARRAY, "LongDecimalColumnWithNoScale");
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(FIXED_LEN_BYTE_ARRAY, decimalType(0, 20), "LongDecimalColumnWithNoScale");
         DecimalType type = createDecimalType(20, 0);
         Int128 zero = Int128.ZERO;
         Int128 hundred = Int128.valueOf(100L);
@@ -362,7 +371,7 @@ public class TestTupleDomainParquetPredicate
         // fail on corrupted statistics
         assertThatExceptionOfType(ParquetCorruptionException.class)
                 .isThrownBy(() -> getDomain(columnDescriptor, type, 10, binaryColumnStats(100L, 10L), ID, UTC))
-                .withMessage("Malformed Parquet file. Corrupted statistics for column \"[] required fixed_len_byte_array(0) LongDecimalColumnWithNoScale\": [min: 0x00000000000000000000000000000064, max: 0x0000000000000000000000000000000A, num_nulls: 0] [testFile]");
+                .withMessage("Malformed Parquet file. Corrupted statistics for column \"[] required fixed_len_byte_array(0) LongDecimalColumnWithNoScale (DECIMAL(20,0))\": [min: 0x00000000000000000000000000000064, max: 0x0000000000000000000000000000000A, num_nulls: 0] [testFile]");
     }
 
     @Test
@@ -495,6 +504,104 @@ public class TestTupleDomainParquetPredicate
         assertThatExceptionOfType(ParquetCorruptionException.class)
                 .isThrownBy(() -> getDomain(columnDescriptor, REAL, 10, floatColumnStats(maximum, minimum), ID, UTC))
                 .withMessage("Malformed Parquet file. Corrupted statistics for column \"[] required float FloatColumn\": [min: 40.3, max: 4.3, num_nulls: 0] [testFile]");
+    }
+
+    @Test
+    public void testDictionaryTypeMismatchLeavesDomainUnnarrowed()
+            throws Exception
+    {
+        // Schema evolution makes the type in the table schema disagree with the physical type the file was written
+        // with. A dictionary is decoded from the physical type just as the row group statistics are, so the same guard
+        // has to stop it, leaving the domain alone rather than letting a ClassCastException escape
+        assertThat(getDomain(createUnboundedVarcharType(), floatDictionaryDescriptor(1.0f)))
+                .isEqualTo(all(createUnboundedVarcharType()));
+
+        assertThat(getDomain(BOOLEAN, doubleDictionaryDescriptor(1, 2)))
+                .isEqualTo(all(BOOLEAN));
+    }
+
+    /**
+     * Statistics are decoded as the physical type of the column in the file, while the domain being narrowed carries
+     * the type from the table schema. The two agree only where the reader agrees, which is what
+     * {@link io.trino.parquet.reader.ColumnReaderFactory#isSupported} decides, minus the conversions which do not
+     * preserve the stored value.
+     */
+    @ParameterizedTest
+    @MethodSource("statisticsTypeCombinations")
+    public void testStatisticsAreUsedOnlyWhereTheReaderAgrees(PrimitiveTypeName physicalType, LogicalTypeAnnotation annotation, Type type, boolean narrows)
+            throws ParquetCorruptionException
+    {
+        ColumnDescriptor column = createColumnDescriptor(physicalType, annotation, "TestColumn");
+
+        Domain domain = getDomain(column, type, 10, statisticsFor(physicalType), ID, UTC);
+
+        if (narrows) {
+            assertThat(domain).isNotEqualTo(notNull(type));
+        }
+        else {
+            assertThat(domain).isEqualTo(notNull(type));
+        }
+    }
+
+    private static Stream<Arguments> statisticsTypeCombinations()
+    {
+        return Stream.of(
+                // the reader produces these values unchanged, so the bounds are the reader's own
+                Arguments.of(PrimitiveTypeName.BOOLEAN, null, BOOLEAN, true),
+                Arguments.of(INT32, null, INTEGER, true),
+                Arguments.of(INT32, null, BIGINT, true),
+                Arguments.of(INT64, null, INTEGER, true),
+                Arguments.of(INT64, null, BIGINT, true),
+                Arguments.of(INT32, dateType(), DATE, true),
+                Arguments.of(FLOAT, null, REAL, true),
+                Arguments.of(PrimitiveTypeName.DOUBLE, null, DOUBLE, true),
+                Arguments.of(BINARY, null, createUnboundedVarcharType(), true),
+                Arguments.of(BINARY, decimalType(2, 10), createDecimalType(10, 2), true),
+                Arguments.of(INT96, null, createTimestampType(3), true),
+                // ColumnReaderFactory reads a fixed length byte array verbatim for an unbounded varchar, and both byte
+                // array physical types hold the statistics as raw bytes
+                Arguments.of(FIXED_LEN_BYTE_ARRAY, null, createUnboundedVarcharType(), true),
+
+                // the reader refuses the column outright
+                Arguments.of(INT32, null, BOOLEAN, false),
+                Arguments.of(FLOAT, null, BIGINT, false),
+                Arguments.of(BINARY, null, INTEGER, false),
+                Arguments.of(PrimitiveTypeName.DOUBLE, null, REAL, false),
+                Arguments.of(INT32, null, DOUBLE, false),
+                Arguments.of(INT64, null, DOUBLE, false),
+                Arguments.of(FLOAT, null, createUnboundedVarcharType(), false),
+                Arguments.of(INT32, null, createUnboundedVarcharType(), false),
+                Arguments.of(FLOAT, null, createDecimalType(5, 2), false),
+                Arguments.of(INT32, null, createTimestampType(3), false),
+                Arguments.of(FIXED_LEN_BYTE_ARRAY, decimalType(2, 20), createUnboundedVarcharType(), false),
+                // an integral column annotated as a decimal with a scale is rescaled by the reader, not read as an integer
+                Arguments.of(INT64, decimalType(2, 18), BIGINT, false),
+                // a decimal needs its annotation to know the scale, so an unannotated column is not a decimal at all
+                Arguments.of(BINARY, null, createDecimalType(10, 2), false),
+
+                // the reader reads these, but getDomain has no branch for the type, so the bounds go unused either way
+                Arguments.of(BINARY, null, VARBINARY, false),
+                Arguments.of(FIXED_LEN_BYTE_ARRAY, uuidType(), UUID, false),
+
+                // the reader accepts the column but does not produce the stored value
+                Arguments.of(BINARY, null, createVarcharType(3), false),
+                Arguments.of(BINARY, null, createCharType(3), false),
+                Arguments.of(BINARY, decimalType(2, 10), createUnboundedVarcharType(), false),
+                // widening float bounds to double is a separate change
+                Arguments.of(FLOAT, null, DOUBLE, false));
+    }
+
+    private static Statistics<?> statisticsFor(PrimitiveTypeName physicalType)
+    {
+        return switch (physicalType) {
+            case PrimitiveTypeName.BOOLEAN -> booleanColumnStats(true, true);
+            case INT32 -> intColumnStats(0, 100);
+            case INT64 -> longColumnStats(0, 100);
+            case FLOAT -> floatColumnStats(1.0f, 2.0f);
+            case PrimitiveTypeName.DOUBLE -> doubleColumnStats(1, 2);
+            case BINARY, FIXED_LEN_BYTE_ARRAY -> stringColumnStats("aa", "bb");
+            case INT96 -> timestampColumnStats(LocalDateTime.of(2026, 1, 1, 1, 1), LocalDateTime.of(2026, 1, 1, 1, 1));
+        };
     }
 
     @Test
@@ -637,7 +744,7 @@ public class TestTupleDomainParquetPredicate
     {
         String value = "Test";
         ColumnDescriptor column = createColumnDescriptor(BINARY, "VarcharColumn");
-        TupleDomain<ColumnDescriptor> effectivePredicate = getEffectivePredicate(column, createVarcharType(255), utf8Slice(value));
+        TupleDomain<ColumnDescriptor> effectivePredicate = getEffectivePredicate(column, createUnboundedVarcharType(), utf8Slice(value));
         TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column), UTC);
         PrimitiveType type = column.getPrimitiveType();
         Statistics<?> stats = Statistics.getBuilderForReading(type)
@@ -647,6 +754,15 @@ public class TestTupleDomainParquetPredicate
                 .build();
         assertThat(parquetPredicate.getIndexLookupCandidates(ImmutableMap.of(column, 2L), ImmutableMap.of(column, stats), ID))
                 .isEqualTo(Optional.of(ImmutableList.of(column)));
+
+        // The reader truncates a bounded varchar to its length while the statistics hold the untruncated bytes, so the
+        // column is worth no further inspection either
+        TupleDomainParquetPredicate boundedPredicate = new TupleDomainParquetPredicate(
+                getEffectivePredicate(column, createVarcharType(255), utf8Slice(value)),
+                singletonList(column),
+                UTC);
+        assertThat(boundedPredicate.getIndexLookupCandidates(ImmutableMap.of(column, 2L), ImmutableMap.of(column, stats), ID))
+                .isEqualTo(Optional.of(ImmutableList.of()));
     }
 
     @Test
@@ -692,14 +808,14 @@ public class TestTupleDomainParquetPredicate
     public void testVarcharMatchesWithDictionaryDescriptor()
     {
         ColumnDescriptor column = new ColumnDescriptor(new String[] {"path"}, Types.optional(BINARY).named("Test column"), 0, 0);
-        TupleDomain<ColumnDescriptor> effectivePredicate = getEffectivePredicate(column, createVarcharType(255), EMPTY_SLICE);
+        TupleDomain<ColumnDescriptor> effectivePredicate = getEffectivePredicate(column, createUnboundedVarcharType(), EMPTY_SLICE);
         TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column), UTC);
         DictionaryPage page = new DictionaryPage(Slices.wrappedBuffer(new byte[] {0, 0, 0, 0}), 1, PLAIN_DICTIONARY);
         assertThat(parquetPredicate.matches(new DictionaryDescriptor(column, true, Optional.of(page)))).isTrue();
         assertThat(parquetPredicate.matches(new DictionaryDescriptor(column, false, Optional.of(page)))).isTrue();
 
         effectivePredicate = withColumnDomains(ImmutableMap.of(
-                column, singleValue(createVarcharType(255), Slices.utf8Slice("abc"), true)));
+                column, singleValue(createUnboundedVarcharType(), Slices.utf8Slice("abc"), true)));
         parquetPredicate = new TupleDomainParquetPredicate(effectivePredicate, singletonList(column), UTC);
         assertThat(parquetPredicate.matches(new DictionaryDescriptor(column, true, Optional.of(page)))).isTrue();
         assertThat(parquetPredicate.matches(new DictionaryDescriptor(column, false, Optional.of(page)))).isFalse();

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
@@ -620,7 +620,17 @@ public class TestTupleDomainParquetPredicate
                 // the reader accepts the column but does not produce the stored value
                 Arguments.of(BINARY, null, createVarcharType(3), false),
                 Arguments.of(BINARY, null, createCharType(3), false),
-                Arguments.of(BINARY, decimalType(2, 10), createUnboundedVarcharType(), false));
+                Arguments.of(BINARY, decimalType(2, 10), createUnboundedVarcharType(), false),
+                // RealType is an integer type, so the reader takes a real over an integral column and reinterprets
+                // the stored integer as float bits
+                Arguments.of(INT32, null, REAL, false),
+                Arguments.of(INT64, null, REAL, false),
+                Arguments.of(BINARY, decimalType(0, 9), REAL, false),
+
+                // the reader reads a zero scale short decimal as an integer, but a byte array holds its statistics as
+                // two's complement bytes rather than as a number
+                Arguments.of(BINARY, decimalType(0, 9), INTEGER, false),
+                Arguments.of(FIXED_LEN_BYTE_ARRAY, decimalType(0, 9), BIGINT, false));
     }
 
     /**

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
@@ -607,7 +607,11 @@ public class TestTupleDomainParquetPredicate
                 Arguments.of(INT32, null, createUnboundedVarcharType(), false),
                 Arguments.of(FLOAT, null, createDecimalType(5, 2), false),
                 Arguments.of(INT32, null, createTimestampType(3), false),
+                // a decimal annotated byte array holds a number in its bytes, which the reader refuses to hand back
+                // as text or as raw bytes, whichever of the two widths it is stored in
                 Arguments.of(FIXED_LEN_BYTE_ARRAY, decimalType(2, 20), createUnboundedVarcharType(), false),
+                Arguments.of(BINARY, decimalType(2, 10), createUnboundedVarcharType(), false),
+                Arguments.of(BINARY, decimalType(2, 10), VARBINARY, false),
                 // an integral column annotated as a decimal with a scale is rescaled by the reader, not read as an integer
                 Arguments.of(INT64, decimalType(2, 18), BIGINT, false),
                 // a decimal needs its annotation to know the scale, so an unannotated column is not a decimal at all
@@ -620,7 +624,6 @@ public class TestTupleDomainParquetPredicate
                 // the reader accepts the column but does not produce the stored value
                 Arguments.of(BINARY, null, createVarcharType(3), false),
                 Arguments.of(BINARY, null, createCharType(3), false),
-                Arguments.of(BINARY, decimalType(2, 10), createUnboundedVarcharType(), false),
                 // RealType is an integer type, so the reader takes a real over an integral column and reinterprets
                 // the stored integer as float bits
                 Arguments.of(INT32, null, REAL, false),

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/predicate/TestDomainUserDefinedPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/predicate/TestDomainUserDefinedPredicate.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.predicate;
+
+import io.trino.parquet.predicate.TupleDomainParquetPredicate.DomainUserDefinedPredicate;
+import io.trino.spi.predicate.Domain;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.filter2.predicate.Statistics;
+import org.apache.parquet.schema.Types;
+import org.junit.jupiter.api.Test;
+
+import java.util.Comparator;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.lang.Float.floatToRawIntBits;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.joda.time.DateTimeZone.UTC;
+
+/**
+ * {@link DomainUserDefinedPredicate#canDrop} is the consumer of the shared statistics decoding which parquet-mr calls
+ * itself, through {@link TupleDomainParquetPredicate#toParquetFilter}, so it is reached without any of the wrapping the
+ * other three entry points have.
+ */
+public class TestDomainUserDefinedPredicate
+{
+    private static final ColumnDescriptor FLOAT_COLUMN = new ColumnDescriptor(
+            new String[] {"FloatColumn"},
+            Types.required(FLOAT).named("FloatColumn"),
+            0,
+            0);
+
+    @Test
+    public void testCanDropOnTypeMismatchedColumn()
+    {
+        // a float column read as varchar decodes to Float, which used to reach the varchar branch and be cast to Slice
+        DomainUserDefinedPredicate<Float> predicate = new DomainUserDefinedPredicate<>(
+                FLOAT_COLUMN,
+                Domain.singleValue(createUnboundedVarcharType(), utf8Slice("abc")),
+                UTC);
+
+        assertThat(predicate.canDrop(new Statistics<>(1.0f, 2.0f, Comparator.<Float>naturalOrder()))).isFalse();
+    }
+
+    @Test
+    public void testCanDropOnMatchingColumn()
+    {
+        DomainUserDefinedPredicate<Float> predicate = new DomainUserDefinedPredicate<>(
+                FLOAT_COLUMN,
+                Domain.singleValue(REAL, (long) floatToRawIntBits(9.0f)),
+                UTC);
+
+        assertThat(predicate.canDrop(new Statistics<>(1.0f, 2.0f, Comparator.<Float>naturalOrder()))).isTrue();
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderFactory.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderFactory.java
@@ -13,16 +13,60 @@
  */
 package io.trino.parquet.reader;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.parquet.ParquetReaderOptions;
 import io.trino.parquet.PrimitiveField;
 import io.trino.parquet.reader.flat.FlatColumnReader;
+import io.trino.spi.TrinoException;
+import io.trino.spi.type.Type;
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.parquet.reader.ColumnReaderFactory.isSupported;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.createTimeType;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.UuidType.UUID;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.MICROS;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.MILLIS;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit.NANOS;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.dateType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.decimalType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.intType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.timeType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.timestampType;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.uuidType;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
@@ -55,5 +99,103 @@ public class TestColumnReaderFactory
                 new ColumnDescriptor(new String[] {"topLevelRequiredPrimitiveField test"}, primitiveType, 0, 0),
                 0);
         assertThat(columnReaderFactory.create(topLevelRequiredPrimitiveField, newSimpleAggregatedMemoryContext())).isInstanceOf(FlatColumnReader.class);
+    }
+
+    /**
+     * {@link ColumnReaderFactory#isSupported} exists so that callers which prune on statistics can ask whether a column
+     * is readable without restating the rules of {@link ColumnReaderFactory#create}. A restatement drifts; this walks
+     * every combination the two are expected to agree on and fails the moment they stop agreeing.
+     */
+    @ParameterizedTest
+    @MethodSource("readerTypeCombinations")
+    public void testIsSupportedAgreesWithCreate(Type type, PrimitiveType parquetType)
+    {
+        ColumnReaderFactory columnReaderFactory = new ColumnReaderFactory(UTC, ParquetReaderOptions.defaultOptions());
+        PrimitiveField field = new PrimitiveField(
+                type,
+                true,
+                new ColumnDescriptor(new String[] {"test"}, parquetType, 0, 0),
+                0);
+
+        boolean readerExists;
+        try {
+            columnReaderFactory.create(field, newSimpleAggregatedMemoryContext());
+            readerExists = true;
+        }
+        catch (TrinoException _) {
+            readerExists = false;
+        }
+
+        assertThat(isSupported(type, parquetType))
+                .describedAs("%s over %s", type, parquetType)
+                .isEqualTo(readerExists);
+    }
+
+    private static Stream<Arguments> readerTypeCombinations()
+    {
+        List<Type> trinoTypes = ImmutableList.of(
+                BOOLEAN,
+                TINYINT,
+                SMALLINT,
+                INTEGER,
+                BIGINT,
+                DATE,
+                REAL,
+                DOUBLE,
+                createDecimalType(9, 0),
+                createDecimalType(10, 2),
+                createDecimalType(30, 2),
+                createVarcharType(10),
+                VARCHAR,
+                createCharType(10),
+                VARBINARY,
+                UUID,
+                createTimeType(3),
+                createTimeType(6),
+                createTimestampType(3),
+                createTimestampType(9),
+                createTimestampWithTimeZoneType(3),
+                createTimestampWithTimeZoneType(9));
+
+        List<PrimitiveType> parquetTypes = ImmutableList.of(
+                primitiveType(PrimitiveTypeName.BOOLEAN, null),
+                primitiveType(INT32, null),
+                primitiveType(INT32, intType(32, true)),
+                primitiveType(INT32, intType(8, true)),
+                primitiveType(INT32, intType(32, false)),
+                primitiveType(INT32, decimalType(0, 9)),
+                primitiveType(INT32, decimalType(2, 9)),
+                primitiveType(INT32, dateType()),
+                primitiveType(INT32, timeType(false, MILLIS)),
+                primitiveType(INT64, null),
+                primitiveType(INT64, intType(64, true)),
+                primitiveType(INT64, decimalType(0, 18)),
+                primitiveType(INT64, decimalType(2, 18)),
+                primitiveType(INT64, timeType(false, MICROS)),
+                primitiveType(INT64, timestampType(true, MILLIS)),
+                primitiveType(INT64, timestampType(true, MICROS)),
+                primitiveType(INT64, timestampType(false, NANOS)),
+                primitiveType(INT96, null),
+                primitiveType(FLOAT, null),
+                primitiveType(PrimitiveTypeName.DOUBLE, null),
+                primitiveType(BINARY, null),
+                primitiveType(BINARY, stringType()),
+                primitiveType(BINARY, decimalType(0, 9)),
+                primitiveType(BINARY, decimalType(2, 10)),
+                primitiveType(FIXED_LEN_BYTE_ARRAY, null),
+                primitiveType(FIXED_LEN_BYTE_ARRAY, decimalType(2, 20)),
+                primitiveType(FIXED_LEN_BYTE_ARRAY, uuidType()));
+
+        return trinoTypes.stream()
+                .flatMap(type -> parquetTypes.stream().map(parquetType -> Arguments.of(type, parquetType)));
+    }
+
+    private static PrimitiveType primitiveType(PrimitiveTypeName typeName, LogicalTypeAnnotation annotation)
+    {
+        Types.PrimitiveBuilder<PrimitiveType> builder = Types.optional(typeName);
+        if (typeName == FIXED_LEN_BYTE_ARRAY) {
+            builder = builder.length(16);
+        }
+        return builder.as(annotation).named("test");
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderFactory.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderFactory.java
@@ -183,6 +183,7 @@ public class TestColumnReaderFactory
                 primitiveType(BINARY, decimalType(0, 9)),
                 primitiveType(BINARY, decimalType(2, 10)),
                 primitiveType(FIXED_LEN_BYTE_ARRAY, null),
+                primitiveType(FIXED_LEN_BYTE_ARRAY, decimalType(0, 9)),
                 primitiveType(FIXED_LEN_BYTE_ARRAY, decimalType(2, 20)),
                 primitiveType(FIXED_LEN_BYTE_ARRAY, uuidType()));
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderFactory.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnReaderFactory.java
@@ -102,6 +102,21 @@ public class TestColumnReaderFactory
     }
 
     /**
+     * A decimal annotated byte array holds a number in its bytes, so handing those bytes back as text or as raw bytes
+     * is not a read of the column at all. The two byte array widths have to answer that the same way.
+     */
+    @Test
+    public void testDecimalAnnotatedBinaryIsNotReadAsBytes()
+    {
+        PrimitiveType decimalBinary = primitiveType(BINARY, decimalType(2, 10));
+        for (Type type : ImmutableList.of(VARCHAR, createVarcharType(10), createCharType(10), VARBINARY)) {
+            assertThat(isSupported(type, decimalBinary))
+                    .describedAs("%s over %s", type, decimalBinary)
+                    .isFalse();
+        }
+    }
+
+    /**
      * {@link ColumnReaderFactory#isSupported} exists so that callers which prune on statistics can ask whether a column
      * is readable without restating the rules of {@link ColumnReaderFactory#create}. A restatement drifts; this walks
      * every combination the two are expected to agree on and fails the moment they stop agreeing.

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -5963,6 +5963,13 @@ public abstract class BaseHiveConnectorTest
             assertQuery("SELECT c FROM " + widenedTable, "VALUES 1.5, 2.5");
             // the pushed-down predicate neither fails the query nor drops the row it matches
             assertQuery("SELECT c FROM " + widenedTable + " WHERE c = DOUBLE '1.5'", "VALUES 1.5");
+
+            // and the float statistics still narrow the domain, so a value outside them reads no rows at all
+            assertQueryStats(
+                    getSession(),
+                    "SELECT c FROM " + widenedTable + " WHERE c = DOUBLE '99.5'",
+                    queryStats -> assertThat(queryStats.getPhysicalInputPositions()).isEqualTo(0),
+                    results -> assertThat(results.getRowCount()).isEqualTo(0));
         }
         finally {
             assertUpdate("DROP TABLE IF EXISTS " + widenedTable);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -5949,6 +5949,28 @@ public abstract class BaseHiveConnectorTest
     }
 
     @Test
+    public void testParquetPredicateOnWidenedColumnType()
+    {
+        // The connector cannot express ALTER TABLE ... CHANGE COLUMN real -> double, so reach the same state through an
+        // external table declaring double over a Parquet file which physically stores float
+        String sourceTable = "test_widened_column_source_" + randomNameSuffix();
+        String widenedTable = "test_widened_column_double_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + sourceTable + " (c real) WITH (format = 'PARQUET')");
+        try {
+            assertUpdate("INSERT INTO " + sourceTable + " VALUES REAL '1.5', REAL '2.5'", 2);
+            assertUpdate(format("CREATE TABLE %s (c double) WITH (format = 'PARQUET', external_location = '%s')", widenedTable, getTableLocation(sourceTable)));
+
+            assertQuery("SELECT c FROM " + widenedTable, "VALUES 1.5, 2.5");
+            // the pushed-down predicate neither fails the query nor drops the row it matches
+            assertQuery("SELECT c FROM " + widenedTable + " WHERE c = DOUBLE '1.5'", "VALUES 1.5");
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + widenedTable);
+            assertUpdate("DROP TABLE IF EXISTS " + sourceTable);
+        }
+    }
+
+    @Test
     public void testParquetWithMissingColumns()
     {
         Session sessionUsingColumnIndex = Session.builder(getSession())

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestBloomFilterStore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestBloomFilterStore.java
@@ -35,6 +35,7 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.values.bloomfilter.BloomFilter;
 import org.apache.parquet.format.CompressionCodec;
 import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Types;
 import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.plugin.hive.HiveTestUtils.toNativeContainerValue;
 import static io.trino.spi.predicate.Domain.multipleValues;
 import static io.trino.spi.predicate.TupleDomain.withColumnDomains;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -64,7 +66,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
-import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static java.util.Objects.requireNonNull;
@@ -83,6 +85,9 @@ import static org.apache.parquet.hadoop.ParquetOutputFormat.BLOOM_FILTER_ENABLED
 import static org.apache.parquet.hadoop.ParquetOutputFormat.WRITER_VERSION;
 import static org.apache.parquet.hadoop.metadata.ColumnPath.fromDotString;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
@@ -92,8 +97,12 @@ public class TestBloomFilterStore
     private static final String COLUMN_NAME = "test_column";
     private static final int DOMAIN_COMPACTION_THRESHOLD = 32;
 
-    // here PrimitiveType#getPrimitiveTypeName is dummy, since predicate matches is via column name
-    ColumnDescriptor columnDescriptor = new ColumnDescriptor(new String[] {COLUMN_NAME}, new PrimitiveType(REQUIRED, BINARY, COLUMN_NAME), 0, 0);
+    // The filter is looked up by column name, but parquet-mr hashed each value at the physical width of the column,
+    // so the descriptor has to carry the type the column was actually written with
+    private static ColumnDescriptor columnDescriptor(PrimitiveTypeName typeName)
+    {
+        return new ColumnDescriptor(new String[] {COLUMN_NAME}, new PrimitiveType(REQUIRED, typeName, COLUMN_NAME), 0, 0);
+    }
 
     static Stream<BloomFilterTypeTestCase> bloomFilterTypeTests()
     {
@@ -102,55 +111,65 @@ public class TestBloomFilterStore
                 new BloomFilterTypeTestCase(
                         Arrays.asList("hello", "parquet", "bloom", "filter"),
                         Arrays.asList("NotExist", "fdsvit"),
-                        createVarcharType(255),
+                        createUnboundedVarcharType(),
+                        BINARY,
                         javaStringObjectInspector),
                 // integer test case, 32-bit signed two’s complement integer, between -2^31 and 2^31 - 1
                 new BloomFilterTypeTestCase(
                         Arrays.asList(12321, 3344, 72334, 321, Integer.MAX_VALUE, Integer.MIN_VALUE),
                         Arrays.asList(89899, 897773),
                         INTEGER,
+                        INT32,
                         javaIntObjectInspector),
                 // double test case, 64-bit inexact
                 new BloomFilterTypeTestCase(
                         Arrays.asList(892.22d, 341112.2222d, 43232.222121d, 99988.22d, Double.MAX_VALUE, Double.POSITIVE_INFINITY, Double.MIN_VALUE, Double.NEGATIVE_INFINITY),
                         Arrays.asList(321.44d, 776541.3214d, Double.MAX_VALUE / 2),
                         DOUBLE,
+                        PrimitiveTypeName.DOUBLE,
                         javaDoubleObjectInspector),
                 // real test case, 32-bit inexact
                 new BloomFilterTypeTestCase(
                         Arrays.asList(32.22f, 341112.2222f, 43232.222121f, 32322.22f, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.MIN_VALUE, Float.MAX_VALUE),
                         Arrays.asList(321.44f, 321.3214f, Float.MIN_VALUE / 2),
                         REAL,
+                        FLOAT,
                         javaFloatObjectInspector),
                 // tinyint test case, 8 bits signed integer, between -2^7 and 2^7 - 1
                 new BloomFilterTypeTestCase(
                         Arrays.asList((byte) 32, (byte) 67, Byte.MAX_VALUE, Byte.MAX_VALUE, (byte) 89),
                         Arrays.asList((byte) 0, (byte) 33, (byte) 75),
                         TINYINT,
+                        INT32,
                         javaByteObjectInspector),
                 // smallint test case, 16 bits signed integer, between -2^15 and 2^15 - 1
                 new BloomFilterTypeTestCase(
                         Arrays.asList((short) 32, (short) 3000, Short.MIN_VALUE, Short.MAX_VALUE),
                         Arrays.asList((short) 0, (short) 33, (short) 43),
                         SMALLINT,
+                        INT32,
                         javaShortObjectInspector),
                 // date test case
                 new BloomFilterTypeTestCase(
                         Arrays.asList(ofEpochDay(0), ofEpochDay(325), ofEpochDay(99875553), ofEpochDay(2456524)),
                         Arrays.asList(ofEpochDay(45), ofEpochDay(67439216)),
                         DATE,
+                        INT32,
                         javaDateObjectInspector),
                 // varbinary test case, variable length binary data.
                 new BloomFilterTypeTestCase(
                         Arrays.asList("hello".getBytes(StandardCharsets.UTF_8), "parquet  ".getBytes(StandardCharsets.UTF_8), "bloom".getBytes(StandardCharsets.UTF_8), "filter".getBytes(StandardCharsets.UTF_8)),
                         Arrays.asList("not".getBytes(StandardCharsets.UTF_8), "exist".getBytes(StandardCharsets.UTF_8), "testcaseX".getBytes(StandardCharsets.UTF_8), "parquet".getBytes(StandardCharsets.UTF_8)),
                         VARBINARY,
+                        BINARY,
                         javaByteArrayObjectInspector),
                 // uuid test case, represents a UUID
                 new BloomFilterTypeTestCase(
                         Arrays.asList(uuidToBytes(UUID.fromString("783176de-b6c5-4c5a-905d-0460ae103050")), uuidToBytes(UUID.fromString("b1a71c78-bd96-4117-a91a-18671530196a"))),
                         Arrays.asList(uuidToBytes(UUID.fromString("98a5f99c-7adb-4a92-ae10-6d2469d59423")), uuidToBytes(UUID.fromString("19fd9aed-7a93-4ada-8966-f89014f499ec"))),
                         UuidType.UUID,
+                        // a uuid column is stored as a 16 byte fixed length array; the bytes hash the same either way
+                        FIXED_LEN_BYTE_ARRAY,
                         javaByteArrayObjectInspector));
     }
 
@@ -164,11 +183,14 @@ public class TestBloomFilterStore
             assertThat(bloomFilterEnabled.getBloomFilter(fromDotString(COLUMN_NAME))).isPresent();
             BloomFilter bloomFilter = bloomFilterEnabled.getBloomFilter(fromDotString(COLUMN_NAME)).get();
 
+            TupleDomainParquetPredicate.BloomFilterHasher hasher = TupleDomainParquetPredicate
+                    .bloomFilterHasher(typeTestCase.sqlType, columnDescriptor(typeTestCase.physicalType).getPrimitiveType())
+                    .orElseThrow();
             for (Object data : typeTestCase.matchingValues) {
-                assertThat(TupleDomainParquetPredicate.checkInBloomFilter(bloomFilter, data, typeTestCase.sqlType)).isTrue();
+                assertThat(bloomFilter.findHash(hasher.hash(bloomFilter, data))).isTrue();
             }
             for (Object data : typeTestCase.nonMatchingValues) {
-                assertThat(TupleDomainParquetPredicate.checkInBloomFilter(bloomFilter, data, typeTestCase.sqlType)).isFalse();
+                assertThat(bloomFilter.findHash(hasher.hash(bloomFilter, data))).isFalse();
             }
         }
 
@@ -185,6 +207,7 @@ public class TestBloomFilterStore
     {
         try (ParquetTester.TempFile tempFile = new ParquetTester.TempFile("testbloomfilter", ".parquet")) {
             BloomFilterStore bloomFilterStore = generateBloomFilterStore(tempFile, true, typeTestCase.writeValues, typeTestCase.objectInspector);
+            ColumnDescriptor columnDescriptor = columnDescriptor(typeTestCase.physicalType);
 
             TupleDomain<ColumnDescriptor> domain = withColumnDomains(singletonMap(columnDescriptor, multipleValues(typeTestCase.sqlType, typeTestCase.matchingValues)));
             TupleDomainParquetPredicate parquetPredicate = new TupleDomainParquetPredicate(domain, singletonList(columnDescriptor), UTC);
@@ -196,9 +219,9 @@ public class TestBloomFilterStore
             // bloomfilter store has the column, but values not match
             assertThat(parquetPredicateWithoutMatch.matches(bloomFilterStore, DOMAIN_COMPACTION_THRESHOLD)).isFalse();
 
-            ColumnDescriptor columnDescriptor = new ColumnDescriptor(new String[] {"non_exist_path"}, Types.optional(BINARY).named("Test column"), 0, 0);
-            TupleDomain<ColumnDescriptor> domainForColumnWithoutBloomFilter = withColumnDomains(singletonMap(columnDescriptor, multipleValues(typeTestCase.sqlType, typeTestCase.nonMatchingValues)));
-            TupleDomainParquetPredicate predicateForColumnWithoutBloomFilter = new TupleDomainParquetPredicate(domainForColumnWithoutBloomFilter, singletonList(columnDescriptor), UTC);
+            ColumnDescriptor missingColumn = new ColumnDescriptor(new String[] {"non_exist_path"}, Types.optional(BINARY).named("Test column"), 0, 0);
+            TupleDomain<ColumnDescriptor> domainForColumnWithoutBloomFilter = withColumnDomains(singletonMap(missingColumn, multipleValues(typeTestCase.sqlType, typeTestCase.nonMatchingValues)));
+            TupleDomainParquetPredicate predicateForColumnWithoutBloomFilter = new TupleDomainParquetPredicate(domainForColumnWithoutBloomFilter, singletonList(missingColumn), UTC);
             // bloomfilter store does not have the column
             assertThat(predicateForColumnWithoutBloomFilter.matches(bloomFilterStore, DOMAIN_COMPACTION_THRESHOLD)).isTrue();
         }
@@ -210,6 +233,7 @@ public class TestBloomFilterStore
     {
         try (ParquetTester.TempFile tempFile = new ParquetTester.TempFile("testbloomfilter", ".parquet")) {
             BloomFilterStore bloomFilterStore = generateBloomFilterStore(tempFile, true, Arrays.asList(60, 61, 62, 63, 64, 65), javaIntObjectInspector);
+            ColumnDescriptor columnDescriptor = columnDescriptor(INT32);
 
             // case 1, bloomfilter store has the column, and ranges expanded successfully and overlap
             TupleDomain<ColumnDescriptor> domain = TupleDomain.withColumnDomains(singletonMap(columnDescriptor, Domain.create(SortedRangeSet.copyOf(
@@ -241,6 +265,7 @@ public class TestBloomFilterStore
         // null values in parquet will only update column's repetition level and definition level, bloomfilter matching will be based on non-null values
         try (ParquetTester.TempFile tempFile = new ParquetTester.TempFile("testbloomfilter", ".parquet")) {
             BloomFilterStore bloomFilterStore = generateBloomFilterStore(tempFile, true, Arrays.asList(null, null, 62, 63, 64, 65), javaIntObjectInspector);
+            ColumnDescriptor columnDescriptor = columnDescriptor(INT32);
 
             TupleDomain<ColumnDescriptor> domain = TupleDomain.withColumnDomains(singletonMap(columnDescriptor, Domain.create(SortedRangeSet.copyOf(
                     INTEGER,
@@ -265,12 +290,34 @@ public class TestBloomFilterStore
         // if the predicate contains null values, bloomfilter matches will return true, since the bloom filter bitset contains only non-null values
         try (ParquetTester.TempFile tempFile = new ParquetTester.TempFile("testbloomfilter", ".parquet")) {
             BloomFilterStore bloomFilterStore = generateBloomFilterStore(tempFile, true, Arrays.asList(62, 63, 64, 65), javaIntObjectInspector);
+            ColumnDescriptor columnDescriptor = columnDescriptor(INT32);
 
             TupleDomain<ColumnDescriptor> domainWithoutMatch = TupleDomain.withColumnDomains(singletonMap(columnDescriptor, Domain.create(SortedRangeSet.copyOf(
                     INTEGER,
                     ImmutableList.of(Range.range(INTEGER, -68L, true, -60L, true))), true)));
             TupleDomainParquetPredicate parquetPredicateWithoutMatch = new TupleDomainParquetPredicate(domainWithoutMatch, singletonList(columnDescriptor), UTC);
             assertThat(parquetPredicateWithoutMatch.matches(bloomFilterStore, DOMAIN_COMPACTION_THRESHOLD)).isTrue();
+        }
+    }
+
+    @Test
+    public void testBloomFilterIsIgnoredWhenTypeDoesNotMatchColumn()
+            throws Exception
+    {
+        // parquet-mr hashed these values at the 32 bits of the physical column. Looking one of them up as a bigint
+        // hashes at 64 bits and finds nothing, which would drop a row group that does hold the value
+        try (ParquetTester.TempFile tempFile = new ParquetTester.TempFile("testbloomfilter", ".parquet")) {
+            BloomFilterStore bloomFilterStore = generateBloomFilterStore(tempFile, true, Arrays.asList(62, 63, 64, 65), javaIntObjectInspector);
+            ColumnDescriptor columnDescriptor = columnDescriptor(INT32);
+
+            TupleDomain<ColumnDescriptor> presentValue = withColumnDomains(singletonMap(columnDescriptor, multipleValues(BIGINT, ImmutableList.of(63L))));
+            assertThat(new TupleDomainParquetPredicate(presentValue, singletonList(columnDescriptor), UTC).matches(bloomFilterStore, DOMAIN_COMPACTION_THRESHOLD))
+                    .isTrue();
+
+            // and with the filter out of reach, a value which is genuinely absent no longer eliminates anything either
+            TupleDomain<ColumnDescriptor> absentValue = withColumnDomains(singletonMap(columnDescriptor, multipleValues(BIGINT, ImmutableList.of(4242L))));
+            assertThat(new TupleDomainParquetPredicate(absentValue, singletonList(columnDescriptor), UTC).matches(bloomFilterStore, DOMAIN_COMPACTION_THRESHOLD))
+                    .isTrue();
         }
     }
 
@@ -310,11 +357,13 @@ public class TestBloomFilterStore
         private final List<Object> nonMatchingValues;
         private final List<Object> writeValues;
         private final Type sqlType;
+        private final PrimitiveTypeName physicalType;
         private final ObjectInspector objectInspector;
 
-        private BloomFilterTypeTestCase(List<Object> writeValues, List<Object> nonMatchingValues, Type sqlType, ObjectInspector objectInspector)
+        private BloomFilterTypeTestCase(List<Object> writeValues, List<Object> nonMatchingValues, Type sqlType, PrimitiveTypeName physicalType, ObjectInspector objectInspector)
         {
             this.sqlType = requireNonNull(sqlType);
+            this.physicalType = requireNonNull(physicalType);
             this.objectInspector = requireNonNull(objectInspector);
             this.writeValues = requireNonNull(writeValues);
 


### PR DESCRIPTION
## Description

- Closes #30544.

`TupleDomainParquetPredicate.getDomain` picks its decoding branch from the Trino type in the pushed-down `Domain`, but the min/max values it decodes come from the physical type of the column in the file. Schema evolution makes the two disagree, so a predicate on a widened column fails while any file still stores the original physical type:

```
Malformed Parquet file. Corrupted statistics for column "[c] optional float c": [min: 1.5, max: 2.5, num_nulls: 0]
Caused by: java.lang.ClassCastException: class java.lang.Float cannot be cast to class java.lang.Double
```

Reading the column has always worked; only the statistics side was blind. `DecimalType` was the sole branch that reconciled the two, via `isDecimalRescaled`.

Every branch of `getDomain` now decides on the physical type it is about to decode, and one that cannot interpret those values as its own type returns the `Domain.create(ValueSet.all(type), hasNullValue)` the method already returns for unusable statistics. Deciding it inside the dispatch covers all three entry points at once, including the dictionary one, which had no exception handling of its own and let the `ClassCastException` escape as `HIVE_CANNOT_OPEN_SPLIT`.

`checkInBloomFilter` decides the same way, because parquet-mr hashes values at their physical width, so an int and a long hash of the same value never agree and the row group is dropped rather than kept. `int -> bigint` reaches that path today and already returns wrong results. A `varchar` is looked up over `BINARY` alone, since `ColumnReaderFactory` reads a `FIXED_LEN_BYTE_ARRAY` as one only when it is unbounded, and pruning a column the reader would refuse turns a read failure into an empty result.

`float -> double` keeps its row group pruning rather than losing it, because every float is exactly representable as a double and `ColumnReaderFactory` widens such a column unconditionally. Integer statistics stay unused for a double column, because readability there depends on a logical annotation the statistics never see.

## Additional context and related issues

No connector compares types before building the `TupleDomain<ColumnDescriptor>`, so Hive, Iceberg, Delta Lake, Hudi and Lakehouse are all affected, which is why the fix belongs in `lib/trino-parquet` rather than in each connector.

Not a recent regression: the statistics cast dates to fce0521b4202 and the bloom filter dispatch to 47fd225f7dc2.

Tests cover all three entry points, a matching and a mismatched physical type for every branch of both dispatches, and an end to end Hive case which declares `double` over Parquet files physically storing `float` through `external_location`, since the connector cannot express `ALTER TABLE ... CHANGE COLUMN` in SQL. Every new test was confirmed to fail without the fix.

### Follow-ups

- Iceberg has the same defect one layer higher, in `IcebergSplitSource.domainForStatistics`, so an Iceberg query on a promoted column still fails before reaching the Parquet layer. 5ec84e4a6b2 fixed `int -> bigint` there but not `float -> double`. Separate pull request against #30544.
- Two pre-existing combinations still build a wrong range instead of being rejected: a `DecimalType` domain over an unannotated BINARY or FIXED_LEN_BYTE_ARRAY column, and the integer branch over a column with a non zero scale decimal annotation.
- Also pre-existing: `getShortDecimalValue` returns 0 rather than failing when handed more than eight bytes, reachable on a legal file through a `FIXED_LEN_BYTE_ARRAY(16)` column annotated `decimal(10,2)` and read as that same type.
- Unrelated to type widening: a bounded `varchar(n)` over BINARY is truncated by the reader while the statistics and the bloom filter describe the untruncated bytes, so a longer stored value can be pruned away. The fix is to truncate the bounds, not to reject the combination.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive connector
* Fix query failure, and possible wrong results with Parquet bloom filters, for a predicate on a column whose type was widened. ({issue}`30544`)

## Iceberg connector
* Fix query failure, and possible wrong results with Parquet bloom filters, for a predicate on a column whose type was widened. ({issue}`30544`)

## Delta Lake connector
* Fix query failure, and possible wrong results with Parquet bloom filters, for a predicate on a column whose type was widened. ({issue}`30544`)

## Hudi connector
* Fix query failure, and possible wrong results with Parquet bloom filters, for a predicate on a column whose type was widened. ({issue}`30544`)

## Lakehouse connector
* Fix query failure, and possible wrong results with Parquet bloom filters, for a predicate on a column whose type was widened. ({issue}`30544`)
```

