### PR TITLE
Add ALTER MATERIALIZED VIEW ... EXECUTE syntax

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -126,6 +126,10 @@ statement
         RENAME TO to=qualifiedName                                     #renameMaterializedView
     | ALTER MATERIALIZED VIEW qualifiedName
         SET PROPERTIES propertyAssignments                             #setMaterializedViewProperties
+    | ALTER MATERIALIZED VIEW qualifiedName
+        EXECUTE procedureName=identifier
+        ('(' (argument (',' argument)*)? ')')?
+        (WHERE where=booleanExpression)?                               #materializedViewExecute
     | DROP VIEW (IF EXISTS)? qualifiedName                             #dropView
     | ALTER VIEW from=qualifiedName RENAME TO to=qualifiedName         #renameView
     | ALTER VIEW viewName=qualifiedName REFRESH                        #refreshView

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -96,6 +96,7 @@ import io.trino.sql.tree.LeaveStatement;
 import io.trino.sql.tree.LikeClause;
 import io.trino.sql.tree.Limit;
 import io.trino.sql.tree.LoopStatement;
+import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.MergeCase;
 import io.trino.sql.tree.MergeDelete;
@@ -1919,6 +1920,26 @@ public final class SqlFormatter
         protected Void visitTableExecute(TableExecute node, Integer indent)
         {
             builder.append("ALTER TABLE ");
+            builder.append(formatName(node.getTable().getName()));
+            builder.append(" EXECUTE ");
+            builder.append(formatName(node.getProcedureName()));
+            if (!node.getArguments().isEmpty()) {
+                builder.append("(");
+                formatCallArguments(indent, node.getArguments());
+                builder.append(")");
+            }
+            node.getWhere().ifPresent(where -> builder
+                    .append("\n")
+                    .append(indentString(indent))
+                    .append("WHERE ")
+                    .append(formatExpression(where)));
+            return null;
+        }
+
+        @Override
+        protected Void visitMaterializedViewExecute(MaterializedViewExecute node, Integer indent)
+        {
+            builder.append("ALTER MATERIALIZED VIEW ");
             builder.append(formatName(node.getTable().getName()));
             builder.append(" EXECUTE ");
             builder.append(formatName(node.getProcedureName()));

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -185,6 +185,7 @@ import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.LoopStatement;
 import io.trino.sql.tree.MatchPredicate;
+import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.MeasureDefinition;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.MergeCase;
@@ -974,6 +975,22 @@ class AstBuilder
         return new TableExecute(
                 getLocation(context),
                 new Table(getLocation(context.TABLE()), getQualifiedName(context.tableName)),
+                (Identifier) visit(context.procedureName),
+                arguments,
+                visitIfPresent(context.booleanExpression(), Expression.class));
+    }
+
+    @Override
+    public Node visitMaterializedViewExecute(SqlBaseParser.MaterializedViewExecuteContext context)
+    {
+        List<CallArgument> arguments = ImmutableList.of();
+        if (context.argument() != null) {
+            arguments = visit(context.argument(), CallArgument.class);
+        }
+
+        return new MaterializedViewExecute(
+                getLocation(context),
+                new Table(getLocation(context.MATERIALIZED()), getQualifiedName(context.qualifiedName())),
                 (Identifier) visit(context.procedureName),
                 arguments,
                 visitIfPresent(context.booleanExpression(), Expression.class));

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -812,6 +812,11 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitMaterializedViewExecute(MaterializedViewExecute node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
     protected R visitAnalyze(Analyze node, C context)
     {
         return visitStatement(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/MaterializedViewExecute.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/MaterializedViewExecute.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class MaterializedViewExecute
+        extends Statement
+{
+    private final Table table;
+    private final Identifier procedureName;
+    private final List<CallArgument> arguments;
+    private final Optional<Expression> where;
+
+    public MaterializedViewExecute(
+            NodeLocation location,
+            Table table,
+            Identifier procedureName,
+            List<CallArgument> arguments,
+            Optional<Expression> where)
+    {
+        super(location);
+        this.table = requireNonNull(table, "table is null");
+        this.procedureName = requireNonNull(procedureName, "procedureName is null");
+        this.arguments = ImmutableList.copyOf(requireNonNull(arguments, "arguments is null"));
+        this.where = requireNonNull(where, "where is null");
+    }
+
+    public Table getTable()
+    {
+        return table;
+    }
+
+    public QualifiedName getName()
+    {
+        return table.getName();
+    }
+
+    public Identifier getProcedureName()
+    {
+        return procedureName;
+    }
+
+    public List<CallArgument> getArguments()
+    {
+        return arguments;
+    }
+
+    public Optional<Expression> getWhere()
+    {
+        return where;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitMaterializedViewExecute(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        ImmutableList.Builder<Node> nodes = ImmutableList.builder();
+        nodes.addAll(arguments);
+        where.ifPresent(nodes::add);
+        return nodes.build();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(table, procedureName, arguments, where);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MaterializedViewExecute that = (MaterializedViewExecute) o;
+        return Objects.equals(table, that.table) &&
+                Objects.equals(procedureName, that.procedureName) &&
+                Objects.equals(arguments, that.arguments) &&
+                Objects.equals(where, that.where);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("table", table)
+                .add("procedureName", procedureName)
+                .add("arguments", arguments)
+                .add("where", where)
+                .toString();
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -18,9 +18,11 @@ import io.trino.sql.tree.AddColumn;
 import io.trino.sql.tree.AllColumns;
 import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.CallArgument;
 import io.trino.sql.tree.ColumnDefinition;
 import io.trino.sql.tree.ColumnPosition;
 import io.trino.sql.tree.Comment;
+import io.trino.sql.tree.ComparisonPredicate;
 import io.trino.sql.tree.CreateBranch;
 import io.trino.sql.tree.CreateCatalog;
 import io.trino.sql.tree.CreateMaterializedView;
@@ -37,9 +39,11 @@ import io.trino.sql.tree.GenericDataType;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.Insert;
 import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.MergeDelete;
 import io.trino.sql.tree.NodeLocation;
+import io.trino.sql.tree.Predicated;
 import io.trino.sql.tree.Property;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Query;
@@ -495,6 +499,41 @@ public class TestSqlFormatter
                         FROM
                           test_base
                         """);
+    }
+
+    @Test
+    public void testMaterializedViewExecute()
+    {
+        Table mv = new Table(QualifiedName.of("test_mv"));
+        Identifier procedure = new Identifier("optimize", false);
+
+        assertThat(formatSql(
+                new MaterializedViewExecute(new NodeLocation(1, 1), mv, procedure, ImmutableList.of(), Optional.empty())))
+                .isEqualTo("ALTER MATERIALIZED VIEW test_mv EXECUTE optimize");
+
+        assertThat(formatSql(
+                new MaterializedViewExecute(
+                        new NodeLocation(1, 1),
+                        mv,
+                        procedure,
+                        ImmutableList.of(new CallArgument(new NodeLocation(1, 1), Optional.of(new Identifier("file_size_threshold", false)), new StringLiteral("10MB"))),
+                        Optional.empty())))
+                .isEqualTo("ALTER MATERIALIZED VIEW test_mv EXECUTE optimize(file_size_threshold => '10MB')");
+
+        assertThat(formatSql(
+                new MaterializedViewExecute(
+                        new NodeLocation(1, 1),
+                        mv,
+                        procedure,
+                        ImmutableList.of(),
+                        Optional.of(new Predicated(
+                                new NodeLocation(1, 1),
+                                new Identifier("age", false),
+                                new ComparisonPredicate(new NodeLocation(1, 1), ComparisonPredicate.Operator.GREATER_THAN, new LongLiteral("17")))))))
+                .isEqualTo(
+                        """
+                        ALTER MATERIALIZED VIEW test_mv EXECUTE optimize
+                        WHERE (age > 17)""");
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -136,6 +136,7 @@ import io.trino.sql.tree.Literal;
 import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.MatchPredicate;
+import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.MeasureDefinition;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.MergeDelete;
@@ -5115,6 +5116,29 @@ public class TestSqlParser
                                         location(1, 50),
                                         new Identifier(location(1, 46), "age", false),
                                         new ComparisonPredicate(location(1, 50), ComparisonPredicate.Operator.GREATER_THAN, new LongLiteral(location(1, 52), "17"))))));
+    }
+
+    @Test
+    public void testMaterializedViewExecute()
+    {
+        Table mv = new Table(location(1, 7), QualifiedName.of(ImmutableList.of(new Identifier(location(1, 25), "foo", false))));
+        Identifier procedure = new Identifier(location(1, 37), "bar", false);
+
+        assertThat(statement("ALTER MATERIALIZED VIEW foo EXECUTE bar"))
+                .isEqualTo(new MaterializedViewExecute(location(1, 1), mv, procedure, ImmutableList.of(), Optional.empty()));
+        assertThat(statement("ALTER MATERIALIZED VIEW foo EXECUTE bar(bah => 1, wuh => 'clap') WHERE age > 17")).isEqualTo(
+                new MaterializedViewExecute(
+                        location(1, 1),
+                        mv,
+                        procedure,
+                        ImmutableList.of(
+                                new CallArgument(location(1, 41), Optional.of(new Identifier(location(1, 41), "bah", false)), new LongLiteral(location(1, 48), "1")),
+                                new CallArgument(location(1, 51), Optional.of(new Identifier(location(1, 51), "wuh", false)), new StringLiteral(location(1, 58), "clap"))),
+                        Optional.of(
+                                new Predicated(
+                                        location(1, 76),
+                                        new Identifier(location(1, 72), "age", false),
+                                        new ComparisonPredicate(location(1, 76), ComparisonPredicate.Operator.GREATER_THAN, new LongLiteral(location(1, 78), "17"))))));
     }
 
     @Test


### PR DESCRIPTION
## Description

Add `ALTER MATERIALIZED VIEW ... EXECUTE` syntax, that would allow running procedures for the MVs (or their storage table)

## Additional context and related issues

Motivation to do that is to have ability to execute iceberg maintenance procedures on the MV storage tables, see: https://github.com/trinodb/trino/pull/30432 for more context.

Part of: https://github.com/trinodb/trino/issues/21797

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
##General
* Add support for `ALTER MATERIALIZED VIEW ... EXECUTE` syntax
```
