### PR TITLE
Fix stale resource group scheduling settings

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
@@ -571,13 +571,25 @@ public class InternalResourceGroup
     @Override
     public void setSchedulingPolicy(SchedulingPolicy policy)
     {
+        setSchedulingPolicy(policy, true);
+    }
+
+    private void setSchedulingPolicy(SchedulingPolicy policy, boolean checkPriority)
+    {
         synchronized (root) {
             if (policy == schedulingPolicy) {
                 return;
             }
 
-            if (parent.isPresent() && parent.get().schedulingPolicy == QUERY_PRIORITY) {
+            if (checkPriority && parent.isPresent() && parent.get().schedulingPolicy == QUERY_PRIORITY) {
                 checkArgument(policy == QUERY_PRIORITY, "Parent of %s uses query priority scheduling, so %s must also", id, id);
+            }
+
+            if (policy != QUERY_PRIORITY && schedulingPolicy == QUERY_PRIORITY) {
+                // Sub groups inherit query-priority scheduling from their parent.
+                for (InternalResourceGroup group : subGroups.values()) {
+                    group.setSchedulingPolicy(FAIR, false);
+                }
             }
 
             // Switch to the appropriate queue implementation to implement the desired policy

--- a/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
+++ b/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
@@ -166,6 +166,11 @@ public class TestResourceGroups
         assertThat(root.getSchedulingPolicy()).isEqualTo(QUERY_PRIORITY);
         assertThat(root.getOrCreateSubGroup("1").getSchedulingPolicy()).isEqualTo(QUERY_PRIORITY);
         assertThat(root.getOrCreateSubGroup("2").getSchedulingPolicy()).isEqualTo(QUERY_PRIORITY);
+
+        root.setSchedulingPolicy(FAIR);
+        assertThat(root.getSchedulingPolicy()).isEqualTo(FAIR);
+        assertThat(root.getOrCreateSubGroup("1").getSchedulingPolicy()).isEqualTo(FAIR);
+        assertThat(root.getOrCreateSubGroup("2").getSchedulingPolicy()).isEqualTo(FAIR);
     }
 
     @Test

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
@@ -38,6 +38,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verifyNotNull;
 import static io.trino.spi.StandardErrorCode.INVALID_RESOURCE_GROUP;
+import static io.trino.spi.resourcegroups.SchedulingPolicy.FAIR;
+import static io.trino.spi.resourcegroups.SchedulingPolicy.QUERY_PRIORITY;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.function.Predicate.isEqual;
@@ -45,6 +47,8 @@ import static java.util.function.Predicate.isEqual;
 public abstract class AbstractResourceConfigurationManager
         implements ResourceGroupConfigurationManager<ResourceGroupIdTemplate>
 {
+    private static final int DEFAULT_SCHEDULING_WEIGHT = 1;
+
     @GuardedBy("memoryPoolFraction")
     private final Map<ResourceGroup, Double> memoryPoolFraction = new HashMap<>();
     @GuardedBy("memoryPoolFraction")
@@ -215,8 +219,14 @@ public abstract class AbstractResourceConfigurationManager
         group.setMaxQueuedQueries(match.getMaxQueued());
         group.setSoftConcurrencyLimit(match.getSoftConcurrencyLimit().orElse(match.getHardConcurrencyLimit()));
         group.setHardConcurrencyLimit(match.getHardConcurrencyLimit());
-        match.getSchedulingPolicy().ifPresent(group::setSchedulingPolicy);
-        match.getSchedulingWeight().ifPresent(group::setSchedulingWeight);
+        if (match.getSchedulingPolicy().isPresent()) {
+            group.setSchedulingPolicy(match.getSchedulingPolicy().get());
+        }
+        else if (group.getSchedulingPolicy() != QUERY_PRIORITY || group.getId().getParent().isEmpty()) {
+            // A child of a query-priority group inherits that policy. The parent resets inherited policies when it changes.
+            group.setSchedulingPolicy(FAIR);
+        }
+        group.setSchedulingWeight(match.getSchedulingWeight().orElse(DEFAULT_SCHEDULING_WEIGHT));
         match.getJmxExport().filter(isEqual(group.getJmxExport()).negate()).ifPresent(group::setJmxExport);
         match.getSoftCpuLimit().map(Duration::toMillis).map(java.time.Duration::ofMillis).ifPresent(group::setSoftCpuLimit);
         match.getHardCpuLimit().map(Duration::toMillis).map(java.time.Duration::ofMillis).ifPresent(group::setHardCpuLimit);

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/ResourceGroupSpec.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/ResourceGroupSpec.java
@@ -85,6 +85,7 @@ public class ResourceGroupSpec
         softConcurrencyLimit.ifPresent(soft -> checkArgument(this.hardConcurrencyLimit >= soft, "hardConcurrencyLimit must be greater than or equal to softConcurrencyLimit"));
         this.schedulingPolicy = schedulingPolicy.map(value -> SchedulingPolicy.valueOf(value.toUpperCase(ENGLISH)));
         this.schedulingWeight = requireNonNull(schedulingWeight, "schedulingWeight is null");
+        this.schedulingWeight.ifPresent(weight -> checkArgument(weight > 0, "schedulingWeight must be positive"));
 
         requireNonNull(softMemoryLimit, "softMemoryLimit is null");
         if (softMemoryLimit.isEmpty()) {

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestFileResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestFileResourceGroupConfigurationManager.java
@@ -37,6 +37,7 @@ import static io.trino.plugin.resourcegroups.TestingResourceGroups.groupIdTempla
 import static io.trino.plugin.resourcegroups.TestingResourceGroups.managerSpec;
 import static io.trino.plugin.resourcegroups.TestingResourceGroups.resourceGroupSpec;
 import static io.trino.plugin.resourcegroups.TestingResourceGroups.selectorSpec;
+import static io.trino.spi.resourcegroups.SchedulingPolicy.FAIR;
 import static io.trino.spi.resourcegroups.SchedulingPolicy.WEIGHTED;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,6 +57,7 @@ public class TestFileResourceGroupConfigurationManager
         assertFails("resource_groups_config_bad_group_id.json", "Invalid resource group name. 'glo.bal' contains a '.'");
         assertFails("resource_groups_config_bad_soft_memory_limit.json", "softMemoryLimit percentage is over 100%");
         assertFails("resource_groups_config_bad_weighted_scheduling_policy.json", "Must specify scheduling weight for all sub-groups of 'requests' or none of them");
+        assertFails("resource_groups_config_bad_scheduling_weight.json", "schedulingWeight must be positive");
         assertFails("resource_groups_config_unused_field.json", "Unknown property at line 8:6: maxFoo");
         assertFails(
                 "resource_groups_config_bad_query_priority_scheduling_policy.json",
@@ -223,7 +225,7 @@ public class TestFileResourceGroupConfigurationManager
         assertThat(global.getMaxQueuedQueries()).isEqualTo(1000);
         assertThat(global.getHardConcurrencyLimit()).isEqualTo(100);
         assertThat(global.getSchedulingPolicy()).isEqualTo(WEIGHTED);
-        assertThat(global.getSchedulingWeight()).isEqualTo(0);
+        assertThat(global.getSchedulingWeight()).isEqualTo(1);
         assertThat(global.getJmxExport()).isTrue();
 
         ResourceGroupId subId = new ResourceGroupId(globalId, "sub");
@@ -232,7 +234,7 @@ public class TestFileResourceGroupConfigurationManager
         assertThat(sub.getSoftMemoryLimitBytes()).isEqualTo(DataSize.of(2, MEGABYTE).toBytes());
         assertThat(sub.getHardConcurrencyLimit()).isEqualTo(3);
         assertThat(sub.getMaxQueuedQueries()).isEqualTo(4);
-        assertThat(sub.getSchedulingPolicy()).isNull();
+        assertThat(sub.getSchedulingPolicy()).isEqualTo(FAIR);
         assertThat(sub.getSchedulingWeight()).isEqualTo(5);
         assertThat(sub.getJmxExport()).isFalse();
         assertThat(sub.getHardPhysicalDataScanLimitBytes()).isEqualTo(DataSize.of(10, MEGABYTE).toBytes());

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
@@ -45,6 +45,7 @@ import java.util.regex.Pattern;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.trino.execution.resourcegroups.InternalResourceGroup.DEFAULT_WEIGHT;
 import static io.trino.spi.resourcegroups.SchedulingPolicy.FAIR;
+import static io.trino.spi.resourcegroups.SchedulingPolicy.QUERY_PRIORITY;
 import static io.trino.spi.resourcegroups.SchedulingPolicy.WEIGHTED;
 import static io.trino.testing.assertions.Assert.assertEventually;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
@@ -220,6 +221,49 @@ public class TestDbResourceGroupConfigurationManager
             MILLISECONDS.sleep(500);
         }
         while (!globalSub.isDisabled());
+    }
+
+    @Test
+    public void testReconfiguringQueryPriorityGroupResetsInheritedChildren()
+    {
+        H2DaoProvider daoProvider = setup("test_query_priority_reconfig");
+        H2ResourceGroupsDao dao = daoProvider.get();
+        dao.createResourceGroupsGlobalPropertiesTable();
+        dao.createResourceGroupsTable();
+        dao.createSelectorsTable();
+        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "query_priority", null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(3, "nested", "3MB", 2, 1, 1, null, null, null, null, null, null, 2L, ENVIRONMENT);
+        dao.insertSelector(2, 1, null, null, null, null, null, null, null, null, null);
+
+        DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(_ -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
+        InternalResourceGroup global = new InternalResourceGroup("global", (_, _) -> {}, directExecutor());
+        manager.configure(global, new SelectionContext<>(global.getId(), new ResourceGroupIdTemplate("global")));
+        InternalResourceGroup sub = global.getOrCreateSubGroup("sub");
+        manager.configure(sub, new SelectionContext<>(sub.getId(), new ResourceGroupIdTemplate("global.sub")));
+        InternalResourceGroup nested = sub.getOrCreateSubGroup("nested");
+        manager.configure(nested, new SelectionContext<>(nested.getId(), new ResourceGroupIdTemplate("global.sub.nested")));
+
+        assertThat(global.getSchedulingPolicy()).isEqualTo(QUERY_PRIORITY);
+        assertThat(sub.getSchedulingPolicy()).isEqualTo(QUERY_PRIORITY);
+        assertThat(nested.getSchedulingPolicy()).isEqualTo(QUERY_PRIORITY);
+
+        dao.updateResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, null, null, null, null, null, ENVIRONMENT);
+        manager.load();
+        assertThat(global.getSchedulingPolicy()).isEqualTo(WEIGHTED);
+        assertThat(sub.getSchedulingPolicy()).isEqualTo(FAIR);
+        assertThat(nested.getSchedulingPolicy()).isEqualTo(FAIR);
+
+        dao.updateResourceGroup(2, "sub", "2MB", 4, 3, 3, "weighted", 6, null, null, null, null, 1L, ENVIRONMENT);
+        manager.load();
+        assertThat(sub.getSchedulingPolicy()).isEqualTo(WEIGHTED);
+        assertThat(sub.getSchedulingWeight()).isEqualTo(6);
+
+        dao.updateResourceGroup(2, "sub", "2MB", 4, 3, 3, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        manager.load();
+        assertThat(sub.getSchedulingPolicy()).isEqualTo(FAIR);
+        assertThat(sub.getSchedulingWeight()).isEqualTo(DEFAULT_WEIGHT);
+        manager.destroy();
     }
 
     @Test

--- a/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config_bad_scheduling_weight.json
+++ b/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config_bad_scheduling_weight.json
@@ -1,0 +1,15 @@
+{
+  "rootGroups": [
+    {
+      "name": "global",
+      "hardConcurrencyLimit": 1,
+      "maxQueued": 1,
+      "schedulingWeight": 0
+    }
+  ],
+  "selectors": [
+    {
+      "group": "global"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Apply the documented defaults for `schedulingPolicy` and `schedulingWeight` whenever a resource group is configured or reconfigured. This fixes stale values after a database-backed resource group configuration reload removes either optional setting.

The change also resets descendants that inherited `query_priority` when their parent changes to another policy, and rejects non-positive scheduling weights while building `ResourceGroupSpec`.

## Additional context and related issues

Fixes #30547

The tests cover file-manager defaults and invalid weights, database reloads including clearing values and changing a query-priority hierarchy, and query-priority propagation in `InternalResourceGroup`.

Verification:

* `./mvnw -pl plugin/trino-resource-group-managers -Dtest=TestFileResourceGroupConfigurationManager,TestDbResourceGroupConfigurationManager -Dskip.installbun=true -Dskip.bun=true -Dair.check.skip-all=true test`
* `./mvnw -pl core/trino-main -Dtest=TestResourceGroups -Dair.check.skip-all=true test`

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Resource groups
* Fix stale scheduling policy and weight after a database resource group configuration reload. ({issue}`30547`)
```
