### PR TITLE
Fix scheduling policy reset during resource group reconfiguration

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
@@ -113,6 +113,8 @@ public class InternalResourceGroup
     @GuardedBy("root")
     private SchedulingPolicy schedulingPolicy = FAIR;
     @GuardedBy("root")
+    private boolean schedulingPolicyExplicit;
+    @GuardedBy("root")
     private boolean jmxExport;
     private volatile boolean disabled;
 
@@ -572,12 +574,34 @@ public class InternalResourceGroup
     public void setSchedulingPolicy(SchedulingPolicy policy)
     {
         synchronized (root) {
+            if (parent.isPresent() && parent.get().schedulingPolicy == QUERY_PRIORITY) {
+                checkArgument(policy == QUERY_PRIORITY, "Parent of %s uses query priority scheduling, so %s must also", id, id);
+            }
+            schedulingPolicyExplicit = true;
+            setSchedulingPolicyInternal(policy);
+        }
+    }
+
+    private void setSchedulingPolicyInternal(SchedulingPolicy policy)
+    {
+        synchronized (root) {
             if (policy == schedulingPolicy) {
                 return;
             }
+            boolean queryPriorityDisabled = schedulingPolicy == QUERY_PRIORITY;
 
-            if (parent.isPresent() && parent.get().schedulingPolicy == QUERY_PRIORITY) {
-                checkArgument(policy == QUERY_PRIORITY, "Parent of %s uses query priority scheduling, so %s must also", id, id);
+            if (policy == QUERY_PRIORITY) {
+                // Sub groups must use query priority to ensure ordering
+                for (InternalResourceGroup group : subGroups.values()) {
+                    group.setSchedulingPolicyInternal(QUERY_PRIORITY);
+                }
+            }
+            else if (queryPriorityDisabled) {
+                for (InternalResourceGroup group : subGroups.values()) {
+                    if (!group.schedulingPolicyExplicit) {
+                        group.setSchedulingPolicyInternal(FAIR);
+                    }
+                }
             }
 
             // Switch to the appropriate queue implementation to implement the desired policy
@@ -597,10 +621,6 @@ public class InternalResourceGroup
                     queryQueue = new IndexedPriorityQueue<>();
                 }
                 case QUERY_PRIORITY -> {
-                    // Sub groups must use query priority to ensure ordering
-                    for (InternalResourceGroup group : subGroups.values()) {
-                        group.setSchedulingPolicy(QUERY_PRIORITY);
-                    }
                     queue = new IndexedPriorityQueue<>();
                     queryQueue = new IndexedPriorityQueue<>();
                 }
@@ -624,7 +644,8 @@ public class InternalResourceGroup
     public void resetSchedulingPolicy()
     {
         synchronized (root) {
-            setSchedulingPolicy(parent.isPresent() && parent.get().schedulingPolicy == QUERY_PRIORITY ? QUERY_PRIORITY : FAIR);
+            schedulingPolicyExplicit = false;
+            setSchedulingPolicyInternal(parent.isPresent() && parent.get().schedulingPolicy == QUERY_PRIORITY ? QUERY_PRIORITY : FAIR);
         }
     }
 
@@ -670,7 +691,7 @@ public class InternalResourceGroup
             InternalResourceGroup subGroup = new InternalResourceGroup(Optional.of(this), name, jmxExportListener, executor);
             // Sub group must use query priority to ensure ordering
             if (schedulingPolicy == QUERY_PRIORITY) {
-                subGroup.setSchedulingPolicy(QUERY_PRIORITY);
+                subGroup.setSchedulingPolicyInternal(QUERY_PRIORITY);
             }
             subGroups.put(name, subGroup);
             return subGroup;

--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
@@ -621,6 +621,14 @@ public class InternalResourceGroup
     }
 
     @Override
+    public void resetSchedulingPolicy()
+    {
+        synchronized (root) {
+            setSchedulingPolicy(parent.isPresent() && parent.get().schedulingPolicy == QUERY_PRIORITY ? QUERY_PRIORITY : FAIR);
+        }
+    }
+
+    @Override
     public boolean getJmxExport()
     {
         synchronized (root) {

--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
@@ -577,8 +577,26 @@ public class InternalResourceGroup
             if (parent.isPresent() && parent.get().schedulingPolicy == QUERY_PRIORITY) {
                 checkArgument(policy == QUERY_PRIORITY, "Parent of %s uses query priority scheduling, so %s must also", id, id);
             }
+            if (policy == QUERY_PRIORITY) {
+                validateQueryPrioritySubGroups(id);
+            }
             schedulingPolicyExplicit = true;
             setSchedulingPolicyInternal(policy);
+        }
+    }
+
+    private void validateQueryPrioritySubGroups(ResourceGroupId queryPriorityGroup)
+    {
+        synchronized (root) {
+            for (InternalResourceGroup group : subGroups.values()) {
+                checkArgument(
+                        !group.schedulingPolicyExplicit || group.schedulingPolicy == QUERY_PRIORITY,
+                        "Cannot set %s to query priority scheduling because descendant %s explicitly uses %s",
+                        queryPriorityGroup,
+                        group.id,
+                        group.schedulingPolicy);
+                group.validateQueryPrioritySubGroups(queryPriorityGroup);
+            }
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
+++ b/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
@@ -50,6 +50,7 @@ import static io.trino.spi.resourcegroups.SchedulingPolicy.WEIGHTED;
 import static io.trino.spi.resourcegroups.SchedulingPolicy.WEIGHTED_FAIR;
 import static java.util.Collections.reverse;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestResourceGroups
 {
@@ -211,6 +212,22 @@ public class TestResourceGroups
 
         root.setSchedulingPolicy(FAIR);
         assertThat(group.getSchedulingPolicy()).isEqualTo(FAIR);
+    }
+
+    @Test
+    public void testInvalidQueryPrioritySubtree()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        InternalResourceGroup group = root.getOrCreateSubGroup("group");
+        InternalResourceGroup leaf = group.getOrCreateSubGroup("leaf");
+        leaf.setSchedulingPolicy(WEIGHTED);
+
+        assertThatThrownBy(() -> root.setSchedulingPolicy(QUERY_PRIORITY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cannot set root to query priority scheduling because descendant root.group.leaf explicitly uses WEIGHTED");
+        assertThat(root.getSchedulingPolicy()).isEqualTo(FAIR);
+        assertThat(group.getSchedulingPolicy()).isEqualTo(FAIR);
+        assertThat(leaf.getSchedulingPolicy()).isEqualTo(WEIGHTED);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
+++ b/core/trino-main/src/test/java/io/trino/execution/resourcegroups/TestResourceGroups.java
@@ -169,6 +169,51 @@ public class TestResourceGroups
     }
 
     @Test
+    public void testInheritedPolicyCleared()
+    {
+        InternalResourceGroup a = new InternalResourceGroup("a", (_, _) -> {}, directExecutor());
+        InternalResourceGroup b = a.getOrCreateSubGroup("b");
+        InternalResourceGroup c = b.getOrCreateSubGroup("c");
+        InternalResourceGroup d = c.getOrCreateSubGroup("d");
+
+        a.setSchedulingPolicy(QUERY_PRIORITY);
+        c.setSchedulingPolicy(QUERY_PRIORITY);
+        a.setSchedulingPolicy(FAIR);
+
+        assertThat(a.getSchedulingPolicy()).isEqualTo(FAIR);
+        assertThat(b.getSchedulingPolicy()).isEqualTo(FAIR);
+        assertThat(c.getSchedulingPolicy()).isEqualTo(QUERY_PRIORITY);
+        assertThat(d.getSchedulingPolicy()).isEqualTo(QUERY_PRIORITY);
+    }
+
+    @Test
+    public void testExplicitPolicyReset()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        InternalResourceGroup group = root.getOrCreateSubGroup("group");
+
+        root.setSchedulingPolicy(QUERY_PRIORITY);
+        group.setSchedulingPolicy(QUERY_PRIORITY);
+        group.resetSchedulingPolicy();
+        assertThat(group.getSchedulingPolicy()).isEqualTo(QUERY_PRIORITY);
+
+        root.setSchedulingPolicy(FAIR);
+        assertThat(group.getSchedulingPolicy()).isEqualTo(FAIR);
+    }
+
+    @Test
+    public void testPolicyInheritedOnCreate()
+    {
+        InternalResourceGroup root = new InternalResourceGroup("root", (_, _) -> {}, directExecutor());
+        root.setSchedulingPolicy(QUERY_PRIORITY);
+        InternalResourceGroup group = root.getOrCreateSubGroup("group");
+        assertThat(group.getSchedulingPolicy()).isEqualTo(QUERY_PRIORITY);
+
+        root.setSchedulingPolicy(FAIR);
+        assertThat(group.getSchedulingPolicy()).isEqualTo(FAIR);
+    }
+
+    @Test
     @Timeout(10)
     public void testFairQueuing()
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/ResourceGroup.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/ResourceGroup.java
@@ -103,6 +103,14 @@ public interface ResourceGroup
      */
     void setSchedulingPolicy(SchedulingPolicy policy);
 
+    /**
+     * Resets the scheduling policy of this group to the effective default.
+     */
+    default void resetSchedulingPolicy()
+    {
+        setSchedulingPolicy(SchedulingPolicy.FAIR);
+    }
+
     boolean getJmxExport();
 
     /**

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
@@ -38,6 +38,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verifyNotNull;
 import static io.trino.spi.StandardErrorCode.INVALID_RESOURCE_GROUP;
+import static io.trino.spi.resourcegroups.SchedulingPolicy.QUERY_PRIORITY;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.function.Predicate.isEqual;
@@ -58,11 +59,20 @@ public abstract class AbstractResourceConfigurationManager
 
     protected void validateRootGroups(ManagerSpec managerSpec)
     {
-        Queue<ResourceGroupSpec> groups = new LinkedList<>(managerSpec.getRootGroups());
+        Queue<GroupValidationContext> groups = new LinkedList<>();
+        managerSpec.getRootGroups().forEach(group -> groups.add(new GroupValidationContext(group, false)));
         while (!groups.isEmpty()) {
-            ResourceGroupSpec group = groups.poll();
+            GroupValidationContext context = groups.poll();
+            ResourceGroupSpec group = context.group();
             List<ResourceGroupSpec> subGroups = group.getSubGroups();
-            groups.addAll(subGroups);
+            if (context.queryPriorityRequired()) {
+                checkArgument(
+                        group.getSchedulingPolicy().isEmpty() || group.getSchedulingPolicy().get() == QUERY_PRIORITY,
+                        "Resource group '%s' must use 'query_priority' scheduling policy or inherit it because an ancestor uses 'query_priority'",
+                        group.getName());
+            }
+            boolean queryPriorityRequired = context.queryPriorityRequired() || group.getSchedulingPolicy().filter(isEqual(QUERY_PRIORITY)).isPresent();
+            subGroups.forEach(subGroup -> groups.add(new GroupValidationContext(subGroup, queryPriorityRequired)));
             if (group.getSoftCpuLimit().isPresent() || group.getHardCpuLimit().isPresent()) {
                 checkArgument(managerSpec.getCpuQuotaPeriod().isPresent(), "cpuQuotaPeriod must be specified to use CPU limits on group: %s", group.getName());
             }
@@ -93,6 +103,8 @@ public abstract class AbstractResourceConfigurationManager
             }
         }
     }
+
+    private record GroupValidationContext(ResourceGroupSpec group, boolean queryPriorityRequired) {}
 
     protected List<ResourceGroupSelector> buildSelectors(ManagerSpec managerSpec)
     {

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManager.java
@@ -165,6 +165,12 @@ public class DbResourceGroupConfigurationManager
     protected void configureGroup(ResourceGroup group, ResourceGroupSpec groupSpec)
     {
         super.configureGroup(group, groupSpec);
+        if (groupSpec.getSchedulingPolicy().isEmpty()) {
+            group.resetSchedulingPolicy();
+        }
+        if (groupSpec.getSchedulingWeight().isEmpty()) {
+            group.setSchedulingWeight(1);
+        }
         specsUsedToConfigureGroups.put(group.getId(), groupSpec);
     }
 

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestFileResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestFileResourceGroupConfigurationManager.java
@@ -60,6 +60,9 @@ public class TestFileResourceGroupConfigurationManager
         assertFails(
                 "resource_groups_config_bad_query_priority_scheduling_policy.json",
                 "Must use 'weighted' or 'weighted_fair' scheduling policy if specifying scheduling weight for 'requests'");
+        assertFails(
+                "resource_groups_config_bad_query_priority_subtree.json",
+                "Resource group 'leaf' must use 'query_priority' scheduling policy or inherit it because an ancestor uses 'query_priority'");
         assertFails("resource_groups_config_bad_extract_variable.json", "Invalid resource group name.*");
         assertFails("resource_groups_config_bad_query_type.json", "Selector specifies an invalid query type: invalid_query_type");
         assertFails("resource_groups_config_bad_selector.json", "Selector refers to nonexistent group: a.b.c.X");

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
@@ -45,6 +45,7 @@ import java.util.regex.Pattern;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.trino.execution.resourcegroups.InternalResourceGroup.DEFAULT_WEIGHT;
 import static io.trino.spi.resourcegroups.SchedulingPolicy.FAIR;
+import static io.trino.spi.resourcegroups.SchedulingPolicy.QUERY_PRIORITY;
 import static io.trino.spi.resourcegroups.SchedulingPolicy.WEIGHTED;
 import static io.trino.testing.assertions.Assert.assertEventually;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
@@ -220,6 +221,53 @@ public class TestDbResourceGroupConfigurationManager
             MILLISECONDS.sleep(500);
         }
         while (!globalSub.isDisabled());
+    }
+
+    @Test
+    public void testSchedulingDefaultsRestored()
+    {
+        H2DaoProvider daoProvider = setup("test_scheduling_defaults");
+        H2ResourceGroupsDao dao = daoProvider.get();
+        dao.createResourceGroupsGlobalPropertiesTable();
+        dao.createResourceGroupsTable();
+        dao.createSelectorsTable();
+        dao.insertResourceGroup(1, "defaults", "1MB", 10, 10, 10, "weighted", 6, null, null, null, null, null, ENVIRONMENT);
+        dao.insertSelector(1, 1, null, null, null, null, null, null, null, null, null);
+
+        DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(_ -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
+        InternalResourceGroup defaults = new InternalResourceGroup("defaults", (_, _) -> {}, directExecutor());
+        manager.configure(defaults, new SelectionContext<>(defaults.getId(), new ResourceGroupIdTemplate("defaults")));
+        assertThat(defaults.getSchedulingPolicy()).isEqualTo(WEIGHTED);
+        assertThat(defaults.getSchedulingWeight()).isEqualTo(6);
+
+        dao.updateResourceGroup(1, "defaults", "1MB", 10, 10, 10, null, null, null, null, null, null, null, ENVIRONMENT);
+        manager.load();
+        assertThat(defaults.getSchedulingPolicy()).isEqualTo(FAIR);
+        assertThat(defaults.getSchedulingWeight()).isEqualTo(DEFAULT_WEIGHT);
+    }
+
+    @Test
+    public void testInheritedQueryPriorityOnReset()
+    {
+        H2DaoProvider daoProvider = setup("test_scheduling_policy_inheritance");
+        H2ResourceGroupsDao dao = daoProvider.get();
+        dao.createResourceGroupsGlobalPropertiesTable();
+        dao.createResourceGroupsTable();
+        dao.createSelectorsTable();
+        dao.insertResourceGroup(1, "priority", "1MB", 10, 10, 10, "query_priority", null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "sub", "1MB", 10, 10, 10, "query_priority", null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertSelector(2, 1, null, null, null, null, null, null, null, null, null);
+
+        DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(_ -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
+        InternalResourceGroup priority = new InternalResourceGroup("priority", (_, _) -> {}, directExecutor());
+        manager.configure(priority, new SelectionContext<>(priority.getId(), new ResourceGroupIdTemplate("priority")));
+        InternalResourceGroup sub = priority.getOrCreateSubGroup("sub");
+        manager.configure(sub, new SelectionContext<>(sub.getId(), new ResourceGroupIdTemplate("priority.sub")));
+        assertThat(sub.getSchedulingPolicy()).isEqualTo(QUERY_PRIORITY);
+
+        dao.updateResourceGroup(2, "sub", "1MB", 10, 10, 10, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        manager.load();
+        assertThat(sub.getSchedulingPolicy()).isEqualTo(QUERY_PRIORITY);
     }
 
     @Test

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
@@ -271,6 +271,39 @@ public class TestDbResourceGroupConfigurationManager
     }
 
     @Test
+    public void testInheritedPolicyCleared()
+    {
+        H2DaoProvider daoProvider = setup("test_inherited_policy_cleared");
+        H2ResourceGroupsDao dao = daoProvider.get();
+        dao.createResourceGroupsGlobalPropertiesTable();
+        dao.createResourceGroupsTable();
+        dao.createSelectorsTable();
+        dao.insertResourceGroup(1, "a", "1MB", 10, 10, 10, "query_priority", null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "b", "1MB", 10, 10, 10, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(3, "c", "1MB", 10, 10, 10, "query_priority", null, null, null, null, null, 2L, ENVIRONMENT);
+        dao.insertResourceGroup(4, "d", "1MB", 10, 10, 10, null, null, null, null, null, null, 3L, ENVIRONMENT);
+        dao.insertSelector(4, 1, null, null, null, null, null, null, null, null, null);
+
+        DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(_ -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
+        InternalResourceGroup a = new InternalResourceGroup("a", (_, _) -> {}, directExecutor());
+        manager.configure(a, new SelectionContext<>(a.getId(), new ResourceGroupIdTemplate("a")));
+        InternalResourceGroup b = a.getOrCreateSubGroup("b");
+        manager.configure(b, new SelectionContext<>(b.getId(), new ResourceGroupIdTemplate("a.b")));
+        InternalResourceGroup c = b.getOrCreateSubGroup("c");
+        manager.configure(c, new SelectionContext<>(c.getId(), new ResourceGroupIdTemplate("a.b.c")));
+        InternalResourceGroup d = c.getOrCreateSubGroup("d");
+        manager.configure(d, new SelectionContext<>(d.getId(), new ResourceGroupIdTemplate("a.b.c.d")));
+
+        dao.updateResourceGroup(1, "a", "1MB", 10, 10, 10, null, null, null, null, null, null, null, ENVIRONMENT);
+        manager.load();
+
+        assertThat(a.getSchedulingPolicy()).isEqualTo(FAIR);
+        assertThat(b.getSchedulingPolicy()).isEqualTo(FAIR);
+        assertThat(c.getSchedulingPolicy()).isEqualTo(QUERY_PRIORITY);
+        assertThat(d.getSchedulingPolicy()).isEqualTo(QUERY_PRIORITY);
+    }
+
+    @Test
     public void testExactMatchSelector()
     {
         H2DaoProvider daoProvider = setup("test_exact_match_selector");

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
@@ -304,6 +304,32 @@ public class TestDbResourceGroupConfigurationManager
     }
 
     @Test
+    public void testInvalidQueryPriorityReload()
+    {
+        H2DaoProvider daoProvider = setup("test_invalid_query_priority_reload");
+        H2ResourceGroupsDao dao = daoProvider.get();
+        dao.createResourceGroupsGlobalPropertiesTable();
+        dao.createResourceGroupsTable();
+        dao.createSelectorsTable();
+        dao.insertResourceGroup(1, "a", "1MB", 10, 10, 10, "fair", null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "b", "1MB", 10, 10, 10, "weighted", null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertSelector(2, 1, null, null, null, null, null, null, null, null, null);
+
+        DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(_ -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
+        InternalResourceGroup a = new InternalResourceGroup("a", (_, _) -> {}, directExecutor());
+        manager.configure(a, new SelectionContext<>(a.getId(), new ResourceGroupIdTemplate("a")));
+        InternalResourceGroup b = a.getOrCreateSubGroup("b");
+        manager.configure(b, new SelectionContext<>(b.getId(), new ResourceGroupIdTemplate("a.b")));
+
+        dao.updateResourceGroup(1, "a", "1MB", 10, 10, 10, "query_priority", null, null, null, null, null, null, ENVIRONMENT);
+        manager.load();
+
+        assertThat(manager.getRefreshFailures().getTotalCount()).isEqualTo(1);
+        assertThat(a.getSchedulingPolicy()).isEqualTo(FAIR);
+        assertThat(b.getSchedulingPolicy()).isEqualTo(WEIGHTED);
+    }
+
+    @Test
     public void testExactMatchSelector()
     {
         H2DaoProvider daoProvider = setup("test_exact_match_selector");

--- a/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config_bad_query_priority_subtree.json
+++ b/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config_bad_query_priority_subtree.json
@@ -1,0 +1,33 @@
+{
+  "rootGroups": [
+    {
+      "name": "root",
+      "softMemoryLimit": "80%",
+      "hardConcurrencyLimit": 10,
+      "maxQueued": 100,
+      "schedulingPolicy": "query_priority",
+      "subGroups": [
+        {
+          "name": "group",
+          "softMemoryLimit": "80%",
+          "hardConcurrencyLimit": 10,
+          "maxQueued": 100,
+          "subGroups": [
+            {
+              "name": "leaf",
+              "softMemoryLimit": "80%",
+              "hardConcurrencyLimit": 10,
+              "maxQueued": 100,
+              "schedulingPolicy": "weighted"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "selectors": [
+    {
+      "group": "root.group.leaf"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Fix database-backed resource group scheduling state during dynamic reconfiguration.

- restore the default scheduling policy and weight when the corresponding database settings are changed to `NULL`
- distinguish explicitly configured scheduling policies from inherited `QUERY_PRIORITY`
- clear inherited `QUERY_PRIORITY` when an ancestor switches to a non-priority policy, while preserving explicitly configured descendants
- reject configurations that explicitly use a non-`QUERY_PRIORITY` scheduling policy below a `QUERY_PRIORITY` ancestor, both during configuration validation and at runtime

### Tests

- `TestResourceGroups`
- `TestFileResourceGroupConfigurationManager`
- `TestDbResourceGroupConfigurationManager`
- `trino-spi` package build

## Additional context and related issues

Closes #30562
Closes #30564
Closes #30572

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix database resource group scheduling policies and weights not reverting to defaults when policy field or weight field is set to NULL. ({issue}`30562`)
* Fix inherited query priority scheduling policies not being cleared when an ancestor's policy changes. ({issue}`30564`)
* Reject incompatible scheduling policies below query priority resource groups during configuration loading. ({issue}`30572`)
```
