### PR TITLE
Reject non-positive scheduling weights before runtime

### DIFF
--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/ResourceGroupSpec.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/ResourceGroupSpec.java
@@ -85,6 +85,7 @@ public class ResourceGroupSpec
         softConcurrencyLimit.ifPresent(soft -> checkArgument(this.hardConcurrencyLimit >= soft, "hardConcurrencyLimit must be greater than or equal to softConcurrencyLimit"));
         this.schedulingPolicy = schedulingPolicy.map(value -> SchedulingPolicy.valueOf(value.toUpperCase(ENGLISH)));
         this.schedulingWeight = requireNonNull(schedulingWeight, "schedulingWeight is null");
+        this.schedulingWeight.ifPresent(weight -> checkArgument(weight > 0, "schedulingWeight must be positive"));
 
         requireNonNull(softMemoryLimit, "softMemoryLimit is null");
         if (softMemoryLimit.isEmpty()) {

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestFileResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestFileResourceGroupConfigurationManager.java
@@ -56,6 +56,7 @@ public class TestFileResourceGroupConfigurationManager
         assertFails("resource_groups_config_bad_group_id.json", "Invalid resource group name. 'glo.bal' contains a '.'");
         assertFails("resource_groups_config_bad_soft_memory_limit.json", "softMemoryLimit percentage is over 100%");
         assertFails("resource_groups_config_bad_weighted_scheduling_policy.json", "Must specify scheduling weight for all sub-groups of 'requests' or none of them");
+        assertFails("resource_groups_config_bad_scheduling_weight.json", "schedulingWeight must be positive");
         assertFails("resource_groups_config_unused_field.json", "Unknown property at line 8:6: maxFoo");
         assertFails(
                 "resource_groups_config_bad_query_priority_scheduling_policy.json",

--- a/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config_bad_scheduling_weight.json
+++ b/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config_bad_scheduling_weight.json
@@ -1,0 +1,15 @@
+{
+  "rootGroups": [
+    {
+      "name": "global",
+      "hardConcurrencyLimit": 1,
+      "maxQueued": 1,
+      "schedulingWeight": 0
+    }
+  ],
+  "selectors": [
+    {
+      "group": "global"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Reject non-positive `schedulingWeight` values while loading resource group configuration, before they are applied to a live resource group. Both zero and negative values are invalid.

### Tests

- `TestFileResourceGroupConfigurationManager`

## Additional context and related issues

- Fixes #30563

Previously, a non-positive scheduling weight was accepted during configuration parsing and rejected only when the configuration was applied to a live resource group.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
