### PR TITLE
Preserve original case in TrinoPrincipal

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -318,9 +318,9 @@ public class InformationSchemaPageSource
         List<GrantInfo> grants = ImmutableList.copyOf(listTablePrivileges(session, metadata, accessControl, prefix));
         for (GrantInfo grant : grants) {
             addRecord(
-                    grant.getGrantor().map(TrinoPrincipal::getName).orElse(null),
+                    grant.getGrantor().map(TrinoPrincipal::getPrincipalName).orElse(null),
                     grant.getGrantor().map(principal -> principal.getType().toString()).orElse(null),
-                    grant.getGrantee().getName(),
+                    grant.getGrantee().getPrincipalName(),
                     grant.getGrantee().getType().toString(),
                     prefix.getCatalogName(),
                     grant.getSchemaTableName().getSchemaName(),
@@ -357,7 +357,7 @@ public class InformationSchemaPageSource
         Optional<String> catalogName = metadata.isCatalogManagedSecurity(session, this.catalogName) ? Optional.of(this.catalogName) : Optional.empty();
         for (RoleGrant grant : metadata.listApplicableRoles(session, new TrinoPrincipal(USER, session.getUser()), catalogName)) {
             addRecord(
-                    grant.getGrantee().getName(),
+                    grant.getGrantee().getPrincipalName(),
                     grant.getGrantee().getType().toString(),
                     grant.getRoleName(),
                     grant.isGrantable() ? "YES" : "NO");

--- a/core/trino-main/src/main/java/io/trino/connector/system/FunctionsAuthorization.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/FunctionsAuthorization.java
@@ -98,7 +98,7 @@ public class FunctionsAuthorization
                     schemaFunctionName.schemaName(),
                     schemaFunctionName.functionName(),
                     trinoPrincipal.getType().toString(),
-                    trinoPrincipal.getName());
+                    trinoPrincipal.getPrincipalName());
         }
         return table.build().cursor();
     }

--- a/core/trino-main/src/main/java/io/trino/connector/system/SchemasAuthorization.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SchemasAuthorization.java
@@ -95,7 +95,7 @@ public class SchemasAuthorization
                     catalogSchemaAuthorization.catalog(),
                     catalogSchemaAuthorization.schemaAuthorization().schemaName(),
                     trinoPrincipal.getType().toString(),
-                    trinoPrincipal.getName());
+                    trinoPrincipal.getPrincipalName());
         }
         return table.build().cursor();
     }

--- a/core/trino-main/src/main/java/io/trino/connector/system/TablesAuthorization.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/TablesAuthorization.java
@@ -95,7 +95,7 @@ public class TablesAuthorization
                     schemaTableName.getSchemaName(),
                     schemaTableName.getTableName(),
                     trinoPrincipal.getType().toString(),
-                    trinoPrincipal.getName());
+                    trinoPrincipal.getPrincipalName());
         }
         return table.build().cursor();
     }

--- a/core/trino-main/src/main/java/io/trino/execution/GrantRolesTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/GrantRolesTask.java
@@ -79,10 +79,10 @@ public class GrantRolesTask
         specifiedRoles.addAll(roles);
         grantees.stream()
                 .filter(principal -> principal.getType() == ROLE)
-                .map(TrinoPrincipal::getName)
+                .map(TrinoPrincipal::getPrincipalName)
                 .forEach(specifiedRoles::add);
         if (grantor.isPresent() && grantor.get().getType() == ROLE) {
-            specifiedRoles.add(grantor.get().getName());
+            specifiedRoles.add(grantor.get().getPrincipalName());
         }
 
         for (String role : specifiedRoles) {

--- a/core/trino-main/src/main/java/io/trino/execution/RevokeRolesTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RevokeRolesTask.java
@@ -79,10 +79,10 @@ public class RevokeRolesTask
         specifiedRoles.addAll(roles);
         grantees.stream()
                 .filter(principal -> principal.getType() == ROLE)
-                .map(TrinoPrincipal::getName)
+                .map(TrinoPrincipal::getPrincipalName)
                 .forEach(specifiedRoles::add);
         if (grantor.isPresent() && grantor.get().getType() == ROLE) {
-            specifiedRoles.add(grantor.get().getName());
+            specifiedRoles.add(grantor.get().getPrincipalName());
         }
 
         for (String role : specifiedRoles) {

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataUtil.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataUtil.java
@@ -248,8 +248,8 @@ public final class MetadataUtil
     {
         PrincipalType type = principal.getType();
         return switch (type) {
-            case USER -> new PrincipalSpecification(PrincipalSpecification.Type.USER, new Identifier(principal.getName()));
-            case ROLE -> new PrincipalSpecification(PrincipalSpecification.Type.ROLE, new Identifier(principal.getName()));
+            case USER -> new PrincipalSpecification(PrincipalSpecification.Type.USER, new Identifier(principal.getPrincipalName()));
+            case ROLE -> new PrincipalSpecification(PrincipalSpecification.Type.ROLE, new Identifier(principal.getPrincipalName()));
         };
     }
 
@@ -265,7 +265,7 @@ public final class MetadataUtil
     public static void checkRoleExists(Session session, Node node, Metadata metadata, TrinoPrincipal principal, Optional<String> catalog)
     {
         if (principal.getType() == ROLE) {
-            checkRoleExists(session, node, metadata, principal.getName(), catalog);
+            checkRoleExists(session, node, metadata, principal.getPrincipalName(), catalog);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -1906,7 +1906,7 @@ public class TracingMetadata
                     entity.entityKind(),
                     entity.name(),
                     grantee.getType(),
-                    grantee.getName(),
+                    grantee.getPrincipalName(),
                     privileges.stream().map(EntityPrivilege::name).collect(Collectors.joining("-")),
                     grantOption ? "-grantOption" : "");
             span.setAttribute(TrinoAttributes.PRIVILEGE_GRANT, grant);

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -548,6 +548,14 @@
                                     <code>java.method.addedToInterface</code>
                                     <new>method boolean io.trino.spi.spool.SpoolingManager::isRecoverableException(java.io.IOException)</new>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>method java.lang.String io.trino.spi.security.TrinoPrincipal::getName()</old>
+                                    <new>method java.lang.String io.trino.spi.security.TrinoPrincipal::getName()</new>
+                                    <annotation>@com.fasterxml.jackson.annotation.JsonProperty</annotation>
+                                    <justification>getName() is deprecated and replaced by getPrincipalName() which preserves the original case of USER principal names. The @JsonProperty annotation is moved to getPrincipalName() so that JSON serialization reflects the stored name verbatim.</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/security/TrinoPrincipal.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/TrinoPrincipal.java
@@ -14,6 +14,7 @@
 package io.trino.spi.security;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
@@ -30,7 +31,8 @@ public class TrinoPrincipal
     public TrinoPrincipal(@JsonProperty("type") PrincipalType type, @JsonProperty("name") String name)
     {
         this.type = requireNonNull(type, "type is null");
-        this.name = name.toLowerCase(ENGLISH);
+        requireNonNull(name, "name is null");
+        this.name = type == PrincipalType.USER ? name : name.toLowerCase(ENGLISH);
     }
 
     @JsonProperty
@@ -39,10 +41,22 @@ public class TrinoPrincipal
         return type;
     }
 
-    @JsonProperty
-    public String getName()
+    @JsonProperty("name")
+    public String getPrincipalName()
     {
         return name;
+    }
+
+    /**
+     * @deprecated Use {@link #getPrincipalName()} which preserves the original case of the principal name.
+     *         This method lowercases the name, which causes identity mismatches when the principal
+     *         was created with a mixed-case name.
+     */
+    @Deprecated
+    @JsonIgnore
+    public String getName()
+    {
+        return name.toLowerCase(ENGLISH);
     }
 
     @Override

--- a/lib/trino-metastore/src/main/java/io/trino/metastore/HivePrincipal.java
+++ b/lib/trino-metastore/src/main/java/io/trino/metastore/HivePrincipal.java
@@ -62,7 +62,7 @@ public class HivePrincipal
 
     public static HivePrincipal from(TrinoPrincipal trinoPrincipal)
     {
-        return new HivePrincipal(trinoPrincipal.getType(), trinoPrincipal.getName());
+        return new HivePrincipal(trinoPrincipal.getType(), trinoPrincipal.getPrincipalName());
     }
 
     private final PrincipalType type;

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AuthorizationRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AuthorizationRule.java
@@ -68,8 +68,8 @@ public class AuthorizationRule
     private boolean matches(TrinoPrincipal newPrincipal)
     {
         return switch (newPrincipal.getType()) {
-            case USER -> newUserPattern.map(regex -> regex.matcher(newPrincipal.getName()).matches()).orElse(false);
-            case ROLE -> newRolePattern.map(regex -> regex.matcher(newPrincipal.getName()).matches()).orElse(false);
+            case USER -> newUserPattern.map(regex -> regex.matcher(newPrincipal.getPrincipalName()).matches()).orElse(false);
+            case ROLE -> newRolePattern.map(regex -> regex.matcher(newPrincipal.getPrincipalName()).matches()).orElse(false);
         };
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1404,7 +1404,7 @@ public class DeltaLakeMetadata
                 .setDatabaseName(schemaName)
                 .setLocation(location)
                 .setOwnerType(Optional.of(owner.getType()))
-                .setOwnerName(Optional.of(owner.getName()))
+                .setOwnerName(Optional.of(owner.getPrincipalName()))
                 .setParameters(ImmutableMap.of(TRINO_QUERY_ID_NAME, queryId))
                 .build();
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -1007,7 +1007,7 @@ public class HiveMetadata
                 .setDatabaseName(schemaName)
                 .setLocation(location)
                 .setOwnerType(usingSystemSecurity ? Optional.empty() : Optional.of(owner.getType()))
-                .setOwnerName(usingSystemSecurity ? Optional.empty() : Optional.of(owner.getName()))
+                .setOwnerName(usingSystemSecurity ? Optional.empty() : Optional.of(owner.getPrincipalName()))
                 .setParameters(ImmutableMap.of(TRINO_QUERY_ID_NAME, session.getQueryId()))
                 .build();
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -302,7 +302,7 @@ public class TrinoGlueCatalog
     public void createNamespace(ConnectorSession session, String namespace, Map<String, Object> properties, TrinoPrincipal owner)
     {
         checkArgument(owner.getType() == PrincipalType.USER, "Owner type must be USER");
-        checkArgument(owner.getName().equals(session.getUser().toLowerCase(ENGLISH)), "Explicit schema owner is not supported");
+        checkArgument(owner.getPrincipalName().equals(session.getUser()), "Explicit schema owner is not supported");
 
         try {
             glueClient.createDatabase(createDatabaseInput(namespace, properties));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -228,7 +228,7 @@ public class TrinoHiveCatalog
         Database.Builder database = Database.builder()
                 .setDatabaseName(namespace)
                 .setOwnerType(isUsingSystemSecurity ? Optional.empty() : Optional.of(owner.getType()))
-                .setOwnerName(isUsingSystemSecurity ? Optional.empty() : Optional.of(owner.getName()));
+                .setOwnerName(isUsingSystemSecurity ? Optional.empty() : Optional.of(owner.getPrincipalName()));
 
         properties.forEach((property, value) -> {
             switch (property) {

--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoGrantPrincipal.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoGrantPrincipal.java
@@ -24,7 +24,7 @@ public record TrinoGrantPrincipal(String type, String name)
 {
     public static TrinoGrantPrincipal fromTrinoPrincipal(TrinoPrincipal principal)
     {
-        return new TrinoGrantPrincipal(principal.getType().name(), principal.getName());
+        return new TrinoGrantPrincipal(principal.getType().name(), principal.getPrincipalName());
     }
 
     public TrinoGrantPrincipal

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
@@ -481,7 +481,7 @@ final class TestOpaAccessControl
                         "type": "%s"
                     }
                 }
-                """.formatted(schema.getCatalogName(), schema.getSchemaName(), principal.getName(), principal.getType());
+                """.formatted(schema.getCatalogName(), schema.getSchemaName(), principal.getPrincipalName(), principal.getType());
         assertAccessControlMethodBehaviour(methodWrapper, ImmutableSet.of(expectedRequest));
     }
 
@@ -522,7 +522,7 @@ final class TestOpaAccessControl
                         table.getCatalogName(),
                         table.getSchemaTableName().getSchemaName(),
                         table.getSchemaTableName().getTableName(),
-                        principal.getName(),
+                        principal.getPrincipalName(),
                         principal.getType());
         assertAccessControlMethodBehaviour(wrappedMethod, ImmutableSet.of(expectedRequest));
     }

--- a/testing/trino-tests/src/test/java/io/trino/security/TestingSystemSecurityMetadata.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestingSystemSecurityMetadata.java
@@ -336,19 +336,19 @@ class TestingSystemSecurityMetadata
         List<String> name = entityKindAndName.name();
         if (entityKindAndName.entityKind().contains("VIEW")) {
             checkArgument(principal.getType() == USER, "Only a user can be a view owner");
-            viewOwners.put(new CatalogSchemaTableName(name.get(0), name.get(1), name.get(2)), Identity.ofUser(principal.getName()));
+            viewOwners.put(new CatalogSchemaTableName(name.get(0), name.get(1), name.get(2)), Identity.ofUser(principal.getPrincipalName()));
         }
         else if (entityKindAndName.entityKind().startsWith("TABLE")) {
             checkArgument(principal.getType() == USER, "Only a user can be a table owner");
-            tableOwners.put(new CatalogSchemaTableName(name.get(0), name.get(1), name.get(2)), Identity.ofUser(principal.getName()));
+            tableOwners.put(new CatalogSchemaTableName(name.get(0), name.get(1), name.get(2)), Identity.ofUser(principal.getPrincipalName()));
         }
         else if (entityKindAndName.entityKind().startsWith("FUNCTION")) {
             checkArgument(principal.getType() == USER, "Only a user can be a function owner");
-            functionOwners.put(new CatalogSchemaFunctionName(name.get(0), name.get(1), name.get(2)), Identity.ofUser(principal.getName()));
+            functionOwners.put(new CatalogSchemaFunctionName(name.get(0), name.get(1), name.get(2)), Identity.ofUser(principal.getPrincipalName()));
         }
         else if (entityKindAndName.entityKind().startsWith("SCHEMA")) {
             checkArgument(principal.getType() == USER, "Only a user can be a schema owner");
-            schemaOwners.put(new CatalogSchemaName(name.get(0), name.get(1)), Identity.ofUser(principal.getName()));
+            schemaOwners.put(new CatalogSchemaName(name.get(0), name.get(1)), Identity.ofUser(principal.getPrincipalName()));
         }
         else {
             throw new UnsupportedOperationException();


### PR DESCRIPTION
TrinoPrincipal previously lowercased the principal name unconditionally in the constructor. This corrupted names that must preserve their original case causing identity mismatches in case-sensitive deployments.

The constructor now stores the name verbatim. getPrincipalName() is the new canonical accessor - it returns the original case and is the serialized JSON property. getName() is deprecated and retained for backward compatibility; it computes and returns the lowercase form but is excluded from serialization.

equals() and hashCode() compare the original name, making their semantics consistent with getPrincipalName().

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

This is not user-visible or is docs only, and no release notes are required.

