### PR TITLE
Add trino-ranger in build-test-matrix instead of test-other-modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,7 @@ jobs:
             !:trino-parquet,
             !:trino-pinot,
             !:trino-postgresql,
+            !:trino-ranger,
             !:trino-redis,
             !:trino-redshift,
             !:trino-resource-group-managers,
@@ -489,6 +490,7 @@ jobs:
             - { modules: plugin/trino-oracle }
             - { modules: plugin/trino-pinot }
             - { modules: plugin/trino-postgresql }
+            - { modules: plugin/trino-ranger }
             - { modules: plugin/trino-redis }
             - { modules: plugin/trino-redshift }
             - { modules: plugin/trino-redshift, profile: cloud-tests }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Currently trino-ranger unit tests are enabled in ci test-other-modules workflow. making it to standout like other modules.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
