### PR TITLE
Add Case Connector Expression

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
@@ -56,6 +56,7 @@ import io.trino.sql.ir.Lambda;
 import io.trino.sql.ir.Let;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.WhenClause;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.type.JoniRegexp;
 import io.trino.type.JsonPathType;
@@ -257,6 +258,10 @@ public final class ConnectorExpressionTranslator
 
             if (expression instanceof io.trino.spi.expression.Lambda lambda) {
                 return translateLambda(lambda, lambdaArguments);
+            }
+
+            if (expression instanceof io.trino.spi.expression.Case caseExpression) {
+                return translateCase(caseExpression, lambdaArguments);
             }
 
             if (expression instanceof io.trino.spi.expression.Call call) {
@@ -503,6 +508,27 @@ public final class ConnectorExpressionTranslator
         {
             return translateExpressions(arguments, lambdaArguments)
                     .map(Coalesce::new);
+        }
+
+        private Optional<Expression> translateCase(io.trino.spi.expression.Case caseExpression, Map<String, Symbol> lambdaArguments)
+        {
+            ImmutableList.Builder<WhenClause> whenClauses = ImmutableList.builderWithExpectedSize(caseExpression.getWhenClauses().size());
+            for (io.trino.spi.expression.Case.WhenClause whenClause : caseExpression.getWhenClauses()) {
+                Optional<Expression> condition = translate(whenClause.getCondition(), lambdaArguments);
+                if (condition.isEmpty()) {
+                    return Optional.empty();
+                }
+
+                Optional<Expression> result = translate(whenClause.getResult(), lambdaArguments);
+                if (result.isEmpty()) {
+                    return Optional.empty();
+                }
+
+                whenClauses.add(new WhenClause(condition.get(), result.get()));
+            }
+
+            return translate(caseExpression.getDefaultValue(), lambdaArguments)
+                    .map(defaultValue -> new Case(whenClauses.build(), defaultValue));
         }
 
         private Optional<ComparisonOperator> comparisonOperatorForFunctionName(FunctionName functionName)
@@ -953,14 +979,30 @@ public final class ConnectorExpressionTranslator
             if (!isComplexExpressionPushdown(session)) {
                 return Optional.empty();
             }
-            // Generic Case isn't translated; only the trivial NULLIF shape
-            // (`if(first = second) then null else first`) is recognized so it can be pushed as
+            // The trivial NULLIF shape (`if(first = second) then null else first`) is pushed as
             // `$nullif`. The Let-wrapped NULLIF is handled by `visitLet`.
             IrExpressions.NullIf nullIf = matchNullIf(node);
-            if (nullIf == null) {
-                return Optional.empty();
+            if (nullIf != null) {
+                return translateNullIfPattern(nullIf, node.type(), context);
             }
-            return translateNullIfPattern(nullIf, ((Expression) node).type(), context);
+
+            ImmutableList.Builder<io.trino.spi.expression.Case.WhenClause> whenClauses = ImmutableList.builderWithExpectedSize(node.whenClauses().size());
+            for (WhenClause whenClause : node.whenClauses()) {
+                Optional<ConnectorExpression> condition = process(whenClause.getOperand(), context);
+                if (condition.isEmpty()) {
+                    return Optional.empty();
+                }
+
+                Optional<ConnectorExpression> result = process(whenClause.getResult(), context);
+                if (result.isEmpty()) {
+                    return Optional.empty();
+                }
+
+                whenClauses.add(new io.trino.spi.expression.Case.WhenClause(condition.get(), result.get()));
+            }
+
+            return process(node.defaultValue(), context)
+                    .map(defaultValue -> new io.trino.spi.expression.Case(node.type(), whenClauses.build(), defaultValue));
         }
 
         private Optional<ConnectorExpression> translateNullIfPattern(IrExpressions.NullIf pattern, Type type, Context context)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
@@ -26,7 +26,6 @@ import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.FieldDereference;
 import io.trino.spi.expression.FunctionName;
-import io.trino.spi.expression.StandardFunctions;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.ArrayType;
@@ -74,13 +73,18 @@ import static io.trino.spi.expression.StandardFunctions.BETWEEN_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.CAST_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.COALESCE_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.DIVIDE_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.IN_PREDICATE_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.IS_NULL_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OPERATOR_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LIKE_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.MODULO_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.MULTIPLY_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.NEGATE_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.NOT_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.NULLIF_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.OR_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.SUBTRACT_FUNCTION_NAME;
 import static io.trino.spi.function.OperatorType.ADD;
 import static io.trino.spi.function.OperatorType.DIVIDE;
@@ -200,15 +204,15 @@ public class TestConnectorExpressionTranslator
                                     comparison(ComparisonOperator.EQUAL, new Reference(DOUBLE, "double_symbol_1"), new Reference(DOUBLE, "double_symbol_2")))),
                     new io.trino.spi.expression.Call(
                             BOOLEAN,
-                            operator == Logical.Operator.AND ? StandardFunctions.AND_FUNCTION_NAME : StandardFunctions.OR_FUNCTION_NAME,
+                            operator == Logical.Operator.AND ? AND_FUNCTION_NAME : OR_FUNCTION_NAME,
                             List.of(
                                     new io.trino.spi.expression.Call(
                                             BOOLEAN,
-                                            StandardFunctions.LESS_THAN_OPERATOR_FUNCTION_NAME,
+                                            LESS_THAN_OPERATOR_FUNCTION_NAME,
                                             List.of(new Variable("double_symbol_1", DOUBLE), new Variable("double_symbol_2", DOUBLE))),
                                     new io.trino.spi.expression.Call(
                                             BOOLEAN,
-                                            StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME,
+                                            EQUAL_OPERATOR_FUNCTION_NAME,
                                             List.of(new Variable("double_symbol_1", DOUBLE), new Variable("double_symbol_2", DOUBLE))))));
         }
     }
@@ -225,11 +229,11 @@ public class TestConnectorExpressionTranslator
                                 comparison(ComparisonOperator.EQUAL, new Reference(DOUBLE, "double_symbol_1"), new Reference(DOUBLE, "double_symbol_2")))),
                 new io.trino.spi.expression.Call(
                         BOOLEAN,
-                        StandardFunctions.AND_FUNCTION_NAME,
+                        AND_FUNCTION_NAME,
                         List.of(
                                 new io.trino.spi.expression.Call(
                                         BOOLEAN,
-                                        StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME,
+                                        EQUAL_OPERATOR_FUNCTION_NAME,
                                         List.of(new Variable("double_symbol_1", DOUBLE), new Variable("double_symbol_2", DOUBLE))))));
     }
 
@@ -479,7 +483,7 @@ public class TestConnectorExpressionTranslator
                     String pattern = "%pattern%";
                     io.trino.spi.expression.Call translated = new io.trino.spi.expression.Call(
                             BOOLEAN,
-                            StandardFunctions.LIKE_FUNCTION_NAME,
+                            LIKE_FUNCTION_NAME,
                             List.of(new Variable("varchar_symbol_1", VARCHAR_TYPE),
                                     new io.trino.spi.expression.Constant(Slices.wrappedBuffer(pattern.getBytes(UTF_8)), createVarcharType(pattern.length()))));
 
@@ -506,7 +510,7 @@ public class TestConnectorExpressionTranslator
                     String escape = "\\";
                     translated = new io.trino.spi.expression.Call(
                             BOOLEAN,
-                            StandardFunctions.LIKE_FUNCTION_NAME,
+                            LIKE_FUNCTION_NAME,
                             List.of(
                                     new Variable("varchar_symbol_1", VARCHAR_TYPE),
                                     new io.trino.spi.expression.Constant(Slices.wrappedBuffer(pattern.getBytes(UTF_8)), createVarcharType(pattern.length())),
@@ -676,7 +680,7 @@ public class TestConnectorExpressionTranslator
                         List.of(new Reference(VARCHAR, "varchar_symbol_1"), new Constant(VARCHAR, utf8Slice(value)))),
                 new io.trino.spi.expression.Call(
                         BOOLEAN,
-                        StandardFunctions.IN_PREDICATE_FUNCTION_NAME,
+                        IN_PREDICATE_FUNCTION_NAME,
                         List.of(
                                 new Variable("varchar_symbol_1", VARCHAR_TYPE),
                                 new io.trino.spi.expression.Call(VARCHAR_ARRAY_TYPE, ARRAY_CONSTRUCTOR_FUNCTION_NAME,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
@@ -36,6 +36,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import io.trino.sql.ir.Bind;
 import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Case;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.ComparisonOperator;
@@ -47,6 +48,8 @@ import io.trino.sql.ir.IsNull;
 import io.trino.sql.ir.Lambda;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.Row;
+import io.trino.sql.ir.WhenClause;
 import io.trino.testing.TestingSession;
 import io.trino.transaction.TestingTransactionManager;
 import io.trino.transaction.TransactionManager;
@@ -569,6 +572,58 @@ public class TestConnectorExpressionTranslator
                                 new Variable("varchar_symbol_1", VARCHAR_TYPE),
                                 new io.trino.spi.expression.Constant(null, VARCHAR_TYPE),
                                 new io.trino.spi.expression.Constant(utf8Slice("fallback"), VARCHAR_TYPE))));
+    }
+
+    @Test
+    public void testTranslateCase()
+    {
+        assertTranslationRoundTrips(
+                new Case(
+                        ImmutableList.of(new WhenClause(
+                                new Reference(BOOLEAN, "boolean_symbol_1"),
+                                new Reference(VARCHAR, "varchar_symbol_1"))),
+                        new Constant(VARCHAR_TYPE, utf8Slice("fallback"))),
+                new io.trino.spi.expression.Case(
+                        VARCHAR_TYPE,
+                        ImmutableList.of(new io.trino.spi.expression.Case.WhenClause(
+                                new Variable("boolean_symbol_1", BOOLEAN),
+                                new Variable("varchar_symbol_1", VARCHAR_TYPE))),
+                        new io.trino.spi.expression.Constant(utf8Slice("fallback"), VARCHAR_TYPE)));
+
+        assertTranslationRoundTrips(
+                new Case(
+                        ImmutableList.of(
+                                new WhenClause(
+                                        comparison(ComparisonOperator.LESS_THAN, new Reference(DOUBLE, "double_symbol_1"), new Reference(DOUBLE, "double_symbol_2")),
+                                        new Reference(DOUBLE, "double_symbol_1")),
+                                new WhenClause(
+                                        comparison(ComparisonOperator.EQUAL, new Reference(DOUBLE, "double_symbol_1"), new Reference(DOUBLE, "double_symbol_2")),
+                                        new Constant(DOUBLE, 42.0))),
+                        new Constant(DOUBLE, null)),
+                new io.trino.spi.expression.Case(
+                        DOUBLE,
+                        ImmutableList.of(
+                                new io.trino.spi.expression.Case.WhenClause(
+                                        new io.trino.spi.expression.Call(
+                                                BOOLEAN,
+                                                LESS_THAN_OPERATOR_FUNCTION_NAME,
+                                                ImmutableList.of(new Variable("double_symbol_1", DOUBLE), new Variable("double_symbol_2", DOUBLE))),
+                                        new Variable("double_symbol_1", DOUBLE)),
+                                new io.trino.spi.expression.Case.WhenClause(
+                                        new io.trino.spi.expression.Call(
+                                                BOOLEAN,
+                                                EQUAL_OPERATOR_FUNCTION_NAME,
+                                                ImmutableList.of(new Variable("double_symbol_1", DOUBLE), new Variable("double_symbol_2", DOUBLE))),
+                                        new io.trino.spi.expression.Constant(42.0, DOUBLE))),
+                        new io.trino.spi.expression.Constant(null, DOUBLE)));
+
+        Row untranslatable = new Row(ImmutableList.of(new Constant(INTEGER, 1L), new Constant(createVarcharType(5), utf8Slice("a"))));
+        assertTranslationToConnectorExpression(
+                TEST_SESSION,
+                new Case(
+                        ImmutableList.of(new WhenClause(new Reference(BOOLEAN, "boolean_symbol_1"), untranslatable)),
+                        untranslatable),
+                Optional.empty());
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
@@ -46,13 +46,12 @@ import io.trino.spi.type.FunctionType;
 import io.trino.spi.type.Type;
 import io.trino.sql.ir.Bind;
 import io.trino.sql.ir.Call;
-import io.trino.sql.ir.Case;
 import io.trino.sql.ir.ComparisonOperator;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Reference;
-import io.trino.sql.ir.WhenClause;
+import io.trino.sql.ir.Row;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.FilterNode;
@@ -74,8 +73,6 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
-import static io.trino.sql.ir.Booleans.FALSE;
-import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.ComparisonOperator.EQUAL;
 import static io.trino.sql.ir.Logical.Operator.AND;
 import static io.trino.sql.ir.Logical.Operator.OR;
@@ -248,14 +245,10 @@ public class TestPushPredicateIntoTableScan
                                                         .build(),
                                                 new Constant(DOUBLE, 42.0)),
                                         // non-translatable to connector expression
-                                        new Case(
-                                                ImmutableList.of(new WhenClause(
-                                                        TRUE,
-                                                        comparison(
-                                                                EQUAL,
-                                                                new Call(MODULO_BIGINT, ImmutableList.of(new Reference(BIGINT, "nationkey"), new Constant(BIGINT, 17L))),
-                                                                new Constant(BIGINT, 44L)))),
-                                                FALSE),
+                                        comparison(
+                                                EQUAL,
+                                                new Row(ImmutableList.of(new Call(MODULO_BIGINT, ImmutableList.of(new Reference(BIGINT, "nationkey"), new Constant(BIGINT, 17L))))),
+                                                new Row(ImmutableList.of(new Reference(BIGINT, "nationkey")))),
                                         Logical.or(
                                                 comparison(EQUAL, new Reference(BIGINT, "nationkey"), new Constant(BIGINT, 44L)),
                                                 comparison(EQUAL, new Reference(BIGINT, "nationkey"), new Constant(BIGINT, 45L))))),
@@ -276,8 +269,8 @@ public class TestPushPredicateIntoTableScan
                                                 new Constant(DOUBLE, 42.0)),
                                         comparison(
                                                 EQUAL,
-                                                new Call(MODULO_BIGINT, ImmutableList.of(new Reference(BIGINT, "nationkey"), new Constant(BIGINT, 17L))),
-                                                new Constant(BIGINT, 44L))),
+                                                new Row(ImmutableList.of(new Call(MODULO_BIGINT, ImmutableList.of(new Reference(BIGINT, "nationkey"), new Constant(BIGINT, 17L))))),
+                                                new Row(ImmutableList.of(new Reference(BIGINT, "nationkey"))))),
                                 constrainedTableScanWithTableLayout(
                                         "nation",
                                         ImmutableMap.of("nationkey", singleValue(BIGINT, (long) 44)),

--- a/core/trino-spi/src/main/java/io/trino/spi/expression/Case.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/expression/Case.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.expression;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.type.Type;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+/**
+ * Represents a SQL CASE expression: {@code CASE WHEN condition THEN result [WHEN ...] [ELSE default] END}.
+ * Conditions are evaluated in order, so that only the first matching result is evaluated and returned.
+ * When no condition matches, the default value is evaluated and returned. A CASE without an explicit ELSE
+ * clause carries a null {@link Constant} as the default value.
+ */
+public final class Case
+        extends ConnectorExpression
+{
+    private final List<WhenClause> whenClauses;
+    private final ConnectorExpression defaultValue;
+
+    @JsonCreator
+    public Case(
+            @JsonProperty("type") Type type,
+            @JsonProperty("whenClauses") List<WhenClause> whenClauses,
+            @JsonProperty("defaultValue") ConnectorExpression defaultValue)
+    {
+        super(type);
+        whenClauses = List.copyOf(requireNonNull(whenClauses, "whenClauses is null"));
+        requireNonNull(defaultValue, "defaultValue is null");
+
+        if (whenClauses.isEmpty()) {
+            throw new IllegalArgumentException("whenClauses is empty");
+        }
+        for (WhenClause whenClause : whenClauses) {
+            if (!whenClause.getCondition().getType().equals(BOOLEAN)) {
+                throw new IllegalArgumentException("condition must be boolean: " + whenClause.getCondition());
+            }
+            if (!whenClause.getResult().getType().equals(type)) {
+                throw new IllegalArgumentException("result type does not match expression type %s: %s".formatted(type, whenClause.getResult()));
+            }
+        }
+        if (!defaultValue.getType().equals(type)) {
+            throw new IllegalArgumentException("default value type does not match expression type %s: %s".formatted(type, defaultValue));
+        }
+
+        this.whenClauses = whenClauses;
+        this.defaultValue = defaultValue;
+    }
+
+    @JsonProperty("whenClauses")
+    public List<WhenClause> getWhenClauses()
+    {
+        return whenClauses;
+    }
+
+    @JsonProperty("defaultValue")
+    public ConnectorExpression getDefaultValue()
+    {
+        return defaultValue;
+    }
+
+    @Override
+    public List<? extends ConnectorExpression> getChildren()
+    {
+        List<ConnectorExpression> children = new ArrayList<>(whenClauses.size() * 2 + 1);
+        for (WhenClause whenClause : whenClauses) {
+            children.add(whenClause.getCondition());
+            children.add(whenClause.getResult());
+        }
+        children.add(defaultValue);
+        return unmodifiableList(children);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Case that = (Case) o;
+        return Objects.equals(whenClauses, that.whenClauses) &&
+                Objects.equals(defaultValue, that.defaultValue) &&
+                Objects.equals(getType(), that.getType());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(whenClauses, defaultValue, getType());
+    }
+
+    @Override
+    public String toString()
+    {
+        return new StringJoiner(", ", Case.class.getSimpleName() + "[", "]")
+                .add("whenClauses=" + whenClauses.stream()
+                        .map(WhenClause::toString)
+                        .collect(joining(", ", "[", "]")))
+                .add("defaultValue=" + defaultValue)
+                .toString();
+    }
+
+    public static final class WhenClause
+    {
+        private final ConnectorExpression condition;
+        private final ConnectorExpression result;
+
+        @JsonCreator
+        public WhenClause(
+                @JsonProperty("condition") ConnectorExpression condition,
+                @JsonProperty("result") ConnectorExpression result)
+        {
+            this.condition = requireNonNull(condition, "condition is null");
+            this.result = requireNonNull(result, "result is null");
+        }
+
+        @JsonProperty("condition")
+        public ConnectorExpression getCondition()
+        {
+            return condition;
+        }
+
+        @JsonProperty("result")
+        public ConnectorExpression getResult()
+        {
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            WhenClause that = (WhenClause) o;
+            return Objects.equals(condition, that.condition) &&
+                    Objects.equals(result, that.result);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(condition, result);
+        }
+
+        @Override
+        public String toString()
+        {
+            return new StringJoiner(", ", WhenClause.class.getSimpleName() + "[", "]")
+                    .add("condition=" + condition)
+                    .add("result=" + result)
+                    .toString();
+        }
+    }
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/expression/TestCase.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/expression/TestCase.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.expression;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestCase
+{
+    private static final Variable CONDITION = new Variable("condition", BOOLEAN);
+    private static final Variable RESULT = new Variable("result", BIGINT);
+    private static final Variable DEFAULT_VALUE = new Variable("default", BIGINT);
+
+    @Test
+    public void testValidCase()
+    {
+        Case.WhenClause whenClause = new Case.WhenClause(CONDITION, RESULT);
+        Case caseExpression = new Case(BIGINT, List.of(whenClause), DEFAULT_VALUE);
+
+        assertThat(caseExpression.getType()).isEqualTo(BIGINT);
+        assertThat(caseExpression.getWhenClauses()).containsExactly(whenClause);
+        assertThat(caseExpression.getDefaultValue()).isEqualTo(DEFAULT_VALUE);
+        assertThat(caseExpression.getChildren()).isEqualTo(List.of(CONDITION, RESULT, DEFAULT_VALUE));
+        assertThat(caseExpression).hasToString(
+                "Case[whenClauses=[WhenClause[condition=condition::boolean, result=result::bigint]], defaultValue=default::bigint]");
+    }
+
+    @Test
+    public void testMultipleWhenClauses()
+    {
+        Case.WhenClause first = new Case.WhenClause(CONDITION, RESULT);
+        Case.WhenClause second = new Case.WhenClause(new Variable("other_condition", BOOLEAN), new Variable("other_result", BIGINT));
+        Case caseExpression = new Case(BIGINT, List.of(first, second), DEFAULT_VALUE);
+
+        assertThat(caseExpression.getWhenClauses()).containsExactly(first, second);
+        assertThat(caseExpression.getChildren()).isEqualTo(List.of(
+                first.getCondition(),
+                first.getResult(),
+                second.getCondition(),
+                second.getResult(),
+                DEFAULT_VALUE));
+    }
+
+    @Test
+    public void testConstructorValidation()
+    {
+        assertThatThrownBy(() -> new Case(BIGINT, List.of(), DEFAULT_VALUE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("whenClauses is empty");
+
+        assertThatThrownBy(() -> new Case(BIGINT, List.of(new Case.WhenClause(RESULT, RESULT)), DEFAULT_VALUE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("condition must be boolean");
+
+        assertThatThrownBy(() -> new Case(BIGINT, List.of(new Case.WhenClause(CONDITION, CONDITION)), DEFAULT_VALUE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("result type does not match expression type");
+
+        assertThatThrownBy(() -> new Case(BIGINT, List.of(new Case.WhenClause(CONDITION, RESULT)), CONDITION))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("default value type does not match expression type");
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionPatterns.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionPatterns.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.matching.Pattern;
 import io.trino.matching.Property;
 import io.trino.spi.expression.Call;
+import io.trino.spi.expression.Case;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
 import io.trino.spi.expression.FunctionName;
@@ -121,6 +122,11 @@ public final class ConnectorExpressionPatterns
     public static Pattern<Variable> variable()
     {
         return Pattern.typeOf(Variable.class);
+    }
+
+    public static Pattern<Case> caseExpression()
+    {
+        return Pattern.typeOf(Case.class);
     }
 
     public static Predicate<List<? extends ConnectorExpression>> expressionTypes(Type... types)

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/projection/ApplyProjectionUtil.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/projection/ApplyProjectionUtil.java
@@ -16,6 +16,7 @@ package io.trino.plugin.base.projection;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.expression.Call;
+import io.trino.spi.expression.Case;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
 import io.trino.spi.expression.FieldDereference;
@@ -143,6 +144,17 @@ public final class ApplyProjectionUtil
                     call.getArguments().stream()
                             .map(argument -> replaceWithNewVariables(argument, expressionToVariableMappings, localVariables))
                             .collect(toImmutableList()));
+        }
+
+        if (expression instanceof Case caseExpression) {
+            return new Case(
+                    caseExpression.getType(),
+                    caseExpression.getWhenClauses().stream()
+                            .map(whenClause -> new Case.WhenClause(
+                                    replaceWithNewVariables(whenClause.getCondition(), expressionToVariableMappings, localVariables),
+                                    replaceWithNewVariables(whenClause.getResult(), expressionToVariableMappings, localVariables)))
+                            .collect(toImmutableList()),
+                    replaceWithNewVariables(caseExpression.getDefaultValue(), expressionToVariableMappings, localVariables));
         }
 
         // We cannot skip processing for unsupported expression shapes. This may lead to variables being left in ProjectionApplicationResult

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/projection/TestApplyProjectionUtil.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/projection/TestApplyProjectionUtil.java
@@ -15,6 +15,7 @@ package io.trino.plugin.base.projection;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.expression.Call;
+import io.trino.spi.expression.Case;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
 import io.trino.spi.expression.FieldDereference;
@@ -33,6 +34,7 @@ import java.util.function.Predicate;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.replaceWithNewVariables;
 import static io.trino.spi.expression.StandardFunctions.ADD_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RowType.field;
 import static io.trino.spi.type.RowType.rowType;
@@ -148,6 +150,27 @@ public class TestApplyProjectionUtil
                         INTEGER_TO_INTEGER,
                         ImmutableList.of(lambdaArgument),
                         new Call(INTEGER, ADD_FUNCTION_NAME, ImmutableList.of(lambdaArgument, newCapture))));
+    }
+
+    @Test
+    public void testReplaceWithNewVariablesInCase()
+    {
+        Variable condition = new Variable("condition", BOOLEAN);
+        Variable result = new Variable("result", INTEGER);
+        Variable newCondition = new Variable("projected_condition", BOOLEAN);
+        Variable newResult = new Variable("projected_result", INTEGER);
+        ConnectorExpression expression = new Case(
+                INTEGER,
+                ImmutableList.of(new Case.WhenClause(condition, result)),
+                INT_VARIABLE);
+
+        assertThat(replaceWithNewVariables(expression, Map.of(
+                condition, newCondition,
+                result, newResult)))
+                .isEqualTo(new Case(
+                        INTEGER,
+                        ImmutableList.of(new Case.WhenClause(newCondition, newResult)),
+                        INT_VARIABLE));
     }
 
     /**


### PR DESCRIPTION
## Description

Translates case expressions to a new `Case` `ConnectorExpression` so that connectors can push them down. This also covers `IF` expressions, which are evaluated as `Case` expressions.

This could either be implemented as a function with lambda value suppliers (to ensure lazy evaluation of values), or as a dedicated connector expression, as I've drafted here. The last conversations around this happened before lambda pushdowns were [implemented](https://github.com/trinodb/trino/pull/29532). I'm open to discussion around which approach is best, but I found this one to be the most straightforward from the connectors' perspective.

Fixes https://github.com/trinodb/trino/issues/11699

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

`TestPushPredicateIntoTableScan` used `CASE` as a non-pushable predicate, so that had to be updated.

Simple case/`Match` expressions are still not able to be pushed down. These are slightly more complex, as the matched value should only be evaluated once, but may be evaluated multiple times when pushed down to a connector. We could consider limiting this to a constant or variable, but this seemed out of scope of the linked issue.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

