### PR TITLE
Recognize exhaustive IF/CASE branches as satisfying function RETURN check

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
@@ -361,12 +361,37 @@ public class SqlRoutineAnalyzer
         switch (statement) {
             case ReturnStatement _ -> {}
             case CompoundStatement body -> {
-                if (!(getLast(body.getStatements(), null) instanceof ReturnStatement)) {
+                if (!alwaysReturns(body)) {
                     throw semanticException(MISSING_RETURN, body, "Function must end in a RETURN statement");
                 }
             }
             default -> throw new IllegalArgumentException("Invalid function statement: " + statement);
         }
+    }
+
+    // Determines whether a statement is guaranteed to execute a RETURN on every path through it,
+    // e.g. an IF/ELSEIF/ELSE (or CASE/WHEN/ELSE) whose branches all return, even without a
+    // trailing RETURN of their own. Loops are never considered exhaustive, since a LEAVE can
+    // exit one before its body reaches a RETURN.
+    private static boolean alwaysReturns(ControlStatement statement)
+    {
+        return switch (statement) {
+            case ReturnStatement _ -> true;
+            case CompoundStatement body -> alwaysReturns(body.getStatements());
+            case IfStatement ifStatement -> ifStatement.getElseClause().isPresent() &&
+                    alwaysReturns(ifStatement.getStatements()) &&
+                    ifStatement.getElseIfClauses().stream().allMatch(clause -> alwaysReturns(clause.getStatements())) &&
+                    alwaysReturns(ifStatement.getElseClause().orElseThrow().getStatements());
+            case CaseStatement caseStatement -> caseStatement.getElseClause().isPresent() &&
+                    caseStatement.getWhenClauses().stream().allMatch(clause -> alwaysReturns(clause.getStatements())) &&
+                    alwaysReturns(caseStatement.getElseClause().orElseThrow().getStatements());
+            default -> false;
+        };
+    }
+
+    private static boolean alwaysReturns(List<ControlStatement> statements)
+    {
+        return !statements.isEmpty() && alwaysReturns(getLast(statements, null));
     }
 
     private class StatementVisitor

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
@@ -74,7 +74,6 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Iterables.getLast;
 import static io.trino.SystemSessionProperties.getCharVarcharCoercion;
 import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
@@ -362,12 +361,35 @@ public class SqlRoutineAnalyzer
         switch (statement) {
             case ReturnStatement _ -> {}
             case CompoundStatement body -> {
-                if (!(getLast(body.getStatements(), null) instanceof ReturnStatement)) {
+                if (!alwaysReturns(body)) {
                     throw semanticException(MISSING_RETURN, body, "Function must end in a RETURN statement");
                 }
             }
             default -> throw new IllegalArgumentException("Invalid function statement: " + statement);
         }
+    }
+
+    // Determines whether a statement is guaranteed to execute a RETURN on every path through it.
+    // Loops are never considered exhaustive, since a LEAVE can exit one before its body reaches a RETURN.
+    private static boolean alwaysReturns(ControlStatement statement)
+    {
+        return switch (statement) {
+            case ReturnStatement _ -> true;
+            case CompoundStatement body -> alwaysReturns(body.getStatements());
+            case IfStatement ifStatement -> ifStatement.getElseClause().isPresent() &&
+                    alwaysReturns(ifStatement.getStatements()) &&
+                    ifStatement.getElseIfClauses().stream().allMatch(clause -> alwaysReturns(clause.getStatements())) &&
+                    alwaysReturns(ifStatement.getElseClause().orElseThrow().getStatements());
+            case CaseStatement caseStatement -> caseStatement.getElseClause().isPresent() &&
+                    caseStatement.getWhenClauses().stream().allMatch(clause -> alwaysReturns(clause.getStatements())) &&
+                    alwaysReturns(caseStatement.getElseClause().orElseThrow().getStatements());
+            default -> false;
+        };
+    }
+
+    private static boolean alwaysReturns(List<ControlStatement> statements)
+    {
+        return !statements.isEmpty() && alwaysReturns(statements.getLast());
     }
 
     private class StatementVisitor

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestInlineFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestInlineFunctions.java
@@ -408,6 +408,25 @@ public class TestInlineFunctions
                 """))
                 .matches("VALUES 256");
 
+        // IF/ELSEIF/ELSE that returns on every branch, without a fallthrough RETURN of its
+        // own; verbatim from https://trino.io/docs/current/udf/sql/if.html
+        assertThat(assertions.query(
+                """
+                WITH FUNCTION simple_if(a bigint) RETURNS varchar
+                BEGIN
+                  IF a = 0 THEN
+                    RETURN 'zero';
+                  ELSEIF a = 1 THEN
+                    RETURN 'one';
+                  ELSE
+                    RETURN 'more than one or negative';
+                  END IF;
+                END
+                SELECT simple_if(a)
+                FROM (VALUES 0, 1, -5) t(a)
+                """))
+                .matches("VALUES VARCHAR 'zero', 'one', 'more than one or negative'");
+
         assertThat(assertions.query(
                 """
                 WITH

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestInlineFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestInlineFunctions.java
@@ -408,6 +408,40 @@ public class TestInlineFunctions
                 """))
                 .matches("VALUES 256");
 
+        // exhaustive IF with no trailing RETURN
+        assertThat(assertions.query(
+                """
+                WITH FUNCTION simple_if(a bigint) RETURNS varchar
+                BEGIN
+                  IF a = 0 THEN
+                    RETURN 'zero';
+                  ELSEIF a = 1 THEN
+                    RETURN 'one';
+                  ELSE
+                    RETURN 'more than one or negative';
+                  END IF;
+                END
+                SELECT simple_if(a)
+                FROM (VALUES 0, 1, -5) t(a)
+                """))
+                .matches("VALUES VARCHAR 'zero', 'one', 'more than one or negative'");
+
+        // exhaustive CASE with no trailing RETURN
+        assertThat(assertions.query(
+                """
+                WITH FUNCTION simple_case(a bigint) RETURNS varchar
+                BEGIN
+                  CASE a
+                    WHEN 0 THEN RETURN 'zero';
+                    WHEN 1 THEN RETURN 'one';
+                    ELSE RETURN 'more than one or negative';
+                  END CASE;
+                END
+                SELECT simple_case(a)
+                FROM (VALUES 0, 1, -5) t(a)
+                """))
+                .matches("VALUES VARCHAR 'zero', 'one', 'more than one or negative'");
+
         assertThat(assertions.query(
                 """
                 WITH

--- a/core/trino-main/src/test/java/io/trino/sql/routine/TestSqlRoutineAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/routine/TestSqlRoutineAnalyzer.java
@@ -318,6 +318,113 @@ class TestSqlRoutineAnalyzer
                 """)
                 .hasErrorCode(MISSING_RETURN)
                 .hasMessage("line 2:1: Function must end in a RETURN statement");
+
+        // an ELSEIF chain with no final ELSE can still fall through, regardless of whether
+        // every existing branch returns
+        assertFails(
+                """
+                FUNCTION test() RETURNS int
+                BEGIN
+                  IF false THEN
+                    RETURN 13;
+                  ELSEIF true THEN
+                    RETURN 14;
+                  END IF;
+                END
+                """)
+                .hasErrorCode(MISSING_RETURN)
+                .hasMessage("line 2:1: Function must end in a RETURN statement");
+
+        assertFails(
+                """
+                FUNCTION test() RETURNS int
+                BEGIN
+                  CASE
+                    WHEN false THEN RETURN 13;
+                  END CASE;
+                END
+                """)
+                .hasErrorCode(MISSING_RETURN)
+                .hasMessage("line 2:1: Function must end in a RETURN statement");
+    }
+
+    @Test
+    void testExhaustiveIfReturn()
+    {
+        // an IF/ELSEIF/ELSE that returns on every branch satisfies the RETURN requirement
+        // without needing a redundant trailing RETURN of its own
+        analyze(
+                """
+                FUNCTION test(a bigint) RETURNS varchar
+                BEGIN
+                  IF a = 0 THEN
+                    RETURN 'zero';
+                  ELSEIF a = 1 THEN
+                    RETURN 'one';
+                  ELSE
+                    RETURN 'more than one or negative';
+                  END IF;
+                END
+                """);
+
+        analyze(
+                """
+                FUNCTION test(a bigint) RETURNS varchar
+                BEGIN
+                  IF a = 0 THEN
+                    RETURN 'zero';
+                  ELSE
+                    RETURN 'nonzero';
+                  END IF;
+                END
+                """);
+
+        // nested IF statements are checked recursively
+        analyze(
+                """
+                FUNCTION test(a bigint, b bigint) RETURNS varchar
+                BEGIN
+                  IF a = 0 THEN
+                    IF b = 0 THEN
+                      RETURN 'both zero';
+                    ELSE
+                      RETURN 'a zero';
+                    END IF;
+                  ELSE
+                    RETURN 'a nonzero';
+                  END IF;
+                END
+                """);
+    }
+
+    @Test
+    void testExhaustiveCaseReturn()
+    {
+        // a CASE/WHEN/ELSE that returns on every branch satisfies the RETURN requirement
+        // without needing a redundant trailing RETURN of its own
+        analyze(
+                """
+                FUNCTION test(a int) RETURNS int
+                BEGIN
+                  CASE
+                    WHEN a = 0 THEN RETURN 0;
+                    WHEN a = 1 THEN RETURN 1;
+                    ELSE RETURN -1;
+                  END CASE;
+                END
+                """);
+
+        analyze(
+                """
+                FUNCTION test(a int) RETURNS int
+                BEGIN
+                  CASE a
+                    WHEN 0 THEN RETURN 0;
+                    WHEN 1 THEN RETURN 1;
+                    ELSE RETURN -1;
+                  END CASE;
+                END
+                """);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/routine/TestSqlRoutineAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/routine/TestSqlRoutineAnalyzer.java
@@ -318,6 +318,169 @@ class TestSqlRoutineAnalyzer
                 """)
                 .hasErrorCode(MISSING_RETURN)
                 .hasMessage("line 2:1: Function must end in a RETURN statement");
+
+        // an ELSEIF chain with no final ELSE can still fall through, regardless of whether
+        // every existing branch returns
+        assertFails(
+                """
+                FUNCTION test() RETURNS int
+                BEGIN
+                  IF false THEN
+                    RETURN 13;
+                  ELSEIF true THEN
+                    RETURN 14;
+                  END IF;
+                END
+                """)
+                .hasErrorCode(MISSING_RETURN)
+                .hasMessage("line 2:1: Function must end in a RETURN statement");
+
+        assertFails(
+                """
+                FUNCTION test() RETURNS int
+                BEGIN
+                  CASE
+                    WHEN false THEN RETURN 13;
+                  END CASE;
+                END
+                """)
+                .hasErrorCode(MISSING_RETURN)
+                .hasMessage("line 2:1: Function must end in a RETURN statement");
+
+        // a loop as the last statement still requires a trailing RETURN
+        assertFails(
+                """
+                FUNCTION test() RETURNS int
+                BEGIN
+                  WHILE true DO
+                    RETURN 13;
+                  END WHILE;
+                END
+                """)
+                .hasErrorCode(MISSING_RETURN)
+                .hasMessage("line 2:1: Function must end in a RETURN statement");
+
+        assertFails(
+                """
+                FUNCTION test() RETURNS int
+                BEGIN
+                  REPEAT
+                    RETURN 13;
+                  UNTIL true
+                  END REPEAT;
+                END
+                """)
+                .hasErrorCode(MISSING_RETURN)
+                .hasMessage("line 2:1: Function must end in a RETURN statement");
+
+        // an exhaustive IF followed by another statement does not satisfy the RETURN requirement
+        assertFails(
+                """
+                FUNCTION test() RETURNS int
+                BEGIN
+                  DECLARE x int;
+                  IF true THEN
+                    RETURN 13;
+                  ELSE
+                    RETURN 14;
+                  END IF;
+                  SET x = 1;
+                END
+                """)
+                .hasErrorCode(MISSING_RETURN)
+                .hasMessage("line 2:1: Function must end in a RETURN statement");
+    }
+
+    @Test
+    void testExhaustiveIfReturn()
+    {
+        // every branch returns, so no trailing RETURN is needed
+        analyze(
+                """
+                FUNCTION test(a bigint) RETURNS varchar
+                BEGIN
+                  IF a = 0 THEN
+                    RETURN 'zero';
+                  ELSEIF a = 1 THEN
+                    RETURN 'one';
+                  ELSE
+                    RETURN 'more than one or negative';
+                  END IF;
+                END
+                """);
+
+        analyze(
+                """
+                FUNCTION test(a bigint) RETURNS varchar
+                BEGIN
+                  IF a = 0 THEN
+                    RETURN 'zero';
+                  ELSE
+                    RETURN 'nonzero';
+                  END IF;
+                END
+                """);
+
+        // nested IF statements are checked recursively
+        analyze(
+                """
+                FUNCTION test(a bigint, b bigint) RETURNS varchar
+                BEGIN
+                  IF a = 0 THEN
+                    IF b = 0 THEN
+                      RETURN 'both zero';
+                    ELSE
+                      RETURN 'a zero';
+                    END IF;
+                  ELSE
+                    RETURN 'a nonzero';
+                  END IF;
+                END
+                """);
+
+        // a BEGIN/END block as a branch body
+        analyze(
+                """
+                FUNCTION test(a bigint) RETURNS varchar
+                BEGIN
+                  IF a = 0 THEN
+                    BEGIN
+                      RETURN 'zero';
+                    END;
+                  ELSE
+                    RETURN 'nonzero';
+                  END IF;
+                END
+                """);
+    }
+
+    @Test
+    void testExhaustiveCaseReturn()
+    {
+        // every branch returns, so no trailing RETURN is needed
+        analyze(
+                """
+                FUNCTION test(a int) RETURNS int
+                BEGIN
+                  CASE
+                    WHEN a = 0 THEN RETURN 0;
+                    WHEN a = 1 THEN RETURN 1;
+                    ELSE RETURN -1;
+                  END CASE;
+                END
+                """);
+
+        analyze(
+                """
+                FUNCTION test(a int) RETURNS int
+                BEGIN
+                  CASE a
+                    WHEN 0 THEN RETURN 0;
+                    WHEN 1 THEN RETURN 1;
+                    ELSE RETURN -1;
+                  END CASE;
+                END
+                """);
     }
 
     @Test


### PR DESCRIPTION
## Description

A SQL UDF whose body ends in an `IF`/`ELSEIF`/`ELSE` or `CASE`/`WHEN`/`ELSE` that returns a value from every branch fails with `MISSING_RETURN`, because the check only accepts a literal `RETURN` as the last statement of the body. The `simple_if` example in the UDF documentation cannot be run as written.

The check now also accepts an `IF` or `CASE` as the last statement, when an `ELSE` clause is present and every branch body itself definitely returns. This is applied recursively, so nested `IF` statements and `BEGIN`/`END` branch bodies work too.

## Additional context and related issues

Loops are deliberately not treated as exhaustive, since a `LEAVE` can exit one before its body reaches a `RETURN`. An `IF`/`ELSEIF` chain with no final `ELSE` still requires a trailing `RETURN`, because there is no way to know the branches cover every input.

* Fixes #30582

Full disclosure... built with Claude, but sent by me ;)

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix failure when a SQL UDF ends in an `IF` or `CASE` statement that returns a
  value from every branch. ({issue}`30582`)
```
