### PR TITLE
Classify overlay failures on invalid geometries as user errors

### DIFF
--- a/docs/src/main/sphinx/functions/geospatial.md
+++ b/docs/src/main/sphinx/functions/geospatial.md
@@ -7,6 +7,24 @@ geometries that are operated on are both simple and valid. For example, it does 
 make sense to calculate the area of a polygon that has a hole defined outside the
 polygon, or to construct a polygon from a non-simple boundary line.
 
+By default, an overlay or union operation that fails on a topologically invalid
+input reports `INVALID_FUNCTION_ARGUMENT` with a message describing the invalidity
+and its location. Setting the JVM property
+`-Dtrino.geospatial.legacy-lenient-overlay=true` instead repairs the input and
+retries the operation once, matching the lenient behavior of the legacy Esri
+engine. The repair can change the geometry and is not guaranteed to reproduce
+every result from the legacy engine.
+
+The property is read once during startup and must be identical on every node, so
+changing it requires restarting the cluster. During a rolling restart both modes
+are live at once, and the same query can fail or succeed depending on which nodes
+execute it.
+
+The policy applies to {func}`ST_Intersection`, {func}`ST_Difference`,
+{func}`ST_SymDifference`, {func}`ST_Union`, {func}`geometry_union`, and
+{func}`geometry_union_agg`. {func}`convex_hull_agg` is not subject to it, because
+a convex hull is well defined even for topologically invalid input.
+
 Trino Geospatial functions support Well-Known Text (WKT), Extended Well-Known
 Text (EWKT), Well-Known Binary (WKB), and Extended Well-Known Binary (EWKB)
 forms of spatial objects:

--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/GeometryUtils.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/GeometryUtils.java
@@ -27,11 +27,15 @@ import org.locationtech.jts.geom.MultiPoint;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.TopologyException;
 import org.locationtech.jts.geom.impl.CoordinateArraySequence;
+import org.locationtech.jts.geom.util.GeometryFixer;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.geojson.GeoJsonReader;
 import org.locationtech.jts.io.geojson.GeoJsonWriter;
 import org.locationtech.jts.operation.union.UnaryUnionOp;
+import org.locationtech.jts.operation.valid.IsValidOp;
+import org.locationtech.jts.operation.valid.TopologyValidationError;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -41,9 +45,19 @@ import java.util.Set;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOfObjectArray;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static java.util.stream.Collectors.joining;
 
 public final class GeometryUtils
 {
+    /**
+     * When set to {@code true} (JVM flag {@code -Dtrino.geospatial.legacy-lenient-overlay=true}),
+     * an overlay or union operation that fails on a topologically invalid input repairs it with
+     * {@link GeometryFixer} and retries once, matching the lenient behavior of the legacy Esri
+     * engine. By default such a failure is reported as {@code INVALID_FUNCTION_ARGUMENT}.
+     */
+    public static final String LEGACY_LENIENT_OVERLAY_PROPERTY = "trino.geospatial.legacy-lenient-overlay";
+    private static final boolean LEGACY_LENIENT_OVERLAY = parseLegacyLenientOverlay(System.getProperty(LEGACY_LENIENT_OVERLAY_PROPERTY));
+
     private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
     private static final long POINT_INSTANCE_SIZE = instanceSize(Point.class);
     private static final long LINE_STRING_INSTANCE_SIZE = instanceSize(LineString.class);
@@ -203,8 +217,13 @@ public final class GeometryUtils
     /**
      * Unions two geometries, handling GeometryCollection inputs that JTS's
      * standard union method doesn't support.
+     * <p>
+     * When JTS fails because an operand is topologically invalid, {@code repairInvalidInputs}
+     * selects between repairing the operand and retrying, and failing with a user error naming it.
+     * Callers pass {@link #legacyLenientOverlay()}, so the repair is unreachable unless that
+     * property is enabled.
      */
-    public static Geometry safeUnion(Geometry left, Geometry right)
+    public static Geometry safeUnion(Geometry left, Geometry right, boolean repairInvalidInputs)
     {
         // JTS union doesn't support GeometryCollection, so flatten and use UnaryUnionOp
         List<Geometry> geometries = new ArrayList<>();
@@ -213,7 +232,109 @@ public final class GeometryUtils
         if (geometries.isEmpty()) {
             return GEOMETRY_FACTORY.createGeometryCollection();
         }
-        return UnaryUnionOp.union(geometries);
+        try {
+            return UnaryUnionOp.union(geometries);
+        }
+        catch (TopologyException failure) {
+            boolean leftValid;
+            boolean rightValid;
+            try {
+                leftValid = left.isValid();
+                rightValid = right.isValid();
+            }
+            catch (RuntimeException validationFailure) {
+                failure.addSuppressed(validationFailure);
+                throw failure;
+            }
+            if (leftValid && rightValid) {
+                throw failure;
+            }
+            if (!repairInvalidInputs) {
+                throw invalidInputGeometryException(invalidInputs(left, right, leftValid, rightValid), failure);
+            }
+
+            try {
+                // Repair the original inputs, not their components: an invalid MultiPolygon can consist of valid polygons
+                List<Geometry> repairedGeometries = new ArrayList<>();
+                flattenGeometry(leftValid ? left : GeometryFixer.fix(left), repairedGeometries);
+                flattenGeometry(rightValid ? right : GeometryFixer.fix(right), repairedGeometries);
+                if (repairedGeometries.isEmpty()) {
+                    return GEOMETRY_FACTORY.createGeometryCollection();
+                }
+                return UnaryUnionOp.union(repairedGeometries);
+            }
+            catch (RuntimeException retryFailure) {
+                throw invalidInputGeometryException(invalidInputs(left, right, leftValid, rightValid), failure, retryFailure);
+            }
+        }
+    }
+
+    /**
+     * Whether {@link #LEGACY_LENIENT_OVERLAY_PROPERTY} is enabled.
+     */
+    public static boolean legacyLenientOverlay()
+    {
+        return LEGACY_LENIENT_OVERLAY;
+    }
+
+    static boolean parseLegacyLenientOverlay(String value)
+    {
+        if (value == null || value.equals("false")) {
+            return false;
+        }
+        if (value.equals("true")) {
+            return true;
+        }
+        throw new IllegalArgumentException("System property %s must be 'true' or 'false', but was: %s"
+                .formatted(LEGACY_LENIENT_OVERLAY_PROPERTY, value));
+    }
+
+    public static TrinoException invalidInputGeometryException(List<Geometry> invalidInputs, TopologyException failure)
+    {
+        return new TrinoException(INVALID_FUNCTION_ARGUMENT, invalidInputGeometryMessage(invalidInputs), failure);
+    }
+
+    public static TrinoException invalidInputGeometryException(List<Geometry> invalidInputs, TopologyException failure, RuntimeException retryFailure)
+    {
+        failure.addSuppressed(retryFailure);
+        return invalidInputGeometryException(invalidInputs, failure);
+    }
+
+    private static String invalidInputGeometryMessage(List<Geometry> invalidInputs)
+    {
+        String reasons = invalidInputs.stream()
+                .limit(3)
+                .map(GeometryUtils::describeInvalidity)
+                .collect(joining("; "));
+        if (invalidInputs.size() > 3) {
+            reasons += " (and %s more invalid inputs)".formatted(invalidInputs.size() - 3);
+        }
+        return "Invalid input geometry: " + reasons;
+    }
+
+    private static List<Geometry> invalidInputs(Geometry left, Geometry right, boolean leftValid, boolean rightValid)
+    {
+        List<Geometry> invalidInputs = new ArrayList<>();
+        if (!leftValid) {
+            invalidInputs.add(left);
+        }
+        if (!rightValid) {
+            invalidInputs.add(right);
+        }
+        return invalidInputs;
+    }
+
+    private static String describeInvalidity(Geometry geometry)
+    {
+        TopologyValidationError error = new IsValidOp(geometry).getValidationError();
+        if (error == null) {
+            return "unknown validity error";
+        }
+        Coordinate coordinate = error.getCoordinate();
+        if (coordinate == null) {
+            return error.getMessage();
+        }
+        return "%s at or near (%s %s)".formatted(error.getMessage(), coordinate.getX(), coordinate.getY());
     }
 
     /**

--- a/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/TestGeometryUtils.java
+++ b/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/TestGeometryUtils.java
@@ -13,15 +13,27 @@
  */
 package io.trino.geospatial;
 
+import io.trino.spi.TrinoException;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.TopologyException;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 
+import java.util.List;
+
 import static io.trino.geospatial.GeometryUtils.contains;
 import static io.trino.geospatial.GeometryUtils.estimateMemorySize;
+import static io.trino.geospatial.GeometryUtils.invalidInputGeometryException;
 import static io.trino.geospatial.GeometryUtils.jsonFromJtsGeometry;
+import static io.trino.geospatial.GeometryUtils.parseLegacyLenientOverlay;
+import static io.trino.geospatial.GeometryUtils.safeUnion;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 final class TestGeometryUtils
 {
@@ -71,5 +83,129 @@ final class TestGeometryUtils
 
         assertThat(geometryCollection.getGeometryN(1).contains(polygon)).isTrue();
         assertThat(contains(geometryCollection, polygon)).isTrue();
+    }
+
+    @Test
+    void testSafeUnionFailsOnInvalidGeometryWithoutRepair()
+            throws ParseException
+    {
+        WKTReader reader = new WKTReader();
+        Geometry invalid = reader.read("POLYGON ((0 0, 2 2, 0 2, 2 0, 0 0))");
+        Geometry valid = reader.read("POLYGON ((-1 -1, 3 -1, 3 3, -1 3, -1 -1))");
+
+        assertThatThrownBy(() -> safeUnion(invalid, valid, false))
+                .isInstanceOfSatisfying(TrinoException.class, e ->
+                        assertThat(e.getErrorCode()).isEqualTo(INVALID_FUNCTION_ARGUMENT.toErrorCode()))
+                .hasMessageContaining("Invalid input geometry")
+                .hasMessageContaining("Self-intersection at or near (1.0 1.0)");
+
+        // An invalid singleton the union accepts comes back as is
+        Geometry empty = reader.read("GEOMETRYCOLLECTION EMPTY");
+        assertThat(safeUnion(invalid, empty, false).equalsExact(invalid)).isTrue();
+
+        // The flag has no effect on operations that succeed
+        assertThat(safeUnion(valid, valid, false).equalsTopo(valid)).isTrue();
+    }
+
+    @Test
+    void testLegacyLenientOverlayPropertyParsing()
+    {
+        assertThat(parseLegacyLenientOverlay(null)).isFalse();
+        assertThat(parseLegacyLenientOverlay("false")).isFalse();
+        assertThat(parseLegacyLenientOverlay("true")).isTrue();
+
+        assertThatThrownBy(() -> parseLegacyLenientOverlay("yes"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be 'true' or 'false'");
+        assertThatThrownBy(() -> parseLegacyLenientOverlay("TRUE"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be 'true' or 'false'");
+    }
+
+    @Test
+    void testRepairFailureBecomesUserErrorAndPreservesDiagnostics()
+            throws ParseException
+    {
+        Geometry invalid = new WKTReader().read("POLYGON ((0 0, 2 2, 0 2, 2 0, 0 0))");
+        TopologyException originalFailure = new TopologyException("original overlay failure");
+        RuntimeException retryFailure = new IllegalStateException("repair retry failure");
+
+        TrinoException failure = invalidInputGeometryException(List.of(invalid), originalFailure, retryFailure);
+
+        assertThat(failure.getErrorCode()).isEqualTo(INVALID_FUNCTION_ARGUMENT.toErrorCode());
+        assertThat(failure).hasMessageContaining("Self-intersection at or near (1.0 1.0)");
+        assertThat(failure.getCause()).isSameAs(originalFailure);
+        assertThat(originalFailure.getSuppressed()).containsExactly(retryFailure);
+    }
+
+    @Test
+    void testRepairFailureThroughSafeUnionBecomesUserError()
+            throws ParseException
+    {
+        WKTReader reader = new WKTReader();
+        Geometry unrepairable = new UnrepairablePolygon((Polygon) reader.read("POLYGON ((0 0, 2 2, 0 2, 2 0, 0 0))"));
+        Geometry valid = reader.read("POLYGON ((-1 -1, 3 -1, 3 3, -1 3, -1 -1))");
+
+        // A repair failure keeps the original failure as the cause and attaches the retry failure
+        assertThatThrownBy(() -> safeUnion(unrepairable, valid, true))
+                .isInstanceOfSatisfying(TrinoException.class, e ->
+                        assertThat(e.getErrorCode()).isEqualTo(INVALID_FUNCTION_ARGUMENT.toErrorCode()))
+                .cause()
+                .isInstanceOf(TopologyException.class)
+                .satisfies(failure -> assertThat(failure.getSuppressed())
+                        .satisfiesExactly(suppressed -> assertThat(suppressed)
+                                .isInstanceOf(IllegalStateException.class)
+                                .hasMessage("synthetic repair failure")));
+    }
+
+    @Test
+    void testSafeUnionRepairsInvalidGeometryWithoutDroppingValidComponents()
+            throws ParseException
+    {
+        WKTReader reader = new WKTReader();
+        // The invalid input is disjoint from the valid one, so its repaired coordinates are asserted
+        Geometry invalid = reader.read("POLYGON ((0 0, 2 2, 0 2, 2 0, 0 0))");
+        Geometry valid = reader.read("GEOMETRYCOLLECTION (POINT (20 20), LINESTRING (20 10, 21 11), POLYGON ((10 10, 12 10, 12 12, 10 12, 10 10)))");
+        Geometry expected = reader.read("GEOMETRYCOLLECTION (POINT (20 20), LINESTRING (20 10, 21 11), POLYGON ((0 0, 1 1, 2 0, 0 0)), POLYGON ((0 2, 2 2, 1 1, 0 2)), POLYGON ((10 10, 10 12, 12 12, 12 10, 10 10)))");
+
+        assertThat(invalid.isValid()).isFalse();
+
+        Geometry result = safeUnion(invalid, valid, true);
+
+        assertThat(result.isValid()).isTrue();
+        // 2 for the repaired bow-tie plus 4 for the disjoint square
+        assertThat(result.getArea()).isEqualTo(6.0);
+        assertThat(result.norm()).isEqualTo(expected.norm());
+    }
+
+    /**
+     * Bow-tie polygon whose repair fails: the first union runs on the real coordinates, and the
+     * isValid() call that follows arms the double so only GeometryFixer throws.
+     */
+    private static final class UnrepairablePolygon
+            extends Polygon
+    {
+        private boolean armed;
+
+        UnrepairablePolygon(Polygon polygon)
+        {
+            super(polygon.getExteriorRing(), new LinearRing[0], polygon.getFactory());
+        }
+
+        @Override
+        public boolean isValid()
+        {
+            armed = true;
+            return false;
+        }
+
+        @Override
+        public GeometryFactory getFactory()
+        {
+            if (armed) {
+                throw new IllegalStateException("synthetic repair failure");
+            }
+            return super.getFactory();
+        }
     }
 }

--- a/plugin/trino-geospatial/pom.xml
+++ b/plugin/trino-geospatial/pom.xml
@@ -226,4 +226,57 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>legacy-lenient-overlay-tests</id>
+            <activation>
+                <!-- A command-line -Dtest selection overrides Surefire includes in every execution. -->
+                <property>
+                    <name>!test</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>legacy-lenient-overlay-enabled</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <includes>
+                                        <include>**/LegacyLenientOverlayEnabledCase.java</include>
+                                    </includes>
+                                    <forkCount>1</forkCount>
+                                    <reuseForks>false</reuseForks>
+                                    <systemPropertyVariables>
+                                        <trino.geospatial.legacy-lenient-overlay>true</trino.geospatial.legacy-lenient-overlay>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>legacy-lenient-overlay-malformed</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <includes>
+                                        <include>**/LegacyLenientOverlayMalformedCase.java</include>
+                                    </includes>
+                                    <forkCount>1</forkCount>
+                                    <reuseForks>false</reuseForks>
+                                    <systemPropertyVariables>
+                                        <trino.geospatial.legacy-lenient-overlay>yes</trino.geospatial.legacy-lenient-overlay>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoFunctions.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoFunctions.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.geospatial;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
@@ -52,6 +53,8 @@ import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.geom.TopologyException;
+import org.locationtech.jts.geom.util.GeometryFixer;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.locationtech.jts.io.WKTWriter;
@@ -76,6 +79,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -83,6 +87,7 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.geospatial.GeometryType.GEOMETRY_COLLECTION;
 import static io.trino.geospatial.GeometryType.LINE_STRING;
@@ -91,8 +96,10 @@ import static io.trino.geospatial.GeometryType.MULTI_POINT;
 import static io.trino.geospatial.GeometryType.MULTI_POLYGON;
 import static io.trino.geospatial.GeometryType.POINT;
 import static io.trino.geospatial.GeometryType.POLYGON;
+import static io.trino.geospatial.GeometryUtils.invalidInputGeometryException;
 import static io.trino.geospatial.GeometryUtils.jsonFromJtsGeometry;
 import static io.trino.geospatial.GeometryUtils.jtsGeometryFromJson;
+import static io.trino.geospatial.GeometryUtils.legacyLenientOverlay;
 import static io.trino.geospatial.serde.JtsGeometrySerde.hasZ;
 import static io.trino.geospatial.serde.JtsGeometrySerde.serializeWithoutSrid;
 import static io.trino.geospatial.serde.JtsGeometrySerde.validateAndGetSrid;
@@ -1136,7 +1143,13 @@ public final class GeoFunctions
 
     private static Geometry stUnionGeometries(Iterable<Geometry> inputGeometries)
     {
-        List<Geometry> geometries = new ArrayList<>();
+        return stUnionGeometries(inputGeometries, legacyLenientOverlay());
+    }
+
+    @VisibleForTesting
+    static Geometry stUnionGeometries(Iterable<Geometry> inputGeometries, boolean repairInvalidInputs)
+    {
+        List<Geometry> sourceGeometries = new ArrayList<>();
         int expectedSrid = 0;
         for (Geometry geometry : inputGeometries) {
             // Ignore null inputs
@@ -1154,11 +1167,12 @@ public final class GeoFunctions
                         format("SRID mismatch: %d vs %d", expectedSrid, srid));
             }
             if (!geometry.isEmpty()) {
-                // Flatten geometry collections to get individual geometries
-                flattenGeometry(geometry, geometries);
+                sourceGeometries.add(geometry);
             }
         }
 
+        List<Geometry> geometries = new ArrayList<>();
+        sourceGeometries.forEach(geometry -> flattenGeometry(geometry, geometries));
         if (geometries.isEmpty()) {
             // Return empty geometry collection instead of null for empty inputs
             Geometry result = GEOMETRY_FACTORY.createGeometryCollection();
@@ -1167,7 +1181,55 @@ public final class GeoFunctions
         }
 
         // JTS UnaryUnionOp handles mixed dimensions properly
-        Geometry result = UnaryUnionOp.union(geometries);
+        Geometry result;
+        try {
+            result = UnaryUnionOp.union(geometries);
+        }
+        catch (TopologyException failure) {
+            // isValid() builds an index, so compute it once per input and carry the result forward
+            Set<Geometry> invalidSet = Collections.newSetFromMap(new IdentityHashMap<>());
+            try {
+                for (Geometry geometry : sourceGeometries) {
+                    if (!geometry.isValid()) {
+                        invalidSet.add(geometry);
+                    }
+                }
+            }
+            catch (RuntimeException validationFailure) {
+                failure.addSuppressed(validationFailure);
+                throw failure;
+            }
+            if (invalidSet.isEmpty()) {
+                throw failure;
+            }
+            List<Geometry> invalidGeometries = sourceGeometries.stream()
+                    .filter(invalidSet::contains)
+                    .collect(toImmutableList());
+            if (!repairInvalidInputs) {
+                throw invalidInputGeometryException(invalidGeometries, failure);
+            }
+            List<Geometry> repairedGeometries = new ArrayList<>();
+            try {
+                for (Geometry geometry : sourceGeometries) {
+                    // Repair the original input, not its components: an invalid MultiPolygon can consist of valid polygons
+                    flattenGeometry(invalidSet.contains(geometry) ? GeometryFixer.fix(geometry) : geometry, repairedGeometries);
+                }
+            }
+            catch (RuntimeException retryFailure) {
+                throw invalidInputGeometryException(invalidGeometries, failure, retryFailure);
+            }
+            if (repairedGeometries.isEmpty()) {
+                result = GEOMETRY_FACTORY.createGeometryCollection();
+            }
+            else {
+                try {
+                    result = UnaryUnionOp.union(repairedGeometries);
+                }
+                catch (RuntimeException retryFailure) {
+                    throw invalidInputGeometryException(invalidGeometries, failure, retryFailure);
+                }
+            }
+        }
 
         // Post-process to match ESRI behavior:
         // 1. Merge connected line segments
@@ -1687,7 +1749,7 @@ public final class GeoFunctions
     public static Geometry stDifference(@SqlType(StandardTypes.GEOMETRY) Geometry leftGeometry, @SqlType(StandardTypes.GEOMETRY) Geometry rightGeometry)
     {
         // Use OverlayNGRobust for better handling of edge cases and invalid geometries
-        Geometry result = OverlayNGRobust.overlay(leftGeometry, rightGeometry, OverlayNG.DIFFERENCE);
+        Geometry result = overlayRobustly(leftGeometry, rightGeometry, OverlayNG.DIFFERENCE);
         result.setSRID(validateAndGetSrid(leftGeometry, rightGeometry));
         return result;
     }
@@ -1745,7 +1807,7 @@ public final class GeoFunctions
     @SqlType(StandardTypes.GEOMETRY)
     public static Geometry stIntersection(@SqlType(StandardTypes.GEOMETRY) Geometry leftGeometry, @SqlType(StandardTypes.GEOMETRY) Geometry rightGeometry)
     {
-        Geometry result = OverlayNGRobust.overlay(leftGeometry, rightGeometry, OverlayNG.INTERSECTION);
+        Geometry result = overlayRobustly(leftGeometry, rightGeometry, OverlayNG.INTERSECTION);
         result.setSRID(validateAndGetSrid(leftGeometry, rightGeometry));
         return result;
     }
@@ -1756,9 +1818,59 @@ public final class GeoFunctions
     public static Geometry stSymmetricDifference(@SqlType(StandardTypes.GEOMETRY) Geometry leftGeometry, @SqlType(StandardTypes.GEOMETRY) Geometry rightGeometry)
     {
         // Use OverlayNGRobust for better handling of edge cases and invalid geometries
-        Geometry result = OverlayNGRobust.overlay(leftGeometry, rightGeometry, OverlayNG.SYMDIFFERENCE);
+        Geometry result = overlayRobustly(leftGeometry, rightGeometry, OverlayNG.SYMDIFFERENCE);
         result.setSRID(validateAndGetSrid(leftGeometry, rightGeometry));
         return result;
+    }
+
+    /**
+     * Runs an OverlayNG operation under the {@link io.trino.geospatial.GeometryUtils#LEGACY_LENIENT_OVERLAY_PROPERTY} policy.
+     */
+    private static Geometry overlayRobustly(Geometry left, Geometry right, int opCode)
+    {
+        return overlayRobustly(left, right, opCode, legacyLenientOverlay());
+    }
+
+    @VisibleForTesting
+    static Geometry overlayRobustly(Geometry left, Geometry right, int opCode, boolean repairInvalidInputs)
+    {
+        try {
+            return OverlayNGRobust.overlay(left, right, opCode);
+        }
+        catch (TopologyException failure) {
+            boolean leftValid;
+            boolean rightValid;
+            try {
+                leftValid = left.isValid();
+                rightValid = right.isValid();
+            }
+            catch (RuntimeException validationFailure) {
+                failure.addSuppressed(validationFailure);
+                throw failure;
+            }
+            if (leftValid && rightValid) {
+                throw failure;
+            }
+            List<Geometry> invalidInputs = new ArrayList<>();
+            if (!leftValid) {
+                invalidInputs.add(left);
+            }
+            if (!rightValid) {
+                invalidInputs.add(right);
+            }
+            if (!repairInvalidInputs) {
+                throw invalidInputGeometryException(invalidInputs, failure);
+            }
+            try {
+                return OverlayNGRobust.overlay(
+                        leftValid ? left : GeometryFixer.fix(left),
+                        rightValid ? right : GeometryFixer.fix(right),
+                        opCode);
+            }
+            catch (RuntimeException retryFailure) {
+                throw invalidInputGeometryException(invalidInputs, failure, retryFailure);
+            }
+        }
     }
 
     @Description("Returns merged LineStrings from the input geometry")

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoPlugin.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoPlugin.java
@@ -24,6 +24,7 @@ import io.trino.spi.type.Type;
 
 import java.util.Set;
 
+import static io.trino.geospatial.GeometryUtils.legacyLenientOverlay;
 import static io.trino.plugin.geospatial.BingTileType.BING_TILE;
 import static io.trino.plugin.geospatial.GeometryType.GEOMETRY;
 import static io.trino.plugin.geospatial.KdbTreeType.KDB_TREE;
@@ -32,6 +33,12 @@ import static io.trino.plugin.geospatial.SphericalGeographyType.SPHERICAL_GEOGRA
 public class GeoPlugin
         implements Plugin
 {
+    public GeoPlugin()
+    {
+        // Fail plugin initialization on a malformed JVM flag instead of silently enabling lenient mode.
+        legacyLenientOverlay();
+    }
+
     @Override
     public Iterable<Type> getTypes()
     {

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/aggregation/ConvexHullAggregation.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/aggregation/ConvexHullAggregation.java
@@ -25,7 +25,6 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 import org.locationtech.jts.geom.Geometry;
 
-import static io.trino.geospatial.GeometryUtils.safeUnion;
 import static io.trino.geospatial.serde.JtsGeometrySerde.validateAndGetSrid;
 import static io.trino.plugin.geospatial.GeometryType.GEOMETRY;
 
@@ -52,7 +51,7 @@ public final class ConvexHullAggregation
         else {
             int srid = validateAndGetSrid(state.getGeometry(), geometry);
             if (!geometry.isEmpty()) {
-                Geometry result = safeUnion(state.getGeometry(), geometry).convexHull();
+                Geometry result = convexHullOf(state.getGeometry(), geometry.convexHull());
                 result.setSRID(srid);
                 state.setGeometry(result);
             }
@@ -73,7 +72,7 @@ public final class ConvexHullAggregation
         else if (otherState.getGeometry() != null) {
             int srid = validateAndGetSrid(state.getGeometry(), otherState.getGeometry());
             if (!otherState.getGeometry().isEmpty()) {
-                Geometry result = safeUnion(state.getGeometry(), otherState.getGeometry()).convexHull();
+                Geometry result = convexHullOf(state.getGeometry(), otherState.getGeometry());
                 result.setSRID(srid);
                 state.setGeometry(result);
             }
@@ -81,6 +80,15 @@ public final class ConvexHullAggregation
                 updateGeometrySrid(state, srid);
             }
         }
+    }
+
+    /**
+     * Hull of two hulls, which equals the hull of their inputs. Taking it over the coordinates
+     * avoids an overlay, so no input is ever repaired and the result is independent of input order.
+     */
+    private static Geometry convexHullOf(Geometry left, Geometry right)
+    {
+        return left.getFactory().createGeometryCollection(new Geometry[] {left, right}).convexHull();
     }
 
     private static void updateGeometrySrid(GeometryState state, int srid)

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/aggregation/GeometryUnionAgg.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/aggregation/GeometryUnionAgg.java
@@ -25,6 +25,7 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 import org.locationtech.jts.geom.Geometry;
 
+import static io.trino.geospatial.GeometryUtils.legacyLenientOverlay;
 import static io.trino.geospatial.GeometryUtils.safeUnion;
 import static io.trino.geospatial.serde.JtsGeometrySerde.validateAndGetSrid;
 import static io.trino.plugin.geospatial.GeometryType.GEOMETRY;
@@ -42,13 +43,18 @@ public final class GeometryUnionAgg
     @InputFunction
     public static void input(@AggregationState GeometryState state, @SqlType(StandardTypes.GEOMETRY) Geometry geometry)
     {
+        input(state, geometry, legacyLenientOverlay());
+    }
+
+    static void input(GeometryState state, Geometry geometry, boolean repairInvalidInputs)
+    {
         if (state.getGeometry() == null) {
             state.setGeometry(geometry);
         }
         else {
             int srid = validateAndGetSrid(state.getGeometry(), geometry);
             if (!geometry.isEmpty()) {
-                Geometry result = safeUnion(state.getGeometry(), geometry);
+                Geometry result = safeUnion(state.getGeometry(), geometry, repairInvalidInputs);
                 result.setSRID(srid);
                 state.setGeometry(result);
             }
@@ -61,13 +67,19 @@ public final class GeometryUnionAgg
     @CombineFunction
     public static void combine(@AggregationState GeometryState state, @AggregationState GeometryState otherState)
     {
+        combine(state, otherState, legacyLenientOverlay());
+    }
+
+    static void combine(GeometryState state, GeometryState otherState, boolean repairInvalidInputs)
+    {
+        // The same policy as input(), so the result does not depend on how rows are batched
         if (state.getGeometry() == null) {
             state.setGeometry(otherState.getGeometry());
         }
         else if (otherState.getGeometry() != null) {
             int srid = validateAndGetSrid(state.getGeometry(), otherState.getGeometry());
             if (!otherState.getGeometry().isEmpty()) {
-                Geometry result = safeUnion(state.getGeometry(), otherState.getGeometry());
+                Geometry result = safeUnion(state.getGeometry(), otherState.getGeometry(), repairInvalidInputs);
                 result.setSRID(srid);
                 state.setGeometry(result);
             }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/LegacyLenientOverlayEnabledCase.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/LegacyLenientOverlayEnabledCase.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.geospatial;
+
+import io.trino.plugin.geospatial.aggregation.GeometryState;
+import io.trino.plugin.geospatial.aggregation.GeometryStateFactory;
+import io.trino.plugin.geospatial.aggregation.GeometryUnionAgg;
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.TopologyException;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+import org.locationtech.jts.operation.overlayng.OverlayNG;
+import org.locationtech.jts.operation.overlayng.OverlayNGRobust;
+
+import java.util.Map;
+
+import static io.trino.geospatial.GeometryUtils.legacyLenientOverlay;
+import static io.trino.plugin.geospatial.GeoTestUtils.assertSpatialEquals;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class LegacyLenientOverlayEnabledCase
+{
+    private static final String INVALID_BOW_TIE = "POLYGON ((0 0, 2 2, 0 2, 2 0, 0 0))";
+    private static final String LEFT_HALF = "POLYGON ((0 0, 1 0, 1 2, 0 2, 0 0))";
+    private static final String DISJOINT_SQUARE = "POLYGON ((10 10, 12 10, 12 12, 10 12, 10 10))";
+    private static final String REPAIRED_BOW_TIE_WITH_DISJOINT_SQUARE =
+            "MULTIPOLYGON (((0 0, 1 1, 2 0, 0 0)), ((0 2, 2 2, 1 1, 0 2)), ((10 10, 10 12, 12 12, 12 10, 10 10)))";
+
+    @Test
+    void testScalarOverlayFallback()
+    {
+        assertThat(legacyLenientOverlay()).isTrue();
+
+        Geometry invalid = geometry(INVALID_BOW_TIE);
+        Geometry clipping = geometry(LEFT_HALF);
+
+        assertThat(invalid.isValid()).isFalse();
+        assertThatThrownBy(() -> OverlayNGRobust.overlay(invalid, clipping, OverlayNG.INTERSECTION))
+                .isInstanceOf(TopologyException.class)
+                .hasMessageContaining("side location conflict");
+
+        assertGeometry(
+                GeoFunctions.stIntersection(invalid, clipping),
+                "MULTIPOLYGON (((1 1, 1 0, 0 0, 1 1)), ((0 2, 1 2, 1 1, 0 2)))");
+        assertGeometry(
+                GeoFunctions.stDifference(invalid, clipping),
+                "MULTIPOLYGON (((2 0, 1 0, 1 1, 2 0)), ((2 2, 1 1, 1 2, 2 2)))");
+        assertGeometry(
+                GeoFunctions.stDifference(clipping, invalid),
+                "POLYGON ((0 0, 0 2, 1 1, 0 0))");
+        assertGeometry(
+                GeoFunctions.stSymmetricDifference(invalid, clipping),
+                "MULTIPOLYGON (((0 0, 0 2, 1 1, 0 0)), ((2 0, 1 0, 1 1, 2 0)), ((2 2, 1 1, 1 2, 2 2)))");
+        assertGeometry(
+                GeoFunctions.stUnion(invalid, clipping),
+                "POLYGON ((2 0, 1 0, 0 0, 0 2, 1 2, 2 2, 1 1, 2 0))");
+
+        // GeometryFixer must not mutate the input object.
+        assertThat(invalid.isValid()).isFalse();
+        assertThat(invalid.getSRID()).isEqualTo(4326);
+    }
+
+    @Test
+    void testFallbackPreservesSridAndZ()
+    {
+        Geometry invalid = geometry("POLYGON Z ((0 0 1, 2 2 2, 0 2 3, 2 0 4, 0 0 1))");
+        Geometry clipping = geometry("POLYGON Z ((0 0 10, 1 0 11, 1 2 12, 0 2 13, 0 0 10))");
+
+        Geometry result = GeoFunctions.stIntersection(invalid, clipping);
+
+        assertSridAndZ(result);
+        assertSridAndZ(GeoFunctions.stUnion(invalid, clipping));
+
+        GeometryState unionState = new GeometryStateFactory.SingleGeometryState();
+        GeometryUnionAgg.input(unionState, invalid);
+        GeometryUnionAgg.input(unionState, clipping);
+        assertSridAndZ(unionState.getGeometry());
+    }
+
+    @Test
+    void testAggregationFallbackInBothInputOrders()
+    {
+        // The square is disjoint from the bow-tie, so both results carry the repaired coordinates
+        assertUnionAggregation(INVALID_BOW_TIE, DISJOINT_SQUARE);
+        assertUnionAggregation(DISJOINT_SQUARE, INVALID_BOW_TIE);
+    }
+
+    @Test
+    void testSqlPathRepairsInvalidGeometry()
+    {
+        try (QueryAssertions assertions = new QueryAssertions()) {
+            assertions.addPlugin(new GeoPlugin());
+            // JTS 1.20 OverlayNGRobust throws "side location conflict" for this self-intersecting polygon.
+            String invalidGeometry = "ST_SetSRID(ST_GeometryFromText('POLYGON ((0 0, 2 2, 0 2, 2 0, 0 0))'), 4326)";
+            String clippingGeometry = "ST_SetSRID(ST_GeometryFromText('POLYGON ((0 0, 1 0, 1 2, 0 2, 0 0))'), 4326)";
+
+            assertThat(assertions.function("ST_IsValid", invalidGeometry))
+                    .isEqualTo(false);
+
+            Map<String, String> expectedResults = Map.of(
+                    "ST_Intersection(%s, %s)".formatted(invalidGeometry, clippingGeometry), "MULTIPOLYGON (((1 1, 1 0, 0 0, 1 1)), ((0 2, 1 2, 1 1, 0 2)))",
+                    "ST_Difference(%s, %s)".formatted(invalidGeometry, clippingGeometry), "MULTIPOLYGON (((2 0, 1 0, 1 1, 2 0)), ((2 2, 1 1, 1 2, 2 2)))",
+                    "ST_Difference(%s, %s)".formatted(clippingGeometry, invalidGeometry), "POLYGON ((0 0, 0 2, 1 1, 0 0))",
+                    "ST_SymDifference(%s, %s)".formatted(invalidGeometry, clippingGeometry), "MULTIPOLYGON (((0 0, 0 2, 1 1, 0 0)), ((2 0, 1 0, 1 1, 2 0)), ((2 2, 1 1, 1 2, 2 2)))",
+                    "ST_Union(%s, %s)".formatted(invalidGeometry, clippingGeometry), "POLYGON ((2 0, 1 0, 0 0, 0 2, 1 2, 2 2, 1 1, 2 0))",
+                    "geometry_union(ARRAY[%s, %s])".formatted(invalidGeometry, clippingGeometry), "POLYGON ((2 0, 1 0, 0 0, 0 2, 1 2, 2 2, 1 1, 2 0))");
+
+            expectedResults.forEach((expression, expectedWkt) -> {
+                assertSpatialEquals(assertions, expression, expectedWkt);
+                assertThat(assertions.function("ST_IsValid", expression))
+                        .isEqualTo(true);
+                assertThat(assertions.function("ST_SRID", expression))
+                        .isEqualTo(4326);
+            });
+
+            String invalidGeometryWithZ = "ST_SetSRID(ST_GeometryFromText('POLYGON Z ((0 0 1, 2 2 2, 0 2 3, 2 0 4, 0 0 1))'), 4326)";
+            String clippingGeometryWithZ = "ST_SetSRID(ST_GeometryFromText('POLYGON Z ((0 0 10, 1 0 11, 1 2 12, 0 2 13, 0 0 10))'), 4326)";
+            String intersectionWithZ = "ST_Intersection(%s, %s)".formatted(invalidGeometryWithZ, clippingGeometryWithZ);
+
+            assertThat(assertions.function("ST_IsValid", intersectionWithZ))
+                    .isEqualTo(true);
+            assertThat(assertions.function("ST_SRID", intersectionWithZ))
+                    .isEqualTo(4326);
+            assertThat(assertions.function("ST_CoordDim", intersectionWithZ))
+                    .hasType(TINYINT)
+                    .isEqualTo((byte) 3);
+        }
+    }
+
+    private static void assertUnionAggregation(String first, String second)
+    {
+        GeometryState state = new GeometryStateFactory.SingleGeometryState();
+        GeometryUnionAgg.input(state, geometry(first));
+        GeometryUnionAgg.input(state, geometry(second));
+        assertGeometry(state.getGeometry(), REPAIRED_BOW_TIE_WITH_DISJOINT_SQUARE);
+        // 2 for the repaired bow-tie plus 4 for the disjoint square
+        assertThat(state.getGeometry().getArea()).isEqualTo(6.0);
+    }
+
+    private static Geometry geometry(String wkt)
+    {
+        try {
+            Geometry geometry = new WKTReader().read(wkt);
+            geometry.setSRID(4326);
+            return geometry;
+        }
+        catch (ParseException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static void assertGeometry(Geometry actual, String expectedWkt)
+    {
+        Geometry expected = geometry(expectedWkt);
+        assertThat(actual.isValid()).isTrue();
+        assertThat(actual.getSRID()).isEqualTo(4326);
+        assertThat(actual.equalsTopo(expected))
+                .describedAs("expected %s, but got %s", expected, actual)
+                .isTrue();
+    }
+
+    private static void assertSridAndZ(Geometry geometry)
+    {
+        assertThat(geometry.isValid()).isTrue();
+        assertThat(geometry.getSRID()).isEqualTo(4326);
+        assertThat(geometry.getCoordinates())
+                .allMatch(coordinate -> Double.isFinite(coordinate.getZ()))
+                .anyMatch(coordinate -> coordinate.getZ() == 2.5);
+    }
+}

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/LegacyLenientOverlayMalformedCase.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/LegacyLenientOverlayMalformedCase.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.geospatial;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+final class LegacyLenientOverlayMalformedCase
+{
+    @Test
+    void testMalformedJVMPropertyFailsPluginInitialization()
+    {
+        Throwable failure = catchThrowable(GeoPlugin::new);
+
+        assertThat(failure).isInstanceOf(ExceptionInInitializerError.class);
+        assertThat(failure.getCause())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be 'true' or 'false'");
+    }
+}

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestInvalidGeometryOverlay.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestInvalidGeometryOverlay.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.geospatial;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.geospatial.aggregation.GeometryState;
+import io.trino.plugin.geospatial.aggregation.GeometryStateFactory;
+import io.trino.plugin.geospatial.aggregation.GeometryUnionAgg;
+import io.trino.spi.TrinoException;
+import io.trino.sql.query.QueryAssertions;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+import org.locationtech.jts.operation.overlayng.OverlayNG;
+import org.locationtech.jts.operation.overlayng.OverlayNGRobust;
+
+import java.util.List;
+
+import static io.trino.geospatial.GeometryUtils.legacyLenientOverlay;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestInvalidGeometryOverlay
+{
+    private static final String INVALID_BOW_TIE = "POLYGON ((0 0, 2 2, 0 2, 2 0, 0 0))";
+    private static final String LEFT_HALF = "POLYGON ((0 0, 1 0, 1 2, 0 2, 0 0))";
+    private static final String OUTER = "POLYGON ((-1 -1, 3 -1, 3 3, -1 3, -1 -1))";
+
+    @Test
+    void testInvalidInputsAreRejectedByDefault()
+    {
+        assertThat(legacyLenientOverlay()).isFalse();
+
+        // Operations that fail on the self-intersecting input report a user error
+        Geometry invalid = geometry(INVALID_BOW_TIE);
+        Geometry clipping = geometry(LEFT_HALF);
+        assertThatThrownBy(() -> GeoFunctions.stIntersection(invalid, clipping))
+                .isInstanceOfSatisfying(TrinoException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(INVALID_FUNCTION_ARGUMENT.toErrorCode()))
+                .hasMessageContaining("Self-intersection at or near (1.0 1.0)");
+        assertThatThrownBy(() -> GeoFunctions.stUnion(invalid, clipping))
+                .isInstanceOfSatisfying(TrinoException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(INVALID_FUNCTION_ARGUMENT.toErrorCode()));
+
+        // The union aggregation rejects in every position, including combine()
+        GeometryState unionState = new GeometryStateFactory.SingleGeometryState();
+        GeometryUnionAgg.input(unionState, geometry(OUTER));
+        assertThatThrownBy(() -> GeometryUnionAgg.input(unionState, invalid))
+                .isInstanceOfSatisfying(TrinoException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(INVALID_FUNCTION_ARGUMENT.toErrorCode()));
+        assertThatThrownBy(() -> GeometryUnionAgg.combine(geometryState(geometry(OUTER)), geometryState(invalid)))
+                .isInstanceOfSatisfying(TrinoException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(INVALID_FUNCTION_ARGUMENT.toErrorCode()));
+
+        assertSqlPathRejectsInvalidGeometry();
+    }
+
+    /**
+     * Covers the SQL entry points, which need a test owning the JVM because the property is read once.
+     */
+    private static void assertSqlPathRejectsInvalidGeometry()
+    {
+        String invalidGeometry = "ST_GeometryFromText('POLYGON ((0 0, 2 2, 0 2, 2 0, 0 0))')";
+        String clippingGeometry = "ST_GeometryFromText('POLYGON ((0 0, 1 0, 1 2, 0 2, 0 0))')";
+
+        try (QueryAssertions assertions = new QueryAssertions()) {
+            assertions.addPlugin(new GeoPlugin());
+
+            assertThat(assertions.query("SELECT ST_Intersection(%s, %s)".formatted(invalidGeometry, clippingGeometry)))
+                    .failure()
+                    .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                    .hasMessageContaining("Self-intersection at or near (1.0 1.0)");
+
+            assertThat(assertions.query("SELECT geometry_union_agg(geometry) FROM (VALUES %s, %s) t(geometry)".formatted(clippingGeometry, invalidGeometry)))
+                    .failure()
+                    .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                    .hasMessageContaining("Self-intersection at or near (1.0 1.0)");
+
+            // Valid inputs keep working, so the default rejects rather than breaks the functions
+            assertThat(assertions.query("SELECT ST_AsText(ST_Intersection(%s, %s))".formatted(clippingGeometry, clippingGeometry)))
+                    .matches("VALUES VARCHAR 'POLYGON ((0 0, 0 2, 1 2, 1 0, 0 0))'");
+        }
+    }
+
+    @Test
+    void testExplicitRepairFlagDisabled()
+    {
+        Geometry invalid = geometry(INVALID_BOW_TIE);
+        Geometry clipping = geometry(LEFT_HALF);
+
+        assertThatThrownBy(() -> GeoFunctions.overlayRobustly(invalid, clipping, OverlayNG.INTERSECTION, false))
+                .isInstanceOfSatisfying(TrinoException.class, e ->
+                        assertThat(e.getErrorCode()).isEqualTo(INVALID_FUNCTION_ARGUMENT.toErrorCode()))
+                .hasMessageContaining("Invalid input geometry")
+                .hasMessageContaining("Self-intersection at or near (1.0 1.0)");
+
+        // A degenerate invalid polygon that the overlay accepts comes back unchanged
+        Geometry degenerate = geometry("POLYGON ((0 0, 1 0, 2 0, 0 0))");
+        assertThat(GeoFunctions.overlayRobustly(degenerate, degenerate, OverlayNG.INTERSECTION, false)
+                .equalsTopo(OverlayNGRobust.overlay(degenerate, degenerate, OverlayNG.INTERSECTION))).isTrue();
+
+        assertThatThrownBy(() -> GeoFunctions.stUnionGeometries(ImmutableList.of(invalid, clipping), false))
+                .isInstanceOfSatisfying(TrinoException.class, e ->
+                        assertThat(e.getErrorCode()).isEqualTo(INVALID_FUNCTION_ARGUMENT.toErrorCode()))
+                .hasMessageContaining("Invalid input geometry")
+                .hasMessageContaining("Self-intersection at or near (1.0 1.0)");
+
+        // A singleton invalid input that the union accepts comes back without repair
+        assertThat(GeoFunctions.stUnionGeometries(ImmutableList.of(invalid), false).isValid()).isFalse();
+
+        // The flag does not affect operations on valid inputs
+        Geometry outer = geometry(OUTER);
+        assertThat(GeoFunctions.overlayRobustly(clipping, outer, OverlayNG.INTERSECTION, false).equalsTopo(clipping)).isTrue();
+        assertThat(GeoFunctions.stUnionGeometries(ImmutableList.of(clipping, outer), false).equalsTopo(outer)).isTrue();
+    }
+
+    @Test
+    void testInvalidInputMessageTruncatesAfterThreeInputs()
+    {
+        // UnaryUnionOp fails on these four disjoint bow-ties, so the truncation runs on a live path
+        List<Geometry> invalidInputs = List.of(
+                geometry("POLYGON ((0 0, 2 2, 0 2, 2 0, 0 0))"),
+                geometry("POLYGON ((10 0, 12 2, 10 2, 12 0, 10 0))"),
+                geometry("POLYGON ((20 0, 22 2, 20 2, 22 0, 20 0))"),
+                geometry("POLYGON ((30 0, 32 2, 30 2, 32 0, 30 0))"));
+
+        assertThatThrownBy(() -> GeoFunctions.stUnionGeometries(invalidInputs, false))
+                .isInstanceOfSatisfying(TrinoException.class, e ->
+                        assertThat(e.getErrorCode()).isEqualTo(INVALID_FUNCTION_ARGUMENT.toErrorCode()))
+                .hasMessageContaining("Self-intersection at or near (1.0 1.0)")
+                .hasMessageContaining("Self-intersection at or near (11.0 1.0)")
+                .hasMessageContaining("Self-intersection at or near (21.0 1.0)")
+                // The fourth input is summarised rather than described, keeping the message bounded
+                .hasMessageNotContaining("31.0")
+                .hasMessageEndingWith("(and 1 more invalid inputs)");
+    }
+
+    private static Geometry geometry(String wkt)
+    {
+        try {
+            Geometry geometry = new WKTReader().read(wkt);
+            geometry.setSRID(4326);
+            return geometry;
+        }
+        catch (ParseException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static GeometryState geometryState(Geometry geometry)
+    {
+        GeometryState state = new GeometryStateFactory.SingleGeometryState();
+        state.setGeometry(geometry);
+        return state;
+    }
+}

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/aggregation/TestGeometryConvexHullGeoAggregation.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/aggregation/TestGeometryConvexHullGeoAggregation.java
@@ -221,6 +221,22 @@ public class TestGeometryConvexHullGeoAggregation
                 "POLYGON ((1 1, 3 1, 3 2, 3 3, 1 3, 1 1))",
                 "POLYGON ((1 1, 3 1, 3 3, 1 3, 1 1))",
                 "POINT (3 2)");
+
+        // The invalid polygon sits outside the valid one, so its coordinates are hull vertices and a
+        // result that dropped it would be the square's own hull instead.
+        assertAggregatedGeometries(
+                "self-intersecting polygon contributes its coordinates",
+                "POLYGON ((0 0, 2 0, 12 10, 12 12, 10 12, 0 2, 0 0))",
+                "POLYGON ((0 0, 2 2, 0 2, 2 0, 0 0))",
+                "POLYGON ((10 10, 12 10, 12 12, 10 12, 10 10))");
+
+        // A ring outside the shell is not a hull vertex, matching ST_ConvexHull on the same polygon.
+        // Repairing the input would promote it to a polygon and move the hull out to 101.
+        assertAggregatedGeometries(
+                "polygon with a ring outside its shell",
+                "POLYGON ((0 0, 10 0, 12 10, 12 12, 10 12, 0 10, 0 0))",
+                "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (100 100, 101 100, 101 101, 100 101, 100 100))",
+                "POLYGON ((10 10, 12 10, 12 12, 10 12, 10 10))");
     }
 
     @Test

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/aggregation/TestGeometryUnionGeoAggregation.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/aggregation/TestGeometryUnionGeoAggregation.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static io.trino.plugin.geospatial.GeoTestUtils.assertSpatialEquals;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static java.lang.String.format;
 import static java.util.Collections.reverse;
@@ -389,6 +390,81 @@ public class TestGeometryUnionGeoAggregation
         GeometryUnionAgg.combine(state, otherState);
 
         assertThat(state.getGeometry().getSRID()).isEqualTo(4326);
+    }
+
+    @Test
+    public void testInvalidInputIsRejectedInEveryPositionWithoutRepair()
+            throws ParseException
+    {
+        Geometry invalid = geometry("POLYGON ((0 0, 2 2, 0 2, 2 0, 0 0))", 4326);
+        Geometry valid = geometry("POLYGON ((10 10, 12 10, 12 12, 10 12, 10 10))", 4326);
+
+        // The accumulated state can be a raw input, so rejection cannot depend on operand position
+        GeometryState validThenInvalid = new GeometryStateFactory.SingleGeometryState();
+        GeometryUnionAgg.input(validThenInvalid, valid, false);
+        Geometry stateBeforeFailure = validThenInvalid.getGeometry();
+        assertTrinoExceptionThrownBy(() -> GeometryUnionAgg.input(validThenInvalid, invalid, false))
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("Self-intersection at or near (1.0 1.0)");
+        assertThat(validThenInvalid.getGeometry()).isSameAs(stateBeforeFailure);
+
+        GeometryState invalidThenValid = new GeometryStateFactory.SingleGeometryState();
+        GeometryUnionAgg.input(invalidThenValid, invalid, false);
+        assertTrinoExceptionThrownBy(() -> GeometryUnionAgg.input(invalidThenValid, valid, false))
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("Self-intersection at or near (1.0 1.0)");
+
+        // combine() applies the same policy, so the result does not depend on how rows are batched
+        assertTrinoExceptionThrownBy(() -> GeometryUnionAgg.combine(geometryState(valid.copy()), geometryState(invalid.copy()), false))
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
+        assertTrinoExceptionThrownBy(() -> GeometryUnionAgg.combine(geometryState(invalid.copy()), geometryState(valid.copy()), false))
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
+    }
+
+    @Test
+    public void testInvalidInputIsRepairedInEveryPositionWhenEnabled()
+            throws ParseException
+    {
+        Geometry invalid = geometry("POLYGON ((0 0, 2 2, 0 2, 2 0, 0 0))", 4326);
+        Geometry valid = geometry("POLYGON ((10 10, 12 10, 12 12, 10 12, 10 10))", 4326);
+        Geometry expected = geometry("MULTIPOLYGON (((0 0, 1 1, 2 0, 0 0)), ((0 2, 2 2, 1 1, 0 2)), ((10 10, 10 12, 12 12, 12 10, 10 10)))", 4326);
+
+        GeometryState validThenInvalid = new GeometryStateFactory.SingleGeometryState();
+        GeometryUnionAgg.input(validThenInvalid, valid.copy(), true);
+        GeometryUnionAgg.input(validThenInvalid, invalid.copy(), true);
+        assertCombinedGeometry(validThenInvalid.getGeometry(), expected);
+
+        GeometryState invalidThenValid = new GeometryStateFactory.SingleGeometryState();
+        GeometryUnionAgg.input(invalidThenValid, invalid.copy(), true);
+        GeometryUnionAgg.input(invalidThenValid, valid.copy(), true);
+        assertCombinedGeometry(invalidThenValid.getGeometry(), expected);
+
+        GeometryState combinedValidFirst = geometryState(valid.copy());
+        GeometryUnionAgg.combine(combinedValidFirst, geometryState(invalid.copy()), true);
+        assertCombinedGeometry(combinedValidFirst.getGeometry(), expected);
+
+        GeometryState combinedInvalidFirst = geometryState(invalid.copy());
+        GeometryUnionAgg.combine(combinedInvalidFirst, geometryState(valid.copy()), true);
+        assertCombinedGeometry(combinedInvalidFirst.getGeometry(), expected);
+    }
+
+    private static GeometryState geometryState(Geometry geometry)
+    {
+        GeometryState state = new GeometryStateFactory.SingleGeometryState();
+        state.setGeometry(geometry);
+        return state;
+    }
+
+    private static void assertCombinedGeometry(Geometry actual, Geometry expected)
+            throws ParseException
+    {
+        assertThat(actual.isValid()).isTrue();
+        assertThat(actual.getSRID()).isEqualTo(4326);
+        assertThat(actual.equalsTopo(expected)).isTrue();
+        assertThat(actual.getArea()).isEqualTo(6.0);
+        assertThat(actual.covers(geometry("POINT (1 0.25)", 4326))).isTrue();
+        assertThat(actual.covers(geometry("POINT (1 1.75)", 4326))).isTrue();
+        assertThat(actual.covers(geometry("POINT (11 11)", 4326))).isTrue();
     }
 
     private static Geometry geometry(String wkt, int srid)


### PR DESCRIPTION
- Fixes #30584

## Description

Replacing the Esri geometry library with JTS (#27881, released in 481) made overlay and union operations fail with a raw JTS `TopologyException`, surfaced as `GENERIC_INTERNAL_ERROR`, when an input geometry is topologically invalid such as a self-intersecting polygon. Esri silently repaired those inputs, so queries that ran on 480 and earlier started failing after an upgrade:

```sql
SELECT ST_AsText(ST_Intersection(
    ST_GeometryFromText('POLYGON ((0 0, 20 20, 20 0, 0 20, 0 0))'),
    ST_GeometryFromText('POLYGON ((0 0, 30 0, 30 30, 0 30, 0 0))')));
-- 476: MULTIPOLYGON (((0 0, 10 10, 0 20, 0 0)), ((20 0, 20 20, 10 10, 20 0)))
-- 481+: GENERIC_INTERNAL_ERROR: side location conflict: arg 0 [ (10.0, 10.0, NaN) ]
```

JTS behavior stays the default. Anything JTS accepts is still returned unchanged, so queries that work today keep working. When an overlay or union throws `TopologyException` and at least one input is invalid, the failure is now `INVALID_FUNCTION_ARGUMENT` describing each invalid input and the location of its invalidity, in the same format as `geometry_invalid_reason`. Failures with all-valid inputs are rethrown unchanged so genuine robustness bugs stay visible.

The JVM property `trino.geospatial.legacy-lenient-overlay=true` opts back into the old behavior. It repairs only the invalid inputs with `GeometryFixer` and retries once, which returns a geometrically identical result to Esri for the reproduction above. A malformed property value fails plugin initialization.

`convex_hull_agg` no longer unions its inputs before taking the hull. It computes the hull over the input coordinates, the same as scalar `ST_ConvexHull`, so it never fails or repairs on an invalid input and its result does not depend on input order.

## Additional context and related issues

* The 481 release notes documented the stricter WKT parsing and two `ST_Union` semantic changes, but not this one.
* Per the JTS maintainer, `TopologyException` on invalid input is expected library behavior (locationtech/jts#639), distinct from robustness failures on valid input (locationtech/jts#1051, fixed by RelateNG in JTS 1.20), so handling invalid input belongs in Trino rather than in JTS.
* The lenient switch is a JVM system property rather than a configuration property because the geospatial plugin only contributes functions and has no configuration binding point. The name follows the existing `trino.compiler.dump-classes-directory`.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix {func}`ST_Intersection`, {func}`ST_Difference`, {func}`ST_SymDifference`, {func}`ST_Union`, {func}`geometry_union`, and {func}`geometry_union_agg` failing with an internal error when an input geometry is topologically invalid. These failures are now reported as an invalid-argument error that describes the invalidity and its location. ({issue}`30584`)
* Fix {func}`convex_hull_agg` failing with an internal error when an input geometry is topologically invalid. ({issue}`30584`)
* Add the `trino.geospatial.legacy-lenient-overlay` JVM property to repair topologically invalid inputs to overlay and union operations and retry once, restoring the lenient behavior of the legacy Esri engine used before version 481. ({issue}`30584`)
```

cc/ @dain @raunaqmorarka @ebyhr

