### PR TITLE
Don't call ConnectorPageSource once its finished

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemPageSourceProvider.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemPageSourceProvider.java
@@ -132,8 +132,8 @@ public class SystemPageSourceProvider
         TupleDomain<Integer> newConstraint = systemSplit.getConstraint().transformKeys(columnHandle ->
                 columnsByName.get(((SystemColumnHandle) columnHandle).columnName()));
 
-        ConnectorAccessControl accessControl1 = new InjectedConnectorAccessControl(
-                accessControl,
+        ConnectorAccessControl accessControl = new InjectedConnectorAccessControl(
+                this.accessControl,
                 new SecurityContext(
                         systemTransaction.getTransactionId(),
                         ((FullConnectorSession) session).getSession().getIdentity(),
@@ -155,7 +155,7 @@ public class SystemPageSourceProvider
                             systemTransaction.getConnectorTransactionHandle(),
                             session,
                             newConstraint,
-                            accessControl1),
+                            accessControl),
                     userToSystemFieldIndex.build());
         }
         catch (UnsupportedOperationException e) {
@@ -167,7 +167,7 @@ public class SystemPageSourceProvider
                             newConstraint,
                             requiredColumns.build(),
                             systemSplit,
-                            accessControl1),
+                            accessControl),
                     userToSystemFieldIndex.build()));
         }
     }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -506,8 +506,8 @@ public class EventDrivenFaultTolerantQueryScheduler
                         (_, stageInfo) -> stageInfo.withSubStages(
                                 sourceFragments.stream()
                                         .map(sourceFragment -> {
-                                            StageInfo stageInfo1 = reportedStageInfos.get(sourceFragment);
-                                            return stageInfo1.stageId();
+                                            StageInfo fragmentStageInfo = reportedStageInfos.get(sourceFragment);
+                                            return fragmentStageInfo.stageId();
                                         })
                                         .collect(toImmutableList())));
             });

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -271,6 +271,9 @@ public class TableScanOperator
         }
         if (source == null) {
             source = pageSourceProvider.createPageSource(operatorContext.getSession(), split, table, tableCredentials, columns, DynamicFilter.EMPTY, pageSourceMemoryContext::setBytes);
+            if (source.isFinished()) {
+                return null;
+            }
         }
 
         SourcePage sourcePage = source.getNextSourcePage();

--- a/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalCasts.java
@@ -385,8 +385,8 @@ public final class DecimalCasts
     public static long longDecimalToSmallint(Int128 decimal, long precision, long scale, Int128 tenToScale)
     {
         try {
-            Int128 decimal1 = rescale(decimal, DecimalConversions.intScale(-scale));
-            return Shorts.checkedCast(decimal1.toLongExact());
+            Int128 rescaled = rescale(decimal, DecimalConversions.intScale(-scale));
+            return Shorts.checkedCast(rescaled.toLongExact());
         }
         catch (ArithmeticException | IllegalArgumentException e) {
             throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Cannot cast '%s' to SMALLINT", Decimals.toString(decimal, DecimalConversions.intScale(scale))));

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSource.java
@@ -54,6 +54,7 @@ public interface ConnectorPageSource
 
     /**
      * Gets the next page of data. This method is allowed to return null.
+     * This method is not called after {@link #isFinished()} returns {@code true}.
      */
     default SourcePage getNextSourcePage()
     {

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/LongOutputStreamV2.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/LongOutputStreamV2.java
@@ -213,8 +213,8 @@ public class LongOutputStreamV2
         // we need to compute zigzag values for DIRECT encoding if we decide to
         // break early for delta overflows or for shorter runs
         if (signed) {
-            for (int i1 = 0; i1 < numLiterals; i1++) {
-                zigzagLiterals[i1] = zigzagEncode(literals[i1]);
+            for (int i = 0; i < numLiterals; i++) {
+                zigzagLiterals[i] = zigzagEncode(literals[i]);
             }
         }
         else {

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestAggregations.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestAggregations.java
@@ -1506,27 +1506,27 @@ public abstract class AbstractTestAggregations
     @Test
     public void testApproxMostFrequentWithLongGroupBy()
     {
-        MaterializedResult actual1 = computeActual("SELECT k, approx_most_frequent(3, cast(v as bigint), 15) FROM (values ('a', 1), ('b', 2), ('a', 1), ('c', 3), ('a', 1), ('b', 2), ('c', 3), ('a', 4), ('b', 5)) t(k, v) GROUP BY 1 ORDER BY 1");
-        assertThat(actual1.getRowCount()).isEqualTo(3);
-        assertThat(actual1.getMaterializedRows().get(0).getFields().get(0)).isEqualTo("a");
-        assertThat(actual1.getMaterializedRows().get(0).getFields().get(1)).isEqualTo(ImmutableMap.of(1L, 3L, 4L, 1L));
-        assertThat(actual1.getMaterializedRows().get(1).getFields().get(0)).isEqualTo("b");
-        assertThat(actual1.getMaterializedRows().get(1).getFields().get(1)).isEqualTo(ImmutableMap.of(2L, 2L, 5L, 1L));
-        assertThat(actual1.getMaterializedRows().get(2).getFields().get(0)).isEqualTo("c");
-        assertThat(actual1.getMaterializedRows().get(2).getFields().get(1)).isEqualTo(ImmutableMap.of(3L, 2L));
+        MaterializedResult actual = computeActual("SELECT k, approx_most_frequent(3, cast(v as bigint), 15) FROM (values ('a', 1), ('b', 2), ('a', 1), ('c', 3), ('a', 1), ('b', 2), ('c', 3), ('a', 4), ('b', 5)) t(k, v) GROUP BY 1 ORDER BY 1");
+        assertThat(actual.getRowCount()).isEqualTo(3);
+        assertThat(actual.getMaterializedRows().get(0).getFields().get(0)).isEqualTo("a");
+        assertThat(actual.getMaterializedRows().get(0).getFields().get(1)).isEqualTo(ImmutableMap.of(1L, 3L, 4L, 1L));
+        assertThat(actual.getMaterializedRows().get(1).getFields().get(0)).isEqualTo("b");
+        assertThat(actual.getMaterializedRows().get(1).getFields().get(1)).isEqualTo(ImmutableMap.of(2L, 2L, 5L, 1L));
+        assertThat(actual.getMaterializedRows().get(2).getFields().get(0)).isEqualTo("c");
+        assertThat(actual.getMaterializedRows().get(2).getFields().get(1)).isEqualTo(ImmutableMap.of(3L, 2L));
     }
 
     @Test
     public void testApproxMostFrequentWithStringGroupBy()
     {
-        MaterializedResult actual1 = computeActual("SELECT k, approx_most_frequent(3, v, 15) FROM (values ('a', 'A'), ('b', 'B'), ('a', 'A'), ('c', 'C'), ('a', 'A'), ('b', 'B'), ('c', 'C'), ('a', 'D'), ('b', 'E')) t(k, v) GROUP BY 1 ORDER BY 1");
-        assertThat(actual1.getRowCount()).isEqualTo(3);
-        assertThat(actual1.getMaterializedRows().get(0).getFields().get(0)).isEqualTo("a");
-        assertThat(actual1.getMaterializedRows().get(0).getFields().get(1)).isEqualTo(ImmutableMap.of("A", 3L, "D", 1L));
-        assertThat(actual1.getMaterializedRows().get(1).getFields().get(0)).isEqualTo("b");
-        assertThat(actual1.getMaterializedRows().get(1).getFields().get(1)).isEqualTo(ImmutableMap.of("B", 2L, "E", 1L));
-        assertThat(actual1.getMaterializedRows().get(2).getFields().get(0)).isEqualTo("c");
-        assertThat(actual1.getMaterializedRows().get(2).getFields().get(1)).isEqualTo(ImmutableMap.of("C", 2L));
+        MaterializedResult actual = computeActual("SELECT k, approx_most_frequent(3, v, 15) FROM (values ('a', 'A'), ('b', 'B'), ('a', 'A'), ('c', 'C'), ('a', 'A'), ('b', 'B'), ('c', 'C'), ('a', 'D'), ('b', 'E')) t(k, v) GROUP BY 1 ORDER BY 1");
+        assertThat(actual.getRowCount()).isEqualTo(3);
+        assertThat(actual.getMaterializedRows().get(0).getFields().get(0)).isEqualTo("a");
+        assertThat(actual.getMaterializedRows().get(0).getFields().get(1)).isEqualTo(ImmutableMap.of("A", 3L, "D", 1L));
+        assertThat(actual.getMaterializedRows().get(1).getFields().get(0)).isEqualTo("b");
+        assertThat(actual.getMaterializedRows().get(1).getFields().get(1)).isEqualTo(ImmutableMap.of("B", 2L, "E", 1L));
+        assertThat(actual.getMaterializedRows().get(2).getFields().get(0)).isEqualTo("c");
+        assertThat(actual.getMaterializedRows().get(2).getFields().get(1)).isEqualTo(ImmutableMap.of("C", 2L));
     }
 
     @Test


### PR DESCRIPTION
It's natural expectation that `getNextSourcePage()` is not called when page source is finished. Fix the code not to violate that.
