### PR TITLE
Replace decimal avg with sum and count when sum is already computed

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -131,6 +131,7 @@ import io.trino.operator.scalar.CombineHashFunction;
 import io.trino.operator.scalar.ConcatWsFunction;
 import io.trino.operator.scalar.DataSizeFunctions;
 import io.trino.operator.scalar.DateTimeFunctions;
+import io.trino.operator.scalar.DivideRoundToScale;
 import io.trino.operator.scalar.EmptyMapConstructor;
 import io.trino.operator.scalar.FailureFunction;
 import io.trino.operator.scalar.FormatNumberFunction;
@@ -537,6 +538,7 @@ public final class SystemFunctionBundle
                 .scalars(featuresConfig.isLegacyVarcharToCharCoercion() ? LegacyCharToVarcharCast.class : CharToVarcharCast.class)
                 .scalars(LuhnCheckFunction.class)
                 .scalar(DecimalOperators.Negation.class)
+                .scalars(DivideRoundToScale.class)
                 .functions(IDENTITY_CAST, CAST_FROM_UNKNOWN)
                 .scalar(ArrayRemoveFunction.class)
                 .scalar(ArrayElementAtFunction.class)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DivideRoundToScale.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DivideRoundToScale.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.Int128Math;
+import io.trino.spi.type.StandardTypes;
+
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
+import static io.trino.spi.type.Decimals.overflows;
+
+/// Divides a decimal by an integer count and rounds the quotient (HALF_UP) to the dividend's scale.
+/// This is unlike the built-in decimal `/` operator, which widens the result scale to at least 6.
+///
+/// This can be used when exact original scale is needed and `/ + CAST`'s double rounding is
+/// unacceptable. In particular, this is designed so that:
+/// ```
+/// avg(x) = divide_round_to_scale(sum(x), count(x))
+/// ```
+public final class DivideRoundToScale
+{
+    public static final String NAME = "$divide_round_to_scale";
+
+    private DivideRoundToScale() {}
+
+    @ScalarFunction(value = NAME, hidden = true)
+    @Description("Divides a decimal by an integer count, rounding HALF_UP to the dividend's scale")
+    @LiteralParameters({"p", "s"})
+    @SqlType("decimal(p, s)")
+    public static Int128 divideRoundToScale(
+            @SqlType("decimal(p, s)") Int128 dividend,
+            @SqlType(StandardTypes.BIGINT) long count)
+    {
+        Int128 result = Int128Math.divideRoundUp(dividend.getHigh(), dividend.getLow(), 0, 0, count, 0);
+        if (overflows(result)) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Decimal overflow");
+        }
+        return result;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -217,6 +217,7 @@ import io.trino.sql.planner.iterative.rule.RemoveUnreferencedScalarApplyNodes;
 import io.trino.sql.planner.iterative.rule.RemoveUnreferencedScalarSubqueries;
 import io.trino.sql.planner.iterative.rule.RemoveUnsupportedDynamicFilters;
 import io.trino.sql.planner.iterative.rule.ReorderJoins;
+import io.trino.sql.planner.iterative.rule.ReplaceDecimalSumAndAvgWithSumAndCount;
 import io.trino.sql.planner.iterative.rule.ReplaceJoinOverConstantWithProject;
 import io.trino.sql.planner.iterative.rule.ReplaceRedundantJoinWithProject;
 import io.trino.sql.planner.iterative.rule.ReplaceRedundantJoinWithSource;
@@ -837,6 +838,7 @@ public class PlanOptimizers
                         .add(new InlineProjections())
                         .add(new PushFilterIntoValues(plannerContext))
                         .add(new ReplaceJoinOverConstantWithProject())
+                        .add(new ReplaceDecimalSumAndAvgWithSumAndCount(plannerContext)) // must run after unreferenced columns are pruned
                         .build()));
 
         builder.add(new IterativeOptimizer(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReplaceDecimalSumAndAvgWithSumAndCount.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReplaceDecimalSumAndAvgWithSumAndCount.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.operator.scalar.DivideRoundToScale;
+import io.trino.spi.function.CatalogSchemaFunctionName;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Type;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.analyzer.TypeDescriptorProvider;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Cast;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.AggregationNode;
+import io.trino.sql.planner.plan.AggregationNode.Aggregation;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.ProjectNode;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.planner.plan.AggregationNode.Step.SINGLE;
+import static io.trino.sql.planner.plan.Patterns.Aggregation.step;
+import static io.trino.sql.planner.plan.Patterns.aggregation;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Rewrites a decimal {@code avg(x)} into a projection over {@code sum(x)} and {@code count(x)} when
+ * the aggregation already computes {@code sum(x)}, so the decimal summation is not done twice.
+ * <p>
+ * Decimal only: for {@code double}/{@code real}/{@code bigint} avg and count cost about the same.
+ */
+public class ReplaceDecimalSumAndAvgWithSumAndCount
+        implements Rule<AggregationNode>
+{
+    private static final CatalogSchemaFunctionName AVG_NAME = builtinFunctionName("avg");
+    private static final CatalogSchemaFunctionName SUM_NAME = builtinFunctionName("sum");
+    private static final CatalogSchemaFunctionName COUNT_NAME = builtinFunctionName("count");
+
+    private static final Pattern<AggregationNode> PATTERN = aggregation()
+            .with(step().equalTo(SINGLE));
+
+    private final PlannerContext plannerContext;
+
+    public ReplaceDecimalSumAndAvgWithSumAndCount(PlannerContext plannerContext)
+    {
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+    }
+
+    @Override
+    public Pattern<AggregationNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(AggregationNode node, Captures captures, Context context)
+    {
+        Map<Symbol, Aggregation> aggregations = node.getAggregations();
+
+        Map<Symbol, Aggregation> newAggregations = new LinkedHashMap<>(aggregations);
+        Assignments.Builder projections = Assignments.builder()
+                .putIdentities(node.getGroupingKeys());
+        boolean rewritten = false;
+
+        for (Map.Entry<Symbol, Aggregation> entry : aggregations.entrySet()) {
+            Symbol symbol = entry.getKey();
+            if (!isDecimalAvg(entry.getValue())) {
+                projections.putIdentity(symbol);
+                continue;
+            }
+            Aggregation avg = entry.getValue();
+            Expression argument = getOnlyElement(avg.getArguments());
+
+            Optional<Symbol> sumSymbol = matchingAggregation(aggregations, SUM_NAME, argument, avg.getMask());
+            if (sumSymbol.isEmpty()) {
+                projections.putIdentity(symbol);
+                continue;
+            }
+
+            // Reuse an existing count(x) over the same argument and mask or create new one
+            Symbol countSymbol = matchingAggregation(aggregations, COUNT_NAME, argument, avg.getMask())
+                    .orElseGet(() -> {
+                        ResolvedFunction countFunction = plannerContext.getMetadata()
+                                .resolveBuiltinFunction("count", TypeDescriptorProvider.fromTypes(argument.type()));
+                        Symbol newCount = context.getSymbolAllocator().newSymbol("count", BIGINT);
+                        newAggregations.put(newCount, new Aggregation(
+                                countFunction,
+                                ImmutableList.of(argument),
+                                false,
+                                Optional.empty(),
+                                Optional.empty(),
+                                avg.getMask()));
+                        return newCount;
+                    });
+
+            newAggregations.remove(symbol);
+
+            Type sumType = aggregations.get(sumSymbol.get()).getResolvedFunction().signature().getReturnType();
+            ResolvedFunction reconstruct = plannerContext.getMetadata()
+                    .resolveBuiltinFunction(DivideRoundToScale.NAME, TypeDescriptorProvider.fromTypes(sumType, BIGINT));
+            Expression average = new Call(reconstruct, ImmutableList.of(
+                    sumSymbol.get().toSymbolReference(),
+                    countSymbol.toSymbolReference()));
+
+            Type avgOutputType = avg.getResolvedFunction().signature().getReturnType();
+            projections.put(symbol, castIfNecessary(average, avgOutputType));
+            rewritten = true;
+        }
+
+        if (!rewritten) {
+            return Result.empty();
+        }
+
+        AggregationNode newAggregation = AggregationNode.builderFrom(node)
+                .setAggregations(newAggregations)
+                .build();
+
+        return Result.ofPlanNode(new ProjectNode(
+                context.getIdAllocator().getNextId(),
+                newAggregation,
+                projections.build()));
+    }
+
+    private static boolean isDecimalAvg(Aggregation aggregation)
+    {
+        return aggregation.getResolvedFunction().signature().getName().equals(AVG_NAME)
+                && isPlainSingleArgument(aggregation)
+                && getOnlyElement(aggregation.getArguments()).type() instanceof DecimalType;
+    }
+
+    private static Optional<Symbol> matchingAggregation(Map<Symbol, Aggregation> aggregations, CatalogSchemaFunctionName name, Expression argument, Optional<Symbol> mask)
+    {
+        for (Map.Entry<Symbol, Aggregation> candidate : aggregations.entrySet()) {
+            Aggregation aggregation = candidate.getValue();
+            if (aggregation.getResolvedFunction().signature().getName().equals(name)
+                    && isPlainSingleArgument(aggregation)
+                    && getOnlyElement(aggregation.getArguments()).equals(argument)
+                    && aggregation.getMask().equals(mask)) {
+                return Optional.of(candidate.getKey());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isPlainSingleArgument(Aggregation aggregation)
+    {
+        return !aggregation.isDistinct()
+                && aggregation.getFilter().isEmpty()
+                && aggregation.getOrderingScheme().isEmpty()
+                && aggregation.getArguments().size() == 1;
+    }
+
+    private static Expression castIfNecessary(Expression expression, Type targetType)
+    {
+        if (expression.type().equals(targetType)) {
+            return expression;
+        }
+        return new Cast(expression, targetType);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceDecimalSumAndAvgWithSumAndCount.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceDecimalSumAndAvgWithSumAndCount.java
@@ -1,0 +1,355 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.scalar.DivideRoundToScale;
+import io.trino.spi.type.DecimalType;
+import io.trino.sql.analyzer.TypeDescriptorProvider;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Cast;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.assertions.ExpressionMatcher;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import io.trino.sql.planner.plan.AggregationNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Predicate;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregationFunction;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+class TestReplaceDecimalSumAndAvgWithSumAndCount
+        extends BaseRuleTest
+{
+    private static final DecimalType DECIMAL = createDecimalType(10, 2);
+    private static final DecimalType SUM_TYPE = createDecimalType(38, 2);
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final ResolvedFunction DIVIDE_ROUND_TO_SCALE = FUNCTIONS.resolveFunction(
+            DivideRoundToScale.NAME,
+            TypeDescriptorProvider.fromTypes(SUM_TYPE, BIGINT));
+
+    // avg is rebuilt as $divide_round_to_scale(sum, count) cast back to avg's decimal(10, 2) output type
+    private static ExpressionMatcher reconstructedAverage(String sumSymbol, String countSymbol)
+    {
+        return expression(new Cast(
+                new Call(DIVIDE_ROUND_TO_SCALE, ImmutableList.of(
+                        new Reference(SUM_TYPE, sumSymbol),
+                        new Reference(BIGINT, countSymbol))),
+                DECIMAL));
+    }
+
+    @Test
+    void testReplacesDecimalAvgReusingSum()
+    {
+        tester().assertThat(new ReplaceDecimalSumAndAvgWithSumAndCount(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol input = p.symbol("col", DECIMAL);
+                    Symbol avgOutput = p.symbol("avg_out", DECIMAL);
+                    Symbol sumOutput = p.symbol("sum_out", createDecimalType(38, 2));
+                    return p.aggregation(a -> a
+                            .globalGrouping()
+                            .addAggregation(
+                                    avgOutput,
+                                    PlanBuilder.aggregation("avg", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL))
+                            .addAggregation(
+                                    sumOutput,
+                                    PlanBuilder.aggregation("sum", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL))
+                            .source(p.values(input)));
+                })
+                .matches(project(
+                        ImmutableMap.of("avg_out", reconstructedAverage("sum_out", "count")),
+                        aggregation(
+                                ImmutableMap.of(
+                                        "sum_out", aggregationFunction("sum", ImmutableList.of("col")),
+                                        "count", aggregationFunction("count", ImmutableList.of("col"))),
+                                values("col"))));
+    }
+
+    @Test
+    void testReplacesDecimalAvgWithGroupBy()
+    {
+        tester().assertThat(new ReplaceDecimalSumAndAvgWithSumAndCount(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol input = p.symbol("col", DECIMAL);
+                    Symbol groupKey = p.symbol("grp", DECIMAL);
+                    Symbol avgOutput = p.symbol("avg_out", DECIMAL);
+                    Symbol sumOutput = p.symbol("sum_out", createDecimalType(38, 2));
+                    return p.aggregation(a -> a
+                            .singleGroupingSet(groupKey)
+                            .addAggregation(
+                                    avgOutput,
+                                    PlanBuilder.aggregation("avg", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL))
+                            .addAggregation(
+                                    sumOutput,
+                                    PlanBuilder.aggregation("sum", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL))
+                            .source(p.values(input, groupKey)));
+                })
+                .matches(project(
+                        ImmutableMap.of("avg_out", reconstructedAverage("sum_out", "count")),
+                        aggregation(
+                                singleGroupingSet("grp"),
+                                ImmutableMap.of(
+                                        "sum_out", aggregationFunction("sum", ImmutableList.of("col")),
+                                        "count", aggregationFunction("count", ImmutableList.of("col"))),
+                                values("col", "grp"))));
+    }
+
+    @Test
+    void testReusesExistingCount()
+    {
+        // When the query already computes count(x), the rewrite must reuse it rather than add a
+        // second identical count. The predicate asserts exactly two aggregations survive (the reused
+        // sum and count), so no duplicate count is introduced.
+        tester().assertThat(new ReplaceDecimalSumAndAvgWithSumAndCount(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol input = p.symbol("col", DECIMAL);
+                    Symbol avgOutput = p.symbol("avg_out", DECIMAL);
+                    Symbol sumOutput = p.symbol("sum_out", createDecimalType(38, 2));
+                    Symbol countOutput = p.symbol("count_out", BIGINT);
+                    return p.aggregation(a -> a
+                            .globalGrouping()
+                            .addAggregation(
+                                    avgOutput,
+                                    PlanBuilder.aggregation("avg", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL))
+                            .addAggregation(
+                                    sumOutput,
+                                    PlanBuilder.aggregation("sum", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL))
+                            .addAggregation(
+                                    countOutput,
+                                    PlanBuilder.aggregation("count", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL))
+                            .source(p.values(input)));
+                })
+                .matches(project(
+                        ImmutableMap.of("avg_out", reconstructedAverage("sum_out", "count_out")),
+                        aggregation(
+                                ImmutableMap.of(
+                                        "sum_out", aggregationFunction("sum", ImmutableList.of("col")),
+                                        "count_out", aggregationFunction("count", ImmutableList.of("col"))),
+                                (Predicate<AggregationNode>) node -> node.getAggregations().size() == 2,
+                                values("col"))));
+    }
+
+    @Test
+    void testDoesNotReuseCountWithDifferentMask()
+    {
+        // avg and sum share a mask so the rewrite fires, but the existing count(x) carries a
+        // different mask, so it must not be reused: a new count with avg's mask is added, leaving
+        // three aggregations (sum, the untouched count, and the new count).
+        tester().assertThat(new ReplaceDecimalSumAndAvgWithSumAndCount(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol input = p.symbol("col", DECIMAL);
+                    Symbol avgSumMask = p.symbol("avg_sum_mask", BOOLEAN);
+                    Symbol countMask = p.symbol("count_mask", BOOLEAN);
+                    Symbol avgOutput = p.symbol("avg_out", DECIMAL);
+                    Symbol sumOutput = p.symbol("sum_out", createDecimalType(38, 2));
+                    Symbol countOutput = p.symbol("count_out", BIGINT);
+                    return p.aggregation(a -> a
+                            .globalGrouping()
+                            .addAggregation(
+                                    avgOutput,
+                                    PlanBuilder.aggregation("avg", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL),
+                                    avgSumMask)
+                            .addAggregation(
+                                    sumOutput,
+                                    PlanBuilder.aggregation("sum", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL),
+                                    avgSumMask)
+                            .addAggregation(
+                                    countOutput,
+                                    PlanBuilder.aggregation("count", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL),
+                                    countMask)
+                            .source(p.values(input, avgSumMask, countMask)));
+                })
+                .matches(project(
+                        aggregation(
+                                ImmutableMap.of("sum_out", aggregationFunction("sum", ImmutableList.of("col"))),
+                                (Predicate<AggregationNode>) node -> node.getAggregations().size() == 3,
+                                values("col", "avg_sum_mask", "count_mask"))));
+    }
+
+    @Test
+    void testPropagatesMaskToCount()
+    {
+        // avg and sum share the same mask, so the rewrite fires; the new count must carry that mask,
+        // otherwise the reconstructed average would divide the masked sum by an unmasked count.
+        tester().assertThat(new ReplaceDecimalSumAndAvgWithSumAndCount(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol input = p.symbol("col", DECIMAL);
+                    Symbol mask = p.symbol("mask", BOOLEAN);
+                    Symbol avgOutput = p.symbol("avg_out", DECIMAL);
+                    Symbol sumOutput = p.symbol("sum_out", createDecimalType(38, 2));
+                    return p.aggregation(a -> a
+                            .globalGrouping()
+                            .addAggregation(
+                                    avgOutput,
+                                    PlanBuilder.aggregation("avg", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL),
+                                    mask)
+                            .addAggregation(
+                                    sumOutput,
+                                    PlanBuilder.aggregation("sum", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL),
+                                    mask)
+                            .source(p.values(input, mask)));
+                })
+                .matches(project(
+                        ImmutableMap.of("avg_out", reconstructedAverage("sum_out", "count")),
+                        aggregation(
+                                ImmutableMap.of(
+                                        "sum_out", aggregationFunction("sum", ImmutableList.of("col")),
+                                        "count", aggregationFunction("count", ImmutableList.of("col"))),
+                                // every surviving aggregation (sum and the new count) keeps the mask
+                                (Predicate<AggregationNode>) node -> node.getAggregations().values().stream()
+                                        .allMatch(aggregation -> aggregation.getMask().isPresent()),
+                                values("col", "mask"))));
+    }
+
+    @Test
+    void testDoesNotFireWhenAvgAndSumMasksDiffer()
+    {
+        tester().assertThat(new ReplaceDecimalSumAndAvgWithSumAndCount(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol input = p.symbol("col", DECIMAL);
+                    Symbol avgMask = p.symbol("avg_mask", BOOLEAN);
+                    Symbol sumMask = p.symbol("sum_mask", BOOLEAN);
+                    Symbol avgOutput = p.symbol("avg_out", DECIMAL);
+                    Symbol sumOutput = p.symbol("sum_out", createDecimalType(38, 2));
+                    return p.aggregation(a -> a
+                            .globalGrouping()
+                            .addAggregation(
+                                    avgOutput,
+                                    PlanBuilder.aggregation("avg", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL),
+                                    avgMask)
+                            .addAggregation(
+                                    sumOutput,
+                                    PlanBuilder.aggregation("sum", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL),
+                                    sumMask)
+                            .source(p.values(input, avgMask, sumMask)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    void testDoesNotFireWithoutMatchingSum()
+    {
+        tester().assertThat(new ReplaceDecimalSumAndAvgWithSumAndCount(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol input = p.symbol("col", DECIMAL);
+                    Symbol avgOutput = p.symbol("avg_out", DECIMAL);
+                    return p.aggregation(a -> a
+                            .globalGrouping()
+                            .addAggregation(
+                                    avgOutput,
+                                    PlanBuilder.aggregation("avg", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL))
+                            .source(p.values(input)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    void testDoesNotFireWhenSumOverDifferentColumn()
+    {
+        tester().assertThat(new ReplaceDecimalSumAndAvgWithSumAndCount(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol input = p.symbol("col", DECIMAL);
+                    Symbol other = p.symbol("other", DECIMAL);
+                    Symbol avgOutput = p.symbol("avg_out", DECIMAL);
+                    Symbol sumOutput = p.symbol("sum_out", createDecimalType(38, 2));
+                    return p.aggregation(a -> a
+                            .globalGrouping()
+                            .addAggregation(
+                                    avgOutput,
+                                    PlanBuilder.aggregation("avg", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL))
+                            .addAggregation(
+                                    sumOutput,
+                                    PlanBuilder.aggregation("sum", ImmutableList.of(new Reference(DECIMAL, "other"))),
+                                    ImmutableList.of(DECIMAL))
+                            .source(p.values(input, other)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    void testDoesNotFireForDoubleAvg()
+    {
+        tester().assertThat(new ReplaceDecimalSumAndAvgWithSumAndCount(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol input = p.symbol("col", DOUBLE);
+                    Symbol avgOutput = p.symbol("avg_out", DOUBLE);
+                    Symbol sumOutput = p.symbol("sum_out", DOUBLE);
+                    return p.aggregation(a -> a
+                            .globalGrouping()
+                            .addAggregation(
+                                    avgOutput,
+                                    PlanBuilder.aggregation("avg", ImmutableList.of(new Reference(DOUBLE, "col"))),
+                                    ImmutableList.of(DOUBLE))
+                            .addAggregation(
+                                    sumOutput,
+                                    PlanBuilder.aggregation("sum", ImmutableList.of(new Reference(DOUBLE, "col"))),
+                                    ImmutableList.of(DOUBLE))
+                            .source(p.values(input)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    void testDoesNotFireForDistinctAvg()
+    {
+        tester().assertThat(new ReplaceDecimalSumAndAvgWithSumAndCount(tester().getPlannerContext()))
+                .on(p -> {
+                    Symbol input = p.symbol("col", DECIMAL);
+                    Symbol avgOutput = p.symbol("avg_out", DECIMAL);
+                    Symbol sumOutput = p.symbol("sum_out", createDecimalType(38, 2));
+                    return p.aggregation(a -> a
+                            .globalGrouping()
+                            .addAggregation(
+                                    avgOutput,
+                                    PlanBuilder.aggregation("avg", true, ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL))
+                            .addAggregation(
+                                    sumOutput,
+                                    PlanBuilder.aggregation("sum", ImmutableList.of(new Reference(DECIMAL, "col"))),
+                                    ImmutableList.of(DECIMAL))
+                            .source(p.values(input)));
+                })
+                .doesNotFire();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestDecimalAvgFromSumAndCount.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestDecimalAvgFromSumAndCount.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregationFunction;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+/**
+ * Exercises {@code ReplaceDecimalAvgWithSumAndCount}: whenever a query computes both {@code sum(x)}
+ * and {@code avg(x)} over a decimal column, avg is reconstructed from the reused sum and a new
+ * count. These queries therefore run through the rewrite, and must return exactly what the built-in
+ * decimal avg would.
+ */
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+final class TestDecimalAvgFromSumAndCount
+{
+    private final QueryAssertions assertions = new QueryAssertions();
+
+    @AfterAll
+    void teardown()
+    {
+        assertions.close();
+    }
+
+    @Test
+    void testReusesSumWithHalfUpRounding()
+    {
+        // 5.00 / 3 = 1.6666... rounds HALF_UP to 1.67
+        assertThat(assertions.query(
+                "SELECT avg(v), sum(v), count(v) " +
+                        "FROM (VALUES DECIMAL '1.00', DECIMAL '2.00', DECIMAL '2.00') t(v)"))
+                .matches("VALUES (DECIMAL '1.67', CAST(DECIMAL '5.00' AS decimal(38, 2)), BIGINT '3')");
+    }
+
+    @Test
+    void testAvgIsReplacedInPlan()
+    {
+        // Guards that the rule is actually wired into the optimizer (registered and placed so it
+        // fires): the aggregation over v must hold sum and count -- the count exists only because
+        // avg was rewritten. Without the rewrite it would be sum and avg, with no count(v). A
+        // result-based test cannot catch this, since avg computed the normal way returns the same
+        // numbers.
+        assertThat(assertions.query(
+                "SELECT avg(v), sum(v) FROM (VALUES DECIMAL '1.00', DECIMAL '2.00') t(v)"))
+                .matches(anyTree(
+                        aggregation(
+                                ImmutableMap.of(
+                                        "sum_out", aggregationFunction("sum", ImmutableList.of("v")),
+                                        "count_out", aggregationFunction("count", ImmutableList.of("v"))),
+                                values("v"))));
+    }
+
+    @Test
+    void testHalfUpTie()
+    {
+        // 0.03 / 2 = 0.015, the HALF_UP tie rounds up to 0.02
+        assertThat(assertions.query(
+                "SELECT avg(v), sum(v) FROM (VALUES DECIMAL '0.01', DECIMAL '0.02') t(v)"))
+                .matches("VALUES (DECIMAL '0.02', CAST(DECIMAL '0.03' AS decimal(38, 2)))");
+    }
+
+    @Test
+    void testNegativeHalfUpTie()
+    {
+        // -0.03 / 2 = -0.015, HALF_UP rounds away from zero to -0.02
+        assertThat(assertions.query(
+                "SELECT avg(v), sum(v) FROM (VALUES DECIMAL '-0.01', DECIMAL '-0.02') t(v)"))
+                .matches("VALUES (DECIMAL '-0.02', CAST(DECIMAL '-0.03' AS decimal(38, 2)))");
+    }
+
+    @Test
+    void testDividesByNonNullCountNotRowCount()
+    {
+        // A null value is summed and counted as absent: avg is 10.00, not 5.00
+        assertThat(assertions.query(
+                "SELECT avg(v), sum(v) FROM (VALUES DECIMAL '10.00', CAST(NULL AS decimal(4, 2))) t(v)"))
+                .matches("VALUES (DECIMAL '10.00', CAST(DECIMAL '10.00' AS decimal(38, 2)))");
+    }
+
+    @Test
+    void testDoesNotForceSumMaterializationWhenSumIsUnused()
+    {
+        // sum(x) overflows decimal(38, 0) but avg(x) does not. The outer predicate `true OR s > 0`
+        // simplifies to TRUE, so sum is unused and gets pruned -- the query must succeed and return
+        // just the average. Reconstructing avg from sum must not pin sum alive and reintroduce the
+        // overflow.
+        assertThat(assertions.query(
+                """
+                SELECT a FROM (
+                  SELECT sum(v) s, avg(v) a
+                  FROM (VALUES DECIMAL '99999999999999999999999999999999999999', DECIMAL '99999999999999999999999999999999999999') t(v)
+                ) u WHERE true OR s > DECIMAL '0'
+                """))
+                .matches("VALUES DECIMAL '99999999999999999999999999999999999999'");
+    }
+
+    @Test
+    void testAllNullGroupIsNull()
+    {
+        assertThat(assertions.query(
+                "SELECT avg(v), sum(v), count(v) FROM (VALUES CAST(NULL AS decimal(10, 2))) t(v)"))
+                .matches("VALUES (CAST(NULL AS decimal(10, 2)), CAST(NULL AS decimal(38, 2)), BIGINT '0')");
+    }
+
+    @Test
+    void testReusesMaskForFilteredAverage()
+    {
+        // avg and sum share the FILTER predicate, so they share a mask and the rewrite fires. The
+        // mask must reach the new count. GROUP BY is used deliberately: for a global aggregation
+        // where every aggregate is filtered, ImplementFilteredAggregations pre-filters the rows
+        // with a FilterNode, which would mask the count regardless. With a grouping set no such
+        // filter is added, so the count's own mask is what restricts it. In group 1 the filter
+        // drops 1.00, leaving 2.00 and 4.00: avg is 6.00 / 2 = 3.00, not 6.00 / 3.
+        assertThat(assertions.query(
+                """
+                SELECT k, avg(v) FILTER (WHERE v > DECIMAL '1.00'), sum(v) FILTER (WHERE v > DECIMAL '1.00')
+                FROM (VALUES (1, DECIMAL '1.00'), (1, DECIMAL '2.00'), (1, DECIMAL '4.00'), (2, DECIMAL '10.00')) t(k, v)
+                GROUP BY k"""))
+                .matches(
+                        """
+                        VALUES
+                          (1, CAST(DECIMAL '3.00' AS decimal(4, 2)), CAST(DECIMAL '6.00' AS decimal(38, 2))),
+                          (2, CAST(DECIMAL '10.00' AS decimal(4, 2)), CAST(DECIMAL '10.00' AS decimal(38, 2)))""");
+    }
+
+    @Test
+    void testGroupBy()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT k, avg(v), sum(v) FROM (VALUES (1, DECIMAL '1.00'), (1, DECIMAL '2.00'), (2, DECIMAL '10.00')) t(k, v)
+                GROUP BY k"""))
+                .matches("VALUES " +
+                        "(1, CAST(DECIMAL '1.50' AS decimal(4, 2)), CAST(DECIMAL '3.00' AS decimal(38, 2))), " +
+                        "(2, CAST(DECIMAL '10.00' AS decimal(4, 2)), CAST(DECIMAL '10.00' AS decimal(38, 2)))");
+    }
+
+    @Test
+    void testAvoidsDoubleRoundingOfPlainDivide()
+    {
+        // 488999.99 / 200000 = 2.44499995. The correct HALF_UP-to-scale-2 average is 2.44. Trino's
+        // decimal / operator instead lands at scale 6 (2.445000, its minimum divide scale for a
+        // scale-2 dividend), and casting that back to scale 2 rounds a second time to 2.45. The
+        // reconstruction rounds only once, to the dividend's scale, so it stays 2.44.
+        assertThat(assertions.query(
+                "SELECT \"$divide_round_to_scale\"(CAST(488999.99 AS decimal(38, 2)), BIGINT '200000')"))
+                .matches("VALUES CAST(2.44 AS decimal(38, 2))");
+        assertThat(assertions.query(
+                "SELECT CAST(CAST(488999.99 AS decimal(38, 2)) / CAST(200000 AS bigint) AS decimal(38, 2))"))
+                .matches("VALUES CAST(2.45 AS decimal(38, 2))");
+    }
+
+    @Test
+    void testLargeSumReusedForAverage()
+    {
+        // sum needs the wide decimal(38, s); the average narrows back to the input precision
+        assertThat(assertions.query(
+                "SELECT avg(v), sum(v) FROM (VALUES DECIMAL '99999999.99', DECIMAL '99999999.99', DECIMAL '99999999.97') t(v)"))
+                .matches("VALUES (DECIMAL '99999999.98', CAST(DECIMAL '299999999.95' AS decimal(38, 2)))");
+    }
+
+    @Test
+    void testLongDecimalReusesSum()
+    {
+        // A long decimal (precision > 18, Int128-backed): the sum overflows a long, so the whole
+        // summation and division runs through the Int128 path. 7.0000 / 3 = 2.33333... rounds
+        // HALF_UP to scale 4 as 2.3333.
+        assertThat(assertions.query(
+                """
+                SELECT avg(v), sum(v), count(v) FROM (VALUES
+                CAST(10000000000000000000.0001 AS decimal(25, 4)),
+                CAST(20000000000000000000.0002 AS decimal(25, 4)),
+                CAST(40000000000000000000.0004 AS decimal(25, 4))) t(v)
+                """))
+                .matches(
+                        """
+                        VALUES (
+                          CAST(23333333333333333333.3336 AS decimal(25, 4)),
+                          CAST(70000000000000000000.0007 AS decimal(38, 4)),
+                          BIGINT '3')""");
+    }
+
+    @Test
+    void testSumOverflowStillFails()
+    {
+        // Built-in avg would survive this via the BigDecimal fallback in DecimalAverageAggregation,
+        // but the query also computes sum(v), which overflows decimal(38, 0). The reconstruction
+        // reuses that sum, so the query must still fail with NUMERIC_VALUE_OUT_OF_RANGE rather than
+        // silently divide an overflowed sum.
+        assertThat(assertions.query(
+                """
+                SELECT avg(v), sum(v) FROM (VALUES
+                  DECIMAL '99999999999999999999999999999999999999',
+                  DECIMAL '99999999999999999999999999999999999999') t(v)
+                """))
+                .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
+    }
+
+    @Test
+    void testLongDecimalHalfUpRounding()
+    {
+        // Int128 rounding at the widest scale: the exact average lands on a HALF_UP tie in the last
+        // digit. 66666666666666666666.6666666667 / 2 = 33333333333333333333.33333333335, which
+        // rounds up to ...334 at scale 10.
+        assertThat(assertions.query(
+                """
+                SELECT avg(v), sum(v), count(v) FROM (VALUES
+                  CAST(33333333333333333333.3333333333 AS decimal(38, 10)),
+                  CAST(33333333333333333333.3333333334 AS decimal(38, 10))) t(v)
+                """))
+                .matches(
+                        """
+                        VALUES (
+                          CAST(33333333333333333333.3333333334 AS decimal(38, 10)),
+                          CAST(66666666666666666666.6666666667 AS decimal(38, 10)),
+                          BIGINT '2')""");
+    }
+}


### PR DESCRIPTION
When an aggregation computes both `avg(x)` and `sum(x)` over the same (decimal) column, `avg`'s accumulator duplicates the summation that `sum(x)` already does. Drop the `avg` aggregation, reuse the existing sum, add a `count(x)`, and reconstruct the average as a projection.

Restricted to decimal: for double/real/bigint, avg and count cost about the same, so the swap would not pay off.

This reduces amount of memory needed for TPCH Q01 aggregation (`avg(l.quantity)`, `avg(l.extendedprice)`).