### PR TITLE
Unwrap `at_timezone` in comparisons for constant zones

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -242,6 +242,7 @@ import io.trino.sql.planner.iterative.rule.TransformExistsApplyToCorrelatedJoin;
 import io.trino.sql.planner.iterative.rule.TransformFilteringSemiJoinToInnerJoin;
 import io.trino.sql.planner.iterative.rule.TransformUncorrelatedInPredicateSubqueryToSemiJoin;
 import io.trino.sql.planner.iterative.rule.TransformUncorrelatedSubqueryToJoin;
+import io.trino.sql.planner.iterative.rule.UnwrapAtTimeZoneInComparison;
 import io.trino.sql.planner.iterative.rule.UnwrapCastInComparison;
 import io.trino.sql.planner.iterative.rule.UnwrapDateTruncInComparison;
 import io.trino.sql.planner.iterative.rule.UnwrapRowSubscript;
@@ -376,6 +377,7 @@ public class PlanOptimizers
                 .addAll(new PushCastIntoRow(plannerContext).rules())
                 .addAll(new UnwrapCastInComparison(plannerContext).rules())
                 .addAll(new UnwrapDateTruncInComparison(plannerContext).rules())
+                .addAll(new UnwrapAtTimeZoneInComparison(plannerContext).rules())
                 .addAll(new UnwrapYearInComparison(plannerContext).rules())
                 .addAll(new RemoveDuplicateConditions().rules())
                 .addAll(new CanonicalizeExpressions(plannerContext).rules())

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapAtTimeZoneInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapAtTimeZoneInComparison.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.type.TimeZoneNotSupportedException;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.VarcharType;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.ExpressionTreeRewriter;
+import io.trino.sql.ir.IrExpressions.Comparison;
+
+import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
+import static io.trino.sql.ir.IrExpressions.comparison;
+import static io.trino.sql.ir.IrExpressions.matchComparison;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Given a constant, valid time zone, converts expressions of the form
+ * <pre>
+ *     at_timezone(ts, zone) ⋈ expression
+ * </pre>
+ * into
+ * <pre>
+ *     ts ⋈ expression
+ * </pre>
+ * <p>
+ * {@code at_timezone} changes only the zone a {@code timestamp with time zone} value is rendered
+ * in, never the instant, and {@code timestamp with time zone} comparisons compare the instant
+ * only, so the call is transparent to every comparison operator. With a constant zone that is
+ * validated at plan time, the call cannot fail at runtime, and since it returns null if and only
+ * if its first argument is null, null semantics (including {@code IDENTICAL}) are preserved by
+ * the rewrite.
+ * <p>
+ * Non-constant and invalid zones are left untouched: a null zone makes the result null (a bare
+ * comparison could then wrongly match) and an invalid zone string fails the query at runtime
+ * (unwrapping would silently swallow the failure). The {@code time with time zone} form of
+ * {@code at_timezone} interacts differently with comparison semantics and is not rewritten.
+ * {@code with_timezone} reinterprets the wall time, changing the instant, and must never be
+ * rewritten this way.
+ *
+ * @see UnwrapCastInComparison
+ * @see UnwrapDateTruncInComparison
+ */
+public class UnwrapAtTimeZoneInComparison
+        extends ExpressionRewriteRuleSet
+{
+    public UnwrapAtTimeZoneInComparison(PlannerContext plannerContext)
+    {
+        super(createRewrite(plannerContext));
+    }
+
+    private static ExpressionRewriter createRewrite(PlannerContext plannerContext)
+    {
+        requireNonNull(plannerContext, "plannerContext is null");
+
+        return (expression, _) -> unwrapAtTimeZone(plannerContext, expression);
+    }
+
+    private static Expression unwrapAtTimeZone(PlannerContext plannerContext, Expression expression)
+    {
+        return ExpressionTreeRewriter.rewriteWith(new Visitor(plannerContext), expression);
+    }
+
+    private static class Visitor
+            extends io.trino.sql.ir.ExpressionRewriter<Void>
+    {
+        private final PlannerContext plannerContext;
+
+        public Visitor(PlannerContext plannerContext)
+        {
+            this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+        }
+
+        @Override
+        public Expression rewriteCall(Call node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        {
+            Call expression = treeRewriter.defaultRewrite(node, null);
+            if (!(matchComparison(expression) instanceof Comparison comparison)) {
+                return expression;
+            }
+
+            Expression left = unwrap(comparison.left());
+            Expression right = unwrap(comparison.right());
+            if (left == comparison.left() && right == comparison.right()) {
+                return expression;
+            }
+            return comparison(plannerContext.getMetadata(), comparison.operator(), left, right);
+        }
+
+        private static Expression unwrap(Expression expression)
+        {
+            while (expression instanceof Call call && isInstantPreservingAtTimeZone(call)) {
+                expression = call.arguments().get(0);
+            }
+            return expression;
+        }
+
+        private static boolean isInstantPreservingAtTimeZone(Call call)
+        {
+            if (!call.function().name().equals(builtinFunctionName("at_timezone")) ||
+                    call.arguments().size() != 2 ||
+                    !(call.type() instanceof TimestampWithTimeZoneType) ||
+                    !call.arguments().get(0).type().equals(call.type())) {
+                return false;
+            }
+            // only a constant zone that is provably valid can be dropped: a null zone makes the
+            // result null and an invalid zone fails the query at runtime
+            Expression zone = call.arguments().get(1);
+            if (!(zone.type() instanceof VarcharType) ||
+                    !(zone instanceof Constant constant) ||
+                    !(constant.value() instanceof Slice slice)) {
+                return false;
+            }
+            try {
+                getTimeZoneKey(slice.toStringUtf8());
+                return true;
+            }
+            catch (TimeZoneNotSupportedException | IllegalArgumentException e) {
+                // getTimeZoneKey throws IllegalArgumentException for an empty zone id
+                return false;
+            }
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapAtTimeZoneInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestUnwrapAtTimeZoneInComparison.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Logical;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.assertions.BasePlanTest;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+import static io.trino.sql.ir.ComparisonOperator.EQUAL;
+import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN;
+import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN_OR_EQUAL;
+import static io.trino.sql.ir.ComparisonOperator.LESS_THAN;
+import static io.trino.sql.ir.ComparisonOperator.LESS_THAN_OR_EQUAL;
+import static io.trino.sql.ir.ComparisonOperator.NOT_EQUAL;
+import static io.trino.sql.ir.Logical.Operator.OR;
+import static io.trino.sql.ir.TestingIr.comparison;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static java.lang.String.format;
+
+public class TestUnwrapAtTimeZoneInComparison
+        extends BasePlanTest
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+    private static final ResolvedFunction RANDOM = FUNCTIONS.resolveFunction("random", fromTypes());
+
+    private static final long EPOCH_MILLIS = LocalDateTime.of(2022, 5, 1, 10, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli();
+    private static final String LITERAL_MILLIS = "TIMESTAMP '2022-05-01 10:00:00.000 UTC'";
+    private static final String LITERAL_MICROS = "TIMESTAMP '2022-05-01 10:00:00.000000 UTC'";
+
+    private static final Reference A_MILLIS = new Reference(TIMESTAMP_TZ_MILLIS, "a");
+    private static final Constant VALUE_MILLIS = new Constant(TIMESTAMP_TZ_MILLIS, packDateTimeWithZone(EPOCH_MILLIS, getTimeZoneKey("UTC")));
+
+    @Test
+    public void testUnwrapComparisons()
+    {
+        testUnwrap("timestamp(3) with time zone", format("at_timezone(a, 'America/Los_Angeles') = %s", LITERAL_MILLIS), comparison(EQUAL, A_MILLIS, VALUE_MILLIS));
+        testUnwrap("timestamp(3) with time zone", format("at_timezone(a, 'America/Los_Angeles') <> %s", LITERAL_MILLIS), comparison(NOT_EQUAL, A_MILLIS, VALUE_MILLIS));
+        testUnwrap("timestamp(3) with time zone", format("at_timezone(a, 'America/Los_Angeles') < %s", LITERAL_MILLIS), comparison(LESS_THAN, A_MILLIS, VALUE_MILLIS));
+        testUnwrap("timestamp(3) with time zone", format("at_timezone(a, 'America/Los_Angeles') <= %s", LITERAL_MILLIS), comparison(LESS_THAN_OR_EQUAL, A_MILLIS, VALUE_MILLIS));
+        testUnwrap("timestamp(3) with time zone", format("at_timezone(a, 'America/Los_Angeles') > %s", LITERAL_MILLIS), comparison(GREATER_THAN, A_MILLIS, VALUE_MILLIS));
+        testUnwrap("timestamp(3) with time zone", format("at_timezone(a, 'America/Los_Angeles') >= %s", LITERAL_MILLIS), comparison(GREATER_THAN_OR_EQUAL, A_MILLIS, VALUE_MILLIS));
+
+        // constant on the left
+        testUnwrap("timestamp(3) with time zone", format("%s < at_timezone(a, 'America/Los_Angeles')", LITERAL_MILLIS), comparison(LESS_THAN, VALUE_MILLIS, A_MILLIS));
+
+        // fixed-offset zones are constants too
+        testUnwrap("timestamp(3) with time zone", format("at_timezone(a, '+08:45') = %s", LITERAL_MILLIS), comparison(EQUAL, A_MILLIS, VALUE_MILLIS));
+
+        // nested calls unwrap to the innermost argument
+        testUnwrap("timestamp(3) with time zone", format("at_timezone(at_timezone(a, 'UTC'), 'Pacific/Apia') > %s", LITERAL_MILLIS), comparison(GREATER_THAN, A_MILLIS, VALUE_MILLIS));
+
+        // long (non-packed) timestamp with time zone representation
+        testUnwrap(
+                "timestamp(6) with time zone",
+                format("at_timezone(a, 'America/Los_Angeles') = %s", LITERAL_MICROS),
+                comparison(
+                        EQUAL,
+                        new Reference(createTimestampWithTimeZoneType(6), "a"),
+                        new Constant(createTimestampWithTimeZoneType(6), LongTimestampWithTimeZone.fromEpochMillisAndFraction(EPOCH_MILLIS, 0, getTimeZoneKey("UTC")))));
+    }
+
+    @Test
+    public void testInvalidZoneIsNotUnwrapped()
+    {
+        // an invalid zone string fails the query at runtime; unwrapping would silently swallow the failure
+        ResolvedFunction atTimezone = FUNCTIONS.resolveFunction("at_timezone", fromTypes(TIMESTAMP_TZ_MILLIS, createVarcharType(12)));
+        testUnwrap(
+                "timestamp(3) with time zone",
+                format("at_timezone(a, 'Mars/Olympus') = %s", LITERAL_MILLIS),
+                comparison(
+                        EQUAL,
+                        new Call(atTimezone, ImmutableList.of(A_MILLIS, new Constant(createVarcharType(12), utf8Slice("Mars/Olympus")))),
+                        VALUE_MILLIS));
+
+        // an empty zone id throws IllegalArgumentException from getTimeZoneKey rather than
+        // TimeZoneNotSupportedException; the rule must bail, not fail planning
+        ResolvedFunction atTimezoneEmptyZone = FUNCTIONS.resolveFunction("at_timezone", fromTypes(TIMESTAMP_TZ_MILLIS, createVarcharType(0)));
+        testUnwrap(
+                "timestamp(3) with time zone",
+                format("at_timezone(a, '') = %s", LITERAL_MILLIS),
+                comparison(
+                        EQUAL,
+                        new Call(atTimezoneEmptyZone, ImmutableList.of(A_MILLIS, new Constant(createVarcharType(0), utf8Slice("")))),
+                        VALUE_MILLIS));
+    }
+
+    @Test
+    public void testWithTimezoneIsNotUnwrapped()
+    {
+        // with_timezone reinterprets the wall time, changing the instant; it must never be unwrapped
+        ResolvedFunction withTimezone = FUNCTIONS.resolveFunction("with_timezone", fromTypes(createTimestampType(3), createVarcharType(3)));
+        testUnwrap(
+                "timestamp(3)",
+                format("with_timezone(a, 'UTC') = %s", LITERAL_MILLIS),
+                comparison(
+                        EQUAL,
+                        new Call(withTimezone, ImmutableList.of(new Reference(createTimestampType(3), "a"), new Constant(createVarcharType(3), utf8Slice("UTC")))),
+                        VALUE_MILLIS));
+    }
+
+    @Test
+    public void testNonConstantZoneIsNotUnwrapped()
+    {
+        // a null zone makes the comparison null (row filtered); a bare comparison could wrongly match
+        ResolvedFunction atTimezone = FUNCTIONS.resolveFunction("at_timezone", fromTypes(TIMESTAMP_TZ_MILLIS, createVarcharType(30)));
+        assertPlan(
+                format("SELECT * FROM (VALUES (CAST(NULL AS timestamp(3) with time zone), CAST(NULL AS varchar(30)))) t(a, z) WHERE at_timezone(a, z) = %s OR rand() = 42", LITERAL_MILLIS),
+                getPlanTester().getDefaultSession(),
+                output(
+                        filter(
+                                new Logical(OR, ImmutableList.of(
+                                        comparison(
+                                                EQUAL,
+                                                new Call(atTimezone, ImmutableList.of(A_MILLIS, new Reference(createVarcharType(30), "z"))),
+                                                VALUE_MILLIS),
+                                        antiOptimization())),
+                                values("a", "z"))));
+    }
+
+    private void testUnwrap(String inputType, String inputPredicate, Expression expected)
+    {
+        if (expected instanceof Logical logical && logical.operator() == OR) {
+            expected = new Logical(OR, ImmutableList.<Expression>builder()
+                    .addAll(logical.terms())
+                    .add(antiOptimization())
+                    .build());
+        }
+        else {
+            expected = new Logical(OR, ImmutableList.of(expected, antiOptimization()));
+        }
+
+        String sql = format("SELECT * FROM (VALUES CAST(NULL AS %s)) t(a) WHERE %s OR rand() = 42", inputType, inputPredicate);
+        try {
+            assertPlan(
+                    sql,
+                    getPlanTester().getDefaultSession(),
+                    output(
+                            filter(
+                                    expected,
+                                    values("a"))));
+        }
+        catch (Throwable e) {
+            e.addSuppressed(new Exception("Query: " + sql));
+            throw e;
+        }
+    }
+
+    private static Expression antiOptimization()
+    {
+        return comparison(EQUAL, new Call(RANDOM, ImmutableList.of()), new Constant(DOUBLE, 42.0));
+    }
+}


### PR DESCRIPTION
# Unwrap `at_timezone` in comparisons for constant zones

## Description

`at_timezone` changes only the zone a `timestamp with time zone` value is rendered in,
never the instant — it repacks the value with a new zone id
(`packDateTimeWithZone(unpackMillisUtc(v), zone)`) — and `timestamp with time zone`
comparisons compare the instant only. The call is therefore transparent to every
comparison operator, but the planner previously kept it in place, blocking connector
pushdown and evaluating the call per row:

```sql
SELECT * FROM t
WHERE at_timezone(ts, 'America/Los_Angeles') >= TIMESTAMP '2025-09-13 01:00:00 +09:00'
-- previously: full scan, at_timezone evaluated per row
-- now:        ts >= TIMESTAMP '2025-09-13 01:00:00 +09:00' — plain range on the column
```

This PR adds `UnwrapAtTimeZoneInComparison`, modeled on `UnwrapCastInComparison` /
`UnwrapDateTruncInComparison`: when the zone is a **constant validated at plan time**
(via `TimeZoneKey`), `at_timezone(ts, zone)` is replaced with `ts` on either side of a
comparison. Nested calls unwrap to the innermost argument. Unlike the `date_trunc`
unwrap, no range arithmetic is needed — the rewrite is a pure identity on the instant.

Registered in the `SimplifyExpressions` rule set alongside the sibling unwrap rules, so
the call is gone before predicate pushdown — enabling `TupleDomain` derivation (e.g.
Iceberg/Hive/Delta partition pruning), connector expression pushdown (e.g. JDBC
connectors), and eliminating the call at execution.

### Safety

- The rewrite fires only for constant `varchar` zones that pass `TimeZoneKey` validation
  at plan time, so the call cannot fail at runtime. Fixed-offset zones (`'+08:45'`) are
  covered.
- `at_timezone` returns null if and only if its first argument is null, so null semantics
  — including `IS NOT DISTINCT FROM` — are preserved.
- **Not** rewritten, deliberately:
  - non-constant zones — a null zone makes the result null (a bare comparison could then
    wrongly match), and an invalid zone string fails the query at runtime, which
    unwrapping would silently swallow;
  - the `time with time zone` form of `at_timezone`, which interacts differently with
    comparison semantics;
  - `with_timezone`, which reinterprets the wall time and changes the instant.

DST transitions do not affect the rewrite: wall-time → instant resolution of literals
happens during analysis, and the unwrap is applied to the already-resolved instants on
both sides.

## Testing

`TestUnwrapAtTimeZoneInComparison` (`BasePlanTest`, exercising the full optimizer
pipeline): all six comparison operators, constant on either side, fixed-offset zone,
nested calls, both the packed and long `timestamp with time zone` representations, and
negative cases asserting invalid zones, non-constant zones, and `with_timezone` are left
untouched. Sibling suites (`TestUnwrapCastInComparison`, `TestUnwrapDateTruncInComparison`,
`TestUnwrapYearInComparison`) and `TestLogicalPlanner` pass unchanged — 144 tests total.

## Additional context and related issues

Follow-up to the review discussion in #30551
(https://github.com/trinodb/trino/pull/30551#discussion_r3719771039), where this rule was
suggested as a separate PR for the constant-zone case. The non-constant zone case (views
exposing `at_timezone(ts, zone_column)`) cannot be handled by a rewrite rule without
changing semantics and remains addressed by the `DomainTranslator` change in #30551.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General

* Improve performance of queries with comparisons over `at_timezone` with a constant
  time zone by removing the redundant call, enabling connector pushdown and partition
  pruning.
```