### PR TITLE
Run metadata queries with retry policy NONE under FTE execution

### DIFF
--- a/core/trino-main/src/main/java/io/trino/Session.java
+++ b/core/trino-main/src/main/java/io/trino/Session.java
@@ -24,6 +24,7 @@ import io.opentelemetry.api.trace.Span;
 import io.trino.client.ProtocolHeaders;
 import io.trino.connector.CatalogHandle;
 import io.trino.metadata.SessionPropertyManager;
+import io.trino.operator.RetryPolicy;
 import io.trino.security.AccessControl;
 import io.trino.security.SecurityContext;
 import io.trino.spi.QueryId;
@@ -54,6 +55,7 @@ import java.util.stream.Collectors;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.trino.SystemSessionProperties.RETRY_POLICY;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
@@ -451,6 +453,13 @@ public final class Session
                 protocolHeaders,
                 exchangeEncryptionKey,
                 queryDataEncoding);
+    }
+
+    public Session withRetryPolicy(RetryPolicy retryPolicy)
+    {
+        Map<String, String> systemProperties = new HashMap<>(this.systemProperties);
+        systemProperties.put(RETRY_POLICY, retryPolicy.name());
+        return withProperties(systemProperties, getCatalogProperties());
     }
 
     public Session withExchangeEncryption(Slice encryptionKey)

--- a/core/trino-main/src/main/java/io/trino/exchange/LazyExchangeDataSource.java
+++ b/core/trino-main/src/main/java/io/trino/exchange/LazyExchangeDataSource.java
@@ -31,6 +31,7 @@ import io.trino.spi.metrics.Metrics;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
@@ -46,7 +47,7 @@ public class LazyExchangeDataSource
     private final DirectExchangeClientSupplier directExchangeClientSupplier;
     private final LocalMemoryContext memoryContext;
     private final TaskFailureListener taskFailureListener;
-    private final RetryPolicy retryPolicy;
+    private final Supplier<RetryPolicy> retryPolicySupplier;
     private final ExchangeManagerRegistry exchangeManagerRegistry;
 
     private final SettableFuture<Void> initializationFuture = SettableFuture.create();
@@ -60,7 +61,7 @@ public class LazyExchangeDataSource
             DirectExchangeClientSupplier directExchangeClientSupplier,
             LocalMemoryContext memoryContext,
             TaskFailureListener taskFailureListener,
-            RetryPolicy retryPolicy,
+            Supplier<RetryPolicy> retryPolicySupplier,
             ExchangeManagerRegistry exchangeManagerRegistry)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
@@ -69,7 +70,7 @@ public class LazyExchangeDataSource
         this.directExchangeClientSupplier = requireNonNull(directExchangeClientSupplier, "directExchangeClientSupplier is null");
         this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");
         this.taskFailureListener = requireNonNull(taskFailureListener, "taskFailureListener is null");
-        this.retryPolicy = requireNonNull(retryPolicy, "retryPolicy is null");
+        this.retryPolicySupplier = requireNonNull(retryPolicySupplier, "retryPolicySupplier is null");
         this.exchangeManagerRegistry = requireNonNull(exchangeManagerRegistry, "exchangeManagerRegistry is null");
     }
 
@@ -131,7 +132,7 @@ public class LazyExchangeDataSource
             ExchangeDataSource dataSource = delegate.get();
             if (dataSource == null) {
                 if (input instanceof DirectExchangeInput) {
-                    DirectExchangeClient client = directExchangeClientSupplier.get(queryId, exchangeId, querySpan, memoryContext, taskFailureListener, retryPolicy);
+                    DirectExchangeClient client = directExchangeClientSupplier.get(queryId, exchangeId, querySpan, memoryContext, taskFailureListener, retryPolicySupplier.get());
                     dataSource = new DirectExchangeDataSource(client);
                 }
                 else if (input instanceof SpoolingExchangeInput) {

--- a/core/trino-main/src/main/java/io/trino/execution/MetadataOnlyQueryPolicyResolver.java
+++ b/core/trino-main/src/main/java/io/trino/execution/MetadataOnlyQueryPolicyResolver.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import io.trino.Session;
+import io.trino.connector.system.GlobalSystemConnector;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.operator.RetryPolicy;
+import io.trino.sql.analyzer.Analysis;
+import io.trino.sql.tree.Query;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static io.trino.SystemSessionProperties.getRetryPolicy;
+import static io.trino.connector.informationschema.InformationSchemaTable.INFORMATION_SCHEMA;
+import static io.trino.operator.RetryPolicy.NONE;
+import static io.trino.operator.RetryPolicy.QUERY;
+import static io.trino.operator.RetryPolicy.TASK;
+import static java.util.Objects.requireNonNull;
+
+public class MetadataOnlyQueryPolicyResolver
+{
+    // Schemas of the global system catalog that only expose metadata
+    private static final Set<String> SYSTEM_METADATA_SCHEMAS = ImmutableSet.of("jdbc", "metadata");
+
+    private final Optional<RetryPolicy> metadataOnlyQueryRetryPolicy;
+
+    @Inject
+    public MetadataOnlyQueryPolicyResolver(QueryManagerConfig config)
+    {
+        requireNonNull(config, "config is null");
+        // Query-level retries are preferred over no retries at all, because they still make the query resilient
+        // against network and connector failures
+        this.metadataOnlyQueryRetryPolicy = config.isRetryPolicyExcludeMetadataOnlyQueries()
+                ? Optional.of(config.getAllowedRetryPolicies().contains(QUERY) ? QUERY : NONE)
+                : Optional.empty();
+    }
+
+    public Session getSessionWithEffectiveRetryPolicy(Session session, Analysis analysis)
+    {
+        if (metadataOnlyQueryRetryPolicy.isEmpty()) {
+            return session;
+        }
+        // Metadata queries are served by the coordinator, so task-level retries only add the overhead of exchange
+        // spooling without ever retrying a task
+        if (getRetryPolicy(session) == TASK && isMetadataOnlyQuery(analysis)) {
+            return session.withRetryPolicy(metadataOnlyQueryRetryPolicy.get());
+        }
+        return session;
+    }
+
+    private static boolean isMetadataOnlyQuery(Analysis analysis)
+    {
+        // Restricted to read-only queries so that writes are never downgraded. SHOW and DESCRIBE statements are
+        // rewritten before the analysis, so they reach this point as queries.
+        if (!(analysis.getStatement() instanceof Query)) {
+            return false;
+        }
+        // Table functions and UNNEST generate rows regardless of the tables the query reads
+        if (analysis.hasTableFunctions() || analysis.hasUnnest()) {
+            return false;
+        }
+        return analysis.getTableNames().stream().allMatch(MetadataOnlyQueryPolicyResolver::isMetadataTable);
+    }
+
+    private static boolean isMetadataTable(QualifiedObjectName table)
+    {
+        if (table.schemaName().equals(INFORMATION_SCHEMA)) {
+            return true;
+        }
+        return table.catalogName().equals(GlobalSystemConnector.NAME) && SYSTEM_METADATA_SCHEMAS.contains(table.schemaName());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
@@ -110,6 +110,7 @@ public class QueryManagerConfig
 
     private RetryPolicy retryPolicy = RetryPolicy.NONE;
     private Set<RetryPolicy> allowedRetryPolicies = EnumSet.allOf(RetryPolicy.class);
+    private boolean retryPolicyExcludeMetadataOnlyQueries = true;
 
     private int queryRetryAttempts = 4;
     private int taskRetryAttemptsPerTask = 4;
@@ -634,10 +635,31 @@ public class QueryManagerConfig
         return this;
     }
 
+    public boolean isRetryPolicyExcludeMetadataOnlyQueries()
+    {
+        return retryPolicyExcludeMetadataOnlyQueries;
+    }
+
+    @Config("retry-policy.exclude-metadata-only-queries")
+    @ConfigDescription("Run queries that only access information_schema, system.metadata or system.jdbc tables without task retries even when the TASK retry policy is configured")
+    public QueryManagerConfig setRetryPolicyExcludeMetadataOnlyQueries(boolean retryPolicyExcludeMetadataOnlyQueries)
+    {
+        this.retryPolicyExcludeMetadataOnlyQueries = retryPolicyExcludeMetadataOnlyQueries;
+        return this;
+    }
+
     @AssertTrue(message = "Selected retry policy not present in retry-policy.allowed list")
     public boolean isRetryPolicyAllowed()
     {
         return allowedRetryPolicies.contains(retryPolicy);
+    }
+
+    @AssertTrue(message = "retry-policy.exclude-metadata-only-queries requires retry-policy.allowed to contain QUERY or NONE")
+    public boolean isMetadataOnlyQueryRetryPolicyAllowed()
+    {
+        return !retryPolicyExcludeMetadataOnlyQueries
+                || allowedRetryPolicies.contains(RetryPolicy.QUERY)
+                || allowedRetryPolicies.contains(RetryPolicy.NONE);
     }
 
     @Min(0)

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -90,6 +90,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -135,7 +136,8 @@ public class QueryStateMachine
     private final QueryId queryId;
     private final String query;
     private final Optional<String> preparedQuery;
-    private final Session session;
+    // effectively final except for replaceSession
+    private volatile Session session;
     private final URI self;
     private final ResourceGroupId resourceGroup;
     private final TransactionManager transactionManager;
@@ -459,6 +461,17 @@ public class QueryStateMachine
     public Session getSession()
     {
         return session;
+    }
+
+    /**
+     * Replaces the session of a query that has not finished yet. Intended for adjustments made once the analysis is
+     * known, such as downgrading the retry policy of a metadata-only query, and not for general session mutation:
+     * anything that already read the session keeps the old value.
+     */
+    public void replaceSession(UnaryOperator<Session> transform)
+    {
+        checkState(!isDone(), "query is already done");
+        session = requireNonNull(transform.apply(session), "transformed session is null");
     }
 
     public Executor getStateMachineExecutor()

--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
@@ -147,6 +147,7 @@ public class SqlQueryExecution
     private final ExchangeManagerRegistry exchangeManagerRegistry;
     private final ExchangeMetricsCollector exchangeMetricsCollector;
     private final EventDrivenTaskSourceFactory eventDrivenTaskSourceFactory;
+    private final MetadataOnlyQueryPolicyResolver metadataOnlyQueryPolicyResolver;
     private final TaskDescriptorStorage taskDescriptorStorage;
     private final PlanOptimizersStatsCollector planOptimizersStatsCollector;
 
@@ -186,6 +187,7 @@ public class SqlQueryExecution
             ExchangeManagerRegistry exchangeManagerRegistry,
             ExchangeMetricsCollector exchangeMetricsCollector,
             EventDrivenTaskSourceFactory eventDrivenTaskSourceFactory,
+            MetadataOnlyQueryPolicyResolver metadataOnlyQueryPolicyResolver,
             TaskDescriptorStorage taskDescriptorStorage)
     {
         try (SetThreadName _ = new SetThreadName("Query-" + stateMachine.getQueryId())) {
@@ -239,6 +241,7 @@ public class SqlQueryExecution
             this.exchangeManagerRegistry = requireNonNull(exchangeManagerRegistry, "exchangeManagerRegistry is null");
             this.exchangeMetricsCollector = requireNonNull(exchangeMetricsCollector, "exchangeMetricsCollector is null");
             this.eventDrivenTaskSourceFactory = requireNonNull(eventDrivenTaskSourceFactory, "taskSourceFactory is null");
+            this.metadataOnlyQueryPolicyResolver = requireNonNull(metadataOnlyQueryPolicyResolver, "metadataOnlyQueryPolicyResolver is null");
             this.taskDescriptorStorage = requireNonNull(taskDescriptorStorage, "taskDescriptorStorage is null");
             this.planOptimizersStatsCollector = requireNonNull(planOptimizersStatsCollector, "planOptimizersStatsCollector is null");
         }
@@ -533,6 +536,10 @@ public class SqlQueryExecution
                 ((OutputNode) rootFragment.getRoot()).getColumnNames(),
                 rootFragment.getTypes());
 
+        // the tables a query reads are only known after the analysis, so the retry policy is settled here, right
+        // before it decides which scheduler to use
+        stateMachine.replaceSession(session -> metadataOnlyQueryPolicyResolver.getSessionWithEffectiveRetryPolicy(session, analysis));
+
         RetryPolicy retryPolicy = getRetryPolicy(getSession());
         QueryScheduler scheduler = switch (retryPolicy) {
             case QUERY, NONE -> new PipelinedQueryScheduler(
@@ -809,6 +816,7 @@ public class SqlQueryExecution
         private final ExchangeManagerRegistry exchangeManagerRegistry;
         private final ExchangeMetricsCollector exchangeMetricsCollector;
         private final EventDrivenTaskSourceFactory eventDrivenTaskSourceFactory;
+        private final MetadataOnlyQueryPolicyResolver metadataOnlyQueryPolicyResolver;
         private final TaskDescriptorStorage taskDescriptorStorage;
 
         @Inject
@@ -842,6 +850,7 @@ public class SqlQueryExecution
                 ExchangeManagerRegistry exchangeManagerRegistry,
                 ExchangeMetricsCollector exchangeMetricsCollector,
                 EventDrivenTaskSourceFactory eventDrivenTaskSourceFactory,
+                MetadataOnlyQueryPolicyResolver metadataOnlyQueryPolicyResolver,
                 TaskDescriptorStorage taskDescriptorStorage)
         {
             this.tracer = requireNonNull(tracer, "tracer is null");
@@ -875,6 +884,7 @@ public class SqlQueryExecution
             this.exchangeManagerRegistry = requireNonNull(exchangeManagerRegistry, "exchangeManagerRegistry is null");
             this.exchangeMetricsCollector = requireNonNull(exchangeMetricsCollector, "exchangeMetricsCollector is null");
             this.eventDrivenTaskSourceFactory = requireNonNull(eventDrivenTaskSourceFactory, "eventDrivenTaskSourceFactory is null");
+            this.metadataOnlyQueryPolicyResolver = requireNonNull(metadataOnlyQueryPolicyResolver, "metadataOnlyQueryPolicyResolver is null");
             this.taskDescriptorStorage = requireNonNull(taskDescriptorStorage, "taskDescriptorStorage is null");
         }
 
@@ -926,6 +936,7 @@ public class SqlQueryExecution
                     exchangeManagerRegistry,
                     exchangeMetricsCollector,
                     eventDrivenTaskSourceFactory,
+                    metadataOnlyQueryPolicyResolver,
                     taskDescriptorStorage);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/operator/ExchangeOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ExchangeOperator.java
@@ -110,7 +110,7 @@ public class ExchangeOperator
                         directExchangeClientSupplier,
                         operatorContext.localUserMemoryContext(),
                         taskContext::sourceTaskFailed,
-                        retryPolicy,
+                        () -> retryPolicy,
                         exchangeManagerRegistry);
             }
             int operatorInstanceId = nextOperatorInstanceId;

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -51,6 +51,7 @@ import io.trino.execution.DynamicFiltersCollector.VersionedDynamicFilterDomains;
 import io.trino.execution.ExecutionFailureInfo;
 import io.trino.execution.ExplainAnalyzeContext;
 import io.trino.execution.ForQueryExecution;
+import io.trino.execution.MetadataOnlyQueryPolicyResolver;
 import io.trino.execution.NodeTaskMap;
 import io.trino.execution.QueryExecution;
 import io.trino.execution.QueryExecutionMBean;
@@ -225,6 +226,7 @@ public class CoordinatorModule
 
         // local dispatcher
         binder.bind(DispatchQueryFactory.class).to(LocalDispatchQueryFactory.class);
+        binder.bind(MetadataOnlyQueryPolicyResolver.class).in(Scopes.SINGLETON);
 
         // cluster memory manager
         binder.bind(ClusterMemoryManager.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -213,14 +213,17 @@ class Query
             ScheduledExecutorService timeoutExecutor,
             BlockEncodingSerde blockEncodingSerde)
     {
+        QueryId queryId = session.getQueryId();
         ExchangeDataSource exchangeDataSource = new LazyExchangeDataSource(
-                session.getQueryId(),
-                new ExchangeId("query-results-exchange-" + session.getQueryId()),
+                queryId,
+                new ExchangeId("query-results-exchange-" + queryId),
                 session.getQuerySpan(),
                 directExchangeClientSupplier,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), Query.class.getSimpleName()),
                 queryManager::outputTaskFailed,
-                getRetryPolicy(session),
+                // the retry policy of a metadata query is downgraded during planning, which happens after this point,
+                // so it has to be read from the query session on every use rather than captured here
+                () -> getRetryPolicy(queryManager.getQuerySession(queryId)),
                 exchangeManagerRegistry);
 
         Query result = new Query(session, slug, queryManager, queryInfoUrl, exchangeDataSource, dataProcessorExecutor, timeoutExecutor, blockEncodingSerde);

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -689,6 +689,13 @@ public class Analysis
                 .collect(toImmutableList());
     }
 
+    public Collection<QualifiedObjectName> getTableNames()
+    {
+        return tables.values().stream()
+                .map(TableEntry::getName)
+                .collect(toImmutableList());
+    }
+
     public void registerTable(
             Table table,
             Optional<TableHandle> handle,
@@ -1075,6 +1082,11 @@ public class Analysis
     public UnnestAnalysis getUnnest(Unnest node)
     {
         return unnestAnalysis.get(NodeRef.of(node));
+    }
+
+    public boolean hasUnnest()
+    {
+        return !unnestAnalysis.isEmpty();
     }
 
     public void setNearest(Nearest node, NearestAnalysis analysis)
@@ -1508,6 +1520,11 @@ public class Analysis
     public TableFunctionInvocationAnalysis getTableFunctionAnalysis(TableFunctionInvocation node)
     {
         return tableFunctionAnalyses.get(NodeRef.of(node));
+    }
+
+    public boolean hasTableFunctions()
+    {
+        return !tableFunctionAnalyses.isEmpty();
     }
 
     public Set<NodeRef<TableFunctionInvocation>> getPolymorphicTableFunctions()

--- a/core/trino-main/src/test/java/io/trino/exchange/TestLazyExchangeDataSource.java
+++ b/core/trino-main/src/test/java/io/trino/exchange/TestLazyExchangeDataSource.java
@@ -82,7 +82,7 @@ public class TestLazyExchangeDataSource
                 (_, _) -> {
                     throw new UnsupportedOperationException();
                 },
-                RetryPolicy.NONE,
+                () -> RetryPolicy.NONE,
                 new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer(), new SecretsResolver(ImmutableMap.of()), new ExchangeManagerConfig()));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestMetadataOnlyQueryPolicyResolver.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestMetadataOnlyQueryPolicyResolver.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.operator.RetryPolicy;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
+import io.trino.sql.analyzer.Analysis;
+import io.trino.sql.analyzer.Scope;
+import io.trino.sql.tree.Deallocate;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.NodeLocation;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.Query;
+import io.trino.sql.tree.Statement;
+import io.trino.sql.tree.Table;
+import io.trino.sql.tree.TableFunctionInvocation;
+import io.trino.sql.tree.TableSubquery;
+import io.trino.sql.tree.Unnest;
+import io.trino.testing.TestingTransactionHandle;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.SystemSessionProperties.RETRY_POLICY;
+import static io.trino.SystemSessionProperties.getRetryPolicy;
+import static io.trino.operator.RetryPolicy.NONE;
+import static io.trino.operator.RetryPolicy.QUERY;
+import static io.trino.operator.RetryPolicy.TASK;
+import static io.trino.sql.analyzer.QueryType.OTHERS;
+import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Arrays.stream;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestMetadataOnlyQueryPolicyResolver
+{
+    private static final MetadataOnlyQueryPolicyResolver RESOLVER = new MetadataOnlyQueryPolicyResolver(new QueryManagerConfig());
+
+    @Test
+    void testRetryPolicyNoneStaysUnchanged()
+    {
+        assertThat(effectiveRetryPolicy(NONE, analysis(someQuery(), "hive.information_schema.tables"))).isEqualTo(NONE);
+    }
+
+    @Test
+    void testRetryPolicyQueryStaysUnchanged()
+    {
+        // query retries still protect against network and connector failures, so there is nothing to gain by dropping them
+        assertThat(effectiveRetryPolicy(QUERY, analysis(someQuery(), "hive.information_schema.tables"))).isEqualTo(QUERY);
+    }
+
+    @Test
+    void testTaskRetryPolicyIsDowngradedToQuery()
+    {
+        assertThat(effectiveRetryPolicy(TASK, analysis(someQuery(), "hive.information_schema.tables"))).isEqualTo(QUERY);
+    }
+
+    @Test
+    void testTaskRetryPolicyIsDowngradedToNoneWhenQueryPolicyIsNotAllowed()
+    {
+        MetadataOnlyQueryPolicyResolver resolver = new MetadataOnlyQueryPolicyResolver(
+                new QueryManagerConfig().setAllowedRetryPolicies(ImmutableSet.of(NONE, TASK)));
+
+        assertThat(effectiveRetryPolicy(resolver, TASK, analysis(someQuery(), "hive.information_schema.tables"))).isEqualTo(NONE);
+    }
+
+    @Test
+    void testInformationSchemaOfAnyCatalogIsMetadataOnly()
+    {
+        assertThat(effectiveRetryPolicy(TASK, analysis(someQuery(), "hive.information_schema.tables"))).isEqualTo(QUERY);
+        assertThat(effectiveRetryPolicy(TASK, analysis(someQuery(), "system.information_schema.tables"))).isEqualTo(QUERY);
+        assertThat(effectiveRetryPolicy(TASK, analysis(someQuery(), "hive.information_schema.columns", "iceberg.information_schema.tables"))).isEqualTo(QUERY);
+    }
+
+    @Test
+    void testSystemMetadataSchemasAreMetadataOnly()
+    {
+        assertThat(effectiveRetryPolicy(TASK, analysis(someQuery(), "system.jdbc.tables"))).isEqualTo(QUERY);
+        assertThat(effectiveRetryPolicy(TASK, analysis(someQuery(), "system.metadata.table_comments"))).isEqualTo(QUERY);
+    }
+
+    @Test
+    void testOtherSystemSchemasKeepRetryPolicy()
+    {
+        assertThat(effectiveRetryPolicy(TASK, analysis(someQuery(), "system.runtime.queries"))).isEqualTo(TASK);
+    }
+
+    @Test
+    void testConnectorSystemTableKeepsRetryPolicy()
+    {
+        // a table such as iceberg.my_schema."my_table$files" is served by the connector, not by the coordinator
+        assertThat(effectiveRetryPolicy(TASK, analysis(someQuery(), "iceberg.my_schema.my_table$files"))).isEqualTo(TASK);
+        assertThat(effectiveRetryPolicy(TASK, analysis(someQuery(), "iceberg.jdbc.my_table"))).isEqualTo(TASK);
+    }
+
+    @Test
+    void testRegularTableKeepsRetryPolicy()
+    {
+        assertThat(effectiveRetryPolicy(TASK, analysis(someQuery(), "hive.my_schema.my_table"))).isEqualTo(TASK);
+    }
+
+    @Test
+    void testMixOfMetadataAndRegularTablesKeepsRetryPolicy()
+    {
+        assertThat(effectiveRetryPolicy(TASK, analysis(someQuery(), "hive.information_schema.tables", "hive.my_schema.my_table"))).isEqualTo(TASK);
+    }
+
+    @Test
+    void testQueryWithoutTablesIsMetadataOnly()
+    {
+        assertThat(effectiveRetryPolicy(TASK, analysis(someQuery()))).isEqualTo(QUERY);
+    }
+
+    @Test
+    void testUnnestKeepsRetryPolicy()
+    {
+        Analysis analysis = analysis(someQuery());
+        analysis.setUnnest(new Unnest(ImmutableList.of(), false), new Analysis.UnnestAnalysis(ImmutableMap.of(), Optional.empty()));
+
+        assertThat(effectiveRetryPolicy(TASK, analysis)).isEqualTo(TASK);
+    }
+
+    @Test
+    void testTableFunctionKeepsRetryPolicy()
+    {
+        Analysis analysis = analysis(someQuery(), "hive.information_schema.tables");
+        analysis.setTableFunctionAnalysis(
+                new TableFunctionInvocation(new NodeLocation(1, 1), QualifiedName.of("some_function"), ImmutableList.of(), ImmutableList.of()),
+                new Analysis.TableFunctionInvocationAnalysis(
+                        TEST_CATALOG_HANDLE,
+                        "some_function",
+                        ImmutableMap.of(),
+                        ImmutableList.of(),
+                        ImmutableMap.of(),
+                        ImmutableList.of(),
+                        0,
+                        new ConnectorTableFunctionHandle() {},
+                        TestingTransactionHandle.create()));
+
+        assertThat(effectiveRetryPolicy(TASK, analysis)).isEqualTo(TASK);
+    }
+
+    @Test
+    void testNonQueryStatementKeepsRetryPolicy()
+    {
+        assertThat(effectiveRetryPolicy(TASK, analysis(deallocate(), "hive.information_schema.tables"))).isEqualTo(TASK);
+    }
+
+    @Test
+    void testExclusionCanBeDisabled()
+    {
+        MetadataOnlyQueryPolicyResolver resolver = new MetadataOnlyQueryPolicyResolver(
+                new QueryManagerConfig().setRetryPolicyExcludeMetadataOnlyQueries(false));
+
+        assertThat(effectiveRetryPolicy(resolver, TASK, analysis(someQuery(), "hive.information_schema.tables"))).isEqualTo(TASK);
+    }
+
+    private static RetryPolicy effectiveRetryPolicy(RetryPolicy retryPolicy, Analysis analysis)
+    {
+        return effectiveRetryPolicy(RESOLVER, retryPolicy, analysis);
+    }
+
+    private static RetryPolicy effectiveRetryPolicy(MetadataOnlyQueryPolicyResolver resolver, RetryPolicy retryPolicy, Analysis analysis)
+    {
+        return getRetryPolicy(resolver.getSessionWithEffectiveRetryPolicy(sessionWithRetryPolicy(retryPolicy), analysis));
+    }
+
+    private static Session sessionWithRetryPolicy(RetryPolicy retryPolicy)
+    {
+        return testSessionBuilder()
+                .setSystemProperty(RETRY_POLICY, retryPolicy.name())
+                .build();
+    }
+
+    private static Analysis analysis(Statement statement, String... tableNames)
+    {
+        Analysis analysis = new Analysis(statement, ImmutableMap.of(), OTHERS);
+        stream(tableNames).forEach(name -> {
+            String[] parts = name.split("\\.", 3);
+            analysis.registerTable(
+                    new Table(new NodeLocation(1, 1), QualifiedName.of(parts[0], parts[1], parts[2])),
+                    Optional.empty(),
+                    new QualifiedObjectName(parts[0], parts[1], parts[2]),
+                    Optional.empty(),
+                    "user",
+                    Scope.create(),
+                    Optional.empty());
+        });
+        return analysis;
+    }
+
+    private static Statement someQuery()
+    {
+        return new Query(
+                new NodeLocation(1, 1),
+                ImmutableList.of(),
+                ImmutableList.of(),
+                Optional.empty(),
+                new TableSubquery(new Query(
+                        new NodeLocation(1, 1),
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        new Table(new NodeLocation(1, 1), QualifiedName.of("some_table")),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty())),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private static Statement deallocate()
+    {
+        return new Deallocate(new NodeLocation(1, 1), new Identifier("foo"));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
@@ -80,6 +80,7 @@ public class TestQueryManagerConfig
                 .setRequiredWorkersMaxWait(new Duration(5, MINUTES))
                 .setRetryPolicy(RetryPolicy.NONE)
                 .setAllowedRetryPolicies(EnumSet.allOf(RetryPolicy.class))
+                .setRetryPolicyExcludeMetadataOnlyQueries(true)
                 .setQueryRetryAttempts(4)
                 .setTaskRetryAttemptsPerTask(4)
                 .setRetryInitialDelay(new Duration(10, SECONDS))
@@ -166,6 +167,7 @@ public class TestQueryManagerConfig
                 .put("query-manager.required-workers-max-wait", "33m")
                 .put("retry-policy", "QUERY")
                 .put("retry-policy.allowed", "QUERY,TASK")
+                .put("retry-policy.exclude-metadata-only-queries", "false")
                 .put("query-retry-attempts", "0")
                 .put("task-retry-attempts-per-task", "9")
                 .put("retry-initial-delay", "1m")
@@ -249,6 +251,7 @@ public class TestQueryManagerConfig
                 .setRequiredWorkersMaxWait(new Duration(33, MINUTES))
                 .setRetryPolicy(RetryPolicy.QUERY)
                 .setAllowedRetryPolicies(EnumSet.of(RetryPolicy.QUERY, RetryPolicy.TASK))
+                .setRetryPolicyExcludeMetadataOnlyQueries(false)
                 .setQueryRetryAttempts(0)
                 .setTaskRetryAttemptsPerTask(9)
                 .setRetryInitialDelay(new Duration(1, MINUTES))
@@ -309,6 +312,19 @@ public class TestQueryManagerConfig
                         .setRetryPolicy(RetryPolicy.QUERY),
                 "retryPolicyAllowed",
                 "Selected retry policy not present in retry-policy.allowed list",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testMetadataOnlyQueryRetryPolicyValidation()
+    {
+        assertFailsValidation(
+                new QueryManagerConfig()
+                        .setAllowedRetryPolicies(EnumSet.of(RetryPolicy.TASK))
+                        .setRetryPolicy(RetryPolicy.TASK)
+                        .setRetryPolicyExcludeMetadataOnlyQueries(true),
+                "metadataOnlyQueryRetryPolicyAllowed",
+                "retry-policy.exclude-metadata-only-queries requires retry-policy.allowed to contain QUERY or NONE",
                 AssertTrue.class);
     }
 }

--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.md
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.md
@@ -76,6 +76,19 @@ execution on a Trino cluster:
     This property is used to prevent a user from configuring a retry policy that
     is not meant to be used on the given cluster.
   - `NONE`, `QUERY`, `TASK` 
+* - `retry-policy.exclude-metadata-only-queries`
+  - When `true`, metadata-only queries submitted with `retry_policy` `TASK` run
+    with `retry_policy` `QUERY` instead, so that they do not pay the overhead of
+    fault-tolerant execution while remaining resilient to network and connector
+    failures. They run with `NONE` when `retry-policy.allowed` does not include
+    `QUERY`. A query is metadata-only when it reads no table at all, or when
+    every table it reads is in the `information_schema` schema of any catalog, or
+    in the `system.jdbc` or `system.metadata` schema, and it invokes no table
+    function and no `UNNEST`. Tables that a connector exposes within its own
+    catalog, such as `example.default."example_table$files"`, are not
+    metadata-only and keep the configured retry policy. Requires
+    `retry-policy.allowed` to include `QUERY` or `NONE`.
+  - `true`
 * - `exchange.deduplication-buffer-size`
   - [Data size](prop-type-data-size) of the coordinator's in-memory buffer used
     by fault-tolerant execution to store output of query

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/TestFaultTolerantMetadataOnlyQueries.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/TestFaultTolerantMetadataOnlyQueries.java
@@ -13,9 +13,11 @@
  */
 package io.trino.faulttolerant;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.MoreCollectors;
 import io.trino.Session;
 import io.trino.execution.QueryState;
+import io.trino.operator.RetryPolicy;
 import io.trino.plugin.blackhole.BlackHolePlugin;
 import io.trino.plugin.memory.MemoryQueryRunner;
 import io.trino.server.BasicQueryInfo;
@@ -27,10 +29,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
-import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.assertions.Assert.assertEventually;
 import static io.trino.tpch.TpchTable.NATION;
@@ -44,96 +46,145 @@ public class TestFaultTolerantMetadataOnlyQueries
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        DistributedQueryRunner queryRunner = MemoryQueryRunner.builder()
+        return MemoryQueryRunner.builder()
                 .setExtraProperties(FaultTolerantExecutionConnectorTestHelper.getExtraProperties())
                 .withExchange("filesystem")
                 .setInitialTables(List.of(NATION))
                 .build();
-
-        try {
-            queryRunner.installPlugin(new BlackHolePlugin());
-            queryRunner.createCatalog("blackhole", "blackhole");
-        }
-        catch (RuntimeException e) {
-            throw closeAllSuppress(e, queryRunner);
-        }
-        return queryRunner;
     }
 
     @Test
     @Timeout(120)
-    public void testMetadataOnlyQueries()
-            throws InterruptedException
+    public void testMetadataOnlyQueriesSucceedUnderResourcePressureWhenExclusionDisabled()
+            throws Exception
     {
-        // enforce single task uses whole node
-        Session highTaskMemorySession = Session.builder(getSession())
-                .setSystemProperty("fault_tolerant_execution_coordinator_task_memory", "500GB")
-                .setSystemProperty("fault_tolerant_execution_task_memory", "500GB")
-                // enforce each split in separate task
-                .setSystemProperty("fault_tolerant_execution_arbitrary_distribution_compute_task_target_size_min", "1B")
-                .setSystemProperty("fault_tolerant_execution_arbitrary_distribution_compute_task_target_size_max", "1B")
-                .build();
+        // With exclusion disabled, metadata queries must still bypass FTE resource constraints
+        // via the existing memory-budget mechanism (not via retry-policy downgrade)
+        Map<String, String> extraProperties = ImmutableMap.<String, String>builder()
+                .putAll(FaultTolerantExecutionConnectorTestHelper.getExtraProperties())
+                .put("retry-policy.exclude-metadata-only-queries", "false")
+                .buildOrThrow();
+        try (DistributedQueryRunner queryRunner = MemoryQueryRunner.builder()
+                .setExtraProperties(extraProperties)
+                .withExchange("filesystem")
+                .setInitialTables(List.of(NATION))
+                .build()) {
+            queryRunner.installPlugin(new BlackHolePlugin());
+            queryRunner.createCatalog("blackhole", "blackhole");
 
-        String slowTableName = "blackhole.default.testMetadataOnlyQueries_" + randomNameSuffix();
-        assertUpdate("CREATE TABLE " + slowTableName + " (a INT, b INT) WITH (split_count = 3, pages_per_split = 1, rows_per_page = 1, page_processing_delay = '1d')");
+            // enforce single task uses whole node
+            Session highTaskMemorySession = Session.builder(queryRunner.getDefaultSession())
+                    .setSystemProperty("fault_tolerant_execution_coordinator_task_memory", "500GB")
+                    .setSystemProperty("fault_tolerant_execution_task_memory", "500GB")
+                    // enforce each split in separate task
+                    .setSystemProperty("fault_tolerant_execution_arbitrary_distribution_compute_task_target_size_min", "1B")
+                    .setSystemProperty("fault_tolerant_execution_arbitrary_distribution_compute_task_target_size_max", "1B")
+                    .build();
 
-        String slowQuery = "select count(*) FROM " + slowTableName;
-        String nonMetadataQuery = "select count(*) non_metadata_query_count_" + System.currentTimeMillis() + " from nation";
+            String slowTableName = "blackhole.default.testMetadataOnlyQueries_" + randomNameSuffix();
+            queryRunner.execute("CREATE TABLE " + slowTableName + " (a INT, b INT) WITH (split_count = 3, pages_per_split = 1, rows_per_page = 1, page_processing_delay = '1d')");
 
-        ExecutorService backgroundExecutor = newCachedThreadPool();
-        try {
-            backgroundExecutor.submit(() -> {
-                assertUpdate(highTaskMemorySession, slowQuery);
-            });
-            assertEventually(() -> assertThat(queryState(slowQuery).orElseThrow()).isEqualTo(QueryState.RUNNING));
+            String slowQuery = "select count(*) FROM " + slowTableName;
+            String nonMetadataQuery = "select count(*) non_metadata_query_count_" + System.currentTimeMillis() + " from nation";
 
-            assertThat(query("DESCRIBE nation")).succeeds();
-            assertThat(query("SHOW TABLES")).succeeds();
-            assertThat(query("SHOW TABLES LIKE 'nat%'")).succeeds();
-            assertThat(query("SHOW SCHEMAS")).succeeds();
-            assertThat(query("SHOW SCHEMAS LIKE 'def%'")).succeeds();
-            assertThat(query("SHOW CATALOGS")).succeeds();
-            assertThat(query("SHOW CATALOGS LIKE 'mem%'")).succeeds();
-            assertThat(query("SHOW FUNCTIONS")).succeeds();
-            assertThat(query("SHOW FUNCTIONS LIKE 'split%'")).succeeds();
-            assertThat(query("SHOW COLUMNS FROM nation")).succeeds();
-            assertThat(query("SHOW SESSION")).succeeds();
-            assertThat(query("SELECT count(*) FROM information_schema.tables")).succeeds();
-            assertThat(query("SELECT * FROM system.jdbc.tables WHERE table_schem LIKE 'def%'")).succeeds();
+            ExecutorService backgroundExecutor = newCachedThreadPool();
+            try {
+                backgroundExecutor.submit(() -> queryRunner.execute(highTaskMemorySession, slowQuery));
+                assertEventually(() -> assertThat(queryState(queryRunner, slowQuery).orElseThrow()).isEqualTo(QueryState.RUNNING));
 
-            // check non-metadata queries still wait for resources
-            backgroundExecutor.submit(() -> {
-                assertUpdate(nonMetadataQuery);
-            });
-            assertEventually(() -> assertThat(queryState(nonMetadataQuery).orElseThrow()).isEqualTo(QueryState.STARTING));
-            Thread.sleep(1000); // wait a bit longer and query should be still STARTING
-            assertThat(queryState(nonMetadataQuery).orElseThrow()).isEqualTo(QueryState.STARTING);
+                queryRunner.execute("DESCRIBE nation");
+                queryRunner.execute("SHOW TABLES");
+                queryRunner.execute("SHOW TABLES LIKE 'nat%'");
+                queryRunner.execute("SHOW SCHEMAS");
+                queryRunner.execute("SHOW SCHEMAS LIKE 'def%'");
+                queryRunner.execute("SHOW CATALOGS");
+                queryRunner.execute("SHOW CATALOGS LIKE 'mem%'");
+                queryRunner.execute("SHOW FUNCTIONS");
+                queryRunner.execute("SHOW FUNCTIONS LIKE 'split%'");
+                queryRunner.execute("SHOW COLUMNS FROM nation");
+                queryRunner.execute("SHOW SESSION");
+                queryRunner.execute("SELECT count(*) FROM information_schema.tables");
+                queryRunner.execute("SELECT * FROM system.jdbc.tables WHERE table_schem LIKE 'def%'");
 
-            // slow query should be still running
-            assertThat(queryState(slowQuery).orElseThrow()).isEqualTo(QueryState.RUNNING);
-        }
-        finally {
-            cancelQuery(slowQuery);
-            cancelQuery(nonMetadataQuery);
-            backgroundExecutor.shutdownNow();
+                // check non-metadata queries still wait for resources
+                backgroundExecutor.submit(() -> queryRunner.execute(nonMetadataQuery));
+                assertEventually(() -> assertThat(queryState(queryRunner, nonMetadataQuery).orElseThrow()).isEqualTo(QueryState.STARTING));
+                Thread.sleep(1000); // wait a bit longer and query should be still STARTING
+                assertThat(queryState(queryRunner, nonMetadataQuery).orElseThrow()).isEqualTo(QueryState.STARTING);
+
+                // slow query should be still running
+                assertThat(queryState(queryRunner, slowQuery).orElseThrow()).isEqualTo(QueryState.RUNNING);
+            }
+            finally {
+                cancelQuery(queryRunner, slowQuery);
+                cancelQuery(queryRunner, nonMetadataQuery);
+                backgroundExecutor.shutdownNow();
+            }
         }
     }
 
-    private Optional<QueryState> queryState(String queryText)
+    @Test
+    @Timeout(120)
+    public void testMetadataOnlyQueriesSkipFaultTolerantExecution()
     {
-        return getDistributedQueryRunner().getCoordinator().getQueryManager().getQueries().stream()
+        List<String> metadataQueries = List.of(
+                "SELECT * FROM information_schema.tables LIMIT 1",
+                "SELECT * FROM system.jdbc.tables LIMIT 1",
+                "SELECT * FROM system.metadata.catalogs LIMIT 1",
+                "SELECT 1",
+                "VALUES 1, 2, 3",
+                "DESCRIBE nation",
+                "SHOW TABLES",
+                "SHOW CATALOGS",
+                "SHOW FUNCTIONS",
+                "SHOW SESSION");
+        for (String sql : metadataQueries) {
+            getQueryRunner().execute(sql);
+        }
+
+        assertRetryPolicy(metadataQueries, RetryPolicy.QUERY);
+    }
+
+    @Test
+    @Timeout(120)
+    public void testNonMetadataOnlyQueriesUseFaultTolerantExecution()
+    {
+        List<String> queries = List.of(
+                "SELECT count(*) FROM nation",
+                "SELECT * FROM UNNEST(sequence(1, 10))",
+                "SELECT * FROM TABLE(exclude_columns(input => TABLE(information_schema.tables), columns => DESCRIPTOR(table_catalog)))");
+        for (String sql : queries) {
+            getQueryRunner().execute(sql);
+        }
+
+        assertRetryPolicy(queries, RetryPolicy.TASK);
+    }
+
+    private void assertRetryPolicy(List<String> queries, RetryPolicy retryPolicy)
+    {
+        getDistributedQueryRunner().getCoordinator().getQueryManager().getQueries().stream()
+                .filter(query -> queries.contains(query.getQuery()))
+                .forEach(query ->
+                        assertThat(query.getRetryPolicy())
+                                .as("unexpected retry policy for query: %s", query.getQuery())
+                                .isEqualTo(retryPolicy));
+    }
+
+    private Optional<QueryState> queryState(DistributedQueryRunner queryRunner, String queryText)
+    {
+        return queryRunner.getCoordinator().getQueryManager().getQueries().stream()
                 .filter(query -> query.getQuery().equals(queryText))
                 .collect(MoreCollectors.toOptional())
                 .map(BasicQueryInfo::getState);
     }
 
-    private void cancelQuery(String queryText)
+    private void cancelQuery(DistributedQueryRunner queryRunner, String queryText)
     {
-        getDistributedQueryRunner().getCoordinator().getQueryManager().getQueries().stream()
+        queryRunner.getCoordinator().getQueryManager().getQueries().stream()
                 .filter(query -> query.getQuery().equals(queryText))
                 .forEach(query -> {
                     try {
-                        getDistributedQueryRunner().getCoordinator().getQueryManager().cancelQuery(query.getQueryId());
+                        queryRunner.getCoordinator().getQueryManager().cancelQuery(query.getQueryId());
                     }
                     catch (Exception e) {
                         // ignore


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
When a cluster runs with `retry-policy=TASK`, metadata-only queries – `SHOW TABLES`, `SHOW SCHEMAS`, `SELECT * FROM information_schema.tables`, `SELECT * FROM system.jdbc.*`, etc. – are routed through FTE unnecessarily. 

This causes two problems:                                            
1. Resource starvation: Under a saturated cluster, FTE resource budgets are exhausted by data queries. Metadata queries block waiting for slots, even though they do no real computation.
2. Unnecessary overhead: FTE adds scheduling, checkpointing, and exchange overhead that provides zero benefit for queries that only read catalog metadata.

### Solution                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                            
Introduced resolver which inspects each incoming query before dispatch and downgrades its retry policy from TASK to NONE when the query qualifies for exclusion. 
Two exclusion mechanisms, both configurable:                                                                                                                                                                                                                                                                                                            
  - `retry-policy.excluded-query-types` (default: DESCRIBE) – excludes queries by QueryType enum value                                                                                                                                                                                                                        
  - `retry-policy.exclude-metadata-only-queries` (default: true) – excludes SELECT queries that reference only information_schema or system catalog tables

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix metadata queries such as `SHOW TABLES` or `SELECT` from `information_schema` being blocked by fault-tolerant execution resource constraints when `retry-policy` is set to TASK.
```
