### PR TITLE
Fix wrong results by failing the query when sum(bigint) overflows in a window function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/BigintSumAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/BigintSumAggregation.java
@@ -92,7 +92,7 @@ public final class BigintSumAggregation
         {
             for (int i = startPosition; i <= endPosition; i++) {
                 if (!index.isNull(0, i)) {
-                    sum += index.getLong(0, i);
+                    sum = BigintOperators.add(sum, index.getLong(0, i));
                     count++;
                 }
             }
@@ -103,7 +103,7 @@ public final class BigintSumAggregation
         {
             for (int i = startPosition; i <= endPosition; i++) {
                 if (!index.isNull(0, i)) {
-                    sum -= index.getLong(0, i);
+                    sum = BigintOperators.subtract(sum, index.getLong(0, i));
                     count--;
                 }
             }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWindow.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.Execution;
 
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -342,5 +343,56 @@ public class TestWindow
                             (2, ARRAY[3, 2, 1]),
                             (2, ARRAY[3, 2, 1])
                         """);
+    }
+
+    @Test
+    public void testBigintSumOverflowInUnboundedFrame()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT sum(a) OVER ()
+                FROM (VALUES BIGINT '9223372036854775807', BIGINT '1') t(a)
+                """))
+                .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE).hasMessage("bigint addition overflow: 9223372036854775807 + 1");
+
+        // the frame total is in range, but the running sum leaves it, just as sum(a) over the same rows does
+        assertThat(assertions.query(
+                """
+                SELECT sum(a) OVER ()
+                FROM (VALUES
+                    BIGINT '9223372036854775807',
+                    BIGINT '9223372036854775807',
+                    BIGINT '-9223372036854775807') t(a)
+                """))
+                .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE).hasMessage("bigint addition overflow: 9223372036854775807 + 9223372036854775807");
+    }
+
+    @Test
+    public void testBigintSumInSlidingFrame()
+    {
+        // Frames at least three rows wide are advanced by removing values from the accumulator,
+        // so the running sum leaves the bigint range on the way out of the frame as well.
+        assertThat(assertions.query(
+                """
+                SELECT sum(a) OVER (ORDER BY b ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
+                FROM (VALUES
+                    (BIGINT '9223372036854775807', 1),
+                    (BIGINT '-9223372036854775807', 2),
+                    (BIGINT '-2', 3),
+                    (BIGINT '5', 4)) t(a, b)
+                """))
+                .failure().hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE).hasMessage("bigint subtraction overflow: -2 - 9223372036854775807");
+
+        // the smallest bigint is removed from the frame
+        assertThat(assertions.query(
+                """
+                SELECT sum(a) OVER (ORDER BY b ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
+                FROM (VALUES
+                    (BIGINT '-9223372036854775808', 1),
+                    (BIGINT '1', 2),
+                    (BIGINT '2', 3),
+                    (BIGINT '3', 4)) t(a, b)
+                """))
+                .matches("VALUES BIGINT '-9223372036854775808', BIGINT '-9223372036854775807', BIGINT '-9223372036854775805', BIGINT '6'");
     }
 }


### PR DESCRIPTION
## Description

`sum(bigint)` as a window function silently wraps on overflow, while the same aggregation fails:

```sql
SELECT sum(a)         FROM (VALUES BIGINT '9223372036854775807', BIGINT '1') t(a);
-- Query failed: bigint addition overflow: 9223372036854775807 + 1

SELECT sum(a) OVER () FROM (VALUES BIGINT '9223372036854775807', BIGINT '1') t(a);
-- -9223372036854775808     <-- silently wrong
```

`BigintSumAggregation.LongSumWindowAccumulator` accumulated with raw `sum +=` / `sum -=`. It now uses `BigintOperators.add` / `BigintOperators.subtract`, the same helpers the aggregation path already uses, so the window form fails with `NUMERIC_VALUE_OUT_OF_RANGE` just like the aggregation.

### Behavior change

The running total is checked at every step, not only at output, so a frame whose total is representable still fails when the running total leaves the bigint range on the way into or out of the frame. That is the same order-dependence `sum` aggregation already has, which is the consistency asked for in review.

## Additional context and related issues

Approach settled in https://github.com/trinodb/trino/pull/30600#discussion_r3726845894 — match `sum` aggregation and fail, rather than widening the accumulator to tolerate temporary overflow.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fail the query instead of returning wrong results when `sum(bigint)` overflows in a window function.
```