### PR TITLE
Always write compression codec to Iceberg table metadata

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -513,6 +513,7 @@ public class IcebergMetadata
     private final Optional<HiveMetastoreFactory> metastoreFactory;
     private final boolean addFilesProcedureEnabled;
     private final Predicate<String> allowedExtraProperties;
+    private final HiveCompressionCodec defaultCompressionCodec;
     private final ExecutorService icebergScanExecutor;
     private final Executor metadataFetchingExecutor;
     private final ExecutorService icebergPlanningExecutor;
@@ -539,6 +540,7 @@ public class IcebergMetadata
             Optional<HiveMetastoreFactory> metastoreFactory,
             boolean addFilesProcedureEnabled,
             Predicate<String> allowedExtraProperties,
+            HiveCompressionCodec defaultCompressionCodec,
             ExecutorService icebergScanExecutor,
             Executor metadataFetchingExecutor,
             ExecutorService icebergPlanningExecutor,
@@ -557,6 +559,7 @@ public class IcebergMetadata
         this.metastoreFactory = requireNonNull(metastoreFactory, "metastoreFactory is null");
         this.addFilesProcedureEnabled = addFilesProcedureEnabled;
         this.allowedExtraProperties = requireNonNull(allowedExtraProperties, "allowedExtraProperties is null");
+        this.defaultCompressionCodec = requireNonNull(defaultCompressionCodec, "defaultCompressionCodec is null");
         this.icebergScanExecutor = requireNonNull(icebergScanExecutor, "icebergScanExecutor is null");
         this.metadataFetchingExecutor = requireNonNull(metadataFetchingExecutor, "metadataFetchingExecutor is null");
         this.icebergPlanningExecutor = requireNonNull(icebergPlanningExecutor, "icebergPlanningExecutor is null");
@@ -1490,7 +1493,7 @@ public class IcebergMetadata
                 validateNotEncryptedForWrite(icebergTable);
                 tableLocation = icebergTable.location();
                 List<PartitionField> existingPartitionFields = getAllPartitionFields(icebergTable);
-                transaction = newCreateTableTransaction(catalog, tableMetadata, session, replace, tableLocation, allowedExtraProperties, existingPartitionFields);
+                transaction = newCreateTableTransaction(catalog, tableMetadata, session, replace, tableLocation, allowedExtraProperties, existingPartitionFields, defaultCompressionCodec);
             }
         }
 
@@ -1500,7 +1503,7 @@ public class IcebergMetadata
         }
 
         if (transaction == null) {
-            transaction = newCreateTableTransaction(catalog, tableMetadata, session, replace, tableLocation, allowedExtraProperties, ImmutableList.of());
+            transaction = newCreateTableTransaction(catalog, tableMetadata, session, replace, tableLocation, allowedExtraProperties, ImmutableList.of(), defaultCompressionCodec);
         }
         Location location = Location.of(transaction.table().location());
         try {
@@ -2671,12 +2674,17 @@ public class IcebergMetadata
 
     public static Map<String, String> calculateTableCompressionProperties(IcebergFileFormat oldFileFormat, IcebergFileFormat newFileFormat, Map<String, String> existingProperties, Map<String, Object> inputProperties)
     {
+        return calculateTableCompressionProperties(oldFileFormat, newFileFormat, existingProperties, inputProperties, Optional.empty());
+    }
+
+    public static Map<String, String> calculateTableCompressionProperties(IcebergFileFormat oldFileFormat, IcebergFileFormat newFileFormat, Map<String, String> existingProperties, Map<String, Object> inputProperties, Optional<HiveCompressionCodec> fallbackCompressionCodec)
+    {
         ImmutableMap.Builder<String, String> newCompressionProperties = ImmutableMap.builder();
 
         Optional<HiveCompressionCodec> oldCompressionCodec = getHiveCompressionCodec(oldFileFormat, existingProperties);
         Optional<HiveCompressionCodec> newCompressionCodec = IcebergTableProperties.getCompressionCodec(inputProperties);
 
-        Optional<HiveCompressionCodec> compressionCodec = newCompressionCodec.or(() -> oldCompressionCodec);
+        Optional<HiveCompressionCodec> compressionCodec = newCompressionCodec.or(() -> oldCompressionCodec).or(() -> fallbackCompressionCodec);
 
         validateCompression(newFileFormat, compressionCodec);
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
@@ -21,6 +21,8 @@ import io.airlift.json.JsonCodec;
 import io.airlift.units.Duration;
 import io.trino.metastore.HiveMetastoreFactory;
 import io.trino.metastore.RawHiveMetastoreFactory;
+import io.trino.plugin.hive.HiveCompressionCodec;
+import io.trino.plugin.hive.HiveCompressionCodecs;
 import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
 import io.trino.plugin.iceberg.delete.DeletionVectorWriter;
 import io.trino.spi.catalog.CatalogName;
@@ -48,6 +50,7 @@ public class IcebergMetadataFactory
     private final Optional<HiveMetastoreFactory> metastoreFactory;
     private final boolean addFilesProcedureEnabled;
     private final Predicate<String> allowedExtraProperties;
+    private final HiveCompressionCodec defaultCompressionCodec;
     private final ExecutorService icebergScanExecutor;
     private final Executor metadataFetchingExecutor;
     private final ExecutorService icebergPlanningExecutor;
@@ -86,6 +89,7 @@ public class IcebergMetadataFactory
         this.metastoreFactory = requireNonNull(metastoreFactory, "metastoreFactory is null");
         this.icebergScanExecutor = requireNonNull(icebergScanExecutor, "icebergScanExecutor is null");
         this.addFilesProcedureEnabled = config.isAddFilesProcedureEnabled();
+        this.defaultCompressionCodec = HiveCompressionCodecs.toCompressionCodec(config.getCompressionCodec());
         if (config.getAllowedExtraProperties().equals(ImmutableList.of("*"))) {
             this.allowedExtraProperties = _ -> true;
         }
@@ -120,6 +124,7 @@ public class IcebergMetadataFactory
                 metastoreFactory,
                 addFilesProcedureEnabled,
                 allowedExtraProperties,
+                defaultCompressionCodec,
                 icebergScanExecutor,
                 metadataFetchingExecutor,
                 icebergPlanningExecutor,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -957,27 +957,39 @@ public final class IcebergUtil
             Predicate<String> allowedExtraProperties,
             List<PartitionField> existingPartitionFields)
     {
+        return newCreateTableTransaction(catalog, tableMetadata, session, replace, tableLocation, allowedExtraProperties, existingPartitionFields, HiveCompressionCodec.ZSTD);
+    }
+
+    public static Transaction newCreateTableTransaction(
+            TrinoCatalog catalog,
+            ConnectorTableMetadata tableMetadata,
+            ConnectorSession session,
+            boolean replace,
+            String tableLocation,
+            Predicate<String> allowedExtraProperties,
+            List<PartitionField> existingPartitionFields,
+            HiveCompressionCodec defaultCompressionCodec)
+    {
         SchemaTableName schemaTableName = tableMetadata.getTable();
         Schema schema = schemaFromMetadata(tableMetadata.getColumns());
         PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()), existingPartitionFields);
         SortOrder sortOrder = parseSortFields(schema, getSortOrder(tableMetadata.getProperties()));
 
         Transaction transaction;
-
         if (replace) {
-            transaction = catalog.newCreateOrReplaceTableTransaction(session, schemaTableName, schema, partitionSpec, sortOrder, tableLocation, createTableProperties(tableMetadata, allowedExtraProperties));
+            transaction = catalog.newCreateOrReplaceTableTransaction(session, schemaTableName, schema, partitionSpec, sortOrder, tableLocation, createTableProperties(tableMetadata, allowedExtraProperties, defaultCompressionCodec));
         }
         else {
             try {
-                transaction = catalog.newCreateTableTransaction(session, schemaTableName, schema, partitionSpec, sortOrder, Optional.ofNullable(tableLocation), createTableProperties(tableMetadata, allowedExtraProperties));
+                transaction = catalog.newCreateTableTransaction(session, schemaTableName, schema, partitionSpec, sortOrder, Optional.ofNullable(tableLocation), createTableProperties(tableMetadata, allowedExtraProperties, defaultCompressionCodec));
             }
             catch (AlreadyExistsException e) {
                 throw new TrinoException(TABLE_ALREADY_EXISTS, "Table %s already exists".formatted(schemaTableName), e);
             }
         }
 
-        // If user doesn't set compression-codec for parquet, we need to remove write.parquet.compression-codec property,
-        // Otherwise Iceberg will set write.parquet.compression-codec to zstd by default.
+        // Remove the sentinel empty string written by createTableProperties to suppress the Iceberg
+        // library's default injection of write.parquet.compression-codec on non-Parquet tables.
         String parquetCompressionValue = transaction.table().properties().get(PARQUET_COMPRESSION);
         if (parquetCompressionValue != null && parquetCompressionValue.isEmpty()) {
             transaction.updateProperties()
@@ -989,6 +1001,11 @@ public final class IcebergUtil
     }
 
     public static Map<String, String> createTableProperties(ConnectorTableMetadata tableMetadata, Predicate<String> allowedExtraProperties)
+    {
+        return createTableProperties(tableMetadata, allowedExtraProperties, HiveCompressionCodec.ZSTD);
+    }
+
+    public static Map<String, String> createTableProperties(ConnectorTableMetadata tableMetadata, Predicate<String> allowedExtraProperties, HiveCompressionCodec defaultCompressionCodec)
     {
         ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builder();
         IcebergFileFormat fileFormat = IcebergTableProperties.getFileFormat(tableMetadata.getProperties());
@@ -1005,13 +1022,15 @@ public final class IcebergUtil
 
         validateCompression(fileFormat, compressionCodec);
 
-        Map<String, String> tableCompressionProperties = calculateTableCompressionProperties(fileFormat, fileFormat, ImmutableMap.of(), tableMetadata.getProperties());
+        Map<String, String> tableCompressionProperties = calculateTableCompressionProperties(fileFormat, fileFormat, ImmutableMap.of(), tableMetadata.getProperties(), Optional.of(defaultCompressionCodec));
 
         tableCompressionProperties.forEach(propertiesBuilder::put);
 
-        // Iceberg will set write.parquet.compression-codec to zstd by default if this property is not set: https://github.com/trinodb/trino/issues/20401,
-        // but we don't want to set this property if this is not explicitly set by customer via set table properties.
-        if (!(fileFormat == PARQUET && compressionCodec.isPresent())) {
+        // For non-Parquet tables, the Iceberg library still injects write.parquet.compression-codec = zstd
+        // by default when the property is absent. Write a sentinel empty string to suppress that injection;
+        // newCreateTableTransaction removes it after the transaction is opened. 
+        // Parquet tables are not affected because the explicit codec above blocks the library default.
+        if (fileFormat != PARQUET) {
             propertiesBuilder.put(PARQUET_COMPRESSION, "");
         }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -113,6 +113,7 @@ public abstract class BaseIcebergConnectorSmokeTest
                         "   comment varchar\n" +
                         "\\)\n" +
                         "WITH \\(\n" +
+                        "   compression_codec = 'ZSTD',\n" +
                         "   format = '" + format.name() + "',\n" +
                         "   format_version = 2,\n" +
                         "   location = '.*/" + schemaName + "/region.*'\n" +

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -439,6 +439,7 @@ public abstract class BaseIcebergConnectorTest
                         "   comment varchar\n" +
                         ")\n" +
                         "WITH (\n" +
+                        "   compression_codec = 'ZSTD',\n" +
                         "   format = '" + format.name() + "',\n" +
                         "   format_version = " + formatVersion + ",\n" +
                         "   location = '\\E.*/tpch/orders-.*\\Q'\n" +
@@ -1343,6 +1344,7 @@ public abstract class BaseIcebergConnectorTest
                         "   order_status varchar\n" +
                         ")\n" +
                         "WITH (\n" +
+                        "   compression_codec = 'ZSTD',\n" +
                         "   format = '%s',\n" +
                         "   format_version = 2,\n" +
                         "   location = '%s',\n" +
@@ -1767,6 +1769,7 @@ public abstract class BaseIcebergConnectorTest
                 ")\n" +
                 "COMMENT '%s'\n" +
                 "WITH (\n" +
+                "   compression_codec = 'ZSTD',\n" +
                 format("   format = '%s',\n", format) +
                 "   format_version = 2,\n" +
                 format("   location = '%s'\n", tempDirPath) +
@@ -1776,6 +1779,7 @@ public abstract class BaseIcebergConnectorTest
                 "   _x bigint\n" +
                 ")\n" +
                 "WITH (\n" +
+                "   compression_codec = 'ZSTD',\n" +
                 "   format = '" + format + "',\n" +
                 "   format_version = 2,\n" +
                 "   location = '" + tempDirPath + "'\n" +
@@ -2082,6 +2086,7 @@ public abstract class BaseIcebergConnectorTest
         assertThat(getTablePropertiesString("test_create_table_like_original")).isEqualTo(format(
                 """
                 WITH (
+                   compression_codec = 'ZSTD',
                    format = '%s',
                    format_version = %s,
                    location = '%s',
@@ -2099,6 +2104,7 @@ public abstract class BaseIcebergConnectorTest
         assertThat(getTablePropertiesString("test_create_table_like_copy1")).isEqualTo(format(
                 """
                 WITH (
+                   compression_codec = 'ZSTD',
                    format = '%s',
                    format_version = %s,
                    location = '%s'
@@ -2111,6 +2117,7 @@ public abstract class BaseIcebergConnectorTest
         assertThat(getTablePropertiesString("test_create_table_like_copy2")).isEqualTo(format(
                 """
                 WITH (
+                   compression_codec = 'ZSTD',
                    format = '%s',
                    format_version = %s,
                    location = '%s'
@@ -7406,6 +7413,30 @@ public abstract class BaseIcebergConnectorTest
 
         assertQueryFails("CREATE TABLE " + tableName + " WITH (format = '" + format + "', compression_codec = 'unsupported') AS SELECT * FROM nation",
                 ".* \\QUnable to set catalog 'iceberg' table property 'compression_codec' to ['unsupported']: Invalid value [unsupported]. Valid values: [NONE, SNAPPY, LZ4, ZSTD, GZIP]");
+    }
+
+    @Test
+    public void testDefaultCompressionCodecWrittenToTableMetadata()
+    {
+        // Verify that the connector-default compression codec (ZSTD) is always present in Iceberg table
+        // metadata even when the user does not explicitly set compression_codec at CREATE TABLE time.
+        // This makes the table self-describing for external Iceberg clients and ensures SHOW CREATE TABLE
+        // reflects the actual codec used for writes.
+        String tableName = format("test_default_compression_%s_%s", format, randomNameSuffix());
+        String compressionProperty = getCompressionPropertyName(format);
+        String expectedIcebergValue = toCompressionCodecTableProperty(format, HiveCompressionCodec.ZSTD);
+
+        assertUpdate(format("CREATE TABLE %s WITH (format = '%s') AS SELECT * FROM nation", tableName, format), "SELECT count(*) FROM nation");
+        try {
+            assertThat(getTableProperties(tableName))
+                    .containsEntry(compressionProperty, expectedIcebergValue);
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))
+                    .contains("compression_codec = 'ZSTD'");
+            assertThat(query("SELECT * FROM " + tableName)).matches("SELECT * FROM nation");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -226,6 +226,7 @@ public abstract class BaseIcebergMaterializedViewTest
                         "\\QCREATE MATERIALIZED VIEW iceberg." + schema + ".test_mv_show_create\n" +
                                 "WHEN STALE INLINE\n" +
                                 "WITH (\n" +
+                                "   compression_codec = 'ZSTD',\n" +
                                 "   format = 'ORC',\n" +
                                 "   format_version = 2,\n" +
                                 "   location = '" + getSchemaDirectory() + "/test_mv_show_create-\\E[0-9a-f]+\\Q',\n" +
@@ -544,6 +545,7 @@ public abstract class BaseIcebergMaterializedViewTest
                 .matches("\\QCREATE MATERIALIZED VIEW " + qualifiedMaterializedViewName + "\n" +
                         "WHEN STALE INLINE\n" +
                         "WITH (\n" +
+                        "   compression_codec = 'ZSTD',\n" +
                         "   format = 'PARQUET',\n" +
                         "   format_version = 2,\n" +
                         "   location = '" + getSchemaDirectory() + "/materialized_view_window-\\E[0-9a-f]+\\Q',\n" +

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -996,7 +996,11 @@ public abstract class BaseIcebergSystemTables
             assertThat(dataFile.getField(3)).isEqualTo(0); // spec_id
             assertThat(dataFile.getField(4)).isEqualTo(1L); // record_count
             assertThat((long) dataFile.getField(5)).isPositive(); // file_size_in_bytes
-            assertThat(dataFile.getField(6)).isEqualTo(Map.of(1, 51L)); // column_sizes
+            // Equality delete files are always written as Parquet. When the table is a Parquet table,
+            // write.parquet.compression-codec = zstd is present in the metadata so the delete is
+            // ZSTD-compressed (smaller). ORC tables have no such property so the library default applies.
+            long equalityDeleteColumnSize = (long) value(45L, 51L);
+            assertThat(dataFile.getField(6)).isEqualTo(Map.of(1, equalityDeleteColumnSize)); // column_sizes
             assertThat(dataFile.getField(7)).isEqualTo(Map.of(1, 1L)); // value_counts
             assertThat(dataFile.getField(8)).isEqualTo(Map.of(1, 0L)); // null_value_counts
             assertThat(dataFile.getField(9)).isEqualTo(Map.of()); // nan_value_counts
@@ -1012,8 +1016,8 @@ public abstract class BaseIcebergSystemTables
                             """
                             {\
                             "dt":{"column_size":null,"value_count":null,"null_value_count":null,"nan_value_count":null,"lower_bound":null,"upper_bound":null},\
-                            "id":{"column_size":51,"value_count":1,"null_value_count":0,"nan_value_count":null,"lower_bound":1,"upper_bound":1}\
-                            }""");
+                            "id":{"column_size":%d,"value_count":1,"null_value_count":0,"nan_value_count":null,"lower_bound":1,"upper_bound":1}\
+                            }""".formatted(equalityDeleteColumnSize));
         }
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -1284,7 +1284,7 @@ public class TestIcebergV2
                                 (2,
                                 'PARQUET',
                                 1L,
-                                JSON '{"3":52}',
+                                JSON '{"3":49}',
                                 JSON '{"3":1}',
                                 JSON '{"3":0}',
                                 JSON '{}',

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
@@ -19,6 +19,7 @@ import io.airlift.log.Logger;
 import io.trino.metastore.TableInfo;
 import io.trino.metastore.TableInfo.ExtendedRelationType;
 import io.trino.plugin.base.util.AutoCloseableCloser;
+import io.trino.plugin.hive.HiveCompressionCodec;
 import io.trino.plugin.hive.orc.OrcReaderConfig;
 import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
@@ -160,6 +161,7 @@ public abstract class BaseTrinoCatalogTest
                     Optional.empty(),
                     false,
                     _ -> false,
+                    HiveCompressionCodec.ZSTD,
                     newDirectExecutorService(),
                     directExecutor(),
                     newDirectExecutorService(),
@@ -203,6 +205,7 @@ public abstract class BaseTrinoCatalogTest
                     Optional.empty(),
                     false,
                     _ -> false,
+                    HiveCompressionCodec.ZSTD,
                     newDirectExecutorService(),
                     directExecutor(),
                     newDirectExecutorService(),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConnectorSmokeTest.java
@@ -108,6 +108,7 @@ public class TestIcebergGlueCatalogConnectorSmokeTest
                                 "   comment varchar\n" +
                                 ")\n" +
                                 "WITH (\n" +
+                                "   compression_codec = 'ZSTD',\n" +
                                 "   format = 'PARQUET',\n" +
                                 "   format_version = 2,\n" +
                                 "   location = '%2$s/%1$s.db/region-\\E.*\\Q'\n" +

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
@@ -19,6 +19,7 @@ import io.airlift.log.Logger;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.metastore.TableInfo;
 import io.trino.plugin.hive.FlociS3AndGlue;
+import io.trino.plugin.hive.HiveCompressionCodec;
 import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
 import io.trino.plugin.iceberg.CommitTaskData;
 import io.trino.plugin.iceberg.IcebergConfig;
@@ -174,6 +175,7 @@ public class TestTrinoGlueCatalog
                     Optional.empty(),
                     false,
                     _ -> false,
+                    HiveCompressionCodec.ZSTD,
                     newDirectExecutorService(),
                     directExecutor(),
                     newDirectExecutorService(),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg.catalog.nessie;
 import com.google.common.collect.ImmutableMap;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
+import io.trino.plugin.hive.HiveCompressionCodec;
 import io.trino.plugin.iceberg.CommitTaskData;
 import io.trino.plugin.iceberg.IcebergMetadata;
 import io.trino.plugin.iceberg.TableStatisticsWriter;
@@ -224,6 +225,7 @@ public class TestTrinoNessieCatalog
                     Optional.empty(),
                     false,
                     _ -> false,
+                    HiveCompressionCodec.ZSTD,
                     newDirectExecutorService(),
                     directExecutor(),
                     newDirectExecutorService(),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest.java
@@ -171,6 +171,7 @@ final class TestIcebergRestCatalogNestedNamespaceConnectorSmokeTest
                         "   comment varchar\n" +
                         "\\)\n" +
                         "WITH \\(\n" +
+                        "   compression_codec = 'ZSTD',\n" +
                         "   format = '" + format.name() + "',\n" +
                         "   format_version = 2,\n" +
                         "   location = '.*/" + schemaName + "/region.*'\n" +

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.cache.EvictableCacheBuilder;
 import io.trino.metastore.TableInfo;
+import io.trino.plugin.hive.HiveCompressionCodec;
 import io.trino.plugin.iceberg.CommitTaskData;
 import io.trino.plugin.iceberg.DefaultIcebergFileSystemFactory;
 import io.trino.plugin.iceberg.IcebergMetadata;
@@ -171,6 +172,7 @@ public class TestTrinoRestCatalog
                     Optional.empty(),
                     false,
                     _ -> false,
+                    HiveCompressionCodec.ZSTD,
                     newDirectExecutorService(),
                     directExecutor(),
                     newDirectExecutorService(),

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/snowflake/TestTrinoSnowflakeCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/snowflake/TestTrinoSnowflakeCatalog.java
@@ -21,6 +21,7 @@ import io.trino.filesystem.s3.S3FileSystemConfig;
 import io.trino.filesystem.s3.S3FileSystemFactory;
 import io.trino.filesystem.s3.S3FileSystemStats;
 import io.trino.metastore.TableInfo;
+import io.trino.plugin.hive.HiveCompressionCodec;
 import io.trino.plugin.iceberg.ColumnIdentity;
 import io.trino.plugin.iceberg.CommitTaskData;
 import io.trino.plugin.iceberg.IcebergMetadata;
@@ -241,6 +242,7 @@ public class TestTrinoSnowflakeCatalog
                 Optional.empty(),
                 false,
                 _ -> false,
+                HiveCompressionCodec.ZSTD,
                 newDirectExecutorService(),
                 directExecutor(),
                 newDirectExecutorService(),

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/BaseLakehouseConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/BaseLakehouseConnectorSmokeTest.java
@@ -129,6 +129,7 @@ public abstract class BaseLakehouseConnectorSmokeTest
                    comment varchar
                 )
                 WITH (
+                   compression_codec = 'ZSTD',
                    format = 'ORC',
                    format_version = 2,
                    location = \\E's3://test-bucket-.*/tpch/create_iceberg-.*'\\Q,

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseConnectorTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseConnectorTest.java
@@ -394,6 +394,7 @@ public class TestLakehouseConnectorTest
                    comment varchar
                 )
                 WITH (
+                   compression_codec = 'ZSTD',
                    format = 'PARQUET',
                    format_version = 2,
                    location = \\E's3://test-bucket-.*/tpch/orders-.*'\\Q,

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseFileConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseFileConnectorSmokeTest.java
@@ -97,6 +97,7 @@ public class TestLakehouseFileConnectorSmokeTest
                    comment varchar
                 )
                 WITH (
+                   compression_codec = 'ZSTD',
                    format = 'PARQUET',
                    format_version = 2,
                    location = 's3://test-bucket/tpch/region-\\E.*\\Q',

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseFlociConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseFlociConnectorSmokeTest.java
@@ -74,6 +74,7 @@ public class TestLakehouseFlociConnectorSmokeTest
                    comment varchar
                 )
                 WITH (
+                   compression_codec = 'ZSTD',
                    format = 'PARQUET',
                    format_version = 2,
                    location = 's3://test-bucket/tpch/region-\\E.*\\Q',

--- a/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-lakehouse/src/test/java/io/trino/plugin/lakehouse/TestLakehouseIcebergConnectorSmokeTest.java
@@ -51,6 +51,7 @@ public class TestLakehouseIcebergConnectorSmokeTest
                    comment varchar
                 )
                 WITH (
+                   compression_codec = 'ZSTD',
                    format = 'PARQUET',
                    format_version = 2,
                    location = \\E's3://test-bucket-.*/tpch/region-.*'\\Q,
@@ -70,7 +71,7 @@ public class TestLakehouseIcebergConnectorSmokeTest
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$files\"")).matches("VALUES (CAST(1 AS BIGINT))");
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$all_entries\"")).matches("VALUES (CAST(1 AS BIGINT))");
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$entries\"")).matches("VALUES (CAST(1 AS BIGINT))");
-        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$properties\"")).matches("VALUES (CAST(6 AS BIGINT))");
+        assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$properties\"")).matches("VALUES (CAST(7 AS BIGINT))");
         assertThat(query("SELECT count(*) FROM lakehouse.tpch.\"region$refs\"")).matches("VALUES (CAST(1 AS BIGINT))");
 
         // This test should get updated if a new system table is added

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
@@ -340,6 +340,7 @@ class TestHiveRedirectionToIceberg
                         "   comment varchar\n" +
                         ")\n" +
                         "WITH (\n" +
+                        "   compression_codec = 'ZSTD',\n" +
                         "   format = 'PARQUET',\n" +
                         "   format_version = 2,\n" +
                         format("   location = 'hdfs://hadoop-master:9000/user/hive/warehouse/%s-\\E.*\\Q',\n", tableName) +

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
@@ -63,6 +63,7 @@ class TestIcebergPartitionEvolution
                                     "   c varchar\n" +
                                     ")\n" +
                                     "WITH (\n" +
+                                    "   compression_codec = 'ZSTD',\n" +
                                     "   format = 'PARQUET',\n" +
                                     "   format_version = 1,\n" +
                                     "   location = 'hdfs://hadoop-master:9000/user/hive/warehouse/" + tableName + "-\\E.*\\Q',\n" +


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

When creating an Iceberg table without an explicit compression_codec table property, Trino wouldn't write the default codec to Iceberg table metadata. It would also suppress the Iceberg library's own default injection, leaving the table with no compression property at all.

This change consistently persists the effective compression codec into the Iceberg table metadata at CREATE TABLE time.

* Fixes #28009 

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Adds a test verifying the default codec is written. Also adjusts a few tests to now expect compression_codec = 'ZSTD' where before there was nothing.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Always persists effective compression_codec in table metadata when creating Iceberg tables. ({issue}`28009`)
```
