### PR TITLE
Print product test failure details

### DIFF
--- a/testing/trino-product-tests/src/test/java/io/trino/tests/framework/FailureReportingFixture.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/framework/FailureReportingFixture.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.framework;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+
+class FailureReportingFixture
+{
+    @ParameterizedTest(name = "failing invocation [{index}] value={0}")
+    @ValueSource(strings = "test-value")
+    void failingTest(String value)
+    {
+        RuntimeException failure = new RuntimeException("outer failure", new IOException("root failure"));
+        failure.addSuppressed(new IllegalStateException("suppressed failure"));
+        throw failure;
+    }
+}

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/framework/TestSuiteRunnerFailureReporting.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/framework/TestSuiteRunnerFailureReporting.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.framework;
+
+import io.trino.tests.product.suite.SuiteRunner;
+import io.trino.tests.product.suite.SuiteRunner.TestRunResult;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+class TestSuiteRunnerFailureReporting
+{
+    @Test
+    void testPrintsCompleteFailureDetails()
+    {
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(selectClass(FailureReportingFixture.class))
+                .build();
+        SummaryGeneratingListener listener = new SummaryGeneratingListener();
+        Launcher launcher = LauncherFactory.create();
+        launcher.registerTestExecutionListeners(listener);
+        launcher.execute(request);
+
+        assertThat(listener.getSummary().getTestsFailedCount()).isEqualTo(1);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (PrintStream capturedOutput = new PrintStream(output, true, UTF_8)) {
+            SuiteRunner.printSummary(List.of(new TestRunResult("test-run", "TestEnvironment", listener.getSummary())), capturedOutput);
+        }
+
+        assertThat(output.toString(UTF_8))
+                .contains("[ERROR] failing invocation [1] value=\"test-value\" (TestEnvironment)")
+                .contains("java.lang.RuntimeException: outer failure")
+                .contains("Suppressed: java.lang.IllegalStateException: suppressed failure")
+                .contains("Caused by: java.io.IOException: root failure")
+                .containsPattern("at io\\.trino\\.tests\\.framework\\.FailureReportingFixture\\.failingTest\\(FailureReportingFixture\\.java:[0-9]+\\)")
+                .doesNotContain("FailureReportingFixture.java:1)");
+    }
+}

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteRunner.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteRunner.java
@@ -28,6 +28,7 @@ import org.junit.platform.launcher.core.LauncherFactory;
 import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 import org.junit.platform.launcher.listeners.TestExecutionSummary;
 
+import java.io.PrintStream;
 import java.lang.annotation.Annotation;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -102,10 +103,9 @@ public final class SuiteRunner
         if (source instanceof MethodSource methodSource) {
             String className = methodSource.getClassName();
             String methodName = methodSource.getMethodName();
-            String simpleClassName = className.substring(className.lastIndexOf('.') + 1);
-            return new FailureInfo(className, methodName, simpleClassName, failure.getTestIdentifier().getDisplayName());
+            return new FailureInfo(className, methodName, failure.getTestIdentifier().getDisplayName());
         }
-        return new FailureInfo("", "", "", failure.getTestIdentifier().getDisplayName());
+        return new FailureInfo("", "", failure.getTestIdentifier().getDisplayName());
     }
 
     private static TestRunResult run(
@@ -186,9 +186,20 @@ public final class SuiteRunner
      */
     public static void printSummary(List<TestRunResult> results)
     {
-        System.out.println("\n========================================");
-        System.out.println("           COMBINED TEST SUMMARY        ");
-        System.out.println("========================================\n");
+        printSummary(results, System.out);
+    }
+
+    /**
+     * Prints a combined summary of all test runs to the specified output.
+     *
+     * @param results the list of test run results
+     * @param output the destination for the summary
+     */
+    public static void printSummary(List<TestRunResult> results, PrintStream output)
+    {
+        output.println("\n========================================");
+        output.println("           COMBINED TEST SUMMARY        ");
+        output.println("========================================\n");
 
         long totalFound = 0;
         long totalSucceeded = 0;
@@ -204,7 +215,7 @@ public final class SuiteRunner
             totalSkipped += summary.getTestsSkippedCount();
             totalContainerFailed += summary.getContainersFailedCount();
 
-            System.out.printf(
+            output.printf(
                     "%-30s | Found: %3d | Passed: %3d | Failed: %3d | Skipped: %3d | CFail: %3d%n",
                     result.runName(),
                     summary.getTestsFoundCount(),
@@ -214,8 +225,8 @@ public final class SuiteRunner
                     summary.getContainersFailedCount());
         }
 
-        System.out.println("----------------------------------------");
-        System.out.printf(
+        output.println("----------------------------------------");
+        output.printf(
                 "%-30s | Found: %3d | Passed: %3d | Failed: %3d | Skipped: %3d | CFail: %3d%n",
                 "TOTAL",
                 totalFound,
@@ -223,11 +234,11 @@ public final class SuiteRunner
                 totalFailed,
                 totalSkipped,
                 totalContainerFailed);
-        System.out.println("========================================\n");
+        output.println("========================================\n");
 
         if (hasFailures(results)) {
-            System.out.println("FAILURE DETAILS:");
-            System.out.println("----------------");
+            output.println("FAILURE DETAILS:");
+            output.println("----------------");
             for (TestRunResult result : results) {
                 List<TestExecutionSummary.Failure> failures = result.summary().getFailures().stream()
                         .sorted(Comparator
@@ -236,25 +247,24 @@ public final class SuiteRunner
                                 .thenComparing(failure -> failureInfo(failure).displayName()))
                         .toList();
                 if (!failures.isEmpty()) {
-                    System.out.println("\n" + result.runName() + " (" + result.environmentName() + "):");
+                    output.println("\n" + result.runName() + " (" + result.environmentName() + "):");
                     for (TestExecutionSummary.Failure failure : failures) {
                         Throwable exception = failure.getException();
                         String prefix = (exception instanceof AssertionError) ? "[FAILURE]" : "[ERROR]";
                         FailureInfo info = failureInfo(failure);
 
                         if (!info.className().isEmpty()) {
-                            System.out.println(prefix + " " + info.methodName() + "(" + result.environmentName() + ")");
-                            System.out.println("    at " + info.className() + "." + info.methodName() + "(" + info.simpleClassName() + ".java:1)");
+                            output.println(prefix + " " + info.displayName() + " (" + result.environmentName() + ")");
                         }
                         else {
-                            System.out.println(prefix + " " + info.displayName());
+                            output.println(prefix + " " + info.displayName());
                         }
 
-                        System.out.println("    " + exception.getClass().getSimpleName() + ": " + exception.getMessage());
+                        exception.printStackTrace(output);
                     }
                 }
             }
-            System.out.println();
+            output.println();
         }
     }
 
@@ -337,7 +347,6 @@ public final class SuiteRunner
     private record FailureInfo(
             String className,
             String methodName,
-            String simpleClassName,
             String displayName) {}
 
     /**


### PR DESCRIPTION
## Description

JUnit product test summaries currently discard throwable cause chains and replace source locations with a fabricated line number. This makes intermittent CI failures impossible to diagnose from the retained job log.

Preserve the actual parameterized invocation and complete throwable stack, including suppressed failures and server-side causes. The summary formatter accepts an explicit output stream so this behavior can be covered without replacing global process state.

## Additional context and related issues

Related to #30594. This restores the information needed to diagnose the intermittent Iceberg writer failure; it does not claim to fix that underlying failure.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
