### PR TITLE
Improve product test logging

### DIFF
--- a/testing/trino-product-tests/pom.xml
+++ b/testing/trino-product-tests/pom.xml
@@ -131,6 +131,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/Logging.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/Logging.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.suite;
+
+import io.airlift.log.Format;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.google.common.base.Strings.nullToEmpty;
+import static java.util.logging.Level.WARNING;
+
+public final class Logging
+{
+    private static final Map<String, Logger> LOGGERS = new ConcurrentHashMap<>();
+
+    private Logging() {}
+
+    public static void configureConsoleLogging()
+    {
+        Formatter formatter = Format.TEXT.createFormatter(Map.of());
+        for (Handler handler : Logger.getLogger("").getHandlers()) {
+            if (handler instanceof ConsoleHandler) {
+                handler.setFormatter(formatter);
+                handler.setFilter(record -> {
+                    String message = nullToEmpty(record.getMessage());
+                    return !message.startsWith("Pulling image layers:") && !message.equals("Starting to pull image");
+                });
+            }
+        }
+        setLevel("org.testcontainers.images.PullPolicy", WARNING);
+        setLevel("org.testcontainers.utility.ImageNameSubstitutor", WARNING);
+        setLevel("org.testcontainers.DockerClientFactory", WARNING);
+        setLevel("org.testcontainers.dockerclient.DockerClientProviderStrategy", WARNING);
+    }
+
+    private static void setLevel(String logger, Level level)
+    {
+        LOGGERS.computeIfAbsent(logger, Logger::getLogger).setLevel(level);
+    }
+}

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteRunner.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteRunner.java
@@ -36,6 +36,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.TimeZone;
 
+import static io.trino.tests.product.suite.Logging.configureConsoleLogging;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -115,6 +116,9 @@ public final class SuiteRunner
             List<String> excludeTags)
             throws Exception
     {
+        Thread.currentThread().setName(environmentClass.getSimpleName());
+        configureConsoleLogging();
+
         // Legacy launcher forced this timezone for all product test JVM executions.
         TimeZone.setDefault(TimeZone.getTimeZone(ZoneId.of(PRODUCT_TESTS_TIME_ZONE)));
         System.setProperty("user.timezone", PRODUCT_TESTS_TIME_ZONE);


### PR DESCRIPTION
## Description

Format product test console logs on one line and suppress noisy Testcontainers image pull progress messages.

## Additional context and related issues

Testcontainers JUL output currently splits log metadata and messages across lines and repeatedly reports image-layer progress.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```