### PR TITLE
Restore product test query retries

### DIFF
--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/azure/AzureEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/azure/AzureEnvironment.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static io.trino.testing.SystemEnvironmentUtils.requireEnv;
+import static io.trino.testing.containers.environment.QueryRetry.executeWithRetry;
 import static io.trino.tests.product.hive.HiveCatalogPropertiesBuilder.hadoopMetastoreUri;
 import static io.trino.tests.product.hive.HiveCatalogPropertiesBuilder.hiveCatalog;
 import static io.trino.tests.product.iceberg.IcebergCatalogPropertiesBuilder.icebergCatalog;
@@ -246,10 +247,14 @@ public class AzureEnvironment
     @Override
     public QueryResult executeSpark(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery(sql)) {
-            return QueryResult.forResultSet(rs);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement();
+                        ResultSet rs = stmt.executeQuery(sql)) {
+                    return QueryResult.forResultSet(rs);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark query: " + sql, e);

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/DeltaLakeOssEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/DeltaLakeOssEnvironment.java
@@ -30,6 +30,8 @@ import java.sql.Statement;
 import java.util.List;
 import java.util.Map;
 
+import static io.trino.testing.containers.environment.QueryRetry.executeWithRetry;
+
 /**
  * Single-node Delta Lake environment with Spark, Hive Metastore, and Floci storage.
  */
@@ -128,10 +130,14 @@ public class DeltaLakeOssEnvironment
 
     public QueryResult executeSpark(String sql)
     {
-        try (Connection connection = createSparkConnection();
-                Statement statement = connection.createStatement();
-                ResultSet resultSet = statement.executeQuery(sql)) {
-            return QueryResult.forResultSet(resultSet);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection connection = createSparkConnection();
+                        Statement statement = connection.createStatement();
+                        ResultSet resultSet = statement.executeQuery(sql)) {
+                    return QueryResult.forResultSet(resultSet);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark query: " + sql, e);
@@ -140,9 +146,13 @@ public class DeltaLakeOssEnvironment
 
     public int executeSparkUpdate(String sql)
     {
-        try (Connection connection = createSparkConnection();
-                Statement statement = connection.createStatement()) {
-            return statement.executeUpdate(sql);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection connection = createSparkConnection();
+                        Statement statement = connection.createStatement()) {
+                    return statement.executeUpdate(sql);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark update: " + sql, e);

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/gcs/GcsEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/gcs/GcsEnvironment.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static io.trino.testing.SystemEnvironmentUtils.requireEnv;
+import static io.trino.testing.containers.environment.QueryRetry.executeWithRetry;
 import static io.trino.tests.product.hive.HiveCatalogPropertiesBuilder.hadoopMetastoreUri;
 import static io.trino.tests.product.hive.HiveCatalogPropertiesBuilder.hiveCatalog;
 import static io.trino.tests.product.iceberg.IcebergCatalogPropertiesBuilder.icebergCatalog;
@@ -183,10 +184,14 @@ public class GcsEnvironment
     @Override
     public QueryResult executeSpark(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery(sql)) {
-            return QueryResult.forResultSet(rs);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement();
+                        ResultSet rs = stmt.executeQuery(sql)) {
+                    return QueryResult.forResultSet(rs);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark query: " + sql, e);

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/HiveHudiRedirectionsEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/HiveHudiRedirectionsEnvironment.java
@@ -30,6 +30,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
 
+import static io.trino.testing.containers.environment.QueryRetry.executeWithRetry;
 import static io.trino.tests.product.hive.HiveCatalogPropertiesBuilder.hiveCatalog;
 
 /**
@@ -162,10 +163,14 @@ public class HiveHudiRedirectionsEnvironment
      */
     public QueryResult executeSpark(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery(sql)) {
-            return QueryResult.forResultSet(rs);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement();
+                        ResultSet rs = stmt.executeQuery(sql)) {
+                    return QueryResult.forResultSet(rs);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark query: " + sql, e);
@@ -180,9 +185,13 @@ public class HiveHudiRedirectionsEnvironment
      */
     public int executeSparkUpdate(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement()) {
-            return stmt.executeUpdate(sql);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement()) {
+                    return stmt.executeUpdate(sql);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark update: " + sql, e);

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/HiveSparkEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/HiveSparkEnvironment.java
@@ -29,6 +29,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
 
+import static io.trino.testing.containers.environment.QueryRetry.executeWithRetry;
 import static io.trino.tests.product.hive.HiveCatalogPropertiesBuilder.hiveCatalog;
 
 /**
@@ -129,10 +130,14 @@ public class HiveSparkEnvironment
      */
     public QueryResult executeSpark(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery(sql)) {
-            return QueryResult.forResultSet(rs);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement();
+                        ResultSet rs = stmt.executeQuery(sql)) {
+                    return QueryResult.forResultSet(rs);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark query: " + sql, e);
@@ -147,9 +152,13 @@ public class HiveSparkEnvironment
      */
     public int executeSparkUpdate(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement()) {
-            return stmt.executeUpdate(sql);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement()) {
+                    return stmt.executeUpdate(sql);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark update: " + sql, e);

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/HiveSparkNoStatsFallbackEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/HiveSparkNoStatsFallbackEnvironment.java
@@ -29,6 +29,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
 
+import static io.trino.testing.containers.environment.QueryRetry.executeWithRetry;
 import static io.trino.tests.product.hive.HiveCatalogPropertiesBuilder.hiveCatalog;
 
 /**
@@ -118,10 +119,14 @@ public class HiveSparkNoStatsFallbackEnvironment
      */
     public QueryResult executeSpark(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery(sql)) {
-            return QueryResult.forResultSet(rs);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement();
+                        ResultSet rs = stmt.executeQuery(sql)) {
+                    return QueryResult.forResultSet(rs);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark query: " + sql, e);
@@ -136,9 +141,13 @@ public class HiveSparkNoStatsFallbackEnvironment
      */
     public int executeSparkUpdate(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement()) {
-            return stmt.executeUpdate(sql);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement()) {
+                    return stmt.executeUpdate(sql);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark update: " + sql, e);

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hudi/HudiEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hudi/HudiEnvironment.java
@@ -29,6 +29,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
 
+import static io.trino.testing.containers.environment.QueryRetry.executeWithRetry;
+
 /**
  * Hudi product test environment for interoperability testing.
  * <p>
@@ -129,10 +131,14 @@ public class HudiEnvironment
      */
     public QueryResult executeSpark(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery(sql)) {
-            return QueryResult.forResultSet(rs);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement();
+                        ResultSet rs = stmt.executeQuery(sql)) {
+                    return QueryResult.forResultSet(rs);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark query: " + sql, e);
@@ -147,9 +153,13 @@ public class HudiEnvironment
      */
     public int executeSparkUpdate(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement()) {
-            return stmt.executeUpdate(sql);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement()) {
+                    return stmt.executeUpdate(sql);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark update: " + sql, e);

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/iceberg/SparkIcebergEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/iceberg/SparkIcebergEnvironment.java
@@ -33,6 +33,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
 
+import static io.trino.testing.containers.environment.QueryRetry.executeWithRetry;
 import static io.trino.tests.product.iceberg.IcebergCatalogPropertiesBuilder.icebergCatalog;
 import static java.util.Objects.requireNonNull;
 
@@ -151,10 +152,14 @@ public class SparkIcebergEnvironment
      */
     public QueryResult executeSpark(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery(sql)) {
-            return QueryResult.forResultSet(rs);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement();
+                        ResultSet rs = stmt.executeQuery(sql)) {
+                    return QueryResult.forResultSet(rs);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark query: " + sql, e);
@@ -169,15 +174,19 @@ public class SparkIcebergEnvironment
      */
     public int executeSparkUpdate(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement()) {
-            if (stmt.execute(sql)) {
-                try (ResultSet ignored = stmt.getResultSet()) {
-                    // intentionally ignored
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement()) {
+                    if (stmt.execute(sql)) {
+                        try (ResultSet ignored = stmt.getResultSet()) {
+                            // intentionally ignored
+                        }
+                        return -1;
+                    }
+                    return stmt.getUpdateCount();
                 }
-                return -1;
-            }
-            return stmt.getUpdateCount();
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark update: " + sql, e);

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/iceberg/SparkIcebergJdbcCatalogEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/iceberg/SparkIcebergJdbcCatalogEnvironment.java
@@ -33,6 +33,7 @@ import java.sql.Statement;
 import java.time.Duration;
 import java.util.Map;
 
+import static io.trino.testing.containers.environment.QueryRetry.executeWithRetry;
 import static java.util.Map.entry;
 
 /**
@@ -239,9 +240,13 @@ public class SparkIcebergJdbcCatalogEnvironment
     @Override
     public QueryResult executeSpark(String sql)
     {
-        try (Statement stmt = sparkConnection().createStatement();
-                ResultSet rs = stmt.executeQuery(sql)) {
-            return QueryResult.forResultSet(rs);
+        try {
+            return executeWithRetry(() -> {
+                try (Statement stmt = sparkConnection().createStatement();
+                        ResultSet rs = stmt.executeQuery(sql)) {
+                    return QueryResult.forResultSet(rs);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark query: " + sql, e);
@@ -257,8 +262,12 @@ public class SparkIcebergJdbcCatalogEnvironment
     @Override
     public int executeSparkUpdate(String sql)
     {
-        try (Statement stmt = sparkConnection().createStatement()) {
-            return stmt.executeUpdate(sql);
+        try {
+            return executeWithRetry(() -> {
+                try (Statement stmt = sparkConnection().createStatement()) {
+                    return stmt.executeUpdate(sql);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark update: " + sql, e);

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/iceberg/SparkIcebergNessieEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/iceberg/SparkIcebergNessieEnvironment.java
@@ -28,6 +28,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
 
+import static io.trino.testing.containers.environment.QueryRetry.executeWithRetry;
+
 /**
  * Spark/Iceberg with Nessie catalog product test environment.
  * <p>
@@ -143,10 +145,14 @@ public class SparkIcebergNessieEnvironment
     @Override
     public QueryResult executeSpark(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery(sql)) {
-            return QueryResult.forResultSet(rs);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement();
+                        ResultSet rs = stmt.executeQuery(sql)) {
+                    return QueryResult.forResultSet(rs);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark query: " + sql, e);
@@ -162,9 +168,13 @@ public class SparkIcebergNessieEnvironment
     @Override
     public int executeSparkUpdate(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement()) {
-            return stmt.executeUpdate(sql);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement()) {
+                    return stmt.executeUpdate(sql);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark update: " + sql, e);

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/iceberg/SparkIcebergRestEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/iceberg/SparkIcebergRestEnvironment.java
@@ -34,6 +34,8 @@ import java.sql.Statement;
 import java.time.Duration;
 import java.util.Map;
 
+import static io.trino.testing.containers.environment.QueryRetry.executeWithRetry;
+
 /**
  * Spark/Iceberg with REST Catalog product test environment for interoperability testing.
  * <p>
@@ -194,10 +196,14 @@ public class SparkIcebergRestEnvironment
     @Override
     public QueryResult executeSpark(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement();
-                ResultSet rs = stmt.executeQuery(sql)) {
-            return QueryResult.forResultSet(rs);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement();
+                        ResultSet rs = stmt.executeQuery(sql)) {
+                    return QueryResult.forResultSet(rs);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark query: " + sql, e);
@@ -213,9 +219,13 @@ public class SparkIcebergRestEnvironment
     @Override
     public int executeSparkUpdate(String sql)
     {
-        try (Connection conn = createSparkConnection();
-                Statement stmt = conn.createStatement()) {
-            return stmt.executeUpdate(sql);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createSparkConnection();
+                        Statement stmt = conn.createStatement()) {
+                    return stmt.executeUpdate(sql);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException("Failed to execute Spark update: " + sql, e);

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/environment/ProductTestEnvironment.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/environment/ProductTestEnvironment.java
@@ -19,6 +19,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 
+import static io.trino.testing.containers.environment.QueryRetry.executeWithRetry;
+
 /**
  * Represents a product test environment consisting of Trino and supporting services.
  * <p>
@@ -136,8 +138,12 @@ public abstract class ProductTestEnvironment
      */
     public QueryResult executeTrino(String sql)
     {
-        try (Statement stmt = getTrinoSessionConnection().createStatement()) {
-            return executeTrinoStatement(stmt, sql);
+        try {
+            return executeWithRetry(() -> {
+                try (Statement stmt = getTrinoSessionConnection().createStatement()) {
+                    return executeTrinoStatement(stmt, sql);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
@@ -153,9 +159,13 @@ public abstract class ProductTestEnvironment
      */
     public QueryResult executeTrino(String sql, String user)
     {
-        try (Connection conn = createTrinoConnection(user);
-                Statement stmt = conn.createStatement()) {
-            return executeTrinoStatement(stmt, sql);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createTrinoConnection(user);
+                        Statement stmt = conn.createStatement()) {
+                    return executeTrinoStatement(stmt, sql);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
@@ -172,8 +182,12 @@ public abstract class ProductTestEnvironment
      */
     public int executeTrinoUpdate(String sql)
     {
-        try (Statement stmt = getTrinoSessionConnection().createStatement()) {
-            return executeTrinoUpdateStatement(stmt, sql);
+        try {
+            return executeWithRetry(() -> {
+                try (Statement stmt = getTrinoSessionConnection().createStatement()) {
+                    return executeTrinoUpdateStatement(stmt, sql);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
@@ -189,9 +203,13 @@ public abstract class ProductTestEnvironment
      */
     public int executeTrinoUpdate(String sql, String user)
     {
-        try (Connection conn = createTrinoConnection(user);
-                Statement stmt = conn.createStatement()) {
-            return executeTrinoUpdateStatement(stmt, sql);
+        try {
+            return executeWithRetry(() -> {
+                try (Connection conn = createTrinoConnection(user);
+                        Statement stmt = conn.createStatement()) {
+                    return executeTrinoUpdateStatement(stmt, sql);
+                }
+            });
         }
         catch (SQLException e) {
             throw new RuntimeException(e.getMessage(), e);
@@ -314,15 +332,17 @@ public abstract class ProductTestEnvironment
         public QueryResult executeQuery(String sql)
                 throws SQLException
         {
-            try (ResultSet rs = statement.executeQuery(sql)) {
-                return QueryResult.forResultSet(rs);
-            }
+            return executeWithRetry(() -> {
+                try (ResultSet rs = statement.executeQuery(sql)) {
+                    return QueryResult.forResultSet(rs);
+                }
+            });
         }
 
         public int executeUpdate(String sql)
                 throws SQLException
         {
-            return statement.executeUpdate(sql);
+            return executeWithRetry(() -> statement.executeUpdate(sql));
         }
 
         public Connection getConnection()

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/environment/QueryRetry.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/environment/QueryRetry.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.containers.environment;
+
+import com.google.common.base.Throwables;
+import dev.failsafe.Failsafe;
+import dev.failsafe.FailsafeException;
+import dev.failsafe.RetryPolicy;
+import io.airlift.log.Logger;
+
+import java.sql.SQLException;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+/// Executes JDBC operations with retries for known transient product-test failures.
+public final class QueryRetry
+{
+    private static final Logger log = Logger.get(QueryRetry.class);
+
+    private static final RetryPolicy<Object> RETRY_POLICY = RetryPolicy.builder()
+            .handleIf(QueryRetry::isRetryableFailure)
+            .withBackoff(1, 10, SECONDS)
+            .withMaxRetries(30)
+            .onRetry(event -> log.warn(event.getLastException(), "Query failed on attempt %d, will retry.", event.getAttemptCount()))
+            .build();
+
+    private QueryRetry() {}
+
+    public static <T> T executeWithRetry(SqlOperation<T> operation)
+            throws SQLException
+    {
+        try {
+            return Failsafe.with(RETRY_POLICY).get(operation::execute);
+        }
+        catch (FailsafeException failure) {
+            if (failure.getCause() instanceof SQLException sqlException) {
+                throw sqlException;
+            }
+            throw failure;
+        }
+    }
+
+    private static boolean isRetryableFailure(Throwable failure)
+    {
+        String value = Throwables.getStackTraceAsString(failure);
+        return value.contains("could only be replicated to 0 nodes instead of minReplication") ||
+                value.contains("could only be written to 0 of the 1 minReplication");
+    }
+
+    @FunctionalInterface
+    public interface SqlOperation<T>
+    {
+        T execute()
+                throws SQLException;
+    }
+}


### PR DESCRIPTION
## Description

Restore retries for known transient HDFS minimum-replication failures in Trino and Spark product-test execution paths.

## Additional context and related issues

The retry behavior was lost when product tests migrated to JUnit. Other failures are preserved, and retry warnings include complete exception chains.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```