### PR TITLE
Fix planner failure when pushing down BETWEEN over a non-column expression

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
@@ -16,6 +16,7 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.cost.StatsProvider;
 import io.trino.matching.Capture;
@@ -42,6 +43,7 @@ import io.trino.sql.planner.DomainTranslator;
 import io.trino.sql.planner.EngineExpressions;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
+import io.trino.sql.planner.SymbolsExtractor;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.PlanNode;
@@ -163,6 +165,10 @@ public class PushPredicateIntoTableScan
                 session,
                 splitExpression.getDeterministicPredicate());
 
+        if (!isKeyedByScanAssignments(decomposedPredicate.getTupleDomain(), node)) {
+            return Optional.empty();
+        }
+
         TupleDomain<ColumnHandle> newDomain = decomposedPredicate.getTupleDomain()
                 .transformKeys(node.getAssignments()::get)
                 .intersect(node.getEnforcedConstraint());
@@ -211,6 +217,11 @@ public class PushPredicateIntoTableScan
                     decomposedPredicate.getRemainingExpression());
 
             if (!Booleans.TRUE.equals(resultingPredicate)) {
+                if (!referencesOnlySourceSymbols(resultingPredicate, node)) {
+                    // Nothing was pushed on this path - the scan is unchanged - so declining leaves the
+                    // original, valid plan in place.
+                    return Optional.empty();
+                }
                 return Optional.of(new FilterNode(filterNode.getId(), node, resultingPredicate));
             }
 
@@ -282,10 +293,53 @@ public class PushPredicateIntoTableScan
                 remainingDecomposedPredicate);
 
         if (!Booleans.TRUE.equals(resultingPredicate)) {
+            if (!referencesOnlySourceSymbols(resultingPredicate, tableScan)) {
+                // Keep the pushdown, but restore the original predicate above the scan. Re-applying an
+                // already enforced predicate is redundant, never wrong, and it keeps the constraint that
+                // the connector recorded during applyFilter - which matters for connectors that require a
+                // partition filter to have been pushed (they inspect the recorded constraint columns).
+                return Optional.of(new FilterNode(filterNode.getId(), tableScan, filterNode.getPredicate()));
+            }
             return Optional.of(new FilterNode(filterNode.getId(), tableScan, resultingPredicate));
         }
 
         return Optional.of(tableScan);
+    }
+
+    /**
+     * Tells whether the extracted domain is keyed only by symbols the table scan produces.
+     * <p>
+     * Every free symbol of a filter sitting directly on a table scan is produced by that scan, so this
+     * holds for any valid plan. When it does not - see {@link #referencesOnlySourceSymbols} for how such
+     * a plan comes about - the domain cannot be mapped to column handles. Declining to rewrite leaves the
+     * plan untouched and lets plan validation report the real problem, rather than failing with an opaque
+     * "mapping function returned null" {@link NullPointerException} from {@link TupleDomain#transformKeys}.
+     */
+    static boolean isKeyedByScanAssignments(TupleDomain<Symbol> domain, TableScanNode node)
+    {
+        return domain.getDomains()
+                .map(domains -> node.getAssignments().keySet().containsAll(domains.keySet()))
+                .orElse(true);
+    }
+
+    /**
+     * Tells whether every free symbol of the rewritten predicate is produced by the new source.
+     * <p>
+     * The rewrite round-trips the predicate through {@link ConnectorExpressionTranslator} and the IR
+     * optimizer, both of which may allocate symbols. When a {@code Let} binder is lost on the way, the
+     * rewritten predicate can reference a symbol that no node produces - the {@code between_N} symbol
+     * that {@code BETWEEN} over a non-column expression is desugared into is one such case. The
+     * resulting plan is invalid, and a later application of this rule fails while mapping the extracted
+     * domain back to column handles ("mapping function returned null for between_N").
+     * <p>
+     * Callers fall back to the original predicate, which is valid by construction, so results are
+     * unaffected. The only cost is that a predicate the connector already enforced may be evaluated
+     * once more above the scan.
+     */
+    private static boolean referencesOnlySourceSymbols(Expression predicate, PlanNode source)
+    {
+        return ImmutableSet.copyOf(source.getOutputSymbols())
+                .containsAll(SymbolsExtractor.extractUnique(predicate));
     }
 
     // PushPredicateIntoTableScan might be executed after AddExchanges and DetermineTableScanNodePartitioning.

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantPredicateAboveTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantPredicateAboveTableScan.java
@@ -46,6 +46,7 @@ import static io.trino.sql.ir.IrUtils.extractConjuncts;
 import static io.trino.sql.ir.IrUtils.filterDeterministicConjuncts;
 import static io.trino.sql.ir.IrUtils.filterNonDeterministicConjuncts;
 import static io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan.createResultingPredicate;
+import static io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan.isKeyedByScanAssignments;
 import static io.trino.sql.planner.plan.Patterns.filter;
 import static io.trino.sql.planner.plan.Patterns.source;
 import static io.trino.sql.planner.plan.Patterns.tableScan;
@@ -96,6 +97,10 @@ public class RemoveRedundantPredicateAboveTableScan
 
         if (decomposedPredicate.getTupleDomain().isAll()) {
             // no conjunct could be fully converted to tuple domain
+            return Result.empty();
+        }
+
+        if (!isKeyedByScanAssignments(decomposedPredicate.getTupleDomain(), node)) {
             return Result.empty();
         }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
@@ -56,6 +56,7 @@ import io.trino.sql.ir.WhenClause;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.testing.TestingTransactionHandle;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -316,6 +317,62 @@ public class TestPushPredicateIntoTableScan
                                 ImmutableMap.of(p.symbol("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT)),
                                 TupleDomain.all())))
                 .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireWhenPredicateReferencesSymbolNotProducedByTableScan()
+    {
+        // A filter sitting directly on a table scan can only reference symbols that the scan produces.
+        // When that invariant is broken, the extracted domain cannot be mapped to column handles, and the
+        // rule used to fail with "mapping function ... returned null for <symbol>". BETWEEN over a
+        // non-column expression hit this: it is desugared into a Let, and the binder was lost while the
+        // predicate was round-tripped through the connector expression translator. Declining to rewrite
+        // keeps the plan untouched so that the real problem surfaces through plan validation instead.
+        tester().assertThat(pushPredicateIntoTableScan)
+                .on(p -> p.filter(
+                        comparison(EQUAL, new Reference(BIGINT, "between_0"), new Constant(BIGINT, 1L)),
+                        p.tableScan(
+                                nationTableHandle,
+                                ImmutableList.of(p.symbol("nationkey", BIGINT)),
+                                ImmutableMap.of(p.symbol("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT)))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testRestoresOriginalPredicateWhenRewriteWouldReferenceUnknownSymbol()
+    {
+        // Here the unknown symbol sits in a conjunct that cannot be turned into a domain, so the rule gets
+        // past the extracted-domain check and pushes the rest down. The predicate it would put back above
+        // the scan still references that symbol, which is exactly the shape the connector expression
+        // round-trip produces in production for BETWEEN over a non-column expression. The rule must keep
+        // the pushdown - connectors that require a partition filter inspect the constraint they recorded -
+        // and restore the original predicate so that the plan stays valid.
+        Expression original = new Logical(AND, ImmutableList.of(
+                comparison(EQUAL, new Reference(VARCHAR, "col"), new Constant(VARCHAR, utf8Slice("G"))),
+                comparison(
+                        EQUAL,
+                        new Call(MODULO_BIGINT, ImmutableList.of(new Reference(BIGINT, "between_0"), new Constant(BIGINT, 17L))),
+                        new Constant(BIGINT, 44L))));
+
+        Session session = Session.builder(tester().getSession())
+                .setCatalog(MOCK_CATALOG)
+                .build();
+        tester().assertThat(pushPredicateIntoTableScan)
+                .withSession(session)
+                .on(p -> p.filter(
+                        original,
+                        p.tableScan(
+                                mockTableHandle(CONNECTOR_PARTITIONED_TABLE_HANDLE),
+                                ImmutableList.of(p.symbol("col", VARCHAR)),
+                                ImmutableMap.of(p.symbol("col", VARCHAR), MOCK_COLUMN_HANDLE))))
+                .matches(node(
+                        FilterNode.class,
+                        // the domain for the extractable conjunct must have reached the connector, otherwise
+                        // the plan shape alone would also match a rule that pushed nothing down
+                        tableScan("partitioned").with(TableScanNode.class, scan -> scan.getEnforcedConstraint()
+                                .equals(TupleDomain.withColumnDomains(ImmutableMap.of(
+                                        MOCK_COLUMN_HANDLE, singleValue(VARCHAR, utf8Slice("G")))))))
+                        .with(FilterNode.class, filter -> filter.getPredicate().equals(original)));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantPredicateAboveTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantPredicateAboveTableScan.java
@@ -95,6 +95,27 @@ public class TestRemoveRedundantPredicateAboveTableScan
     }
 
     @Test
+    public void doesNotFireWhenPredicateReferencesSymbolNotProducedByTableScan()
+    {
+        // Same invariant as in TestPushPredicateIntoTableScan: a filter sitting directly on a table scan
+        // can only reference symbols the scan produces. Without the guard the extracted domain cannot be
+        // mapped to column handles and the rule fails with "mapping function ... returned null".
+        // The enforced constraint must not be ALL, otherwise the rule's pattern does not even match and the
+        // assertion below would hold without ever reaching the guard.
+        ColumnHandle columnHandle = new TpchColumnHandle("nationkey", BIGINT);
+        tester().assertThat(removeRedundantPredicateAboveTableScan)
+                .on(p -> p.filter(
+                        comparison(EQUAL, new Reference(BIGINT, "between_0"), new Constant(BIGINT, 1L)),
+                        p.tableScan(
+                                nationTableHandle,
+                                ImmutableList.of(p.symbol("nationkey", BIGINT)),
+                                ImmutableMap.of(p.symbol("nationkey", BIGINT), columnHandle),
+                                TupleDomain.fromFixedValues(ImmutableMap.of(
+                                        columnHandle, NullableValue.of(BIGINT, 44L))))))
+                .doesNotFire();
+    }
+
+    @Test
     public void consumesDeterministicPredicateIfNewDomainIsSame()
     {
         ColumnHandle columnHandle = new TpchColumnHandle("nationkey", BIGINT);


### PR DESCRIPTION
## Description

Fixes #30608, where `BETWEEN` over a non-column expression makes `PushPredicateIntoTableScan` fail at planning time:

```
mapping function io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan$$Lambda/0x...
  returned null for between_21::[varchar]
    at io.trino.spi.predicate.TupleDomain.transformKeys(TupleDomain.java:638)
    at PushPredicateIntoTableScan.pushFilterIntoTableScan(PushPredicateIntoTableScan.java:167)
```

The rule maps the domain extracted from the filter predicate to column handles. A filter that sits directly on a table scan only references symbols that scan produces, so for a valid plan the mapping always succeeds. `BETWEEN` is desugared into a `Let` binding, and the round-trip through `$engine_expression` and the IR optimizer can drop the binder, leaving the `Let`-bound symbol as a free reference in the predicate the rule puts back above the scan. A later application of the rule then fails on that predicate.

**This PR does not fix whatever drops the binder.** It guards both ends of the rewrite so that an invalid predicate is neither produced nor able to crash the rule. Neither guard can trigger for a valid plan.

* Before mapping the extracted domain, verify it is keyed by scan assignments only. Nothing has been pushed at that point, so declining leaves the plan untouched and lets plan validation report the real problem instead of failing here with an opaque `NullPointerException`.

* Before returning a new `FilterNode`, verify the rewritten predicate only references symbols the new source produces. **The pushdown is kept and the original predicate is restored**, rather than abandoning the rewrite. That distinction matters: `HiveMetadata.validateScan` decides whether a partition filter was supplied by inspecting `handle.getConstraintColumns()`, which is populated during `applyFilter`. Skipping the pushdown would replace the `NullPointerException` with `Pruning required ... on at least one of the partition columns` for tables that require a partition filter - a different failure, not a fix. Re-applying a predicate the connector already enforced is redundant, never wrong, and the original predicate is valid by construction.

`RemoveRedundantPredicateAboveTableScan` performs the same `transformKeys(node.getAssignments()::get)` mapping, so it gets the same domain guard - without it the same input would just fail there instead. It does not round-trip expressions through a connector, so it can only encounter such a predicate, never produce one, and does not need the output guard.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Per #30608 this is an interaction between two changes that both landed in 482, so 482 is affected as well:

* #29659 introduces the `Let` desugaring for `BETWEEN`, which is where the `between_N` symbol comes from.
* #29289 introduces the `$engine_expression` round-trip in `PushPredicateIntoTableScan`.

I could not pin down which rewrite drops the binder, so I went with guards that keep affected queries working. Happy to change direction if you would rather fix that directly - the guards would then become redundant, or remain as a cheap invariant check.

Tests added:

* `TestPushPredicateIntoTableScan.testDoesNotFireWhenPredicateReferencesSymbolNotProducedByTableScan` reproduces the reported `NullPointerException` without involving any connector, and asserts the rule declines.
* `TestPushPredicateIntoTableScan.testRestoresOriginalPredicateWhenRewriteWouldReferenceUnknownSymbol` places the unknown symbol in a conjunct that cannot be converted to a domain, so the rule gets past the domain guard and pushes the rest down. It asserts both that the domain reached the connector, by checking the resulting `enforcedConstraint`, and that the filter keeps the original predicate.
* The corresponding guard test for `RemoveRedundantPredicateAboveTableScan`, with a non-`ALL` enforced constraint so the rule's pattern actually matches.

Each assertion was verified to fail with the corresponding guard disabled, so none of them pass vacuously.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix query failure when a `BETWEEN` predicate is applied to an expression rather than a column. ({issue}`30608`)
```