### PR TITLE
Remove Jackson annotations from TrinoPrincipal and RoleGrant

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -575,6 +575,99 @@
                                     <old>method io.trino.spi.connector.ConnectorMergeSink io.trino.spi.connector.ConnectorPageSinkProvider::createMergeSink(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorMergeTableHandle, java.util.Optional&lt;io.trino.spi.connector.ConnectorTableCredentials&gt;, io.trino.spi.connector.ConnectorPageSinkId)</old>
                                     <new>method io.trino.spi.connector.ConnectorMergeSink io.trino.spi.connector.ConnectorPageSinkProvider::createMergeSink(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorMergeTableHandle, java.util.Optional&lt;io.trino.spi.connector.ConnectorTableCredentials&gt;, io.trino.spi.connector.ConnectorPageSinkId, io.trino.spi.connector.MemoryContext)</new>
                                 </item>
+                                <!--
+                                    TrinoPrincipal and RoleGrant are plain SPI value objects and no longer depend on Jackson.
+                                    JSON serialization of role grants now lives in the file metastore, which maps them to its own
+                                    HiveRoleGrant DTO, so the on-disk format is unchanged.
+                                -->
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>method void io.trino.spi.security.RoleGrant::&lt;init&gt;(io.trino.spi.security.TrinoPrincipal, java.lang.String, boolean)</old>
+                                    <new>method void io.trino.spi.security.RoleGrant::&lt;init&gt;(io.trino.spi.security.TrinoPrincipal, java.lang.String, boolean)</new>
+                                    <annotation>@com.fasterxml.jackson.annotation.JsonCreator</annotation>
+                                    <justification>Serialization of RoleGrant is the responsibility of the code that persists it, not of the SPI.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>parameter void io.trino.spi.security.RoleGrant::&lt;init&gt;(===io.trino.spi.security.TrinoPrincipal===, java.lang.String, boolean)</old>
+                                    <new>parameter void io.trino.spi.security.RoleGrant::&lt;init&gt;(===io.trino.spi.security.TrinoPrincipal===, java.lang.String, boolean)</new>
+                                    <annotation>@com.fasterxml.jackson.annotation.JsonProperty("grantee")</annotation>
+                                    <justification>Serialization of RoleGrant is the responsibility of the code that persists it, not of the SPI.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>parameter void io.trino.spi.security.RoleGrant::&lt;init&gt;(io.trino.spi.security.TrinoPrincipal, ===java.lang.String===, boolean)</old>
+                                    <new>parameter void io.trino.spi.security.RoleGrant::&lt;init&gt;(io.trino.spi.security.TrinoPrincipal, ===java.lang.String===, boolean)</new>
+                                    <annotation>@com.fasterxml.jackson.annotation.JsonProperty("roleName")</annotation>
+                                    <justification>Serialization of RoleGrant is the responsibility of the code that persists it, not of the SPI.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>parameter void io.trino.spi.security.RoleGrant::&lt;init&gt;(io.trino.spi.security.TrinoPrincipal, java.lang.String, ===boolean===)</old>
+                                    <new>parameter void io.trino.spi.security.RoleGrant::&lt;init&gt;(io.trino.spi.security.TrinoPrincipal, java.lang.String, ===boolean===)</new>
+                                    <annotation>@com.fasterxml.jackson.annotation.JsonProperty("grantable")</annotation>
+                                    <justification>Serialization of RoleGrant is the responsibility of the code that persists it, not of the SPI.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>method io.trino.spi.security.TrinoPrincipal io.trino.spi.security.RoleGrant::getGrantee()</old>
+                                    <new>method io.trino.spi.security.TrinoPrincipal io.trino.spi.security.RoleGrant::getGrantee()</new>
+                                    <annotation>@com.fasterxml.jackson.annotation.JsonProperty</annotation>
+                                    <justification>Serialization of RoleGrant is the responsibility of the code that persists it, not of the SPI.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>method java.lang.String io.trino.spi.security.RoleGrant::getRoleName()</old>
+                                    <new>method java.lang.String io.trino.spi.security.RoleGrant::getRoleName()</new>
+                                    <annotation>@com.fasterxml.jackson.annotation.JsonProperty</annotation>
+                                    <justification>Serialization of RoleGrant is the responsibility of the code that persists it, not of the SPI.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>method boolean io.trino.spi.security.RoleGrant::isGrantable()</old>
+                                    <new>method boolean io.trino.spi.security.RoleGrant::isGrantable()</new>
+                                    <annotation>@com.fasterxml.jackson.annotation.JsonProperty</annotation>
+                                    <justification>Serialization of RoleGrant is the responsibility of the code that persists it, not of the SPI.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>method void io.trino.spi.security.TrinoPrincipal::&lt;init&gt;(io.trino.spi.security.PrincipalType, java.lang.String)</old>
+                                    <new>method void io.trino.spi.security.TrinoPrincipal::&lt;init&gt;(io.trino.spi.security.PrincipalType, java.lang.String)</new>
+                                    <annotation>@com.fasterxml.jackson.annotation.JsonCreator</annotation>
+                                    <justification>Serialization of TrinoPrincipal is the responsibility of the code that persists it, not of the SPI.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>parameter void io.trino.spi.security.TrinoPrincipal::&lt;init&gt;(===io.trino.spi.security.PrincipalType===, java.lang.String)</old>
+                                    <new>parameter void io.trino.spi.security.TrinoPrincipal::&lt;init&gt;(===io.trino.spi.security.PrincipalType===, java.lang.String)</new>
+                                    <annotation>@com.fasterxml.jackson.annotation.JsonProperty("type")</annotation>
+                                    <justification>Serialization of TrinoPrincipal is the responsibility of the code that persists it, not of the SPI.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>parameter void io.trino.spi.security.TrinoPrincipal::&lt;init&gt;(io.trino.spi.security.PrincipalType, ===java.lang.String===)</old>
+                                    <new>parameter void io.trino.spi.security.TrinoPrincipal::&lt;init&gt;(io.trino.spi.security.PrincipalType, ===java.lang.String===)</new>
+                                    <annotation>@com.fasterxml.jackson.annotation.JsonProperty("name")</annotation>
+                                    <justification>Serialization of TrinoPrincipal is the responsibility of the code that persists it, not of the SPI.</justification>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>method io.trino.spi.security.PrincipalType io.trino.spi.security.TrinoPrincipal::getType()</old>
+                                    <new>method io.trino.spi.security.PrincipalType io.trino.spi.security.TrinoPrincipal::getType()</new>
+                                    <annotation>@com.fasterxml.jackson.annotation.JsonProperty</annotation>
+                                    <justification>Serialization of TrinoPrincipal is the responsibility of the code that persists it, not of the SPI.</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/security/RoleGrant.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/RoleGrant.java
@@ -13,9 +13,6 @@
  */
 package io.trino.spi.security;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Objects;
 
 import static java.util.Locale.ENGLISH;
@@ -27,27 +24,23 @@ public class RoleGrant
     private final String roleName;
     private final boolean grantable;
 
-    @JsonCreator
-    public RoleGrant(@JsonProperty("grantee") TrinoPrincipal grantee, @JsonProperty("roleName") String roleName, @JsonProperty("grantable") boolean grantable)
+    public RoleGrant(TrinoPrincipal grantee, String roleName, boolean grantable)
     {
         this.grantee = requireNonNull(grantee, "grantee is null");
         this.roleName = roleName.toLowerCase(ENGLISH);
         this.grantable = grantable;
     }
 
-    @JsonProperty
     public String getRoleName()
     {
         return roleName;
     }
 
-    @JsonProperty
     public TrinoPrincipal getGrantee()
     {
         return grantee;
     }
 
-    @JsonProperty
     public boolean isGrantable()
     {
         return grantable;

--- a/core/trino-spi/src/main/java/io/trino/spi/security/TrinoPrincipal.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/TrinoPrincipal.java
@@ -13,10 +13,6 @@
  */
 package io.trino.spi.security;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Objects;
 
 import static java.util.Locale.ENGLISH;
@@ -27,21 +23,18 @@ public class TrinoPrincipal
     private final PrincipalType type;
     private final String name;
 
-    @JsonCreator
-    public TrinoPrincipal(@JsonProperty("type") PrincipalType type, @JsonProperty("name") String name)
+    public TrinoPrincipal(PrincipalType type, String name)
     {
         this.type = requireNonNull(type, "type is null");
         requireNonNull(name, "name is null");
         this.name = type == PrincipalType.USER ? name : name.toLowerCase(ENGLISH);
     }
 
-    @JsonProperty
     public PrincipalType getType()
     {
         return type;
     }
 
-    @JsonProperty("name")
     public String getPrincipalName()
     {
         return name;
@@ -53,7 +46,6 @@ public class TrinoPrincipal
      *         was created with a mixed-case name.
      */
     @Deprecated
-    @JsonIgnore
     public String getName()
     {
         return name.toLowerCase(ENGLISH);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -161,7 +161,7 @@ public class FileHiveMetastore
     private final JsonCodec<List<PermissionMetadata>> permissionsCodec = listJsonCodec(PermissionMetadata.class);
     private final JsonCodec<LanguageFunction> functionCodec = jsonCodec(LanguageFunction.class);
     private final JsonCodec<List<String>> rolesCodec = listJsonCodec(String.class);
-    private final JsonCodec<List<RoleGrant>> roleGrantsCodec = listJsonCodec(RoleGrant.class);
+    private final JsonCodec<List<HiveRoleGrant>> roleGrantsCodec = listJsonCodec(HiveRoleGrant.class);
 
     public FileHiveMetastore(NodeVersion nodeVersion, TrinoFileSystemFactory fileSystemFactory, boolean hideDeltaLakeTables, FileHiveMetastoreConfig config)
     {
@@ -1025,13 +1025,17 @@ public class FileHiveMetastore
     @GuardedBy("this")
     private Set<RoleGrant> readRoleGrantsFile()
     {
-        return ImmutableSet.copyOf(readFile("roleGrants", getRoleGrantsFile(), roleGrantsCodec).orElse(ImmutableList.of()));
+        return readFile("roleGrants", getRoleGrantsFile(), roleGrantsCodec).orElse(ImmutableList.of()).stream()
+                .map(HiveRoleGrant::toRoleGrant)
+                .collect(toImmutableSet());
     }
 
     @GuardedBy("this")
     private void writeRoleGrantsFile(Set<RoleGrant> roleGrants)
     {
-        writeFile("roleGrants", getRoleGrantsFile(), roleGrantsCodec, ImmutableList.copyOf(roleGrants), true);
+        writeFile("roleGrants", getRoleGrantsFile(), roleGrantsCodec, roleGrants.stream()
+                .map(HiveRoleGrant::fromRoleGrant)
+                .collect(toImmutableList()), true);
     }
 
     private synchronized Optional<List<String>> getAllPartitionNames(String databaseName, String tableName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/HiveRoleGrant.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/HiveRoleGrant.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.file;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.metastore.HivePrincipal;
+import io.trino.spi.security.RoleGrant;
+
+import static java.util.Objects.requireNonNull;
+
+class HiveRoleGrant
+{
+    private final HivePrincipal grantee;
+    private final String roleName;
+    private final boolean grantable;
+
+    @JsonCreator
+    HiveRoleGrant(
+            @JsonProperty("grantee") HivePrincipal grantee,
+            @JsonProperty("roleName") String roleName,
+            @JsonProperty("grantable") boolean grantable)
+    {
+        this.grantee = requireNonNull(grantee, "grantee is null");
+        this.roleName = requireNonNull(roleName, "roleName is null");
+        this.grantable = grantable;
+    }
+
+    @JsonProperty
+    public HivePrincipal getGrantee()
+    {
+        return grantee;
+    }
+
+    @JsonProperty
+    public String getRoleName()
+    {
+        return roleName;
+    }
+
+    @JsonProperty
+    public boolean isGrantable()
+    {
+        return grantable;
+    }
+
+    RoleGrant toRoleGrant()
+    {
+        return new RoleGrant(grantee.toTrinoPrincipal(), roleName, grantable);
+    }
+
+    static HiveRoleGrant fromRoleGrant(RoleGrant grant)
+    {
+        return new HiveRoleGrant(
+                HivePrincipal.from(grant.getGrantee()),
+                grant.getRoleName(),
+                grant.isGrantable());
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/file/TestFileHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/file/TestFileHiveMetastore.java
@@ -14,18 +14,24 @@
 package io.trino.plugin.hive.metastore.file;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
 import io.trino.filesystem.local.LocalFileSystemFactory;
 import io.trino.metastore.Column;
 import io.trino.metastore.Database;
 import io.trino.metastore.HiveMetastore;
+import io.trino.metastore.HivePrincipal;
 import io.trino.metastore.StorageFormat;
 import io.trino.metastore.Table;
 import io.trino.plugin.hive.metastore.AbstractTestHiveMetastore;
 import io.trino.spi.NodeVersion;
+import io.trino.spi.security.RoleGrant;
+import io.trino.spi.security.TrinoPrincipal;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
@@ -39,6 +45,7 @@ import static io.trino.metastore.HiveType.HIVE_INT;
 import static io.trino.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.HiveMetadata.TRINO_QUERY_ID_NAME;
 import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
+import static io.trino.spi.security.PrincipalType.USER;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.nio.file.Files.createTempDirectory;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -53,11 +60,14 @@ final class TestFileHiveMetastore
             throws IOException
     {
         tempDir = createTempDirectory("test");
-        LocalFileSystemFactory fileSystemFactory = new LocalFileSystemFactory(tempDir);
+        metastore = createMetastore(tempDir);
+    }
 
-        metastore = new FileHiveMetastore(
+    private static HiveMetastore createMetastore(Path directory)
+    {
+        return new FileHiveMetastore(
                 new NodeVersion("testversion"),
-                fileSystemFactory,
+                new LocalFileSystemFactory(directory),
                 false,
                 new FileHiveMetastoreConfig()
                         .setCatalogDirectory("local:///")
@@ -76,6 +86,26 @@ final class TestFileHiveMetastore
     protected HiveMetastore getMetastore()
     {
         return metastore;
+    }
+
+    @Test
+    void testReadRoleGrantsFile()
+            throws IOException
+    {
+        Path directory = createTempDirectory("test");
+        try {
+            try (InputStream roleGrants = Resources.getResource(getClass(), "role_grants.json").openStream()) {
+                Files.copy(roleGrants, directory.resolve(".roleGrants"));
+            }
+
+            assertThat(createMetastore(directory).listRoleGrants(new HivePrincipal(USER, "alice")))
+                    .containsExactlyInAnyOrder(
+                            new RoleGrant(new TrinoPrincipal(USER, "alice"), "public", false),
+                            new RoleGrant(new TrinoPrincipal(USER, "alice"), "admin", true));
+        }
+        finally {
+            deleteRecursively(directory, ALLOW_INSECURE);
+        }
     }
 
     @Test

--- a/plugin/trino-hive/src/test/resources/io/trino/plugin/hive/metastore/file/role_grants.json
+++ b/plugin/trino-hive/src/test/resources/io/trino/plugin/hive/metastore/file/role_grants.json
@@ -1,0 +1,10 @@
+[
+  {
+    "grantee": {
+      "type": "USER",
+      "name": "alice"
+    },
+    "roleName": "admin",
+    "grantable": true
+  }
+]


### PR DESCRIPTION
TrinoPrincipal and RoleGrant are SPI types — they form a stable public contract between Trino core and connector plugins. Having @JsonCreator / @JsonProperty on them couples the SPI to Jackson, a framework detail that connectors should not need to care about.

The only production caller that actually serializes these types to JSON is FileHiveMetastore, which persists role grants to a flat file (.roleGrants). Serialization concern belongs in the plugin, not in the SPI. Moving it there via a new package-private RoleGrantJson DTO keeps the on-disk format identical (backwards compatible with existing metastore files) while leaving TrinoPrincipal and RoleGrant as plain value objects with no framework dependencies.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
