### PR TITLE
Fix reading null Parquet structures with VARIANT

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -93,8 +93,6 @@ import static io.trino.parquet.ParquetWriteValidation.WriteChecksumBuilder.creat
 import static io.trino.parquet.reader.ListColumnReader.calculateCollectionOffsets;
 import static io.trino.parquet.reader.PageReader.createPageReader;
 import static io.trino.spi.block.Bitmap.isSet;
-import static io.trino.spi.block.Bitmap.set;
-import static io.trino.spi.block.Bitmap.wordsForBits;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VariantType.VARIANT;
@@ -529,33 +527,23 @@ public class ParquetReader
         ColumnChunk metadataChunk = readColumnChunk(field.getMetadata());
         ColumnChunk valueChunk = readColumnChunk(field.getValue());
 
-        // position count and nulls are derived from metadata def levels
-        int positionsCount = metadataChunk.getDefinitionLevels().length;
-        int variantDefLevel = field.getDefinitionLevel();
-        long[] valueIsValid = null;
-        for (int i = 0; i < positionsCount; i++) {
-            if (metadataChunk.getDefinitionLevels()[i] >= variantDefLevel) {
-                if (valueIsValid != null) {
-                    set(valueIsValid, 0, i);
-                }
-            }
-            else if (valueIsValid == null) {
-                valueIsValid = new long[wordsForBits(positionsCount)];
-                for (int position = 0; position < i; position++) {
-                    set(valueIsValid, 0, position);
-                }
-            }
-        }
+        StructColumnReader.RowBlockPositions variantPositions = StructColumnReader.calculateStructOffsets(
+                field,
+                metadataChunk.getDefinitionLevels(),
+                metadataChunk.getRepetitionLevels());
+        int positionsCount = variantPositions.positionsCount();
+        Optional<long[]> valueIsValid = variantPositions.valueIsValid();
 
         // if isNull is present, we need to convert the blocks to not-null-suppressed blocks
         Block metadataBlock = metadataChunk.getBlock();
         Block valueBlock = valueChunk.getBlock();
-        if (valueIsValid != null) {
-            metadataBlock = toNotNullSupressedBlock(positionsCount, valueIsValid, metadataBlock);
-            valueBlock = toNotNullSupressedBlock(positionsCount, valueIsValid, valueBlock);
+        if (valueIsValid.isPresent()) {
+            long[] variantIsValid = valueIsValid.orElseThrow();
+            metadataBlock = toNotNullSupressedBlock(positionsCount, variantIsValid, metadataBlock);
+            valueBlock = toNotNullSupressedBlock(positionsCount, variantIsValid, valueBlock);
         }
 
-        Block variantBlock = VariantBlock.create(positionsCount, metadataBlock, valueBlock, Optional.ofNullable(valueIsValid));
+        Block variantBlock = VariantBlock.create(positionsCount, metadataBlock, valueBlock, valueIsValid);
         return new ColumnChunk(variantBlock, metadataChunk.getDefinitionLevels(), metadataChunk.getRepetitionLevels());
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV3ParquetConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV3ParquetConnectorTest.java
@@ -13,11 +13,38 @@
  */
 package io.trino.plugin.iceberg;
 
+import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 class TestIcebergV3ParquetConnectorTest
         extends BaseIcebergParquetConnectorTest
 {
     TestIcebergV3ParquetConnectorTest()
     {
         super(3);
+    }
+
+    @Test
+    void testNullNestedRowWithVariantRoundTrip()
+    {
+        try (TestTable table = newTrinoTable(
+                "test_null_nested_row_with_variant_",
+                "AS SELECT CAST(NULL AS ROW(b ROW(c VARCHAR, d VARIANT))) AS a")) {
+            assertThat(query("SELECT a IS NULL FROM " + table.getName()))
+                    .matches("VALUES true");
+        }
+    }
+
+    @Test
+    void testNullMapWithVariantValueRoundTrip()
+    {
+        try (TestTable table = newTrinoTable(
+                "test_null_map_with_variant_value_",
+                "AS SELECT CAST(NULL AS MAP(VARCHAR, VARIANT)) AS a")) {
+            assertThat(query("SELECT a IS NULL FROM " + table.getName()))
+                    .matches("VALUES true");
+        }
     }
 }


### PR DESCRIPTION
## Description

Fix reading null `ROW` and `MAP` values whose nested types include `VARIANT` from Parquet files.

Parquet definition-level streams contain entries describing null optional ancestors that do not correspond to positions at the `VARIANT` level. Treating every entry as a `VARIANT` position creates blocks that do not align with the enclosing `ROW` or `MAP`.

Use the existing struct position calculation to distinguish absent, null, and defined `VARIANT` positions. Add Iceberg Parquet round-trip regression coverage for both affected structures.

## Additional context and related issues

Writing the affected values succeeds. Reading them from Parquet previously failed because the enclosing structure's child blocks had different position counts.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Fix failures when reading null `ROW` or `MAP` values whose nested types include `VARIANT` from Parquet files. ({issue}`issuenumber`)
```