### PR TITLE
Fix dangling reference when copying a plan containing a Let expression

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
@@ -20,6 +20,7 @@ import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.ExpressionRewriter;
 import io.trino.sql.ir.ExpressionTreeRewriter;
 import io.trino.sql.ir.Lambda;
+import io.trino.sql.ir.Let;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.PartitioningScheme;
@@ -168,8 +169,22 @@ public class SymbolMapper
                         .collect(toImmutableList());
 
                 Expression body = treeRewriter.rewrite(node.body(), context);
-                if (body != node.body()) {
+                if (!arguments.equals(node.arguments()) || body != node.body()) {
                     return new Lambda(arguments, body);
+                }
+
+                return node;
+            }
+
+            @Override
+            public Expression rewriteLet(Let node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                // The bound name is a binder and must be mapped like the references to it in the body.
+                Symbol name = map(node.name());
+                Expression value = treeRewriter.rewrite(node.value(), context);
+                Expression body = treeRewriter.rewrite(node.body(), context);
+                if (!name.equals(node.name()) || value != node.value() || body != node.body()) {
+                    return new Let(name, value, body);
                 }
 
                 return node;
@@ -343,38 +358,25 @@ public class SymbolMapper
 
     private ExpressionAndValuePointers map(ExpressionAndValuePointers expressionAndValuePointers)
     {
-        // Map only the input symbols of ValuePointers. These are the symbols produced by the source node.
-        // Other symbols present in the ExpressionAndValuePointers structure are synthetic unique symbols
-        // with no outer usage or dependencies.
+        // Map the input symbols of ValuePointers, which are produced by the source node. Assignment
+        // symbols are synthetic and only referenced by the expression, so both are left alone.
+        // Aggregation arguments go through map(Expression), which also renames references to the
+        // classifier and match-number symbols, so those fields are mapped alongside to stay
+        // consistent with the arguments.
         ImmutableList.Builder<ExpressionAndValuePointers.Assignment> newAssignments = ImmutableList.builder();
         for (ExpressionAndValuePointers.Assignment assignment : expressionAndValuePointers.getAssignments()) {
             ValuePointer newPointer = switch (assignment.valuePointer()) {
                 case ClassifierValuePointer pointer -> pointer;
                 case MatchNumberValuePointer pointer -> pointer;
                 case ScalarValuePointer pointer -> new ScalarValuePointer(pointer.getLogicalIndexPointer(), map(pointer.getInputSymbol()));
-                case AggregationValuePointer pointer -> {
-                    List<Expression> newArguments = pointer.getArguments().stream()
-                            .map(expression -> ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
-                            {
-                                @Override
-                                public Expression rewriteReference(Reference node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
-                                {
-                                    if (pointer.getClassifierSymbol().isPresent() && Symbol.from(node).equals(pointer.getClassifierSymbol().get()) ||
-                                            pointer.getMatchNumberSymbol().isPresent() && Symbol.from(node).equals(pointer.getMatchNumberSymbol().get())) {
-                                        return node;
-                                    }
-                                    return map(node);
-                                }
-                            }, expression))
-                            .collect(toImmutableList());
-
-                    yield new AggregationValuePointer(
-                            pointer.getFunction(),
-                            pointer.getSetDescriptor(),
-                            newArguments,
-                            pointer.getClassifierSymbol(),
-                            pointer.getMatchNumberSymbol());
-                }
+                case AggregationValuePointer pointer -> new AggregationValuePointer(
+                        pointer.getFunction(),
+                        pointer.getSetDescriptor(),
+                        pointer.getArguments().stream()
+                                .map(this::map)
+                                .collect(toImmutableList()),
+                        pointer.getClassifierSymbol().map(this::map),
+                        pointer.getMatchNumberSymbol().map(this::map));
             };
 
             newAssignments.add(new ExpressionAndValuePointers.Assignment(assignment.symbol(), newPointer));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestSymbolMapper.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestSymbolMapper.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.optimizations;
+
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.sql.ir.Case;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.Lambda;
+import io.trino.sql.ir.Let;
+import io.trino.sql.ir.WhenClause;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+import io.trino.sql.planner.SymbolsExtractor;
+import io.trino.sql.planner.plan.DataOrganizationSpecification;
+import io.trino.sql.planner.plan.PatternRecognitionNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.ValuesNode;
+import io.trino.sql.planner.rowpattern.AggregatedSetDescriptor;
+import io.trino.sql.planner.rowpattern.AggregationValuePointer;
+import io.trino.sql.planner.rowpattern.ExpressionAndValuePointers;
+import io.trino.sql.planner.rowpattern.ir.IrLabel;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+import static io.trino.sql.planner.optimizations.SymbolMapper.symbolMapper;
+import static io.trino.sql.planner.optimizations.SymbolMapper.symbolReallocator;
+import static io.trino.sql.planner.plan.RowsPerMatch.ONE;
+import static io.trino.sql.planner.plan.SkipToPosition.PAST_LAST;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSymbolMapper
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution();
+
+    @Test
+    public void testReallocateSymbolsInLetKeepsBinderAndBodyConsistent()
+    {
+        Symbol input = new Symbol(VARCHAR, "input");
+        Symbol bound = new Symbol(VARCHAR, "bound");
+        Map<Symbol, Symbol> mapping = new HashMap<>();
+        // Seed the allocator so that reallocation actually renames the symbols being mapped.
+        SymbolMapper mapper = symbolReallocator(mapping, new SymbolAllocator(List.of(input, bound)));
+
+        Expression mapped = mapper.map(new Let(bound, input.toSymbolReference(), bound.toSymbolReference()));
+
+        assertThat(mapped).isInstanceOf(Let.class);
+        Let let = (Let) mapped;
+
+        // The binder is reallocated together with the references to it.
+        assertThat(let.name()).isNotEqualTo(bound);
+        assertThat(let.body()).isEqualTo(let.name().toSymbolReference());
+
+        // Only the free symbol is a dependency; the bound one must not leak out.
+        assertThat(SymbolsExtractor.extractUnique(let)).containsExactly(mapper.map(input));
+    }
+
+    @Test
+    public void testReallocateSymbolsInNestedLet()
+    {
+        Symbol input = new Symbol(VARCHAR, "input");
+        Symbol outer = new Symbol(VARCHAR, "outer");
+        Symbol inner = new Symbol(VARCHAR, "inner");
+        Map<Symbol, Symbol> mapping = new HashMap<>();
+        SymbolMapper mapper = symbolReallocator(mapping, new SymbolAllocator(List.of(input, outer, inner)));
+
+        Let let = (Let) mapper.map(new Let(
+                outer,
+                input.toSymbolReference(),
+                new Let(inner, outer.toSymbolReference(), inner.toSymbolReference())));
+
+        Let nested = (Let) let.body();
+        assertThat(let.name()).isNotEqualTo(outer);
+        assertThat(nested.name()).isNotEqualTo(inner);
+        assertThat(nested.value()).isEqualTo(let.name().toSymbolReference());
+        assertThat(nested.body()).isEqualTo(nested.name().toSymbolReference());
+        assertThat(SymbolsExtractor.extractUnique(let)).containsExactly(mapper.map(input));
+    }
+
+    @Test
+    public void testReallocateSymbolsInLambdaWithConstantBody()
+    {
+        Symbol argument = new Symbol(VARCHAR, "argument");
+        Constant body = new Constant(BIGINT, 1L);
+        Map<Symbol, Symbol> mapping = new HashMap<>();
+        SymbolMapper mapper = symbolReallocator(mapping, new SymbolAllocator(List.of(argument)));
+
+        Lambda lambda = (Lambda) mapper.map(new Lambda(List.of(argument), body));
+
+        assertThat(lambda.arguments()).containsExactly(mapper.map(argument));
+        assertThat(lambda.arguments()).doesNotContain(argument);
+        assertThat(lambda.body()).isSameAs(body);
+    }
+
+    @Test
+    public void testReallocateSymbolsInAggregationValuePointer()
+    {
+        Symbol input = new Symbol(BIGINT, "input");
+        Symbol bound = new Symbol(BIGINT, "bound");
+        Symbol classifier = new Symbol(VARCHAR, "classifier");
+        Symbol matchNumber = new Symbol(BIGINT, "match_number");
+        Symbol aggregationResult = new Symbol(BIGINT, "aggregation_result");
+        IrLabel label = new IrLabel("A");
+
+        Expression argument = new Let(
+                bound,
+                input.toSymbolReference(),
+                new Case(
+                        List.of(new WhenClause(new IsNull(classifier.toSymbolReference()), bound.toSymbolReference())),
+                        matchNumber.toSymbolReference()));
+        AggregationValuePointer pointer = new AggregationValuePointer(
+                FUNCTIONS.resolveFunction("max", fromTypes(BIGINT)),
+                new AggregatedSetDescriptor(Set.of(label), false),
+                List.of(argument),
+                Optional.of(classifier),
+                Optional.of(matchNumber));
+        Expression predicate = new IsNull(aggregationResult.toSymbolReference());
+        ExpressionAndValuePointers definition = new ExpressionAndValuePointers(
+                predicate,
+                List.of(new ExpressionAndValuePointers.Assignment(aggregationResult, pointer)));
+
+        ValuesNode source = new ValuesNode(new PlanNodeId("source"), List.of(input));
+        PatternRecognitionNode node = new PatternRecognitionNode(
+                new PlanNodeId("pattern"),
+                source,
+                new DataOrganizationSpecification(List.of(), Optional.empty()),
+                Set.of(),
+                0,
+                Map.of(),
+                Map.of(),
+                Optional.empty(),
+                ONE,
+                Set.of(),
+                PAST_LAST,
+                true,
+                label,
+                Map.of(label, definition));
+
+        Map<Symbol, Symbol> mapping = new HashMap<>();
+        // Seed every original symbol so all expected remappings are observable.
+        SymbolMapper mapper = symbolReallocator(
+                mapping,
+                new SymbolAllocator(List.of(input, bound, classifier, matchNumber, aggregationResult)));
+        Symbol mappedInput = mapper.map(input);
+        ValuesNode mappedSource = new ValuesNode(source.getId(), List.of(mappedInput));
+
+        PatternRecognitionNode mappedNode = mapper.map(node, mappedSource);
+        ExpressionAndValuePointers mappedDefinition = mappedNode.getVariableDefinitions().get(label);
+        ExpressionAndValuePointers.Assignment mappedAssignment = mappedDefinition.getAssignments().getFirst();
+        AggregationValuePointer mappedPointer = (AggregationValuePointer) mappedAssignment.valuePointer();
+        Let mappedArgument = (Let) mappedPointer.getArguments().getFirst();
+        Case mappedBody = (Case) mappedArgument.body();
+        Symbol mappedClassifier = mappedPointer.getClassifierSymbol().orElseThrow();
+        Symbol mappedMatchNumber = mappedPointer.getMatchNumberSymbol().orElseThrow();
+
+        // The synthetic assignment and its top-level expression belong to this definition and stay local.
+        assertThat(mappedDefinition.getExpression()).isEqualTo(predicate);
+        assertThat(mappedAssignment.symbol()).isEqualTo(aggregationResult);
+
+        assertThat(mappedArgument.name()).isNotEqualTo(bound);
+        assertThat(mappedArgument.value()).isEqualTo(mappedInput.toSymbolReference());
+        assertThat(mappedBody.whenClauses().getFirst().getResult()).isEqualTo(mappedArgument.name().toSymbolReference());
+
+        assertThat(mappedClassifier).isNotEqualTo(classifier);
+        assertThat(((IsNull) mappedBody.whenClauses().getFirst().getOperand()).value()).isEqualTo(mappedClassifier.toSymbolReference());
+        assertThat(mappedMatchNumber).isNotEqualTo(matchNumber);
+        assertThat(mappedBody.defaultValue()).isEqualTo(mappedMatchNumber.toSymbolReference());
+
+        assertThat(mappedDefinition.getInputSymbols()).containsExactly(mappedInput);
+    }
+
+    @Test
+    public void testCanonicalizeLeavesLetBinderAloneWhenNotMapped()
+    {
+        Symbol from = new Symbol(VARCHAR, "from");
+        Symbol to = new Symbol(VARCHAR, "to");
+        Symbol bound = new Symbol(VARCHAR, "bound");
+        SymbolMapper mapper = symbolMapper(Map.of(from, to));
+
+        Let let = (Let) mapper.map(new Let(bound, from.toSymbolReference(), bound.toSymbolReference()));
+
+        // The binder is unchanged because it is not a key in the canonicalization map.
+        assertThat(let.name()).isEqualTo(bound);
+        assertThat(let.value()).isEqualTo(to.toSymbolReference());
+        assertThat(let.body()).isEqualTo(bound.toSymbolReference());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestIssue30608.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestIssue30608.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorTableHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.sql.ir.Let;
+import io.trino.sql.planner.Plan;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.testing.PlanTester;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.trino.SystemSessionProperties.DISTINCT_AGGREGATIONS_STRATEGY;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIssue30608
+{
+    @Test
+    public void test()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("mock")
+                .setSchema("default")
+                .setSystemProperty(DISTINCT_AGGREGATIONS_STRATEGY, "split_to_subqueries")
+                .build();
+
+        try (PlanTester planTester = PlanTester.create(session)) {
+            // The rule only fires for connectors that allow splitting the read into multiple subqueries
+            planTester.createCatalog(
+                    "mock",
+                    MockConnectorFactory.builder()
+                            .withAllowSplittingReadIntoMultipleSubQueries(true)
+                            .withGetTableHandle((_, schemaTableName) -> new MockConnectorTableHandle(schemaTableName))
+                            .withGetColumns(_ -> ImmutableList.of(
+                                    new ColumnMetadata("orderkey", BIGINT),
+                                    new ColumnMetadata("partkey", BIGINT),
+                                    new ColumnMetadata("comment", VARCHAR)))
+                            .build(),
+                    ImmutableMap.of());
+
+            planTester.inTransaction(transactionSession -> {
+                Plan plan = planTester.createPlan(
+                        transactionSession,
+                        "SELECT count(DISTINCT orderkey), count(DISTINCT partkey) FROM test_table WHERE substring(comment, 1, 3) BETWEEN 'a' AND 'b'");
+
+                // The rule fired: each distinct aggregation reads its own copy of the source subtree,
+                // and each copy carries its own Let with a consistently renamed binder
+                assertThat(searchFrom(plan.getRoot()).whereIsInstanceOfAny(JoinNode.class).count()).isEqualTo(1);
+                assertThat(searchFrom(plan.getRoot()).whereIsInstanceOfAny(TableScanNode.class).count()).isEqualTo(2);
+
+                List<PlanNode> filters = searchFrom(plan.getRoot()).whereIsInstanceOfAny(FilterNode.class).findAll();
+                assertThat(filters).hasSize(2);
+                assertThat(filters).allSatisfy(filter -> assertThat(((FilterNode) filter).getPredicate()).isInstanceOf(Let.class));
+                return null;
+            });
+        }
+    }
+}

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -609,6 +609,25 @@ public class TestMemoryConnectorTest
     }
 
     @Test
+    void testDistinctAggregationsOverBetweenOnExpression()
+    {
+        // Splitting distinct aggregations over a BETWEEN expression must remap the Let binder with its body.
+        Session session = Session.builder(getSession())
+                .setSystemProperty("distinct_aggregations_strategy", "split_to_subqueries")
+                .build();
+
+        try (TestTable table = newTrinoTable(
+                "test_distinct_over_between",
+                "AS SELECT * FROM (VALUES (1, 10, 'abc'), (2, 20, 'abd'), (3, 30, 'zzz')) x(orderkey, partkey, comment)")) {
+            assertThat(query(
+                    session,
+                    "SELECT count(DISTINCT orderkey), count(DISTINCT partkey) FROM " + table.getName() +
+                            " WHERE substring(comment, 1, 3) BETWEEN 'a' AND 'b'"))
+                    .matches("VALUES (BIGINT '2', BIGINT '2')");
+        }
+    }
+
+    @Test
     void testInsertAfterTruncate()
     {
         try (TestTable table = newTrinoTable("test_truncate", "AS SELECT 1 x")) {


### PR DESCRIPTION
## Description

- Fixes #30608.

`SymbolMapper.map(Expression)` remaps every `Reference` it walks, but the name bound by a `Let` was left untouched. There was no `rewriteLet` override, so `ExpressionTreeRewriter.visitLet` kept `node.name()` as it was while the body's references to it were renamed. The body then depends on a symbol the `Let` no longer binds. The lambda case was already handled, so this is an omission from when `Let` was introduced rather than a deliberate difference.

This becomes visible through plan copying. `PlanCopier.copyPlan` finishes with `UnaliasSymbolReferences.reallocateSymbols`, which reallocates every symbol in the copied subtree, so any `Let` in it comes out with a dangling reference. `BETWEEN` over a non-column expression desugars into a `Let`, and two or more `DISTINCT` aggregations make `MultipleDistinctAggregationsToSubqueries` copy the source subtree.

Depending on which rule reaches the invalid predicate first, this surfaces either as a validation failure:

```
Invalid node. Predicate dependencies ([..., between_20::[varchar]]) not in source plan output ([...])
    at io.trino.sql.planner.sanity.ValidateDependenciesChecker.checkDependencies(ValidateDependenciesChecker.java:954)
```

or as the `NullPointerException` from `PushPredicateIntoTableScan` that #30608 was reported with, where the extracted domain ends up keyed by the dangling symbol, which has no column handle.

The fix adds a `rewriteLet` override that maps the binder along with the references to it. Two related gaps are closed at the same time:

- `rewriteLambda` left `arguments` out of its change check, so a lambda with a constant body returned the original node and discarded its mapped arguments.
- `map(ExpressionAndValuePointers)` used a local rewriter that only handled `Reference`, so a `Let` in an `AggregationValuePointer` argument had the same bug. Aggregation arguments now go through `map(Expression)`.

## Additional context and related issues

Routing aggregation arguments through `map(Expression)` is a behavior change, not just a simplification. The local rewriter it replaces went out of its way to leave the `AggregationValuePointer` classifier and match-number symbols alone. The shared rewriter renames references to them, so those two fields are now mapped as well to stay consistent with the arguments. Nothing depends on their names: every consumer compares them against the pointer's own fields. `getInputSymbols` filters the arguments against them, `LocalExecutionPlanner` uses them to pick the `CLASSIFIER` and `MATCH_NUMBER` channels, and `PushDownProjectionsFromPatternRecognition` builds `runtimeEvaluatedSymbols` from them.

The strategy that triggers the copy is only considered when every table scan reports `allowSplittingReadIntoMultipleSubQueries`, and it is cost-based. That is why #30608 appeared connector-specific: whether `SPLIT_TO_SUBQUERIES` is picked depends on the table as well as the connector. Setting `distinct_aggregations_strategy` to `SPLIT_TO_SUBQUERIES` reproduces it directly, while `SINGLE_STEP`, `MARK_DISTINCT` and `PRE_AGGREGATE` do not. Rewriting the `BETWEEN` as `>= AND <=` also avoids it, since no `Let` is produced.

Tests:

- `TestSymbolMapper` covers binder reallocation, including a nested `Let`, an aggregation argument, and a constant-body lambda. It also pins that canonicalization leaves a binder alone when it is not a mapping key, which held before this change too.
- `TestIssue30608` pins the plan shape the fix depends on, and fails the dependency validation without it.
- `TestMemoryConnectorTest.testDistinctAggregationsOverBetweenOnExpression` executes the query. Without the fix it fails with the `PushPredicateIntoTableScan` error from the issue.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix query failure when a `BETWEEN` predicate is applied to an expression and the query contains more than one `DISTINCT` aggregation. ({issue}`30608`)
```
