### PR TITLE
Filter product tests using GIB

### DIFF
--- a/.github/bin/build-pt-matrix.py
+++ b/.github/bin/build-pt-matrix.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 
+import argparse
 import json
+import logging
+import sys
+import unittest
 from pathlib import Path
 
 
@@ -88,27 +92,330 @@ BUCKETS = [
     ]),
 ]
 
+ALL_SUITES = frozenset(suite for _, suites in BUCKETS for suite in suites)
+ALL_CONNECTORS_SMOKE = frozenset({"SuiteAllConnectorsSmoke"})
+DATABRICKS_SUITES = frozenset({
+    "SuiteDeltaLakeDatabricks133",
+    "SuiteDeltaLakeDatabricks143",
+    "SuiteDeltaLakeDatabricks154",
+    "SuiteDeltaLakeDatabricks164",
+    "SuiteDeltaLakeDatabricks173",
+})
+DELTA_LAKE_SUITES = DATABRICKS_SUITES | {
+    "SuiteAzure",
+    "SuiteDeltaLakeOss",
+    "SuiteGcs",
+}
+HIVE_SUITES = DATABRICKS_SUITES | {
+    "SuiteAuthorization",
+    "SuiteAzure",
+    "SuiteClients",
+    "SuiteCompatibility",
+    "SuiteDeltaLakeOss",
+    "SuiteGcs",
+    "SuiteHdfsImpersonation",
+    "SuiteHive4",
+    "SuiteHiveAlluxioCaching",
+    "SuiteHiveBasic",
+    "SuiteHiveSpark",
+    "SuiteHiveStorageFormats",
+    "SuiteHiveTransactional",
+    "SuiteHmsOnly",
+    "SuiteHudi",
+    "SuiteIceberg",
+    "SuiteParquet",
+    "SuiteSqlCancel",
+    "SuiteStorageFormatsDetailed",
+    "SuiteTpcds",
+    "SuiteTpch",
+    "SuiteTwoHives",
+}
+ICEBERG_SUITES = {
+    "SuiteAzure",
+    "SuiteCompatibility",
+    "SuiteDeltaLakeOss",
+    "SuiteGcs",
+    "SuiteHiveStorageFormats",
+    "SuiteHmsOnly",
+    "SuiteIceberg",
+    "SuiteStorageFormatsDetailed",
+}
+JDBC_CONNECTOR_SUITES = ALL_CONNECTORS_SMOKE | {
+    "SuiteClickhouse",
+    "SuiteClients",
+    "SuiteExasol",
+    "SuiteIgnite",
+    "SuiteMysql",
+    "SuitePostgresql",
+    "SuiteRanger",
+    "SuiteSnowflake",
+    "SuiteSqlServer",
+}
 
-declared_suites = [suite for _, suites in BUCKETS for suite in suites]
-duplicate_suites = sorted({suite for suite in declared_suites if declared_suites.count(suite) > 1})
-if duplicate_suites:
-    raise SystemExit(f"Suites declared more than once: {', '.join(duplicate_suites)}")
+# Only modules in this map are eligible for matrix filtering. The suites include secondary
+# connectors and services used by each environment, not only the connector named by the suite.
+# Any impacted module absent from this map causes a full run.
+MODULE_TO_SUITES = {
+    # The old product-test impact analysis was connector-oriented. Keep this first pass at the
+    # same level: shared libraries, clients, core, and other infrastructure cause a full run.
+    "plugin/trino-base-jdbc": JDBC_CONNECTOR_SUITES,
+    "plugin/trino-blob-cache-alluxio": {
+        "SuiteDeltaLakeOss",
+        "SuiteHiveAlluxioCaching",
+        "SuiteIceberg",
+    },
+    "plugin/trino-exchange-filesystem": {"SuiteFaultTolerant"},
+    "plugin/trino-example-jdbc": set(),
+    "plugin/trino-spooling-filesystem": {"SuitePostgresql"},
 
-actual_suites = {path.stem for path in SUITE_DIR.glob("Suite*.java")} - SUITE_HELPERS
-missing_suites = sorted(set(declared_suites) - actual_suites)
-if missing_suites:
-    raise SystemExit(f"Declared product test suites are missing: {', '.join(missing_suites)}")
+    # Connectors loaded by the all-connectors smoke environment, plus their focused suites.
+    "plugin/trino-bigquery": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-blackhole": ALL_CONNECTORS_SMOKE | {"SuiteBlackHole"},
+    "plugin/trino-cassandra": ALL_CONNECTORS_SMOKE | {"SuiteCassandra"},
+    "plugin/trino-clickhouse": ALL_CONNECTORS_SMOKE | {"SuiteClickhouse"},
+    "plugin/trino-delta-lake": ALL_CONNECTORS_SMOKE | DELTA_LAKE_SUITES,
+    "plugin/trino-druid": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-duckdb": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-elasticsearch": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-exasol": {"SuiteExasol"},
+    "plugin/trino-faker": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-google-sheets": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-hive": ALL_CONNECTORS_SMOKE | HIVE_SUITES,
+    "plugin/trino-hudi": ALL_CONNECTORS_SMOKE | {"SuiteHudi"},
+    "plugin/trino-iceberg": ALL_CONNECTORS_SMOKE | ICEBERG_SUITES,
+    "plugin/trino-ignite": ALL_CONNECTORS_SMOKE | {"SuiteIgnite"},
+    "plugin/trino-jmx": ALL_CONNECTORS_SMOKE | {
+        "SuiteDeltaLakeOss",
+        "SuiteHiveAlluxioCaching",
+        "SuiteIceberg",
+    },
+    "plugin/trino-kafka": ALL_CONNECTORS_SMOKE | {"SuiteKafka"},
+    "plugin/trino-loki": ALL_CONNECTORS_SMOKE | {"SuiteLoki"},
+    "plugin/trino-mariadb": ALL_CONNECTORS_SMOKE | {"SuiteMysql", "SuiteRanger"},
+    "plugin/trino-memory": ALL_CONNECTORS_SMOKE | {"SuiteClients", "SuiteJdbcKerberos"},
+    "plugin/trino-mongodb": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-mysql": ALL_CONNECTORS_SMOKE | {"SuiteMysql"},
+    "plugin/trino-opensearch": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-oracle": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-pinot": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-postgresql": ALL_CONNECTORS_SMOKE | {"SuiteClients", "SuitePostgresql"},
+    "plugin/trino-prometheus": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-redis": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-redshift": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-singlestore": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-snowflake": ALL_CONNECTORS_SMOKE | {"SuiteSnowflake"},
+    "plugin/trino-sqlserver": ALL_CONNECTORS_SMOKE | {"SuiteSqlServer"},
+    "plugin/trino-tpcds": ALL_CONNECTORS_SMOKE | {"SuiteFunctions", "SuiteParquet", "SuiteTpcds"},
+    "plugin/trino-thrift": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-thrift-api": ALL_CONNECTORS_SMOKE,
+    "plugin/trino-thrift-testing-server": ALL_CONNECTORS_SMOKE,
 
-unwired_suites = sorted(actual_suites - set(declared_suites))
-if unwired_suites:
-    raise SystemExit(f"Product test suites are missing from the CI matrix: {', '.join(unwired_suites)}")
+    # Security and function plugins exercised outside connector-named suites.
+    "plugin/trino-ldap-group-provider": {"SuiteLdap"},
+    "plugin/trino-password-authenticators": {"SuiteLdap"},
+    "plugin/trino-ranger": {"SuiteRanger"},
+    "plugin/trino-teradata-functions": {"SuiteFunctions"},
+}
 
-include = [
-    {
-        "bucket": bucket,
-        "suites": " ".join(suites),
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Build the JUnit product-test matrix, optionally filtered by GIB impacted modules."
+    )
+    parser.add_argument(
+        "-i",
+        "--impacted",
+        type=argparse.FileType("r"),
+        help="File containing affected Maven module paths, one per line",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_const",
+        dest="loglevel",
+        const=logging.INFO,
+        default=logging.WARNING,
+        help="Print matrix filtering decisions",
+    )
+    parser.add_argument(
+        "-t",
+        "--test",
+        action="store_true",
+        help="Test this script instead of executing it",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=args.loglevel, format="%(levelname)s: %(message)s")
+
+    if args.test:
+        sys.argv = [sys.argv[0]]
+        unittest.main()
+        return
+
+    impacted_modules = None
+    if args.impacted is not None:
+        impacted_modules = {line.strip() for line in args.impacted if line.strip()}
+    print(json.dumps(build_matrix(impacted_modules)))
+
+
+def build_matrix(impacted_modules):
+    selected_suites = suites_for_impacted_modules(impacted_modules)
+    if selected_suites is None:
+        selected_suites = ALL_SUITES
+
+    include = []
+    for bucket, suites in BUCKETS:
+        filtered_suites = [suite for suite in suites if suite in selected_suites]
+        if filtered_suites:
+            include.append({
+                "bucket": bucket,
+                "suites": " ".join(filtered_suites),
+            })
+    return {"include": include} if include else {}
+
+
+def suites_for_impacted_modules(impacted_modules):
+    if impacted_modules is None:
+        logging.info("Impact filtering was not requested; using the full product-test matrix")
+        return None
+    if not impacted_modules:
+        logging.info("GIB reported no modules; using the full product-test matrix")
+        return None
+
+    unknown_modules = impacted_modules - MODULE_TO_SUITES.keys()
+    if unknown_modules:
+        logging.info(
+            "Modules without an unambiguous product-test mapping (%s); using the full product-test matrix",
+            ", ".join(sorted(unknown_modules)),
+        )
+        return None
+
+    selected_suites = set()
+    for module in impacted_modules:
+        selected_suites.update(MODULE_TO_SUITES[module])
+    logging.info("GIB impacted modules: %s", ", ".join(sorted(impacted_modules)))
+    logging.info("Selected product-test suites: %s", ", ".join(sorted(selected_suites)))
+    return selected_suites
+
+
+def validate_configuration(suite_dir=SUITE_DIR):
+    declared_suites = [suite for _, suites in BUCKETS for suite in suites]
+    duplicate_suites = sorted({suite for suite in declared_suites if declared_suites.count(suite) > 1})
+    if duplicate_suites:
+        raise ValueError(f"Suites declared more than once: {', '.join(duplicate_suites)}")
+
+    actual_suites = {path.stem for path in suite_dir.glob("Suite*.java")} - SUITE_HELPERS
+    missing_suites = sorted(set(declared_suites) - actual_suites)
+    if missing_suites:
+        raise ValueError(f"Declared product test suites are missing: {', '.join(missing_suites)}")
+
+    unwired_suites = sorted(actual_suites - set(declared_suites))
+    if unwired_suites:
+        raise ValueError(f"Product test suites are missing from the CI matrix: {', '.join(unwired_suites)}")
+
+    invalid_mapped_suites = sorted(set().union(*MODULE_TO_SUITES.values()) - set(declared_suites))
+    if invalid_mapped_suites:
+        raise ValueError(f"Module mappings contain unknown suites: {', '.join(invalid_mapped_suites)}")
+
+    missing_modules = sorted(module for module in MODULE_TO_SUITES if not Path(module, "pom.xml").is_file())
+    if missing_modules:
+        raise ValueError(f"Mapped Maven modules are missing: {', '.join(missing_modules)}")
+
+
+class TestBuildMatrix(unittest.TestCase):
+    def test_connector_only_change(self):
+        self.assertEqual(
+            build_matrix({"plugin/trino-mysql"}),
+            {
+                "include": [
+                    {"bucket": "jdbc-core", "suites": "SuiteMysql"},
+                    {"bucket": "connector-smoke", "suites": "SuiteAllConnectorsSmoke"},
+                ],
+            },
+        )
+
+    def test_secondary_connector(self):
+        self.assertEqual(
+            build_matrix({"plugin/trino-mariadb"}),
+            {
+                "include": [
+                    {"bucket": "jdbc-core", "suites": "SuiteMysql"},
+                    {"bucket": "connector-smoke", "suites": "SuiteAllConnectorsSmoke"},
+                    {"bucket": "auth-and-clients", "suites": "SuiteRanger"},
+                ],
+            },
+        )
+
+    def test_shared_connector_module(self):
+        # GIB includes all downstream modules. trino-example-jdbc is understood to have no product suite.
+        impacted_modules = {
+            "plugin/trino-base-jdbc",
+            "plugin/trino-clickhouse",
+            "plugin/trino-druid",
+            "plugin/trino-duckdb",
+            "plugin/trino-example-jdbc",
+            "plugin/trino-exasol",
+            "plugin/trino-ignite",
+            "plugin/trino-mariadb",
+            "plugin/trino-mysql",
+            "plugin/trino-oracle",
+            "plugin/trino-postgresql",
+            "plugin/trino-redshift",
+            "plugin/trino-singlestore",
+            "plugin/trino-snowflake",
+            "plugin/trino-sqlserver",
+        }
+        matrix = build_matrix(impacted_modules)
+        selected_suites = suites_from_matrix(matrix)
+        self.assertEqual(selected_suites, JDBC_CONNECTOR_SUITES)
+
+    def test_multiple_understood_modules(self):
+        matrix = build_matrix({"plugin/trino-kafka", "plugin/trino-loki"})
+        self.assertEqual(
+            suites_from_matrix(matrix),
+            {"SuiteAllConnectorsSmoke", "SuiteKafka", "SuiteLoki"},
+        )
+
+    def test_core_change_runs_full_matrix(self):
+        self.assertEqual(build_matrix({"core/trino-main"}), build_matrix(None))
+
+    def test_shared_infrastructure_change_runs_full_matrix(self):
+        self.assertEqual(build_matrix({"lib/trino-plugin-toolkit"}), build_matrix(None))
+
+    def test_product_test_framework_change_runs_full_matrix(self):
+        self.assertEqual(build_matrix({"testing/trino-product-tests"}), build_matrix(None))
+
+    def test_unknown_module_runs_full_matrix(self):
+        self.assertEqual(build_matrix({"plugin/trino-new-connector"}), build_matrix(None))
+
+    def test_unknown_module_mixed_with_understood_module_runs_full_matrix(self):
+        self.assertEqual(
+            build_matrix({"plugin/trino-mysql", "plugin/trino-new-connector"}),
+            build_matrix(None),
+        )
+
+    def test_empty_gib_output_runs_full_matrix(self):
+        self.assertEqual(build_matrix(set()), build_matrix(None))
+
+    def test_forced_full_run(self):
+        self.assertEqual(suites_from_matrix(build_matrix(None)), ALL_SUITES)
+
+    def test_understood_module_without_product_tests_produces_empty_matrix(self):
+        self.assertEqual(build_matrix({"plugin/trino-example-jdbc"}), {})
+
+    def test_matrix_is_complete(self):
+        validate_configuration()
+
+
+def suites_from_matrix(matrix):
+    return {
+        suite
+        for item in matrix.get("include", [])
+        for suite in item["suites"].split()
     }
-    for bucket, suites in BUCKETS
-]
 
-print(json.dumps({"include": include}))
+
+validate_configuration()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
   path-filters:
     runs-on: ubuntu-latest
     outputs:
+      ci: ${{ steps.filter.outputs.ci }}
       docs: ${{ steps.filter.outputs.docs }}
       non_docs: ${{ steps.filter.outputs.non_docs }}
     steps:
@@ -72,6 +73,7 @@ jobs:
           # Note: `docs` output is currently unused. The docs changes are tested by maven-checks job, leveraging GIB impact analysis.
           # TODO remove use of non_docs filters and remove `path-filters` job. Use GIB impact analysis to guard job skipping.
           filters: |
+            ci: '.github/**'
             docs: 'docs/**'
             non_docs: '!docs/**'
 
@@ -865,6 +867,17 @@ jobs:
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           $MAVEN clean install ${MAVEN_FAST_INSTALL} -pl '!:trino-docs'
+      - name: Determine impacted Maven modules
+        if: >-
+          github.event_name == 'pull_request' &&
+          needs.path-filters.outputs.ci != 'true' &&
+          !contains(github.event.pull_request.labels.*.name, 'tests:all') &&
+          !contains(github.event.pull_request.labels.*.name, 'tests:all-product')
+        run: |
+          export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
+          $MAVEN validate ${MAVEN_FAST_INSTALL} ${MAVEN_GIB} -Dgib.logImpactedTo=gib-impacted.log -pl '!:trino-docs'
+          # If GIB does not create the output, an empty file conservatively produces a full matrix.
+          touch gib-impacted.log
       - name: Build Trino Docker image for product tests
         run: |
           cd core/docker
@@ -886,9 +899,22 @@ jobs:
           name: product tests m2 io.trino
           path: ~/.m2/repository/io/trino
           retention-days: 1
+      - name: Build product-test matrix from impacted modules
+        if: >-
+          github.event_name == 'pull_request' &&
+          needs.path-filters.outputs.ci != 'true' &&
+          !contains(github.event.pull_request.labels.*.name, 'tests:all') &&
+          !contains(github.event.pull_request.labels.*.name, 'tests:all-product')
+        run: .github/bin/build-pt-matrix.py -v -i gib-impacted.log > matrix.json
+      - name: Build full product-test matrix
+        if: >-
+          github.event_name != 'pull_request' ||
+          needs.path-filters.outputs.ci == 'true' ||
+          contains(github.event.pull_request.labels.*.name, 'tests:all') ||
+          contains(github.event.pull_request.labels.*.name, 'tests:all-product')
+        run: .github/bin/build-pt-matrix.py -v > matrix.json
       - id: set-matrix
         run: |
-          .github/bin/build-pt-matrix.py > matrix.json
           echo "PT matrix: $(jq '.' matrix.json)"
           echo "matrix=$(jq -c '.' matrix.json)" >> $GITHUB_OUTPUT
       - name: Cancel merge queue workflow


### PR DESCRIPTION
## Description

Product-test jobs currently run every JUnit suite even when a pull request only affects a bounded connector. This restores conservative GIB-based build avoidance while preserving full runs whenever the impact cannot be mapped safely.

The affected Maven modules are mapped explicitly to JUnit suites, suites are filtered before the existing CI buckets are packed, and unknown, core, shared infrastructure, product-test framework, CI, and forced-full changes retain the complete matrix.

## Additional context and related issues

This intentionally keeps the first pass connector-oriented, matching the old product-test impact-analysis model. Shared clients and libraries remain conservative full-run cases so the suite and job organization can evolve independently.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
