### PR TITLE
Include principal in OPA request payload

### DIFF
--- a/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoIdentity.java
+++ b/plugin/trino-opa/src/main/java/io/trino/plugin/opa/schema/TrinoIdentity.java
@@ -16,24 +16,28 @@ package io.trino.plugin.opa.schema;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.security.Identity;
 
+import java.security.Principal;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
 public record TrinoIdentity(
         String user,
+        String principal,
         Set<String> groups)
 {
     public static TrinoIdentity fromTrinoIdentity(Identity identity)
     {
         return new TrinoIdentity(
                 identity.getUser(),
+                identity.getPrincipal().map(Principal::getName).orElseGet(identity::getUser),
                 identity.getGroups());
     }
 
     public TrinoIdentity
     {
         requireNonNull(user, "user is null");
+        requireNonNull(principal, "principal is null");
         groups = ImmutableSet.copyOf(requireNonNull(groups, "groups is null"));
     }
 }

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/RequestTestUtilities.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/RequestTestUtilities.java
@@ -20,6 +20,7 @@ import io.trino.plugin.opa.HttpClientUtils.MockResponse;
 import io.trino.spi.security.Identity;
 
 import java.io.IOException;
+import java.security.Principal;
 import java.util.Collection;
 import java.util.Set;
 import java.util.function.Function;
@@ -65,6 +66,10 @@ public final class RequestTestUtilities
         return parsedRequest -> {
             if (!parsedRequest.at("/input/context/identity/user").asText().equals(expectedUser.getUser())) {
                 throw new AssertionError("Request had invalid user in the identity block");
+            }
+            String expectedPrincipal = expectedUser.getPrincipal().map(Principal::getName).orElseGet(expectedUser::getUser);
+            if (!parsedRequest.at("/input/context/identity/principal").asText().equals(expectedPrincipal)) {
+                throw new AssertionError("Request had invalid principal in the identity block");
             }
             ImmutableSet.Builder<String> groupsInRequestBuilder = ImmutableSet.builder();
             parsedRequest.at("/input/context/identity/groups").iterator().forEachRemaining(node -> groupsInRequestBuilder.add(node.asText()));

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControl.java
@@ -29,6 +29,7 @@ import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaRoutineName;
 import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ColumnSchema;
+import io.trino.spi.security.BasicPrincipal;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.SystemAccessControlFactory;
@@ -224,6 +225,7 @@ final class TestOpaAccessControl
             FunctionalHelpers.Consumer3<OpaAccessControl, Identity, Identity> callable)
     {
         Identity dummyIdentity = Identity.forUser("dummy-user")
+                .withPrincipal(new BasicPrincipal("dummy-principal"))
                 .withGroups(ImmutableSet.of("some-group"))
                 .build();
         ThrowingMethodWrapper wrappedMethod = new ThrowingMethodWrapper(
@@ -236,6 +238,7 @@ final class TestOpaAccessControl
                     "resource": {
                         "user": {
                             "user": "dummy-user",
+                            "principal": "dummy-principal",
                             "groups": ["some-group"]
                         }
                     }
@@ -668,7 +671,10 @@ final class TestOpaAccessControl
                 ImmutableMap.of("opa.policy.uri", OPA_SERVER_URI.toString()),
                 Optional.of(mockClient),
                 accessControlContext);
-        Identity sampleIdentityWithGroups = Identity.forUser("test_user").withGroups(ImmutableSet.of("some_group")).build();
+        Identity sampleIdentityWithGroups = Identity.forUser("test_user")
+                .withPrincipal(new BasicPrincipal("test_principal"))
+                .withGroups(ImmutableSet.of("some_group"))
+                .build();
 
         authorizer.checkCanExecuteQuery(sampleIdentityWithGroups, TEST_QUERY_ID);
 
@@ -681,6 +687,7 @@ final class TestOpaAccessControl
                     "context": {
                         "identity": {
                             "user": "test_user",
+                            "principal": "test_principal",
                             "groups": ["some_group"]
                         },
                         "softwareStack": {
@@ -702,6 +709,7 @@ final class TestOpaAccessControl
                 ImmutableMap.of("opa.policy.uri", OPA_SERVER_URI.toString(), "opa.context-file", OPA_ADDITIONAL_CONTEXT_FILE.toString()),
                 Optional.of(mockClient),
                 Optional.empty());
+        // no principal set, the identity falls back to reporting the user name as the principal
         Identity sampleIdentityWithGroups = Identity.forUser("test_user").withGroups(ImmutableSet.of("some_group")).build();
 
         authorizer.checkCanExecuteQuery(sampleIdentityWithGroups, TEST_QUERY_ID);
@@ -716,6 +724,7 @@ final class TestOpaAccessControl
                     "context": {
                         "identity": {
                             "user": "test_user",
+                            "principal": "test_user",
                             "groups": ["some_group"]
                         },
                         "softwareStack": {

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControlFiltering.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaAccessControlFiltering.java
@@ -75,6 +75,7 @@ final class TestOpaAccessControlFiltering
                             "resource": {
                                 "user": {
                                     "user": "user-one",
+                                    "principal": "user-one",
                                     "groups": []
                                 }
                             }
@@ -87,6 +88,7 @@ final class TestOpaAccessControlFiltering
                             "resource": {
                                 "user": {
                                     "user": "user-two",
+                                    "principal": "user-two",
                                     "groups": []
                                 }
                             }

--- a/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaBatchAccessControlFiltering.java
+++ b/plugin/trino-opa/src/test/java/io/trino/plugin/opa/TestOpaBatchAccessControlFiltering.java
@@ -64,18 +64,21 @@ final class TestOpaBatchAccessControlFiltering
                         {
                             "user": {
                                 "user": "user-one",
+                                "principal": "user-one",
                                 "groups": []
                             }
                         },
                         {
                             "user": {
                                 "user": "user-two",
+                                "principal": "user-two",
                                 "groups": []
                             }
                         },
                         {
                             "user": {
                                 "user": "user-three",
+                                "principal": "user-three",
                                 "groups": []
                             }
                         }


### PR DESCRIPTION
## Description

Add a `principal` field to the `identity` object sent to OPA, alongside the existing
`user` and `groups`. It is populated from `Identity.getPrincipal()`, falling back to
the user name when no principal is present, so the field is always set.

The field appears in both places `TrinoIdentity` is serialized:

* `context.identity`: on every authorization request
* `action.resource.user`: for identity-resource operations such as `ViewQueryOwnedBy`,
  `KillQueryOwnedBy` and `FilterViewQueryOwnedBy`

The change is additive; existing policies that only read `user` and `groups` are unaffected.

## Additional context and related issues

Supersedes #25895, which was auto-closed as stale before review, in order to fix #25415

With impersonation, `user` is the impersonated user while the principal identifies the
authenticated caller doing the impersonating. Without the principal, a policy cannot tell
which upstream connection a request came from. The motivating case is a Metabase-Trino
integration where several connections impersonate users through a shared service identity,
and OPA needs to apply per-connection constraints.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## OPA access control
* Add the `principal` of the authenticated caller to the `identity` object in requests sent to OPA.
```
