### PR TITLE
Add retry for getTable when creating session in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
@@ -82,8 +82,16 @@ public class ReadSessionCreator
     public ReadSession create(ConnectorSession session, TableId remoteTable, List<BigQueryColumnHandle> selectedFields, Optional<String> filter, int currentWorkerCount)
     {
         BigQueryClient client = bigQueryClientFactory.create(session);
-        TableInfo tableDetails = client.getTable(remoteTable)
-                .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(remoteTable.getDataset(), remoteTable.getTable())));
+        // The table was already resolved during planning, so "not found" here is most likely a transient
+        // metadata blip, or a transient server error reported as an empty result
+        TableInfo tableDetails = Failsafe.with(RetryPolicy.builder()
+                        .withMaxRetries(maxCreateReadSessionRetries)
+                        .withBackoff(10, 500, MILLIS)
+                        .onRetry(event -> log.debug("Get table request failed, retrying: %s", event.getLastException()))
+                        .handleIf(throwable -> BigQueryUtil.isRetryable(throwable) || throwable instanceof TableNotFoundException)
+                        .build())
+                .get(() -> client.getTable(remoteTable)
+                        .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(remoteTable.getDataset(), remoteTable.getTable()))));
 
         TableInfo actualTable = getActualTable(client, tableDetails, selectedFields, isViewMaterializationWithFilter(session) ? filter : Optional.empty());
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

encountered error in BigQuery connector, but with retry success, so adding retry for getTable:
```
2026-08-05T21:16:49.405-0600	INFO	main	io.trino.testing.containers.junit.ReportLeakedContainers	DockerClientFactory not initialized, so there should be no leaked containers, skipping the check
	at io.trino.testing.QueryAssertions.assertDistributedQuery(QueryAssertions.java:303)
	at io.trino.testing.QueryAssertions.assertQuery(QueryAssertions.java:191)
	at io.trino.testing.QueryAssertions.assertQuery(QueryAssertions.java:164)
	at io.trino.testing.AbstractTestQueryFramework.assertQuery(AbstractTestQueryFramework.java:359)
	at io.trino.testing.BaseConnectorTest.testDataMapping(BaseConnectorTest.java:6789)
	at io.trino.testing.BaseConnectorTest.testDataMappingSmokeTest(BaseConnectorTest.java:6743)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool.helpJoin(ForkJoinPool.java:2304)
	at java.base/java.util.concurrent.ForkJoinTask.awaitDone(ForkJoinTask.java:499)
	at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:669)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: io.trino.testing.QueryFailedException: Table 'tpch.test_data_mapping_smoke_doubleae9zuw1dld' not found
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:664)
	at io.trino.testing.DistributedQueryRunner.executeWithQueryId(DistributedQueryRunner.java:653)
	at io.trino.testing.QueryAssertions.assertDistributedQuery(QueryAssertions.java:294)
	... 14 more
	Suppressed: java.lang.Exception: SQL: SELECT row_id FROM test_data_mapping_smoke_doubleae9zuw1dld WHERE value IS NULL OR value = DOUBLE '1234567890123.123'
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:671)
		... 16 more
Caused by: io.trino.spi.connector.TableNotFoundException: Table 'tpch.test_data_mapping_smoke_doubleae9zuw1dld' not found
	at io.trino.plugin.bigquery.ReadSessionCreator.lambda$create$0(ReadSessionCreator.java:86)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at io.trino.plugin.bigquery.ReadSessionCreator.create(ReadSessionCreator.java:86)
	at io.trino.plugin.bigquery.BigQuerySplitSource.createReadSession(BigQuerySplitSource.java:221)
	at io.trino.plugin.bigquery.BigQuerySplitSource.readFromBigQuery(BigQuerySplitSource.java:209)
	at io.trino.plugin.bigquery.BigQuerySplitSource.getSplits(BigQuerySplitSource.java:175)
	at io.trino.plugin.bigquery.BigQuerySplitSource.getNextBatch(BigQuerySplitSource.java:105)
	at io.trino.split.ConnectorAwareSplitSource.getNextBatch(ConnectorAwareSplitSource.java:75)
	at io.trino.split.TracingSplitSource.getNextBatch(TracingSplitSource.java:65)
	at io.trino.split.BufferingSplitSource$GetNextBatch.fetchSplits(BufferingSplitSource.java:137)
	at io.trino.split.BufferingSplitSource$GetNextBatch.fetchNextBatchAsync(BufferingSplitSource.java:119)
	at io.trino.split.BufferingSplitSource.getNextBatch(BufferingSplitSource.java:62)
	at io.trino.split.TracingSplitSource.getNextBatch(TracingSplitSource.java:65)
	at io.trino.execution.scheduler.SourcePartitionedScheduler.schedule(SourcePartitionedScheduler.java:265)
	at io.trino.execution.scheduler.SourcePartitionedScheduler$1.schedule(SourcePartitionedScheduler.java:186)
	at io.trino.execution.scheduler.PipelinedQueryScheduler$DistributedStagesScheduler.schedule(PipelinedQueryScheduler.java:1517)
	at io.trino.$gen.Trino_testversion____20260806_025856_409.run(Unknown Source)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
```



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
