### PR TITLE
Disable REST catalog table cache

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogPropertiesProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogPropertiesProvider.java
@@ -23,6 +23,7 @@ import java.util.Map.Entry;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.CatalogProperties.AUTH_SESSION_TIMEOUT_MS;
+import static org.apache.iceberg.rest.RESTCatalogProperties.TABLE_CACHE_MAX_ENTRIES;
 
 public class IcebergRestCatalogPropertiesProvider
 {
@@ -55,6 +56,12 @@ public class IcebergRestCatalogPropertiesProvider
         for (Entry<String, String> entry : restConfig.getHttpHeaders().entrySet()) {
             properties.put("header.".concat(entry.getKey()), entry.getValue());
         }
+
+        // Disable the table cache because it is not useful here. Trino generates a random
+        // `SessionCatalog.SessionContext.sessionId` for every catalog access and uses it as the cache key.
+        // Disabling the cache avoids unnecessary memory consumption since cached data would
+        // otherwise be kept for `RESTCatalogProperties.TABLE_CACHE_EXPIRE_AFTER_WRITE_MS_DEFAULT`.
+        properties.put(TABLE_CACHE_MAX_ENTRIES, "0");
 
         catalogProperties = properties.buildOrThrow();
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The Iceberg REST catalog client (`RESTSessionCatalog`) maintains an internal table cache keyed by `SessionCatalog.SessionContext.sessionId`. Trino generates a random UUID for the session ID on every catalog access (see `TrinoRestCatalog`), so cached entries are never hit. The cache just accumulates unreachable entries that sit in memory until they expire after `TABLE_CACHE_EXPIRE_AFTER_WRITE_MS_DEFAULT` (5 minutes).

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

* The table cache was introduced in:
   *  https://github.com/apache/iceberg/pull/14398

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
