### PR TITLE
Reject negative divisor in $divide_round_to_scale 

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DivideRoundToScale.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DivideRoundToScale.java
@@ -25,7 +25,7 @@ import io.trino.spi.type.StandardTypes;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.Decimals.overflows;
 
-/// Divides a decimal by an integer count and rounds the quotient (HALF_UP) to the dividend's scale.
+/// Divides a decimal by an integer divisor and rounds the quotient (HALF_UP) to the dividend's scale.
 /// This is unlike the built-in decimal `/` operator, which widens the result scale to at least 6.
 ///
 /// This can be used when exact original scale is needed and `/ + CAST`'s double rounding is
@@ -40,14 +40,14 @@ public final class DivideRoundToScale
     private DivideRoundToScale() {}
 
     @ScalarFunction(value = NAME, hidden = true)
-    @Description("Divides a decimal by an integer count, rounding HALF_UP to the dividend's scale")
+    @Description("Divides a decimal by an integer divisor, rounding HALF_UP to the dividend's scale")
     @LiteralParameters({"p", "s"})
     @SqlType("decimal(p, s)")
     public static Int128 divideRoundToScale(
             @SqlType("decimal(p, s)") Int128 dividend,
-            @SqlType(StandardTypes.BIGINT) long count)
+            @SqlType(StandardTypes.BIGINT) long divisor)
     {
-        Int128 result = Int128Math.divideRoundUp(dividend.getHigh(), dividend.getLow(), 0, 0, count, 0);
+        Int128 result = Int128Math.divideRoundUp(dividend.getHigh(), dividend.getLow(), 0, 0, divisor, 0);
         if (overflows(result)) {
             throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Decimal overflow");
         }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DivideRoundToScale.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DivideRoundToScale.java
@@ -22,6 +22,7 @@ import io.trino.spi.type.Int128;
 import io.trino.spi.type.Int128Math;
 import io.trino.spi.type.StandardTypes;
 
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.Decimals.overflows;
 
@@ -47,6 +48,9 @@ public final class DivideRoundToScale
             @SqlType("decimal(p, s)") Int128 dividend,
             @SqlType(StandardTypes.BIGINT) long divisor)
     {
+        if (divisor < 0) {
+            throw new TrinoException(NOT_SUPPORTED, "Negative divisor is not supported");
+        }
         Int128 result = Int128Math.divideRoundUp(dividend.getHigh(), dividend.getLow(), 0, 0, divisor, 0);
         if (overflows(result)) {
             throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Decimal overflow");

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestDecimalAvgFromSumAndCount.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestDecimalAvgFromSumAndCount.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregationFunction;
@@ -173,6 +174,17 @@ final class TestDecimalAvgFromSumAndCount
         assertThat(assertions.query(
                 "SELECT CAST(CAST(488999.99 AS decimal(38, 2)) / CAST(200000 AS bigint) AS decimal(38, 2))"))
                 .matches("VALUES CAST(2.45 AS decimal(38, 2))");
+    }
+
+    @Test
+    void testNegativeDivisor()
+    {
+        // A negative divisor is currently unsupported
+        assertThat(assertions.query(
+                "SELECT \"$divide_round_to_scale\"(CAST(12345.00 AS decimal(38, 2)), BIGINT '-3')"))
+                .failure()
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessage("Negative divisor is not supported");
     }
 
     @Test


### PR DESCRIPTION
Previously it would produce incorrect result.
This has no end user visible impact, as the function is currently only
ever used with positive divisors.

- follows https://github.com/trinodb/trino/pull/30595