### PR TITLE
Compute `sum(decimal)` in sliding window efficiently

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/BigintAverageAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/BigintAverageAggregations.java
@@ -13,7 +13,6 @@
  */
 package io.trino.operator.aggregation;
 
-import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.operator.aggregation.state.LongAndDoubleState;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.AggregationFunction;
@@ -23,8 +22,6 @@ import io.trino.spi.function.InputFunction;
 import io.trino.spi.function.OutputFunction;
 import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
-import io.trino.spi.function.WindowAccumulator;
-import io.trino.spi.function.WindowIndex;
 import io.trino.spi.type.StandardTypes;
 
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -59,73 +56,6 @@ public final class BigintAverageAggregations
         else {
             double value = state.getDouble();
             DOUBLE.writeDouble(out, value / count);
-        }
-    }
-
-    public static class LongAverageWindowAccumulator
-            implements WindowAccumulator
-    {
-        private long count;
-        private double sum;
-
-        @UsedByGeneratedCode
-        public LongAverageWindowAccumulator() {}
-
-        private LongAverageWindowAccumulator(long count, double sum)
-        {
-            this.count = count;
-            this.sum = sum;
-        }
-
-        @Override
-        public long getEstimatedSize()
-        {
-            return Long.BYTES + Double.BYTES;
-        }
-
-        @Override
-        public WindowAccumulator copy()
-        {
-            return new LongAverageWindowAccumulator(count, sum);
-        }
-
-        @Override
-        public void addInput(WindowIndex index, int startPosition, int endPosition)
-        {
-            for (int i = startPosition; i <= endPosition; i++) {
-                if (!index.isNull(0, i)) {
-                    sum += index.getLong(0, i);
-                    count++;
-                }
-            }
-        }
-
-        @Override
-        public boolean removeInput(WindowIndex index, int startPosition, int endPosition)
-        {
-            // If sum is finite, all value to be removed are finite
-            if (!Double.isFinite(sum)) {
-                return false;
-            }
-
-            for (int i = startPosition; i <= endPosition; i++) {
-                if (!index.isNull(0, i)) {
-                    sum -= index.getLong(0, i);
-                    count--;
-                }
-            }
-            return true;
-        }
-
-        @Override
-        public void output(BlockBuilder blockBuilder)
-        {
-            if (count == 0) {
-                blockBuilder.appendNull();
-            }
-            else {
-                DOUBLE.writeDouble(blockBuilder, sum / count);
-            }
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DecimalSumAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DecimalSumAggregation.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.aggregation;
 
+import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.operator.aggregation.state.LongDecimalWithOverflowState;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.BlockBuilder;
@@ -29,13 +30,15 @@ import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.OutputFunction;
 import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
+import io.trino.spi.function.WindowAccumulator;
+import io.trino.spi.function.WindowIndex;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.Int128;
 
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.Int128Math.addWithOverflow;
 
-@AggregationFunction("sum")
+@AggregationFunction(value = "sum", windowAccumulator = DecimalSumAggregation.DecimalSumWindowAccumulator.class)
 @Description("Calculates the sum over the input values")
 public final class DecimalSumAggregation
 {
@@ -138,6 +141,123 @@ public final class DecimalSumAggregation
         }
         else {
             out.appendNull();
+        }
+    }
+
+    public static class DecimalSumWindowAccumulator
+            implements WindowAccumulator
+    {
+        // sum[0] is the high 64 bits, sum[1] the low 64 bits of the running 128-bit sum
+        private final long[] sum;
+        private long overflow;
+        private long count;
+
+        // The window accumulator is shared by the short- and long-decimal signatures and is not told which one
+        // it serves, so the backing type is detected once from the argument block.
+        private boolean typeResolved;
+        private boolean longDecimal;
+
+        @UsedByGeneratedCode
+        public DecimalSumWindowAccumulator()
+        {
+            this(new long[2], 0, 0);
+        }
+
+        private DecimalSumWindowAccumulator(long[] sum, long overflow, long count)
+        {
+            this.sum = sum;
+            this.overflow = overflow;
+            this.count = count;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return Long.BYTES // count
+                    + Long.BYTES // overflow
+                    + Long.BYTES * 2L; // sum
+        }
+
+        @Override
+        public WindowAccumulator copy()
+        {
+            return new DecimalSumWindowAccumulator(sum.clone(), overflow, count);
+        }
+
+        @Override
+        public void addInput(WindowIndex index, int startPosition, int endPosition)
+        {
+            accumulate(index, startPosition, endPosition, false);
+        }
+
+        @Override
+        public boolean removeInput(WindowIndex index, int startPosition, int endPosition)
+        {
+            // Removal is addition of the negated value: because the accumulator is plain modular 128-bit
+            // arithmetic, this exactly reverses a prior addInput, including the overflow count.
+            accumulate(index, startPosition, endPosition, true);
+            return true;
+        }
+
+        private void accumulate(WindowIndex index, int startPosition, int endPosition, boolean subtract)
+        {
+            for (int i = startPosition; i <= endPosition; i++) {
+                if (index.isNull(0, i)) {
+                    continue;
+                }
+
+                long high;
+                long low;
+                if (longDecimal(index, i)) {
+                    Int128 value = (Int128) index.getObject(0, i);
+                    high = value.getHigh();
+                    low = value.getLow();
+                }
+                else {
+                    long value = index.getLong(0, i);
+                    high = value >> 63;
+                    low = value;
+                }
+
+                if (subtract) {
+                    // Two's-complement negation of the 128-bit addend; decimal magnitudes never reach
+                    // Int128.MIN, so negation cannot overflow.
+                    long negatedHigh = ~high;
+                    if (low == 0) {
+                        negatedHigh++;
+                    }
+                    high = negatedHigh;
+                    low = -low;
+                    count--;
+                }
+                else {
+                    count++;
+                }
+
+                overflow += addWithOverflow(sum[0], sum[1], high, low, sum, 0);
+            }
+        }
+
+        @Override
+        public void output(BlockBuilder blockBuilder)
+        {
+            if (count == 0) {
+                blockBuilder.appendNull();
+                return;
+            }
+            if (overflow != 0 || Decimals.overflows(sum[0], sum[1])) {
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Decimal overflow");
+            }
+            ((Int128ArrayBlockBuilder) blockBuilder).writeInt128(sum[0], sum[1]);
+        }
+
+        private boolean longDecimal(WindowIndex index, int position)
+        {
+            if (!typeResolved) {
+                longDecimal = index.getSingleValueBlock(0, position).getUnderlyingValueBlock() instanceof Int128ArrayBlock;
+                typeResolved = true;
+            }
+            return longDecimal;
         }
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestWindowQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestWindowQueries.java
@@ -753,6 +753,105 @@ public abstract class AbstractTestWindowQueries
     }
 
     @Test
+    public void testDecimalSlidingSum()
+    {
+        // short decimal
+        assertThat(query(
+                """
+                SELECT k, sum(a) OVER (ORDER BY k ROWS BETWEEN 3 PRECEDING AND CURRENT ROW)
+                FROM (VALUES
+                    (1, CAST(10.00 AS decimal(10, 2))),
+                    (2, CAST(-20.00 AS decimal(10, 2))),
+                    (3, CAST(30.00 AS decimal(10, 2))),
+                    (4, CAST(-40.00 AS decimal(10, 2))),
+                    (5, CAST(50.00 AS decimal(10, 2))),
+                    (6, CAST(-60.00 AS decimal(10, 2)))) t(k, a)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, CAST(10.00 AS decimal(38, 2))),
+                            (2, CAST(-10.00 AS decimal(38, 2))),
+                            (3, CAST(20.00 AS decimal(38, 2))),
+                            (4, CAST(-20.00 AS decimal(38, 2))),
+                            (5, CAST(20.00 AS decimal(38, 2))),
+                            (6, CAST(-20.00 AS decimal(38, 2)))
+                        """);
+
+        // long decimal
+        assertThat(query(
+                """
+                SELECT k, sum(a) OVER (ORDER BY k ROWS BETWEEN 3 PRECEDING AND CURRENT ROW)
+                FROM (VALUES
+                    (1, DECIMAL '10000000000000000000'),
+                    (2, DECIMAL '-20000000000000000000'),
+                    (3, DECIMAL '30000000000000000000'),
+                    (4, DECIMAL '-40000000000000000000'),
+                    (5, DECIMAL '50000000000000000000'),
+                    (6, DECIMAL '-60000000000000000000')) t(k, a)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, CAST(DECIMAL '10000000000000000000' AS decimal(38, 0))),
+                            (2, CAST(DECIMAL '-10000000000000000000' AS decimal(38, 0))),
+                            (3, CAST(DECIMAL '20000000000000000000' AS decimal(38, 0))),
+                            (4, CAST(DECIMAL '-20000000000000000000' AS decimal(38, 0))),
+                            (5, CAST(DECIMAL '20000000000000000000' AS decimal(38, 0))),
+                            (6, CAST(DECIMAL '-20000000000000000000' AS decimal(38, 0)))
+                        """);
+
+        // long decimal, removing values whose low 64-bit word is zero (2^64 and -2^64): exercises the carry into the high word during negation
+        assertThat(query(
+                """
+                SELECT k, sum(a) OVER (ORDER BY k ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
+                FROM (VALUES
+                    (1, DECIMAL '18446744073709551616'),
+                    (2, DECIMAL '-18446744073709551616'),
+                    (3, DECIMAL '0'),
+                    (4, DECIMAL '0'),
+                    (5, DECIMAL '0')) t(k, a)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, CAST(DECIMAL '18446744073709551616' AS decimal(38, 0))),
+                            (2, CAST(DECIMAL '0' AS decimal(38, 0))),
+                            (3, CAST(DECIMAL '0' AS decimal(38, 0))),
+                            (4, CAST(DECIMAL '-18446744073709551616' AS decimal(38, 0))),
+                            (5, CAST(DECIMAL '0' AS decimal(38, 0)))
+                        """);
+
+        // long decimal, overflow-counter cancellation: with A = 9e37 the removeInput before the incoming add pushes the
+        // accumulator transiently past +2^127 (partition 'plus') or -2^127 (partition 'minus'), so the overflow counter must reverse
+        assertThat(query(
+                """
+                SELECT k, p, sum(a) OVER (PARTITION BY p ORDER BY k ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
+                FROM (VALUES
+                    (1, 'plus', DECIMAL '-90000000000000000000000000000000000000'),
+                    (2, 'plus', DECIMAL '90000000000000000000000000000000000000'),
+                    (3, 'plus', DECIMAL '90000000000000000000000000000000000000'),
+                    (4, 'plus', DECIMAL '-90000000000000000000000000000000000000'),
+                    (1, 'minus', DECIMAL '90000000000000000000000000000000000000'),
+                    (2, 'minus', DECIMAL '-90000000000000000000000000000000000000'),
+                    (3, 'minus', DECIMAL '-90000000000000000000000000000000000000'),
+                    (4, 'minus', DECIMAL '90000000000000000000000000000000000000')) t(k, p, a)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, 'plus', CAST(DECIMAL '-90000000000000000000000000000000000000' AS decimal(38, 0))),
+                            (2, 'plus', CAST(DECIMAL '0' AS decimal(38, 0))),
+                            (3, 'plus', CAST(DECIMAL '90000000000000000000000000000000000000' AS decimal(38, 0))),
+                            (4, 'plus', CAST(DECIMAL '90000000000000000000000000000000000000' AS decimal(38, 0))),
+                            (1, 'minus', CAST(DECIMAL '90000000000000000000000000000000000000' AS decimal(38, 0))),
+                            (2, 'minus', CAST(DECIMAL '0' AS decimal(38, 0))),
+                            (3, 'minus', CAST(DECIMAL '-90000000000000000000000000000000000000' AS decimal(38, 0))),
+                            (4, 'minus', CAST(DECIMAL '-90000000000000000000000000000000000000' AS decimal(38, 0)))
+                        """);
+    }
+
+    @Test
     public void testDuplicateColumnsInWindowOrderByClause()
     {
         MaterializedResult actual = computeActual("SELECT a, row_number() OVER (ORDER BY a ASC, a DESC) FROM (VALUES 3, 2, 1) t(a)");

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestWindowQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestWindowQueries.java
@@ -617,6 +617,142 @@ public abstract class AbstractTestWindowQueries
     }
 
     @Test
+    public void testBigintAverage()
+    {
+        assertThat(query(
+                """
+                SELECT k, avg(a) OVER (ORDER BY k)
+                FROM (VALUES
+                    (1, BIGINT '12'),
+                    (2, BIGINT '-24'),
+                    (3, BIGINT '36'),
+                    (4, BIGINT '-48'),
+                    (5, BIGINT '60'),
+                    (6, BIGINT '-72')) t(k, a)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, DOUBLE '12.0'),
+                            (2, DOUBLE '-6.0'),
+                            (3, DOUBLE '8.0'),
+                            (4, DOUBLE '-6.0'),
+                            (5, DOUBLE '7.2'),
+                            (6, DOUBLE '-6.0')
+                        """);
+
+        assertThat(query(
+                """
+                SELECT k, avg(v) OVER (ORDER BY k)
+                FROM (VALUES
+                    (1, BIGINT '9223372036854775807'),
+                    (2, BIGINT '1'),
+                    (3, BIGINT '1'),
+                    (4, BIGINT '1'),
+                    (5, BIGINT '1')) t(k, v)"""))
+                .matches(
+                        """
+                        VALUES
+                            (1, DOUBLE '9223372036854776000'),
+                            (2, DOUBLE '4611686018427388000'),
+                            (3, DOUBLE '3074457345618259000'),
+                            (4, DOUBLE '2305843009213694000'),
+                            (5, DOUBLE '1844674407370955300')""");
+
+        assertThat(query(
+                """
+                SELECT k, avg(v) OVER (ORDER BY k)
+                FROM (VALUES
+                    (1, BIGINT '9223372036854775807'),
+                    (2, BIGINT '1'),
+                    (3, BIGINT '-9223372036854775807'),
+                    (4, BIGINT '-1'),
+                    (5, BIGINT '1'),
+                    (6, BIGINT '1'),
+                    (7, BIGINT '1'),
+                    (8, BIGINT '1')) t(k, v)"""))
+                .matches(
+                        """
+                        VALUES
+                            (1, DOUBLE '9223372036854776000'),
+                            (2, DOUBLE '4611686018427388000'),
+                            (3, DOUBLE '0'),
+                            (4, DOUBLE '-0.25'),
+                            (5, DOUBLE '0'),
+                            (6, DOUBLE '0.16666666666666666'),
+                            (7, DOUBLE '0.2857142857142857'),
+                            (8, DOUBLE '0.375')""");
+    }
+
+    @Test
+    public void testBigintSlidingAverage()
+    {
+        assertThat(query(
+                """
+                SELECT k, avg(a) OVER (ORDER BY k ROWS BETWEEN 3 PRECEDING AND CURRENT ROW)
+                FROM (VALUES
+                    (1, BIGINT '12'),
+                    (2, BIGINT '-24'),
+                    (3, BIGINT '36'),
+                    (4, BIGINT '-48'),
+                    (5, BIGINT '60'),
+                    (6, BIGINT '-72')) t(k, a)
+                """))
+                .matches(
+                        """
+                        VALUES
+                            (1, DOUBLE '12.0'),
+                            (2, DOUBLE '-6.0'),
+                            (3, DOUBLE '8.0'),
+                            (4, DOUBLE '-6.0'),
+                            (5, DOUBLE '6.0'),
+                            (6, DOUBLE '-6.0')
+                        """);
+
+        assertThat(query(
+                """
+                SELECT k, avg(v) OVER (ORDER BY k ROWS BETWEEN 3 PRECEDING AND CURRENT ROW)
+                FROM (VALUES
+                    (1, BIGINT '9223372036854775807'),
+                    (2, BIGINT '1'),
+                    (3, BIGINT '1'),
+                    (4, BIGINT '1'),
+                    (5, BIGINT '1')) t(k, v)"""))
+                .matches(
+                        """
+                        VALUES
+                            (1, DOUBLE '9223372036854776000'),
+                            (2, DOUBLE '4611686018427388000'),
+                            (3, DOUBLE '3074457345618259000'),
+                            (4, DOUBLE '2305843009213694000'),
+                            (5, DOUBLE '1')""");
+
+        assertThat(query(
+                """
+                SELECT k, avg(v) OVER (ORDER BY k ROWS BETWEEN 3 PRECEDING AND CURRENT ROW)
+                FROM (VALUES
+                    (1, BIGINT '9223372036854775807'),
+                    (2, BIGINT '1'),
+                    (3, BIGINT '-9223372036854775807'),
+                    (4, BIGINT '-1'),
+                    (5, BIGINT '1'),
+                    (6, BIGINT '1'),
+                    (7, BIGINT '1'),
+                    (8, BIGINT '1')) t(k, v)"""))
+                .matches(
+                        """
+                        VALUES
+                            (1, DOUBLE '9223372036854776000'),
+                            (2, DOUBLE '4611686018427388000'),
+                            (3, DOUBLE '0'),
+                            (4, DOUBLE '-0.25'),
+                            (5, DOUBLE '-2305843009213694000'),
+                            (6, DOUBLE '-2305843009213694000'),
+                            (7, DOUBLE '0.5'),
+                            (8, DOUBLE '1')""");
+    }
+
+    @Test
     public void testDuplicateColumnsInWindowOrderByClause()
     {
         MaterializedResult actual = computeActual("SELECT a, row_number() OVER (ORDER BY a ASC, a DESC) FROM (VALUES 3, 2, 1) t(a)");


### PR DESCRIPTION
Add sliding window execution for `sum(decimal)` aggregation.
Remove unplugged sliding window accumulator for `avg(bigint)` . Plugging it in would affect query results.