### PR TITLE
Support Hive NOT NULL column constraints

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeColumnHandle.java
@@ -136,7 +136,8 @@ public record DeltaLakeColumnHandle(
                 basePhysicalType,
                 projectionInfo.map(DeltaLakeColumnProjectionInfo::toHiveColumnProjectionInfo),
                 columnType.toHiveColumnType(),
-                Optional.empty());
+                Optional.empty(),
+                true);
     }
 
     public static DeltaLakeColumnHandle rowPositionColumnHandle()

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
@@ -419,7 +419,8 @@ public class DeltaLakePageSourceProvider
                         deltaLakeColumnHandle.basePhysicalType(),
                         hiveColumnProjectionInfo,
                         deltaLakeColumnHandle.columnType().toHiveColumnType(),
-                        Optional.empty()));
+                        Optional.empty(),
+                        true));
             }
             case NAME, NONE -> {
                 checkArgument(fieldIdToName.isEmpty(), "Mapping between field id and name must be empty: %s", fieldIdToName);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -357,7 +357,8 @@ public class CheckpointEntryIterator
                         toHiveType(type),
                         type)),
                 ColumnType.REGULAR,
-                column.getComment());
+                column.getComment(),
+                true);
 
         ImmutableMap.Builder<HiveColumnHandle, Domain> domains = ImmutableMap.<HiveColumnHandle, Domain>builder()
                 .put(handle, Domain.notNull(handle.getType()));
@@ -382,7 +383,8 @@ public class CheckpointEntryIterator
                         DeltaHiveTypeTranslator.toHiveType(partitionColumn.type()),
                         partitionColumn.type())),
                 HiveColumnHandle.ColumnType.REGULAR,
-                addColumn.getComment());
+                addColumn.getComment(),
+                true);
     }
 
     private DeltaLakeTransactionLogEntry buildProtocolEntry(ConnectorSession session, int pagePosition, Block block)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveColumnHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveColumnHandle.java
@@ -94,6 +94,7 @@ public class HiveColumnHandle
     private final HiveType baseHiveType;
     private final Type baseType;
     private final Optional<String> comment;
+    private final boolean nullable;
 
     // Information about parts of the base column to be referenced by this column handle.
     private final Optional<HiveColumnProjectionInfo> hiveColumnProjectionInfo;
@@ -109,7 +110,8 @@ public class HiveColumnHandle
             @JsonProperty("baseType") Type baseType,
             @JsonProperty("hiveColumnProjectionInfo") Optional<HiveColumnProjectionInfo> hiveColumnProjectionInfo,
             @JsonProperty("columnType") ColumnType columnType,
-            @JsonProperty("comment") Optional<String> comment)
+            @JsonProperty("comment") Optional<String> comment,
+            @JsonProperty("nullable") Boolean nullable)
     {
         this.baseColumnName = requireNonNull(baseColumnName, "baseColumnName is null");
         checkArgument(baseHiveColumnIndex >= 0 || columnType == PARTITION_KEY || columnType == SYNTHESIZED, "baseHiveColumnIndex is negative");
@@ -123,6 +125,8 @@ public class HiveColumnHandle
 
         this.columnType = requireNonNull(columnType, "columnType is null");
         this.comment = requireNonNull(comment, "comment is null");
+        // Default to true (nullable) when deserializing from pre-NOT-NULL serialized handles
+        this.nullable = nullable == null || nullable;
     }
 
     public static HiveColumnHandle createBaseColumn(
@@ -133,12 +137,12 @@ public class HiveColumnHandle
             ColumnType columnType,
             Optional<String> comment)
     {
-        return new HiveColumnHandle(topLevelColumnName, topLevelColumnIndex, hiveType, type, Optional.empty(), columnType, comment);
+        return new HiveColumnHandle(topLevelColumnName, topLevelColumnIndex, hiveType, type, Optional.empty(), columnType, comment, true);
     }
 
     public HiveColumnHandle getBaseColumn()
     {
-        return isBaseColumn() ? this : createBaseColumn(baseColumnName, baseHiveColumnIndex, baseHiveType, baseType, columnType, comment);
+        return isBaseColumn() ? this : new HiveColumnHandle(baseColumnName, baseHiveColumnIndex, baseHiveType, baseType, Optional.empty(), columnType, comment, nullable);
     }
 
     public String getName()
@@ -196,12 +200,19 @@ public class HiveColumnHandle
         return columnType == SYNTHESIZED;
     }
 
+    @JsonProperty
+    public boolean isNullable()
+    {
+        return nullable;
+    }
+
     public ColumnMetadata getColumnMetadata()
     {
         return ColumnMetadata.builder()
                 .setName(name)
                 .setType(getType())
                 .setHidden(isHidden())
+                .setNullable(nullable)
                 .build();
     }
 
@@ -225,7 +236,7 @@ public class HiveColumnHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(baseColumnName, baseHiveColumnIndex, baseHiveType, baseType, hiveColumnProjectionInfo, columnType, comment);
+        return Objects.hash(baseColumnName, baseHiveColumnIndex, baseHiveType, baseType, hiveColumnProjectionInfo, columnType, comment, nullable);
     }
 
     @Override
@@ -245,7 +256,8 @@ public class HiveColumnHandle
                 Objects.equals(this.hiveColumnProjectionInfo, other.hiveColumnProjectionInfo) &&
                 Objects.equals(this.name, other.name) &&
                 this.columnType == other.columnType &&
-                Objects.equals(this.comment, other.comment);
+                Objects.equals(this.comment, other.comment) &&
+                this.nullable == other.nullable;
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnector.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnector.java
@@ -21,6 +21,7 @@ import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorCapabilities;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
@@ -39,6 +40,8 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Sets.immutableEnumSet;
+import static io.trino.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
 import static io.trino.spi.transaction.IsolationLevel.READ_UNCOMMITTED;
 import static io.trino.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static java.util.Objects.requireNonNull;
@@ -107,6 +110,12 @@ public class HiveConnector
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.singleStatementWritesOnly = singleStatementWritesOnly;
         this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public Set<ConnectorCapabilities> getCapabilities()
+    {
+        return immutableEnumSet(NOT_NULL_COLUMN_CONSTRAINT);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -151,6 +151,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -364,6 +365,7 @@ public class HiveMetadata
     public static final String TRINO_VERSION_NAME = "trino_version";
     public static final String TRINO_CREATED_BY = "trino_created_by";
     public static final String TRINO_QUERY_ID_NAME = "trino_query_id";
+    public static final String TRINO_NOT_NULL_COLUMN_PARAM_PREFIX = "trino_not_null_col_";
     private static final String BUCKETING_VERSION = "bucketing_version";
     public static final String STORAGE_TABLE = "storage_table";
     public static final String TRANSACTIONAL = "transactional";
@@ -1119,6 +1121,22 @@ public class HiveMetadata
             }
         }
 
+        Set<String> partitionColumnNames = ImmutableSet.copyOf(partitionedBy);
+        List<ColumnMetadata> notNullColumns = tableMetadata.getColumns().stream()
+                .filter(column -> !column.isNullable() && !partitionColumnNames.contains(column.getName()) && !column.isHidden())
+                .collect(toImmutableList());
+        if (!notNullColumns.isEmpty() && external) {
+            throw new TrinoException(NOT_SUPPORTED, "NOT NULL is not supported for external tables");
+        }
+        if (!notNullColumns.isEmpty()) {
+            ImmutableMap.Builder<String, String> tablePropertiesWithNotNull = ImmutableMap.builder();
+            tablePropertiesWithNotNull.putAll(tableProperties);
+            for (ColumnMetadata column : notNullColumns) {
+                tablePropertiesWithNotNull.put(TRINO_NOT_NULL_COLUMN_PARAM_PREFIX + column.getName(), "true");
+            }
+            tableProperties = tablePropertiesWithNotNull.buildOrThrow();
+        }
+
         Table table = buildTableObject(
                 session.getQueryId(),
                 schemaName,
@@ -1522,6 +1540,10 @@ public class HiveMetadata
         }
         verify(position instanceof ColumnPosition.Last, "ColumnPosition must be instance of Last");
 
+        if (!column.isNullable()) {
+            throw new TrinoException(NOT_SUPPORTED, "This connector does not support adding not null columns");
+        }
+
         HiveTableHandle handle = (HiveTableHandle) tableHandle;
         failIfAvroSchemaIsSet(handle);
 
@@ -1536,6 +1558,20 @@ public class HiveMetadata
         HiveColumnHandle sourceHandle = (HiveColumnHandle) source;
 
         metastore.renameColumn(hiveTableHandle.getSchemaName(), hiveTableHandle.getTableName(), sourceHandle.getName(), target);
+        if (!sourceHandle.isNullable()) {
+            Table table = metastore.getTable(hiveTableHandle.getSchemaName(), hiveTableHandle.getTableName())
+                    .orElseThrow(() -> new TableNotFoundException(hiveTableHandle.getSchemaTableName()));
+            Table updatedTable = Table.builder(table)
+                    .apply(builder -> {
+                        Map<String, String> params = new LinkedHashMap<>(table.getParameters());
+                        params.remove(TRINO_NOT_NULL_COLUMN_PARAM_PREFIX + sourceHandle.getName());
+                        params.put(TRINO_NOT_NULL_COLUMN_PARAM_PREFIX + target, "true");
+                        return builder.setParameters(params);
+                    })
+                    .build();
+            PrincipalPrivileges principalPrivileges = usingSystemSecurity ? NO_PRIVILEGES : buildInitialPrivilegeSet(session.getUser());
+            metastore.replaceTable(hiveTableHandle.getSchemaName(), hiveTableHandle.getTableName(), updatedTable, principalPrivileges);
+        }
     }
 
     @Override
@@ -1546,6 +1582,30 @@ public class HiveMetadata
         HiveColumnHandle columnHandle = (HiveColumnHandle) column;
 
         metastore.dropColumn(hiveTableHandle.getSchemaName(), hiveTableHandle.getTableName(), columnHandle.getName());
+        if (!columnHandle.isNullable()) {
+            removeNotNullColumnParameter(session, hiveTableHandle, columnHandle.getName());
+        }
+    }
+
+    @Override
+    public void dropNotNullConstraint(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        HiveTableHandle hiveTableHandle = (HiveTableHandle) tableHandle;
+        HiveColumnHandle hiveColumnHandle = (HiveColumnHandle) columnHandle;
+        removeNotNullColumnParameter(session, hiveTableHandle, hiveColumnHandle.getName());
+    }
+
+    private void removeNotNullColumnParameter(ConnectorSession session, HiveTableHandle hiveTableHandle, String columnName)
+    {
+        Table table = metastore.getTable(hiveTableHandle.getSchemaName(), hiveTableHandle.getTableName())
+                .orElseThrow(() -> new TableNotFoundException(hiveTableHandle.getSchemaTableName()));
+        Map<String, String> params = new LinkedHashMap<>(table.getParameters());
+        params.remove(TRINO_NOT_NULL_COLUMN_PARAM_PREFIX + columnName);
+        Table updatedTable = Table.builder(table)
+                .setParameters(params)
+                .build();
+        PrincipalPrivileges principalPrivileges = usingSystemSecurity ? NO_PRIVILEGES : buildInitialPrivilegeSet(session.getUser());
+        metastore.replaceTable(hiveTableHandle.getSchemaName(), hiveTableHandle.getTableName(), updatedTable, principalPrivileges);
     }
 
     @Override
@@ -3285,7 +3345,8 @@ public class HiveMetadata
                 column.getBaseType(),
                 Optional.of(columnProjectionInfo),
                 column.getColumnType(),
-                column.getComment());
+                column.getComment(),
+                column.isNullable());
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
@@ -590,7 +590,8 @@ public class HivePageSourceProvider
                                 createTypeFromCoercer(typeManager, fromHiveTypeBase, columnHandle.getBaseHiveType(), coercionContext),
                                 newColumnProjectionInfo,
                                 columnHandle.getColumnType(),
-                                columnHandle.getComment());
+                                columnHandle.getComment(),
+                                columnHandle.isNullable());
                     })
                     .collect(toList());
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -127,7 +127,8 @@ public class ParquetPageSourceFactory
             BIGINT,
             Optional.empty(),
             HiveColumnHandle.ColumnType.SYNTHESIZED,
-            Optional.empty());
+            Optional.empty(),
+            true);
 
     private static final Set<String> PARQUET_SERDE_CLASS_NAMES = ImmutableSet.<String>builder()
             .add(PARQUET_HIVE_SERDE_CLASS)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -101,6 +101,7 @@ import static io.trino.plugin.hive.HiveMetadata.ORC_BLOOM_FILTER_FPP_KEY;
 import static io.trino.plugin.hive.HiveMetadata.PARQUET_BLOOM_FILTER_COLUMNS_KEY;
 import static io.trino.plugin.hive.HiveMetadata.SKIP_FOOTER_COUNT_KEY;
 import static io.trino.plugin.hive.HiveMetadata.SKIP_HEADER_COUNT_KEY;
+import static io.trino.plugin.hive.HiveMetadata.TRINO_NOT_NULL_COLUMN_PARAM_PREFIX;
 import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
 import static io.trino.plugin.hive.HiveTableProperties.ORC_BLOOM_FILTER_FPP;
 import static io.trino.plugin.hive.projection.PartitionProjectionProperties.getPartitionProjectionTrinoColumnProperties;
@@ -545,12 +546,14 @@ public final class HiveUtil
     {
         ImmutableList.Builder<HiveColumnHandle> columns = ImmutableList.builder();
 
+        Map<String, String> tableParameters = table.getParameters();
         int hiveColumnIndex = 0;
         for (Column field : table.getDataColumns()) {
             // ignore unsupported types rather than failing
             HiveType hiveType = field.getType();
             if (typeSupported(hiveType.getTypeInfo(), table.getStorage().getStorageFormat())) {
-                columns.add(createBaseColumn(field.getName(), hiveColumnIndex, hiveType, getType(hiveType, typeManager, timestampPrecision), REGULAR, field.getComment()));
+                boolean nullable = !"true".equals(tableParameters.get(TRINO_NOT_NULL_COLUMN_PARAM_PREFIX + field.getName()));
+                columns.add(new HiveColumnHandle(field.getName(), hiveColumnIndex, hiveType, getType(hiveType, typeManager, timestampPrecision), Optional.empty(), REGULAR, field.getComment(), nullable));
             }
             hiveColumnIndex++;
         }
@@ -847,6 +850,7 @@ public final class HiveUtil
                 .setComment(handle.isHidden() ? Optional.empty() : columnComment.get(handle.getName()))
                 .setExtraInfo(columnExtraInfo(handle.isPartitionKey()))
                 .setHidden(handle.isHidden())
+                .setNullable(handle.isNullable())
                 .setProperties(getPartitionProjectionTrinoColumnProperties(table, handle.getName()))
                 .build();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -193,6 +193,7 @@ import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SHOW_COLUMNS;
 import static io.trino.testing.TestingAccessControlManager.privilege;
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_ADD_COLUMN_NOT_NULL_CONSTRAINT;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_MERGE;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_ROW_LEVEL_UPDATE;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_UPDATE;
@@ -283,7 +284,8 @@ public abstract class BaseHiveConnectorTest
         return switch (connectorBehavior) {
             case SUPPORTS_MULTI_STATEMENT_WRITES,
                  SUPPORTS_REPORTING_WRITTEN_BYTES -> true; // FIXME: Fails because only allowed with transactional tables
-            case SUPPORTS_ADD_COLUMN_WITH_POSITION,
+            case SUPPORTS_ADD_COLUMN_NOT_NULL_CONSTRAINT,
+                 SUPPORTS_ADD_COLUMN_WITH_POSITION,
                  SUPPORTS_ADD_FIELD,
                  SUPPORTS_CREATE_MATERIALIZED_VIEW,
                  SUPPORTS_DEFAULT_COLUMN_VALUE,
@@ -292,15 +294,21 @@ public abstract class BaseHiveConnectorTest
                  // MERGE, UPDATE are supported only on transactional tables, so not supported in current setup
                  SUPPORTS_MERGE,
                  SUPPORTS_UPDATE,
-                 SUPPORTS_NOT_NULL_CONSTRAINT,
                  SUPPORTS_REFRESH_VIEW,
                  SUPPORTS_RENAME_FIELD,
                  SUPPORTS_SET_COLUMN_TYPE,
                  SUPPORTS_TOPN_PUSHDOWN,
                  SUPPORTS_TRUNCATE -> false;
+            case SUPPORTS_NOT_NULL_CONSTRAINT -> true;
             case SUPPORTS_CREATE_FUNCTION -> true;
             default -> super.hasBehavior(connectorBehavior);
         };
+    }
+
+    @Override
+    protected String errorMessageForInsertIntoNotNullColumn(String columnName)
+    {
+        return "NULL value not allowed for NOT NULL column: " + columnName;
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveColumnHandle.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveColumnHandle.java
@@ -81,7 +81,8 @@ public class TestHiveColumnHandle
                 baseType,
                 Optional.of(columnProjectionInfo),
                 REGULAR,
-                Optional.empty());
+                Optional.empty(),
+                true);
 
         testRoundTrip(projectedColumn);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -2110,7 +2110,8 @@ public final class TestHiveFileFormats
                     baseType,
                     Optional.of(new HiveColumnProjectionInfo(ImmutableList.of(0), ImmutableList.of(name), toHiveType(type), type)),
                     partitionKey ? PARTITION_KEY : REGULAR,
-                    Optional.empty());
+                    Optional.empty(),
+                    true);
         }
 
         public TestColumn withDereferenceFirstField(Object writeValue, Object expectedValue)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSource.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSource.java
@@ -70,9 +70,9 @@ public class TestHivePageSource
         String bucketColumnName = "bucket_col";
 
         List<HiveColumnHandle> columns = ImmutableList.of(
-                new HiveColumnHandle(partitionColumnName, 0, HIVE_STRING, VARCHAR, Optional.empty(), PARTITION_KEY, Optional.empty()),
-                new HiveColumnHandle("regular_col", 1, HIVE_STRING, VARCHAR, Optional.empty(), REGULAR, Optional.empty()),
-                new HiveColumnHandle(bucketColumnName, 2, HIVE_LONG, BIGINT, Optional.empty(), REGULAR, Optional.empty()));
+                new HiveColumnHandle(partitionColumnName, 0, HIVE_STRING, VARCHAR, Optional.empty(), PARTITION_KEY, Optional.empty(), true),
+                new HiveColumnHandle("regular_col", 1, HIVE_STRING, VARCHAR, Optional.empty(), REGULAR, Optional.empty(), true),
+                new HiveColumnHandle(bucketColumnName, 2, HIVE_LONG, BIGINT, Optional.empty(), REGULAR, Optional.empty(), true));
 
         String partitionColumnValue = "1";
         List<HivePartitionKey> partitionKeys = ImmutableList.of(new HivePartitionKey(partitionColumnName, partitionColumnValue));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveReaderProjectionsUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveReaderProjectionsUtil.java
@@ -84,6 +84,7 @@ public class TestHiveReaderProjectionsUtil
                 column.getBaseType(),
                 Optional.of(columnProjection),
                 column.getColumnType(),
-                column.getComment());
+                column.getComment(),
+                column.isNullable());
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestNodeLocalDynamicSplitPruning.java
@@ -68,7 +68,8 @@ class TestNodeLocalDynamicSplitPruning
             INTEGER,
             Optional.empty(),
             REGULAR,
-            Optional.empty());
+            Optional.empty(),
+            true);
     private static final HiveColumnHandle PARTITION_HIVE_COLUMN_HANDLE = new HiveColumnHandle(
             PARTITION_COLUMN.getName(),
             0,
@@ -76,7 +77,8 @@ class TestNodeLocalDynamicSplitPruning
             INTEGER,
             Optional.empty(),
             PARTITION_KEY,
-            Optional.empty());
+            Optional.empty(),
+            true);
 
     @Test
     void testDynamicBucketPruning()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestMetastoreUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestMetastoreUtil.java
@@ -123,6 +123,6 @@ public class TestMetastoreUtil
 
     private static HiveColumnHandle partitionColumn(String name)
     {
-        return new HiveColumnHandle(name, 0, HIVE_STRING, VARCHAR, Optional.empty(), PARTITION_KEY, Optional.empty());
+        return new HiveColumnHandle(name, 0, HIVE_STRING, VARCHAR, Optional.empty(), PARTITION_KEY, Optional.empty(), true);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -151,7 +151,8 @@ public class TestConnectorPushdownRulesWithHive
                         toHiveType(BIGINT),
                         BIGINT)),
                 REGULAR,
-                Optional.empty());
+                Optional.empty(),
+                true);
 
         HiveTableHandle hiveTable = new HiveTableHandle(SCHEMA_NAME, tableName, ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty());
         TableHandle table = new TableHandle(catalogHandle, hiveTable, new HiveTransactionHandle(false));
@@ -306,7 +307,8 @@ public class TestConnectorPushdownRulesWithHive
                         toHiveType(BIGINT),
                         BIGINT)),
                 REGULAR,
-                Optional.empty());
+                Optional.empty(),
+                true);
 
         // Test projection pushdown with duplicate column references
         tester().assertThat(pushProjectionIntoTableScan)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPredicates.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPredicates.java
@@ -102,7 +102,8 @@ class TestOrcPredicates
                     HiveType.HIVE_LONG,
                     BIGINT)),
             STRUCT_COLUMN.getColumnType(),
-            STRUCT_COLUMN.getComment());
+            STRUCT_COLUMN.getComment(),
+            true);
     private static final List<HiveColumnHandle> PROJECTED_COLUMNS = ImmutableList.of(BIGINT_COLUMN, STRUCT_FIELD1_COLUMN);
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetPageSourceFactory.java
@@ -74,7 +74,8 @@ public class TestParquetPageSourceFactory
                                 toHiveType(IntegerType.INTEGER),
                                 IntegerType.INTEGER)),
                 REGULAR,
-                Optional.empty());
+                Optional.empty(),
+                true);
         MessageType fileSchema = new MessageType(
                 "hive_schema",
                 new GroupType(OPTIONAL, "optional_level1",

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/predicate/TestParquetPredicateUtils.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/predicate/TestParquetPredicateUtils.java
@@ -171,7 +171,8 @@ public class TestParquetPredicateUtils
                 baseType,
                 Optional.of(columnProjectionInfo),
                 REGULAR,
-                Optional.empty());
+                Optional.empty(),
+                true);
 
         Domain predicateDomain = Domain.singleValue(INTEGER, 123L);
         TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(projectedColumn, predicateDomain));
@@ -214,7 +215,8 @@ public class TestParquetPredicateUtils
                 baseType,
                 Optional.of(columnProjectionInfo),
                 REGULAR,
-                Optional.empty());
+                Optional.empty(),
+                true);
 
         Domain predicateDomain = Domain.onlyNull(c1Type);
         TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(projectedColumn, predicateDomain));
@@ -257,7 +259,8 @@ public class TestParquetPredicateUtils
                 baseType,
                 Optional.of(columnProjectionInfo),
                 REGULAR,
-                Optional.empty());
+                Optional.empty(),
+                true);
 
         Domain predicateDomain = Domain.singleValue(INTEGER, 123L);
         TupleDomain<HiveColumnHandle> tupleDomain = withColumnDomains(ImmutableMap.of(projectedColumn, predicateDomain));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Implements the remaining work from issue #2923. The engine-level write enforcement already existed (from #4144). This commit allows it to apply to Hive tables.

NOT NULL is a write-only guarantee — existing rows in data files are unaffected.

* Fixes #2923

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

NOT NULL is persisted in table parameters as `trino_not_null_col_<name>=true` (compatible with both Thrift HMS and the file-based metastore, since ThriftMetastoreUtil rejects column-level properties). This is the same approach used by the Iceberg Glue catalog. 

The constraint is read back via HiveUtil.getRegularColumnHandles and surfaced through ColumnMetadata and HiveColumnHandle.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Enforce NOT NULL on Hive INSERT/MERGE/UPDATE. ({issue}`2923`)
```
