### PR TITLE
Validate time zone offset when encoding time with time zone

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/AtTimeZoneWithOffset.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/AtTimeZoneWithOffset.java
@@ -24,6 +24,7 @@ import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.type.DateTimeEncoding.packTimeWithTimeZone;
 import static io.trino.spi.type.DateTimeEncoding.unpackOffsetMinutes;
 import static io.trino.spi.type.DateTimeEncoding.unpackTimeNanos;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_DAY;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MINUTE;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_DAY;
@@ -56,12 +57,15 @@ public final class AtTimeZoneWithOffset
     {
         int offsetMinutes = getZoneOffsetMinutes(zoneOffset);
         long picos = time.getPicoseconds() - (time.getOffsetMinutes() - offsetMinutes) * PICOSECONDS_PER_MINUTE;
-        return new LongTimeWithTimeZone(floorMod(picos, PICOSECONDS_PER_DAY), getZoneOffsetMinutes(zoneOffset));
+        return new LongTimeWithTimeZone(floorMod(picos, PICOSECONDS_PER_DAY), offsetMinutes);
     }
 
     private static int getZoneOffsetMinutes(long interval)
     {
         checkCondition((interval % 60_000L) == 0L, INVALID_FUNCTION_ARGUMENT, "Invalid time zone offset interval: interval contains seconds");
-        return toIntExact(interval / 60_000L);
+        long offsetMinutes = interval / 60_000L;
+        // validate offset is supported
+        getTimeZoneKeyForOffset(offsetMinutes);
+        return toIntExact(offsetMinutes);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timetz/TestTimeWithTimeZone.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timetz/TestTimeWithTimeZone.java
@@ -2403,6 +2403,30 @@ public class TestTimeWithTimeZone
     }
 
     @Test
+    public void testAtTimeZoneWithOffsetOutOfRange()
+    {
+        // offsets outside [-14:00, 14:00] must be rejected, see https://github.com/trinodb/trino/issues/9288
+        assertThat(assertions.expression("TIME '01:23:45+00:00' AT TIME ZONE INTERVAL '840' MINUTE")).matches("TIME '15:23:45+14:00'");
+        assertThat(assertions.expression("TIME '01:23:45+00:00' AT TIME ZONE INTERVAL '-840' MINUTE")).matches("TIME '11:23:45-14:00'");
+
+        assertTrinoExceptionThrownBy(assertions.expression("TIME '01:23:45' AT TIME ZONE INTERVAL '841' MINUTE")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("Invalid offset minutes 841");
+
+        // 134217728 days is 45 * 2^32 minutes, which would truncate to a valid-looking offset of 0;
+        // validating as a long reports it instead of failing in toIntExact with "integer overflow"
+        assertTrinoExceptionThrownBy(assertions.expression("TIME '01:23:45' AT TIME ZONE INTERVAL '134217728' DAY")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("Invalid offset minutes 193273528320");
+
+        // long representation (precision > 9) stores the offset unpacked, so 2048 used to survive here and
+        // fail only when the value was rendered, unlike the packed path where it wrapped around to 0
+        assertTrinoExceptionThrownBy(assertions.expression("TIME '01:23:45.123456789123' AT TIME ZONE INTERVAL '2048' MINUTE")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("Invalid offset minutes 2048");
+    }
+
+    @Test
     public void testComparisonOperators()
     {
         // short (precision <= 9 → ShortTimeWithTimeZoneType)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DateTimeEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DateTimeEncoding.java
@@ -72,8 +72,13 @@ public final class DateTimeEncoding
         return pack(newMillsUtc, (short) (dateTimeWithTimeZone & TIME_ZONE_MASK));
     }
 
+    /**
+     * @throws io.trino.spi.TrinoException when {@code offsetMinutes} is outside the range supported by {@code time with time zone}
+     */
     public static long packTimeWithTimeZone(long nanos, int offsetMinutes)
     {
+        // validate offset is supported
+        getTimeZoneKeyForOffset(offsetMinutes);
         // offset is encoded as a 2s complement 11-bit number
         return (nanos << 11) | (offsetMinutes & 0b111_1111_1111);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimeWithTimeZone.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimeWithTimeZone.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.type.TimeWithTimeZoneTypes.normalize;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
 
 public final class LongTimeWithTimeZone
         implements Comparable<LongTimeWithTimeZone>
@@ -26,8 +27,13 @@ public final class LongTimeWithTimeZone
     private final long picoseconds;
     private final int offsetMinutes;
 
+    /**
+     * @throws io.trino.spi.TrinoException when {@code offsetMinutes} is outside the range supported by {@code time with time zone}
+     */
     public LongTimeWithTimeZone(long picoseconds, int offsetMinutes)
     {
+        // validate offset is supported
+        getTimeZoneKeyForOffset(offsetMinutes);
         this.picoseconds = picoseconds;
         this.offsetMinutes = offsetMinutes;
     }


### PR DESCRIPTION
## Description
Currently, `time AT TIME ZONE <interval>` doesn't validate the offset against the `[-14:00, 14:00]` range valid for `time with time zone`, and `packTimeWithTimeZone` encodes it as an 11-bit two's complement field, so out-of-range offsets wrap and silently produce a wrong result:
```SQL
    SELECT TIME '01:23:45' AT TIME ZONE INTERVAL '2048' MINUTE;  -- 22:31:45Z
    SELECT TIME '01:23:45' AT TIME ZONE INTERVAL '2148' MINUTE;  -- 00:11:45+01:40
```
The wrapped offset propagates, so this is not only a rendering artifact: `timezone_hour(TIME '01:23:45' AT TIME ZONE INTERVAL '2048' MINUTE)` returns `0`.

This PR validates the offset in `packTimeWithTimeZone` and in the `LongTimeWithTimeZone` constructor, so every producer is covered, matching `timestamp with time zone`. **Both are SPI, so offsets from external data are affected too: the ISO-8601 JSON decoder (ISO-8601 permits `±18:00`), Python UDF return values**.

## Additional context and related issues

- Fixes #9288.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix `time AT TIME ZONE <interval>` silently returning a wrong time zone offset
  for offsets outside the `[-14:00, 14:00]` range. ({issue}`9288`)
* Reject `time with time zone` values whose time zone offset is outside the
  `[-14:00, 14:00]` range instead of silently wrapping it, including values
  decoded from external data. ({issue}`9288`)
## SPI
* `DateTimeEncoding.packTimeWithTimeZone` and the `LongTimeWithTimeZone` constructor now
  reject time zone offsets outside the `[-14:00, 14:00]` range. ({issue}`9288`)
```
