### PR TITLE
Fix(filesystem): improve missing scheme configuration errors

### DIFF
--- a/lib/trino-filesystem-manager/pom.xml
+++ b/lib/trino-filesystem-manager/pom.xml
@@ -82,6 +82,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
@@ -41,6 +41,7 @@ import io.trino.filesystem.s3.S3FileSystemModule;
 import io.trino.filesystem.switching.SwitchingFileSystemFactory;
 import io.trino.filesystem.tracing.TracingFileSystemFactory;
 import io.trino.filesystem.tracking.TrackingFileSystemFactory;
+import io.trino.spi.TrinoException;
 import io.trino.spi.cache.BlobCache;
 import io.trino.spi.cache.CacheRequirements;
 import io.trino.spi.connector.ConnectorContext;
@@ -53,6 +54,7 @@ import java.util.function.Function;
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
 import static io.trino.spi.cache.CacheCapability.CAN_EXCEED_HEAP_SIZE;
 import static io.trino.spi.cache.CacheCapability.LOW_LATENCY;
 import static java.util.Objects.requireNonNull;
@@ -177,7 +179,7 @@ public class FileSystemModule
         Function<Location, TrinoFileSystemFactory> loader = location -> location.scheme()
                 .map(factories::get)
                 .or(() -> hdfsFactory)
-                .orElseThrow(() -> new IllegalArgumentException("No factory for location: " + location));
+                .orElseThrow(() -> noFactoryForLocation(location));
 
         TrinoFileSystemFactory delegate = new SwitchingFileSystemFactory(loader);
         delegate = new TracingFileSystemFactory(tracer, delegate);
@@ -190,5 +192,26 @@ public class FileSystemModule
             return new CacheFileSystemFactory(tracer, delegate, blobCache.orElseThrow(), keyProvider.orElseThrow());
         }
         return delegate;
+    }
+
+    static TrinoException noFactoryForLocation(Location location)
+    {
+        String scheme = location.scheme().orElse("unknown");
+        String enableProperty = switch (scheme) {
+            case "s3", "s3a", "s3n" -> "fs.s3.enabled";
+            case "gs" -> "fs.gcs.enabled";
+            case "abfs", "abfss", "wasb", "wasbs" -> "fs.azure.enabled";
+            case "hdfs" -> "fs.hadoop.enabled";
+            default -> null;
+        };
+        if (enableProperty != null) {
+            return new TrinoException(
+                    CONFIGURATION_INVALID,
+                    "No file system factory registered for location %s. Enable the file system by setting %s=true in the catalog configuration."
+                            .formatted(location, enableProperty));
+        }
+        return new TrinoException(
+                CONFIGURATION_INVALID,
+                "No file system factory registered for location %s.".formatted(location));
     }
 }

--- a/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemModule.java
+++ b/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemModule.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.manager;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.spi.TrinoException;
+import io.trino.spi.security.ConnectorIdentity;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestFileSystemModule
+{
+    @Test
+    public void testMissingS3Factory()
+    {
+        TrinoFileSystemFactory fileSystemFactory = createFileSystemFactory(Map.of());
+        Location location = Location.of("s3://bucket/path");
+
+        assertThatThrownBy(() -> fileSystemFactory.create(ConnectorIdentity.ofUser("test")).newInputFile(location))
+                .isInstanceOf(TrinoException.class)
+                .matches(throwable -> ((TrinoException) throwable).getErrorCode().equals(CONFIGURATION_INVALID.toErrorCode()))
+                .hasMessageContaining("fs.s3.enabled");
+    }
+
+    @Test
+    public void testS3FactoryResolvesWhenRegistered()
+    {
+        TrinoFileSystemFactory s3Factory = _ -> {
+            throw new UnsupportedOperationException("resolved s3 factory");
+        };
+        TrinoFileSystemFactory fileSystemFactory = createFileSystemFactory(Map.of("s3", s3Factory));
+        Location location = Location.of("s3://bucket/path");
+
+        assertThatThrownBy(() -> fileSystemFactory.create(ConnectorIdentity.ofUser("test")).newInputFile(location))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("resolved s3 factory");
+    }
+
+    @Test
+    public void testMissingGcsFactory()
+    {
+        TrinoFileSystemFactory fileSystemFactory = createFileSystemFactory(Map.of());
+        Location location = Location.of("gs://bucket/path");
+
+        assertThatThrownBy(() -> fileSystemFactory.create(ConnectorIdentity.ofUser("test")).newInputFile(location))
+                .isInstanceOf(TrinoException.class)
+                .matches(throwable -> ((TrinoException) throwable).getErrorCode().equals(CONFIGURATION_INVALID.toErrorCode()))
+                .hasMessageContaining("fs.gcs.enabled");
+    }
+
+    @Test
+    public void testUnknownSchemeUsesGenericMessage()
+    {
+        TrinoFileSystemFactory fileSystemFactory = createFileSystemFactory(Map.of());
+        Location location = Location.of("unknown://bucket/path");
+
+        assertThatThrownBy(() -> fileSystemFactory.create(ConnectorIdentity.ofUser("test")).newInputFile(location))
+                .isInstanceOf(TrinoException.class)
+                .matches(throwable -> ((TrinoException) throwable).getErrorCode().equals(CONFIGURATION_INVALID.toErrorCode()))
+                .hasMessageContaining("unknown://bucket/path")
+                .matches(throwable -> !throwable.getMessage().contains("fs.s3.enabled"));
+    }
+
+    private static TrinoFileSystemFactory createFileSystemFactory(Map<String, TrinoFileSystemFactory> factories)
+    {
+        return FileSystemModule.createFileSystemFactory(
+                new FileSystemConfig(),
+                Optional.empty(),
+                factories,
+                Optional.empty(),
+                Optional.empty(),
+                OpenTelemetry.noop().getTracer("test"));
+    }
+}


### PR DESCRIPTION
Replace IllegalArgumentException with TrinoException(CONFIGURATION_INVALID) when no file system factory is registered for a location, including scheme-specific hints such as fs.s3.enabled for s3 URIs.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Improve error reporting when a catalog location uses a filesystem scheme (for example s3://) that is not enabled.
```
