### PR TITLE
Require filesystem enabled for REST catalog vended credentials

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogModule.java
@@ -16,13 +16,18 @@ package io.trino.plugin.iceberg.catalog.rest;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.filesystem.manager.FileSystemConfig;
 import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.IcebergFileSystemFactory;
 import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
 import io.trino.spi.TrinoException;
 
+import java.net.URI;
+import java.util.Optional;
+
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 
 public class IcebergRestCatalogModule
@@ -32,7 +37,8 @@ public class IcebergRestCatalogModule
     protected void setup(Binder binder)
     {
         configBinder(binder).bindConfig(IcebergRestCatalogConfig.class);
-        install(switch (buildConfigObject(IcebergRestCatalogConfig.class).getSecurity()) {
+        IcebergRestCatalogConfig icebergRestCatalogConfig = buildConfigObject(IcebergRestCatalogConfig.class);
+        install(switch (icebergRestCatalogConfig.getSecurity()) {
             case OAUTH2 -> new OAuth2SecurityModule();
             case SIGV4 -> new SigV4SecurityModule();
             case GOOGLE -> new GoogleSecurityModule();
@@ -43,10 +49,62 @@ public class IcebergRestCatalogModule
         binder.bind(TrinoCatalogFactory.class).to(TrinoIcebergRestCatalogFactory.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, IcebergFileSystemFactory.class).setBinding().to(IcebergRestCatalogFileSystemFactory.class).in(Scopes.SINGLETON);
 
-        IcebergConfig icebergConfig = buildConfigObject(IcebergConfig.class);
-        IcebergRestCatalogConfig restCatalogConfig = buildConfigObject(IcebergRestCatalogConfig.class);
-        if (restCatalogConfig.isVendedCredentialsEnabled() && icebergConfig.isRegisterTableProcedureEnabled()) {
-            throw new TrinoException(NOT_SUPPORTED, "Using the `register_table` procedure with vended credentials is currently not supported");
+        validateConfiguration(icebergRestCatalogConfig);
+    }
+
+    private void validateConfiguration(IcebergRestCatalogConfig restCatalogConfig)
+    {
+        if (restCatalogConfig.isVendedCredentialsEnabled()) {
+            IcebergConfig icebergConfig = buildConfigObject(IcebergConfig.class);
+            if (icebergConfig.isRegisterTableProcedureEnabled()) {
+                throw new TrinoException(NOT_SUPPORTED, "Using the `register_table` procedure with vended credentials is currently not supported");
+            }
+            FileSystemConfig fileSystemConfig = buildConfigObject(FileSystemConfig.class);
+            Optional<String> warehouseScheme = restCatalogConfig.getWarehouse().flatMap(warehouse -> {
+                try {
+                    return Optional.ofNullable(URI.create(warehouse).getScheme());
+                }
+                catch (IllegalArgumentException _) {
+                    return Optional.empty();
+                }
+            });
+            if (warehouseScheme.isPresent()) {
+                validateFileSystemEnabledForScheme(warehouseScheme.orElseThrow(), fileSystemConfig);
+                return;
+            }
+            if (!fileSystemConfig.isS3Enabled() && !fileSystemConfig.isGcsEnabled() && !fileSystemConfig.isAzureEnabled()) {
+                throw new TrinoException(
+                        CONFIGURATION_INVALID,
+                        "Vended credentials require a native cloud filesystem to be enabled (set fs.s3.enabled, fs.gcs.enabled, or fs.azure.enabled to true, or disable iceberg.rest-catalog.vended-credentials-enabled)");
+            }
+        }
+    }
+
+    private static void validateFileSystemEnabledForScheme(String scheme, FileSystemConfig fileSystemConfig)
+    {
+        switch (scheme) {
+            case "s3", "s3a", "s3n" -> {
+                if (!fileSystemConfig.isS3Enabled()) {
+                    throw new TrinoException(
+                            CONFIGURATION_INVALID,
+                            "Vended credentials require fs.s3.enabled=true when warehouse location uses the s3 scheme (or disable iceberg.rest-catalog.vended-credentials-enabled)");
+                }
+            }
+            case "gs" -> {
+                if (!fileSystemConfig.isGcsEnabled()) {
+                    throw new TrinoException(
+                            CONFIGURATION_INVALID,
+                            "Vended credentials require fs.gcs.enabled=true when warehouse location uses the gs scheme (or disable iceberg.rest-catalog.vended-credentials-enabled)");
+                }
+            }
+            case "abfs", "abfss", "wasb", "wasbs" -> {
+                if (!fileSystemConfig.isAzureEnabled()) {
+                    throw new TrinoException(
+                            CONFIGURATION_INVALID,
+                            "Vended credentials require fs.azure.enabled=true when warehouse location uses the %s scheme (or disable iceberg.rest-catalog.vended-credentials-enabled)".formatted(scheme));
+                }
+            }
+            default -> throw new TrinoException(CONFIGURATION_INVALID, "Vended credentials do not support warehouse locations with the %s scheme".formatted(scheme));
         }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
@@ -295,6 +295,43 @@ public class TestIcebergPlugin
     }
 
     @Test
+    public void testRestCatalogVendedCredentialsRequiresNativeFilesystem()
+    {
+        ConnectorFactory factory = getConnectorFactory();
+
+        assertThatThrownBy(() -> factory.create(
+                        "test",
+                        Map.of(
+                                "iceberg.catalog.type", "rest",
+                                "iceberg.rest-catalog.uri", "https://foo:1234",
+                                "iceberg.rest-catalog.vended-credentials-enabled", "true",
+                                "bootstrap.quiet", "true"),
+                        new TestingConnectorContext())
+                .shutdown())
+                .isInstanceOf(ApplicationConfigurationException.class)
+                .hasMessageContaining("Vended credentials require a native cloud filesystem to be enabled");
+    }
+
+    @Test
+    public void testRestCatalogVendedCredentialsRequiresS3ForS3Warehouse()
+    {
+        ConnectorFactory factory = getConnectorFactory();
+
+        assertThatThrownBy(() -> factory.create(
+                        "test",
+                        Map.of(
+                                "iceberg.catalog.type", "rest",
+                                "iceberg.rest-catalog.uri", "https://foo:1234",
+                                "iceberg.rest-catalog.warehouse", "s3://bucket/warehouse",
+                                "iceberg.rest-catalog.vended-credentials-enabled", "true",
+                                "bootstrap.quiet", "true"),
+                        new TestingConnectorContext())
+                .shutdown())
+                .isInstanceOf(ApplicationConfigurationException.class)
+                .hasMessageContaining("Vended credentials require fs.s3.enabled=true");
+    }
+
+    @Test
     public void testRestCatalogHttpHeaders()
     {
         ConnectorFactory factory = getConnectorFactory();


### PR DESCRIPTION
## Description

- Add eager startup validation in `IcebergRestCatalogModule.setup()` when
  `iceberg.rest-catalog.vended-credentials-enabled=true` but the matching
  native filesystem scheme is not enabled (`fs.s3.enabled`, `fs.gcs.enabled`,
  or `fs.azure.enabled`).
- Fail fast with `CONFIGURATION_INVALID` and an actionable error message
  instead of a cryptic query-time `GENERIC_INTERNAL_ERROR`.

## Additional context and related issues 

- Vended credentials and native filesystem registration are orthogonal. Without 
`fs.s3.enabled` (or `fs.gcs.enabled` / `fs.azure.enabled`), catalogs start
successfully and fail at query time with `GENERIC_INTERNAL_ERROR: No factory
for location: s3://…`.

- Related to #21189 (maintainer noted vended-credentials misconfiguration should fail
startup), and complementary PR #30633 (clearer query-time error in
`FileSystemModule`).

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

## Iceberg connector
* Fail at catalog startup with a clear configuration error when REST catalog
  vended credentials are enabled but the required native cloud filesystem is
  not enabled. (#30634)
  

