### PR TITLE
Wait for socks-proxy before Kerberos Hadoop tests

### DIFF
--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/HiveKerberosEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/HiveKerberosEnvironment.java
@@ -21,6 +21,7 @@ import io.trino.testing.containers.environment.ProductTestEnvironment;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.trino.TrinoContainer;
 
 import java.io.IOException;
@@ -105,6 +106,7 @@ public class HiveKerberosEnvironment
 {
     private static final Logger log = Logger.get(HiveKerberosEnvironment.class);
     private static final Logger hadoopLog = Logger.get("Hadoop");
+    protected static final Duration KERBEROS_HADOOP_STARTUP_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration HIVE_METASTORE_STARTUP_TIMEOUT = Duration.ofMinutes(2);
     private static final Duration HIVE_METASTORE_STARTUP_POLL_INTERVAL = Duration.ofSeconds(2);
     private static final int HIVE_METASTORE_STABLE_SUCCESS_POLL_COUNT = 3;
@@ -485,6 +487,8 @@ public class HiveKerberosEnvironment
         HadoopContainer container = createKerberosBaseHadoopContainer()
                 .withNetwork(network)
                 .withNetworkAliases(HadoopContainer.HOST_NAME);
+        container.waitingFor(Wait.forLogMessage(".*success: socks-proxy entered RUNNING state.*", 1)
+                .withStartupTimeout(KERBEROS_HADOOP_STARTUP_TIMEOUT));
 
         // Set JAVA_TOOL_OPTIONS so all JVM processes can find krb5.conf
         // This is necessary because supervisord-started services don't inherit

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TwoKerberosHivesEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TwoKerberosHivesEnvironment.java
@@ -20,6 +20,7 @@ import io.trino.testing.containers.TrinoProductTestContainer;
 import io.trino.testing.containers.environment.ProductTestEnvironment;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.trino.TrinoContainer;
 
@@ -29,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -85,6 +87,7 @@ public class TwoKerberosHivesEnvironment
     private static final Logger log = Logger.get(TwoKerberosHivesEnvironment.class);
     private static final Logger hadoop1Log = Logger.get("Hadoop1");
     private static final Logger hadoop2Log = Logger.get("Hadoop2");
+    private static final Duration KERBEROS_HADOOP_STARTUP_TIMEOUT = Duration.ofMinutes(5);
 
     // Hostnames for the two Hadoop clusters
     private static final String HADOOP1_HOST = HadoopContainer.HOST_NAME;  // "hadoop-master"
@@ -239,6 +242,8 @@ public class TwoKerberosHivesEnvironment
         HadoopContainer container = HadoopContainer.withHostName(hostName)
                 .withNetwork(network)
                 .withNetworkAliases(hostName);
+        container.waitingFor(Wait.forLogMessage(".*success: socks-proxy entered RUNNING state.*", 1)
+                .withStartupTimeout(KERBEROS_HADOOP_STARTUP_TIMEOUT));
 
         // Set JAVA_TOOL_OPTIONS so all JVM processes can find krb5.conf
         container.withEnv("JAVA_TOOL_OPTIONS", "-Djava.security.krb5.conf=/etc/krb5.conf");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Increase timeout for the flaky test `hive-kerberos`: https://github.com/trinodb/trino/actions/runs/31290692553/job/93188164889


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
