### PR TITLE
Add keystore-based S3 credentials

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-system-s3.md
+++ b/docs/src/main/sphinx/object-storage/file-system-s3.md
@@ -157,6 +157,44 @@ fails at startup.
       (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
 :::
 
+## Keystore credentials
+
+Use the following properties to load S3 credentials from a JCEKS keystore file
+instead of plaintext keys. This matches the Hadoop `secrets.jceks` pattern used
+on many CDP clusters. Configure either global aliases or a per-bucket alias
+prefix, but not both.
+
+:::{list-table}
+:widths: 40, 60
+:header-rows: 1
+
+* - Property
+  - Description
+* - `s3.keystore.path`
+  - Path to the JCEKS keystore file containing credential aliases.
+* - `s3.keystore.type`
+  - Keystore type. Defaults to `JCEKS`.
+* - `s3.keystore.password`
+  - Password for the keystore file. Defaults to the
+    `HADOOP_CREDSTORE_PASSWORD` environment variable, then `none`.
+* - `s3.keystore.entry-password`
+  - Password protecting individual keystore entries. Defaults to
+    `s3.keystore.password`.
+* - `s3.aws-access-key-alias`
+  - Keystore alias for the global S3 access key. Requires
+    `s3.aws-secret-key-alias` and cannot be combined with
+    `s3.keystore.bucket-key-prefix`.
+* - `s3.aws-secret-key-alias`
+  - Keystore alias for the global S3 secret key. Requires
+    `s3.aws-access-key-alias` and cannot be combined with
+    `s3.keystore.bucket-key-prefix`.
+* - `s3.keystore.bucket-key-prefix`
+  - Prefix for per-bucket credential aliases. For bucket `my-bucket`, aliases
+    are resolved as `<prefix>my-bucket.access.key` and
+    `<prefix>my-bucket.secret.key`. Requires `s3.keystore.path` and cannot be
+    combined with global aliases or `s3.security-mapping.enabled`.
+:::
+
 ## Security mapping
 
 Trino supports flexible security mapping for S3, allowing for separate

--- a/docs/src/main/sphinx/object-storage/file-system-s3.md
+++ b/docs/src/main/sphinx/object-storage/file-system-s3.md
@@ -159,10 +159,11 @@ fails at startup.
 
 ## Keystore credentials
 
-Use the following properties to load S3 credentials from a JCEKS keystore file
-instead of plaintext keys. This matches the Hadoop `secrets.jceks` pattern used
-on many CDP clusters. Configure either global aliases or a per-bucket alias
-prefix, but not both.
+Use the following properties to load S3 credentials from a Java KeyStore file
+instead of plaintext keys. This follows the same alias-based pattern as the JDBC
+KEYSTORE credential provider. The keystore is loaded once at startup; credentials
+cannot be combined with `s3.aws-access-key` and `s3.aws-secret-key`. Configure
+either global aliases or a per-bucket alias prefix, but not both.
 
 :::{list-table}
 :widths: 40, 60
@@ -170,16 +171,6 @@ prefix, but not both.
 
 * - Property
   - Description
-* - `s3.keystore.path`
-  - Path to the JCEKS keystore file containing credential aliases.
-* - `s3.keystore.type`
-  - Keystore type. Defaults to `JCEKS`.
-* - `s3.keystore.password`
-  - Password for the keystore file. Defaults to the
-    `HADOOP_CREDSTORE_PASSWORD` environment variable, then `none`.
-* - `s3.keystore.entry-password`
-  - Password protecting individual keystore entries. Defaults to
-    `s3.keystore.password`.
 * - `s3.aws-access-key-alias`
   - Keystore alias for the global S3 access key. Requires
     `s3.aws-secret-key-alias` and cannot be combined with
@@ -193,6 +184,16 @@ prefix, but not both.
     are resolved as `<prefix>my-bucket.access.key` and
     `<prefix>my-bucket.secret.key`. Requires `s3.keystore.path` and cannot be
     combined with global aliases or `s3.security-mapping.enabled`.
+* - `s3.keystore.entry-password`
+  - Password protecting individual keystore entries. Defaults to
+    `s3.keystore.password`.
+* - `s3.keystore.password`
+  - Password for the keystore file. Defaults to the
+    `HADOOP_CREDSTORE_PASSWORD` environment variable, then `none`.
+* - `s3.keystore.path`
+  - Path to the Java KeyStore file containing credential aliases.
+* - `s3.keystore.type`
+  - Keystore type. Defaults to `JCEKS`.
 :::
 
 ## Security mapping

--- a/lib/trino-filesystem-s3/pom.xml
+++ b/lib/trino-filesystem-s3/pom.xml
@@ -221,6 +221,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>configuration-testing</artifactId>
             <scope>test</scope>
         </dependency>
@@ -259,6 +265,12 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.hadoop</groupId>
+            <artifactId>hadoop-apache</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3BucketCredentialFileSystemLoader.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3BucketCredentialFileSystemLoader.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import com.google.inject.Inject;
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.spi.security.ConnectorIdentity;
+import jakarta.annotation.PreDestroy;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+final class S3BucketCredentialFileSystemLoader
+        implements Function<Location, TrinoFileSystemFactory>
+{
+    private final S3FileSystemLoader delegate;
+    private final Map<String, BucketFileSystemFactory> factoriesByBucket = new ConcurrentHashMap<>();
+
+    @Inject
+    S3BucketCredentialFileSystemLoader(OpenTelemetry openTelemetry, S3FileSystemConfig config, S3FileSystemStats stats)
+    {
+        this.delegate = new S3FileSystemLoader(openTelemetry, config, stats, S3KeystoreCredentials.createAliasResolver(config));
+    }
+
+    @Override
+    public TrinoFileSystemFactory apply(Location location)
+    {
+        String bucket = new S3Location(location).bucket();
+        return factoriesByBucket.computeIfAbsent(bucket, delegate::createFactoryForBucket);
+    }
+
+    @PreDestroy
+    public void destroy()
+    {
+        factoriesByBucket.values().forEach(BucketFileSystemFactory::destroy);
+        delegate.destroy();
+    }
+
+    static final class BucketFileSystemFactory
+            implements TrinoFileSystemFactory
+    {
+        private final S3Client client;
+        private final S3Presigner preSigner;
+        private final S3Context context;
+        private final Executor uploadExecutor;
+
+        BucketFileSystemFactory(S3Client client, S3Presigner preSigner, S3Context context, Executor uploadExecutor)
+        {
+            this.client = requireNonNull(client, "client is null");
+            this.preSigner = requireNonNull(preSigner, "preSigner is null");
+            this.context = requireNonNull(context, "context is null");
+            this.uploadExecutor = requireNonNull(uploadExecutor, "uploadExecutor is null");
+        }
+
+        @Override
+        public TrinoFileSystem create(ConnectorIdentity identity)
+        {
+            return new S3FileSystem(uploadExecutor, client, preSigner, context.withCredentials(identity));
+        }
+
+        void destroy()
+        {
+            try (client) {
+                preSigner.close();
+            }
+        }
+    }
+}

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -21,6 +21,7 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
+import io.airlift.configuration.validation.FileExists;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
@@ -144,6 +145,13 @@ public class S3FileSystemConfig
 
     private String awsAccessKey;
     private String awsSecretKey;
+    private String keystorePath;
+    private String keystoreType = "JCEKS";
+    private String keystorePassword;
+    private String keystoreEntryPassword;
+    private String keystoreBucketKeyPrefix;
+    private String awsAccessKeyAlias;
+    private String awsSecretKeyAlias;
     private String endpoint;
     private String region;
     private boolean pathStyleAccess;
@@ -202,6 +210,110 @@ public class S3FileSystemConfig
     {
         this.awsSecretKey = awsSecretKey;
         return this;
+    }
+
+    @FileExists
+    public String getKeystorePath()
+    {
+        return keystorePath;
+    }
+
+    @Config("s3.keystore.path")
+    @ConfigDescription("Path to a Java KeyStore file (JCEKS) containing S3 credential aliases")
+    public S3FileSystemConfig setKeystorePath(String keystorePath)
+    {
+        this.keystorePath = keystorePath;
+        return this;
+    }
+
+    public String getKeystoreType()
+    {
+        return keystoreType;
+    }
+
+    @Config("s3.keystore.type")
+    @ConfigDescription("Java KeyStore type (default JCEKS)")
+    public S3FileSystemConfig setKeystoreType(String keystoreType)
+    {
+        this.keystoreType = keystoreType;
+        return this;
+    }
+
+    public String getKeystorePassword()
+    {
+        return keystorePassword;
+    }
+
+    @Config("s3.keystore.password")
+    @ConfigDescription("Password for the keystore file. Defaults to HADOOP_CREDSTORE_PASSWORD environment variable or 'none'")
+    @ConfigSecuritySensitive
+    public S3FileSystemConfig setKeystorePassword(String keystorePassword)
+    {
+        this.keystorePassword = keystorePassword;
+        return this;
+    }
+
+    public String getKeystoreEntryPassword()
+    {
+        return keystoreEntryPassword;
+    }
+
+    @Config("s3.keystore.entry-password")
+    @ConfigDescription("Password protecting individual keystore entries. Defaults to s3.keystore.password")
+    @ConfigSecuritySensitive
+    public S3FileSystemConfig setKeystoreEntryPassword(String keystoreEntryPassword)
+    {
+        this.keystoreEntryPassword = keystoreEntryPassword;
+        return this;
+    }
+
+    public String getKeystoreBucketKeyPrefix()
+    {
+        return keystoreBucketKeyPrefix;
+    }
+
+    @Config("s3.keystore.bucket-key-prefix")
+    @ConfigDescription("Prefix for per-bucket credential aliases. Access and secret key aliases are resolved as <prefix><bucket>.access.key and <prefix><bucket>.secret.key. Cannot be combined with s3.aws-access-key-alias and s3.aws-secret-key-alias, or with s3.security-mapping.enabled")
+    public S3FileSystemConfig setKeystoreBucketKeyPrefix(String keystoreBucketKeyPrefix)
+    {
+        this.keystoreBucketKeyPrefix = keystoreBucketKeyPrefix;
+        return this;
+    }
+
+    public String getAwsAccessKeyAlias()
+    {
+        return awsAccessKeyAlias;
+    }
+
+    @Config("s3.aws-access-key-alias")
+    @ConfigDescription("Keystore alias for the S3 access key when using s3.keystore.path")
+    public S3FileSystemConfig setAwsAccessKeyAlias(String awsAccessKeyAlias)
+    {
+        this.awsAccessKeyAlias = awsAccessKeyAlias;
+        return this;
+    }
+
+    public String getAwsSecretKeyAlias()
+    {
+        return awsSecretKeyAlias;
+    }
+
+    @Config("s3.aws-secret-key-alias")
+    @ConfigDescription("Keystore alias for the S3 secret key when using s3.keystore.path")
+    public S3FileSystemConfig setAwsSecretKeyAlias(String awsSecretKeyAlias)
+    {
+        this.awsSecretKeyAlias = awsSecretKeyAlias;
+        return this;
+    }
+
+    public boolean isKeystoreConfigured()
+    {
+        return keystorePath != null;
+    }
+
+    public boolean isKeystoreBucketPrefixConfigured()
+    {
+        return keystorePath != null && keystoreBucketKeyPrefix != null;
     }
 
     public String getEndpoint()
@@ -439,18 +551,65 @@ public class S3FileSystemConfig
         return (authType == S3AuthType.IAM_ROLE) == (iamRole != null);
     }
 
-    @AssertTrue(message = "s3.auth-type=ANONYMOUS and s3.auth-type=WEB_IDENTITY cannot be used with other authentication properties (s3.aws-access-key, s3.aws-secret-key, s3.external-id, s3.sts.endpoint, s3.sts.region)")
+    @AssertTrue(message = "s3.auth-type=ANONYMOUS and s3.auth-type=WEB_IDENTITY cannot be used with other authentication properties (s3.aws-access-key, s3.aws-secret-key, s3.aws-access-key-alias, s3.aws-secret-key-alias, s3.keystore.path, s3.external-id, s3.sts.endpoint, s3.sts.region)")
     public boolean isCredentialFreeAuthTypeValid()
     {
         // s3.external-id and s3.sts.* remain allowed under DEFAULT for security-mapping roles.
         if (authType == S3AuthType.ANONYMOUS || authType == S3AuthType.WEB_IDENTITY) {
             return awsAccessKey == null &&
                     awsSecretKey == null &&
+                    awsAccessKeyAlias == null &&
+                    awsSecretKeyAlias == null &&
+                    keystorePath == null &&
                     externalId == null &&
                     stsEndpoint == null &&
                     stsRegion == null;
         }
         return true;
+    }
+
+    @AssertTrue(message = "s3.aws-access-key and s3.aws-secret-key must be configured together")
+    public boolean isPlaintextCredentialsValid()
+    {
+        return (awsAccessKey == null) == (awsSecretKey == null);
+    }
+
+    @AssertTrue(message = "plaintext and alias S3 credentials cannot be mixed")
+    public boolean isPlaintextAndAliasCredentialsValid()
+    {
+        boolean hasPlaintext = awsAccessKey != null || awsSecretKey != null;
+        boolean hasAlias = awsAccessKeyAlias != null || awsSecretKeyAlias != null || keystorePath != null;
+        return !(hasPlaintext && hasAlias);
+    }
+
+    @AssertTrue(message = "s3.keystore.path requires s3.aws-access-key-alias and s3.aws-secret-key-alias, or s3.keystore.bucket-key-prefix")
+    public boolean isKeystoreConfigurationValid()
+    {
+        if (keystorePath == null) {
+            return keystoreBucketKeyPrefix == null &&
+                    awsAccessKeyAlias == null &&
+                    awsSecretKeyAlias == null;
+        }
+        return (awsAccessKeyAlias != null && awsSecretKeyAlias != null) ||
+                keystoreBucketKeyPrefix != null;
+    }
+
+    @AssertTrue(message = "s3.keystore.bucket-key-prefix requires s3.keystore.path")
+    public boolean isKeystoreBucketPrefixValid()
+    {
+        if (keystoreBucketKeyPrefix == null) {
+            return true;
+        }
+        return keystorePath != null;
+    }
+
+    @AssertTrue(message = "s3.aws-access-key-alias and s3.aws-secret-key-alias cannot be used with s3.keystore.bucket-key-prefix")
+    public boolean isKeystoreGlobalAliasAndBucketPrefixMutuallyExclusive()
+    {
+        if (keystoreBucketKeyPrefix == null) {
+            return true;
+        }
+        return awsAccessKeyAlias == null && awsSecretKeyAlias == null;
     }
 
     public Optional<SignerType> getSignerType()

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemFactory.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemFactory.java
@@ -22,6 +22,7 @@ import jakarta.annotation.PreDestroy;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
+import java.util.Optional;
 import java.util.concurrent.Executor;
 
 import static io.trino.filesystem.s3.S3FileSystemUtils.createS3PreSigner;
@@ -40,7 +41,7 @@ public final class S3FileSystemFactory
     {
         this.loader = new S3FileSystemLoader(openTelemetry, config, stats);
         this.client = loader.createClient();
-        this.preSigner = createS3PreSigner(config, client);
+        this.preSigner = createS3PreSigner(config, client, loader.aliasResolver(), Optional.empty());
         this.context = loader.context();
         this.uploadExecutor = loader.uploadExecutor();
     }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
@@ -22,6 +22,7 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.s3.S3Context.S3SseContext;
 import io.trino.filesystem.s3.S3FileSystemConfig.S3AuthType;
 import io.trino.filesystem.s3.S3FileSystemConfig.SignerType;
+import io.trino.filesystem.s3.keystore.KeyStoreCredentialAliasResolver;
 import jakarta.annotation.PreDestroy;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -56,8 +57,8 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.filesystem.s3.S3FileSystemConfig.RetryMode.getRetryStrategy;
+import static io.trino.filesystem.s3.S3FileSystemUtils.createCredentialsProvider;
 import static io.trino.filesystem.s3.S3FileSystemUtils.createS3PreSigner;
-import static io.trino.filesystem.s3.S3FileSystemUtils.createStaticCredentialsProvider;
 import static io.trino.filesystem.s3.S3FileSystemUtils.createStsClient;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -68,8 +69,10 @@ final class S3FileSystemLoader
         implements Function<Location, TrinoFileSystemFactory>
 {
     private final Optional<S3SecurityMappingProvider> mappingProvider;
+    private final Optional<KeyStoreCredentialAliasResolver> aliasResolver;
     private final SdkHttpClient httpClient;
-    private final S3ClientFactory clientFactory;
+    private final OpenTelemetry openTelemetry;
+    private final MetricPublisher metricPublisher;
     private final S3FileSystemConfig config;
     private final S3Context context;
     private final ExecutorService uploadExecutor = newCachedThreadPool(daemonThreadsNamed("s3-upload-%s"));
@@ -79,23 +82,32 @@ final class S3FileSystemLoader
     @Inject
     public S3FileSystemLoader(S3SecurityMappingProvider mappingProvider, OpenTelemetry openTelemetry, S3FileSystemConfig config, S3FileSystemStats stats)
     {
-        this(Optional.of(mappingProvider), openTelemetry, config, stats);
+        this(Optional.of(mappingProvider), openTelemetry, config, stats, S3KeystoreCredentials.createAliasResolver(config));
     }
 
     S3FileSystemLoader(OpenTelemetry openTelemetry, S3FileSystemConfig config, S3FileSystemStats stats)
     {
-        this(Optional.empty(), openTelemetry, config, stats);
+        this(Optional.empty(), openTelemetry, config, stats, S3KeystoreCredentials.createAliasResolver(config));
     }
 
-    private S3FileSystemLoader(Optional<S3SecurityMappingProvider> mappingProvider, OpenTelemetry openTelemetry, S3FileSystemConfig config, S3FileSystemStats stats)
+    S3FileSystemLoader(OpenTelemetry openTelemetry, S3FileSystemConfig config, S3FileSystemStats stats, Optional<KeyStoreCredentialAliasResolver> aliasResolver)
+    {
+        this(Optional.empty(), openTelemetry, config, stats, aliasResolver);
+    }
+
+    private S3FileSystemLoader(
+            Optional<S3SecurityMappingProvider> mappingProvider,
+            OpenTelemetry openTelemetry,
+            S3FileSystemConfig config,
+            S3FileSystemStats stats,
+            Optional<KeyStoreCredentialAliasResolver> aliasResolver)
     {
         this.mappingProvider = requireNonNull(mappingProvider, "mappingProvider is null");
+        this.aliasResolver = requireNonNull(aliasResolver, "aliasResolver is null");
         this.httpClient = createHttpClient(config);
-
+        this.openTelemetry = requireNonNull(openTelemetry, "openTelemetry is null");
         requireNonNull(stats, "stats is null");
-
-        MetricPublisher metricPublisher = stats.newMetricPublisher();
-        this.clientFactory = s3ClientFactory(httpClient, openTelemetry, config, metricPublisher);
+        this.metricPublisher = stats.newMetricPublisher();
         this.config = requireNonNull(config, "config is null");
         this.context = new S3Context(
                 toIntExact(config.getStreamingPartSize().toBytes()),
@@ -109,14 +121,19 @@ final class S3FileSystemLoader
                 config.getCannedAcl());
     }
 
+    private S3ClientFactory clientFactory(Optional<String> bucket)
+    {
+        return s3ClientFactory(httpClient, openTelemetry, config, metricPublisher, aliasResolver, bucket);
+    }
+
     @Override
     public TrinoFileSystemFactory apply(Location location)
     {
         return identity -> {
             Optional<S3SecurityMappingResult> mapping = mappingProvider.orElseThrow().getMapping(identity, location);
 
-            S3Client client = clients.computeIfAbsent(mapping, _ -> clientFactory.create(mapping));
-            S3Presigner preSigner = preSigners.computeIfAbsent(mapping, _ -> createS3PreSigner(config, client));
+            S3Client client = clients.computeIfAbsent(mapping, _ -> clientFactory(Optional.empty()).create(mapping));
+            S3Presigner preSigner = preSigners.computeIfAbsent(mapping, _ -> createS3PreSigner(config, client, aliasResolver, Optional.empty()));
             S3Context context = this.context.withCredentials(identity);
 
             if (mapping.isPresent() && mapping.get().kmsKeyId().isPresent()) {
@@ -142,7 +159,15 @@ final class S3FileSystemLoader
 
     S3Client createClient()
     {
-        return clientFactory.create(Optional.empty());
+        return clientFactory(Optional.empty()).create(Optional.empty());
+    }
+
+    S3BucketCredentialFileSystemLoader.BucketFileSystemFactory createFactoryForBucket(String bucket)
+    {
+        Optional<String> bucketName = Optional.of(bucket);
+        S3Client client = clientFactory(bucketName).create(Optional.empty());
+        S3Presigner preSigner = createS3PreSigner(config, client, aliasResolver, bucketName);
+        return new S3BucketCredentialFileSystemLoader.BucketFileSystemFactory(client, preSigner, context, uploadExecutor);
     }
 
     S3Context context()
@@ -150,16 +175,27 @@ final class S3FileSystemLoader
         return context;
     }
 
+    Optional<KeyStoreCredentialAliasResolver> aliasResolver()
+    {
+        return aliasResolver;
+    }
+
     Executor uploadExecutor()
     {
         return uploadExecutor;
     }
 
-    private static S3ClientFactory s3ClientFactory(SdkHttpClient httpClient, OpenTelemetry openTelemetry, S3FileSystemConfig config, MetricPublisher metricPublisher)
+    private static S3ClientFactory s3ClientFactory(
+            SdkHttpClient httpClient,
+            OpenTelemetry openTelemetry,
+            S3FileSystemConfig config,
+            MetricPublisher metricPublisher,
+            Optional<KeyStoreCredentialAliasResolver> aliasResolver,
+            Optional<String> bucket)
     {
         ClientOverrideConfiguration overrideConfiguration = createOverrideConfiguration(openTelemetry, config, metricPublisher);
 
-        Optional<AwsCredentialsProvider> staticCredentialsProvider = createStaticCredentialsProvider(config);
+        Optional<AwsCredentialsProvider> staticCredentialsProvider = createCredentialsProvider(config, aliasResolver, bucket);
         Optional<String> staticRegion = Optional.ofNullable(config.getRegion());
         Optional<String> staticEndpoint = Optional.ofNullable(config.getEndpoint());
         boolean pathStyleAccess = config.isPathStyleAccess();

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemModule.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemModule.java
@@ -46,8 +46,16 @@ public class S3FileSystemModule
     {
         configBinder(binder).bindConfig(S3FileSystemConfig.class);
 
+        S3FileSystemConfig config = buildConfigObject(S3FileSystemConfig.class);
+
         if (buildConfigObject(S3SecurityMappingEnabledConfig.class).isEnabled()) {
+            if (config.getKeystoreBucketKeyPrefix() != null) {
+                throw new VerifyException("s3.keystore.bucket-key-prefix cannot be used with s3.security-mapping.enabled");
+            }
             install(new S3SecurityMappingModule());
+        }
+        else if (config.isKeystoreBucketPrefixConfigured()) {
+            install(new S3BucketCredentialModule());
         }
         else {
             binder.bind(TrinoFileSystemFactory.class).annotatedWith(FileSystemS3.class)
@@ -90,6 +98,24 @@ public class S3FileSystemModule
         @Singleton
         @FileSystemS3
         static TrinoFileSystemFactory createFileSystemFactory(S3FileSystemLoader loader)
+        {
+            return new SwitchingFileSystemFactory(loader);
+        }
+    }
+
+    public static class S3BucketCredentialModule
+            extends AbstractConfigurationAwareModule
+    {
+        @Override
+        protected void setup(Binder binder)
+        {
+            binder.bind(S3BucketCredentialFileSystemLoader.class).in(SINGLETON);
+        }
+
+        @Provides
+        @Singleton
+        @FileSystemS3
+        static TrinoFileSystemFactory createFileSystemFactory(S3BucketCredentialFileSystemLoader loader)
         {
             return new SwitchingFileSystemFactory(loader);
         }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemUtils.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemUtils.java
@@ -14,6 +14,8 @@
 package io.trino.filesystem.s3;
 
 import io.trino.filesystem.s3.S3FileSystemConfig.S3AuthType;
+import io.trino.filesystem.s3.keystore.KeyStoreCredentialAliasResolver;
+import io.trino.spi.TrinoException;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -30,13 +32,24 @@ import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import java.net.URI;
 import java.util.Optional;
 
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+
 final class S3FileSystemUtils
 {
     private S3FileSystemUtils() {}
 
     public static S3Presigner createS3PreSigner(S3FileSystemConfig config, S3Client s3Client)
     {
-        Optional<AwsCredentialsProvider> staticCredentialsProvider = createStaticCredentialsProvider(config);
+        return createS3PreSigner(config, s3Client, Optional.empty(), Optional.empty());
+    }
+
+    public static S3Presigner createS3PreSigner(
+            S3FileSystemConfig config,
+            S3Client s3Client,
+            Optional<KeyStoreCredentialAliasResolver> aliasResolver,
+            Optional<String> bucket)
+    {
+        Optional<AwsCredentialsProvider> staticCredentialsProvider = createCredentialsProvider(config, aliasResolver, bucket);
         Optional<String> staticRegion = Optional.ofNullable(config.getRegion());
         Optional<String> staticEndpoint = Optional.ofNullable(config.getEndpoint());
         boolean pathStyleAccess = config.isPathStyleAccess();
@@ -86,9 +99,37 @@ final class S3FileSystemUtils
 
     static Optional<AwsCredentialsProvider> createStaticCredentialsProvider(S3FileSystemConfig config)
     {
-        if ((config.getAwsAccessKey() != null) || (config.getAwsSecretKey() != null)) {
+        return createCredentialsProvider(config, Optional.empty(), Optional.empty());
+    }
+
+    static Optional<AwsCredentialsProvider> createCredentialsProvider(
+            S3FileSystemConfig config,
+            Optional<KeyStoreCredentialAliasResolver> aliasResolver,
+            Optional<String> bucket)
+    {
+        Optional<String> accessKey = Optional.ofNullable(config.getAwsAccessKey());
+        Optional<String> secretKey = Optional.ofNullable(config.getAwsSecretKey());
+
+        if (accessKey.isEmpty() && secretKey.isEmpty() && aliasResolver.isPresent()) {
+            if (config.getAwsAccessKeyAlias() != null && config.getAwsSecretKeyAlias() != null) {
+                KeyStoreCredentialAliasResolver resolver = aliasResolver.get();
+                accessKey = Optional.of(resolver.resolveAlias(config.getAwsAccessKeyAlias()));
+                secretKey = Optional.of(resolver.resolveAlias(config.getAwsSecretKeyAlias()));
+            }
+            else if (config.getKeystoreBucketKeyPrefix() != null && bucket.isPresent()) {
+                KeyStoreCredentialAliasResolver.BucketCredentials bucketCredentials = aliasResolver.get()
+                        .resolveBucketCredentials(config.getKeystoreBucketKeyPrefix(), bucket.get());
+                accessKey = Optional.of(bucketCredentials.accessKey());
+                secretKey = Optional.of(bucketCredentials.secretKey());
+            }
+        }
+
+        if (accessKey.isPresent() && secretKey.isPresent()) {
             return Optional.of(StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create(config.getAwsAccessKey(), config.getAwsSecretKey())));
+                    AwsBasicCredentials.create(accessKey.get(), secretKey.get())));
+        }
+        if (accessKey.isPresent() || secretKey.isPresent()) {
+            throw new TrinoException(CONFIGURATION_INVALID, "Both S3 access key and secret key must be configured");
         }
         return Optional.empty();
     }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3KeystoreCredentials.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3KeystoreCredentials.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import io.airlift.log.Logger;
+import io.trino.filesystem.s3.keystore.KeyStoreCredentialAliasResolver;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+final class S3KeystoreCredentials
+{
+    static final String HADOOP_CREDSTORE_PASSWORD_ENVIRONMENT_VARIABLE = "HADOOP_CREDSTORE_PASSWORD";
+
+    private static final Logger log = Logger.get(S3KeystoreCredentials.class);
+
+    private S3KeystoreCredentials() {}
+
+    static Optional<KeyStoreCredentialAliasResolver> createAliasResolver(S3FileSystemConfig config)
+    {
+        return createAliasResolver(config, System::getenv);
+    }
+
+    static Optional<KeyStoreCredentialAliasResolver> createAliasResolver(S3FileSystemConfig config, Function<String, String> environment)
+    {
+        if (!config.isKeystoreConfigured()) {
+            return Optional.empty();
+        }
+
+        PasswordResolution passwordResolution = resolveKeystorePassword(config, environment);
+        log.info("Using keystore password from %s", passwordResolution.source());
+
+        String entryPassword = Optional.ofNullable(config.getKeystoreEntryPassword())
+                .orElse(passwordResolution.password());
+
+        return Optional.of(new KeyStoreCredentialAliasResolver(
+                config.getKeystorePath(),
+                config.getKeystoreType(),
+                passwordResolution.password(),
+                entryPassword));
+    }
+
+    static PasswordResolution resolveKeystorePassword(S3FileSystemConfig config, Function<String, String> environment)
+    {
+        if (config.getKeystorePassword() != null) {
+            return new PasswordResolution(config.getKeystorePassword(), "s3.keystore.password");
+        }
+        String environmentPassword = environment.apply(HADOOP_CREDSTORE_PASSWORD_ENVIRONMENT_VARIABLE);
+        if (environmentPassword != null) {
+            return new PasswordResolution(environmentPassword, HADOOP_CREDSTORE_PASSWORD_ENVIRONMENT_VARIABLE + " environment variable");
+        }
+        return new PasswordResolution("none", "default ('none')");
+    }
+
+    record PasswordResolution(String password, String source) {}
+}

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/keystore/KeyStoreCredentialAliasResolver.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/keystore/KeyStoreCredentialAliasResolver.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3.keystore;
+
+import io.trino.spi.TrinoException;
+
+import java.security.KeyStore;
+import java.util.Locale;
+
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+import static java.util.Objects.requireNonNull;
+
+public final class KeyStoreCredentialAliasResolver
+{
+    private final KeyStore keyStore;
+    private final String keystorePassword;
+    private final String entryPassword;
+
+    public KeyStoreCredentialAliasResolver(String keystorePath, String keystoreType, String keystorePassword, String entryPassword)
+    {
+        requireNonNull(keystorePath, "keystorePath is null");
+        requireNonNull(keystoreType, "keystoreType is null");
+        requireNonNull(keystorePassword, "keystorePassword is null");
+        requireNonNull(entryPassword, "entryPassword is null");
+
+        try {
+            this.keyStore = KeyStoreUtils.loadKeyStore(keystoreType, keystorePath, keystorePassword);
+        }
+        catch (Exception e) {
+            throw new TrinoException(CONFIGURATION_INVALID, "Failed to load keystore from " + keystorePath, e);
+        }
+        this.keystorePassword = keystorePassword;
+        this.entryPassword = entryPassword;
+    }
+
+    public String resolveAlias(String alias)
+    {
+        alias = alias.toLowerCase(Locale.US);
+        try {
+            if (!keyStore.containsAlias(alias)) {
+                throw new TrinoException(CONFIGURATION_INVALID, "Unknown credential alias: " + alias);
+            }
+            return KeyStoreUtils.readEntity(keyStore, alias, keystorePassword, entryPassword);
+        }
+        catch (Exception e) {
+            if (e instanceof TrinoException trinoException) {
+                throw trinoException;
+            }
+            throw new TrinoException(CONFIGURATION_INVALID, "Failed to resolve credential alias: " + alias, e);
+        }
+    }
+
+    public BucketCredentials resolveBucketCredentials(String bucketKeyPrefix, String bucket)
+    {
+        requireNonNull(bucketKeyPrefix, "bucketKeyPrefix is null");
+        requireNonNull(bucket, "bucket is null");
+        String accessKeyAlias = bucketKeyPrefix + bucket + ".access.key";
+        String secretKeyAlias = bucketKeyPrefix + bucket + ".secret.key";
+        return new BucketCredentials(resolveAlias(accessKeyAlias), resolveAlias(secretKeyAlias));
+    }
+
+    public record BucketCredentials(String accessKey, String secretKey) {}
+}

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/keystore/KeyStoreUtils.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/keystore/KeyStoreUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3.keystore;
+
+import io.trino.spi.TrinoException;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStore.PasswordProtection;
+import java.security.KeyStore.SecretKeyEntry;
+
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+final class KeyStoreUtils
+{
+    private KeyStoreUtils() {}
+
+    static KeyStore loadKeyStore(String keyStoreType, String keyStorePath, String keyStorePassword)
+            throws IOException, GeneralSecurityException
+    {
+        KeyStore keyStore = KeyStore.getInstance(keyStoreType);
+        try (InputStream stream = new FileInputStream(keyStorePath)) {
+            keyStore.load(stream, keyStorePassword.toCharArray());
+        }
+        return keyStore;
+    }
+
+    static String readEntity(KeyStore keyStore, String entityAlias, String keystorePassword, String entryPassword)
+            throws GeneralSecurityException
+    {
+        try {
+            // Hadoop CredentialProvider format: UTF-8 credential bytes in a SecretKeySpec (setKeyEntry)
+            if (keyStore.isKeyEntry(entityAlias)) {
+                Key key = keyStore.getKey(entityAlias, keystorePassword.toCharArray());
+                if (key instanceof SecretKeySpec secretKeySpec) {
+                    return new String(secretKeySpec.getEncoded(), UTF_8);
+                }
+            }
+
+            // JDBC KEYSTORE provider format: PBE-protected SecretKeyEntry (getEntry)
+            var entry = keyStore.getEntry(entityAlias, new PasswordProtection(entryPassword.toCharArray()));
+            if (!(entry instanceof SecretKeyEntry secretKeyEntry)) {
+                throw new TrinoException(CONFIGURATION_INVALID, "Unsupported keystore entry format for alias: " + entityAlias);
+            }
+            SecretKeyFactory factory = SecretKeyFactory.getInstance(secretKeyEntry.getSecretKey().getAlgorithm());
+            PBEKeySpec keySpec = (PBEKeySpec) factory.getKeySpec(secretKeyEntry.getSecretKey(), PBEKeySpec.class);
+            return new String(keySpec.getPassword());
+        }
+        catch (ClassCastException e) {
+            throw new TrinoException(CONFIGURATION_INVALID, "Unsupported keystore entry format for alias: " + entityAlias, e);
+        }
+    }
+}

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
@@ -15,6 +15,7 @@ package io.trino.filesystem.s3;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
+import io.airlift.configuration.validation.FileExists;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.filesystem.s3.S3FileSystemConfig.ObjectCannedAcl;
@@ -24,8 +25,12 @@ import io.trino.filesystem.s3.S3FileSystemConfig.StorageClassType;
 import jakarta.validation.constraints.AssertTrue;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
@@ -47,6 +52,13 @@ public class TestS3FileSystemConfig
         assertRecordedDefaults(recordDefaults(S3FileSystemConfig.class)
                 .setAwsAccessKey(null)
                 .setAwsSecretKey(null)
+                .setKeystorePath(null)
+                .setKeystoreType("JCEKS")
+                .setKeystorePassword(null)
+                .setKeystoreEntryPassword(null)
+                .setKeystoreBucketKeyPrefix(null)
+                .setAwsAccessKeyAlias(null)
+                .setAwsSecretKeyAlias(null)
                 .setEndpoint(null)
                 .setRegion(null)
                 .setPathStyleAccess(false)
@@ -173,7 +185,76 @@ public class TestS3FileSystemConfig
                 .setStsEndpoint("sts.example.com")
                 .setStsRegion("us-west-2"));
 
-        assertFullMapping(properties, expected);
+        assertFullMapping(properties, expected, Set.of(
+                "s3.keystore.path",
+                "s3.keystore.password",
+                "s3.keystore.entry-password",
+                "s3.keystore.bucket-key-prefix",
+                "s3.keystore.type",
+                "s3.aws-access-key-alias",
+                "s3.aws-secret-key-alias"));
+    }
+
+    @Test
+    public void testKeystorePropertyMappings()
+            throws Exception
+    {
+        Path keystoreFile = Files.createTempFile("keystore", ".jceks");
+        keystoreFile.toFile().deleteOnExit();
+
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("s3.keystore.path", keystoreFile.toString())
+                .put("s3.keystore.password", "none")
+                .put("s3.aws-access-key-alias", "access.alias")
+                .put("s3.aws-secret-key-alias", "secret.alias")
+                .buildOrThrow();
+
+        S3FileSystemConfig expected = new S3FileSystemConfig()
+                .setKeystorePath(keystoreFile.toString())
+                .setKeystorePassword("none")
+                .setAwsAccessKeyAlias("access.alias")
+                .setAwsSecretKeyAlias("secret.alias");
+
+        assertFullMapping(properties, expected, Set.of(
+                "s3.application-id",
+                "s3.auth-type",
+                "s3.aws-access-key",
+                "s3.aws-secret-key",
+                "s3.canned-acl",
+                "s3.connection-max-idle-time",
+                "s3.connection-ttl",
+                "s3.cross-region-access",
+                "s3.endpoint",
+                "s3.expect-continue-enabled",
+                "s3.external-id",
+                "s3.http-proxy",
+                "s3.http-proxy.non-proxy-hosts",
+                "s3.http-proxy.password",
+                "s3.http-proxy.preemptive-basic-auth",
+                "s3.http-proxy.secure",
+                "s3.http-proxy.username",
+                "s3.iam-role",
+                "s3.keystore.bucket-key-prefix",
+                "s3.keystore.entry-password",
+                "s3.keystore.type",
+                "s3.max-connections",
+                "s3.max-error-retries",
+                "s3.path-style-access",
+                "s3.region",
+                "s3.requester-pays",
+                "s3.retry-mode",
+                "s3.role-session-name",
+                "s3.signer-type",
+                "s3.socket-connect-timeout",
+                "s3.socket-timeout",
+                "s3.sse.customer-key",
+                "s3.sse.kms-key-id",
+                "s3.sse.type",
+                "s3.storage-class",
+                "s3.streaming.part-size",
+                "s3.sts.endpoint",
+                "s3.sts.region",
+                "s3.tcp-keep-alive"));
     }
 
     @Test
@@ -193,7 +274,14 @@ public class TestS3FileSystemConfig
                 "s3.iam-role",
                 "s3.external-id",
                 "s3.sts.endpoint",
-                "s3.sts.region"));
+                "s3.sts.region",
+                "s3.keystore.path",
+                "s3.keystore.password",
+                "s3.keystore.entry-password",
+                "s3.keystore.bucket-key-prefix",
+                "s3.keystore.type",
+                "s3.aws-access-key-alias",
+                "s3.aws-secret-key-alias"));
     }
 
     @Test
@@ -206,7 +294,7 @@ public class TestS3FileSystemConfig
                 AssertTrue.class);
     }
 
-    private static final String CREDENTIAL_FREE_MESSAGE = "s3.auth-type=ANONYMOUS and s3.auth-type=WEB_IDENTITY cannot be used with other authentication properties (s3.aws-access-key, s3.aws-secret-key, s3.external-id, s3.sts.endpoint, s3.sts.region)";
+    private static final String CREDENTIAL_FREE_MESSAGE = "s3.auth-type=ANONYMOUS and s3.auth-type=WEB_IDENTITY cannot be used with other authentication properties (s3.aws-access-key, s3.aws-secret-key, s3.aws-access-key-alias, s3.aws-secret-key-alias, s3.keystore.path, s3.external-id, s3.sts.endpoint, s3.sts.region)";
     private static final String IAM_ROLE_MESSAGE = "s3.iam-role must be set when, and only when, s3.auth-type=IAM_ROLE";
 
     @Test
@@ -326,5 +414,85 @@ public class TestS3FileSystemConfig
                         .setExternalId("external-id")
                         .setStsEndpoint("sts.example.com")
                         .setStsRegion("us-west-2"));
+    }
+
+    @Test
+    public void testKeystorePathWithoutAliases()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setKeystorePath("/jceks/secrets.jceks"),
+                "keystoreConfigurationValid",
+                "s3.keystore.path requires s3.aws-access-key-alias and s3.aws-secret-key-alias, or s3.keystore.bucket-key-prefix",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testPartialPlaintextCredentials()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setAwsAccessKey("only-access"),
+                "plaintextCredentialsValid",
+                "s3.aws-access-key and s3.aws-secret-key must be configured together",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testPlaintextAndAliasCredentialsMixed()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setKeystorePath("/jceks/secrets.jceks")
+                        .setAwsAccessKeyAlias("access.alias")
+                        .setAwsSecretKeyAlias("secret.alias")
+                        .setAwsAccessKey("plaintext"),
+                "plaintextAndAliasCredentialsValid",
+                "plaintext and alias S3 credentials cannot be mixed",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testKeystoreBucketPrefixWithoutPath()
+    {
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setKeystoreBucketKeyPrefix("fs.s3a.bucket."),
+                "keystoreBucketPrefixValid",
+                "s3.keystore.bucket-key-prefix requires s3.keystore.path",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testKeystorePathMustExist()
+            throws Exception
+    {
+        File missingFile = new File("/doesNotExist-" + UUID.randomUUID());
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setKeystorePath(missingFile.getPath())
+                        .setAwsAccessKeyAlias("access.alias")
+                        .setAwsSecretKeyAlias("secret.alias"),
+                "keystorePath",
+                "file does not exist: " + missingFile,
+                FileExists.class);
+    }
+
+    @Test
+    public void testGlobalAliasAndBucketPrefixMutuallyExclusive()
+            throws Exception
+    {
+        File keystoreFile = Files.createTempFile("keystore", ".jceks").toFile();
+        keystoreFile.deleteOnExit();
+
+        assertFailsValidation(
+                new S3FileSystemConfig()
+                        .setKeystorePath(keystoreFile.getPath())
+                        .setAwsAccessKeyAlias("access.alias")
+                        .setAwsSecretKeyAlias("secret.alias")
+                        .setKeystoreBucketKeyPrefix("fs.s3a.bucket."),
+                "keystoreGlobalAliasAndBucketPrefixMutuallyExclusive",
+                "s3.aws-access-key-alias and s3.aws-secret-key-alias cannot be used with s3.keystore.bucket-key-prefix",
+                AssertTrue.class);
     }
 }

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemLoaderKeystore.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemLoaderKeystore.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.filesystem.s3.keystore.KeyStoreTestFixture;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.filesystem.s3.S3FileSystemUtils.createCredentialsProvider;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestS3FileSystemLoaderKeystore
+{
+    @Test
+    public void testGlobalAliasLoaderWiring()
+            throws Exception
+    {
+        Path keystorePath = KeyStoreTestFixture.createKeyStore(
+                Map.of(
+                        "s3.access.key", "loader-access",
+                        "s3.secret.key", "loader-secret"),
+                "none");
+
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setRegion("us-east-1")
+                .setKeystorePath(keystorePath.toString())
+                .setKeystorePassword("none")
+                .setAwsAccessKeyAlias("s3.access.key")
+                .setAwsSecretKeyAlias("s3.secret.key");
+
+        S3FileSystemLoader loader = new S3FileSystemLoader(OpenTelemetry.noop(), config, new S3FileSystemStats());
+        Optional<AwsCredentialsProvider> credentialsProvider = createCredentialsProvider(
+                config,
+                loader.aliasResolver(),
+                Optional.empty());
+
+        assertThat(credentialsProvider).isPresent();
+        AwsBasicCredentials credentials = (AwsBasicCredentials) credentialsProvider.get().resolveCredentials();
+        assertThat(credentials.accessKeyId()).isEqualTo("loader-access");
+        assertThat(credentials.secretAccessKey()).isEqualTo("loader-secret");
+    }
+
+    @Test
+    public void testBucketPrefixLoaderWiring()
+            throws Exception
+    {
+        Path keystorePath = KeyStoreTestFixture.createKeyStore(
+                Map.of(
+                        "fs.s3a.bucket.orders.access.key", "bucket-access",
+                        "fs.s3a.bucket.orders.secret.key", "bucket-secret"),
+                "none");
+
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setRegion("us-east-1")
+                .setKeystorePath(keystorePath.toString())
+                .setKeystorePassword("none")
+                .setKeystoreBucketKeyPrefix("fs.s3a.bucket.");
+
+        S3FileSystemLoader loader = new S3FileSystemLoader(OpenTelemetry.noop(), config, new S3FileSystemStats());
+        S3BucketCredentialFileSystemLoader.BucketFileSystemFactory bucketFactory = loader.createFactoryForBucket("orders");
+
+        Optional<AwsCredentialsProvider> credentialsProvider = createCredentialsProvider(
+                config,
+                loader.aliasResolver(),
+                Optional.of("orders"));
+
+        assertThat(credentialsProvider).isPresent();
+        AwsBasicCredentials credentials = (AwsBasicCredentials) credentialsProvider.get().resolveCredentials();
+        assertThat(credentials.accessKeyId()).isEqualTo("bucket-access");
+        assertThat(credentials.secretAccessKey()).isEqualTo("bucket-secret");
+        assertThat(bucketFactory).isNotNull();
+    }
+}

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemModule.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemModule.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Key;
+import io.airlift.bootstrap.Bootstrap;
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.s3.keystore.KeyStoreTestFixture;
+import io.trino.filesystem.switching.SwitchingFileSystemFactory;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static com.google.common.io.Resources.getResource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestS3FileSystemModule
+{
+    @Test
+    public void testDefaultFactoryBinding()
+    {
+        TrinoFileSystemFactory factory = bootstrap(Map.of(
+                "s3.region", "us-east-1",
+                "s3.aws-access-key", "access",
+                "s3.aws-secret-key", "secret"))
+                .initialize()
+                .getInstance(Key.get(TrinoFileSystemFactory.class, FileSystemS3.class));
+
+        assertThat(factory).isInstanceOf(S3FileSystemFactory.class);
+    }
+
+    @Test
+    public void testGlobalAliasKeystoreFactoryBinding()
+            throws Exception
+    {
+        Path keystorePath = KeyStoreTestFixture.createKeyStore(
+                Map.of(
+                        "s3.access.key", "access",
+                        "s3.secret.key", "secret"),
+                "none");
+
+        TrinoFileSystemFactory factory = bootstrap(Map.of(
+                "s3.region", "us-east-1",
+                "s3.keystore.path", keystorePath.toString(),
+                "s3.keystore.password", "none",
+                "s3.aws-access-key-alias", "s3.access.key",
+                "s3.aws-secret-key-alias", "s3.secret.key"))
+                .initialize()
+                .getInstance(Key.get(TrinoFileSystemFactory.class, FileSystemS3.class));
+
+        assertThat(factory).isInstanceOf(S3FileSystemFactory.class);
+    }
+
+    @Test
+    public void testBucketPrefixFactoryBinding()
+            throws Exception
+    {
+        Path keystorePath = KeyStoreTestFixture.createKeyStore(
+                Map.of(
+                        "fs.s3a.bucket.test-bucket.access.key", "access",
+                        "fs.s3a.bucket.test-bucket.secret.key", "secret"),
+                "none");
+
+        TrinoFileSystemFactory factory = bootstrap(Map.of(
+                "s3.region", "us-east-1",
+                "s3.keystore.path", keystorePath.toString(),
+                "s3.keystore.password", "none",
+                "s3.keystore.bucket-key-prefix", "fs.s3a.bucket."))
+                .initialize()
+                .getInstance(Key.get(TrinoFileSystemFactory.class, FileSystemS3.class));
+
+        assertThat(factory).isInstanceOf(SwitchingFileSystemFactory.class);
+        assertThat(factory).isNotInstanceOf(S3FileSystemFactory.class);
+    }
+
+    @Test
+    public void testSecurityMappingFactoryBinding()
+    {
+        TrinoFileSystemFactory factory = bootstrap(Map.of(
+                "s3.region", "us-east-1",
+                "s3.security-mapping.enabled", "true",
+                "s3.security-mapping.config-file", securityMappingConfigFile()))
+                .initialize()
+                .getInstance(Key.get(TrinoFileSystemFactory.class, FileSystemS3.class));
+
+        assertThat(factory).isInstanceOf(SwitchingFileSystemFactory.class);
+        assertThat(factory).isNotInstanceOf(S3FileSystemFactory.class);
+    }
+
+    @Test
+    public void testSecurityMappingWithBucketPrefixFailsStartup()
+            throws Exception
+    {
+        Path keystorePath = KeyStoreTestFixture.createKeyStore(
+                Map.of(
+                        "fs.s3a.bucket.test-bucket.access.key", "access",
+                        "fs.s3a.bucket.test-bucket.secret.key", "secret"),
+                "none");
+
+        assertThatThrownBy(() -> bootstrap(ImmutableMap.<String, String>builder()
+                .put("s3.region", "us-east-1")
+                .put("s3.security-mapping.enabled", "true")
+                .put("s3.security-mapping.config-file", securityMappingConfigFile())
+                .put("s3.keystore.path", keystorePath.toString())
+                .put("s3.keystore.password", "none")
+                .put("s3.keystore.bucket-key-prefix", "fs.s3a.bucket.")
+                .buildOrThrow())
+                .initialize())
+                .hasMessageContaining("s3.keystore.bucket-key-prefix cannot be used with s3.security-mapping.enabled");
+    }
+
+    private static String securityMappingConfigFile()
+    {
+        return new File(getResource(TestS3FileSystemModule.class, "security-mapping.json").getFile()).getPath();
+    }
+
+    private static Bootstrap bootstrap(Map<String, String> properties)
+    {
+        return new Bootstrap(
+                binder -> binder.bind(OpenTelemetry.class).toInstance(OpenTelemetry.noop()),
+                new S3FileSystemModule())
+                .setRequiredConfigurationProperties(properties)
+                .doNotInitializeLogging()
+                .quiet();
+    }
+}

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemUtilsKeyStore.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemUtilsKeyStore.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import io.trino.filesystem.s3.keystore.KeyStoreCredentialAliasResolver;
+import io.trino.filesystem.s3.keystore.KeyStoreTestFixture;
+import io.trino.spi.TrinoException;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestS3FileSystemUtilsKeyStore
+{
+    @Test
+    public void testExplicitAliasCredentials()
+            throws Exception
+    {
+        Path keystorePath = KeyStoreTestFixture.createKeyStore(
+                Map.of(
+                        "s3.access.key", "access-from-alias",
+                        "s3.secret.key", "secret-from-alias"),
+                "none");
+
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setKeystorePath(keystorePath.toString())
+                .setKeystorePassword("none")
+                .setAwsAccessKeyAlias("s3.access.key")
+                .setAwsSecretKeyAlias("s3.secret.key");
+
+        KeyStoreCredentialAliasResolver resolver = S3KeystoreCredentials.createAliasResolver(config).orElseThrow();
+
+        Optional<AwsCredentialsProvider> credentialsProvider = S3FileSystemUtils.createCredentialsProvider(
+                config,
+                Optional.of(resolver),
+                Optional.empty());
+
+        assertThat(credentialsProvider).isPresent();
+        AwsBasicCredentials credentials = (AwsBasicCredentials) credentialsProvider.get().resolveCredentials();
+        assertThat(credentials.accessKeyId()).isEqualTo("access-from-alias");
+        assertThat(credentials.secretAccessKey()).isEqualTo("secret-from-alias");
+    }
+
+    @Test
+    public void testBucketPrefixCredentials()
+            throws Exception
+    {
+        Path keystorePath = KeyStoreTestFixture.createKeyStore(
+                Map.of(
+                        "fs.s3a.bucket.test-bucket.access.key", "bucket-access",
+                        "fs.s3a.bucket.test-bucket.secret.key", "bucket-secret"),
+                "none");
+
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setKeystorePath(keystorePath.toString())
+                .setKeystorePassword("none")
+                .setKeystoreBucketKeyPrefix("fs.s3a.bucket.");
+
+        KeyStoreCredentialAliasResolver resolver = S3KeystoreCredentials.createAliasResolver(config).orElseThrow();
+
+        Optional<AwsCredentialsProvider> credentialsProvider = S3FileSystemUtils.createCredentialsProvider(
+                config,
+                Optional.of(resolver),
+                Optional.of("test-bucket"));
+
+        assertThat(credentialsProvider).isPresent();
+        AwsBasicCredentials credentials = (AwsBasicCredentials) credentialsProvider.get().resolveCredentials();
+        assertThat(credentials.accessKeyId()).isEqualTo("bucket-access");
+        assertThat(credentials.secretAccessKey()).isEqualTo("bucket-secret");
+    }
+
+    @Test
+    public void testPartialPlaintextCredentialsRejected()
+    {
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setAwsAccessKey("only-access");
+
+        assertThatThrownBy(() -> S3FileSystemUtils.createCredentialsProvider(
+                config,
+                Optional.empty(),
+                Optional.empty()))
+                .isInstanceOfSatisfying(TrinoException.class, e -> {
+                    assertThat(e.getErrorCode()).isEqualTo(CONFIGURATION_INVALID.toErrorCode());
+                    assertThat(e).hasMessageContaining("Both S3 access key and secret key must be configured");
+                });
+    }
+}

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3KeystoreCredentials.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3KeystoreCredentials.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import io.trino.filesystem.s3.keystore.KeyStoreCredentialAliasResolver;
+import io.trino.filesystem.s3.keystore.KeyStoreTestFixture;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestS3KeystoreCredentials
+{
+    @Test
+    public void testEnvironmentKeystorePasswordFallback()
+            throws Exception
+    {
+        Path keystorePath = KeyStoreTestFixture.createKeyStore(
+                Map.of("s3.access.key", "env-access"),
+                "env-password");
+
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setKeystorePath(keystorePath.toString())
+                .setAwsAccessKeyAlias("s3.access.key")
+                .setAwsSecretKeyAlias("s3.access.key");
+
+        S3KeystoreCredentials.PasswordResolution resolution = S3KeystoreCredentials.resolveKeystorePassword(
+                config,
+                name -> name.equals(S3KeystoreCredentials.HADOOP_CREDSTORE_PASSWORD_ENVIRONMENT_VARIABLE) ? "env-password" : null);
+        assertThat(resolution.password()).isEqualTo("env-password");
+        assertThat(resolution.source()).isEqualTo("HADOOP_CREDSTORE_PASSWORD environment variable");
+
+        Optional<KeyStoreCredentialAliasResolver> resolver = S3KeystoreCredentials.createAliasResolver(
+                config,
+                name -> name.equals(S3KeystoreCredentials.HADOOP_CREDSTORE_PASSWORD_ENVIRONMENT_VARIABLE) ? "env-password" : null);
+        assertThat(resolver.orElseThrow().resolveAlias("s3.access.key")).isEqualTo("env-access");
+    }
+
+    @Test
+    public void testConfigPasswordTakesPrecedenceOverEnvironment()
+            throws Exception
+    {
+        Path keystorePath = KeyStoreTestFixture.createKeyStore(
+                Map.of("s3.access.key", "config-access"),
+                "config-password");
+
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setKeystorePath(keystorePath.toString())
+                .setKeystorePassword("config-password")
+                .setAwsAccessKeyAlias("s3.access.key")
+                .setAwsSecretKeyAlias("s3.access.key");
+
+        S3KeystoreCredentials.PasswordResolution resolution = S3KeystoreCredentials.resolveKeystorePassword(
+                config,
+                _ -> "env-password");
+        assertThat(resolution.password()).isEqualTo("config-password");
+        assertThat(resolution.source()).isEqualTo("s3.keystore.password");
+    }
+
+    @Test
+    public void testDefaultPasswordWhenUnset()
+    {
+        S3KeystoreCredentials.PasswordResolution resolution = S3KeystoreCredentials.resolveKeystorePassword(
+                new S3FileSystemConfig().setKeystorePath("/tmp/unused.jceks"),
+                _ -> null);
+        assertThat(resolution.password()).isEqualTo("none");
+        assertThat(resolution.source()).isEqualTo("default ('none')");
+    }
+}

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/keystore/KeyStoreTestFixture.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/keystore/KeyStoreTestFixture.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3.keystore;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.alias.CredentialProvider;
+import org.apache.hadoop.security.alias.CredentialProviderFactory;
+
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public final class KeyStoreTestFixture
+{
+    private KeyStoreTestFixture() {}
+
+    /**
+     * Create a JCEKS file using the same PBE SecretKeyEntry pattern as Hadoop LocalJavaKeyStoreProvider.
+     */
+    public static Path createKeyStore(Map<String, String> aliases, String password)
+            throws Exception
+    {
+        KeyStore keyStore = KeyStore.getInstance("JCEKS");
+        keyStore.load(null, password.toCharArray());
+
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
+        for (Map.Entry<String, String> entry : aliases.entrySet()) {
+            String alias = entry.getKey().toLowerCase(Locale.US);
+            PBEKeySpec keySpec = new PBEKeySpec(entry.getValue().toCharArray());
+            SecretKey key = factory.generateSecret(keySpec);
+            keyStore.setEntry(alias, new KeyStore.SecretKeyEntry(key), new KeyStore.PasswordProtection(password.toCharArray()));
+        }
+
+        return writeKeyStore(keyStore, password);
+    }
+
+    /**
+     * Create a JCEKS file via Hadoop CredentialProviderFactory (SecretKeySpec entry format).
+     */
+    public static Path createHadoopKeyStore(Map<String, String> aliases, String password)
+            throws IOException
+    {
+        Path keystorePath = Files.createTempFile("hadoop-credentials", ".jceks");
+        keystorePath.toFile().deleteOnExit();
+
+        String providerPath = "localjceks://file" + keystorePath.toAbsolutePath();
+        Configuration configuration = new Configuration(false);
+        configuration.set(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH, providerPath);
+        configuration.set("hadoop.security.credential.provider.password", password);
+
+        List<CredentialProvider> providers = CredentialProviderFactory.getProviders(configuration);
+        CredentialProvider provider = providers.getFirst();
+        for (Map.Entry<String, String> entry : aliases.entrySet()) {
+            provider.createCredentialEntry(entry.getKey(), entry.getValue().toCharArray());
+        }
+        provider.flush();
+
+        return keystorePath;
+    }
+
+    private static Path writeKeyStore(KeyStore keyStore, String password)
+            throws Exception
+    {
+        Path keystorePath = Files.createTempFile("credentials", ".jceks");
+        keystorePath.toFile().deleteOnExit();
+        try (OutputStream out = Files.newOutputStream(keystorePath)) {
+            keyStore.store(out, password.toCharArray());
+        }
+        return keystorePath;
+    }
+}

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/keystore/TestKeyStoreCredentialAliasResolver.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/keystore/TestKeyStoreCredentialAliasResolver.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3.keystore;
+
+import io.trino.spi.TrinoException;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestKeyStoreCredentialAliasResolver
+{
+    @Test
+    public void testResolveS3Aliases()
+            throws Exception
+    {
+        Path keystorePath = KeyStoreTestFixture.createKeyStore(
+                Map.of(
+                        "fs.s3a.bucket.testbucket.access.key", "AKIATEST",
+                        "fs.s3a.bucket.testbucket.secret.key", "SECRETTEST"),
+                "none");
+
+        KeyStoreCredentialAliasResolver resolver = new KeyStoreCredentialAliasResolver(
+                keystorePath.toString(),
+                "JCEKS",
+                "none",
+                "none");
+
+        assertThat(resolver.resolveAlias("fs.s3a.bucket.testbucket.access.key")).isEqualTo("AKIATEST");
+        assertThat(resolver.resolveAlias("FS.S3A.BUCKET.TESTBUCKET.SECRET.KEY")).isEqualTo("SECRETTEST");
+    }
+
+    @Test
+    public void testResolveBucketCredentials()
+            throws Exception
+    {
+        Path keystorePath = KeyStoreTestFixture.createKeyStore(
+                Map.of(
+                        "fs.s3a.bucket.my-bucket.access.key", "access-key",
+                        "fs.s3a.bucket.my-bucket.secret.key", "secret-key"),
+                "none");
+
+        KeyStoreCredentialAliasResolver resolver = new KeyStoreCredentialAliasResolver(
+                keystorePath.toString(),
+                "JCEKS",
+                "none",
+                "none");
+
+        KeyStoreCredentialAliasResolver.BucketCredentials credentials = resolver.resolveBucketCredentials("fs.s3a.bucket.", "my-bucket");
+        assertThat(credentials.accessKey()).isEqualTo("access-key");
+        assertThat(credentials.secretKey()).isEqualTo("secret-key");
+    }
+
+    @Test
+    public void testUnknownAlias()
+            throws Exception
+    {
+        Path keystorePath = KeyStoreTestFixture.createKeyStore(Map.of("known.alias", "value"), "none");
+
+        KeyStoreCredentialAliasResolver resolver = new KeyStoreCredentialAliasResolver(
+                keystorePath.toString(),
+                "JCEKS",
+                "none",
+                "none");
+
+        assertThatThrownBy(() -> resolver.resolveAlias("missing.alias"))
+                .isInstanceOfSatisfying(TrinoException.class, e -> {
+                    assertThat(e.getErrorCode()).isEqualTo(CONFIGURATION_INVALID.toErrorCode());
+                    assertThat(e).hasMessageContaining("Unknown credential alias");
+                });
+    }
+
+    @Test
+    public void testReadHadoopCreatedKeystore()
+            throws Exception
+    {
+        Path keystorePath = KeyStoreTestFixture.createHadoopKeyStore(
+                Map.of(
+                        "fs.s3a.bucket.example-bucket.access.key", "example-access",
+                        "fs.s3a.bucket.example-bucket.secret.key", "example-secret"),
+                "none");
+
+        KeyStoreCredentialAliasResolver resolver = new KeyStoreCredentialAliasResolver(
+                keystorePath.toString(),
+                "JCEKS",
+                "none",
+                "none");
+
+        assertThat(resolver.resolveAlias("fs.s3a.bucket.example-bucket.access.key")).isEqualTo("example-access");
+        assertThat(resolver.resolveAlias("fs.s3a.bucket.example-bucket.secret.key")).isEqualTo("example-secret");
+    }
+}


### PR DESCRIPTION

## Description

The native S3 filesystem currently accepts plaintext access keys or the default AWS credential chain. This adds a third option: resolve static AWS credentials from a Java KeyStore file by alias.

When s3.keystore.path is set, credentials can be resolved via:

* Global aliases — s3.aws-access-key-alias and s3.aws-secret-key-alias for a single shared credential pair used by one S3 client.
* Per-bucket aliases — s3.keystore.bucket-key-prefix resolves <prefix><bucket>.access.key and <prefix><bucket>.secret.key, building a separate S3 client per bucket on first access.

The keystore is loaded once at startup with the standard java.security.KeyStore API. No Hadoop CredentialProviderFactory or other runtime Hadoop dependency is added to the production classpath. `hadoop-apache` is test-scoped only (keystore fixture generation). The reader supports both JDBC-style PBE SecretKeyEntry entries and AES SecretKeySpec entries commonly written by external credential tooling. 



## Additional context and related issues

New configuration properties:

Property | Purpose
-- | --
s3.keystore.path | Path to the Java KeyStore file
s3.keystore.type | KeyStore type (default JCEKS)
s3.keystore.password | Keystore password; falls back to HADOOP_CREDSTORE_PASSWORD env or none
s3.keystore.entry-password | Per-entry password; defaults to keystore password
s3.aws-access-key-alias / s3.aws-secret-key-alias | Global alias pair
s3.keystore.bucket-key-prefix | Prefix for per-bucket alias resolution


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add `s3.keystore.*` configuration for resolving native S3 credentials from a Java KeyStore file by alias, including per-bucket alias support via `s3.keystore.bucket-key-prefix`.
```
