### PR TITLE
Verify and create java.io.tmpdir at startup if missing

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
@@ -20,12 +20,15 @@ import com.sun.management.UnixOperatingSystemMXBean;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
+import java.io.IOException;
 import java.lang.Runtime.Version;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Year;
 import java.util.List;
 import java.util.Locale;
@@ -43,6 +46,7 @@ final class TrinoSystemRequirements
     public static void verifySystemRequirements()
     {
         verifyJvmRequirements();
+        verifyTemporaryDirectory();
         verifySystemTimeIsReasonable();
     }
 
@@ -197,5 +201,19 @@ final class TrinoSystemRequirements
     private static void warnRequirement(String format, Object... args)
     {
         System.err.println("WARNING: " + format(format, args));
+    }
+
+    private static void verifyTemporaryDirectory()
+    {
+        Path tempDir = Path.of(System.getProperty("java.io.tmpdir"));
+        if (!Files.isDirectory(tempDir, NOFOLLOW_LINKS)) {
+            try {
+                Files.createDirectories(tempDir);
+                warnRequirement("Temporary directory %s did not exist and was created", tempDir);
+            }
+            catch (IOException e) {
+                failRequirement("Temporary directory %s does not exist and could not be created: %s", tempDir, e);
+            }
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
@@ -35,6 +35,7 @@ import java.util.Locale;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
+import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
 
 final class TrinoSystemRequirements
 {


### PR DESCRIPTION
## Description

When `java.io.tmpdir` is configured to a non-existent directory, Trino fails to start with a confusing wall of 18+ unrelated Guice/HdfsEnvironment errors instead of a clear root cause. The Hadoop native library fails to extract itself into the missing temp directory, which poisons the `HdfsEnvironment` static initializer and cascades through every Hive page source factory binding.

### Changes

1. **`TrinoSystemRequirements.verifyTemporaryDirectory()`** — new method that checks whether the configured `java.io.tmpdir` exists at startup. If it does not exist, Trino creates it with `mkdir -p` semantics (matching how `node.data-dir` itself is handled). If creation fails, Trino fails with a clear, early error message instead of cascading Guice errors.

### Testing

- Manual: verified that the fix produces a clear warning when the temp directory is missing and is auto-created, and a clear error when creation fails (e.g. permission denied)
- The `TrinoSystemRequirements` test pattern is followed: `failRequirement` calls `System.exit(100)` after printing the error

Closes #30640