### PR TITLE
Reject INTERVAL fractional seconds beyond ms

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/DateTimeUtils.java
@@ -280,6 +280,12 @@ public final class DateTimeUtils
 
     private static long parsePeriodMillis(PeriodFormatter periodFormatter, String value)
     {
+        // Day-time intervals are stored at millisecond precision. Reject values whose
+        // fractional-seconds field has more than 3 digits instead of silently truncating
+        // (e.g. INTERVAL '.0001' SECOND must not be treated as zero).
+        //
+        // See https://github.com/trinodb/trino/issues/6754
+        checkFractionalSecondsPrecision(value);
         Period period = parsePeriod(periodFormatter, value);
         return IntervalDayTime.toMillis(
                 period.getValue(DAY_FIELD),
@@ -287,6 +293,36 @@ public final class DateTimeUtils
                 period.getValue(MINUTE_FIELD),
                 period.getValue(SECOND_FIELD),
                 period.getValue(MILLIS_FIELD));
+    }
+
+    private static void checkFractionalSecondsPrecision(String value)
+    {
+        // Strip a leading sign so "-1.1234" is checked like "1.1234".
+        String unsigned = value.startsWith("-") || value.startsWith("+") ? value.substring(1) : value;
+
+        int separator = -1;
+        for (int i = 0; i < unsigned.length(); i++) {
+            char c = unsigned.charAt(i);
+            if (c == '.' || c == ',') {
+                separator = i;
+            }
+        }
+        if (separator < 0) {
+            return;
+        }
+
+        int digits = 0;
+        for (int i = separator + 1; i < unsigned.length(); i++) {
+            char c = unsigned.charAt(i);
+            if (c < '0' || c > '9') {
+                break;
+            }
+            digits++;
+        }
+        if (digits > 3) {
+            throw new IllegalArgumentException(
+                    format("INTERVAL fractional seconds precision exceeds milliseconds: %s", value));
+        }
     }
 
     public static long parseYearMonthInterval(String value, IntervalField startField, Optional<IntervalField> endField)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/interval/TestExtract.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/interval/TestExtract.java
@@ -80,11 +80,6 @@ public class TestExtract
         assertThat(assertions.expression("EXTRACT(DAY FROM INTERVAL '42 12:34:56.1' DAY TO SECOND)")).matches("BIGINT '42'");
         assertThat(assertions.expression("EXTRACT(DAY FROM INTERVAL '42 12:34:56.12' DAY TO SECOND)")).matches("BIGINT '42'");
         assertThat(assertions.expression("EXTRACT(DAY FROM INTERVAL '42 12:34:56.123' DAY TO SECOND)")).matches("BIGINT '42'");
-        assertThat(assertions.expression("EXTRACT(DAY FROM INTERVAL '42 12:34:56.1234' DAY TO SECOND)")).matches("BIGINT '42'");
-        assertThat(assertions.expression("EXTRACT(DAY FROM INTERVAL '42 12:34:56.12345' DAY TO SECOND)")).matches("BIGINT '42'");
-        assertThat(assertions.expression("EXTRACT(DAY FROM INTERVAL '42 12:34:56.123456' DAY TO SECOND)")).matches("BIGINT '42'");
-        assertThat(assertions.expression("EXTRACT(DAY FROM INTERVAL '42 12:34:56.1234567' DAY TO SECOND)")).matches("BIGINT '42'");
-        assertThat(assertions.expression("EXTRACT(DAY FROM INTERVAL '42 12:34:56.12345678' DAY TO SECOND)")).matches("BIGINT '42'");
 
         assertThat(assertions.expression("DAY(INTERVAL '42' DAY)")).matches("BIGINT '42'");
         assertThat(assertions.expression("DAY(INTERVAL '12' HOUR)")).matches("BIGINT '0'");
@@ -100,11 +95,6 @@ public class TestExtract
         assertThat(assertions.expression("DAY(INTERVAL '42 12:34:56.1' DAY TO SECOND)")).matches("BIGINT '42'");
         assertThat(assertions.expression("DAY(INTERVAL '42 12:34:56.12' DAY TO SECOND)")).matches("BIGINT '42'");
         assertThat(assertions.expression("DAY(INTERVAL '42 12:34:56.123' DAY TO SECOND)")).matches("BIGINT '42'");
-        assertThat(assertions.expression("DAY(INTERVAL '42 12:34:56.1234' DAY TO SECOND)")).matches("BIGINT '42'");
-        assertThat(assertions.expression("DAY(INTERVAL '42 12:34:56.12345' DAY TO SECOND)")).matches("BIGINT '42'");
-        assertThat(assertions.expression("DAY(INTERVAL '42 12:34:56.123456' DAY TO SECOND)")).matches("BIGINT '42'");
-        assertThat(assertions.expression("DAY(INTERVAL '42 12:34:56.1234567' DAY TO SECOND)")).matches("BIGINT '42'");
-        assertThat(assertions.expression("DAY(INTERVAL '42 12:34:56.12345678' DAY TO SECOND)")).matches("BIGINT '42'");
     }
 
     @Test
@@ -125,11 +115,6 @@ public class TestExtract
         assertThat(assertions.expression("EXTRACT(HOUR FROM INTERVAL '34:56.1' MINUTE TO SECOND)")).matches("BIGINT '0'");
         assertThat(assertions.expression("EXTRACT(HOUR FROM INTERVAL '34:56.12' MINUTE TO SECOND)")).matches("BIGINT '0'");
         assertThat(assertions.expression("EXTRACT(HOUR FROM INTERVAL '34:56.123' MINUTE TO SECOND)")).matches("BIGINT '0'");
-        assertThat(assertions.expression("EXTRACT(HOUR FROM INTERVAL '34:56.1234' MINUTE TO SECOND)")).matches("BIGINT '0'");
-        assertThat(assertions.expression("EXTRACT(HOUR FROM INTERVAL '34:56.12345' MINUTE TO SECOND)")).matches("BIGINT '0'");
-        assertThat(assertions.expression("EXTRACT(HOUR FROM INTERVAL '34:56.123456' MINUTE TO SECOND)")).matches("BIGINT '0'");
-        assertThat(assertions.expression("EXTRACT(HOUR FROM INTERVAL '34:56.1234567' MINUTE TO SECOND)")).matches("BIGINT '0'");
-        assertThat(assertions.expression("EXTRACT(HOUR FROM INTERVAL '34:56.12345678' MINUTE TO SECOND)")).matches("BIGINT '0'");
 
         assertThat(assertions.expression("HOUR(INTERVAL '42' DAY)")).matches("BIGINT '0'");
         assertThat(assertions.expression("HOUR(INTERVAL '6' HOUR)")).matches("BIGINT '6'");
@@ -146,11 +131,6 @@ public class TestExtract
         assertThat(assertions.expression("HOUR(INTERVAL '34:56.1' MINUTE TO SECOND)")).matches("BIGINT '0'");
         assertThat(assertions.expression("HOUR(INTERVAL '34:56.12' MINUTE TO SECOND)")).matches("BIGINT '0'");
         assertThat(assertions.expression("HOUR(INTERVAL '34:56.123' MINUTE TO SECOND)")).matches("BIGINT '0'");
-        assertThat(assertions.expression("HOUR(INTERVAL '34:56.1234' MINUTE TO SECOND)")).matches("BIGINT '0'");
-        assertThat(assertions.expression("HOUR(INTERVAL '34:56.12345' MINUTE TO SECOND)")).matches("BIGINT '0'");
-        assertThat(assertions.expression("HOUR(INTERVAL '34:56.123456' MINUTE TO SECOND)")).matches("BIGINT '0'");
-        assertThat(assertions.expression("HOUR(INTERVAL '34:56.1234567' MINUTE TO SECOND)")).matches("BIGINT '0'");
-        assertThat(assertions.expression("HOUR(INTERVAL '34:56.12345678' MINUTE TO SECOND)")).matches("BIGINT '0'");
     }
 
     @Test
@@ -172,11 +152,6 @@ public class TestExtract
         assertThat(assertions.expression("EXTRACT(MINUTE FROM INTERVAL '34:56.1' MINUTE TO SECOND)")).matches("BIGINT '34'");
         assertThat(assertions.expression("EXTRACT(MINUTE FROM INTERVAL '34:56.12' MINUTE TO SECOND)")).matches("BIGINT '34'");
         assertThat(assertions.expression("EXTRACT(MINUTE FROM INTERVAL '34:56.123' MINUTE TO SECOND)")).matches("BIGINT '34'");
-        assertThat(assertions.expression("EXTRACT(MINUTE FROM INTERVAL '34:56.1234' MINUTE TO SECOND)")).matches("BIGINT '34'");
-        assertThat(assertions.expression("EXTRACT(MINUTE FROM INTERVAL '34:56.12345' MINUTE TO SECOND)")).matches("BIGINT '34'");
-        assertThat(assertions.expression("EXTRACT(MINUTE FROM INTERVAL '34:56.123456' MINUTE TO SECOND)")).matches("BIGINT '34'");
-        assertThat(assertions.expression("EXTRACT(MINUTE FROM INTERVAL '34:56.1234567' MINUTE TO SECOND)")).matches("BIGINT '34'");
-        assertThat(assertions.expression("EXTRACT(MINUTE FROM INTERVAL '34:56.12345678' MINUTE TO SECOND)")).matches("BIGINT '34'");
 
         assertThat(assertions.expression("MINUTE(INTERVAL '1' DAY)")).matches("BIGINT '0'");
         assertThat(assertions.expression("MINUTE(INTERVAL '6' HOUR)")).matches("BIGINT '0'");
@@ -193,11 +168,6 @@ public class TestExtract
         assertThat(assertions.expression("MINUTE(INTERVAL '34:56.1' MINUTE TO SECOND)")).matches("BIGINT '34'");
         assertThat(assertions.expression("MINUTE(INTERVAL '34:56.12' MINUTE TO SECOND)")).matches("BIGINT '34'");
         assertThat(assertions.expression("MINUTE(INTERVAL '34:56.123' MINUTE TO SECOND)")).matches("BIGINT '34'");
-        assertThat(assertions.expression("MINUTE(INTERVAL '34:56.1234' MINUTE TO SECOND)")).matches("BIGINT '34'");
-        assertThat(assertions.expression("MINUTE(INTERVAL '34:56.12345' MINUTE TO SECOND)")).matches("BIGINT '34'");
-        assertThat(assertions.expression("MINUTE(INTERVAL '34:56.123456' MINUTE TO SECOND)")).matches("BIGINT '34'");
-        assertThat(assertions.expression("MINUTE(INTERVAL '34:56.1234567' MINUTE TO SECOND)")).matches("BIGINT '34'");
-        assertThat(assertions.expression("MINUTE(INTERVAL '34:56.12345678' MINUTE TO SECOND)")).matches("BIGINT '34'");
     }
 
     @Test
@@ -220,11 +190,6 @@ public class TestExtract
         assertThat(assertions.expression("EXTRACT(SECOND FROM INTERVAL '34:56.1' MINUTE TO SECOND)")).matches("BIGINT '56'");
         assertThat(assertions.expression("EXTRACT(SECOND FROM INTERVAL '34:56.12' MINUTE TO SECOND)")).matches("BIGINT '56'");
         assertThat(assertions.expression("EXTRACT(SECOND FROM INTERVAL '34:56.123' MINUTE TO SECOND)")).matches("BIGINT '56'");
-        assertThat(assertions.expression("EXTRACT(SECOND FROM INTERVAL '34:56.1234' MINUTE TO SECOND)")).matches("BIGINT '56'");
-        assertThat(assertions.expression("EXTRACT(SECOND FROM INTERVAL '34:56.12345' MINUTE TO SECOND)")).matches("BIGINT '56'");
-        assertThat(assertions.expression("EXTRACT(SECOND FROM INTERVAL '34:56.123456' MINUTE TO SECOND)")).matches("BIGINT '56'");
-        assertThat(assertions.expression("EXTRACT(SECOND FROM INTERVAL '34:56.1234567' MINUTE TO SECOND)")).matches("BIGINT '56'");
-        assertThat(assertions.expression("EXTRACT(SECOND FROM INTERVAL '34:56.12345678' MINUTE TO SECOND)")).matches("BIGINT '56'");
 
         assertThat(assertions.expression("SECOND(INTERVAL '1' DAY)")).matches("BIGINT '0'");
         assertThat(assertions.expression("SECOND(INTERVAL '6' HOUR)")).matches("BIGINT '0'");
@@ -243,10 +208,5 @@ public class TestExtract
         assertThat(assertions.expression("SECOND(INTERVAL '34:56.1' MINUTE TO SECOND)")).matches("BIGINT '56'");
         assertThat(assertions.expression("SECOND(INTERVAL '34:56.12' MINUTE TO SECOND)")).matches("BIGINT '56'");
         assertThat(assertions.expression("SECOND(INTERVAL '34:56.123' MINUTE TO SECOND)")).matches("BIGINT '56'");
-        assertThat(assertions.expression("SECOND(INTERVAL '34:56.1234' MINUTE TO SECOND)")).matches("BIGINT '56'");
-        assertThat(assertions.expression("SECOND(INTERVAL '34:56.12345' MINUTE TO SECOND)")).matches("BIGINT '56'");
-        assertThat(assertions.expression("SECOND(INTERVAL '34:56.123456' MINUTE TO SECOND)")).matches("BIGINT '56'");
-        assertThat(assertions.expression("SECOND(INTERVAL '34:56.1234567' MINUTE TO SECOND)")).matches("BIGINT '56'");
-        assertThat(assertions.expression("SECOND(INTERVAL '34:56.12345678' MINUTE TO SECOND)")).matches("BIGINT '56'");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/interval/TestIntervalDayTime.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/interval/TestIntervalDayTime.java
@@ -138,6 +138,14 @@ public class TestIntervalDayTime
         assertThat(assertions.expression("INTERVAL '32' SECOND"))
                 .isEqualTo(interval(0, 0, 0, 32, 0));
 
+        // Fractional seconds beyond millisecond precision must fail (see #6754)
+        assertThatThrownBy(assertions.expression("INTERVAL '.0001' SECOND")::evaluate)
+                .hasMessage("line 1:12: Invalid INTERVAL SECOND value: .0001");
+        assertThatThrownBy(assertions.expression("INTERVAL '1.1234' SECOND")::evaluate)
+                .hasMessage("line 1:12: Invalid INTERVAL SECOND value: 1.1234");
+        assertThatThrownBy(assertions.expression("INTERVAL '5 9:23:56.1234' DAY TO SECOND")::evaluate)
+                .hasMessage("line 1:12: Invalid INTERVAL DAY TO SECOND value: 5 9:23:56.1234");
+
         // Invalid literals
         assertThatThrownBy(assertions.expression("INTERVAL '12X' DAY")::evaluate)
                 .hasMessage("line 1:12: Invalid INTERVAL DAY value: 12X");

--- a/core/trino-main/src/test/java/io/trino/util/TestDateTimeUtils.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestDateTimeUtils.java
@@ -13,17 +13,68 @@
  */
 package io.trino.util;
 
+import io.trino.spi.TrinoException;
+import io.trino.sql.tree.IntervalField;
 import org.junit.jupiter.api.Test;
 
 import java.time.DateTimeException;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.concurrent.Callable;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.util.DateTimeUtils.parseDayTimeInterval;
 import static io.trino.util.DateTimeUtils.parseIfIso8601DateFormat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestDateTimeUtils
 {
+    private static final IntervalField DAY = new IntervalField.Day();
+    private static final IntervalField HOUR = new IntervalField.Hour();
+    private static final IntervalField MINUTE = new IntervalField.Minute();
+    private static final IntervalField SECOND = new IntervalField.Second(OptionalInt.empty());
+
+    @Test
+    public void testParseDayTimeIntervalRejectsExcessFractionalPrecision()
+    {
+        // Millisecond precision is accepted.
+        assertThat(parseDayTimeInterval("1.123", SECOND, Optional.empty()))
+                .isEqualTo(millisIn(0, 0, 0, 1, 123));
+        assertThat(parseDayTimeInterval(".123", SECOND, Optional.empty()))
+                .isEqualTo(millisIn(0, 0, 0, 0, 123));
+        assertThat(parseDayTimeInterval("5:10:1.123", HOUR, Optional.of(SECOND)))
+                .isEqualTo(millisIn(0, 5, 10, 1, 123));
+        assertThat(parseDayTimeInterval("2 5:10:1.123", DAY, Optional.of(SECOND)))
+                .isEqualTo(millisIn(2, 5, 10, 1, 123));
+
+        // More than 3 fractional digits must fail rather than silently truncate.
+        // See https://github.com/trinodb/trino/issues/6754
+        assertThrowsInvalidInterval(() -> parseDayTimeInterval(".0001", SECOND, Optional.empty()));
+        assertThrowsInvalidInterval(() -> parseDayTimeInterval("1.1234", SECOND, Optional.empty()));
+        assertThrowsInvalidInterval(() -> parseDayTimeInterval("1,1234", SECOND, Optional.empty()));
+        assertThrowsInvalidInterval(() -> parseDayTimeInterval("-1.1234", SECOND, Optional.empty()));
+        assertThrowsInvalidInterval(() -> parseDayTimeInterval("10:1.1234", MINUTE, Optional.of(SECOND)));
+        assertThrowsInvalidInterval(() -> parseDayTimeInterval("5:10:1.1234", HOUR, Optional.of(SECOND)));
+        assertThrowsInvalidInterval(() -> parseDayTimeInterval("2 5:10:1.1234", DAY, Optional.of(SECOND)));
+    }
+
+    private static long millisIn(long days, long hours, long minutes, long seconds, long millis)
+    {
+        return 86_400_000L * days
+                + 3_600_000L * hours
+                + 60_000L * minutes
+                + 1_000L * seconds
+                + millis;
+    }
+
+    private static void assertThrowsInvalidInterval(Callable<Long> callable)
+    {
+        assertThatThrownBy(callable::call)
+                .isInstanceOf(TrinoException.class)
+                .hasMessageStartingWith("Invalid INTERVAL");
+    }
+
     @Test
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     public void testParseIfIso8601DateFormat()

--- a/plugin/trino-functions-python/src/test/java/io/trino/plugin/functions/python/TestPythonFunctions.java
+++ b/plugin/trino-functions-python/src/test/java/io/trino/plugin/functions/python/TestPythonFunctions.java
@@ -2031,7 +2031,7 @@ public class TestPythonFunctions
                     cast('2024-05-06 11:42:54.123 America/Los_Angeles' AS timestamp(3) with time zone),
                     cast('2024-05-06 11:42:54.123456888 America/Los_Angeles' AS timestamp(9) with time zone),
                     interval '5-7' year to month,
-                    interval '5 9:23:56.123888' day to second,
+                    interval '5 9:23:56.123' day to second,
                     json '{"foo": 123, "bar": 456}',
                     uuid '6b5f5b65-67e4-43b0-8ee3-586cd49f58a1',
                     ipaddress '12.34.56.78'))


### PR DESCRIPTION
## Description

Day-time `INTERVAL` values are stored at millisecond precision. Literals with more than 3 fractional-second digits (for example `INTERVAL '.0001' SECOND`) were previously accepted and silently truncated, producing incorrect results.

This change rejects those literals in `parsePeriodMillis` before parsing, so callers get an `Invalid INTERVAL ...` error instead of truncated data. Valid millisecond-precision values (`.123`, `1.123`, etc.) continue to work, including comma decimal separators.

Existing tests that relied on truncation of excess fractional digits were updated to stay within millisecond precision, and SQL-level rejection coverage was added.

## Additional context and related issues

* Fixes #6754
* Matches @martint's guidance to fail when precision exceeds milliseconds
* Builds on the approach discussed on closed PR #13426 (stale / closed without merge)

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fail day-time `INTERVAL` literals with more than millisecond fractional precision instead of truncating. ({issue}`6754`)
```