### PR TITLE
Enable Iceberg BigLake metastore register table tests

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
@@ -246,57 +246,6 @@ final class TestIcebergBigLakeMetastoreConnectorSmokeTest
                 .hasStackTraceContaining("Malformed request: The table `location` property can only point to the default path:");
     }
 
-    // TODO: https://github.com/trinodb/trino/issues/30440
-    // Enable the register table tests below once BigLake metastore accepts registering metadata under the suffixed table locations it assigns at creation
-    @Test
-    @Override
-    public void testRegisterTableWithTableLocation()
-    {
-        abort("skipped");
-    }
-
-    @Test
-    @Override
-    public void testRegisterTableWithComments()
-    {
-        abort("skipped");
-    }
-
-    @Test
-    @Override
-    public void testRegisterTableWithShowCreateTable()
-    {
-        abort("skipped");
-    }
-
-    @Test
-    @Override
-    public void testRegisterTableWithReInsert()
-    {
-        abort("skipped");
-    }
-
-    @Test
-    @Override
-    public void testRegisterTableWithMetadataFile()
-    {
-        abort("skipped");
-    }
-
-    @Test
-    @Override
-    public void testUnregisterTable()
-    {
-        abort("skipped");
-    }
-
-    @Test
-    @Override
-    public void testRepeatUnregisterTable()
-    {
-        abort("skipped");
-    }
-
     @Test
     @Override // BigLake metastore requires table location to start with the prefix with the table name
     public void testRegisterTableWithDifferentTableName()


### PR DESCRIPTION
BigLake Metastore now supports registering tables created under server-assigned suffixed locations ({namespace_path}/{table_name}/{random_suffix}).

Fixes #30440

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Re-enable the Iceberg register table tests in `TestIcebergBigLakeMetastoreConnectorSmokeTest`. BigLake Metastore now supports registering tables created under server-assigned suffixed locations.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes #30440


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
