### PR TITLE
Fix REST catalog test servlet ETag handling

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/VendedCredentialsRestCatalogServlet.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/VendedCredentialsRestCatalogServlet.java
@@ -16,8 +16,8 @@ package io.trino.plugin.iceberg.catalog.rest;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.hc.core5.http.ContentType;
+import org.apache.iceberg.rest.QuotedETagRestCatalogServlet;
 import org.apache.iceberg.rest.RESTCatalogAdapter;
-import org.apache.iceberg.rest.RESTCatalogServlet;
 import org.apache.iceberg.rest.credentials.ImmutableCredential;
 import org.apache.iceberg.rest.responses.ImmutableLoadCredentialsResponse;
 import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
@@ -28,10 +28,10 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Extends {@link RESTCatalogServlet} to handle the {@code GET .../credentials} custom endpoint.
+ * Extends {@link QuotedETagRestCatalogServlet} to handle the {@code GET .../credentials} custom endpoint.
  */
 public abstract class VendedCredentialsRestCatalogServlet
-        extends RESTCatalogServlet
+        extends QuotedETagRestCatalogServlet
 {
     private final AtomicInteger vendedCredentialsRefreshCount = new AtomicInteger();
 

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/DelegatingRestSessionCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/DelegatingRestSessionCatalog.java
@@ -70,7 +70,7 @@ public class DelegatingRestSessionCatalog
                 .setHttpAcceptorThreads(4)
                 .setAcceptQueueSize(10);
         HttpServerInfo httpServerInfo = new HttpServerInfo(config, Optional.of(httpConfig), Optional.empty(), nodeInfo);
-        RESTCatalogServlet servlet = new RESTCatalogServlet(adapter);
+        RESTCatalogServlet servlet = new QuotedETagRestCatalogServlet(adapter);
 
         return new TestingHttpServer(
                 "rest-catalog",

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/QuotedETagRestCatalogServlet.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/QuotedETagRestCatalogServlet.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iceberg.rest;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+import org.apache.hc.core5.http.HttpHeaders;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Enumeration;
+
+// TODO: remove once https://github.com/apache/iceberg/pull/17598 is included in the Iceberg dependency
+public class QuotedETagRestCatalogServlet
+        extends RESTCatalogServlet
+{
+    public QuotedETagRestCatalogServlet(RESTCatalogAdapter restCatalogAdapter)
+    {
+        super(restCatalogAdapter);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws IOException
+    {
+        super.doGet(withNormalizedIfNoneMatch(request), withQuotedETag(response));
+    }
+
+    @Override
+    protected void doHead(HttpServletRequest request, HttpServletResponse response)
+            throws IOException
+    {
+        super.doHead(withNormalizedIfNoneMatch(request), withQuotedETag(response));
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws IOException
+    {
+        super.doPost(withNormalizedIfNoneMatch(request), withQuotedETag(response));
+    }
+
+    @Override
+    protected void doDelete(HttpServletRequest request, HttpServletResponse response)
+            throws IOException
+    {
+        super.doDelete(withNormalizedIfNoneMatch(request), withQuotedETag(response));
+    }
+
+    @Override
+    protected void execute(ServletRequestContext context, HttpServletResponse response)
+            throws IOException
+    {
+        super.execute(context, withQuotedETag(response));
+    }
+
+    private static HttpServletRequest withNormalizedIfNoneMatch(HttpServletRequest request)
+    {
+        return new HttpServletRequestWrapper(request)
+        {
+            @Override
+            public String getHeader(String name)
+            {
+                return normalizeIfNoneMatch(name, super.getHeader(name));
+            }
+
+            @Override
+            public Enumeration<String> getHeaders(String name)
+            {
+                return Collections.enumeration(Collections.list(super.getHeaders(name)).stream()
+                        .map(value -> normalizeIfNoneMatch(name, value))
+                        .toList());
+            }
+        };
+    }
+
+    private static HttpServletResponse withQuotedETag(HttpServletResponse response)
+    {
+        return new HttpServletResponseWrapper(response)
+        {
+            @Override
+            public void setHeader(String name, String value)
+            {
+                super.setHeader(name, quoteETag(name, value));
+            }
+
+            @Override
+            public void addHeader(String name, String value)
+            {
+                super.addHeader(name, quoteETag(name, value));
+            }
+        };
+    }
+
+    private static String quoteETag(String name, String value)
+    {
+        if (!HttpHeaders.ETAG.equalsIgnoreCase(name) || value == null || isQuotedETag(value)) {
+            return value;
+        }
+        return "\"" + value + "\"";
+    }
+
+    private static String normalizeIfNoneMatch(String name, String value)
+    {
+        if (!HttpHeaders.IF_NONE_MATCH.equalsIgnoreCase(name) || value == null || value.contains(",") || !isQuotedETag(value)) {
+            return value;
+        }
+        if (value.startsWith("W/\"")) {
+            return value.substring(3, value.length() - 1);
+        }
+        return value.substring(1, value.length() - 1);
+    }
+
+    private static boolean isQuotedETag(String value)
+    {
+        return (value.startsWith("\"") && value.endsWith("\"")) ||
+                (value.startsWith("W/\"") && value.endsWith("\""));
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/TestDelegatingRestSessionCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/TestDelegatingRestSessionCatalog.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StringResponseHandler;
+import io.airlift.http.client.jetty.JettyHttpClient;
+import io.airlift.http.server.HttpConfig;
+import io.airlift.http.server.HttpServer;
+import io.airlift.http.server.HttpServerConfig;
+import io.airlift.http.server.HttpServerInfo;
+import io.airlift.http.server.ServerFeature;
+import io.airlift.http.server.testing.TestingHttpServer;
+import io.airlift.node.NodeInfo;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static io.airlift.http.client.HeaderNames.ACCEPT_ENCODING;
+import static io.airlift.http.client.HeaderNames.ETAG;
+import static io.airlift.http.client.HeaderNames.IF_NONE_MATCH;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static io.trino.plugin.iceberg.catalog.rest.RestCatalogTestUtils.backendCatalog;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_MODIFIED;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+final class TestDelegatingRestSessionCatalog
+{
+    @Test
+    void testETagConditionalRequests(@TempDir Path tempDir)
+            throws Exception
+    {
+        try (HttpClient client = new JettyHttpClient();
+                JdbcCatalog backendCatalog = (JdbcCatalog) backendCatalog(tempDir);
+                DelegatingRestSessionCatalog restCatalog = DelegatingRestSessionCatalog.builder()
+                        .delegate(backendCatalog)
+                        .build()) {
+            TableIdentifier table = createTable(backendCatalog);
+            TestingHttpServer server = restCatalog.testServer();
+            try {
+                server.start();
+
+                URI tableUri = tableUri(server, table);
+                StringResponseHandler.StringResponse firstResponse = client.execute(prepareGet(tableUri).build(), createStringResponseHandler());
+                assertThat(firstResponse.getStatusCode()).isEqualTo(SC_OK);
+
+                StringResponseHandler.StringResponse secondResponse = client.execute(prepareGet(tableUri)
+                        .setHeader(IF_NONE_MATCH, firstResponse.getHeader(ETAG).orElseThrow())
+                        .build(), createStringResponseHandler());
+                assertThat(secondResponse.getStatusCode()).isEqualTo(SC_NOT_MODIFIED);
+            }
+            finally {
+                server.stop();
+            }
+        }
+    }
+
+    @Test
+    void testIcebergRestCatalogServletStillRequiresQuotedETagWorkaround(@TempDir Path tempDir)
+            throws Exception
+    {
+        try (HttpClient client = new JettyHttpClient();
+                JdbcCatalog backendCatalog = (JdbcCatalog) backendCatalog(tempDir)) {
+            TableIdentifier table = createTable(backendCatalog);
+            TestingHttpServer server = testServer(new RESTCatalogServlet(new RESTCatalogAdapter(backendCatalog)));
+            try {
+                server.start();
+
+                URI tableUri = tableUri(server, table);
+                StringResponseHandler.StringResponse firstResponse = client.execute(prepareGet(tableUri).build(), createStringResponseHandler());
+                assertThat(firstResponse.getStatusCode()).isEqualTo(SC_OK);
+
+                StringResponseHandler.StringResponse secondResponse = client.execute(prepareGet(tableUri)
+                        .setHeader(IF_NONE_MATCH, firstResponse.getHeader(ETAG).orElseThrow())
+                        .build(), createStringResponseHandler());
+                if (secondResponse.getStatusCode() == SC_NOT_MODIFIED) {
+                    fail("Iceberg likely fixed the bug from https://github.com/apache/iceberg/pull/17598. " +
+                            "In that case, remove this test and org.apache.iceberg.rest.QuotedETagRestCatalogServlet, " +
+                            "and replace its usages with org.apache.iceberg.rest.RESTCatalogServlet.");
+                }
+                assertThat(secondResponse.getStatusCode()).isEqualTo(SC_OK);
+            }
+            finally {
+                server.stop();
+            }
+        }
+    }
+
+    // Copy of org.apache.iceberg.rest.DelegatingRestSessionCatalog.testServer with support for a custom servlet.
+    private TestingHttpServer testServer(RESTCatalogServlet servlet)
+            throws IOException
+    {
+        NodeInfo nodeInfo = new NodeInfo("test");
+        HttpServerConfig config = new HttpServerConfig()
+                .setMinThreads(4)
+                .setMaxThreads(8)
+                .setHttpEnabled(true);
+        HttpConfig httpConfig = new HttpConfig()
+                .setHttpPort(0)
+                .setHttpAcceptorThreads(4)
+                .setAcceptQueueSize(10);
+        HttpServerInfo httpServerInfo = new HttpServerInfo(config, Optional.of(httpConfig), Optional.empty(), nodeInfo);
+
+        return new TestingHttpServer(
+                "rest-catalog",
+                httpServerInfo,
+                nodeInfo,
+                config,
+                Optional.of(httpConfig),
+                Optional.empty(),
+                servlet,
+                ImmutableSet.of(),
+                ImmutableSet.of(),
+                ServerFeature.builder()
+                        // Required due to URIs like: HEAD /v1/namespaces/level_1%1Flevel_2
+                        .withLegacyUriCompliance(true)
+                        .build(),
+                HttpServer.ClientCertificate.NONE);
+    }
+
+    private static TableIdentifier createTable(JdbcCatalog backendCatalog)
+    {
+        Namespace namespace = Namespace.of("test_quoted_etag_" + randomNameSuffix());
+        TableIdentifier table = TableIdentifier.of(namespace, "test_table");
+        backendCatalog.createNamespace(namespace);
+        backendCatalog.createTable(
+                table,
+                new Schema(required(1, "id", Types.LongType.get())),
+                PartitionSpec.unpartitioned(),
+                ImmutableMap.of("padding", "x".repeat(4096)));
+        return table;
+    }
+
+    private static Request.Builder prepareGet(URI tableUri)
+    {
+        return Request.Builder.prepareGet()
+                .setUri(tableUri)
+                .setHeader(ACCEPT_ENCODING, "gzip");
+    }
+
+    private static URI tableUri(TestingHttpServer server, TableIdentifier table)
+    {
+        return server.getBaseUrl().resolve("/" + ResourcePaths.forCatalogProperties(ImmutableMap.of()).table(table));
+    }
+}


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Temporarily apply the ETag behavior from:

* apache/iceberg#17598

to Trino’s in-process Iceberg REST catalog test servlet until the Iceberg dependency includes the upstream fix.

Without this, the REST catalog table cache is not properly tested. Although it was disabled in:

* https://github.com/trinodb/trino/pull/30624

we should still exercise it.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
