### PR TITLE
Report missing Iceberg metadata and manifest files as not-found

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergExceptions.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergExceptions.java
@@ -28,7 +28,7 @@ public final class IcebergExceptions
 {
     private IcebergExceptions() {}
 
-    private static boolean isNotFoundException(Throwable failure)
+    public static boolean isNotFoundException(Throwable failure)
     {
         return getCausalChain(failure).stream().anyMatch(e ->
                 e instanceof NotFoundException || e instanceof FileNotFoundException);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
@@ -57,6 +57,8 @@ import static io.trino.hive.formats.HiveClassNames.FILE_INPUT_FORMAT_CLASS;
 import static io.trino.hive.formats.HiveClassNames.FILE_OUTPUT_FORMAT_CLASS;
 import static io.trino.hive.formats.HiveClassNames.LAZY_SIMPLE_SERDE_CLASS;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_MISSING_METADATA;
+import static io.trino.plugin.iceberg.IcebergExceptions.isNotFoundException;
 import static io.trino.plugin.iceberg.IcebergExceptions.translateMetadataException;
 import static io.trino.plugin.iceberg.IcebergTableName.isMaterializedViewStorage;
 import static io.trino.plugin.iceberg.IcebergUtil.METADATA_FOLDER_NAME;
@@ -305,6 +307,9 @@ public abstract class AbstractIcebergTableOperations
                     .get(() -> metadataLoader.apply(newLocation));
         }
         catch (UncheckedIOException e) {
+            if (isNotFoundException(e)) {
+                throw new TrinoException(ICEBERG_MISSING_METADATA, "Metadata not found in metadata location for table " + getSchemaTableName().toString(), e);
+            }
             throw new TrinoException(ICEBERG_INVALID_METADATA, "Error accessing metadata file for table %s".formatted(getSchemaTableName().toString()), e);
         }
         catch (Throwable failure) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RemoveOrphanFiles.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RemoveOrphanFiles.java
@@ -45,6 +45,7 @@ import java.util.concurrent.Future;
 
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
+import static io.trino.plugin.iceberg.IcebergExceptions.isNotFoundException;
 import static io.trino.plugin.iceberg.IcebergUtil.fileName;
 import static io.trino.plugin.iceberg.IcebergUtil.loadAllManifestsFromManifestList;
 import static io.trino.plugin.iceberg.IcebergUtil.loadAllManifestsFromSnapshot;
@@ -99,11 +100,13 @@ public final class RemoveOrphanFiles
                             validFileNames.add(fileName(contentFile.location()));
                         }
                     }
-                    catch (IOException | UncheckedIOException e) {
+                    catch (IOException | UncheckedIOException | NotFoundException e) {
+                        // A missing manifest surfaces as NotFoundException on some file systems and as an
+                        // UncheckedIOException wrapping FileNotFoundException on others (e.g. S3)
+                        if (isNotFoundException(e)) {
+                            throw new TrinoException(ICEBERG_INVALID_METADATA, "Manifest file does not exist: " + manifest.path(), e);
+                        }
                         throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, "Unable to list manifest file content from " + manifest.path(), e);
-                    }
-                    catch (NotFoundException e) {
-                        throw new TrinoException(ICEBERG_INVALID_METADATA, "Manifest file does not exist: " + manifest.path());
                     }
                 }));
             }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestAbstractIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestAbstractIcebergTableOperations.java
@@ -15,22 +15,29 @@ package io.trino.plugin.iceberg.catalog.file;
 
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
 import io.trino.filesystem.local.LocalFileSystemFactory;
 import io.trino.metastore.HiveMetastore;
 import io.trino.plugin.iceberg.fileio.ForwardingFileIo;
+import io.trino.plugin.iceberg.fileio.ForwardingInputFile;
 import org.apache.iceberg.io.InputFile;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Optional;
 
 import static io.trino.metastore.cache.CachingHiveMetastore.createPerTransactionCache;
 import static io.trino.plugin.hive.metastore.file.TestingFileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_MISSING_METADATA;
 import static io.trino.plugin.iceberg.IcebergTestUtils.ENCRYPTION_MANAGER_FACTORY;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
@@ -74,5 +81,113 @@ public class TestAbstractIcebergTableOperations
         };
 
         assertTrinoExceptionThrownBy(fileMetastoreTableOperations::refresh).hasErrorCode(ICEBERG_INVALID_METADATA);
+    }
+
+    @Test
+    public void testMissingMetadataFileReporting()
+            throws IOException
+    {
+        Path tempDir = Files.createTempDirectory("test_missing_metadata_file_reporting");
+        File metastoreDir = tempDir.resolve("iceberg_data").toFile();
+        metastoreDir.mkdirs();
+        TrinoFileSystemFactory fileSystemFactory = new LocalFileSystemFactory(metastoreDir.toPath());
+        HiveMetastore metastore = createTestingFileHiveMetastore(fileSystemFactory, Location.of("local:///"));
+
+        FileMetastoreTableOperations fileMetastoreTableOperations = new FileMetastoreTableOperations(
+                new ForwardingFileIo(fileSystemFactory.create(SESSION), true)
+                {
+                    @Override
+                    public InputFile newInputFile(String path)
+                    {
+                        // Reproduce the S3 shape : opening the stream
+                        // succeeds and the missing object only surfaces on read, so the real
+                        // TableMetadataParser is what wraps FileNotFoundException into
+                        // RuntimeIOException (an UncheckedIOException).
+                        return new ForwardingInputFile(lazyMissingFile(path));
+                    }
+                },
+                createPerTransactionCache(metastore, 1000),
+                SESSION,
+                "test-database",
+                "test-table",
+                Optional.of("test-owner"),
+                Optional.empty(),
+                ENCRYPTION_MANAGER_FACTORY)
+        {
+            @Override
+            protected String getRefreshedLocation(boolean invalidateCaches)
+            {
+                return "local:///0.metadata.json";
+            }
+        };
+
+        assertTrinoExceptionThrownBy(fileMetastoreTableOperations::refresh)
+                .hasErrorCode(ICEBERG_MISSING_METADATA)
+                .hasMessageContaining("Metadata not found in metadata location for table");
+    }
+
+    /**
+     * An input file that behaves like {@code S3InputFile} for a missing object: opening a stream
+     * succeeds, and the absence is only reported once the stream is read.
+     */
+    private static TrinoInputFile lazyMissingFile(String path)
+    {
+        return new TrinoInputFile()
+        {
+            @Override
+            public TrinoInputStream newStream()
+            {
+                return new TrinoInputStream()
+                {
+                    @Override
+                    public int read()
+                            throws IOException
+                    {
+                        throw new FileNotFoundException(path);
+                    }
+
+                    @Override
+                    public long getPosition()
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public void seek(long position) {}
+                };
+            }
+
+            @Override
+            public TrinoInput newInput()
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long length()
+                    throws IOException
+            {
+                throw new FileNotFoundException(path);
+            }
+
+            @Override
+            public Instant lastModified()
+                    throws IOException
+            {
+                throw new FileNotFoundException(path);
+            }
+
+            @Override
+            public boolean exists()
+            {
+                return false;
+            }
+
+            @Override
+            public Location location()
+            {
+                return Location.of(path);
+            }
+        };
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

 In `AbstractIcebergTableOperations.refreshFromMetadataLocation`, the two catch blocks: the fallthrough delegates to `translateMetadataException`, which reports a missing file as `ICEBERG_MISSING_METADATA`, but a narrower `UncheckedIOException` block above it shadows that and reports "Error accessing metadata file" instead. when reading meatdata for the table, If `newStream()` fails eagerly, `ForwardingInputFile` maps `FileNotFoundException` to Iceberg's `NotFoundException`. If the stream opens lazily and the absence surfaces on a later read, it arrives as an `UncheckedIOException` instead.
We should recognize the not found exception from generic "UncheckedIOException" - and the miss match error case currently only happens on S3 since not found exception only throws in `S3InputStream` when start reading manifest file(lazy read).

`RemoveOrphanFiles` has the same asymmetry — a missing manifest arriving wrapped is reported as "Unable to list manifest file content" rather than "Manifest file does not exist".


We encountered the issue internally: 
```
xxx.testCorruptedTableLocation -- Time elapsed: 0.966 s <<< FAILURE!
java.lang.AssertionError:

Expecting message:
  "Error accessing metadata file for table tpch.test_corrupted_table_location_r67ko7ulus"
to match regex:
  "Metadata not found in metadata location for table tpch.test_corrupted_table_location_r67ko7ulus"
but did not.

Throwable that failed the check:

io.trino.testing.QueryFailedException: Error accessing metadata file for table tpch.test_corrupted_table_location_r67ko7ulus
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:672)
	at io.trino.testing.DistributedQueryRunner.executeWithQueryId(DistributedQueryRunner.java:661)
	at io.trino.testing.QueryAssertions.assertQueryFails(QueryAssertions.java:470)
	at io.trino.testing.AbstractTestQueryFramework.assertQueryFails(AbstractTestQueryFramework.java:459)
	at io.trino.plugin.iceberg.BaseIcebergConnectorTest.testCorruptedTableLocation(BaseIcebergConnectorTest.java:9035)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:700)
```


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
