### PR TITLE
Throw correctly div by 0 from divide_round_to_scale

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DivideRoundToScale.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DivideRoundToScale.java
@@ -22,6 +22,7 @@ import io.trino.spi.type.Int128;
 import io.trino.spi.type.Int128Math;
 import io.trino.spi.type.StandardTypes;
 
+import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.Decimals.overflows;
@@ -50,6 +51,9 @@ public final class DivideRoundToScale
     {
         if (divisor < 0) {
             throw new TrinoException(NOT_SUPPORTED, "Negative divisor is not supported");
+        }
+        if (divisor == 0) {
+            throw new TrinoException(DIVISION_BY_ZERO, "Division by zero");
         }
         Int128 result = Int128Math.divideRoundUp(dividend.getHigh(), dividend.getLow(), 0, 0, divisor, 0);
         if (overflows(result)) {

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestDecimalAvgFromSumAndCount.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestDecimalAvgFromSumAndCount.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
+import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
@@ -185,6 +186,16 @@ final class TestDecimalAvgFromSumAndCount
                 .failure()
                 .hasErrorCode(NOT_SUPPORTED)
                 .hasMessage("Negative divisor is not supported");
+    }
+
+    @Test
+    void testZeroDivisor()
+    {
+        assertThat(assertions.query(
+                "SELECT \"$divide_round_to_scale\"(CAST(12345.00 AS decimal(38, 2)), BIGINT '0')"))
+                .failure()
+                .hasErrorCode(DIVISION_BY_ZERO)
+                .hasMessage("Division by zero");
     }
 
     @Test


### PR DESCRIPTION
Without an explicit guard a zero divisor falls through to Int128Math.divideRoundUp, which throws a raw ArithmeticException rather than a categorized TrinoException. Map it to DIVISION_BY_ZERO, matching how the engine reports division by zero elsewhere.
