### PR TITLE
Fix UGI loss after metastore client reconnect on fallback

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
@@ -92,10 +92,10 @@ public class DefaultThriftMetastoreClientFactory
     }
 
     @Override
-    public ThriftMetastoreClient create(URI uri, Optional<String> delegationToken)
+    public ThriftMetastoreClient create(URI uri, Optional<String> delegationToken, ThriftMetastoreClientInitializer clientInitializer)
             throws TTransportException
     {
-        return create(() -> getTransportSupplier(uri, delegationToken), hostname);
+        return create(() -> getTransportSupplier(uri, delegationToken), clientInitializer, hostname);
     }
 
     private TTransport getTransportSupplier(URI uri, Optional<String> delegationToken)
@@ -105,12 +105,13 @@ public class DefaultThriftMetastoreClientFactory
         return createTransport(HostAndPort.fromParts(uri.getHost(), uri.getPort()), delegationToken);
     }
 
-    protected ThriftMetastoreClient create(TransportSupplier transportSupplier, String hostname)
+    protected ThriftMetastoreClient create(TransportSupplier transportSupplier, ThriftMetastoreClientInitializer clientInitializer, String hostname)
             throws TTransportException
     {
         return new ThriftHiveMetastoreClient(
                 transportSupplier,
                 hostname,
+                clientInitializer,
                 catalogName,
                 metastoreSupportsDateStatistics,
                 chosenGetTableAlternative,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticTokenAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticTokenAwareMetastoreClientFactory.java
@@ -87,7 +87,7 @@ public class StaticTokenAwareMetastoreClientFactory
      * connection succeeds or there are no more fallback metastores.
      */
     @Override
-    public ThriftMetastoreClient createMetastoreClient(Optional<String> delegationToken)
+    public ThriftMetastoreClient createMetastoreClient(Optional<String> delegationToken, ThriftMetastoreClientInitializer clientInitializer)
             throws TException
     {
         Comparator<Backoff> comparator = Comparator.comparingLong(Backoff::getBackoffDuration)
@@ -99,7 +99,7 @@ public class StaticTokenAwareMetastoreClientFactory
         TException lastException = null;
         for (Backoff backoff : backoffsSorted) {
             try {
-                return getClient(backoff.getUri(), backoff, delegationToken);
+                return getClient(backoff.getUri(), backoff, delegationToken, clientInitializer);
             }
             catch (TException e) {
                 lastException = e;
@@ -111,10 +111,10 @@ public class StaticTokenAwareMetastoreClientFactory
         throw new TException("Failed connecting to Hive metastore: " + addresses, lastException);
     }
 
-    private ThriftMetastoreClient getClient(URI uri, Backoff backoff, Optional<String> delegationToken)
+    private ThriftMetastoreClient getClient(URI uri, Backoff backoff, Optional<String> delegationToken, ThriftMetastoreClientInitializer clientInitializer)
             throws TException
     {
-        ThriftMetastoreClient client = new FailureAwareThriftMetastoreClient(clientFactory.create(uri, delegationToken), new Callback()
+        ThriftMetastoreClient client = new FailureAwareThriftMetastoreClient(clientFactory.create(uri, delegationToken, clientInitializer), new Callback()
         {
             @Override
             public void success()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -113,6 +113,7 @@ public class ThriftHiveMetastoreClient
     private static final Pattern TABLE_PARAMETER_SAFE_VALUE_PATTERN = Pattern.compile("^[a-zA-Z0-9\\s]*$");
 
     private final TransportSupplier transportSupplier;
+    private final ThriftMetastoreClientInitializer clientInitializer;
     private TTransport transport;
     protected ThriftHiveMetastore.Iface client;
     private final String hostname;
@@ -127,6 +128,7 @@ public class ThriftHiveMetastoreClient
     public ThriftHiveMetastoreClient(
             TransportSupplier transportSupplier,
             String hostname,
+            ThriftMetastoreClientInitializer clientInitializer,
             Optional<String> catalogName,
             MetastoreSupportsDateStatistics metastoreSupportsDateStatistics,
             AtomicInteger chosenGetTableAlternative,
@@ -136,6 +138,7 @@ public class ThriftHiveMetastoreClient
             throws TTransportException
     {
         this.transportSupplier = requireNonNull(transportSupplier, "transportSupplier is null");
+        this.clientInitializer = requireNonNull(clientInitializer, "clientInitializer is null");
         this.hostname = requireNonNull(hostname, "hostname is null");
         this.metastoreSupportsDateStatistics = requireNonNull(metastoreSupportsDateStatistics, "metastoreSupportsDateStatistics is null");
         this.chosenGetTableAlternative = requireNonNull(chosenGetTableAlternative, "chosenGetTableAlternative is null");
@@ -156,6 +159,13 @@ public class ThriftHiveMetastoreClient
             client = newProxy(ThriftHiveMetastore.Iface.class, new LoggingInvocationHandler(client, log::debug));
         }
         this.client = client;
+
+        try {
+            clientInitializer.initialize(this);
+        }
+        catch (TException e) {
+            throw new TTransportException("Failed to initialize metastore client", e);
+        }
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClientInitializer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClientInitializer.java
@@ -13,13 +13,10 @@
  */
 package io.trino.plugin.hive.metastore.thrift;
 
-import org.apache.thrift.transport.TTransportException;
+import org.apache.thrift.TException;
 
-import java.net.URI;
-import java.util.Optional;
-
-public interface ThriftMetastoreClientFactory
+@FunctionalInterface
+public interface ThriftMetastoreClientInitializer
 {
-    ThriftMetastoreClient create(URI uri, Optional<String> delegationToken, ThriftMetastoreClientInitializer clientInitializer)
-            throws TTransportException;
+    void initialize(ThriftMetastoreClient client) throws TException;
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/TokenAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/TokenAwareMetastoreClientFactory.java
@@ -22,6 +22,6 @@ public interface TokenAwareMetastoreClientFactory
     /**
      * Create a connected {@link ThriftMetastoreClient}
      */
-    ThriftMetastoreClient createMetastoreClient(Optional<String> delegationToken)
+    ThriftMetastoreClient createMetastoreClient(Optional<String> delegationToken, ThriftMetastoreClientInitializer clientInitializer)
             throws TException;
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/TokenFetchingMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/TokenFetchingMetastoreClientFactory.java
@@ -71,10 +71,10 @@ public class TokenFetchingMetastoreClientFactory
                 .build();
     }
 
-    private ThriftMetastoreClient createMetastoreClient()
+    private ThriftMetastoreClient createMetastoreClient(Optional<String> delegationToken)
             throws TException
     {
-        return clientProvider.createMetastoreClient(Optional.empty());
+        return clientProvider.createMetastoreClient(delegationToken, _ -> {});
     }
 
     @Override
@@ -82,7 +82,7 @@ public class TokenFetchingMetastoreClientFactory
             throws TException
     {
         if (!impersonationEnabled) {
-            return createMetastoreClient();
+            return createMetastoreClient(Optional.empty());
         }
 
         String username = identity.map(userNameProvider::get)
@@ -90,7 +90,7 @@ public class TokenFetchingMetastoreClientFactory
 
         DelegationToken cachedDelegationToken = getDelegationToken(username);
         try {
-            return clientProvider.createMetastoreClient(Optional.of(cachedDelegationToken.delegationToken()));
+            return createMetastoreClient(Optional.of(cachedDelegationToken.delegationToken()));
         }
         catch (TException e) {
             // Since the cached token may expire due to reasons such as restarting the Hive Metastore, refresh a delegation token and try to connect again.
@@ -98,7 +98,7 @@ public class TokenFetchingMetastoreClientFactory
             if (System.nanoTime() - cachedDelegationToken.writeTimeNanos() >= this.refreshPeriod) {
                 DelegationToken refreshDelegationToken = loadDelegationToken(username);
                 delegationTokenCache.put(username, refreshDelegationToken);
-                return clientProvider.createMetastoreClient(Optional.of(refreshDelegationToken.delegationToken()));
+                return createMetastoreClient(Optional.of(refreshDelegationToken.delegationToken()));
             }
             throw e;
         }
@@ -121,7 +121,7 @@ public class TokenFetchingMetastoreClientFactory
             // added retry and stats for the thrift delegation token
             return (DelegationToken) Failsafe.with(retryPolicy).get((CheckedSupplier<DelegationToken>) () ->
                     stats.getThriftDelegationToken().wrap(() -> {
-                        try (ThriftMetastoreClient client = createMetastoreClient()) {
+                        try (ThriftMetastoreClient client = createMetastoreClient(Optional.empty())) {
                             return new DelegationToken(System.nanoTime(), client.getDelegationToken(username));
                         }
                     }).call());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/UgiBasedMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/UgiBasedMetastoreClientFactory.java
@@ -44,15 +44,14 @@ public class UgiBasedMetastoreClientFactory
     public ThriftMetastoreClient createMetastoreClientFor(Optional<ConnectorIdentity> identity)
             throws TException
     {
-        ThriftMetastoreClient client = clientProvider.createMetastoreClient(Optional.empty());
-
-        if (impersonationEnabled) {
-            String username = identity.map(userNameProvider::get)
-                    .orElseThrow(() -> new IllegalStateException("End-user name should exist when metastore impersonation is enabled"));
-            setMetastoreUserOrClose(client, username);
+        if (!impersonationEnabled) {
+            return clientProvider.createMetastoreClient(Optional.empty(), _ -> {});
         }
 
-        return client;
+        String username = identity.map(userNameProvider::get)
+                .orElseThrow(() -> new IllegalStateException("End-user name should exist when metastore impersonation is enabled"));
+
+        return clientProvider.createMetastoreClient(Optional.empty(), client -> setMetastoreUserOrClose(client, username));
     }
 
     private static void setMetastoreUserOrClose(ThriftMetastoreClient client, String username)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingThriftHiveMetastoreBuilder.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingThriftHiveMetastoreBuilder.java
@@ -83,7 +83,7 @@ public final class TestingThriftHiveMetastoreBuilder
     {
         requireNonNull(client, "client is null");
         checkState(tokenAwareMetastoreClientFactory == null, "Metastore client already set");
-        tokenAwareMetastoreClientFactory = _ -> client;
+        tokenAwareMetastoreClientFactory = (_, _) -> client;
         return this;
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClientFactory.java
@@ -34,7 +34,7 @@ public class MockThriftMetastoreClientFactory
     }
 
     @Override
-    public ThriftMetastoreClient create(URI uri, Optional<String> delegationToken)
+    public ThriftMetastoreClient create(URI uri, Optional<String> delegationToken, ThriftMetastoreClientInitializer clientInitializer)
             throws TTransportException
     {
         checkArgument(delegationToken.isEmpty(), "delegation token is not supported");

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestStaticTokenAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestStaticTokenAwareMetastoreClientFactory.java
@@ -62,7 +62,7 @@ public class TestStaticTokenAwareMetastoreClientFactory
             throws TException
     {
         TokenAwareMetastoreClientFactory clientFactory = createMetastoreClientFactory(CONFIG_WITH_FALLBACK, ImmutableMap.of(DEFAULT_URI, Optional.of(DEFAULT_CLIENT)));
-        assertEqualHiveClient(clientFactory.createMetastoreClient(Optional.empty()), DEFAULT_CLIENT);
+        assertEqualHiveClient(clientFactory.createMetastoreClient(Optional.empty(), _ -> {}), DEFAULT_CLIENT);
     }
 
     @Test
@@ -70,7 +70,7 @@ public class TestStaticTokenAwareMetastoreClientFactory
             throws TException
     {
         TokenAwareMetastoreClientFactory clientFactory = createMetastoreClientFactory(CONFIG_WITH_FALLBACK, ImmutableMap.of(DEFAULT_URI, Optional.empty(), FALLBACK_URI, Optional.of(FALLBACK_CLIENT)));
-        assertEqualHiveClient(clientFactory.createMetastoreClient(Optional.empty()), FALLBACK_CLIENT);
+        assertEqualHiveClient(clientFactory.createMetastoreClient(Optional.empty(), _ -> {}), FALLBACK_CLIENT);
     }
 
     @Test
@@ -92,7 +92,7 @@ public class TestStaticTokenAwareMetastoreClientFactory
             throws TException
     {
         TokenAwareMetastoreClientFactory clientFactory = createMetastoreClientFactory(CONFIG_WITH_FALLBACK_WITH_USER, ImmutableMap.of(DEFAULT_URI, Optional.empty(), FALLBACK_URI, Optional.empty(), FALLBACK2_URI, Optional.of(FALLBACK_CLIENT)));
-        assertEqualHiveClient(clientFactory.createMetastoreClient(Optional.empty()), FALLBACK_CLIENT);
+        assertEqualHiveClient(clientFactory.createMetastoreClient(Optional.empty(), _ -> {}), FALLBACK_CLIENT);
     }
 
     @Test
@@ -108,12 +108,12 @@ public class TestStaticTokenAwareMetastoreClientFactory
     {
         TokenAwareMetastoreClientFactory clientFactory = createMetastoreClientFactory(CONFIG_WITH_FALLBACK, CLIENTS);
 
-        ThriftMetastoreClient metastoreClient1 = clientFactory.createMetastoreClient(Optional.empty());
+        ThriftMetastoreClient metastoreClient1 = clientFactory.createMetastoreClient(Optional.empty(), _ -> {});
         assertEqualHiveClient(metastoreClient1, DEFAULT_CLIENT);
 
         assertGetTableException(metastoreClient1);
 
-        ThriftMetastoreClient metastoreClient2 = clientFactory.createMetastoreClient(Optional.empty());
+        ThriftMetastoreClient metastoreClient2 = clientFactory.createMetastoreClient(Optional.empty(), _ -> {});
         assertEqualHiveClient(metastoreClient2, FALLBACK_CLIENT);
 
         assertGetTableException(metastoreClient2);
@@ -125,20 +125,20 @@ public class TestStaticTokenAwareMetastoreClientFactory
     {
         TokenAwareMetastoreClientFactory clientFactory = createMetastoreClientFactory(CONFIG_WITH_FALLBACK, CLIENTS);
 
-        ThriftMetastoreClient metastoreClient1 = clientFactory.createMetastoreClient(Optional.empty());
+        ThriftMetastoreClient metastoreClient1 = clientFactory.createMetastoreClient(Optional.empty(), _ -> {});
         assertEqualHiveClient(metastoreClient1, DEFAULT_CLIENT);
 
         for (int i = 0; i < 20; ++i) {
             assertGetTableException(metastoreClient1);
         }
 
-        ThriftMetastoreClient metastoreClient2 = clientFactory.createMetastoreClient(Optional.empty());
+        ThriftMetastoreClient metastoreClient2 = clientFactory.createMetastoreClient(Optional.empty(), _ -> {});
         assertEqualHiveClient(metastoreClient2, FALLBACK_CLIENT);
 
         assertGetTableException(metastoreClient2);
 
         // Still get FALLBACK_CLIENT because DEFAULT_CLIENT failed more times before and therefore longer backoff
-        ThriftMetastoreClient metastoreClient3 = clientFactory.createMetastoreClient(Optional.empty());
+        ThriftMetastoreClient metastoreClient3 = clientFactory.createMetastoreClient(Optional.empty(), _ -> {});
         assertEqualHiveClient(metastoreClient3, FALLBACK_CLIENT);
     }
 
@@ -150,17 +150,17 @@ public class TestStaticTokenAwareMetastoreClientFactory
         TokenAwareMetastoreClientFactory clientFactory = createMetastoreClientFactory(CONFIG_WITH_FALLBACK, CLIENTS, ticker);
 
         ticker.increment(10, NANOSECONDS);
-        ThriftMetastoreClient metastoreClient1 = clientFactory.createMetastoreClient(Optional.empty());
+        ThriftMetastoreClient metastoreClient1 = clientFactory.createMetastoreClient(Optional.empty(), _ -> {});
         assertEqualHiveClient(metastoreClient1, DEFAULT_CLIENT);
         assertGetTableException(metastoreClient1);
 
         ticker.increment(10, NANOSECONDS);
-        ThriftMetastoreClient metastoreClient2 = clientFactory.createMetastoreClient(Optional.empty());
+        ThriftMetastoreClient metastoreClient2 = clientFactory.createMetastoreClient(Optional.empty(), _ -> {});
         assertEqualHiveClient(metastoreClient2, FALLBACK_CLIENT);
 
         // even after backoff for DEFAULT_CLIENT passes we should stick to client which we saw working correctly most recently
         ticker.increment(StaticTokenAwareMetastoreClientFactory.Backoff.MAX_BACKOFF, NANOSECONDS);
-        ThriftMetastoreClient metastoreClient3 = clientFactory.createMetastoreClient(Optional.empty());
+        ThriftMetastoreClient metastoreClient3 = clientFactory.createMetastoreClient(Optional.empty(), _ -> {});
         assertEqualHiveClient(metastoreClient3, FALLBACK_CLIENT);
     }
 
@@ -172,17 +172,17 @@ public class TestStaticTokenAwareMetastoreClientFactory
         TokenAwareMetastoreClientFactory clientFactory = createMetastoreClientFactory(CONFIG_WITH_FALLBACK, CLIENTS, ticker);
 
         ticker.increment(10, NANOSECONDS);
-        ThriftMetastoreClient metastoreClient1 = clientFactory.createMetastoreClient(Optional.empty());
+        ThriftMetastoreClient metastoreClient1 = clientFactory.createMetastoreClient(Optional.empty(), _ -> {});
         assertEqualHiveClient(metastoreClient1, DEFAULT_CLIENT);
         assertGetTableException(metastoreClient1);
 
         ticker.increment(10, NANOSECONDS);
-        ThriftMetastoreClient metastoreClient2 = clientFactory.createMetastoreClient(Optional.empty());
+        ThriftMetastoreClient metastoreClient2 = clientFactory.createMetastoreClient(Optional.empty(), _ -> {});
         assertEqualHiveClient(metastoreClient2, FALLBACK_CLIENT);
         assertGetTableException(metastoreClient2);
 
         ticker.increment(10, NANOSECONDS);
-        ThriftMetastoreClient metastoreClient3 = clientFactory.createMetastoreClient(Optional.empty());
+        ThriftMetastoreClient metastoreClient3 = clientFactory.createMetastoreClient(Optional.empty(), _ -> {});
         assertEqualHiveClient(metastoreClient3, DEFAULT_CLIENT);
     }
 
@@ -196,12 +196,12 @@ public class TestStaticTokenAwareMetastoreClientFactory
         StaticTokenAwareMetastoreClientFactory metastoreClientFactory = new StaticTokenAwareMetastoreClientFactory(
                 config, new ThriftMetastoreAuthenticationConfig(), clientFactory, new TestingTicker());
 
-        assertEqualHiveClient(metastoreClientFactory.createMetastoreClient(Optional.empty()), FALLBACK_CLIENT);
+        assertEqualHiveClient(metastoreClientFactory.createMetastoreClient(Optional.empty(), _ -> {}), FALLBACK_CLIENT);
         assertThat(clientFactory.connectionAttempts()).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(
                 URI.create(DEFAULT_URI), 1,
                 URI.create(FALLBACK_URI), 1));
         clientFactory.resetConnectionAttempts();
-        assertEqualHiveClient(metastoreClientFactory.createMetastoreClient(Optional.empty()), FALLBACK_CLIENT);
+        assertEqualHiveClient(metastoreClientFactory.createMetastoreClient(Optional.empty(), _ -> {}), FALLBACK_CLIENT);
         // The previous connection failure on DEFAULT_URI is not attempted first again on the second call
         assertThat(clientFactory.connectionAttempts()).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(
                 URI.create(FALLBACK_URI), 1));
@@ -216,7 +216,7 @@ public class TestStaticTokenAwareMetastoreClientFactory
 
     private static void assertCreateClientFails(TokenAwareMetastoreClientFactory clientFactory, String message)
     {
-        assertThatThrownBy(() -> clientFactory.createMetastoreClient(Optional.empty()))
+        assertThatThrownBy(() -> clientFactory.createMetastoreClient(Optional.empty(), _ -> {}))
                 .hasCauseInstanceOf(TException.class)
                 .hasMessage(message);
     }
@@ -267,11 +267,11 @@ public class TestStaticTokenAwareMetastoreClientFactory
         }
 
         @Override
-        public ThriftMetastoreClient create(URI uri, Optional<String> delegationToken)
+        public ThriftMetastoreClient create(URI uri, Optional<String> delegationToken, ThriftMetastoreClientInitializer clientInitializer)
                 throws TTransportException
         {
             attempts.merge(uri, 1, Integer::sum);
-            return delegate.create(uri, delegationToken);
+            return delegate.create(uri, delegationToken, _ -> {});
         }
 
         public void resetConnectionAttempts()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHiveMetastoreClient.java
@@ -45,6 +45,7 @@ public class TestThriftHiveMetastoreClient
                     return new TTransportMock();
                 },
                 "dummy",
+                _ -> {},
                 Optional.empty(),
                 new MetastoreSupportsDateStatistics(),
                 new AtomicInteger(),
@@ -68,6 +69,46 @@ public class TestThriftHiveMetastoreClient
                 .isEqualTo("first");
         // Alternative call should use chosenOption
         assertThat(connectionCount.get()).isEqualTo(2);
+    }
+
+    @Test
+    public void testInitializerRunsOnReconnect()
+            throws TException
+    {
+        AtomicInteger connectionCount = new AtomicInteger();
+        AtomicInteger initializerCount = new AtomicInteger();
+        ThriftMetastoreClientInitializer initializer = _ -> initializerCount.incrementAndGet();
+
+        ThriftHiveMetastoreClient client = new ThriftHiveMetastoreClient(
+                () -> {
+                    connectionCount.incrementAndGet();
+                    return new TTransportMock();
+                },
+                "dummy",
+                initializer,
+                Optional.empty(),
+                new MetastoreSupportsDateStatistics(),
+                new AtomicInteger(),
+                new AtomicInteger(),
+                new AtomicInteger(),
+                new AtomicInteger());
+
+        // initializer runs once for the initial transport
+        assertThat(connectionCount.get()).isEqualTo(1);
+        assertThat(initializerCount.get()).isEqualTo(1);
+
+        // Force alternativeCall to fall back, which tears down and re-opens the transport
+        AlternativeCall<String> failure = () -> {
+            throw new RuntimeException("force reconnect");
+        };
+        AtomicInteger chosenOption = new AtomicInteger(Integer.MAX_VALUE);
+        assertThat(client.alternativeCall(_ -> false, chosenOption, failure, () -> "ok"))
+                .isEqualTo("ok");
+
+        // A new transport was opened, and the initializer ran again so per-session state
+        // (e.g. setUGI from the factory) is re-applied. This is the bug fix.
+        assertThat(connectionCount.get()).isEqualTo(2);
+        assertThat(initializerCount.get()).isEqualTo(2);
     }
 
     private static class TTransportMock

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingTokenAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingTokenAwareMetastoreClientFactory.java
@@ -52,9 +52,9 @@ public class TestingTokenAwareMetastoreClientFactory
     }
 
     @Override
-    public ThriftMetastoreClient createMetastoreClient(Optional<String> delegationToken)
+    public ThriftMetastoreClient createMetastoreClient(Optional<String> delegationToken, ThriftMetastoreClientInitializer clientInitializer)
             throws TException
     {
-        return metastoreClientAdapterProvider.createThriftMetastoreClientAdapter(factory.create(address, delegationToken));
+        return metastoreClientAdapterProvider.createThriftMetastoreClientAdapter(factory.create(address, delegationToken, clientInitializer));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Fix UGI loss after metastore client reconnect on fallback


When `ThriftHiveMetastoreClient` reconnects due to transport failure, per-session initialization (e.g., `set_ugi`) is lost because it was only done once at the factory level. This change introduces a
  `ThriftMetastoreClientInitializer` callback that is invoked every time a new transport is established, ensuring UGI and other per-session state survive reconnects. The change is non-invasive: existing
  factory and client structures are preserved, and callers pass a no-op lambda when no initialization is needed.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes #30652


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Hive connector
* Fix UGI loss after metastore client reconnect on fallback. ({issue}`30652`)
```
