### PR TITLE
Make Lambda ConnectorExpression subtype JSON serializable

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -674,6 +674,14 @@
                                     <old>method void io.trino.spi.connector.ConnectorMetadata::finishMerge(io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorMergeTableHandle, java.util.List&lt;io.trino.spi.connector.ConnectorTableHandle&gt;, java.util.Collection&lt;io.airlift.slice.Slice&gt;, java.util.Collection&lt;io.trino.spi.statistics.ComputedStatistics&gt;)</old>
                                     <new>method java.util.Optional&lt;io.trino.spi.connector.ConnectorOutputMetadata&gt; io.trino.spi.connector.ConnectorMetadata::finishMerge(io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorMergeTableHandle, java.util.List&lt;io.trino.spi.connector.ConnectorTableHandle&gt;, java.util.Collection&lt;io.airlift.slice.Slice&gt;, java.util.Collection&lt;io.trino.spi.statistics.ComputedStatistics&gt;)</new>
                                 </item>
+                                <item>
+                                    <code>java.annotation.attributeValueChanged</code>
+                                    <old>class io.trino.spi.expression.ConnectorExpression</old>
+                                    <new>class io.trino.spi.expression.ConnectorExpression</new>
+                                    <annotationType>com.fasterxml.jackson.annotation.JsonSubTypes</annotationType>
+                                    <attribute>value</attribute>
+                                    <justification>Lambda was missing a JSON subtype registration; adding it is backwards compatible</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/expression/ConnectorExpression.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/expression/ConnectorExpression.java
@@ -29,6 +29,7 @@ import static java.util.Objects.requireNonNull;
         @JsonSubTypes.Type(value = Variable.class, name = "variable"),
         @JsonSubTypes.Type(value = Call.class, name = "call"),
         @JsonSubTypes.Type(value = FieldDereference.class, name = "field_dereference"),
+        @JsonSubTypes.Type(value = Lambda.class, name = "lambda"),
 })
 public abstract class ConnectorExpression
 {

--- a/core/trino-spi/src/main/java/io/trino/spi/expression/Lambda.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/expression/Lambda.java
@@ -13,6 +13,8 @@
  */
 package io.trino.spi.expression;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.type.FunctionType;
 import io.trino.spi.type.Type;
 
@@ -33,7 +35,11 @@ public final class Lambda
     private final List<Variable> arguments;
     private final ConnectorExpression body;
 
-    public Lambda(Type type, List<Variable> arguments, ConnectorExpression body)
+    @JsonCreator
+    public Lambda(
+            @JsonProperty("type") Type type,
+            @JsonProperty("arguments") List<Variable> arguments,
+            @JsonProperty("body") ConnectorExpression body)
     {
         super(type);
         arguments = List.copyOf(requireNonNull(arguments, "arguments is null"));
@@ -92,11 +98,13 @@ public final class Lambda
         }
     }
 
+    @JsonProperty("arguments")
     public List<Variable> getArguments()
     {
         return arguments;
     }
 
+    @JsonProperty("body")
     public ConnectorExpression getBody()
     {
         return body;

--- a/core/trino-spi/src/test/java/io/trino/spi/expression/TestConnectorExpressionJsonSubTypes.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/expression/TestConnectorExpressionJsonSubTypes.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.expression;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.module.ModuleReader;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestConnectorExpressionJsonSubTypes
+{
+    @Test
+    public void testAllConcreteSubtypesAreRegistered()
+            throws IOException
+    {
+        Set<Class<?>> registeredSubtypes = Arrays.stream(ConnectorExpression.class.getAnnotation(JsonSubTypes.class).value())
+                .map(JsonSubTypes.Type::value)
+                .collect(toImmutableSet());
+
+        Set<Class<?>> concreteSubtypes = findConcreteSubtypesInPackage();
+
+        // Every concrete ConnectorExpression subtype must be registered for JSON deserialization,
+        // otherwise deserializing an expression containing it fails at runtime with an unknown subtype error.
+        assertThat(concreteSubtypes).containsExactlyInAnyOrderElementsOf(registeredSubtypes);
+    }
+
+    private static Set<Class<?>> findConcreteSubtypesInPackage()
+            throws IOException
+    {
+        String packagePrefix = ConnectorExpression.class.getPackageName().replace('.', '/') + "/";
+        try (ModuleReader moduleReader = ConnectorExpression.class.getModule().getLayer()
+                .configuration()
+                .findModule(ConnectorExpression.class.getModule().getName())
+                .orElseThrow()
+                .reference()
+                .open()) {
+            return moduleReader.list()
+                    .filter(name -> name.startsWith(packagePrefix) && name.endsWith(".class") && !name.substring(packagePrefix.length()).contains("/"))
+                    .map(name -> name.substring(0, name.length() - ".class".length()).replace('/', '.'))
+                    .map(TestConnectorExpressionJsonSubTypes::loadClass)
+                    .filter(ConnectorExpression.class::isAssignableFrom)
+                    .filter(clazz -> clazz != ConnectorExpression.class)
+                    .filter(clazz -> !Modifier.isAbstract(clazz.getModifiers()))
+                    .collect(toImmutableSet());
+        }
+    }
+
+    private static Class<?> loadClass(String className)
+    {
+        try {
+            return Class.forName(className, false, ConnectorExpression.class.getClassLoader());
+        }
+        catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Description

`Lambda` was missing from `ConnectorExpression`'s `@JsonSubTypes` and lacked Jackson annotations, so serializing an expression containing a `Lambda` would fail on deserialization with an unknown subtype error. This is a theoretical issue: I haven't seen it hit in practice, and no known caller currently serializes a `ConnectorExpression` containing a `Lambda`.

Also adds a test (`TestConnectorExpressionJsonSubTypes`) that guards against future `ConnectorExpression` subtypes being added without a corresponding JSON subtype registration.

## Additional context and related issues



## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```