### PR TITLE
Resolve column types once in Iceberg statistics

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergStatistics.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergStatistics.java
@@ -31,10 +31,10 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.OptionalLong;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.iceberg.IcebergTypes.convertIcebergValueToTrino;
 import static io.trino.plugin.iceberg.IcebergUtil.deserializePartitionValue;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
-import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
@@ -64,6 +64,7 @@ public record IcebergStatistics(
     {
         private final TypeManager typeManager;
         private final List<Types.NestedField> columns;
+        private final List<io.trino.spi.type.Type> columnTypes;
 
         private long recordCount;
         private long fileCount;
@@ -75,10 +76,13 @@ public record IcebergStatistics(
 
         public Builder(
                 List<Types.NestedField> columns,
+                List<io.trino.spi.type.Type> columnTypes,
                 TypeManager typeManager)
         {
+            checkArgument(columns.size() == columnTypes.size(), "columns and columnTypes must have the same size");
             this.typeManager = requireNonNull(typeManager, "typeManager is null");
             this.columns = ImmutableList.copyOf(columns);
+            this.columnTypes = ImmutableList.copyOf(columnTypes);
         }
 
         public void acceptDataFile(DataFile dataFile, PartitionSpec partitionSpec)
@@ -93,9 +97,10 @@ public record IcebergStatistics(
             mergeLongStatistics(nullCounts, nullValueCounts);
 
             Map<Integer, Optional<String>> identityPartitionValues = getPartitionKeys(dataFile.partition(), partitionSpec);
-            for (Types.NestedField column : columns) {
+            for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+                Types.NestedField column = columns.get(columnIndex);
                 int id = column.fieldId();
-                io.trino.spi.type.Type trinoType = toTrinoType(column.type(), typeManager);
+                io.trino.spi.type.Type trinoType = columnTypes.get(columnIndex);
                 Optional<String> partitionValue = identityPartitionValues.get(id);
                 if (partitionValue != null) {
                     if (partitionValue.isPresent()) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableStatisticsReader.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableStatisticsReader.java
@@ -17,6 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.collect.AbstractSequentialIterator;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -32,6 +33,7 @@ import io.trino.spi.statistics.DoubleRange;
 import io.trino.spi.statistics.Estimate;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.type.FixedWidthType;
+import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import jakarta.annotation.Nullable;
 import org.apache.iceberg.BlobMetadata;
@@ -74,6 +76,7 @@ import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.isMetadataColumnId;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionDomain;
 import static io.trino.plugin.iceberg.IcebergUtil.getPathDomain;
+import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.Long.parseLong;
@@ -174,11 +177,16 @@ public final class TableStatisticsReader
                 .collect(toImmutableList());
         Iterable<CloseableIterable<DataFile>> dataFileIterables = Iterables.transform(filteredManifests, manifestFile -> readManifest(icebergTable, manifestFile, filter, columnIds));
 
-        List<Types.NestedField> columns = icebergTable.schema().columns()
-                .stream()
-                .filter(column -> columnIds.contains(column.fieldId()))
-                .collect(toImmutableList());
-        IcebergStatistics.Builder icebergStatisticsBuilder = new IcebergStatistics.Builder(columns, typeManager);
+        ImmutableList.Builder<Types.NestedField> columnsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<Type> columnTypesBuilder = ImmutableList.builder();
+        for (Types.NestedField column : icebergTable.schema().columns()) {
+            if (columnIds.contains(column.fieldId())) {
+                columnsBuilder.add(column);
+                columnTypesBuilder.add(toTrinoType(column.type(), typeManager));
+            }
+        }
+        List<Types.NestedField> columns = columnsBuilder.build();
+        IcebergStatistics.Builder icebergStatisticsBuilder = new IcebergStatistics.Builder(columns, columnTypesBuilder.build(), typeManager);
         // Decode small manifest sets inline to avoid bottlenecking small scans on resource contention in the shared planning pool
         CloseableIterable<DataFile> dataFileSource;
         if (filteredManifests.size() < INLINE_MANIFEST_DECODE_THRESHOLD) {


### PR DESCRIPTION
## Description

`IcebergStatistics.Builder.acceptDataFile` resolved each projected column's Trino type via `toTrinoType` for every data file processed during table statistics collection — files × columns redundant calls in the per-file accumulation loop. Resolve the types once in the `Builder` constructor instead. No behavior change.

## Additional context and related issues

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)