### PR TITLE
Update TrinoContainer to use compatible substitute for Docker image

### DIFF
--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TrinoProductTestContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TrinoProductTestContainer.java
@@ -269,7 +269,7 @@ public final class TrinoProductTestContainer
          */
         public TrinoContainer build()
         {
-            TrinoContainer container = new TrinoContainer(DockerImageName.parse(imageName));
+            TrinoContainer container = new TrinoContainer(DockerImageName.parse(imageName).asCompatibleSubstituteFor("trinodb/trino"));
 
             // Legacy product tests always ran Trino with Asia/Kathmandu timezone.
             // Keep that behavior for JUnit parity.


### PR DESCRIPTION
## Description

Otherwise, we can't run product tests with local snapshot releases such as `-Dtrino.product-tests.image=trino:484-SNAPSHOT-arm64`: 
```
java.lang.IllegalStateException: Failed to verify that image 'trino:484-SNAPSHOT-arm64' is a compatible substitute for 'trinodb/trino'. This generally means that you are trying to use an image that Testcontainers has not been designed to use. If this is deliberate, and if you are confident that the image is compatible, you should declare compatibility in code using the `asCompatibleSubstituteFor` method. For example:
   DockerImageName myImage = DockerImageName.parse("trino:484-SNAPSHOT-arm64").asCompatibleSubstituteFor("trinodb/trino");
and then use `myImage` instead.
	at org.testcontainers.utility.DockerImageName.assertCompatibleWith(DockerImageName.java:279)
	at org.testcontainers.trino.TrinoContainer.<init>(TrinoContainer.java:43)
	at io.trino.testing.containers.TrinoProductTestContainer$Builder.build(TrinoProductTestContainer.java:272)
	at io.trino.tests.product.iceberg.SparkIcebergEnvironment.start(SparkIcebergEnvironment.java:132)
	at io.trino.testing.containers.environment.EnvironmentManager.acquire(EnvironmentManager.java:155)
	at io.trino.testing.containers.environment.ProductTestExtension.beforeAll(ProductTestExtension.java:99)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
