### PR TITLE
Bound memory usage of Iceberg table statistics collection

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergStatistics.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergStatistics.java
@@ -140,6 +140,27 @@ public record IcebergStatistics(
             }
         }
 
+        public void merge(Builder other)
+        {
+            checkArgument(columns.equals(other.columns), "Cannot merge statistics collected for different columns");
+            recordCount += other.recordCount;
+            fileCount += other.fileCount;
+            size += other.size;
+            mergeLongStatistics(nullCounts, other.nullCounts);
+            mergeLongStatistics(nanCounts, other.nanCounts);
+            mergeLongStatistics(columnSizes, other.columnSizes);
+            other.columnStatistics.forEach((fieldId, statistics) -> {
+                ColumnStatistics existing = columnStatistics.get(fieldId);
+                if (existing == null) {
+                    columnStatistics.put(fieldId, new ColumnStatistics(statistics));
+                }
+                else {
+                    // an absent bound means it was invalidated, which updateMinMax also represents as a null bound
+                    existing.updateMinMax(statistics.getMin().orElse(null), statistics.getMax().orElse(null));
+                }
+            });
+        }
+
         public IcebergStatistics build()
         {
             ImmutableMap.Builder<Integer, Object> minValues = ImmutableMap.builder();
@@ -210,6 +231,14 @@ public record IcebergStatistics(
             this.max = Optional.ofNullable(initialMax);
         }
 
+        public ColumnStatistics(ColumnStatistics other)
+        {
+            requireNonNull(other, "other is null");
+            this.comparisonHandle = other.comparisonHandle;
+            this.min = other.min;
+            this.max = other.max;
+        }
+
         /**
          * Gets the minimum value accumulated during stats collection.
          *
@@ -236,7 +265,7 @@ public record IcebergStatistics(
          * @param lowerBound Trino encoded lower bound value from a file
          * @param upperBound Trino encoded upper bound value from a file
          */
-        public void updateMinMax(Object lowerBound, Object upperBound)
+        public void updateMinMax(@Nullable Object lowerBound, @Nullable Object upperBound)
         {
             if (min.isPresent()) {
                 if (lowerBound == null) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableStatisticsReader.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableStatisticsReader.java
@@ -20,7 +20,6 @@ import com.google.common.collect.AbstractSequentialIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.trino.cache.NonEvictableLoadingCache;
@@ -49,7 +48,6 @@ import org.apache.iceberg.expressions.ManifestEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.puffin.StandardBlobTypes;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.ParallelIterable;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -61,8 +59,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.base.Verify.verifyNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -71,6 +72,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Streams.stream;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.cache.SafeCaches.buildNonEvictableCache;
+import static io.trino.plugin.base.util.ExecutorUtil.processWithAdditionalThreads;
 import static io.trino.plugin.iceberg.ExpressionConverter.toIcebergExpression;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.isMetadataColumnId;
@@ -175,7 +177,6 @@ public final class TableStatisticsReader
                     return evaluator.eval(manifestFile);
                 })
                 .collect(toImmutableList());
-        Iterable<CloseableIterable<DataFile>> dataFileIterables = Iterables.transform(filteredManifests, manifestFile -> readManifest(icebergTable, manifestFile, filter, columnIds));
 
         ImmutableList.Builder<Types.NestedField> columnsBuilder = ImmutableList.builder();
         ImmutableList.Builder<Type> columnTypesBuilder = ImmutableList.builder();
@@ -186,31 +187,36 @@ public final class TableStatisticsReader
             }
         }
         List<Types.NestedField> columns = columnsBuilder.build();
-        IcebergStatistics.Builder icebergStatisticsBuilder = new IcebergStatistics.Builder(columns, columnTypesBuilder.build(), typeManager);
+        List<Type> columnTypes = columnTypesBuilder.build();
+        IcebergStatistics.Builder icebergStatisticsBuilder = new IcebergStatistics.Builder(columns, columnTypes, typeManager);
+
         // Decode small manifest sets inline to avoid bottlenecking small scans on resource contention in the shared planning pool
-        CloseableIterable<DataFile> dataFileSource;
         if (filteredManifests.size() < INLINE_MANIFEST_DECODE_THRESHOLD) {
-            dataFileSource = CloseableIterable.concat(dataFileIterables);
+            for (ManifestFile manifestFile : filteredManifests) {
+                collectManifestStatistics(icebergStatisticsBuilder, icebergTable, manifestFile, filter, columnIds, partitionDomain, pathDomain);
+            }
         }
         else {
-            dataFileSource = new ParallelIterable<>(dataFileIterables, icebergPlanningExecutor);
-        }
-        try (CloseableIterable<DataFile> dataFiles = dataFileSource) {
-            dataFiles.forEach(dataFile -> {
-                PartitionSpec spec = icebergTable.specs().get(dataFile.specId());
-                if (!partitionDomain.isAll() && !partitionDomain.includesNullableValue(utf8Slice(spec.partitionToPath(dataFile.partition())))) {
-                    return;
-                }
-                if (!pathDomain.isAll() && !pathDomain.includesNullableValue(utf8Slice(dataFile.location()))) {
-                    return;
-                }
-
-                // Filtering by $file_modified_time is skipped to avoid making filesystem calls on each matched data file
-                icebergStatisticsBuilder.acceptDataFile(dataFile, spec);
-            });
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
+            // Aggregate each manifest into its own accumulator on the planning pool and merge it into the result
+            // as soon as it is done. Data files are consumed on the thread that decodes them and partial results
+            // are not retained after merging, so memory usage stays independent of the number of data files.
+            List<Callable<Void>> tasks = filteredManifests.stream()
+                    .map(manifestFile -> (Callable<Void>) () -> {
+                        IcebergStatistics.Builder statisticsBuilder = new IcebergStatistics.Builder(columns, columnTypes, typeManager);
+                        collectManifestStatistics(statisticsBuilder, icebergTable, manifestFile, filter, columnIds, partitionDomain, pathDomain);
+                        synchronized (icebergStatisticsBuilder) {
+                            icebergStatisticsBuilder.merge(statisticsBuilder);
+                        }
+                        return null;
+                    })
+                    .collect(toImmutableList());
+            try {
+                processWithAdditionalThreads(tasks, icebergPlanningExecutor);
+            }
+            catch (ExecutionException e) {
+                throwIfUnchecked(e.getCause());
+                throw new RuntimeException(e.getCause());
+            }
         }
 
         IcebergStatistics summary = icebergStatisticsBuilder.build();
@@ -360,6 +366,34 @@ public final class TableStatisticsReader
                 return verifyNotNull(snapshot.parentId(), "snapshot.parentId()");
             }
         };
+    }
+
+    private static void collectManifestStatistics(
+            IcebergStatistics.Builder statisticsBuilder,
+            Table icebergTable,
+            ManifestFile manifestFile,
+            Expression filter,
+            Set<Integer> columnIds,
+            Domain partitionDomain,
+            Domain pathDomain)
+    {
+        try (CloseableIterable<DataFile> dataFiles = readManifest(icebergTable, manifestFile, filter, columnIds)) {
+            for (DataFile dataFile : dataFiles) {
+                PartitionSpec spec = icebergTable.specs().get(dataFile.specId());
+                if (!partitionDomain.isAll() && !partitionDomain.includesNullableValue(utf8Slice(spec.partitionToPath(dataFile.partition())))) {
+                    continue;
+                }
+                if (!pathDomain.isAll() && !pathDomain.includesNullableValue(utf8Slice(dataFile.location()))) {
+                    continue;
+                }
+
+                // Filtering by $file_modified_time is skipped to avoid making filesystem calls on each matched data file
+                statisticsBuilder.acceptDataFile(dataFile, spec);
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private static CloseableIterable<DataFile> readManifest(Table icebergTable, ManifestFile manifestFile, Expression filter, Set<Integer> columnIds)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergStatisticsBuilder.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergStatisticsBuilder.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.type.Type;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static org.apache.iceberg.FileFormat.PARQUET;
+import static org.apache.iceberg.PartitionSpec.unpartitioned;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestIcebergStatisticsBuilder
+{
+    private static final int COLUMN_A_ID = 1;
+    private static final int COLUMN_B_ID = 2;
+    private static final Types.NestedField COLUMN_A = optional(COLUMN_A_ID, "a", Types.LongType.get());
+    private static final Types.NestedField COLUMN_B = optional(COLUMN_B_ID, "b", Types.DoubleType.get());
+    private static final List<Types.NestedField> COLUMNS = ImmutableList.of(COLUMN_A, COLUMN_B);
+    private static final List<Type> COLUMN_TYPES = ImmutableList.of(BIGINT, DOUBLE);
+
+    private static final long RECORD_COUNT = 10;
+    private static final long FILE_SIZE = 1024;
+
+    @Test
+    void testMergeInvalidatesBounds()
+    {
+        IcebergStatistics.Builder target = new IcebergStatistics.Builder(COLUMNS, COLUMN_TYPES, TESTING_TYPE_MANAGER);
+        target.acceptDataFile(dataFile(bounds(COLUMN_A, 1L), bounds(COLUMN_A, 5L), perColumn(COLUMN_A, 0, COLUMN_B, RECORD_COUNT)), unpartitioned());
+
+        // no bounds for column a, and the column is not all nulls, so the bounds are unknown rather than absent
+        IcebergStatistics.Builder other = new IcebergStatistics.Builder(COLUMNS, COLUMN_TYPES, TESTING_TYPE_MANAGER);
+        other.acceptDataFile(dataFile(ImmutableMap.of(), ImmutableMap.of(), perColumn(COLUMN_A, 0, COLUMN_B, RECORD_COUNT)), unpartitioned());
+
+        target.merge(other);
+
+        IcebergStatistics statistics = target.build();
+        assertThat(statistics.minValues()).doesNotContainKey(COLUMN_A_ID);
+        assertThat(statistics.maxValues()).doesNotContainKey(COLUMN_A_ID);
+    }
+
+    @Test
+    void testMergeKeepsBoundsInvalidated()
+    {
+        IcebergStatistics.Builder target = new IcebergStatistics.Builder(COLUMNS, COLUMN_TYPES, TESTING_TYPE_MANAGER);
+        target.acceptDataFile(dataFile(ImmutableMap.of(), ImmutableMap.of(), perColumn(COLUMN_A, 0, COLUMN_B, RECORD_COUNT)), unpartitioned());
+
+        IcebergStatistics.Builder other = new IcebergStatistics.Builder(COLUMNS, COLUMN_TYPES, TESTING_TYPE_MANAGER);
+        other.acceptDataFile(dataFile(bounds(COLUMN_A, 1L), bounds(COLUMN_A, 5L), perColumn(COLUMN_A, 0, COLUMN_B, RECORD_COUNT)), unpartitioned());
+
+        target.merge(other);
+
+        IcebergStatistics statistics = target.build();
+        assertThat(statistics.minValues()).doesNotContainKey(COLUMN_A_ID);
+        assertThat(statistics.maxValues()).doesNotContainKey(COLUMN_A_ID);
+    }
+
+    @Test
+    void testMergeCopiesNewColumn()
+    {
+        // column b is all nulls here, so the target never records statistics for it
+        IcebergStatistics.Builder target = new IcebergStatistics.Builder(COLUMNS, COLUMN_TYPES, TESTING_TYPE_MANAGER);
+        target.acceptDataFile(dataFile(bounds(COLUMN_A, 1L), bounds(COLUMN_A, 5L), perColumn(COLUMN_A, 0, COLUMN_B, RECORD_COUNT)), unpartitioned());
+
+        IcebergStatistics.Builder other = new IcebergStatistics.Builder(COLUMNS, COLUMN_TYPES, TESTING_TYPE_MANAGER);
+        other.acceptDataFile(dataFile(bounds(COLUMN_B, 2.5), bounds(COLUMN_B, 7.5), perColumn(COLUMN_A, RECORD_COUNT, COLUMN_B, 0)), unpartitioned());
+
+        target.merge(other);
+
+        assertThat(target.build().minValues()).isEqualTo(ImmutableMap.of(COLUMN_A_ID, 1L, COLUMN_B_ID, 2.5));
+        assertThat(target.build().maxValues()).isEqualTo(ImmutableMap.of(COLUMN_A_ID, 5L, COLUMN_B_ID, 7.5));
+
+        // the copy is defensive, so later updates to other do not reach the merged statistics
+        other.acceptDataFile(dataFile(bounds(COLUMN_B, 0.5), bounds(COLUMN_B, 9.5), perColumn(COLUMN_A, RECORD_COUNT, COLUMN_B, 0)), unpartitioned());
+        assertThat(target.build().minValues()).containsEntry(COLUMN_B_ID, 2.5);
+        assertThat(target.build().maxValues()).containsEntry(COLUMN_B_ID, 7.5);
+    }
+
+    @Test
+    void testMergeCopiesInvalidatedColumn()
+    {
+        IcebergStatistics.Builder target = new IcebergStatistics.Builder(COLUMNS, COLUMN_TYPES, TESTING_TYPE_MANAGER);
+        target.acceptDataFile(dataFile(bounds(COLUMN_A, 1L), bounds(COLUMN_A, 5L), perColumn(COLUMN_A, 0, COLUMN_B, RECORD_COUNT)), unpartitioned());
+
+        // column b has no bounds and is not all nulls, so other holds an invalidated entry for it
+        IcebergStatistics.Builder other = new IcebergStatistics.Builder(COLUMNS, COLUMN_TYPES, TESTING_TYPE_MANAGER);
+        other.acceptDataFile(dataFile(ImmutableMap.of(), ImmutableMap.of(), perColumn(COLUMN_A, RECORD_COUNT, COLUMN_B, 0)), unpartitioned());
+
+        target.merge(other);
+
+        assertThat(target.build().minValues()).isEqualTo(ImmutableMap.of(COLUMN_A_ID, 1L));
+        assertThat(target.build().maxValues()).isEqualTo(ImmutableMap.of(COLUMN_A_ID, 5L));
+
+        // the copied entry is invalidated rather than absent, so bounds from a later file cannot revive it
+        target.acceptDataFile(dataFile(bounds(COLUMN_B, 2.5), bounds(COLUMN_B, 7.5), perColumn(COLUMN_A, RECORD_COUNT, COLUMN_B, 0)), unpartitioned());
+        assertThat(target.build().minValues()).doesNotContainKey(COLUMN_B_ID);
+        assertThat(target.build().maxValues()).doesNotContainKey(COLUMN_B_ID);
+    }
+
+    @Test
+    void testMergeSumsMetrics()
+    {
+        IcebergStatistics.Builder target = new IcebergStatistics.Builder(COLUMNS, COLUMN_TYPES, TESTING_TYPE_MANAGER);
+        target.acceptDataFile(
+                dataFile(bounds(COLUMN_A, 1L), bounds(COLUMN_A, 5L), perColumn(COLUMN_A, 1, COLUMN_B, 2), perColumn(COLUMN_B, 3), perColumn(COLUMN_A, 64, COLUMN_B, 128)),
+                unpartitioned());
+
+        IcebergStatistics.Builder other = new IcebergStatistics.Builder(COLUMNS, COLUMN_TYPES, TESTING_TYPE_MANAGER);
+        other.acceptDataFile(
+                dataFile(bounds(COLUMN_A, 2L), bounds(COLUMN_A, 9L), perColumn(COLUMN_A, 4, COLUMN_B, 0), perColumn(COLUMN_B, 5), perColumn(COLUMN_A, 32)),
+                unpartitioned());
+
+        target.merge(other);
+
+        IcebergStatistics statistics = target.build();
+        assertThat(statistics.recordCount()).isEqualTo(2 * RECORD_COUNT);
+        assertThat(statistics.fileCount()).isEqualTo(2);
+        assertThat(statistics.size()).isEqualTo(2 * FILE_SIZE);
+        assertThat(statistics.nullCounts()).isEqualTo(ImmutableMap.of(COLUMN_A_ID, 5L, COLUMN_B_ID, 2L));
+        assertThat(statistics.nanCounts()).isEqualTo(ImmutableMap.of(COLUMN_B_ID, 8L));
+        assertThat(statistics.columnSizes()).isEqualTo(ImmutableMap.of(COLUMN_A_ID, 96L, COLUMN_B_ID, 128L));
+        assertThat(statistics.minValues()).containsEntry(COLUMN_A_ID, 1L);
+        assertThat(statistics.maxValues()).containsEntry(COLUMN_A_ID, 9L);
+    }
+
+    @Test
+    void testMergeRejectsDifferentColumns()
+    {
+        IcebergStatistics.Builder target = new IcebergStatistics.Builder(COLUMNS, COLUMN_TYPES, TESTING_TYPE_MANAGER);
+        IcebergStatistics.Builder other = new IcebergStatistics.Builder(ImmutableList.of(COLUMN_A), ImmutableList.of(BIGINT), TESTING_TYPE_MANAGER);
+
+        assertThatThrownBy(() -> target.merge(other))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cannot merge statistics collected for different columns");
+    }
+
+    private static DataFile dataFile(Map<Integer, ByteBuffer> lowerBounds, Map<Integer, ByteBuffer> upperBounds, Map<Integer, Long> nullValueCounts)
+    {
+        return dataFile(lowerBounds, upperBounds, nullValueCounts, ImmutableMap.of(), ImmutableMap.of());
+    }
+
+    private static DataFile dataFile(
+            Map<Integer, ByteBuffer> lowerBounds,
+            Map<Integer, ByteBuffer> upperBounds,
+            Map<Integer, Long> nullValueCounts,
+            Map<Integer, Long> nanValueCounts,
+            Map<Integer, Long> columnSizes)
+    {
+        Metrics metrics = new Metrics(
+                RECORD_COUNT,
+                columnSizes,
+                ImmutableMap.of(),
+                nullValueCounts,
+                nanValueCounts,
+                lowerBounds,
+                upperBounds);
+        return DataFiles.builder(unpartitioned())
+                .withPath("/test/data.parquet")
+                .withFormat(PARQUET)
+                .withFileSizeInBytes(FILE_SIZE)
+                .withRecordCount(RECORD_COUNT)
+                .withMetrics(metrics)
+                .build();
+    }
+
+    private static Map<Integer, ByteBuffer> bounds(Types.NestedField column, Object value)
+    {
+        return ImmutableMap.of(column.fieldId(), Conversions.toByteBuffer(column.type(), value));
+    }
+
+    private static Map<Integer, Long> perColumn(Types.NestedField column, long value)
+    {
+        return ImmutableMap.of(column.fieldId(), value);
+    }
+
+    private static Map<Integer, Long> perColumn(Types.NestedField column, long value, Types.NestedField otherColumn, long otherValue)
+    {
+        return ImmutableMap.of(column.fieldId(), value, otherColumn.fieldId(), otherValue);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -1411,16 +1411,21 @@ public class TestIcebergV2
     public void testStatsManifestDecoding()
     {
         int threshold = TableStatisticsReader.INLINE_MANIFEST_DECODE_THRESHOLD;
+        IcebergColumnHandle column = IcebergColumnHandle.optional(ColumnIdentity.primitiveColumnIdentity(1, "a")).columnType(INTEGER).build();
         try (TestTable testTable = newTrinoTable("test_stats_manifest_decoding_", "(a INT)")) {
             for (int i = 0; i < threshold - 1; i++) {
                 assertUpdate("INSERT INTO " + testTable.getName() + " VALUES (" + i + ")", 1);
             }
+            // manifests are decoded inline and accumulated into a single set of statistics
             assertThat(manifestCount(testTable.getName())).isLessThan(threshold);
             assertThat(tableRowCountFromStatistics(testTable.getName())).isEqualTo(threshold - 1);
+            assertThat(columnRangeFromStatistics(testTable.getName(), column)).contains(new DoubleRange(0, threshold - 2));
 
             assertUpdate("INSERT INTO " + testTable.getName() + " VALUES (100)", 1);
+            // manifests are decoded in parallel and the per-manifest statistics merged
             assertThat(manifestCount(testTable.getName())).isGreaterThanOrEqualTo(threshold);
             assertThat(tableRowCountFromStatistics(testTable.getName())).isEqualTo(threshold);
+            assertThat(columnRangeFromStatistics(testTable.getName(), column)).contains(new DoubleRange(0, 100));
         }
     }
 
@@ -1431,16 +1436,28 @@ public class TestIcebergV2
 
     private double tableRowCountFromStatistics(String tableName)
     {
+        return tableStatistics(tableName, ImmutableSet.of()).getRowCount().getValue();
+    }
+
+    private Optional<DoubleRange> columnRangeFromStatistics(String tableName, IcebergColumnHandle column)
+    {
+        return tableStatistics(tableName, ImmutableSet.of(column))
+                .getColumnStatistics()
+                .get(column)
+                .getRange();
+    }
+
+    private TableStatistics tableStatistics(String tableName, Set<IcebergColumnHandle> projectedColumns)
+    {
         OptionalLong snapshotId = OptionalLong.of((long) computeScalar("SELECT snapshot_id FROM \"" + tableName + "$snapshots\" ORDER BY committed_at DESC FETCH FIRST 1 ROW WITH TIES"));
-        TableStatistics statistics = TableStatisticsReader.makeTableStatistics(
+        return TableStatisticsReader.makeTableStatistics(
                 TESTING_TYPE_MANAGER,
                 loadTable(tableName),
                 snapshotId,
                 TupleDomain.all(),
                 TupleDomain.all(),
-                ImmutableSet.of(),
+                projectedColumns,
                 newDirectExecutorService());
-        return statistics.getRowCount().getValue();
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

`ParallelIterable` queues up to 30000 decoded `DataFile` copies while a single thread consumes them, and every planning thread decodes while only one accumulates, so the queue fills. Each copy carries per-column stats maps sized by the projected column count, so wide tables could hold many GB of heap in the queue alone and OOM the coordinator.

This aggregates each manifest into its own accumulator on the thread that decodes it and merges the O(columns) partial results as they complete, so no decoded `DataFile` is ever queued and peak memory no longer depends on the number of data files.

72000 data files, 50 columns, 24 manifests, with simulated object storage latency:

| | Before | After |
| --- | --- | --- |
| Peak queue depth | 46475 entries | no queue |
| Minimum heap to complete | > 1GB | 64MB |

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The 30000 bound is soft: a task checks it only before opening its manifest and then drains that manifest unchecked, which is why the measured peak exceeds the cap. Object storage latency makes this worse, not better, by staggering task starts so more tasks are simultaneously mid-drain.

The merge is commutative and associative, so results are identical to serial accumulation. `testStatsManifestDecoding` already straddles `INLINE_MANIFEST_DECODE_THRESHOLD` and now also asserts column ranges on both sides of it.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Reduce coordinator memory usage for query planning on iceberg tables. ({issue}`30675`)