### PR TITLE
Prevent memory-exhausted cluster from starving zero-memory FTE tasks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/BinPackingNodeAllocatorService.java
@@ -769,6 +769,7 @@ public class BinPackingNodeAllocatorService
         private final Set<String> nodesWithoutMemory;
         private final Map<String, Long> nodesRemainingMemoryRuntimeAdjusted;
         private final Map<String, Long> speculativeMemoryReserved;
+        private final Map<String, Long> totalFulfilledAcquiresCountByNode;
 
         private final Map<String, MemoryPoolInfo> nodeMemoryPoolInfos;
         private final boolean scheduleOnCoordinator;
@@ -817,10 +818,12 @@ public class BinPackingNodeAllocatorService
 
             Map<String, Long> preReservedMemory = new HashMap<>();
             speculativeMemoryReserved = new HashMap<>();
+            totalFulfilledAcquiresCountByNode = new HashMap<>();
             SetMultimap<String, BinPackingNodeLease> fulfilledAcquiresByNode = HashMultimap.create();
             for (BinPackingNodeLease fulfilledAcquire : fulfilledAcquires) {
                 InternalNode node = fulfilledAcquire.getAssignedNode();
                 long memoryLease = fulfilledAcquire.getMemoryLease();
+                totalFulfilledAcquiresCountByNode.merge(node.getNodeIdentifier(), 1L, Long::sum);
                 if (ignoreAcquiredSpeculative && fulfilledAcquire.isSpeculative()) {
                     speculativeMemoryReserved.merge(node.getNodeIdentifier(), memoryLease, Long::sum);
                 }
@@ -898,6 +901,21 @@ public class BinPackingNodeAllocatorService
                 return ReserveResult.NONE_MATCHING;
             }
 
+            // result of acquire.getMemoryLease() can change; store memory as a variable, so we have consistent value through this method.
+            long memoryRequirements = acquire.getMemoryLease();
+
+            if (memoryRequirements == 0) {
+                // A task which does not reserve any memory, e.g. one only reading catalog metadata, takes nothing away
+                // from a node's memory pool. It can run on any node regardless of memory pressure; pick the least loaded
+                // one so metadata queries do not pile on a single node. The count includes speculative acquires so
+                // metadata tasks avoid nodes busy with speculative work as well.
+                InternalNode selectedNode = candidates.stream()
+                        .min(comparing(node -> totalFulfilledAcquiresCountByNode.getOrDefault(node.getNodeIdentifier(), 0L)))
+                        .orElseThrow();
+                subtractFromRemainingMemory(selectedNode.getNodeIdentifier(), 0);
+                return ReserveResult.reserved(selectedNode);
+            }
+
             candidates = candidates.stream().filter(node -> !nodesWithoutMemory.contains(node.getNodeIdentifier())).collect(toImmutableList());
             if (candidates.isEmpty()) {
                 return ReserveResult.NOT_ENOUGH_RESOURCES_NOW;
@@ -910,9 +928,6 @@ public class BinPackingNodeAllocatorService
             InternalNode selectedNode = candidates.stream()
                     .max(comparator)
                     .orElseThrow();
-
-            // result of acquire.getMemoryLease() can change; store memory as a variable, so we have consistent value through this method.
-            long memoryRequirements = acquire.getMemoryLease();
 
             if (nodesRemainingMemoryRuntimeAdjusted.get(selectedNode.getNodeIdentifier()) >= memoryRequirements || isNodeEmpty(selectedNode.getNodeIdentifier())) {
                 // there is enough unreserved memory on the node
@@ -966,6 +981,7 @@ public class BinPackingNodeAllocatorService
             if (nodesRemainingMemory.get(nodeIdentifier) == 0) {
                 nodesWithoutMemory.add(nodeIdentifier);
             }
+            totalFulfilledAcquiresCountByNode.merge(nodeIdentifier, 1L, Long::sum);
         }
 
         private boolean isNodeEmpty(String nodeIdentifier)

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/BinPackingNodeAllocatorService.java
@@ -912,7 +912,7 @@ public class BinPackingNodeAllocatorService
                 InternalNode selectedNode = candidates.stream()
                         .min(comparing(node -> totalFulfilledAcquiresCountByNode.getOrDefault(node.getNodeIdentifier(), 0L)))
                         .orElseThrow();
-                subtractFromRemainingMemory(selectedNode.getNodeIdentifier(), 0);
+                recordReservation(selectedNode.getNodeIdentifier(), 0);
                 return ReserveResult.reserved(selectedNode);
             }
 
@@ -937,7 +937,7 @@ public class BinPackingNodeAllocatorService
                 // todo: currant logic does not handle heterogenous clusters best. There is a chance that there is a larger node in the cluster but
                 //       with less memory available right now, hence that one was not selected as a candidate.
                 // mark memory reservation
-                subtractFromRemainingMemory(selectedNode.getNodeIdentifier(), memoryRequirements);
+                recordReservation(selectedNode.getNodeIdentifier(), memoryRequirements);
                 return ReserveResult.reserved(selectedNode);
             }
 
@@ -951,7 +951,7 @@ public class BinPackingNodeAllocatorService
             InternalNode fallbackNode = candidates.stream()
                     .max(fallbackComparator)
                     .orElseThrow();
-            subtractFromRemainingMemory(fallbackNode.getNodeIdentifier(), memoryRequirements);
+            recordReservation(fallbackNode.getNodeIdentifier(), memoryRequirements);
             return ReserveResult.NOT_ENOUGH_RESOURCES_NOW;
         }
 
@@ -970,7 +970,7 @@ public class BinPackingNodeAllocatorService
             return comparator.thenComparing(node -> -speculativeMemoryReserved.getOrDefault(node.getNodeIdentifier(), 0L));
         }
 
-        private void subtractFromRemainingMemory(String nodeIdentifier, long memoryLease)
+        private void recordReservation(String nodeIdentifier, long memoryLease)
         {
             nodesRemainingMemoryRuntimeAdjusted.compute(
                     nodeIdentifier,

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestBinPackingNodeAllocator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestBinPackingNodeAllocator.java
@@ -156,6 +156,71 @@ public class TestBinPackingNodeAllocator
 
     @Test
     @Timeout(value = TEST_TIMEOUT, unit = MILLISECONDS)
+    public void testAllocateNoMemoryTaskOnClusterWithoutFreeMemory()
+    {
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault(NODE_1, NODE_2);
+        setupNodeAllocatorService(nodeManager);
+
+        try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION_QUERY_1)) {
+            // reserve all the memory of both nodes (each task requires 32GB and we have 2 nodes with 64GB each)
+            assertAcquired(nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD), NODE_1);
+            assertAcquired(nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD), NODE_2);
+            assertAcquired(nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD), NODE_1);
+            assertAcquired(nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD), NODE_2);
+
+            // tasks requiring memory block, as no node has any left; one per node, so every node is marked as being out of memory
+            assertNotAcquired(nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD));
+            assertNotAcquired(nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD));
+
+            // tasks which do not reserve any memory, e.g. ones only reading catalog metadata, are not blocked by that
+            // and get spread across nodes instead of piling up on a single one
+            assertAcquired(nodeAllocator.acquire(REQ_NONE, DataSize.ofBytes(0), STANDARD), NODE_1);
+            assertAcquired(nodeAllocator.acquire(REQ_NONE, DataSize.ofBytes(0), STANDARD), NODE_2);
+            assertAcquired(nodeAllocator.acquire(REQ_NONE, DataSize.ofBytes(0), STANDARD), NODE_1);
+            assertAcquired(nodeAllocator.acquire(REQ_NONE, DataSize.ofBytes(0), STANDARD), NODE_2);
+        }
+    }
+
+    @Test
+    @Timeout(value = TEST_TIMEOUT, unit = MILLISECONDS)
+    public void testAllocateNoMemoryTaskSpreadWithUnevenPriorLoad()
+    {
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault(NODE_1, NODE_2);
+        setupNodeAllocatorService(nodeManager);
+
+        try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION_QUERY_1)) {
+            // pin memory-consuming tasks to make NODE_1 hold more acquires than NODE_2
+            assertAcquired(nodeAllocator.acquire(REQ_NODE_1, DataSize.of(8, GIGABYTE), STANDARD), NODE_1);
+            assertAcquired(nodeAllocator.acquire(REQ_NODE_1, DataSize.of(8, GIGABYTE), STANDARD), NODE_1);
+            assertAcquired(nodeAllocator.acquire(REQ_NODE_2, DataSize.of(8, GIGABYTE), STANDARD), NODE_2);
+
+            // NODE_1 has 2 acquires, NODE_2 has 1; first zero-memory task goes to the less loaded NODE_2, next balances
+            assertAcquired(nodeAllocator.acquire(REQ_NONE, DataSize.ofBytes(0), STANDARD), NODE_2);
+            assertAcquired(nodeAllocator.acquire(REQ_NONE, DataSize.ofBytes(0), STANDARD), NODE_1);
+        }
+    }
+
+    @Test
+    @Timeout(value = TEST_TIMEOUT, unit = MILLISECONDS)
+    public void testAllocateNoMemoryTaskSpreadCountsSpeculativeAcquires()
+    {
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault(NODE_1, NODE_2);
+        setupNodeAllocatorService(nodeManager);
+
+        try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION_QUERY_1)) {
+            // pin speculative tasks to make NODE_1 hold more speculative acquires than NODE_2
+            assertAcquired(nodeAllocator.acquire(REQ_NODE_1, DataSize.of(8, GIGABYTE), SPECULATIVE), NODE_1);
+            assertAcquired(nodeAllocator.acquire(REQ_NODE_1, DataSize.of(8, GIGABYTE), SPECULATIVE), NODE_1);
+            assertAcquired(nodeAllocator.acquire(REQ_NODE_2, DataSize.of(8, GIGABYTE), SPECULATIVE), NODE_2);
+
+            // standard zero-memory acquire avoids NODE_1: speculative acquires are counted for spread even though their
+            // memory usage is ignored when evaluating standard tasks
+            assertAcquired(nodeAllocator.acquire(REQ_NONE, DataSize.ofBytes(0), STANDARD), NODE_2);
+        }
+    }
+
+    @Test
+    @Timeout(value = TEST_TIMEOUT, unit = MILLISECONDS)
     public void testAllocateSimple()
     {
         TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault(NODE_1, NODE_2);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Under fault-tolerant execution, a task that reserves no memory (e.g. one only reading catalog metadata) does not consume space in a node's memory pool. The bin-packing node allocator, however, excluded any node marked as exhausted from every candidate list, so a busy cluster starved these tasks even though placing them would not have taken memory away from tasks that actually need it. 

### Important changes:                                                                                                                                                                           
  1. **Schedule zero-memory tasks on memory-exhausted nodes.** The `nodesWithoutMemory` filter is skipped when the acquire's memory lease is zero, so a metadata-only task is no longer blocked on a saturated cluster.                                                                                                                                                          
                                                                                                                                                                                                                                         
  2. **Spread zero-memory tasks across nodes by acquire count.** Before, once zero-memory tasks pass the filter, the memory-based comparator ties for every candidate and deterministically returns the first node in identifier order – piling the whole metadata query fleet on a single worker. After the changes the allocator tracks the total number of fulfilled acquires per node (including speculative ones) and picks the least loaded candidate for zero-memory tasks.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Discovered while investigating catalog-metadata query starvation on FTE clusters running large speculative workloads.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
