### PR TITLE
Remove varchar to char saturated floor cast

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -154,6 +154,7 @@ import io.trino.operator.scalar.JoniRegexpReplaceLambdaFunction;
 import io.trino.operator.scalar.JsonFunctions;
 import io.trino.operator.scalar.JsonOperators;
 import io.trino.operator.scalar.LegacyCharToVarcharCast;
+import io.trino.operator.scalar.LegacyVarcharToCharSaturatedFloorCast;
 import io.trino.operator.scalar.LuhnCheckFunction;
 import io.trino.operator.scalar.MapCardinalityFunction;
 import io.trino.operator.scalar.MapConcatFunction;
@@ -655,6 +656,10 @@ public final class SystemFunctionBundle
                 .aggregates(BigintApproximateMostFrequent.class)
                 .aggregates(VarcharApproximateMostFrequent.class)
                 .scalar(ArrayHistogramFunction.class);
+
+        if (featuresConfig.isLegacyVarcharToCharCoercion()) {
+            builder.scalars(LegacyVarcharToCharSaturatedFloorCast.class);
+        }
 
         // timestamp operators and functions
         builder

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/CharacterStringCasts.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/CharacterStringCasts.java
@@ -24,7 +24,6 @@ import io.trino.spi.function.SqlType;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 
-import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SliceUtf8.countCodePoints;
 import static io.airlift.slice.SliceUtf8.getCodePointAt;
 import static io.airlift.slice.SliceUtf8.lengthOfCodePoint;
@@ -68,54 +67,6 @@ public final class CharacterStringCasts
     }
 
     @ScalarOperator(OperatorType.SATURATED_FLOOR_CAST)
-    @SqlType("char(y)")
-    @LiteralParameters({"x", "y"})
-    public static Slice varcharToCharSaturatedFloorCast(@LiteralParameter("y") long y, @SqlType("varchar(x)") Slice slice)
-    {
-        IntList codePoints = toCodePoints(slice);
-
-        // if Varchar(x) value length (including spaces) is greater than y, we can just truncate it
-        if (codePoints.size() >= y) {
-            // char(y) slice representation doesn't contain trailing spaces
-            codePoints.size(Math.min(toIntExact(y), codePoints.size()));
-            trimTrailing(codePoints, ' ');
-            return codePointsToSliceUtf8(codePoints);
-        }
-
-        /*
-         * Value length is smaller than same-represented char(y) value because input varchar has length lower than y.
-         * We decrement last character in input (in fact, we decrement last non-zero character) and pad the value with
-         * max code point up to y characters.
-         */
-        trimTrailing(codePoints, '\0');
-
-        if (codePoints.isEmpty()) {
-            // No non-zero characters in input and input is shorter than y. Input value is smaller than any char(4) casted back to varchar, so we return the smallest char(4) possible
-            return Slices.allocate(toIntExact(y));
-        }
-
-        int lastCodePoint = codePoints.getInt(codePoints.size() - 1) - 1;
-        /*
-         * UTF-8 reserve codepoints from 0xD800 to 0xDFFF for encoding UTF-16
-         * If the lastCodePoint after -1 operation is in this range, it will lead to an InvalidCodePointException
-         * Since the codePoint is originally valid, so the only case will be 0XE00 - 1
-         * So we let it go through this range and become 0xD7FF
-         */
-        if (lastCodePoint == Character.MAX_SURROGATE) {
-            lastCodePoint = Character.MIN_SURROGATE - 1;
-        }
-        codePoints.set(codePoints.size() - 1, lastCodePoint);
-        int toAdd = toIntExact(y) - codePoints.size();
-        for (int i = 0; i < toAdd; i++) {
-            codePoints.add(Character.MAX_CODE_POINT);
-        }
-
-        verify(codePoints.getInt(codePoints.size() - 1) != ' '); // no trailing spaces to trim
-
-        return codePointsToSliceUtf8(codePoints);
-    }
-
-    @ScalarOperator(OperatorType.SATURATED_FLOOR_CAST)
     @SqlType("varchar(y)")
     @LiteralParameters({"x", "y"})
     public static Slice varcharToVarcharSaturatedFloorCast(@LiteralParameter("y") long y, @SqlType("varchar(x)") Slice slice)
@@ -129,7 +80,7 @@ public final class CharacterStringCasts
         return codePointsToSliceUtf8(codePoints);
     }
 
-    private static void trimTrailing(IntList codePoints, int codePointToTrim)
+    static void trimTrailing(IntList codePoints, int codePointToTrim)
     {
         int endIndex = codePoints.size();
         while (endIndex > 0 && codePoints.getInt(endIndex - 1) == codePointToTrim) {
@@ -138,7 +89,7 @@ public final class CharacterStringCasts
         codePoints.size(endIndex);
     }
 
-    private static IntList toCodePoints(Slice slice)
+    static IntList toCodePoints(Slice slice)
     {
         IntList codePoints = new IntArrayList(slice.length());
         for (int offset = 0; offset < slice.length(); ) {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/LegacyVarcharToCharSaturatedFloorCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/LegacyVarcharToCharSaturatedFloorCast.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.function.LiteralParameter;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.OperatorType;
+import io.trino.spi.function.ScalarOperator;
+import io.trino.spi.function.SqlType;
+import it.unimi.dsi.fastutil.ints.IntList;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.operator.scalar.CharacterStringCasts.codePointsToSliceUtf8;
+import static io.trino.operator.scalar.CharacterStringCasts.toCodePoints;
+import static io.trino.operator.scalar.CharacterStringCasts.trimTrailing;
+import static java.lang.Math.toIntExact;
+
+/**
+ * Legacy saturated floor cast from {@code VARCHAR} to {@code CHAR}, matching
+ * {@link LegacyCharToVarcharCast} which re-pads values with spaces to their declared {@code CHAR}
+ * length when casting back. The legacy space-padded coercion is monotone in both directions, so a
+ * saturated floor cast exists; it is registered only when the
+ * {@code deprecated.legacy-varchar-to-char-coercion} configuration property is set. The default
+ * coercion has no varchar to char saturated floor cast, because {@code CAST(char AS varchar)}
+ * returns the unpadded value while {@code char} values compare as if space-padded, so the cast is
+ * not monotone and domain bounds cannot be translated through it.
+ */
+public final class LegacyVarcharToCharSaturatedFloorCast
+{
+    private LegacyVarcharToCharSaturatedFloorCast() {}
+
+    @ScalarOperator(OperatorType.SATURATED_FLOOR_CAST)
+    @SqlType("char(y)")
+    @LiteralParameters({"x", "y"})
+    public static Slice varcharToCharSaturatedFloorCast(@LiteralParameter("y") long y, @SqlType("varchar(x)") Slice slice)
+    {
+        IntList codePoints = toCodePoints(slice);
+
+        // if Varchar(x) value length (including spaces) is greater than y, we can just truncate it
+        if (codePoints.size() >= y) {
+            // char(y) slice representation doesn't contain trailing spaces
+            codePoints.size(Math.min(toIntExact(y), codePoints.size()));
+            trimTrailing(codePoints, ' ');
+            return codePointsToSliceUtf8(codePoints);
+        }
+
+        /*
+         * Value length is smaller than same-represented char(y) value because input varchar has length lower than y.
+         * We decrement last character in input (in fact, we decrement last non-zero character) and pad the value with
+         * max code point up to y characters.
+         */
+        trimTrailing(codePoints, '\0');
+
+        if (codePoints.isEmpty()) {
+            // No non-zero characters in input and input is shorter than y. Input value is smaller than any char(4) casted back to varchar, so we return the smallest char(4) possible
+            return Slices.allocate(toIntExact(y));
+        }
+
+        int lastCodePoint = codePoints.getInt(codePoints.size() - 1) - 1;
+        /*
+         * UTF-8 reserve codepoints from 0xD800 to 0xDFFF for encoding UTF-16
+         * If the lastCodePoint after -1 operation is in this range, it will lead to an InvalidCodePointException
+         * Since the codePoint is originally valid, so the only case will be 0XE00 - 1
+         * So we let it go through this range and become 0xD7FF
+         */
+        if (lastCodePoint == Character.MAX_SURROGATE) {
+            lastCodePoint = Character.MIN_SURROGATE - 1;
+        }
+        codePoints.set(codePoints.size() - 1, lastCodePoint);
+        int toAdd = toIntExact(y) - codePoints.size();
+        for (int i = 0; i < toAdd; i++) {
+            codePoints.add(Character.MAX_CODE_POINT);
+        }
+
+        verify(codePoints.getInt(codePoints.size() - 1) != ' '); // no trailing spaces to trim
+
+        return codePointsToSliceUtf8(codePoints);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainCoercer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainCoercer.java
@@ -19,6 +19,7 @@ import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.Type;
 import org.junit.jupiter.api.Test;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.spi.predicate.Domain.multipleValues;
 import static io.trino.spi.predicate.Range.greaterThan;
@@ -27,11 +28,13 @@ import static io.trino.spi.predicate.Range.lessThan;
 import static io.trino.spi.predicate.Range.lessThanOrEqual;
 import static io.trino.spi.predicate.Range.range;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.CharType.createCharType;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.type.Reals.toReal;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -180,6 +183,21 @@ public class TestDomainCoercer
     public void testUnsupportedCast()
     {
         assertThatThrownBy(() -> applySaturatedCasts(Domain.singleValue(INTEGER, 10L), BIGINT))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void testVarcharToChar()
+    {
+        // With the default coercion (deprecated.legacy-varchar-to-char-coercion disabled) there is
+        // no varchar to char saturated floor cast: CAST(char AS varchar) returns the unpadded value
+        // while char values compare as if space-padded to their declared length, so the cast is not
+        // monotone and domain bounds cannot be translated. RemoveUnsupportedDynamicFilters drops
+        // dynamic filters over CAST(char AS varchar) join keys instead.
+        assertThatThrownBy(() -> applySaturatedCasts(
+                multipleValues(createVarcharType(10), ImmutableList.of(utf8Slice("I"), utf8Slice("P"))),
+                createCharType(10)))
+                .hasMessage("Saturated floor cast operator not found for coercion from varchar(10) to char(10)")
                 .isInstanceOf(IllegalStateException.class);
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
@@ -1545,6 +1545,23 @@ public class TestDomainTranslator
         assertUnsupportedPredicate(equal(cast(C_CHAR, charType), cast(stringLiteral("abc12345678"), charType)));
     }
 
+    @Test
+    public void testCastCharToVarcharComparison()
+    {
+        // With the default coercion (deprecated.legacy-varchar-to-char-coercion disabled),
+        // CAST(char AS varchar) trims trailing spaces and is not monotonic with respect to the two
+        // orderings: char(10) 'abc' + U+0001 sorts below char(10) 'abc ' (char comparison pads
+        // with spaces, and U+0001 is below space), while their varchar forms 'abc' + U+0001 and
+        // 'abc' compare the other way around. The cast must not be peeled off the symbol side
+        // (isImplicitCoercion returns false for it), so the whole comparison stays as a residual
+        // filter instead of becoming a domain on the char column.
+        Type castType = createVarcharType(10);
+        assertUnsupportedPredicate(equal(cast(C_CHAR, castType), new Constant(castType, utf8Slice("abc"))));
+        assertUnsupportedPredicate(greaterThan(cast(C_CHAR, castType), new Constant(castType, utf8Slice("abc\u0001"))));
+        assertUnsupportedPredicate(lessThanOrEqual(cast(C_CHAR, castType), new Constant(castType, utf8Slice("abc\u0001"))));
+        assertUnsupportedPredicate(lessThan(cast(C_CHAR, castType), new Constant(castType, utf8Slice("abc "))));
+    }
+
     private void assertPredicateIsAlwaysTrue(Expression expression)
     {
         assertPredicateTranslates(expression, TupleDomain.all(), TRUE);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
@@ -59,8 +59,10 @@ import java.util.Optional;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.CharType.createCharType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.DynamicFilters.createDynamicFilterExpression;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN;
@@ -330,6 +332,37 @@ public class TestRemoveUnsupportedDynamicFilters
                         join(INNER, builder -> builder
                                 .equiCriteria("LINEITEM_DOUBLE_OK", "ORDERS_OK")
                                 .left(tableScan("lineitem", ImmutableMap.of("LINEITEM_DOUBLE_OK", "orderkey")))
+                                .right(tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))));
+    }
+
+    @Test
+    public void testRemoveCharToVarcharCast()
+    {
+        // Dynamic filter is removed because there is no varchar to char saturated floor cast:
+        // CAST(char AS varchar) is not monotone, so dynamic filter domains cannot be translated
+        // onto the char column
+        Symbol lineitemCharOrderKeySymbol = builder.symbol("LINEITEM_CHAR_OK", createCharType(10));
+        PlanNode root = builder.output(ImmutableList.of(), ImmutableList.of(),
+                builder.join(
+                        INNER,
+                        builder.filter(
+                                createDynamicFilterExpression(metadata, new DynamicFilterId("DF"), createVarcharType(10), new Cast(new Reference(createCharType(10), "LINEITEM_CHAR_OK"), createVarcharType(10))),
+                                builder.tableScan(
+                                        lineitemTableHandle,
+                                        ImmutableList.of(lineitemCharOrderKeySymbol),
+                                        ImmutableMap.of(lineitemCharOrderKeySymbol, new TpchColumnHandle("orderkey", createCharType(10))))),
+                        ordersTableScanNode,
+                        ImmutableList.of(new JoinNode.EquiJoinClause(lineitemCharOrderKeySymbol, ordersOrderKeySymbol)),
+                        ImmutableList.of(lineitemCharOrderKeySymbol),
+                        ImmutableList.of(ordersOrderKeySymbol),
+                        Optional.empty(),
+                        ImmutableMap.of(new DynamicFilterId("DF"), ordersOrderKeySymbol)));
+        assertPlan(
+                removeUnsupportedDynamicFilters(root),
+                output(
+                        join(INNER, builder -> builder
+                                .equiCriteria("LINEITEM_CHAR_OK", "ORDERS_OK")
+                                .left(tableScan("lineitem", ImmutableMap.of("LINEITEM_CHAR_OK", "orderkey")))
                                 .right(tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))));
     }
 

--- a/core/trino-main/src/test/java/io/trino/type/TestCharacterStringCasts.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestCharacterStringCasts.java
@@ -21,8 +21,8 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
 import static io.airlift.slice.Slices.utf8Slice;
-import static io.trino.operator.scalar.CharacterStringCasts.varcharToCharSaturatedFloorCast;
 import static io.trino.operator.scalar.CharacterStringCasts.varcharToVarcharSaturatedFloorCast;
+import static io.trino.operator.scalar.LegacyVarcharToCharSaturatedFloorCast.varcharToCharSaturatedFloorCast;
 import static io.trino.spi.type.CharType.createCharType;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
@@ -186,7 +186,7 @@ public class TestCharacterStringCasts
     }
 
     @Test
-    public void testVarcharToCharSaturatedFloorCast()
+    public void testLegacyVarcharToCharSaturatedFloorCast()
     {
         String nonBmpCharacterMinusOne = new String(Character.toChars(0x1F50C));
         String maxCodePoint = new String(Character.toChars(Character.MAX_CODE_POINT));


### PR DESCRIPTION
## Description

- fixes #30686

Fixes intermittent wrong (empty) join results for queries joining on
`CAST(char_column AS varchar)` keys when a dynamic filter is coerced back onto
the `char` column, e.g.:

```sql
SELECT l.id
FROM left_table l JOIN right_table r
ON CAST(l.c_char_10 AS varchar(10)) = r.c_varchar_10
```

### Root cause

7358100281f ("Reverse the implicit char/varchar coercion direction") made
`CAST(char AS varchar)` return the unpadded value. As a result, casts between
`char` and `varchar` are no longer monotone in either direction: `char` values
compare as if space-padded to their declared length, `varchar` values do not
(e.g. `char(4) '123' || chr(1)` sorts **below** `char(4) '123 '`, while their
varchar forms compare the other way around).

The varchar → char `SATURATED_FLOOR_CAST` operator was left implementing the
floor for the old padded semantics: any value shorter than the `char` length
was floored to a strictly smaller value (last code point decremented, padded
with `U+10FFFF`):

| Input | Old floor to `char(10)` | Correct preimage |
|---|---|---|
| `'I'` | `'H' + U+10FFFF×9` | `'I'` |
| `'P'` | `'O' + U+10FFFF×9` | `'P'` |

`DomainCoercer.applySaturatedCast` drops singleton values whose floor does not
round-trip equal, so a dynamic filter domain like `{'I', 'P'}` collapsed to
`Domain.none` on the `char` probe column. Connectors consuming dynamic filters
(e.g. `DynamicFilteringJdbcSplitSource`) short-circuit to zero splits on a
`none` constraint → empty scan → empty join → **wrong results**. Whether this
manifests depends on the dynamic filter winning the race against split
generation (connectors that block waiting for dynamic filter completion hit it
reliably).

More fundamentally, the saturated floor cast concept and `DomainCoercer`'s
domain translation assume a monotone cast, which no longer holds for
char/varchar — no floor function can translate range bounds correctly in both
directions for a non-monotone cast.

### Fix

Remove the varchar → char `SATURATED_FLOOR_CAST` for the default coercion.
With no operator registered, `RemoveUnsupportedDynamicFilters` drops dynamic
filters over `CAST(char AS varchar)` join keys at planning time — fail-closed —
instead of mistranslating them at runtime.

The legacy space-padded coercion (`deprecated.legacy-varchar-to-char-coercion`)
is monotone in both directions, so its operator remains valid: the previous
implementation is moved verbatim to `LegacyVarcharToCharSaturatedFloorCast`
and registered only when that property is set, mirroring
`CharToVarcharCast` / `LegacyCharToVarcharCast`.

> [!NOTE]
> This forgoes dynamic filter pruning on `CAST(char AS varchar)` join keys,
> which worked correctly before the coercion reversal (482). Reintroducing it
> safely would require a mechanism restricted to single values, which do not
> rely on monotonicity (a value can be kept exactly when its floor casts back
> equal, since the cast is injective on `char` representations) — possible
> follow-up work.

Static predicate pushdown is not affected:
`DomainTranslator.isImplicitCoercion` already refuses to peel
`char → varchar` casts (since 7358100281f) and `UnwrapCastInComparison`
unwraps only the equality family, so such predicates remain residual filters.

### Testing

- `TestRemoveUnsupportedDynamicFilters.testRemoveCharToVarcharCast` (new) —
  a dynamic filter over `CAST(char_col AS varchar)` is removed from the plan.
- `TestDomainCoercer.testVarcharToChar` (new) — the varchar → char coercion is
  unsupported (no saturated floor cast registered).
- `TestDomainTranslator.testCastCharToVarcharComparison` (new) — comparisons
  over `CAST(char_col AS varchar)` are not turned into a domain on the char
  column, including a non-monotonicity example with a code point below space.
- `TestCharacterStringCasts` — the floor cast expectations are retained
  verbatim against the legacy class.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Surfaced as a ~50% flake in a downstream JDBC connector's cast-pushdown join
test once the `char → varchar` cast stopped being pushed down and the join
executed in Trino with dynamic filtering.

- fixes #30686

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
