### PR TITLE
Push legacy CHAR to VARCHAR cast into connectors correctly

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
@@ -34,6 +34,7 @@ import io.trino.spi.expression.Variable;
 import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.CharType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
@@ -95,6 +96,7 @@ import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OR_EQUAL_OP
 import static io.trino.spi.expression.StandardFunctions.IDENTICAL_OPERATOR_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.IN_PREDICATE_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.IS_NULL_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LEGACY_CHAR_TO_VARCHAR_CAST_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OPERATOR_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.MODULO_FUNCTION_NAME;
@@ -126,6 +128,7 @@ import static io.trino.sql.ir.IrExpressions.not;
 import static io.trino.sql.ir.IrUtils.combineConjuncts;
 import static io.trino.sql.ir.IrUtils.extractConjuncts;
 import static io.trino.sql.planner.EngineExpressions.ENGINE_EXPRESSION_FUNCTION_NAME;
+import static io.trino.type.CharVarcharCoercion.LEGACY;
 import static io.trino.type.JoniRegexpType.JONI_REGEXP;
 import static io.trino.type.LikeFunctions.LIKE_FUNCTION_NAME;
 import static io.trino.type.LikeFunctions.LIKE_PATTERN_FUNCTION_NAME;
@@ -337,6 +340,13 @@ public final class ConnectorExpressionTranslator
                 return translateCoalesce(call.getArguments(), lambdaArguments);
             }
             if (CAST_FUNCTION_NAME.equals(call.getFunctionName()) && call.getArguments().size() == 1) {
+                return translateCast(call.getType(), call.getArguments().get(0), lambdaArguments);
+            }
+
+            if (LEGACY_CHAR_TO_VARCHAR_CAST_FUNCTION_NAME.equals(call.getFunctionName())) {
+                if (call.getArguments().size() != 1 || getCharVarcharCoercion(session) != LEGACY) {
+                    return Optional.empty();
+                }
                 return translateCast(call.getType(), call.getArguments().get(0), lambdaArguments);
             }
 
@@ -767,7 +777,14 @@ public final class ConnectorExpressionTranslator
 
             Optional<ConnectorExpression> translatedExpression = process(node.expression(), context);
             if (translatedExpression.isPresent()) {
-                return Optional.of(new io.trino.spi.expression.Call(node.type(), CAST_FUNCTION_NAME, List.of(translatedExpression.get())));
+                FunctionName functionName = CAST_FUNCTION_NAME;
+                if (getCharVarcharCoercion(session) == LEGACY
+                        && node.expression().type() instanceof CharType
+                        && node.type() instanceof VarcharType) {
+                    // Expose semantically different cast under different name so that connectors can distinguish
+                    functionName = LEGACY_CHAR_TO_VARCHAR_CAST_FUNCTION_NAME;
+                }
+                return Optional.of(new io.trino.spi.expression.Call(node.type(), functionName, List.of(translatedExpression.get())));
             }
 
             return Optional.empty();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
@@ -62,6 +62,7 @@ import java.util.Optional;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.SystemSessionProperties.LEGACY_VARCHAR_TO_CHAR_COERCION;
 import static io.trino.SystemSessionProperties.getCharVarcharCoercion;
 import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
 import static io.trino.operator.scalar.ArrayTransformFunction.ARRAY_TRANSFORM_NAME;
@@ -77,6 +78,7 @@ import static io.trino.spi.expression.StandardFunctions.CAST_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.COALESCE_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.DIVIDE_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.IS_NULL_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LEGACY_CHAR_TO_VARCHAR_CAST_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.MODULO_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.MULTIPLY_FUNCTION_NAME;
@@ -91,6 +93,7 @@ import static io.trino.spi.function.OperatorType.MULTIPLY;
 import static io.trino.spi.function.OperatorType.SUBTRACT;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -120,6 +123,7 @@ import static io.trino.type.LikeFunctions.likePattern;
 import static io.trino.type.LikePatternType.LIKE_PATTERN;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestConnectorExpressionTranslator
 {
@@ -142,6 +146,7 @@ public class TestConnectorExpressionTranslator
             .put(new Symbol(DOUBLE, "double_symbol_2"), DOUBLE)
             .put(new Symbol(ROW_TYPE, "row_symbol_1"), ROW_TYPE)
             .put(new Symbol(VARCHAR_TYPE, "varchar_symbol_1"), VARCHAR_TYPE)
+            .put(new Symbol(createCharType(5), "char_symbol_1"), createCharType(5))
             .put(new Symbol(BOOLEAN, "boolean_symbol_1"), BOOLEAN)
             .buildOrThrow();
 
@@ -470,6 +475,36 @@ public class TestConnectorExpressionTranslator
                         VARCHAR_TYPE,
                         CAST_FUNCTION_NAME,
                         List.of(new Variable("varchar_symbol_1", VARCHAR_TYPE))));
+    }
+
+    @Test
+    public void testTranslateLegacyCharToVarcharCast()
+    {
+        Cast cast = new Cast(new Reference(createCharType(5), "char_symbol_1"), VARCHAR_TYPE);
+
+        Session legacySession = Session.builder(TEST_SESSION)
+                .setSystemProperty(LEGACY_VARCHAR_TO_CHAR_COERCION, "true")
+                .build();
+
+        // Under the deprecated varchar-to-char coercion direction the char-to-varchar cast is exposed under a distinct
+        // name so connectors can handle it differently from the default $cast.
+        io.trino.spi.expression.Call legacyCall = new io.trino.spi.expression.Call(
+                VARCHAR_TYPE,
+                LEGACY_CHAR_TO_VARCHAR_CAST_FUNCTION_NAME,
+                List.of(new Variable("char_symbol_1", createCharType(5))));
+        assertThat(translate(legacySession, cast)).hasValue(legacyCall);
+        assertThat(ConnectorExpressionTranslator.translate(legacySession, legacyCall, PLANNER_CONTEXT, variableMappings, emptySymbolAllocator()))
+                .isEqualTo(cast);
+
+        // Under standard semantics, the same cast is a plain $cast
+        assertThat(translate(TEST_SESSION, cast)).hasValue(new io.trino.spi.expression.Call(
+                VARCHAR_TYPE,
+                CAST_FUNCTION_NAME,
+                List.of(new Variable("char_symbol_1", createCharType(5)))));
+        // Under standard semantics, the legacy call cannot be translated back (translating it to a plain Cast would
+        // resolve to the default trimming operator and change the semantics).
+        assertThatThrownBy(() -> ConnectorExpressionTranslator.translate(TEST_SESSION, legacyCall, PLANNER_CONTEXT, variableMappings, emptySymbolAllocator()))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test

--- a/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/expression/StandardFunctions.java
@@ -50,6 +50,10 @@ public final class StandardFunctions
      */
     public static final FunctionName CAST_FUNCTION_NAME = new FunctionName("$cast");
     public static final FunctionName TRY_CAST_FUNCTION_NAME = new FunctionName("$try_cast");
+    /**
+     * A {@code char} to {@code varchar} cast under legacy semantics. The result type is determined by the {@link Call#getType()}.
+     */
+    public static final FunctionName LEGACY_CHAR_TO_VARCHAR_CAST_FUNCTION_NAME = new FunctionName("$legacy_char_to_varchar_cast");
 
     public static final FunctionName EQUAL_OPERATOR_FUNCTION_NAME = new FunctionName("$equal");
     public static final FunctionName NOT_EQUAL_OPERATOR_FUNCTION_NAME = new FunctionName("$not_equal");

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -334,6 +334,15 @@ public abstract class BaseBigQueryConnectorTest
     }
 
     @Test
+    @Override
+    public void testCharToVarcharCastCoercionAcrossPushdown()
+    {
+        assertThatThrownBy(super::testCharToVarcharCastCoercionAcrossPushdown)
+                .hasMessage("Unsupported column type: char(5)")
+                .hasStackTraceContaining("SQL: CREATE TABLE test_char_to_varchar_cast");
+    }
+
+    @Test
     public void testEmptyProjectionTable()
     {
         testEmptyProjection(

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -1895,6 +1895,15 @@ public class TestCassandraConnectorTest
                 "VALUES ('CANADA', 'AMERICA')");
     }
 
+    @Test
+    @Override
+    public void testCharToVarcharCastCoercionAcrossPushdown()
+    {
+        assertThatThrownBy(super::testCharToVarcharCastCoercionAcrossPushdown)
+                .hasMessage("Unsupported type: char(5)")
+                .hasStackTraceContaining("SQL: CREATE TABLE test_char_to_varchar_cast");
+    }
+
     private void assertSelect(String tableName)
     {
         String sql = "SELECT " +

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleCastPushdownTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleCastPushdownTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 @TestInstance(PER_CLASS)
 @Execution(CONCURRENT)
-public class TestOracleCastPushdown
+public class BaseOracleCastPushdownTest
         extends BaseJdbcCastPushdownTest
 {
     private CastDataTypeTestTable left;

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleCastPushdownTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleCastPushdownTest.java
@@ -14,12 +14,10 @@
 package io.trino.plugin.oracle;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.plugin.jdbc.BaseJdbcCastPushdownTest;
 import io.trino.plugin.jdbc.CastDataTypeTestTable;
 import io.trino.sql.planner.plan.ProjectNode;
-import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
 import org.junit.jupiter.api.BeforeAll;
@@ -36,25 +34,12 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 @TestInstance(PER_CLASS)
 @Execution(CONCURRENT)
-public class BaseOracleCastPushdownTest
+public abstract class BaseOracleCastPushdownTest
         extends BaseJdbcCastPushdownTest
 {
     private CastDataTypeTestTable left;
     private CastDataTypeTestTable right;
-    private TestingOracleServer oracleServer;
-
-    @Override
-    protected QueryRunner createQueryRunner()
-            throws Exception
-    {
-        oracleServer = closeAfterClass(new TestingOracleServer());
-        return OracleQueryRunner.builder(oracleServer)
-                .addConnectorProperties(ImmutableMap.<String, String>builder()
-                        .put("jdbc-types-mapped-to-varchar", "interval year(2) to month, timestamp(6) with local time zone")
-                        .put("join-pushdown.enabled", "true")
-                        .buildOrThrow())
-                .build();
-    }
+    protected TestingOracleServer oracleServer;
 
     @Override
     protected SqlExecutor onRemoteDatabase()

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleCastPushdownTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleCastPushdownTest.java
@@ -203,6 +203,20 @@ public abstract class BaseOracleCastPushdownTest
     }
 
     @Test
+    public void testCharToVarcharCastPushdownWithMultibyteData()
+    {
+        // char(10) uses Oracle's default BYTE length semantics, so 'éé' (4 bytes in AL32UTF8) is stored padded with
+        // 6 blanks to 10 bytes, i.e. 8 code points. Oracle's CAST(CHAR AS VARCHAR2) keeps that physical (byte) padding:
+        // it matches the engine's default char-to-varchar coercion (trailing spaces trimmed), but not the deprecated
+        // legacy coercion that re-pads to the char length in code points (so that cast is not pushed down). Verify the
+        // result matches the engine regardless of which coercion direction and pushdown are in effect.
+        try (TestTable table = new TestTable(onRemoteDatabase(), "test_multibyte_char_cast", "(c char(10))", List.of("UNISTR('\\00E9\\00E9')"))) {
+            assertThat(query("SELECT CAST(c AS varchar(20)) FROM " + table.getName()))
+                    .hasCorrectResultsRegardlessOfPushdown();
+        }
+    }
+
+    @Test
     public void testJoinPushdownWithNestedCast()
     {
         CastTestCase testCase = new CastTestCase("c_varchar_10", "varchar(100)", "c_varchar_50");

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleCastPushdown.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleCastPushdown.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.oracle;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.QueryRunner;
+
+class TestOracleCastPushdown
+        extends BaseOracleCastPushdownTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        oracleServer = closeAfterClass(new TestingOracleServer());
+        return OracleQueryRunner.builder(oracleServer)
+                .addConnectorProperties(ImmutableMap.<String, String>builder()
+                        .put("jdbc-types-mapped-to-varchar", "interval year(2) to month, timestamp(6) with local time zone")
+                        .put("join-pushdown.enabled", "true")
+                        .buildOrThrow())
+                .build();
+    }
+}

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleLegacyVarcharToCharCoercionCastPushdown.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleLegacyVarcharToCharCoercionCastPushdown.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.oracle;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.QueryRunner;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class TestOracleLegacyVarcharToCharCoercionCastPushdown
+        extends BaseOracleCastPushdownTest
+{
+    // With the deprecated varchar-to-char coercion direction the engine emits the char -> varchar cast as
+    // $legacy_char_to_varchar_cast, which re-pads the value to the char type length in code points. Oracle's
+    // CAST(CHAR AS VARCHAR2) instead keeps the column's blank padding in bytes, so for multibyte data the two
+    // disagree. The cast is therefore not pushed down and the engine evaluates it.
+    private static final List<CastTestCase> LEGACY_CHAR_TO_VARCHAR_CASTS = ImmutableList.<CastTestCase>builder()
+            .add(new CastTestCase("c_char_10", "varchar(50)", "c_varchar_50"))
+            .add(new CastTestCase("c_char_50", "varchar(50)", "c_varchar_50"))
+            .add(new CastTestCase("c_char_501", "varchar(50)", "c_varchar_50"))
+            .add(new CastTestCase("c_char_520", "varchar(50)", "c_varchar_50"))
+            .add(new CastTestCase("c_nchar_10", "varchar(50)", "c_varchar_50"))
+            .add(new CastTestCase("c_char_unicode", "varchar(50)", "c_varchar_50"))
+            .add(new CastTestCase("c_nchar_unicode", "varchar(50)", "c_varchar_50"))
+            .build();
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        oracleServer = closeAfterClass(new TestingOracleServer());
+        return OracleQueryRunner.builder(oracleServer)
+                .addConnectorProperties(ImmutableMap.<String, String>builder()
+                        .put("jdbc-types-mapped-to-varchar", "interval year(2) to month, timestamp(6) with local time zone")
+                        .put("join-pushdown.enabled", "true")
+                        .buildOrThrow())
+                .addExtraProperty("deprecated.legacy-varchar-to-char-coercion", "true")
+                .build();
+    }
+
+    @Override
+    protected List<CastTestCase> supportedCastTypePushdown()
+    {
+        return super.supportedCastTypePushdown().stream()
+                .filter(testCase -> !LEGACY_CHAR_TO_VARCHAR_CASTS.contains(testCase))
+                .collect(toImmutableList());
+    }
+
+    @Override
+    protected List<CastTestCase> unsupportedCastTypePushdown()
+    {
+        return ImmutableList.<CastTestCase>builder()
+                .addAll(super.unsupportedCastTypePushdown())
+                .addAll(LEGACY_CHAR_TO_VARCHAR_CASTS)
+                .build();
+    }
+}

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -85,6 +85,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
 import static io.trino.SystemSessionProperties.IGNORE_STATS_CALCULATOR_FAILURES;
+import static io.trino.SystemSessionProperties.LEGACY_VARCHAR_TO_CHAR_COERCION;
 import static io.trino.connector.informationschema.InformationSchemaTable.INFORMATION_SCHEMA;
 import static io.trino.server.testing.TestingTrinoServer.SESSION_START_TIME_PROPERTY;
 import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
@@ -417,6 +418,44 @@ public abstract class BaseConnectorTest
             assertQuery(
                     "SELECT k, v FROM " + table.getName() + " WHERE v = CAST('x ' AS char(2))",
                     "VALUES (4, 'x')");
+        }
+    }
+
+    @Test
+    public void testCharToVarcharCastCoercionAcrossPushdown()
+    {
+        skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE));
+
+        try (TestTable table = newTrinoTable(
+                "test_char_to_varchar_cast",
+                """
+                (k, v) AS VALUES
+                   (0, CAST(NULL AS char(5))),
+                   (1, CAST('' AS char(5))),
+                   (2, CAST('ab' AS char(5))),
+                   (3, CAST('abc' AS char(5))),
+                   (4, CAST('abcde' AS char(5)))
+                """)) {
+            for (boolean legacy : List.of(false, true)) {
+                try {
+                    Session session = Session.builder(getSession()).setSystemProperty(LEGACY_VARCHAR_TO_CHAR_COERCION, Boolean.toString(legacy)).build();
+                    // Test potential CAST(char AS varchar) projection pushdown
+                    assertThat(query(session, "SELECT k, CAST(v AS varchar(1)) FROM " + table.getName())).hasCorrectResultsRegardlessOfPushdown();
+                    assertThat(query(session, "SELECT k, CAST(v AS varchar(3)) FROM " + table.getName())).hasCorrectResultsRegardlessOfPushdown();
+                    assertThat(query(session, "SELECT k, CAST(v AS varchar(6)) FROM " + table.getName())).hasCorrectResultsRegardlessOfPushdown();
+
+                    // Test potential CAST(char AS varchar) predicate pushdown
+                    assertThat(query(session, "SELECT k FROM " + table.getName() + " WHERE CAST(v AS varchar(2)) = CAST('ab' AS varchar(3))")).hasCorrectResultsRegardlessOfPushdown();
+                    assertThat(query(session, "SELECT k FROM " + table.getName() + " WHERE CAST(v AS varchar(6)) = CAST('abc' AS varchar(6))")).hasCorrectResultsRegardlessOfPushdown();
+                    assertThat(query(session, "SELECT k FROM " + table.getName() + " WHERE CAST(v AS varchar(6)) = CAST('abc ' AS varchar(6))")).hasCorrectResultsRegardlessOfPushdown();
+                    assertThat(query(session, "SELECT k FROM " + table.getName() + " WHERE CAST(v AS varchar(6)) = CAST('abc  ' AS varchar(6))")).hasCorrectResultsRegardlessOfPushdown();
+                    assertThat(query(session, "SELECT k FROM " + table.getName() + " WHERE CAST(v AS varchar(6)) = CAST('abc   ' AS varchar(6))")).hasCorrectResultsRegardlessOfPushdown();
+                }
+                catch (Throwable t) {
+                    t.addSuppressed(new Exception("Using %s=%s".formatted(LEGACY_VARCHAR_TO_CHAR_COERCION, legacy)));
+                    throw t;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Connectors that push CAST(char AS varchar) down (Oracle, Redshift, ...) rewrite it to trim trailing spaces, matching the default char-to-varchar coercion where char-to-varchar yields the unpadded value. Under the deprecated deprecated.legacy-varchar-to-char-coercion direction the engine instead re-pads the value to the char length, so the trimming pushdown returned a wrong result.

Expose the char-to-varchar cast as a distinct $legacy_char_to_varchar_cast connector expression when legacy coercion is enabled, so connectors do not apply their default (trimming) $cast rewrite to the padding cast. The distinct name is threaded through PlannerContext, and translating it back to a plain Cast is refused unless legacy coercion is in effect. Oracle additionally rewrites the legacy function to a plain CAST, since Oracle's CAST(CHAR AS VARCHAR2) keeps the blank padding and thus matches the engine.

Add BaseConnectorSmokeTest coverage for the char-to-varchar cast in projection and predicate pushdown (skipped when the connector does not store a genuine char column), and add legacy-coercion smoke tests for the JDBC connectors.
