### PR TITLE
Resolve secrets in S3 security mapping JSON

### DIFF
--- a/lib/trino-filesystem-s3/pom.xml
+++ b/lib/trino-filesystem-s3/pom.xml
@@ -239,6 +239,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>secrets-spi</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/lib/trino-filesystem-s3/pom.xml
+++ b/lib/trino-filesystem-s3/pom.xml
@@ -238,6 +238,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>secrets-spi</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3SecurityMappingsFileSource.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3SecurityMappingsFileSource.java
@@ -13,29 +13,44 @@
  */
 package io.trino.filesystem.s3;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import io.airlift.configuration.secrets.SecretsResolver;
 
-import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.function.Supplier;
 
 import static io.trino.plugin.base.util.JsonUtils.parseJson;
+import static java.util.Objects.requireNonNull;
 
 class S3SecurityMappingsFileSource
         implements Supplier<S3SecurityMappings>
 {
-    private final File configFile;
+    private final Path configFile;
     private final String jsonPointer;
+    private final SecretsResolver secretsResolver;
 
     @Inject
-    public S3SecurityMappingsFileSource(S3SecurityMappingConfig config)
+    public S3SecurityMappingsFileSource(S3SecurityMappingConfig config, SecretsResolver secretsResolver)
     {
-        this.configFile = config.getConfigFile().orElseThrow();
+        this.configFile = config.getConfigFile().orElseThrow().toPath();
         this.jsonPointer = config.getJsonPointer();
+        this.secretsResolver = requireNonNull(secretsResolver, "secretsResolver is null");
     }
 
     @Override
     public S3SecurityMappings get()
     {
-        return parseJson(configFile.toPath(), jsonPointer, S3SecurityMappings.class);
+        try {
+            String json = Files.readString(configFile);
+            String resolved = secretsResolver.getResolvedConfiguration(ImmutableMap.of("json", json)).get("json");
+            return parseJson(resolved, jsonPointer, S3SecurityMappings.class);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to read security mapping file: " + configFile, e);
+        }
     }
 }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3SecurityMappingsUriSource.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3SecurityMappingsUriSource.java
@@ -14,7 +14,9 @@
 package io.trino.filesystem.s3;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import io.airlift.configuration.secrets.SecretsResolver;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.HttpStatus;
 import io.airlift.http.client.Request;
@@ -35,19 +37,23 @@ class S3SecurityMappingsUriSource
     private final URI configUri;
     private final HttpClient httpClient;
     private final String jsonPointer;
+    private final SecretsResolver secretsResolver;
 
     @Inject
-    public S3SecurityMappingsUriSource(S3SecurityMappingConfig config, @ForS3SecurityMapping HttpClient httpClient)
+    public S3SecurityMappingsUriSource(S3SecurityMappingConfig config, @ForS3SecurityMapping HttpClient httpClient, SecretsResolver secretsResolver)
     {
         this.configUri = config.getConfigUri().orElseThrow();
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.jsonPointer = config.getJsonPointer();
+        this.secretsResolver = requireNonNull(secretsResolver, "secretsResolver is null");
     }
 
     @Override
     public S3SecurityMappings get()
     {
-        return parseJson(getRawJsonString(), jsonPointer, S3SecurityMappings.class);
+        String json = getRawJsonString();
+        String resolved = secretsResolver.getResolvedConfiguration(ImmutableMap.of("json", json)).get("json");
+        return parseJson(resolved, jsonPointer, S3SecurityMappings.class);
     }
 
     @VisibleForTesting

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3SecurityMapping.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3SecurityMapping.java
@@ -13,7 +13,9 @@
  */
 package io.trino.filesystem.s3;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.configuration.secrets.SecretsResolver;
 import io.trino.filesystem.Location;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.ConnectorIdentity;
@@ -51,7 +53,7 @@ public class TestS3SecurityMapping
                 .setSseCustomerKeyCredentialName(CUSTOMER_KEY_CREDENTIAL_NAME)
                 .setColonReplacement("#");
 
-        var provider = new S3SecurityMappingProvider(mappingConfig, new S3SecurityMappingsFileSource(mappingConfig));
+        var provider = new S3SecurityMappingProvider(mappingConfig, new S3SecurityMappingsFileSource(mappingConfig, new SecretsResolver(ImmutableMap.of())));
 
         // matches prefix -- mapping provides credentials
         assertMapping(
@@ -311,7 +313,7 @@ public class TestS3SecurityMapping
         S3SecurityMappingConfig mappingConfig = new S3SecurityMappingConfig()
                 .setConfigFile(getResourceFile("security-mapping-with-fallback-to-cluster-default.json"));
 
-        var provider = new S3SecurityMappingProvider(mappingConfig, new S3SecurityMappingsFileSource(mappingConfig));
+        var provider = new S3SecurityMappingProvider(mappingConfig, new S3SecurityMappingsFileSource(mappingConfig, new SecretsResolver(ImmutableMap.of())));
 
         // matches prefix -- uses the role from the mapping
         assertMapping(
@@ -329,7 +331,7 @@ public class TestS3SecurityMapping
         S3SecurityMappingConfig mappingConfig = new S3SecurityMappingConfig()
                 .setConfigFile(getResourceFile("security-mapping-without-fallback.json"));
 
-        var provider = new S3SecurityMappingProvider(mappingConfig, new S3SecurityMappingsFileSource(mappingConfig));
+        var provider = new S3SecurityMappingProvider(mappingConfig, new S3SecurityMappingsFileSource(mappingConfig, new SecretsResolver(ImmutableMap.of())));
 
         // matches prefix - return role from the mapping
         assertMapping(

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3SecurityMappingsFileSource.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3SecurityMappingsFileSource.java
@@ -16,42 +16,30 @@ package io.trino.filesystem.s3;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.configuration.secrets.SecretsResolver;
-import io.airlift.http.client.HttpStatus;
-import io.airlift.http.client.Response;
-import io.airlift.http.client.testing.TestingHttpClient;
 import io.trino.filesystem.Location;
 import io.trino.spi.security.ConnectorIdentity;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import java.net.URI;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
-import static com.google.common.net.MediaType.JSON_UTF_8;
-import static io.airlift.http.client.testing.TestingResponse.mockResponse;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestS3SecurityMappingsUriSource
+public class TestS3SecurityMappingsFileSource
 {
-    private static final String MOCK_MAPPINGS_RESPONSE =
-            "{\"mappings\": [{\"iamRole\":\"arn:aws:iam::test\",\"user\":\"test\"}]}";
-
     @Test
-    public void testGetRawJson()
-    {
-        Response response = mockResponse(HttpStatus.OK, JSON_UTF_8, MOCK_MAPPINGS_RESPONSE);
-        S3SecurityMappingConfig config = new S3SecurityMappingConfig().setConfigUri(URI.create("http://test:1234/api/endpoint"));
-        var provider = new S3SecurityMappingsUriSource(config, new TestingHttpClient(_ -> response), new SecretsResolver(ImmutableMap.of()));
-        String result = provider.getRawJsonString();
-        assertThat(result).isEqualTo(MOCK_MAPPINGS_RESPONSE);
-    }
-
-    @Test
-    public void testSecretsResolution()
+    public void testSecretsResolution(@TempDir Path tempDir)
+            throws IOException
     {
         String jsonWithSecrets = "{\"mappings\": [{\"iamRole\":\"${TESTING:my-role}\",\"prefix\":\"s3://my-bucket/\",\"user\":\"test\"}]}";
-        Response response = mockResponse(HttpStatus.OK, JSON_UTF_8, jsonWithSecrets);
-        S3SecurityMappingConfig config = new S3SecurityMappingConfig().setConfigUri(URI.create("http://test:1234/api/endpoint"));
+        Path configFile = tempDir.resolve("mappings.json");
+        Files.writeString(configFile, jsonWithSecrets);
+
+        S3SecurityMappingConfig config = new S3SecurityMappingConfig().setConfigFile(configFile.toFile());
         SecretsResolver secretsResolver = new SecretsResolver(ImmutableMap.of("testing", key -> "arn:aws:iam::resolved-" + key));
-        var provider = new S3SecurityMappingsUriSource(config, new TestingHttpClient(_ -> response), secretsResolver);
+        var provider = new S3SecurityMappingsFileSource(config, secretsResolver);
 
         S3SecurityMappings mappings = provider.get();
         ConnectorIdentity identity = ConnectorIdentity.forUser("test").withGroups(ImmutableSet.of()).build();


### PR DESCRIPTION
## Description

Use Airlift `SecretsResolver` to resolve secret references (e.g. `${ENV:MY_SECRET}`) in S3 security mapping JSON before parsing. This allows sensitive values like IAM roles and credentials to be managed through Airlift secret providers instead of being stored in plaintext in the mapping configuration files.


## Additional context and related issues

Fixes [issue#30687](https://github.com/trinodb/trino/issues/30687)

The resolution happens at the raw JSON string level before Jackson deserialization, matching the pattern used by Airlift's own config property resolution. Both `S3SecurityMappingFileSource` and `S3SecurityMappingUriSource` are updated. `SecretResolver` is already available in the connector injector via Bootstrap.


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:


```markdown
## S3
* Add support for resolving secrets in S3 security mapping configuration files using Airlift secret providers. ({issue}`30687`)
```
