### PR TITLE
Group web UI dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,14 @@ updates:
     directory: "/core/trino-web-ui/src/main/resources/webapp"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "Web UI:"
+    # Group dependabot updates for the web UI dependencies to reduce PR volume.
+    groups:
+      web-ui-dependencies:
+        patterns:
+          - "*"
     allow:
       - dependency-type: "all"
     ignore:


### PR DESCRIPTION
## Description

Group dependabot updates for the web UI dependencies to reduce PR volume.
PRs with multiple bumps will have commit messages and PR titles prefixed with `Web UI:`.

## Additional context and related issues

n/a

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
