### PR TITLE
Make paths relative in the Trino Web UI to support path-based reverse proxying

### DIFF
--- a/core/trino-web-ui/src/main/resources/oauth2/failure.html
+++ b/core/trino-web-ui/src/main/resources/oauth2/failure.html
@@ -20,7 +20,7 @@
     <meta name="description" content="Web Interface - Trino">
     <title>Cluster Overview - Trino</title>
 
-    <link rel="icon" href="/ui/static/trino.ico">
+    <link rel="icon" href="static/trino.ico">
 </head>
 
 <body>

--- a/core/trino-web-ui/src/main/resources/oauth2/logout.html
+++ b/core/trino-web-ui/src/main/resources/oauth2/logout.html
@@ -20,7 +20,7 @@
     <meta name="description" content="Web Interface - Trino">
     <title>Cluster Overview - Trino</title>
 
-    <link rel="icon" href="/ui/static/trino.ico">
+    <link rel="icon" href="static/trino.ico">
 </head>
 
 <body>

--- a/core/trino-web-ui/src/main/resources/oauth2/success.html
+++ b/core/trino-web-ui/src/main/resources/oauth2/success.html
@@ -20,25 +20,7 @@
     <meta name="description" content="Web Interface - Trino">
     <title>Cluster Overview - Trino</title>
 
-    <link rel="icon" href="/ui/assets/favicon.ico">
-
-    <!-- Bootstrap core -->
-    <link href="/ui/vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
-
-    <!-- jQuery -->
-    <script type="text/javascript" src="/ui/vendor/jquery/jquery-3.5.1.min.js"></script>
-
-    <!-- Bootstrap JS -->
-    <script type="text/javascript" src="/ui/vendor/bootstrap/js/bootstrap.js"></script>
-
-    <!-- Sparkline -->
-    <script type="text/javascript" src="/ui/vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
-
-    <!-- CSS loader -->
-    <link href="/ui/vendor/css-loaders/loader.css" rel="stylesheet">
-
-    <!-- Custom CSS -->
-    <link href="/ui/assets/trino.css" rel="stylesheet">
+    <link rel="icon" href="static/trino.ico">
 </head>
 
 <body>

--- a/core/trino-web-ui/src/main/resources/webapp-legacy/assets/js/timeline.js
+++ b/core/trino-web-ui/src/main/resources/webapp-legacy/assets/js/timeline.js
@@ -13,7 +13,7 @@
  */
 
 $(document).ready(function () {
-    $.ajax({url: '/ui/api/query/' + window.location.search.substring(1)})
+    $.ajax({url: '../api/query/' + window.location.search.substring(1)})
         .done(function(data) {
             $('#queryId').text(data.queryId);
             renderTimeline(data);

--- a/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/ClusterHUD.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/ClusterHUD.jsx
@@ -70,7 +70,7 @@ export class ClusterHUD extends React.Component {
     refreshLoop() {
         clearTimeout(this.timeoutId) // to stop multiple series of refreshLoop from going on simultaneously
         $.get(
-            '/ui/api/stats',
+            '../api/stats',
             function (clusterState) {
                 let newRowInputRate = []
                 let newByteInputRate = []

--- a/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/LivePlan.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/LivePlan.jsx
@@ -194,7 +194,7 @@ export class LivePlan extends React.Component<LivePlanProps, LivePlanState> {
 
     refreshLoop = () => {
         clearTimeout(this.timeoutId) // to stop multiple series of refreshLoop from going on simultaneously
-        fetch('/ui/api/query/' + this.props.queryId)
+        fetch('../api/query/' + this.props.queryId)
             .then((response) => response.json())
             .then((query) => {
                 this.setState({

--- a/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/PageTitle.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/PageTitle.jsx
@@ -44,7 +44,7 @@ export class PageTitle extends React.Component<Props, State> {
 
     refreshLoop = () => {
         clearTimeout(this.timeoutId)
-        fetch('/ui/api/cluster')
+        fetch('../api/cluster')
             .then((response) => {
                 if (response.status === 401) {
                     location.reload()
@@ -113,7 +113,7 @@ export class PageTitle extends React.Component<Props, State> {
                                 <tbody>
                                     <tr>
                                         <td>
-                                            <a href="/ui/">
+                                            <a href="./">
                                                 <img src="assets/logo.png" />
                                             </a>
                                         </td>
@@ -129,7 +129,7 @@ export class PageTitle extends React.Component<Props, State> {
                                 <li>
                                     <span className="navbar-cluster-info">
                                         <span className="text">
-                                            <a className="btn btn-info" href="/ui">
+                                            <a className="btn btn-info" href="../">
                                                 New Web UI
                                             </a>
                                         </span>

--- a/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/QueryDetail.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/QueryDetail.jsx
@@ -124,7 +124,7 @@ class TaskList extends React.Component {
                     <Td column="id" value={task.taskStatus.taskId}>
                         <a
                             href={
-                                '/ui/api/worker/' +
+                                '../api/worker/' +
                                 task.taskStatus.nodeId +
                                 '/task/' +
                                 task.taskStatus.taskId +
@@ -933,7 +933,7 @@ export class QueryDetail extends React.Component {
         clearTimeout(this.timeoutId) // to stop multiple series of refreshLoop from going on simultaneously
         const queryId = getFirstParameter(window.location.search)
         $.get(
-            '/ui/api/query/' + queryId,
+            '../api/query/' + queryId,
             function (query) {
                 let lastSnapshotStages = this.state.lastSnapshotStages
                 if (this.state.stageRefresh) {

--- a/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/QueryHeader.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/QueryHeader.jsx
@@ -67,7 +67,7 @@ export class QueryHeader extends React.Component {
                             <a
                                 onClick={() =>
                                     $.ajax({
-                                        url: '/ui/api/query/' + query.queryId + '/preempted',
+                                        url: '../api/query/' + query.queryId + '/preempted',
                                         type: 'PUT',
                                         data: 'Preempted via web UI',
                                     })
@@ -82,7 +82,7 @@ export class QueryHeader extends React.Component {
                             <a
                                 onClick={() =>
                                     $.ajax({
-                                        url: '/ui/api/query/' + query.queryId + '/killed',
+                                        url: '../api/query/' + query.queryId + '/killed',
                                         type: 'PUT',
                                         data: 'Killed via web UI',
                                     })
@@ -149,7 +149,7 @@ export class QueryHeader extends React.Component {
                                         {this.renderTab('timeline.html', 'Splits')}
                                         &nbsp;
                                         <a
-                                            href={'/ui/api/query/' + query.queryId + '?pretty'}
+                                            href={'../api/query/' + query.queryId + '?pretty'}
                                             className="btn btn-info navbar-btn"
                                             target="_blank"
                                         >

--- a/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/QueryList.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/QueryList.jsx
@@ -188,7 +188,7 @@ export class QueryListItem extends React.Component {
                             </div>
                             <div className="col-xs-4 text-right">
                                 <a
-                                    href={'/ui/api/query/' + query.queryId + '?pretty'}
+                                    href={'../api/query/' + query.queryId + '?pretty'}
                                     target="_blank"
                                     data-toggle="tooltip"
                                     data-placement="bottom"
@@ -498,7 +498,7 @@ export class QueryList extends React.Component {
         clearTimeout(this.searchTimeoutId)
 
         $.get(
-            '/ui/api/query',
+            '../api/query',
             function (queryList) {
                 const queryMap = queryList.reduce(function (map, query) {
                     map[query.queryId] = query

--- a/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/ReferenceDetail.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/ReferenceDetail.jsx
@@ -55,7 +55,7 @@ export class ReferenceDetail extends React.Component {
         const queryString = getFirstParameter(window.location.search).split('.')
         const queryId = queryString[0]
 
-        $.get('/ui/api/query/' + queryId + '?pruned=true', (query) => {
+        $.get('../api/query/' + queryId + '?pruned=true', (query) => {
             this.setState({
                 initialized: true,
                 ended: query.finalQueryInfo,

--- a/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/StageDetail.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/StageDetail.jsx
@@ -594,7 +594,7 @@ export class StageDetail extends React.Component {
             }
         }
 
-        $.get('/ui/api/query/' + queryId, (query) => {
+        $.get('../api/query/' + queryId, (query) => {
             this.setState({
                 initialized: true,
                 ended: query.finalQueryInfo,

--- a/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/WorkerList.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/WorkerList.jsx
@@ -37,7 +37,7 @@ export class WorkerList extends React.Component {
     refreshLoop() {
         clearTimeout(this.timeoutId)
         $.get(
-            '/ui/api/worker',
+            '../api/worker',
             function (workers) {
                 if (workers != null) {
                     workers.sort(function (workerA, workerB) {

--- a/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/WorkerStatus.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/WorkerStatus.jsx
@@ -55,7 +55,7 @@ export class WorkerStatus extends React.Component {
         clearTimeout(this.timeoutId) // to stop multiple series of refreshLoop from going on simultaneously
         const nodeId = getFirstParameter(window.location.search)
         $.get(
-            '/ui/api/worker/' + nodeId + '/status',
+            '../api/worker/' + nodeId + '/status',
             function (serverInfo) {
                 this.setState({
                     serverInfo: serverInfo,

--- a/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/WorkerThreadList.jsx
+++ b/core/trino-web-ui/src/main/resources/webapp-legacy/src/components/WorkerThreadList.jsx
@@ -44,7 +44,7 @@ export class WorkerThreadList extends React.Component {
     captureSnapshot() {
         const nodeId = getFirstParameter(window.location.search)
         $.get(
-            '/ui/api/worker/' + nodeId + '/thread',
+            '../api/worker/' + nodeId + '/thread',
             function (threads) {
                 this.setState({
                     threads: WorkerThreadList.processThreads(threads),

--- a/core/trino-web-ui/src/main/resources/webapp/.env.development
+++ b/core/trino-web-ui/src/main/resources/webapp/.env.development
@@ -1,3 +1,4 @@
 # https://vitejs.dev/guide/env-and-mode.html
 
-VITE_BASE_URL=http://127.0.0.1:8080/
+VITE_BASE_URL=/ui/
+VITE_PROXY_TARGET=http://127.0.0.1:8080

--- a/core/trino-web-ui/src/main/resources/webapp/.env.production
+++ b/core/trino-web-ui/src/main/resources/webapp/.env.production
@@ -1,3 +1,3 @@
 # https://vitejs.dev/guide/env-and-mode.html
 
-VITE_BASE_URL=/
+VITE_BASE_URL=./

--- a/core/trino-web-ui/src/main/resources/webapp/package.json
+++ b/core/trino-web-ui/src/main/resources/webapp/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun --bun vite",
-    "build": "bun --bun vite build",
+    "build": "NODE_ENV=production bun --bun vite build",
     "typecheck": "bun --bun tsc -b",
     "lint": "bun --bun eslint . --report-unused-disable-directives --max-warnings 0",
     "package": "bun install && bun run build",

--- a/core/trino-web-ui/src/main/resources/webapp/public/static/disabled.html
+++ b/core/trino-web-ui/src/main/resources/webapp/public/static/disabled.html
@@ -20,7 +20,7 @@
     <meta name="description" content="Web Interface - Trino">
     <title>Cluster Overview - Trino</title>
 
-    <link rel="icon" href="/ui/static/trino.ico">
+    <link rel="icon" href="trino.ico">
 </head>
 
 <body>

--- a/core/trino-web-ui/src/main/resources/webapp/src/App.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/App.tsx
@@ -11,14 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { HashRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
+import { HashRouter as Router, Routes, Route, Navigate, Link } from 'react-router-dom'
 import {
     Box,
     Button,
     Container,
     CssBaseline,
     Grid,
-    Link,
     ThemeProvider,
     Typography,
     useMediaQuery,
@@ -98,7 +97,7 @@ const NotFound = () => {
                 <Grid size={12} spacing={{ md: 10 }}>
                     <Typography variant="h3">404</Typography>
                     <Typography sx={{ mb: 2 }}>The page you’re looking for doesn’t exist.</Typography>
-                    <Button variant="contained" component={Link} href="/">
+                    <Button variant="contained" component={Link} to="/">
                         Back home
                     </Button>
                 </Grid>

--- a/core/trino-web-ui/src/main/resources/webapp/src/api/webapp/api.ts
+++ b/core/trino-web-ui/src/main/resources/webapp/src/api/webapp/api.ts
@@ -378,37 +378,37 @@ export interface WorkerTaskInfo {
 }
 
 export async function clusterApi(): Promise<ApiResponse<Cluster>> {
-    return await api.get<Cluster>('/ui/api/cluster')
+    return await api.get<Cluster>('api/cluster')
 }
 
 export async function statsApi(): Promise<ApiResponse<Stats>> {
-    return await api.get<Stats>('/ui/api/stats')
+    return await api.get<Stats>('api/stats')
 }
 
 export async function workerApi(): Promise<ApiResponse<Worker[]>> {
-    return await api.get<Worker[]>('/ui/api/worker')
+    return await api.get<Worker[]>('api/worker')
 }
 
 export async function workerStatusApi(nodeId: string): Promise<ApiResponse<WorkerStatusInfo>> {
-    return await api.get<WorkerStatusInfo>(`/ui/api/worker/${nodeId}/status`)
+    return await api.get<WorkerStatusInfo>(`api/worker/${nodeId}/status`)
 }
 
 export async function workerThreadApi(nodeId: string): Promise<ApiResponse<WorkerThreadInfo[]>> {
-    return await api.get<WorkerThreadInfo[]>(`/ui/api/worker/${nodeId}/thread`)
+    return await api.get<WorkerThreadInfo[]>(`api/worker/${nodeId}/thread`)
 }
 
 export async function workerTaskApi(nodeId: string, taskId: string): Promise<ApiResponse<WorkerTaskInfo>> {
-    return await api.get<WorkerTaskInfo>(`/ui/api/worker/${nodeId}/task/${taskId}`)
+    return await api.get<WorkerTaskInfo>(`api/worker/${nodeId}/task/${taskId}`)
 }
 
 export async function queryApi(): Promise<ApiResponse<QueryInfo[]>> {
-    return await api.get<QueryInfo[]>('/ui/api/query')
+    return await api.get<QueryInfo[]>('api/query')
 }
 
 export async function queryStatusApi(queryId: string, pruned: boolean = false): Promise<ApiResponse<QueryStatusInfo>> {
-    return await api.get<QueryStatusInfo>(`/ui/api/query/${queryId}${pruned ? '?pruned=true' : ''}`)
+    return await api.get<QueryStatusInfo>(`api/query/${queryId}${pruned ? '?pruned=true' : ''}`)
 }
 
 export async function killQueryApi(queryId: string): Promise<ApiResponse<void>> {
-    return await api.put<void>(`/ui/api/query/${queryId}/killed`, 'Canceled via web UI')
+    return await api.put<void>(`api/query/${queryId}/killed`, 'Canceled via web UI')
 }

--- a/core/trino-web-ui/src/main/resources/webapp/src/api/webapp/auth.ts
+++ b/core/trino-web-ui/src/main/resources/webapp/src/api/webapp/auth.ts
@@ -23,13 +23,13 @@ export interface AuthInfo {
 export type Empty = object
 
 export async function authInfoApi(): Promise<ApiResponse<AuthInfo>> {
-    return api.get('/ui/auth/info')
+    return api.get('auth/info')
 }
 
 export async function loginApi(body: Record<string, string>): Promise<ApiResponse<Empty>> {
-    return api.post('/ui/auth/login', body)
+    return api.post('auth/login', body)
 }
 
 export async function logoutApi(): Promise<ApiResponse<Empty>> {
-    return api.get('/ui/auth/logout')
+    return api.get('auth/logout')
 }

--- a/core/trino-web-ui/src/main/resources/webapp/src/components/AuthProvider.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/AuthProvider.tsx
@@ -95,7 +95,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     const logout = ({ redirect = false }: LogoutParams) => {
         if (redirect) {
-            window.location.href = '/ui/logout'
+            window.location.href = 'logout'
         } else {
             callApi({
                 apiFn: logoutApi,

--- a/core/trino-web-ui/src/main/resources/webapp/src/components/Layout.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/Layout.tsx
@@ -230,8 +230,8 @@ export const RootLayout = (props: { children: React.ReactNode }) => {
                     <Typography
                         variant="h6"
                         noWrap
-                        component="a"
-                        href="/"
+                        component={Link}
+                        to="/"
                         sx={{
                             mx: 2,
                             display: 'flex',

--- a/core/trino-web-ui/src/main/resources/webapp/vite.config.ts
+++ b/core/trino-web-ui/src/main/resources/webapp/vite.config.ts
@@ -19,8 +19,9 @@ export default defineConfig((mode: ConfigEnv) => {
     // @ts-ignore
     const env = loadEnv(mode.mode, process.cwd())
     const baseUrl = env.VITE_BASE_URL
+    const proxyTarget = env.VITE_PROXY_TARGET || 'http://127.0.0.1:8080';
     return {
-        base: '/ui',
+        base: baseUrl,
         plugins: [stripWoffFallback(), react()],
         resolve: {
             // Force a single copy of React: resolution walks up from the importing file, so a stray
@@ -31,11 +32,11 @@ export default defineConfig((mode: ConfigEnv) => {
         server: {
             proxy: {
                 ['/ui/auth']: {
-                    target: baseUrl,
+                    target: proxyTarget,
                     changeOrigin: true,
                 },
                 ['/ui/api']: {
-                    target: baseUrl,
+                    target: proxyTarget,
                     changeOrigin: true,
                 },
             },


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This PR changes absolute paths in the web UIs to relative paths, to support path-based reverse proxying.

For the new web UI the main change is to remove the absolute `/ui/` portion of the paths, and use react router's `Link` component in a few places.

For the legacy UI, the main change is to replace the absolute `/ui/` portion of the paths with `../` since the legacy UI is hosted under `/ui/legacy`

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Related PR to make some paths relative: https://github.com/trinodb/trino/pull/23323

Due to the .env file changes, there was a workaround needed in `package.json` to load the correct environment variables when running `bun run build`: https://github.com/oven-sh/bun/issues/6338


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Make paths relative in the Trino Web UI to support path-based reverse proxying ({issue}`issuenumber`)
```
