### PR TITLE
Fix ORC checkpoint seek at stream end

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/CompressedOrcChunkLoader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/CompressedOrcChunkLoader.java
@@ -90,7 +90,9 @@ public final class CompressedOrcChunkLoader
             throws IOException
     {
         int compressedOffset = decodeCompressedBlockOffset(checkpoint);
-        if (compressedOffset >= dataReader.getSize()) {
+        int decompressedOffset = decodeDecompressedOffset(checkpoint);
+        if (compressedOffset > dataReader.getSize() ||
+                (compressedOffset == dataReader.getSize() && decompressedOffset != 0)) {
             throw new OrcCorruptionException(dataReader.getOrcDataSourceId(), "Seek past end of stream");
         }
         // is the compressed offset within the current compressed buffer
@@ -102,7 +104,7 @@ public final class CompressedOrcChunkLoader
             compressedBufferStream = EMPTY_SLICE.getInput();
         }
 
-        nextUncompressedOffset = decodeDecompressedOffset(checkpoint);
+        nextUncompressedOffset = decompressedOffset;
         lastCheckpoint = checkpoint;
     }
 

--- a/lib/trino-orc/src/test/java/io/trino/orc/stream/TestByteArrayStream.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/stream/TestByteArrayStream.java
@@ -13,12 +13,14 @@
  */
 package io.trino.orc.stream;
 
+import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
 import io.trino.orc.OrcCorruptionException;
 import io.trino.orc.OrcDecompressor;
 import io.trino.orc.checkpoint.ByteArrayStreamCheckpoint;
+import io.trino.orc.metadata.OrcColumnId;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -28,7 +30,10 @@ import java.util.Optional;
 
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.orc.OrcDecompressor.createOrcDecompressor;
+import static io.trino.orc.checkpoint.InputStreamCheckpoint.decodeCompressedBlockOffset;
+import static io.trino.orc.checkpoint.InputStreamCheckpoint.decodeDecompressedOffset;
 import static io.trino.orc.metadata.CompressionKind.SNAPPY;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestByteArrayStream
         extends AbstractTestValueStream<Slice, ByteArrayStreamCheckpoint, ByteArrayOutputStream, ByteArrayInputStream>
@@ -50,6 +55,29 @@ public class TestByteArrayStream
             groups.add(group);
         }
         testWriteValue(groups);
+    }
+
+    @Test
+    public void testSeekToEmptyGroupAtCompressedStreamEnd()
+            throws IOException
+    {
+        ByteArrayOutputStream outputStream = createValueOutputStream();
+        int directWriteSize = 64 * 1024; // Exceeds OrcOutputBuffer's 32 KiB direct flush threshold.
+
+        outputStream.recordCheckpoint();
+        outputStream.writeSlice(Slices.allocate(directWriteSize));
+
+        outputStream.recordCheckpoint();
+        outputStream.close();
+
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(directWriteSize);
+        outputStream.getStreamDataOutput(new OrcColumnId(33)).writeData(sliceOutput);
+
+        ByteArrayStreamCheckpoint emptyGroupCheckpoint = outputStream.getCheckpoints().get(1);
+        assertThat(decodeCompressedBlockOffset(emptyGroupCheckpoint.getInputStreamCheckpoint())).isEqualTo(sliceOutput.size());
+        assertThat(decodeDecompressedOffset(emptyGroupCheckpoint.getInputStreamCheckpoint())).isEqualTo(0);
+
+        createValueStream(sliceOutput.slice()).seekToCheckpoint(emptyGroupCheckpoint);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Allow ORC compressed streams to seek to a checkpoint exactly at the end of the stream when the decompressed offset is zero.

A checkpoint at `(EOF, 0)` is valid when a row group has no additional payload in that stream. Previously, it was incorrectly rejected as a seek past the end of the stream.

Checkpoints beyond EOF, or at EOF with a non-zero decompressed offset, remain invalid.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This can occur when an ORC writer writes data directly to the compressed output and the following row group has no additional payload for that stream.

The issue was observed while optimizing a sorted Iceberg table. Although the table format was Parquet, sorted writing uses temporary ORC files during the merge process.

Fixes #28636.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Bug Fixes
* Fix failures when reading ORC files containing row groups with no payload at the end of a compressed stream. ({issue}`28636`)
```
