### PR TITLE
Update GIB to 4.7.0 and let it see provisio dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,8 @@
         Since 1.1.0, the default behaviour for such conflicts changed from overwriting the artifact to failing the build.
         -->
         <provisio.fallbackTargetFileNameMode>GA</provisio.fallbackTargetFileNameMode>
+        <!-- Enabled by the gib profile, see the gitflow-incremental-builder plugin declaration below. -->
+        <gib-extension.enabled>false</gib-extension.enabled>
     </properties>
 
     <dependencyManagement>
@@ -2782,6 +2784,34 @@
         </pluginManagement>
 
         <plugins>
+            <!-- Enabled by the gib profile, which sets gib-extension.enabled to true.
+            The extension is declared here rather than in the profile because Maven runs the lifecycle
+            participant of the extension declared last first, and GIB only picks up project mutations of
+            extensions that ran before it. Declaring GIB before provisio-maven-plugin makes GIB run after
+            it, so that GIB sees the reactor dependencies provisio derives from its descriptors and does
+            not prune the modules the server assemblies are built from.
+            See https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/issues/1183 -->
+            <plugin>
+                <groupId>io.github.gitflow-incremental-builder</groupId>
+                <artifactId>gitflow-incremental-builder</artifactId>
+                <version>4.7.0</version>
+                <extensions>${gib-extension.enabled}</extensions>
+                <configuration>
+                    <compareToMergeBase>true</compareToMergeBase>
+                    <uncommitted>true</uncommitted>
+                    <untracked>true</untracked>
+                    <buildUpstreamMode>impacted</buildUpstreamMode>
+                    <!-- Skip tests and checks for upstream modules since they have not been modified but are still required to be built -->
+                    <skipTestsForUpstreamModules>true</skipTestsForUpstreamModules>
+                    <argsForUpstreamModules>-Dmaven.source.skip=true -Dair.check.skip-all</argsForUpstreamModules>
+                    <!-- Any modules selected with -pl will be built fully (with tests etc.) if the selected module itself is changed
+                    or one of its (non-selected) upstream modules -->
+                    <disableSelectedProjectsHandling>true</disableSelectedProjectsHandling>
+                    <failOnMissingGitDir>true</failOnMissingGitDir>
+                    <failOnError>true</failOnError>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-maven-plugin</artifactId>
@@ -2903,6 +2933,8 @@
         <profile>
             <id>gib</id>
             <properties>
+                <!-- Loads the gitflow-incremental-builder extension declared in build/plugins, see the comment there. -->
+                <gib-extension.enabled>true</gib-extension.enabled>
                 <!-- the *local* master, not refs/remotes/... -->
                 <gib.referenceBranch>master</gib.referenceBranch>
                 <!-- set as properties, not configuration, to allow overriding them -->
@@ -2910,30 +2942,6 @@
                 <gib.buildUpstream>true</gib.buildUpstream>
                 <gib.disableIfBranchMatches>master</gib.disableIfBranchMatches>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.github.gitflow-incremental-builder</groupId>
-                        <artifactId>gitflow-incremental-builder</artifactId>
-                        <version>4.6.0</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <compareToMergeBase>true</compareToMergeBase>
-                            <uncommitted>true</uncommitted>
-                            <untracked>true</untracked>
-                            <buildUpstreamMode>impacted</buildUpstreamMode>
-                            <!-- Skip tests and checks for upstream modules since they have not been modified but are still required to be built -->
-                            <skipTestsForUpstreamModules>true</skipTestsForUpstreamModules>
-                            <argsForUpstreamModules>-Dmaven.source.skip=true -Dair.check.skip-all</argsForUpstreamModules>
-                            <!-- Any modules selected with -pl will be built fully (with tests etc.) if the selected module itself is changed
-                            or one of its (non-selected) upstream modules -->
-                            <disableSelectedProjectsHandling>true</disableSelectedProjectsHandling>
-                            <failOnMissingGitDir>true</failOnMissingGitDir>
-                            <failOnError>true</failOnError>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Updates GIB and removes workarounds for https://github.com/gitflow-incremental-builder/gitflow-incremental-builder/issues/1183

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
