### PR TITLE
Skip check-commit-messages job for dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,8 +36,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 2
-    commit-message:
-      prefix: "Web UI:"
     # Group dependabot updates for the web UI dependencies to reduce PR volume.
     groups:
       web-ui-dependencies:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ concurrency:
 
 jobs:
   check-commit-messages:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
     permissions:
       contents: read
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Grouped dependabot updates can generate too long PR message bodies, for example when listing many dependency bumps. For example:  https://github.com/trinodb/trino/pull/30704.

These are generated by Dependabot and are not easy to control from the repository config, so skip commit message policing for dependabot PRs altogether. More context at https://github.com/trinodb/trino/pull/30690#discussion_r3775625755

This PR also removes the custom `Web UI:` Dependabot prefix. The `web-ui-dependencies` group name already identifies grouped web UI updates.

## Additional context and related issues

n/a

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
