### PR TITLE
Remove unused gcs-analytics-core from Iceberg

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -448,13 +448,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.cloud.gcs.analytics</groupId>
-            <artifactId>gcs-analytics-core</artifactId>
-            <version>1.2.3</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>http-client</artifactId>
             <scope>runtime</scope>


### PR DESCRIPTION
## Description

- Relates to https://github.com/apache/iceberg/pull/16258
- Closes #30666
- Closes #30345

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.