### PR TITLE
Fix Oracle pooled connection factory ignoring session extraCredentials

### DIFF
--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OraclePoolConnectionFactory.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OraclePoolConnectionFactory.java
@@ -37,6 +37,7 @@ public class OraclePoolConnectionFactory
         implements ConnectionFactory
 {
     private final DataSource dataSource;
+    private final CredentialProvider credentialProvider;
 
     public OraclePoolConnectionFactory(
             String connectionUrl,
@@ -49,6 +50,8 @@ public class OraclePoolConnectionFactory
             OpenTelemetry openTelemetry)
             throws SQLException
     {
+        this.credentialProvider = credentialProvider;
+
         PoolDataSource dataSource = PoolDataSourceFactory.getPoolDataSource();
 
         // Setting connection properties of the data source
@@ -63,24 +66,12 @@ public class OraclePoolConnectionFactory
         dataSource.setConnectionProperties(connectionProperties);
         dataSource.setInactiveConnectionTimeout(toIntExact(inactiveConnectionTimeout.roundTo(SECONDS)));
         dataSource.setConnectionWaitDuration(connectionPoolWaitDuration.toJavaTime());
-        credentialProvider.getConnectionUser(Optional.empty())
-                .ifPresent(user -> {
-                    try {
-                        dataSource.setUser(user);
-                    }
-                    catch (SQLException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-        credentialProvider.getConnectionPassword(Optional.empty())
-                .ifPresent(password -> {
-                    try {
-                        dataSource.setPassword(password);
-                    }
-                    catch (SQLException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
+        // Credentials are intentionally not set here: they are resolved per-connection in
+        // openConnection() below, since a session's extraCredentials (used by
+        // ExtraCredentialProvider) are only available once a real ConnectorIdentity exists, which
+        // this constructor does not have. Oracle's UCP supports heterogeneous pooling (different
+        // credentials per checkout from the same pool) via getConnection(username, password), so
+        // no default needs to be configured on the pool itself.
 
         JdbcTelemetry jdbcTelemetry = JdbcTelemetry.builder(openTelemetry)
                 .setDataSourceInstrumenterEnabled(true)
@@ -92,7 +83,12 @@ public class OraclePoolConnectionFactory
     public Connection openConnection(ConnectorSession session)
             throws SQLException
     {
-        Connection connection = dataSource.getConnection();
+        Optional<String> user = credentialProvider.getConnectionUser(Optional.of(session.getIdentity()));
+        Optional<String> password = credentialProvider.getConnectionPassword(Optional.of(session.getIdentity()));
+
+        Connection connection = user.isPresent()
+                ? dataSource.getConnection(user.get(), password.orElse(null))
+                : dataSource.getConnection();
         // Oracle's pool doesn't reset autocommit state of connections when reusing them so we explicitly enable
         // autocommit by default to match the JDBC specification.
         connection.setAutoCommit(true);

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleCredentialPassthrough.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleCredentialPassthrough.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.oracle;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.spi.security.Identity;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.util.Map;
+
+import static io.trino.plugin.oracle.TestingOracleServer.TEST_PASS;
+import static io.trino.plugin.oracle.TestingOracleServer.TEST_SCHEMA;
+import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+/**
+ * Regression test for the pooled Oracle connection factory: credentials must be resolved from the
+ * query session's extraCredentials on every connection checkout, not once (with no session
+ * available) when the connection pool is built. The connector-level connection-user/password are
+ * deliberately left blank here so the query can only succeed if the session-scoped credentials are
+ * actually used.
+ */
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestOracleCredentialPassthrough
+{
+    private TestingOracleServer oracleServer;
+    private QueryRunner queryRunner;
+
+    @Test
+    public void testCredentialPassthroughWithConnectionPool()
+    {
+        queryRunner.execute(getSession(), "CREATE TABLE test_create (a bigint)");
+    }
+
+    @BeforeAll
+    public void createQueryRunner()
+            throws Exception
+    {
+        oracleServer = new TestingOracleServer();
+        queryRunner = OracleQueryRunner.builder(oracleServer)
+                .addConnectorProperties(ImmutableMap.<String, String>builder()
+                        // Intentionally blank: proves the query below cannot succeed via a static
+                        // connector-level credential fallback, only via the session's extraCredentials.
+                        .put("connection-user", "")
+                        .put("connection-password", "")
+                        .put("user-credential-name", "oracle.user")
+                        .put("password-credential-name", "oracle.password")
+                        .put("oracle.connection-pool.enabled", "true")
+                        .buildOrThrow())
+                .build();
+    }
+
+    @AfterAll
+    public final void destroy()
+    {
+        queryRunner.close();
+        queryRunner = null;
+        oracleServer.close();
+        oracleServer = null;
+    }
+
+    private static Session getSession()
+    {
+        Map<String, String> extraCredentials = ImmutableMap.of("oracle.user", TEST_USER, "oracle.password", TEST_PASS);
+        return testSessionBuilder()
+                .setCatalog("oracle")
+                .setSchema(TEST_SCHEMA)
+                .setIdentity(Identity.forUser(TEST_USER)
+                        .withExtraCredentials(extraCredentials)
+                        .build())
+                .build();
+    }
+}


### PR DESCRIPTION
## Description

- Fixes #19205.

`OraclePoolConnectionFactory` resolved the connection user/password once, at
pool construction time, by calling `credentialProvider.getConnectionUser(Optional.empty())`
(no session identity available yet). `ExtraCredentialProvider` can only look
up a session's `extraCredentials` when given a real `ConnectorIdentity`, so
with `Optional.empty()` it always fell through to the static
`connection-user`/`connection-password` config, silently ignoring
`user-credential-name`/`password-credential-name` for the pooled connector.
The non-pooled `OracleConnectionFactory` path does not have this problem
since it resolves credentials per `ConnectorSession` already.

This moves credential resolution into `openConnection(ConnectorSession)`,
where a real session is available, and uses Oracle UCP's heterogeneous
pooling support (`PoolDataSource#getConnection(username, password)`) to
check out a connection with the resolved per-session credentials, falling
back to `dataSource.getConnection()` when no user is present.

## Testing

Added `TestOracleCredentialPassthrough`, modeled on trino-mysql's
`TestCredentialPassthrough`. It configures the Oracle connector with
`oracle.connection-pool.enabled=true` and blank
`connection-user`/`connection-password`, so the test query can only
succeed if the session's `extraCredentials` are actually used - this
would fail before this change and pass after.

I wasn't able to run the TestContainers-based Oracle integration tests in
my local environment (no Docker available there), so I'd appreciate a CI
run / maintainer review of the test itself in addition to the fix.

<!--
If you have not contributed to Trino before or you don't have your name in Notable Changes yet, please add your name to the entry in scripts/notable-change-authors.txt.
-->

== RELEASE NOTES ==

Oracle Connector Changes
* Fix the pooled Oracle connector ignoring per-session `extraCredentials`, always using the static `connection-user`/`connection-password` instead. ({issue}`19205`)