### PR TITLE
Make ANALYZE table redirection aware

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -882,12 +882,14 @@ class StatementAnalyzer
         @Override
         protected Scope visitAnalyze(Analyze node, Optional<Scope> scope)
         {
-            QualifiedObjectName tableName = createQualifiedObjectName(session, node, node.getTableName());
-            if (metadata.isView(session, tableName)) {
+            QualifiedObjectName originalName = createQualifiedObjectName(session, node, node.getTableName());
+            if (metadata.isView(session, originalName)) {
                 throw semanticException(NOT_SUPPORTED, node, "Analyzing views is not supported");
             }
 
-            TableHandle tableHandle = metadata.getTableHandle(session, tableName)
+            RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, originalName);
+            QualifiedObjectName tableName = redirection.redirectedTableName().orElse(originalName);
+            TableHandle tableHandle = redirection.tableHandle()
                     .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, node, "Table '%s' does not exist", tableName));
 
             analysis.setUpdateType("ANALYZE");

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -36,6 +36,7 @@ import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ColumnPosition;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorAnalyzeMetadata;
 import io.trino.spi.connector.ConnectorCapabilities;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
@@ -105,6 +106,7 @@ import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.statistics.ComputedStatistics;
 import io.trino.spi.statistics.TableStatistics;
+import io.trino.spi.statistics.TableStatisticsMetadata;
 import io.trino.spi.transaction.IsolationLevel;
 import io.trino.spi.type.Type;
 
@@ -835,6 +837,21 @@ public class MockConnector
         {
             return Optional.empty();
         }
+
+        @Override
+        public ConnectorAnalyzeMetadata getStatisticsCollectionMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, Map<String, Object> analyzeProperties)
+        {
+            return new ConnectorAnalyzeMetadata(tableHandle, TableStatisticsMetadata.empty());
+        }
+
+        @Override
+        public ConnectorTableHandle beginStatisticsCollection(ConnectorSession session, ConnectorTableHandle tableHandle)
+        {
+            return tableHandle;
+        }
+
+        @Override
+        public void finishStatisticsCollection(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<ComputedStatistics> computedStatistics) {}
 
         @Override
         public Optional<ConnectorTableLayout> getInsertLayout(ConnectorSession session, ConnectorTableHandle tableHandle)

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestTableRedirection.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestTableRedirection.java
@@ -21,11 +21,14 @@ import io.trino.connector.MockConnectorFactory;
 import io.trino.connector.MockConnectorInsertTableHandle;
 import io.trino.connector.MockConnectorPlugin;
 import io.trino.connector.MockConnectorTableHandle;
+import io.trino.metadata.AnalyzeTableHandle;
 import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.sql.planner.Plan;
+import io.trino.sql.planner.plan.StatisticsWriterNode;
+import io.trino.sql.planner.plan.StatisticsWriterNode.WriteStatisticsHandle;
 import io.trino.sql.planner.plan.TableFinishNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.TableWriterNode;
@@ -443,6 +446,34 @@ public class TestTableRedirection
                     assertThat(((MockConnectorTableHandle) mergeTarget.getHandle().connectorHandle()).getTableName()).isEqualTo(schemaTableName(SCHEMA_TWO, VALID_REDIRECTION_TARGET));
                     assertThat(mergeTarget.getSchemaTableName()).isEqualTo(schemaTableName(SCHEMA_TWO, VALID_REDIRECTION_TARGET));
                 });
+    }
+
+    @Test
+    public void testAnalyze()
+    {
+        assertUpdate(
+                getSession(),
+                format("ANALYZE %s.%s", SCHEMA_ONE, VALID_REDIRECTION_SRC),
+                // Verify the plan instead of the collected statistics, because statistics collection is a no-op for Mock connector
+                plan -> {
+                    StatisticsWriterNode statisticsWriter = (StatisticsWriterNode) searchFrom(plan.getRoot())
+                            .where(StatisticsWriterNode.class::isInstance)
+                            .findOnlyElement();
+                    AnalyzeTableHandle handle = ((WriteStatisticsHandle) statisticsWriter.getTarget()).getHandle();
+                    assertThat(((MockConnectorTableHandle) handle.connectorHandle()).getTableName()).isEqualTo(schemaTableName(SCHEMA_TWO, VALID_REDIRECTION_TARGET));
+                });
+
+        assertThat(query(format("ANALYZE %s.%s", SCHEMA_ONE, BAD_REDIRECTION_SRC)))
+                .failure()
+                .hasMessageContaining(
+                        "Table '%s' redirected to '%s', but the target table '%s' does not exist",
+                        new CatalogSchemaTableName(CATALOG_NAME, SCHEMA_ONE, BAD_REDIRECTION_SRC),
+                        new CatalogSchemaTableName(CATALOG_NAME, SCHEMA_TWO, NON_EXISTENT_TABLE),
+                        new CatalogSchemaTableName(CATALOG_NAME, SCHEMA_TWO, NON_EXISTENT_TABLE));
+
+        assertThat(query(format("ANALYZE %s.%s", SCHEMA_ONE, REDIRECTION_LOOP_PING)))
+                .failure()
+                .hasMessageContaining("Table redirections form a loop");
     }
 
     // TODO: Add tests for redirection in CommentsSystemTable and CREATE TABLE LIKE


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

- Update `StatementAnalyzer.visitAnalyze` to resolve the target with `getRedirectionAwareTableHandle`, matching `INSERT` / `DELETE` / `UPDATE` / `ALTER TABLE EXECUTE`.
- After redirection, use the redirected table name and handle for statistics collection, analyze properties, column references, and insert privilege checks.

Without this, `ANALYZE` on a redirected table (e.g. Hive → Iceberg) does not run against the destination table.



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- Fixes #30714

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. #30714 )
```
