### PR TITLE
Allow branch reads through table redirection

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2378,16 +2378,7 @@ class StatementAnalyzer
             // This can only be a table
             RedirectionAwareTableHandle redirection = getTableHandle(table, name, scope);
             Optional<TableHandle> tableHandle = redirection.tableHandle();
-            QualifiedObjectName targetTableName;
-            if (redirection.redirectedTableName().isPresent()) {
-                if (getBranchName(table).isPresent()) {
-                    throw semanticException(NOT_SUPPORTED, table, "Table redirection is not supported for branch tables");
-                }
-                targetTableName = redirection.redirectedTableName().get();
-            }
-            else {
-                targetTableName = name;
-            }
+            QualifiedObjectName targetTableName = redirection.redirectedTableName().orElse(name);
             analysis.addEmptyColumnReferencesForTable(accessControl, session.getIdentity(), targetTableName, getBranchName(table));
 
             if (tableHandle.isEmpty()) {

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestTableRedirection.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestTableRedirection.java
@@ -73,6 +73,7 @@ public class TestTableRedirection
     private static final String INTERMEDIATE_TABLE = "intermediate_table";
     private static final String REDIRECTION_LOOP_PING = "redirection_loop_ping";
     private static final String REDIRECTION_LOOP_PONG = "redirection_loop_pong";
+    private static final String TEST_BRANCH = "test_branch";
     private static final List<String> REDIRECTION_CHAIN = IntStream.range(0, MAX_TABLE_REDIRECTIONS + 1).boxed()
             .map(i -> "redirection_chain_table_" + i)
             .collect(toImmutableList());
@@ -188,6 +189,7 @@ public class TestTableRedirection
                     return Optional.ofNullable(REDIRECTIONS.get(schemaTableName))
                             .map(target -> new CatalogSchemaTableName(CATALOG_NAME, target));
                 })
+                .withBranches(ImmutableList.of(TEST_BRANCH))
                 .build();
     }
 
@@ -227,6 +229,15 @@ public class TestTableRedirection
                         REDIRECTION_CHAIN.stream()
                                 .map(table -> new CatalogSchemaTableName(CATALOG_NAME, SCHEMA_THREE, table).toString())
                                 .collect(Collectors.joining(", ")));
+    }
+
+    @Test
+    public void testTableScanWithBranch()
+    {
+        assertQuery(
+                format("SELECT c2 FROM %s.%s FOR VERSION AS OF '%s'", SCHEMA_ONE, VALID_REDIRECTION_SRC, TEST_BRANCH),
+                "SELECT 1 WHERE 1=0",
+                verifySingleTableScan(SCHEMA_TWO, VALID_REDIRECTION_TARGET));
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/security/TestBranchingAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestBranchingAccessControl.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.connector.MockConnectorPlugin;
 import io.trino.connector.MockConnectorTableHandle;
+import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.type.BigintType;
@@ -68,6 +69,12 @@ final class TestBranchingAccessControl
                     throw new UnsupportedOperationException();
                 })
                 .withBranches(ImmutableList.of("main", "dev"))
+                .withRedirectTable((_, tableName) -> {
+                    if (tableName.equals(new SchemaTableName("tiny", "nation_redirect"))) {
+                        return Optional.of(new CatalogSchemaTableName("mock", "tiny", "nation"));
+                    }
+                    return Optional.empty();
+                })
                 .withData(schemaTableName -> {
                     if (schemaTableName.equals(new SchemaTableName("tiny", "nation"))) {
                         return TPCH_NATION_DATA;
@@ -120,6 +127,15 @@ final class TestBranchingAccessControl
                 "SELECT nationkey FROM mock.tiny.nation FOR VERSION AS OF 'dev'",
                 "Cannot select from columns \\[nationkey] in branch dev in table mock.tiny.nation",
                 privilege("nation", SELECT_COLUMN));
+    }
+
+    @Test
+    void testSelectFromRedirectedBranchDeniedByBranchPrivilege()
+    {
+        assertAccessDenied(
+                "SELECT nationkey FROM mock.tiny.nation_redirect FOR VERSION AS OF 'dev'",
+                "Cannot select from columns \\[nationkey] in branch dev in table mock.tiny.nation",
+                branchPrivilege("nation", "dev", SELECT_COLUMN));
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Queries using a branch reference fail when the source catalog redirects the
table to another connector. A common example is a Hive catalog configured to
redirect Iceberg tables to an Iceberg catalog:

```sql
SELECT *
FROM hive.schema.iceberg_table FOR VERSION AS OF 'development';
```

The query fails during analysis with:

```text
Table redirection is not supported for branch tables
```

The same branch can be read by querying the Iceberg catalog directly.

This behavior was introduced by commit `4cc380cf457` and regresses branch and tag
reads that previously worked through table redirection.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- fixes #30721 


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. #30721 )
```
