### PR TITLE
Include values in Variant.toString

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/variant/Variant.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/variant/Variant.java
@@ -29,6 +29,7 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -104,6 +105,7 @@ import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
+import static java.util.stream.Collectors.joining;
 
 public record Variant(Slice data, Metadata metadata, BasicType basicType, PrimitiveType primitiveType)
 {
@@ -1131,8 +1133,61 @@ public record Variant(Slice data, Metadata metadata, BasicType basicType, Primit
     @Override
     public String toString()
     {
+        String value;
+        try {
+            value = formatValue();
+        }
+        catch (RuntimeException e) {
+            // Decoding a malformed value must not hide the type information, which is all this method used to report
+            value = "<unreadable: " + e + ">";
+        }
         return "Variant[" +
                 "basicType=" + basicType + ", " +
-                "primitiveType=" + primitiveType + ']';
+                "primitiveType=" + primitiveType + ", " +
+                "value=" + value + ']';
+    }
+
+    /// Formats the value of this Variant, recursively for containers.
+    /// Strings are single quoted with embedded quotes doubled, and binary is Base64 encoded.
+    private String formatValue()
+    {
+        return switch (basicType) {
+            case PRIMITIVE -> formatPrimitiveValue();
+            case SHORT_STRING -> formatString(getStringUtf8());
+            case ARRAY -> arrayElements()
+                    .map(Variant::formatValue)
+                    .collect(joining(", ", "[", "]"));
+            case OBJECT -> objectFields()
+                    .map(field -> metadata.get(field.fieldId()).toStringUtf8() + "=" + field.value().formatValue())
+                    .collect(joining(", ", "{", "}"));
+        };
+    }
+
+    private String formatPrimitiveValue()
+    {
+        return switch (primitiveType) {
+            case NULL -> "null";
+            case BOOLEAN_TRUE -> "true";
+            case BOOLEAN_FALSE -> "false";
+            case INT8 -> String.valueOf(getByte());
+            case INT16 -> String.valueOf(getShort());
+            case INT32 -> String.valueOf(getInt());
+            case INT64 -> String.valueOf(getLong());
+            case FLOAT -> String.valueOf(getFloat());
+            case DOUBLE -> String.valueOf(getDouble());
+            case DECIMAL4, DECIMAL8, DECIMAL16 -> getDecimal().toString();
+            case DATE -> getLocalDate().toString();
+            case TIME_NTZ_MICROS -> getLocalTime().toString();
+            case TIMESTAMP_UTC_MICROS, TIMESTAMP_UTC_NANOS -> getInstant().toString();
+            case TIMESTAMP_NTZ_MICROS, TIMESTAMP_NTZ_NANOS -> getLocalDateTime().toString();
+            case BINARY -> Base64.getEncoder().encodeToString(getBinary().getBytes());
+            case STRING -> formatString(getStringUtf8());
+            case UUID -> getUuid().toString();
+        };
+    }
+
+    private static String formatString(String value)
+    {
+        return "'" + value.replace("'", "''") + "'";
     }
 }

--- a/core/trino-spi/src/test/java/io/trino/spi/variant/TestVariant.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/variant/TestVariant.java
@@ -53,6 +53,7 @@ import static io.trino.spi.variant.Header.metadataHeader;
 import static io.trino.spi.variant.Header.objectFieldIdSize;
 import static io.trino.spi.variant.Header.objectFieldOffsetSize;
 import static io.trino.spi.variant.Header.objectIsLarge;
+import static io.trino.spi.variant.Header.primitiveHeader;
 import static io.trino.spi.variant.Metadata.EMPTY_METADATA;
 import static io.trino.spi.variant.VariantEncoder.ENCODED_DECIMAL16_SIZE;
 import static io.trino.spi.variant.VariantEncoder.ENCODED_DECIMAL4_SIZE;
@@ -1548,6 +1549,125 @@ class TestVariant
         assertThat(left.metadata().get(1)).isNotEqualTo(right.metadata().get(1));
 
         assertEqualAndSameHash(left, right);
+    }
+
+    @Test
+    void testToStringPrimitiveValues()
+    {
+        assertThat(Variant.NULL_VALUE).hasToString("Variant[basicType=PRIMITIVE, primitiveType=NULL, value=null]");
+        assertThat(Variant.ofBoolean(true)).hasToString("Variant[basicType=PRIMITIVE, primitiveType=BOOLEAN_TRUE, value=true]");
+        assertThat(Variant.ofBoolean(false)).hasToString("Variant[basicType=PRIMITIVE, primitiveType=BOOLEAN_FALSE, value=false]");
+        assertThat(Variant.ofByte((byte) -12)).hasToString("Variant[basicType=PRIMITIVE, primitiveType=INT8, value=-12]");
+        assertThat(Variant.ofShort((short) 1234)).hasToString("Variant[basicType=PRIMITIVE, primitiveType=INT16, value=1234]");
+        assertThat(Variant.ofInt(123456)).hasToString("Variant[basicType=PRIMITIVE, primitiveType=INT32, value=123456]");
+        assertThat(Variant.ofLong(1234567890123L)).hasToString("Variant[basicType=PRIMITIVE, primitiveType=INT64, value=1234567890123]");
+        assertThat(Variant.ofFloat(1.5f)).hasToString("Variant[basicType=PRIMITIVE, primitiveType=FLOAT, value=1.5]");
+        assertThat(Variant.ofDouble(-2.25)).hasToString("Variant[basicType=PRIMITIVE, primitiveType=DOUBLE, value=-2.25]");
+        assertThat(Variant.ofDate(LocalDate.of(2026, 4, 7))).hasToString("Variant[basicType=PRIMITIVE, primitiveType=DATE, value=2026-04-07]");
+        assertThat(Variant.ofTimeMicrosNtz(LocalTime.of(1, 2, 3, 456_000_000))).hasToString("Variant[basicType=PRIMITIVE, primitiveType=TIME_NTZ_MICROS, value=01:02:03.456]");
+        assertThat(Variant.ofUuid(UUID.fromString("12151fd2-7586-11e9-8f9e-2a86e4085a59")))
+                .hasToString("Variant[basicType=PRIMITIVE, primitiveType=UUID, value=12151fd2-7586-11e9-8f9e-2a86e4085a59]");
+
+        // decimals are encoded in the smallest representation that fits the unscaled value,
+        // and are rendered with BigDecimal.toString() like the cast from VARIANT to VARCHAR
+        assertThat(Variant.ofDecimal(new BigDecimal("123.45"))).hasToString("Variant[basicType=PRIMITIVE, primitiveType=DECIMAL4, value=123.45]");
+        assertThat(Variant.ofDecimal(new BigDecimal("-0.000000000001"))).hasToString("Variant[basicType=PRIMITIVE, primitiveType=DECIMAL4, value=-1E-12]");
+        assertThat(Variant.ofDecimal(new BigDecimal("12345678901.23"))).hasToString("Variant[basicType=PRIMITIVE, primitiveType=DECIMAL8, value=12345678901.23]");
+        assertThat(Variant.ofDecimal(new BigDecimal("123456789012345678901.23"))).hasToString("Variant[basicType=PRIMITIVE, primitiveType=DECIMAL16, value=123456789012345678901.23]");
+
+        // binary is Base64 encoded, consistently with SqlVarbinary
+        assertThat(Variant.ofBinary(wrappedBuffer(new byte[] {0x01, 0x02, 0x03})))
+                .hasToString("Variant[basicType=PRIMITIVE, primitiveType=BINARY, value=AQID]");
+        assertThat(Variant.ofBinary(Slices.EMPTY_SLICE)).hasToString("Variant[basicType=PRIMITIVE, primitiveType=BINARY, value=]");
+    }
+
+    @Test
+    void testToStringTimestampValues()
+    {
+        Instant instant = Instant.parse("2026-04-07T07:26:21.123456Z");
+        assertThat(Variant.ofTimestampMicrosUtc(instant))
+                .hasToString("Variant[basicType=PRIMITIVE, primitiveType=TIMESTAMP_UTC_MICROS, value=2026-04-07T07:26:21.123456Z]");
+        assertThat(Variant.ofTimestampNanosUtc(instant))
+                .hasToString("Variant[basicType=PRIMITIVE, primitiveType=TIMESTAMP_UTC_NANOS, value=2026-04-07T07:26:21.123456Z]");
+
+        LocalDateTime localDateTime = LocalDateTime.parse("2026-04-07T07:26:21.123456");
+        assertThat(Variant.ofTimestampMicrosNtz(localDateTime))
+                .hasToString("Variant[basicType=PRIMITIVE, primitiveType=TIMESTAMP_NTZ_MICROS, value=2026-04-07T07:26:21.123456]");
+        assertThat(Variant.ofTimestampNanosNtz(localDateTime))
+                .hasToString("Variant[basicType=PRIMITIVE, primitiveType=TIMESTAMP_NTZ_NANOS, value=2026-04-07T07:26:21.123456]");
+    }
+
+    @Test
+    void testToStringStringValues()
+    {
+        assertThat(Variant.ofString("a")).hasToString("Variant[basicType=SHORT_STRING, primitiveType=null, value='a']");
+        assertThat(Variant.ofString("")).hasToString("Variant[basicType=SHORT_STRING, primitiveType=null, value='']");
+
+        // embedded single quotes are doubled, so the value boundaries stay unambiguous
+        assertThat(Variant.ofString("it's")).hasToString("Variant[basicType=SHORT_STRING, primitiveType=null, value='it''s']");
+
+        // strings longer than the short string limit use the STRING primitive encoding
+        String longString = "a".repeat(Header.SHORT_STRING_MAX_LENGTH + 1);
+        assertThat(Variant.ofString(longString))
+                .hasToString("Variant[basicType=PRIMITIVE, primitiveType=STRING, value='" + longString + "']");
+    }
+
+    @Test
+    void testToStringEmptyContainers()
+    {
+        assertThat(Variant.EMPTY_ARRAY).hasToString("Variant[basicType=ARRAY, primitiveType=null, value=[]]");
+        assertThat(Variant.EMPTY_OBJECT).hasToString("Variant[basicType=OBJECT, primitiveType=null, value={}]");
+    }
+
+    @Test
+    void testToStringContainerValues()
+    {
+        assertThat(Variant.ofArray(List.of(Variant.ofInt(1), Variant.ofString("two"), Variant.NULL_VALUE)))
+                .hasToString("Variant[basicType=ARRAY, primitiveType=null, value=[1, 'two', null]]");
+
+        Map<Slice, Variant> fields = new HashMap<>();
+        fields.put(utf8Slice("b"), Variant.ofString("two"));
+        fields.put(utf8Slice("a"), Variant.ofInt(1));
+        fields.put(utf8Slice("c"), Variant.NULL_VALUE);
+        // fields are rendered in field id order, which is the lexicographical field name order
+        assertThat(Variant.ofObject(fields))
+                .hasToString("Variant[basicType=OBJECT, primitiveType=null, value={a=1, b='two', c=null}]");
+    }
+
+    @Test
+    void testToStringNestedContainerValues()
+    {
+        Variant nested = Variant.ofObject(Map.of(
+                utf8Slice("id"), Variant.ofInt(1),
+                utf8Slice("tags"), Variant.ofArray(List.of(Variant.ofString("x"), Variant.NULL_VALUE)),
+                utf8Slice("child"), Variant.ofObject(Map.of(utf8Slice("flag"), Variant.ofBoolean(true)))));
+
+        assertThat(nested).hasToString("Variant[basicType=OBJECT, primitiveType=null, value={child={flag=true}, id=1, tags=['x', null]}]");
+
+        assertThat(Variant.ofArray(List.of(Variant.ofArray(List.of(Variant.ofInt(1))), Variant.EMPTY_OBJECT)))
+                .hasToString("Variant[basicType=ARRAY, primitiveType=null, value=[[1], {}]]");
+    }
+
+    @Test
+    void testToStringDistinguishesDifferentValuesOfSameType()
+    {
+        assertThat(Variant.ofString("a")).doesNotHaveToString(Variant.ofString("b").toString());
+        assertThat(Variant.ofInt(1)).doesNotHaveToString(Variant.ofInt(2).toString());
+        assertThat(Variant.ofArray(List.of(Variant.ofInt(1))))
+                .doesNotHaveToString(Variant.ofArray(List.of(Variant.ofInt(2))).toString());
+    }
+
+    @Test
+    void testToStringMalformedValue()
+    {
+        // the header declares a string, but the length and payload bytes are missing
+        Variant malformed = Variant.from(EMPTY_METADATA, wrappedBuffer(primitiveHeader(Header.PrimitiveType.STRING)));
+        assertThatThrownBy(malformed::getStringUtf8).isInstanceOf(IndexOutOfBoundsException.class);
+
+        assertThat(malformed.toString())
+                .startsWith("Variant[basicType=PRIMITIVE, primitiveType=STRING, value=<unreadable: ")
+                .contains(IndexOutOfBoundsException.class.getName())
+                .endsWith(">]");
     }
 
     private static void assertEqualAndSameHash(Variant leftValue, Variant rightValue)


### PR DESCRIPTION
## Description

`Variant.toString()` printed only `basicType` and `primitiveType`, never the value, so two variants holding different values were indistinguishable in output. The value is now included, rendered recursively for arrays and objects.

Before:

```
Variant[basicType=SHORT_STRING, primitiveType=null]
```

After:

```
Variant[basicType=SHORT_STRING, primitiveType=null, value='a']
```

Nested containers:

```
Variant[basicType=OBJECT, primitiveType=null, value={child={flag=true}, id=1, tags=['x', null]}]
```

Only the `toString()` body is changed, plus three new private helper methods. No public method, field, or type is touched, so the SPI surface is unchanged.

Because the value is now decoded, a malformed variant could make `toString()` throw where the metadata-only implementation could not. Loggers and assertion frameworks call `toString()`, so a throw there would replace a useful failure with an opaque one. The decoding failure is reported inline instead:

```
Variant[basicType=PRIMITIVE, primitiveType=STRING, value=<unreadable: java.lang.IndexOutOfBoundsException: Range [1, 1 + 4) out of bounds for length 1>]
```

## Additional context and related issues

Fixes #29007.

@kkauy expressed interest in this in April and @lazyfetch offered to open a PR in June. I am glad to step aside if either of you is still working on it.

`VariantType.getObjectValue()` returns the `Variant` itself, so `Variant.toString()` is exactly what is printed for a VARIANT column in a failing `MaterializedResult` assertion. That is the failure mode reported in the issue, where actual and expected rendered as the same string.

The rendering follows conventions already used elsewhere in the tree, rather than inventing a new one:

* strings are single quoted, with embedded quotes doubled, so value boundaries stay unambiguous
* binary is Base64 encoded, matching `SqlVarbinary.toString()` and the client protocol encoder in `JsonEncodingUtils`
* decimals use `BigDecimal.toString()`, matching the cast from VARIANT to VARCHAR in `VariantUtil.asVarchar()`
* dates, times, timestamps and UUIDs use the same Java types that `Variant.toObject()` already documents
* object fields are rendered in field id order, which is deterministic, unlike the `HashMap` returned by `toObject()`

`basicType` and `primitiveType` are deliberately kept. They distinguish encodings that render the same value, for example `SHORT_STRING` and `STRING` for a short string, which compare equal but are encoded differently.

Tests cover every primitive type, the empty and nested container cases, `NULL_VALUE`, null elements inside arrays and objects, the empty string, quote escaping, all three decimal widths, and the malformed value path.

One open question for reviewers: values are printed in full, with no length cap. @kkauy raised avoiding cluttered logs for large values, which a cap would address, but a cap needs an arbitrary constant and would elide exactly the part of the value someone is trying to read. I kept full fidelity, and am happy to add a cap if you prefer.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
