### PR TITLE
Remove redundant httpcore from BigQuery pom.xml

### DIFF
--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -26,12 +26,6 @@
                 <artifactId>opencensus-api</artifactId>
                 <version>0.31.1</version>
             </dependency>
-
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpcore</artifactId>
-                <version>4.4.16</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Description

It's defined in the root pom.xml

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
