### PR TITLE
Fix IS NULL for rows of null fields

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -328,6 +328,8 @@ import static io.trino.operator.scalar.MathFunctions.DECIMAL_MOD_FUNCTION;
 import static io.trino.operator.scalar.Re2JCastToRegexpFunction.castCharToRe2JRegexp;
 import static io.trino.operator.scalar.Re2JCastToRegexpFunction.castVarcharToRe2JRegexp;
 import static io.trino.operator.scalar.RowFieldsFunction.ROW_FIELDS_FUNCTION;
+import static io.trino.operator.scalar.RowNullnessFunction.ROW_IS_NOT_NULL_FUNCTION;
+import static io.trino.operator.scalar.RowNullnessFunction.ROW_IS_NULL_FUNCTION;
 import static io.trino.operator.scalar.RowToJsonCast.ROW_TO_JSON;
 import static io.trino.operator.scalar.RowToRowCast.ROW_TO_ROW_CAST;
 import static io.trino.operator.scalar.RowToVariantCast.ROW_TO_VARIANT;
@@ -635,6 +637,8 @@ public final class SystemFunctionBundle
                 .function(FORMAT_FUNCTION)
                 .function(TRY_CAST)
                 .function(ROW_FIELDS_FUNCTION)
+                .function(ROW_IS_NULL_FUNCTION)
+                .function(ROW_IS_NOT_NULL_FUNCTION)
                 .function(new GenericReadValueOperator(typeOperators))
                 .function(new GenericEqualOperator(typeOperators))
                 .function(new GenericHashCodeOperator(typeOperators))

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/RowNullnessFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/RowNullnessFunction.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.annotation.UsedByGeneratedCode;
+import io.trino.metadata.SqlScalarFunction;
+import io.trino.spi.block.SqlRow;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencies;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.Signature;
+import io.trino.spi.type.StandardTypes;
+
+import java.lang.invoke.MethodHandle;
+
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.type.TypeTemplates.type;
+import static io.trino.spi.type.TypeTemplates.typeVariable;
+import static io.trino.util.Reflection.methodHandle;
+
+/// Hidden `$row_is_null` / `$row_is_not_null`. SQL:2023 §8.8 Table 18 makes
+/// those predicates independent for degree greater than 1, so they are two
+/// functions rather than one plus `NOT`.
+public final class RowNullnessFunction
+        extends SqlScalarFunction
+{
+    public static final String IS_NULL_NAME = "$row_is_null";
+    public static final String IS_NOT_NULL_NAME = "$row_is_not_null";
+
+    public static final RowNullnessFunction ROW_IS_NULL_FUNCTION = new RowNullnessFunction(true);
+    public static final RowNullnessFunction ROW_IS_NOT_NULL_FUNCTION = new RowNullnessFunction(false);
+
+    private static final MethodHandle IS_NULL_HANDLE = methodHandle(RowNullnessFunction.class, "rowIsNull", SqlRow.class);
+    private static final MethodHandle IS_NOT_NULL_HANDLE = methodHandle(RowNullnessFunction.class, "rowIsNotNull", SqlRow.class);
+
+    private final boolean nullIfAllFieldsNull;
+
+    private RowNullnessFunction(boolean nullIfAllFieldsNull)
+    {
+        super(metadata(nullIfAllFieldsNull ? IS_NULL_NAME : IS_NOT_NULL_NAME));
+        this.nullIfAllFieldsNull = nullIfAllFieldsNull;
+    }
+
+    private static FunctionMetadata metadata(String name)
+    {
+        return FunctionMetadata.scalarBuilder(name)
+                .signature(Signature.builder()
+                        .rowTypeParameter("T")
+                        .argumentType(typeVariable("T"))
+                        .returnType(type(StandardTypes.BOOLEAN))
+                        .build())
+                .argumentNullability(true)
+                .hidden()
+                .neverFails()
+                .build();
+    }
+
+    @Override
+    public SpecializedSqlScalarFunction specialize(BoundSignature boundSignature, FunctionDependencies functionDependencies)
+    {
+        return new ChoicesSpecializedSqlScalarFunction(
+                boundSignature,
+                FAIL_ON_NULL,
+                ImmutableList.of(BOXED_NULLABLE),
+                nullIfAllFieldsNull ? IS_NULL_HANDLE : IS_NOT_NULL_HANDLE);
+    }
+
+    @UsedByGeneratedCode
+    public static boolean rowIsNull(SqlRow row)
+    {
+        if (row == null) {
+            return true;
+        }
+        int index = row.getRawIndex();
+        for (int i = 0; i < row.getFieldCount(); i++) {
+            if (!row.getRawFieldBlock(i).isNull(index)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @UsedByGeneratedCode
+    public static boolean rowIsNotNull(SqlRow row)
+    {
+        if (row == null) {
+            return false;
+        }
+        int index = row.getRawIndex();
+        for (int i = 0; i < row.getFieldCount(); i++) {
+            if (row.getRawFieldBlock(i).isNull(index)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionBindings.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionBindings.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import io.trino.metadata.Metadata;
+import io.trino.spi.ErrorCodeSupplier;
+import io.trino.spi.type.RowType;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Cast;
+import io.trino.sql.ir.Coalesce;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Let;
+import io.trino.sql.ir.Reference;
+import io.trino.type.CharVarcharCoercion;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static io.trino.operator.scalar.RowNullnessFunction.IS_NOT_NULL_NAME;
+import static io.trino.operator.scalar.RowNullnessFunction.IS_NULL_NAME;
+import static io.trino.sql.ir.IrExpressions.ifExpression;
+import static io.trino.sql.ir.IrExpressions.not;
+import static io.trino.sql.planner.LogicalPlanner.failFunction;
+import static java.util.Objects.requireNonNull;
+
+final class ExpressionBindings
+{
+    private final Metadata metadata;
+    private final CharVarcharCoercion charVarcharCoercion;
+    private final SymbolAllocator symbolAllocator;
+
+    ExpressionBindings(Metadata metadata, CharVarcharCoercion charVarcharCoercion, SymbolAllocator symbolAllocator)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.charVarcharCoercion = requireNonNull(charVarcharCoercion, "charVarcharCoercion is null");
+        this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
+    }
+
+    Expression bindIfNonTrivial(String name, Expression expression, List<Symbol> symbols, List<Expression> bindings)
+    {
+        if (expression instanceof Reference || expression instanceof Constant) {
+            return expression;
+        }
+        Symbol bound = symbolAllocator.newSymbol(name, expression.type());
+        symbols.add(bound);
+        bindings.add(expression);
+        return new Reference(expression.type(), bound.name());
+    }
+
+    /// SQL:2023 §6.12: COALESCE(V1, V2) is CASE WHEN NOT V1 IS NULL THEN V1 ELSE V2 END.
+    /// For rows that is NOT ($row_is_null), not IS NOT NULL. IR Coalesce stays value-nullness.
+    Expression rowCoalesce(List<Expression> operands)
+    {
+        checkArgument(!operands.isEmpty(), "operands is empty");
+        if (operands.stream().noneMatch(operand -> operand.type() instanceof RowType)) {
+            return new Coalesce(operands);
+        }
+        checkState(
+                operands.stream().allMatch(operand -> operand.type() instanceof RowType),
+                "COALESCE of a row must have row-typed operands: %s",
+                operands.stream().map(Expression::type).toList());
+        Expression result = operands.getLast();
+        for (int i = operands.size() - 2; i >= 0; i--) {
+            result = rowCoalesceOperand(operands.get(i), result);
+        }
+        return result;
+    }
+
+    Expression nullNotAllowedColumn(Expression expression, String columnName, ErrorCodeSupplier errorCode)
+    {
+        Expression fail = new Cast(
+                failFunction(metadata, charVarcharCoercion, errorCode, "NULL value not allowed for NOT NULL column: " + columnName),
+                expression.type());
+        if (!(expression.type() instanceof RowType)) {
+            return new Coalesce(expression, fail);
+        }
+        List<Symbol> symbols = new ArrayList<>();
+        List<Expression> bindings = new ArrayList<>();
+        Expression bound = bindIfNonTrivial("row_not_null", expression, symbols, bindings);
+        Expression result = ifExpression(rowIsNotNull(bound), bound, fail);
+        for (int i = symbols.size() - 1; i >= 0; i--) {
+            result = new Let(symbols.get(i), bindings.get(i), result);
+        }
+        return result;
+    }
+
+    private Expression rowCoalesceOperand(Expression operand, Expression rest)
+    {
+        List<Symbol> symbols = new ArrayList<>();
+        List<Expression> bindings = new ArrayList<>();
+        Expression bound = bindIfNonTrivial("row_coalesce", operand, symbols, bindings);
+        Expression result = ifExpression(not(metadata, charVarcharCoercion, rowIsNull(bound)), bound, rest);
+        for (int i = symbols.size() - 1; i >= 0; i--) {
+            result = new Let(symbols.get(i), bindings.get(i), result);
+        }
+        return result;
+    }
+
+    private Call rowIsNull(Expression row)
+    {
+        return BuiltinFunctionCallBuilder.resolve(metadata, charVarcharCoercion)
+                .setName(IS_NULL_NAME)
+                .addArgument(row.type(), row)
+                .build();
+    }
+
+    private Call rowIsNotNull(Expression row)
+    {
+        return BuiltinFunctionCallBuilder.resolve(metadata, charVarcharCoercion)
+                .setName(IS_NOT_NULL_NAME)
+                .addArgument(row.type(), row)
+                .build();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -196,6 +196,7 @@ public class LogicalPlanner
     private final SymbolAllocator symbolAllocator = new SymbolAllocator(ImmutableList.of());
     private final Metadata metadata;
     private final PlannerContext plannerContext;
+    private final ExpressionBindings expressionBindings;
     private final StatisticsAggregationPlanner statisticsAggregationPlanner;
     private final StatsCalculator statsCalculator;
     private final CostCalculator costCalculator;
@@ -235,6 +236,7 @@ public class LogicalPlanner
         this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
         this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.metadata = plannerContext.getMetadata();
+        this.expressionBindings = new ExpressionBindings(metadata, getCharVarcharCoercion(session), symbolAllocator);
         this.statisticsAggregationPlanner = new StatisticsAggregationPlanner(symbolAllocator, plannerContext, session);
         this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
         this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
@@ -568,7 +570,7 @@ public class LogicalPlanner
                 expression = coerceOrCastToTableType(input, tableType, queryType);
             }
             if (!column.isNullable()) {
-                expression = new Coalesce(expression, createNullNotAllowedFailExpression(column.getName(), tableType));
+                expression = nullNotAllowedColumn(expression, column.getName(), CONSTRAINT_VIOLATION);
             }
             assignments.put(output, expression);
             insertedColumnsBuilder.add(column);
@@ -652,9 +654,9 @@ public class LogicalPlanner
         return noTruncationCast(metadata, plannerContext.getTypeManager(), getCharVarcharCoercion(session), symbolAllocator, fieldMapping.toSymbolReference(), queryType, tableType);
     }
 
-    private Expression createNullNotAllowedFailExpression(String columnName, Type type)
+    private Expression nullNotAllowedColumn(Expression expression, String columnName, ErrorCodeSupplier errorCode)
     {
-        return new Cast(failFunction(metadata, getCharVarcharCoercion(session), CONSTRAINT_VIOLATION, "NULL value not allowed for NOT NULL column: " + columnName), type);
+        return expressionBindings.nullNotAllowedColumn(expression, columnName, errorCode);
     }
 
     private static Function<Expression, Expression> failIfPredicateIsNotMet(Metadata metadata, CharVarcharCoercion charVarcharCoercion, ErrorCodeSupplier errorCode, String errorMessage)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -201,6 +201,7 @@ class QueryPlanner
     private final Map<NodeRef<LambdaArgumentDeclaration>, Symbol> lambdaDeclarationToSymbolMap;
     private final PlannerContext plannerContext;
     private final Session session;
+    private final ExpressionBindings expressionBindings;
     private final SubqueryPlanner subqueryPlanner;
     private final Optional<TranslationMap> outerContext;
     private final Map<NodeRef<Node>, RelationPlan> recursiveSubqueries;
@@ -230,6 +231,7 @@ class QueryPlanner
         this.lambdaDeclarationToSymbolMap = lambdaDeclarationToSymbolMap;
         this.plannerContext = plannerContext;
         this.session = session;
+        this.expressionBindings = new ExpressionBindings(plannerContext.getMetadata(), getCharVarcharCoercion(session), symbolAllocator);
         this.outerContext = outerContext;
         this.subqueryPlanner = new SubqueryPlanner(analysis, symbolAllocator, idAllocator, lambdaDeclarationToSymbolMap, plannerContext, outerContext, session, recursiveSubqueries);
         this.recursiveSubqueries = recursiveSubqueries;
@@ -842,7 +844,6 @@ class QueryPlanner
         // The boolean present field, always TRUE for update
         // The tinyint operation number, always UPDATE_OPERATION_NUMBER for update
         // The integer merge case number, always 0 for update
-        Metadata metadata = plannerContext.getMetadata();
         ImmutableList.Builder<Expression> rowBuilder = ImmutableList.builder();
         Assignments.Builder assignments = Assignments.builder();
 
@@ -863,7 +864,7 @@ class QueryPlanner
                 // If the updated column is non-null, check that the value is not null
                 if (mergeAnalysis.getNonNullableColumnHandles().contains(dataColumnHandle)) {
                     String columnName = columnSchema.getName();
-                    rewritten = new Coalesce(rewritten, new Cast(failFunction(metadata, getCharVarcharCoercion(session), INVALID_ARGUMENTS, "NULL value not allowed for NOT NULL column: " + columnName), columnSchema.getType()));
+                    rewritten = expressionBindings.nullNotAllowedColumn(rewritten, columnName, INVALID_ARGUMENTS);
                 }
                 rowBuilder.add(rewritten);
                 assignments.put(field, rewritten);
@@ -1032,7 +1033,7 @@ class QueryPlanner
                     if (nonNullableColumnHandles.contains(dataColumnHandle)) {
                         ColumnSchema columnSchema = dataColumnSchemas.get(fieldNumber);
                         String columnName = columnSchema.getName();
-                        rewritten = new Coalesce(rewritten, new Cast(failFunction(metadata, getCharVarcharCoercion(session), CONSTRAINT_VIOLATION, "NULL value not allowed for NOT NULL column: " + columnName), columnSchema.getType()));
+                        rewritten = expressionBindings.nullNotAllowedColumn(rewritten, columnName, CONSTRAINT_VIOLATION);
                     }
                     rowBuilder.add(rewritten);
                     assignments.put(field, rewritten);
@@ -1048,7 +1049,7 @@ class QueryPlanner
                         }
                         if (nonNullableColumnHandles.contains(dataColumnHandle)) {
                             String columnName = columnSchema.getName();
-                            expression = new Coalesce(expression, new Cast(failFunction(metadata, getCharVarcharCoercion(session), CONSTRAINT_VIOLATION, "NULL value not allowed for NOT NULL column: " + columnName), columnSchema.getType()));
+                            expression = expressionBindings.nullNotAllowedColumn(expression, columnName, CONSTRAINT_VIOLATION);
                         }
                     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -234,6 +234,7 @@ class RelationPlanner
     private final PlannerContext plannerContext;
     private final Optional<TranslationMap> outerContext;
     private final Session session;
+    private final ExpressionBindings expressionBindings;
     private final SubqueryPlanner subqueryPlanner;
     private final Map<NodeRef<Node>, RelationPlan> recursiveSubqueries;
 
@@ -263,6 +264,7 @@ class RelationPlanner
         this.plannerContext = plannerContext;
         this.outerContext = outerContext;
         this.session = session;
+        this.expressionBindings = new ExpressionBindings(plannerContext.getMetadata(), getCharVarcharCoercion(session), symbolAllocator);
         this.subqueryPlanner = new SubqueryPlanner(analysis, symbolAllocator, idAllocator, lambdaDeclarationToSymbolMap, plannerContext, outerContext, session, recursiveSubqueries);
         this.recursiveSubqueries = recursiveSubqueries;
     }
@@ -1189,16 +1191,16 @@ class RelationPlanner
                 Optional.empty());
 
         // Add a projection to produce the outputs of the columns in the USING clause,
-        // which are defined as coalesce(l.k, r.k)
+        // which are defined as coalesce(l.k, r.k). Row keys use SQL COALESCE (NOT IS NULL).
         Assignments.Builder assignments = Assignments.builder();
 
         ImmutableList.Builder<Symbol> outputs = ImmutableList.builder();
         for (Identifier column : joinColumns) {
             Symbol output = symbolAllocator.newSymbol(column.getValue(), analysis.getType(column));
             outputs.add(output);
-            assignments.put(output, new Coalesce(
+            assignments.put(output, expressionBindings.rowCoalesce(ImmutableList.of(
                     leftJoinColumns.get(column).toSymbolReference(),
-                    rightJoinColumns.get(column).toSymbolReference()));
+                    rightJoinColumns.get(column).toSymbolReference())));
         }
 
         for (int field : joinAnalysis.getOtherLeftFields()) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -42,7 +42,6 @@ import io.trino.sql.analyzer.Scope;
 import io.trino.sql.analyzer.TypeDescriptorTranslator;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Case;
-import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.In;
@@ -222,6 +221,7 @@ public class TranslationMap
     private final Session session;
     private final PlannerContext plannerContext;
     private final SymbolAllocator symbolAllocator;
+    private final ExpressionBindings expressionBindings;
 
     // current mappings of underlying field -> symbol for translating direct field references
     private final Symbol[] fieldSymbols;
@@ -271,6 +271,7 @@ public class TranslationMap
         this.session = requireNonNull(session, "session is null");
         this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
+        this.expressionBindings = new ExpressionBindings(plannerContext.getMetadata(), getCharVarcharCoercion(session), symbolAllocator);
         this.substitutions = ImmutableMap.copyOf(substitutions);
         this.predicateSubstitutions = ImmutableMap.copyOf(requireNonNull(predicateSubstitutions, "predicateSubstitutions is null"));
 
@@ -703,9 +704,9 @@ public class TranslationMap
     {
         List<Symbol> symbols = new ArrayList<>();
         List<io.trino.sql.ir.Expression> bindings = new ArrayList<>();
-        io.trino.sql.ir.Expression boundValue = bindIfNonTrivial(value, symbols, bindings);
-        io.trino.sql.ir.Expression boundMin = bindIfNonTrivial(min, symbols, bindings);
-        io.trino.sql.ir.Expression boundMax = bindIfNonTrivial(max, symbols, bindings);
+        io.trino.sql.ir.Expression boundValue = expressionBindings.bindIfNonTrivial("between", value, symbols, bindings);
+        io.trino.sql.ir.Expression boundMin = expressionBindings.bindIfNonTrivial("between", min, symbols, bindings);
+        io.trino.sql.ir.Expression boundMax = expressionBindings.bindIfNonTrivial("between", max, symbols, bindings);
 
         io.trino.sql.ir.Expression result = new Logical(Logical.Operator.OR, ImmutableList.of(
                 new Logical(Logical.Operator.AND, ImmutableList.of(
@@ -721,22 +722,12 @@ public class TranslationMap
         return result;
     }
 
-    private io.trino.sql.ir.Expression bindIfNonTrivial(io.trino.sql.ir.Expression expression, List<Symbol> symbols, List<io.trino.sql.ir.Expression> bindings)
-    {
-        if (expression instanceof Reference || expression instanceof Constant) {
-            return expression;
-        }
-        Symbol bound = symbolAllocator.newSymbol("between", expression.type());
-        symbols.add(bound);
-        bindings.add(expression);
-        return new Reference(expression.type(), bound.name());
-    }
-
     private io.trino.sql.ir.Expression translate(CoalesceExpression expression)
     {
-        return new Coalesce(expression.getOperands().stream()
+        List<io.trino.sql.ir.Expression> operands = expression.getOperands().stream()
                 .map(this::translateExpression)
-                .collect(toImmutableList()));
+                .collect(toImmutableList());
+        return expressionBindings.rowCoalesce(operands);
     }
 
     private io.trino.sql.ir.Expression translate(GenericLiteral expression)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -19,6 +19,7 @@ import io.airlift.slice.Slices;
 import io.trino.Session;
 import io.trino.jsonpath.ir.IrJsonPath;
 import io.trino.metadata.ResolvedFunction;
+import io.trino.operator.scalar.RowNullnessFunction;
 import io.trino.plugin.base.util.JsonTypeUtil;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.ArrayType;
@@ -666,6 +667,12 @@ public class TranslationMap
                 yield predicate.isNegated() ? not(plannerContext.getMetadata(), getCharVarcharCoercion(session), in) : in;
             }
             case IsNullPredicate predicate -> {
+                if (value.type() instanceof RowType) {
+                    yield BuiltinFunctionCallBuilder.resolve(plannerContext.getMetadata(), getCharVarcharCoercion(session))
+                            .setName(predicate.isNegated() ? RowNullnessFunction.IS_NOT_NULL_NAME : RowNullnessFunction.IS_NULL_NAME)
+                            .addArgument(value.type(), value)
+                            .build();
+                }
                 io.trino.sql.ir.Expression isNull = new IsNull(value);
                 yield predicate.isNegated() ? not(plannerContext.getMetadata(), getCharVarcharCoercion(session), isNull) : isNull;
             }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -247,7 +247,8 @@ public class PushAggregationThroughOuterJoin
                 ImmutableMap.of(),
                 Optional.empty());
 
-        // Add coalesce expressions for all aggregation functions
+        // Coalesce aggregation over the live outer row with the same aggregation over a
+        // value-null inner row. Missing groups are the null value, not SQL row IS NULL.
         Assignments.Builder assignmentsBuilder = Assignments.builder();
         for (Symbol symbol : outerJoin.getOutputSymbols()) {
             if (aggregationNode.getAggregations().containsKey(symbol)) {

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -34,11 +34,13 @@ import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.DefaultTraversalVisitor;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.In;
 import io.trino.sql.ir.IrExpressions;
 import io.trino.sql.ir.IsNull;
+import io.trino.sql.ir.Let;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Match;
 import io.trino.sql.ir.MatchClause;
@@ -66,6 +68,7 @@ import io.trino.sql.planner.plan.IndexJoinNode;
 import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.LimitNode;
 import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.planner.plan.SemiJoinNode;
 import io.trino.sql.planner.plan.SemiJoinNode.DistributionType;
 import io.trino.sql.planner.plan.SortNode;
@@ -2755,6 +2758,127 @@ public class TestLogicalPlanner
                                 builder -> builder
                                         .left(any(unnest(values("array"))))
                                         .right(exchange(tableScan("nation"))))))));
+    }
+
+    @Test
+    public void testJoinUsingIntegerStaysCoalesce()
+    {
+        Plan plan = plan(
+                "SELECT k FROM (VALUES 1) t(k) FULL JOIN (VALUES 2) u(k) USING (k)",
+                CREATED);
+        assertThat(containsRowTypedCoalesce(plan.getRoot())).isFalse();
+        assertThat(containsFunction(plan.getRoot(), "$row_is_null")).isFalse();
+        assertThat(containsCoalesce(plan.getRoot())).isTrue();
+    }
+
+    @Test
+    public void testJoinUsingRowKeyUsesRowIsNull()
+    {
+        Plan plan = plan(
+                """
+                SELECT k FROM
+                  (SELECT CAST(ROW(1, 2) AS ROW(a integer, b integer)) AS k) t
+                FULL JOIN
+                  (SELECT CAST(ROW(3, 4) AS ROW(a integer, b integer)) AS k) u
+                USING (k)
+                """,
+                CREATED);
+        assertThat(containsRowTypedCoalesce(plan.getRoot())).isFalse();
+        assertThat(containsFunction(plan.getRoot(), "$row_is_null")).isTrue();
+    }
+
+    @Test
+    public void testRowCoalesceBindsNonTrivialOperand()
+    {
+        Plan plan = plan(
+                """
+                SELECT COALESCE(ROW(x, x), ROW(1, 2))
+                FROM (VALUES 1) t(x)
+                WHERE random() >= 0
+                """,
+                CREATED);
+        assertThat(containsLet(plan.getRoot())).isTrue();
+        assertThat(containsFunction(plan.getRoot(), "$row_is_null")).isTrue();
+    }
+
+    private static boolean containsFunction(PlanNode root, String name)
+    {
+        boolean[] found = {false};
+        DefaultTraversalVisitor<Void> visitor = new DefaultTraversalVisitor<>()
+        {
+            @Override
+            protected Void visitCall(Call node, Void context)
+            {
+                if (node.function().signature().getName().functionName().equals(name)) {
+                    found[0] = true;
+                }
+                return super.visitCall(node, context);
+            }
+        };
+        visitPlanExpressions(root, visitor);
+        return found[0];
+    }
+
+    private static boolean containsCoalesce(PlanNode root)
+    {
+        boolean[] found = {false};
+        DefaultTraversalVisitor<Void> visitor = new DefaultTraversalVisitor<>()
+        {
+            @Override
+            protected Void visitCoalesce(Coalesce node, Void context)
+            {
+                found[0] = true;
+                return super.visitCoalesce(node, context);
+            }
+        };
+        visitPlanExpressions(root, visitor);
+        return found[0];
+    }
+
+    private static boolean containsLet(PlanNode root)
+    {
+        boolean[] found = {false};
+        DefaultTraversalVisitor<Void> visitor = new DefaultTraversalVisitor<>()
+        {
+            @Override
+            protected Void visitLet(Let node, Void context)
+            {
+                found[0] = true;
+                return super.visitLet(node, context);
+            }
+        };
+        visitPlanExpressions(root, visitor);
+        return found[0];
+    }
+
+    private static boolean containsRowTypedCoalesce(PlanNode root)
+    {
+        boolean[] found = {false};
+        DefaultTraversalVisitor<Void> visitor = new DefaultTraversalVisitor<>()
+        {
+            @Override
+            protected Void visitCoalesce(Coalesce node, Void context)
+            {
+                if (node.operands().stream().anyMatch(operand -> operand.type() instanceof RowType)) {
+                    found[0] = true;
+                }
+                return super.visitCoalesce(node, context);
+            }
+        };
+        visitPlanExpressions(root, visitor);
+        return found[0];
+    }
+
+    private static void visitPlanExpressions(PlanNode root, DefaultTraversalVisitor<Void> visitor)
+    {
+        searchFrom(root).findAll().forEach(node -> {
+            if (node instanceof ProjectNode project) {
+                project.getAssignments().expressions().forEach(visitor::process);
+            }
+            else if (node instanceof FilterNode filter) {
+                visitor.process(filter.getPredicate());
+            }
+        });
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJoinUsing.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJoinUsing.java
@@ -188,4 +188,83 @@ public class TestJoinUsing
                 "SELECT * FROM (VALUES (123456789123456789.123456, 2.0)) x (a, b) JOIN (VALUES (123456789123456789.123456, 3.0)) y (a, b) USING(a)"))
                 .matches("VALUES (123456789123456789.123456, 2.0, 3.0)");
     }
+
+    @Test
+    public void testRowKey()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT k FROM
+                  (SELECT CAST(ROW(1) AS ROW(a integer)) AS k) t
+                JOIN
+                  (SELECT CAST(ROW(1) AS ROW(a integer)) AS k) u
+                USING (k)
+                """))
+                .matches("SELECT CAST(ROW(1) AS ROW(a integer))");
+
+        assertThat(assertions.query(
+                """
+                SELECT k FROM
+                  (SELECT CAST(ROW(null) AS ROW(a integer)) AS k) t
+                FULL JOIN
+                  (SELECT CAST(ROW(1) AS ROW(a integer)) AS k) u
+                USING (k)
+                """))
+                .matches(
+                        """
+                        SELECT CAST(NULL AS ROW(a integer))
+                        UNION ALL
+                        SELECT CAST(ROW(1) AS ROW(a integer))
+                        """);
+
+        assertThat(assertions.query(
+                """
+                SELECT k FROM
+                  (SELECT CAST(ROW(1, 2) AS ROW(a integer, b integer)) AS k) t
+                JOIN
+                  (SELECT CAST(ROW(1, 2) AS ROW(a integer, b integer)) AS k) u
+                USING (k)
+                """))
+                .matches("SELECT CAST(ROW(1, 2) AS ROW(a integer, b integer))");
+
+        assertThat(assertions.query(
+                """
+                SELECT k FROM
+                  (SELECT CAST(ROW(null, null) AS ROW(a integer, b integer)) AS k) t
+                FULL JOIN
+                  (SELECT CAST(ROW(1, 2) AS ROW(a integer, b integer)) AS k) u
+                USING (k)
+                """))
+                .matches(
+                        """
+                        SELECT CAST(NULL AS ROW(a integer, b integer))
+                        UNION ALL
+                        SELECT CAST(ROW(1, 2) AS ROW(a integer, b integer))
+                        """);
+
+        assertThat(assertions.query(
+                """
+                SELECT k FROM
+                  (SELECT CAST(ROW(1, null) AS ROW(a integer, b integer)) AS k) t
+                FULL JOIN
+                  (SELECT CAST(ROW(2, 2) AS ROW(a integer, b integer)) AS k) u
+                USING (k)
+                """))
+                .matches(
+                        """
+                        SELECT CAST(ROW(1, null) AS ROW(a integer, b integer))
+                        UNION ALL
+                        SELECT CAST(ROW(2, 2) AS ROW(a integer, b integer))
+                        """);
+
+        assertThat(assertions.query(
+                """
+                SELECT k FROM
+                  (SELECT CAST(ROW(null, null) AS ROW(a integer, b integer)) AS k) t
+                LEFT JOIN
+                  (SELECT CAST(ROW(1, 2) AS ROW(a integer, b integer)) AS k) u
+                USING (k)
+                """))
+                .matches("SELECT CAST(NULL AS ROW(a integer, b integer))");
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
@@ -996,6 +996,49 @@ public class TestRowOperators
     }
 
     @Test
+    public void testRowCoalesce()
+    {
+        assertThat(assertions.query("SELECT COALESCE(CAST(ROW(null) AS ROW(integer)), ROW(1))"))
+                .matches("SELECT CAST(ROW(1) AS ROW(integer))");
+        assertThat(assertions.query("SELECT COALESCE(CAST(ROW(1) AS ROW(integer)), ROW(2))"))
+                .matches("SELECT CAST(ROW(1) AS ROW(integer))");
+        assertThat(assertions.query("SELECT COALESCE(CAST(ROW(null, null) AS ROW(integer, integer)), ROW(1, 2))"))
+                .matches("SELECT CAST(ROW(1, 2) AS ROW(integer, integer))");
+        assertThat(assertions.query("SELECT COALESCE(CAST(ROW(1, null) AS ROW(integer, integer)), ROW(1, 2))"))
+                .matches("SELECT CAST(ROW(1, null) AS ROW(integer, integer))");
+        assertThat(assertions.query("SELECT COALESCE(CAST(null AS ROW(integer, integer)), ROW(1, 2))"))
+                .matches("SELECT CAST(ROW(1, 2) AS ROW(integer, integer))");
+        assertThat(assertions.query(
+                "SELECT COALESCE(CAST(ROW(null, null) AS ROW(integer, integer)), CAST(ROW(1, null) AS ROW(integer, integer)), ROW(9, 9))"))
+                .matches("SELECT CAST(ROW(1, null) AS ROW(integer, integer))");
+        assertThat(assertions.query(
+                "SELECT COALESCE(CAST(ROW(null, null) AS ROW(integer, integer)), CAST(NULL AS ROW(integer, integer)))"))
+                .matches("SELECT CAST(NULL AS ROW(integer, integer))");
+
+        assertThat(assertions.query(
+                """
+                SELECT COALESCE(r, CAST(ROW(1, 2) AS ROW(a integer, b integer)))
+                FROM (
+                    SELECT CAST(ROW(null, null) AS ROW(a integer, b integer)) AS r
+                    FROM (VALUES 1) t(x)
+                    WHERE random() >= 0)
+                """))
+                .matches("SELECT CAST(ROW(1, 2) AS ROW(a integer, b integer))");
+        assertThat(assertions.query(
+                """
+                SELECT COALESCE(r, CAST(ROW(1, 2) AS ROW(a integer, b integer)))
+                FROM (
+                    SELECT CAST(ROW(1, null) AS ROW(a integer, b integer)) AS r
+                    FROM (VALUES 1) t(x)
+                    WHERE random() >= 0)
+                """))
+                .matches("SELECT CAST(ROW(1, null) AS ROW(a integer, b integer))");
+        assertThat(assertions.expression("COALESCE(a, ROW(1, 2))")
+                .binding("a", "CAST(ROW(null, null) AS ROW(integer, integer))"))
+                .isEqualTo(ImmutableList.of(1, 2));
+    }
+
+    @Test
     public void testRowHashOperator()
     {
         assertRowHashOperator("ROW(1, 2)", ImmutableList.of(INTEGER, INTEGER), ImmutableList.of(1, 2));

--- a/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
@@ -789,6 +789,213 @@ public class TestRowOperators
     }
 
     @Test
+    public void testRowIsNull()
+    {
+        assertThat(assertions.query("SELECT (null, null) IS NULL"))
+                .matches("VALUES true");
+        assertThat(assertions.query("SELECT CAST(ROW(null, null) AS ROW(a integer, b integer)) IS NULL"))
+                .matches("VALUES true");
+        assertThat(assertions.query("SELECT ROW(CAST(null AS integer), CAST(null AS varchar), CAST(null AS double)) IS NULL"))
+                .matches("VALUES true");
+
+        assertThat(assertions.expression("a IS NULL")
+                .binding("a", "ROW(CAST(null AS integer), CAST(null AS integer))"))
+                .isEqualTo(true);
+        assertThat(assertions.expression("a IS NULL")
+                .binding("a", "CAST(ROW(null, null) AS ROW(x integer, y integer))"))
+                .isEqualTo(true);
+
+        assertThat(assertions.query("SELECT (null, null) IS NOT NULL"))
+                .matches("VALUES false");
+        assertThat(assertions.query("SELECT (1, null) IS NOT NULL"))
+                .matches("VALUES false");
+        assertThat(assertions.query("SELECT (null, 1) IS NOT NULL"))
+                .matches("VALUES false");
+        assertThat(assertions.query("SELECT (1, 2) IS NOT NULL"))
+                .matches("VALUES true");
+        assertThat(assertions.query("SELECT CAST(null AS ROW(integer, integer)) IS NOT NULL"))
+                .matches("VALUES false");
+        assertThat(assertions.query("SELECT NOT ((1, null) IS NULL)"))
+                .matches("VALUES true");
+
+        assertThat(assertions.query("SELECT CAST(ROW(null) AS ROW(a integer)) IS NULL"))
+                .matches("VALUES true");
+        assertThat(assertions.query("SELECT CAST(ROW(null) AS ROW(a integer)) IS NOT NULL"))
+                .matches("VALUES false");
+        assertThat(assertions.query("SELECT NOT (CAST(ROW(null) AS ROW(a integer)) IS NULL)"))
+                .matches("VALUES false");
+        assertThat(assertions.query("SELECT CAST(ROW(1) AS ROW(a integer)) IS NULL"))
+                .matches("VALUES false");
+        assertThat(assertions.query("SELECT CAST(ROW(1) AS ROW(a integer)) IS NOT NULL"))
+                .matches("VALUES true");
+
+        assertThat(assertions.query("SELECT CAST(ROW(null, null) AS ROW(a integer, b MAP(integer, integer))) IS NULL"))
+                .matches("VALUES true");
+        assertThat(assertions.query("SELECT CAST(ROW(null, ARRAY[null]) AS ROW(a integer, b ARRAY(integer))) IS NULL"))
+                .matches("VALUES false");
+        assertThat(assertions.query("SELECT CAST(ROW(null, ARRAY[null]) AS ROW(a integer, b ARRAY(integer))) IS NOT NULL"))
+                .matches("VALUES false");
+
+        assertThat(assertions.query("SELECT CAST(ROW(null, null) AS ROW(a integer, b integer)) IS DISTINCT FROM NULL"))
+                .matches("VALUES true");
+        assertThat(assertions.query("SELECT CAST(null AS ROW(a integer, b integer)) IS DISTINCT FROM NULL"))
+                .matches("VALUES false");
+    }
+
+    @Test
+    public void testRowIsNullMixedFields()
+    {
+        assertThat(assertions.query("SELECT (1, null) IS NULL"))
+                .matches("VALUES false");
+        assertThat(assertions.query("SELECT (null, 1) IS NULL"))
+                .matches("VALUES false");
+        assertThat(assertions.query("SELECT (1, 2) IS NULL"))
+                .matches("VALUES false");
+        assertThat(assertions.expression("a IS NULL")
+                .binding("a", "ROW(1, CAST(null AS integer))"))
+                .isEqualTo(false);
+        assertThat(assertions.expression("a IS NULL")
+                .binding("a", "ROW(CAST(null AS integer), 2)"))
+                .isEqualTo(false);
+
+        assertThat(assertions.query("SELECT CAST(null AS ROW(integer, integer)) IS NULL"))
+                .matches("VALUES true");
+        assertThat(assertions.expression("a IS NULL")
+                .binding("a", "CAST(null AS ROW(integer, integer))"))
+                .isEqualTo(true);
+
+        assertThat(assertions.query("SELECT ROW(CAST(ROW(null, null) AS ROW(integer, integer))) IS NULL"))
+                .matches("VALUES false");
+        assertThat(assertions.query("SELECT ROW(CAST(ROW(null, null) AS ROW(integer, integer))) IS NOT NULL"))
+                .matches("VALUES true");
+        assertThat(assertions.query("SELECT CAST(ROW(1, ROW(null, null)) AS ROW(a integer, b ROW(integer, integer))) IS NOT NULL"))
+                .matches("VALUES true");
+        assertThat(assertions.query("SELECT CAST(ROW(null, ROW(null, null)) AS ROW(a integer, b ROW(integer, integer))) IS NULL"))
+                .matches("VALUES false");
+        assertThat(assertions.query("SELECT CAST(ROW(null, ROW(null, null)) AS ROW(a integer, b ROW(integer, integer))) IS NOT NULL"))
+                .matches("VALUES false");
+
+        assertThat(assertions.query(
+                """
+                SELECT ROW(r) IS NOT NULL
+                FROM (
+                    SELECT CAST(ROW(null, null) AS ROW(a integer, b integer)) AS r
+                    FROM (VALUES 1) t(x)
+                    WHERE random() >= 0)
+                """))
+                .matches("VALUES true");
+        assertThat(assertions.query(
+                """
+                SELECT r IS NOT DISTINCT FROM NULL
+                FROM (
+                    SELECT CAST(ROW(null, null) AS ROW(a integer, b integer)) AS r
+                    FROM (VALUES 1) t(x)
+                    WHERE random() >= 0)
+                """))
+                .matches("VALUES false");
+        assertThat(assertions.query(
+                """
+                SELECT r IS DISTINCT FROM NULL
+                FROM (
+                    SELECT CAST(ROW(null, null) AS ROW(a integer, b integer)) AS r
+                    FROM (VALUES 1) t(x)
+                    WHERE random() >= 0)
+                """))
+                .matches("VALUES true");
+        assertThat(assertions.query(
+                """
+                SELECT CAST(r AS ROW(x integer, y integer)) IS DISTINCT FROM NULL
+                FROM (
+                    SELECT CAST(ROW(null, null) AS ROW(a integer, b integer)) AS r
+                    FROM (VALUES 1) t(x)
+                    WHERE random() >= 0)
+                """))
+                .matches("VALUES true");
+
+        assertThat(assertions.query(
+                """
+                SELECT CASE WHEN x THEN CAST(ROW(null, null) AS ROW(a integer, b integer))
+                            ELSE CAST(ROW(1, 2) AS ROW(a integer, b integer)) END IS NULL
+                FROM (VALUES true) t(x)
+                """))
+                .matches("VALUES true");
+        assertThat(assertions.query(
+                """
+                SELECT COALESCE(r, CAST(ROW(null, null) AS ROW(a integer, b integer))) IS NULL
+                FROM (SELECT CAST(null AS ROW(a integer, b integer)) AS r)
+                """))
+                .matches("VALUES true");
+    }
+
+    @Test
+    public void testRowIsNullFilter()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT count(*) FROM (
+                    SELECT CAST(ROW(null, null) AS ROW(a integer, b integer)) AS r
+                    FROM (VALUES 1) t(x)
+                    WHERE random() >= 0)
+                WHERE r IS NULL
+                """))
+                .matches("VALUES BIGINT '1'");
+        assertThat(assertions.query(
+                """
+                SELECT count(*) FROM (
+                    SELECT CAST(ROW(1, null) AS ROW(a integer, b integer)) AS r
+                    FROM (VALUES 1) t(x)
+                    WHERE random() >= 0)
+                WHERE r IS NULL
+                """))
+                .matches("VALUES BIGINT '0'");
+        assertThat(assertions.query(
+                """
+                SELECT count(*) FROM (
+                    SELECT CAST(ROW(null, null) AS ROW(a integer, b integer)) AS r
+                    FROM (VALUES 1) t(x)
+                    WHERE random() >= 0)
+                WHERE r IS NOT NULL
+                """))
+                .matches("VALUES BIGINT '0'");
+        assertThat(assertions.query(
+                """
+                SELECT count(*) FROM (
+                    SELECT CAST(ROW(1, null) AS ROW(a integer, b integer)) AS r
+                    FROM (VALUES 1) t(x)
+                    WHERE random() >= 0)
+                WHERE r IS NOT NULL
+                """))
+                .matches("VALUES BIGINT '0'");
+        assertThat(assertions.query(
+                """
+                SELECT count(*) FROM (
+                    SELECT CAST(ROW(1, 2) AS ROW(a integer, b integer)) AS r
+                    FROM (VALUES 1) t(x)
+                    WHERE random() >= 0)
+                WHERE r IS NOT NULL
+                """))
+                .matches("VALUES BIGINT '1'");
+        assertThat(assertions.query(
+                """
+                SELECT count(*) FROM (
+                    SELECT CAST(null AS ROW(a integer, b integer)) AS r
+                    FROM (VALUES 1) t(x)
+                    WHERE random() >= 0)
+                WHERE r IS NULL
+                """))
+                .matches("VALUES BIGINT '1'");
+        assertThat(assertions.query(
+                """
+                SELECT count(*) FROM (
+                    SELECT CAST(ROW(CAST(ROW(null, null) AS ROW(integer, integer))) AS ROW(r ROW(integer, integer))) AS r
+                    FROM (VALUES 1) t(x)
+                    WHERE random() >= 0)
+                WHERE r IS NULL
+                """))
+                .matches("VALUES BIGINT '0'");
+    }
+
+    @Test
     public void testRowHashOperator()
     {
         assertRowHashOperator("ROW(1, 2)", ImmutableList.of(INTEGER, INTEGER), ImmutableList.of(1, 2));

--- a/docs/src/main/sphinx/functions/comparison.md
+++ b/docs/src/main/sphinx/functions/comparison.md
@@ -138,6 +138,8 @@ A nested row field is a value, not the null value, so there is no recursion:
 SELECT ROW(ROW(NULL, NULL)) IS NULL; -- false
 ```
 
+A `NOT NULL` row column rejects `(1, NULL)` and `(NULL, NULL)`.
+
 The anti-join idiom `WHERE b.row_col IS NULL` after a `LEFT JOIN` also returns
 rows that matched whose row column has all fields null. Use
 `b.row_col IS NOT DISTINCT FROM NULL` to test whether the row value itself is

--- a/docs/src/main/sphinx/functions/comparison.md
+++ b/docs/src/main/sphinx/functions/comparison.md
@@ -105,7 +105,8 @@ rules as the equivalent expanded expression.
 ## IS NULL and IS NOT NULL
 
 The `IS NULL` and `IS NOT NULL` operators test whether a value is null
-(undefined).  Both operators work for all data types.
+(undefined). For most types that means the value is the null value. For `ROW`
+values the predicates follow SQL:2023 §8.8, as described below.
 
 Using `NULL` with `IS NULL` evaluates to `true`:
 
@@ -118,6 +119,29 @@ But any other constant does not:
 ```sql
 SELECT 3.0 IS NULL; -- false
 ```
+
+For `ROW` values, `IS NULL` is true when the row is the null value or every field
+is null. `IS NOT NULL` is true only when no field is null. They are not
+complements for rows of degree greater than 1:
+
+```sql
+SELECT (NULL, NULL) IS NULL; -- true
+SELECT (1, NULL) IS NULL; -- false
+SELECT (1, NULL) IS NOT NULL; -- false
+SELECT NOT ((1, NULL) IS NULL); -- true
+SELECT CAST(ROW(NULL, NULL) AS ROW(a integer, b integer)) IS DISTINCT FROM NULL; -- true
+```
+
+A nested row field is a value, not the null value, so there is no recursion:
+
+```sql
+SELECT ROW(ROW(NULL, NULL)) IS NULL; -- false
+```
+
+The anti-join idiom `WHERE b.row_col IS NULL` after a `LEFT JOIN` also returns
+rows that matched whose row column has all fields null. Use
+`b.row_col IS NOT DISTINCT FROM NULL` to test whether the row value itself is
+null.
 
 (is-boolean-test)=
 ## IS TRUE, IS FALSE, and IS UNKNOWN

--- a/docs/src/main/sphinx/functions/conditional.md
+++ b/docs/src/main/sphinx/functions/conditional.md
@@ -151,9 +151,19 @@ each clause with a semicolon `;` and the usage of `END IF`.
 ## COALESCE
 
 :::{function} coalesce(value1, value2[, ...])
-Returns the first non-null `value` in the argument list.
+Returns the first `value` that is not `IS NULL`.
 Like a `CASE` expression, arguments are only evaluated if necessary.
 :::
+
+For `ROW` arguments, `COALESCE` skips a row whose fields are all null and keeps
+a row with mixed null fields:
+
+```sql
+SELECT COALESCE(CAST(ROW(NULL, NULL) AS ROW(integer, integer)), ROW(1, 2)); -- (1, 2)
+SELECT COALESCE(CAST(ROW(1, NULL) AS ROW(integer, integer)), ROW(1, 2)); -- (1, NULL)
+```
+
+See {ref}`is-null-operator`.
 
 (nullif-function)=
 ## NULLIF

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchComplexTypePredicatePushDown.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchComplexTypePredicatePushDown.java
@@ -155,17 +155,23 @@ final class TestElasticsearchComplexTypePredicatePushDown
                 queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isGreaterThan(0),
                 results -> assertThat(results.getRowCount()).isEqualTo(0));
 
-        // no predicate push down for entire ROW
+        // mixed-null rows are not IS NOT NULL. $row_is_not_null is opaque, so there is no field prune.
+        long[] fullScanBytes = {0};
+        assertQueryStats(
+                getSession(),
+                "SELECT * FROM " + tableName + " WHERE true",
+                queryStats -> fullScanBytes[0] = queryStats.getProcessedInputDataSize().toBytes(),
+                results -> assertThat(results.getRowCount()).isEqualTo(4096));
         assertQueryStats(
                 getSession(),
                 "SELECT * FROM " + tableName + " WHERE col IS NOT NULL",
-                queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isGreaterThan(0),
-                results -> assertThat(results.getRowCount()).isEqualTo(4096));
+                queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isEqualTo(fullScanBytes[0]),
+                results -> assertThat(results.getRowCount()).isEqualTo(0));
 
         assertQueryStats(
                 getSession(),
                 "SELECT * FROM " + tableName + " WHERE col IS NULL",
-                queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isGreaterThan(0),
+                queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isEqualTo(fullScanBytes[0]),
                 results -> assertThat(results.getRowCount()).isEqualTo(0));
     }
 

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -621,6 +621,31 @@ public class TestMemoryConnectorTest
         }
     }
 
+    @Test
+    void testRowNotNullConstraint()
+    {
+        try (TestTable table = newTrinoTable("test_row_not_null", "(c ROW(a integer, b integer) NOT NULL)")) {
+            assertQueryFails(
+                    "INSERT INTO " + table.getName() + " SELECT CAST(NULL AS ROW(a integer, b integer))",
+                    errorMessageForInsertIntoNotNullColumn("c"));
+            assertQueryFails(
+                    "INSERT INTO " + table.getName() + " SELECT CAST(ROW(null, null) AS ROW(a integer, b integer))",
+                    errorMessageForInsertIntoNotNullColumn("c"));
+            assertQueryFails(
+                    "INSERT INTO " + table.getName() + " SELECT CAST(ROW(1, null) AS ROW(a integer, b integer))",
+                    errorMessageForInsertIntoNotNullColumn("c"));
+            assertUpdate("INSERT INTO " + table.getName() + " SELECT CAST(ROW(1, 2) AS ROW(a integer, b integer))", 1);
+            assertUpdate(
+                    "INSERT INTO " + table.getName() + " SELECT CAST(ROW(x, x + 1) AS ROW(a integer, b integer)) FROM (VALUES 2) t(x)",
+                    1);
+            assertThat((String) computeScalar(
+                    "EXPLAIN INSERT INTO " + table.getName() + " SELECT ROW(x, x + 1) FROM (VALUES 3) t(x) WHERE random() >= 0"))
+                    .contains("$row_is_not_null");
+            assertThat(query("SELECT c.a, c.b FROM " + table.getName()))
+                    .matches("VALUES (1, 2), (2, 3)");
+        }
+    }
+
     @Override
     protected String errorMessageForInsertIntoNotNullColumn(String columnName)
     {

--- a/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/TestOpenSearchComplexTypePredicatePushDown.java
+++ b/plugin/trino-opensearch/src/test/java/io/trino/plugin/opensearch/TestOpenSearchComplexTypePredicatePushDown.java
@@ -158,17 +158,23 @@ final class TestOpenSearchComplexTypePredicatePushDown
                 queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isGreaterThan(0),
                 results -> assertThat(results.getRowCount()).isEqualTo(0));
 
-        // no predicate push down for entire ROW
+        // mixed-null rows are not IS NOT NULL. $row_is_not_null is opaque, so there is no field prune.
+        long[] fullScanBytes = {0};
+        assertQueryStats(
+                getSession(),
+                "SELECT * FROM " + tableName + " WHERE true",
+                queryStats -> fullScanBytes[0] = queryStats.getProcessedInputDataSize().toBytes(),
+                results -> assertThat(results.getRowCount()).isEqualTo(4096));
         assertQueryStats(
                 getSession(),
                 "SELECT * FROM " + tableName + " WHERE col IS NOT NULL",
-                queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isGreaterThan(0),
-                results -> assertThat(results.getRowCount()).isEqualTo(4096));
+                queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isEqualTo(fullScanBytes[0]),
+                results -> assertThat(results.getRowCount()).isEqualTo(0));
 
         assertQueryStats(
                 getSession(),
                 "SELECT * FROM " + tableName + " WHERE col IS NULL",
-                queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isGreaterThan(0),
+                queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isEqualTo(fullScanBytes[0]),
                 results -> assertThat(results.getRowCount()).isEqualTo(0));
     }
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseComplexTypesPredicatePushDownTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseComplexTypesPredicatePushDownTest.java
@@ -56,17 +56,23 @@ public abstract class BaseComplexTypesPredicatePushDownTest
                 queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isGreaterThan(0),
                 results -> assertThat(results.getRowCount()).isEqualTo(0));
 
-        // no predicate push down for entire ROW
+        // mixed-null rows are not IS NOT NULL. $row_is_not_null is opaque, so there is no field prune.
+        long[] fullScanBytes = {0};
+        assertQueryStats(
+                getSession(),
+                "SELECT * FROM " + tableName + " WHERE true",
+                queryStats -> fullScanBytes[0] = queryStats.getProcessedInputDataSize().toBytes(),
+                results -> assertThat(results.getRowCount()).isEqualTo(4096));
         assertQueryStats(
                 getSession(),
                 "SELECT * FROM " + tableName + " WHERE col IS NOT NULL",
-                queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isGreaterThan(0),
-                results -> assertThat(results.getRowCount()).isEqualTo(4096));
+                queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isEqualTo(fullScanBytes[0]),
+                results -> assertThat(results.getRowCount()).isEqualTo(0));
 
         assertQueryStats(
                 getSession(),
                 "SELECT * FROM " + tableName + " WHERE col IS NULL",
-                queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isGreaterThan(0),
+                queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isEqualTo(fullScanBytes[0]),
                 results -> assertThat(results.getRowCount()).isEqualTo(0));
 
         assertUpdate("DROP TABLE " + tableName);


### PR DESCRIPTION
## Description

SQL:2023 §8.8: `R IS NULL` is true iff every field of row `R` is the null value. `R IS NOT NULL` is true iff no field is the null value. Those predicates are independent when the degree is greater than 1, so `(1, null) IS NOT NULL` is false and is not `NOT ((1, null) IS NULL)`. Trino treated a row of nulls as not SQL-null and implemented `IS NOT NULL` as `NOT (IS NULL)` ([#19444](https://github.com/trinodb/trino/issues/19444)).

This PR desugars SQL row `IS NULL` and `IS NOT NULL` in `TranslationMap` to hidden `$row_is_null` and `$row_is_not_null` calls. IR `IsNull` stays value-nullness. Nested rows are not recursed. `IS DISTINCT FROM NULL` stays the value-nullness test, including on the null producing side of an outer join.

`COALESCE` of rows follows SQL:2023 as `CASE WHEN NOT v IS NULL THEN v ELSE ...`. JOIN USING of a row key uses the same helper. Integer USING stays IR `Coalesce`. A `NOT NULL` constraint on a row column follows `IS NOT NULL`, so `ROW(1, null)` is rejected. There is no session property. The old row `IS NULL` behavior was a bug.

Filters and projections of row `IS NULL` / `IS NOT NULL` no longer use the `IsNull`/`IsNotNull` bitmap kernels. They evaluate `$row_is_null` / `$row_is_not_null` per row through `CallColumnarFilterGenerator` and the `BOXED_NULLABLE` adapter, which boxes a `SqlRow` and walks one level of field `isNull`. A filter on row `IS NULL` / `IS NOT NULL` reads every top level field null bitmap. Unused fields cannot be pruned from that scan. `COALESCE` of rows is planned as nested `CASE` over `NOT $row_is_null`, not IR `Coalesce`, so mixed null rows are kept.

Revival of [#20209](https://github.com/trinodb/trino/pull/20209) by @sahoss. Credit to @sahoss for the original analysis. @martint asked for this desugar.

* Fixes #19444

CLA for this GitHub account is already submitted via #30729.

### How to test

```
export JAVA_HOME="$HOME/.jdks/jdk-25.0.4+7/Contents/Home"

# New tests fail on master without the desugar (commit 1 only):
# TestRowOperators#testRowIsNull: SELECT (null, null) IS NULL actual false, expected true

./mvnw -pl core/trino-main -Dair.check.skip-all=true -Dtest=TestRowOperators,TestJoinUsing,TestLogicalPlanner,TestEvaluateIsNull,TestEvaluateComparison,TestColumnarFilters,TestDomainTranslator,TestConnectorExpressionTranslator test
# Tests run: 336, Failures: 0. BUILD SUCCESS

./mvnw -pl plugin/trino-memory -Dair.check.skip-all=true -Dtest=TestMemoryConnectorTest#testRowNotNullConstraint test
# Tests run: 1, Failures: 0. BUILD SUCCESS

./mvnw -pl core/trino-main -Dair.check.skip-all=true test
# Tests run: 9867, Failures: 1 flake (TestSqlTaskManagerRaceWithCatalogPrune timeout). Isolated re-run 1/0. BUILD SUCCESS.

./mvnw -pl plugin/trino-hive,plugin/trino-iceberg -Dair.check.skip-all=true -Dtest=TestHiveParquetComplexTypePredicatePushDown,TestIcebergParquetComplexTypesPredicatePushDown test
# Hive 6/0, Iceberg 6/0

./mvnw -pl plugin/trino-mongodb -Dair.check.skip-all=true -Dtest=TestMongoComplexTypePredicatePushDown test
# Tests run: 5, Failures: 0. BUILD SUCCESS

./mvnw -pl plugin/trino-elasticsearch -Dair.check.skip-all=true -Dtest=TestElasticsearchComplexTypePredicatePushDown test
# Tests run: 4, Failures: 0. BUILD SUCCESS

./mvnw -pl plugin/trino-opensearch -Dair.check.skip-all=true -Dtest=TestOpenSearchComplexTypePredicatePushDown test
# Tests run: 4, Failures: 0. BUILD SUCCESS
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Engine
* {{breaking}} Fix `IS NULL` and `IS NOT NULL` for row values. A row of all null fields is SQL null. A row with mixed null fields is false for both predicates. `COALESCE` of rows skips a row whose fields are all null and keeps a mixed row. A `NOT NULL` row column rejects any row with a null field, including `(1, NULL)`. `IS NOT DISTINCT FROM NULL` remains the value-null test, including on the null producing side of an outer join. ({issue}`19444`)
```
