### PR TITLE
Fix IN for rows with null fields

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/ChannelSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ChannelSet.java
@@ -13,31 +13,56 @@
  */
 package io.trino.operator;
 
+import com.google.common.base.Throwables;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
+import jakarta.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.FLAT;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FLAT_RETURN;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static java.util.Objects.requireNonNull;
 
 public class ChannelSet
 {
     private final FlatSet set;
+    @Nullable
+    private final Block values;
+    @Nullable
+    private final MethodHandle equalOperator;
+    @Nullable
+    private final MethodHandle indeterminateOperator;
+    private final boolean hasIndeterminate;
 
-    private ChannelSet(FlatSet set)
+    private ChannelSet(
+            FlatSet set,
+            @Nullable Block values,
+            @Nullable MethodHandle equalOperator,
+            @Nullable MethodHandle indeterminateOperator,
+            boolean hasIndeterminate)
     {
         this.set = set;
+        this.values = values;
+        this.equalOperator = equalOperator;
+        this.indeterminateOperator = indeterminateOperator;
+        this.hasIndeterminate = hasIndeterminate;
     }
 
     public long getEstimatedSizeInBytes()
     {
-        return set.getEstimatedSize();
+        return set.getEstimatedSize() + (values == null ? 0 : values.getRetainedSizeInBytes());
     }
 
     public int size()
@@ -50,28 +75,85 @@ public class ChannelSet
         return size() == 0;
     }
 
-    public boolean containsNull()
+    /**
+     * SQL {@code IN} membership for a non-null probe value.
+     * Returns {@code true}, {@code false}, or {@code null} (unknown).
+     */
+    public Boolean containsSql(Block valueBlock, int position)
     {
-        return set.containsNull();
+        boolean identicalMatch = set.contains(valueBlock, position);
+        if (equalOperator == null) {
+            if (identicalMatch) {
+                return true;
+            }
+            return set.containsNull() ? null : false;
+        }
+
+        // Hash lookup uses IS NOT DISTINCT FROM. That is the wrong operator for IN:
+        // ROW(1, 2) IS NOT DISTINCT FROM ROW(1, null) is false, while SQL equality is unknown.
+        // A determinate identical match is also an equality match.
+        boolean probeIndeterminate = isIndeterminate(valueBlock, position);
+        if (identicalMatch) {
+            return probeIndeterminate ? null : true;
+        }
+
+        // Determinate probe vs a determinate-only set: IDENTICAL miss is also an EQUAL miss.
+        // Skip the scan so extra cost stays on sets that actually contain null fields.
+        if (!probeIndeterminate && !hasIndeterminate) {
+            return set.containsNull() ? null : false;
+        }
+
+        boolean unknown = set.containsNull();
+        Block members = requireNonNull(values, "values is null");
+        for (int i = 0; i < members.getPositionCount(); i++) {
+            Boolean equal = equal(valueBlock, position, members, i);
+            if (Boolean.TRUE.equals(equal)) {
+                return true;
+            }
+            if (equal == null) {
+                unknown = true;
+            }
+        }
+        return unknown ? null : false;
     }
 
-    public boolean contains(Block valueBlock, int position)
+    private boolean isIndeterminate(Block block, int position)
     {
-        return set.contains(valueBlock, position);
+        try {
+            return (boolean) indeterminateOperator.invokeExact(block, position);
+        }
+        catch (Throwable throwable) {
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
+        }
     }
 
-    public boolean contains(Block valueBlock, int position, long rawHash)
+    private Boolean equal(Block left, int leftPosition, Block right, int rightPosition)
     {
-        return set.contains(valueBlock, position, rawHash);
+        try {
+            return (Boolean) equalOperator.invokeExact(left, leftPosition, right, rightPosition);
+        }
+        catch (Throwable throwable) {
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
+        }
     }
 
     public static class ChannelSetBuilder
     {
         private final LocalMemoryContext memoryContext;
         private final FlatSet set;
+        @Nullable
+        private final BlockBuilder valuesBuilder;
+        @Nullable
+        private final MethodHandle equalOperator;
+        @Nullable
+        private final MethodHandle indeterminateOperator;
+        private boolean hasIndeterminate;
 
         public ChannelSetBuilder(Type type, TypeOperators typeOperators, LocalMemoryContext memoryContext)
         {
+            requireNonNull(type, "type is null");
             set = new FlatSet(
                     type,
                     typeOperators.getReadValueOperator(type, simpleConvention(FLAT_RETURN, BLOCK_POSITION_NOT_NULL)),
@@ -80,11 +162,25 @@ public class ChannelSet
                     typeOperators.getHashCodeOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL)));
             this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");
             this.memoryContext.setBytes(set.getEstimatedSize());
+
+            if (usesSqlThreeValuedIn(type)) {
+                // Retained even when every member is determinate: an indeterminate probe
+                // still has to EQUAL-scan those members (ROW(1, null) IN (ROW(1, 2))).
+                valuesBuilder = type.createBlockBuilder(null, 16);
+                equalOperator = typeOperators.getEqualOperator(type, simpleConvention(NULLABLE_RETURN, BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL));
+                indeterminateOperator = typeOperators.getIndeterminateOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL));
+            }
+            else {
+                valuesBuilder = null;
+                equalOperator = null;
+                indeterminateOperator = null;
+            }
         }
 
         public ChannelSet build()
         {
-            return new ChannelSet(set);
+            Block values = valuesBuilder == null ? null : valuesBuilder.build();
+            return new ChannelSet(set, values, equalOperator, indeterminateOperator, hasIndeterminate);
         }
 
         public void addAll(Block valueBlock)
@@ -94,15 +190,48 @@ public class ChannelSet
             }
 
             if (valueBlock instanceof RunLengthEncodedBlock rleBlock) {
-                set.add(rleBlock.getValue(), 0);
+                add(rleBlock.getValue(), 0);
             }
             else {
                 for (int position = 0; position < valueBlock.getPositionCount(); position++) {
-                    set.add(valueBlock, position);
+                    add(valueBlock, position);
                 }
             }
 
-            memoryContext.setBytes(set.getEstimatedSize());
+            memoryContext.setBytes(retainedSize());
+        }
+
+        private void add(Block valueBlock, int position)
+        {
+            if (set.add(valueBlock, position) && valuesBuilder != null && !valueBlock.isNull(position)) {
+                valuesBuilder.append(valueBlock.getUnderlyingValueBlock(), valueBlock.getUnderlyingValuePosition(position));
+                if (isIndeterminate(valueBlock, position)) {
+                    hasIndeterminate = true;
+                }
+            }
+        }
+
+        private boolean isIndeterminate(Block block, int position)
+        {
+            try {
+                return (boolean) indeterminateOperator.invokeExact(block, position);
+            }
+            catch (Throwable throwable) {
+                Throwables.throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
+            }
+        }
+
+        private long retainedSize()
+        {
+            return set.getEstimatedSize() + (valuesBuilder == null ? 0 : valuesBuilder.getRetainedSizeInBytes());
+        }
+
+        private static boolean usesSqlThreeValuedIn(Type type)
+        {
+            // Non-null primitive values are determinate. Structural values can contain null fields,
+            // so hash-lookup with IS NOT DISTINCT FROM is not equivalent to SQL IN.
+            return type instanceof RowType || type instanceof ArrayType || type instanceof MapType;
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/FlatSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatSet.java
@@ -143,29 +143,31 @@ final class FlatSet
         return getIndex(block, position, hash) >= 0;
     }
 
-    public void add(Block block, int position)
+    public boolean add(Block block, int position)
     {
         if (block.isNull(position)) {
+            boolean added = !hasNull;
             hasNull = true;
-            return;
+            return added;
         }
-        addNonNull(block, position, valueHashCode(block, position));
+        return addNonNull(block, position, valueHashCode(block, position));
     }
 
-    public void add(Block block, int position, long hash)
+    public boolean add(Block block, int position, long hash)
     {
         if (block.isNull(position)) {
+            boolean added = !hasNull;
             hasNull = true;
-            return;
+            return added;
         }
-        addNonNull(block, position, hash);
+        return addNonNull(block, position, hash);
     }
 
-    private void addNonNull(Block block, int position, long hash)
+    private boolean addNonNull(Block block, int position, long hash)
     {
         int index = getIndex(block, position, hash);
         if (index >= 0) {
-            return;
+            return false;
         }
 
         index = -index - 1;
@@ -174,6 +176,7 @@ final class FlatSet
         if (size >= maxFill) {
             rehash();
         }
+        return true;
     }
 
     private int getIndex(Block block, int position, long hash)

--- a/core/trino-main/src/main/java/io/trino/operator/HashSemiJoinOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HashSemiJoinOperator.java
@@ -190,8 +190,8 @@ public class HashSemiJoinOperator
                     }
                 }
                 else {
-                    boolean contains = channelSet.contains(probeBlock, position);
-                    if (!contains && channelSet.containsNull()) {
+                    Boolean contains = channelSet.containsSql(probeBlock, position);
+                    if (contains == null) {
                         blockBuilder.appendNull();
                     }
                     else {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
@@ -22,6 +22,10 @@ import io.trino.cost.StatsProvider;
 import io.trino.cost.TaskCountEstimator;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
 import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.PlanNode;
@@ -67,12 +71,25 @@ public class DetermineSemiJoinDistributionType
     @Override
     public Result apply(SemiJoinNode semiJoinNode, Captures captures, Context context)
     {
+        // Hash partitioning uses IS NOT DISTINCT FROM. A row/array/map with a null field
+        // hashes differently from a value it compares as unknown under SQL '=', so the
+        // probe never sees that comparison on the worker that owns the probe. Broadcast
+        // the build side so three-valued IN can be applied locally.
+        if (requiresReplicatedIn(semiJoinNode.getSourceJoinSymbol().type())) {
+            return Result.ofPlanNode(semiJoinNode.withDistributionType(REPLICATED));
+        }
+
         JoinDistributionType joinDistributionType = getJoinDistributionType(context.getSession());
         return switch (joinDistributionType) {
             case AUTOMATIC -> Result.ofPlanNode(getCostBasedDistributionType(semiJoinNode, context));
             case PARTITIONED -> Result.ofPlanNode(semiJoinNode.withDistributionType(PARTITIONED));
             case BROADCAST -> Result.ofPlanNode(semiJoinNode.withDistributionType(REPLICATED));
         };
+    }
+
+    private static boolean requiresReplicatedIn(Type type)
+    {
+        return type instanceof RowType || type instanceof ArrayType || type instanceof MapType;
     }
 
     private PlanNode getCostBasedDistributionType(SemiJoinNode node, Context context)

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestExpressionCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestExpressionCompiler.java
@@ -2314,6 +2314,42 @@ public class TestExpressionCompiler
                 .binding("a", "ROW(1, null)"))
                 .isNull(BOOLEAN);
 
+        // https://github.com/trinodb/trino/issues/7798
+        assertThat(assertions.expression("a IN ((1, null))")
+                .binding("a", "ROW(1, 2)"))
+                .isNull(BOOLEAN);
+
+        assertThat(assertions.expression("a IN (ROW(1, null))")
+                .binding("a", "ROW(1, 2)"))
+                .isNull(BOOLEAN);
+
+        assertThat(assertions.expression("a IN ((1, 2))")
+                .binding("a", "ROW(1, 2)"))
+                .hasType(BOOLEAN)
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a IN ((1, 3))")
+                .binding("a", "ROW(1, 2)"))
+                .hasType(BOOLEAN)
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a IN ((1, 2), (1, null))")
+                .binding("a", "ROW(1, 2)"))
+                .hasType(BOOLEAN)
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a IN ((1, 3), (1, null))")
+                .binding("a", "ROW(1, 2)"))
+                .isNull(BOOLEAN);
+
+        assertThat(assertions.expression("a IN ((1, 2))")
+                .binding("a", "ROW(1, null)"))
+                .isNull(BOOLEAN);
+
+        assertThat(assertions.expression("a IN ((1, 2))")
+                .binding("a", "CAST(null AS ROW(integer, integer))"))
+                .isNull(BOOLEAN);
+
         assertThat(assertions.expression("a IN (ROW(2, null))")
                 .binding("a", "ROW(1, null)"))
                 .hasType(BOOLEAN)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDetermineSemiJoinDistributionType.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDetermineSemiJoinDistributionType.java
@@ -38,6 +38,7 @@ import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.trino.SystemSessionProperties.JOIN_MAX_BROADCAST_TABLE_SIZE;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RowType.anonymousRow;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
@@ -346,6 +347,79 @@ public class TestDetermineSemiJoinDistributionType
                         Optional.of(REPLICATED),
                         values(ImmutableMap.of("A1", 0)),
                         filter(TRUE, values(ImmutableMap.of("B1", 0)))));
+    }
+
+    @Test
+    public void testReplicatesStructuralTypeWhenPartitionedRequiredBySession()
+    {
+        Type rowType = anonymousRow(INTEGER, INTEGER);
+        int aRows = 10_000;
+        int bRows = 10_000;
+        assertDetermineSemiJoinDistributionType()
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.PARTITIONED.name())
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(aRows)
+                        .addSymbolStatistics(ImmutableMap.of(new Symbol(UNKNOWN, "A1"), SymbolStatsEstimate.unknown()))
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(bRows)
+                        .addSymbolStatistics(ImmutableMap.of(new Symbol(UNKNOWN, "B1"), SymbolStatsEstimate.unknown()))
+                        .build())
+                .on(p -> {
+                    Symbol a1 = p.symbol("A1", rowType);
+                    Symbol b1 = p.symbol("B1", rowType);
+                    return p.semiJoin(
+                            p.values(new PlanNodeId("valuesA"), aRows, a1),
+                            p.values(new PlanNodeId("valuesB"), bRows, b1),
+                            a1,
+                            b1,
+                            p.symbol("output"),
+                            Optional.empty());
+                })
+                .matches(semiJoin(
+                        "A1",
+                        "B1",
+                        "output",
+                        Optional.of(REPLICATED),
+                        values(ImmutableMap.of("A1", 0)),
+                        values(ImmutableMap.of("B1", 0))));
+    }
+
+    @Test
+    public void testReplicatesStructuralTypeWhenBuildIsLarge()
+    {
+        Type rowType = anonymousRow(INTEGER, INTEGER);
+        int aRows = 10_000;
+        int bRows = 10_000;
+        assertDetermineSemiJoinDistributionType()
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.AUTOMATIC.name())
+                .setSystemProperty(JOIN_MAX_BROADCAST_TABLE_SIZE, "1B")
+                .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(aRows)
+                        .addSymbolStatistics(ImmutableMap.of(new Symbol(UNKNOWN, "A1"), SymbolStatsEstimate.unknown()))
+                        .build())
+                .overrideStats("valuesB", PlanNodeStatsEstimate.builder()
+                        .setOutputRowCount(bRows)
+                        .addSymbolStatistics(ImmutableMap.of(new Symbol(UNKNOWN, "B1"), SymbolStatsEstimate.unknown()))
+                        .build())
+                .on(p -> {
+                    Symbol a1 = p.symbol("A1", rowType);
+                    Symbol b1 = p.symbol("B1", rowType);
+                    return p.semiJoin(
+                            p.values(new PlanNodeId("valuesA"), aRows, a1),
+                            p.values(new PlanNodeId("valuesB"), bRows, b1),
+                            a1,
+                            b1,
+                            p.symbol("output"),
+                            Optional.empty());
+                })
+                .matches(semiJoin(
+                        "A1",
+                        "B1",
+                        "output",
+                        Optional.of(REPLICATED),
+                        values(ImmutableMap.of("A1", 0)),
+                        values(ImmutableMap.of("B1", 0))));
     }
 
     private RuleBuilder assertDetermineSemiJoinDistributionType()

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import java.util.List;
 import java.util.Optional;
 
+import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -1693,6 +1694,73 @@ public class TestSubqueries
         assertThat(assertions.query(
                 "SELECT NULL IN (SELECT 1, BIGINT '2')"))
                 .describedAs("Multi-column row type, null value")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        // https://github.com/trinodb/trino/issues/7798
+        assertThat(assertions.query(
+                "SELECT ROW(ROW(1, 2)) IN (SELECT ROW(1, null))"))
+                .describedAs("Nested row value vs subquery of a row-typed column with a null field")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT ROW(1, 2) IN (SELECT 1, null)"))
+                .describedAs("Multi-column row vs subquery with a null field")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT ROW(1, 2) IN (VALUES (1, 2), (1, CAST(NULL AS integer)))"))
+                .describedAs("Equal element wins over a null field")
+                .matches("VALUES true");
+
+        assertThat(assertions.query(
+                "SELECT ROW(1, 2) IN (VALUES (1, 3), (1, CAST(NULL AS integer)))"))
+                .describedAs("No equal element and a null-field comparison")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT ROW(1, CAST(NULL AS integer)) IN (VALUES (1, 2))"))
+                .describedAs("Indeterminate probe vs determinate subquery row")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT ROW(1, CAST(NULL AS integer)) IN (VALUES (1, CAST(NULL AS integer)))"))
+                .describedAs("Identical indeterminate rows are still unknown under SQL equality")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        Session partitioned = assertions.sessionBuilder()
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "PARTITIONED")
+                .build();
+        assertThat(assertions.query(
+                partitioned,
+                "SELECT ROW(1, 2) IN (SELECT 1, null)"))
+                .describedAs("Partitioned session still uses three-valued IN for rows")
+                .matches("VALUES CAST(NULL AS boolean)");
+        assertThat(assertions.query(
+                partitioned,
+                "SELECT ROW(1, CAST(NULL AS integer)) IN (VALUES (1, 2))"))
+                .describedAs("Partitioned session, indeterminate probe vs determinate build")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT ARRAY[1] IN (SELECT ARRAY[CAST(NULL AS integer)])"))
+                .describedAs("Array IN uses the same SemiJoin helper as row IN")
+                .matches("VALUES CAST(NULL AS boolean)");
+        assertThat(assertions.query(
+                "SELECT ARRAY[CAST(NULL AS integer)] IN (SELECT ARRAY[CAST(NULL AS integer)])"))
+                .describedAs("Identical indeterminate arrays are unknown under SQL equality")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT ROW(1, 2) NOT IN (SELECT 1, 2)"))
+                .describedAs("NOT IN, equal element")
+                .matches("VALUES false");
+        assertThat(assertions.query(
+                "SELECT ROW(1, 2) NOT IN (SELECT 1, 3)"))
+                .describedAs("NOT IN, no equal element")
+                .matches("VALUES true");
+        assertThat(assertions.query(
+                "SELECT ROW(1, 2) NOT IN (SELECT 1, null)"))
+                .describedAs("NOT IN is unknown when IN is unknown")
                 .matches("VALUES CAST(NULL AS boolean)");
     }
 

--- a/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
@@ -789,6 +789,55 @@ public class TestRowOperators
     }
 
     @Test
+    public void testInPredicate()
+    {
+        // https://github.com/trinodb/trino/issues/7798
+        // ROW(1, 2) = ROW(1, null) is unknown, so IN is unknown unless another element is equal.
+
+        assertThat(assertions.query("SELECT ROW(1, 2) IN ((1, null))"))
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query("SELECT ROW(1, 2) IN (ROW(1, null))"))
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.expression("a IN ((1, null))")
+                .binding("a", "ROW(1, 2)"))
+                .isNull(BOOLEAN);
+
+        assertThat(assertions.expression("a IN (ROW(1, null))")
+                .binding("a", "ROW(1, 2)"))
+                .isNull(BOOLEAN);
+
+        assertThat(assertions.expression("a IN ((1, 2))")
+                .binding("a", "ROW(1, 2)"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a IN ((1, 3))")
+                .binding("a", "ROW(1, 2)"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a IN ((1, 2), (1, null))")
+                .binding("a", "ROW(1, 2)"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a IN ((1, 3), (1, null))")
+                .binding("a", "ROW(1, 2)"))
+                .isNull(BOOLEAN);
+
+        assertThat(assertions.expression("a IN ((1, 2))")
+                .binding("a", "ROW(1, null)"))
+                .isNull(BOOLEAN);
+
+        assertThat(assertions.expression("a IN ((1, 2))")
+                .binding("a", "CAST(null AS ROW(integer, integer))"))
+                .isNull(BOOLEAN);
+
+        assertThat(assertions.expression("a IN ((1, null))")
+                .binding("a", "ROW(1, null)"))
+                .isNull(BOOLEAN);
+    }
+
+    @Test
     public void testRowHashOperator()
     {
         assertRowHashOperator("ROW(1, 2)", ImmutableList.of(INTEGER, INTEGER), ImmutableList.of(1, 2));


### PR DESCRIPTION
## Description

- Fixes #7798.

Value-list `IN` already uses SQL `=`. The subquery form is a SemiJoin
whose set membership used `IS NOT DISTINCT FROM`, so

```sql
SELECT ROW(1, 2) IN ((1, null))           -- already NULL (value list)
SELECT ROW(ROW(1, 2)) IN (SELECT ROW(1, null))  -- was false; now NULL
SELECT ROW(1, 2) IN (SELECT 1, null)      -- was false; now NULL
```

`ROW(1, 2) = ROW(1, null)` is unknown, so `IN` is unknown unless
another element is equal. This does not treat `=` as
`IS NOT DISTINCT FROM`, and does not make `ROW(null) = ROW(null)`
true (that is #24739; identity is `IS NOT DISTINCT FROM`).

Not in scope: #7797 (type mismatch, already closed), #19444 / row
`IS NULL`, quantified `ALL`/`ANY`.

## Additional context and related issues

`ChannelSet` still hashes with identical. After a miss, structural
types EQUAL-scan distinct members. A determinate probe against a
determinate-only set stays O(1).

Hash partitioning still sends `ROW(1, 2)` and `ROW(1, null)` to
different workers (`replicateNullsAndAny` only copies top-level
NULL). This change broadcasts row/array/map SemiJoins so the local
EQUAL path sees every build value — including past
`join_max_broadcast_table_size` and `join_distribution_type=PARTITIONED`.

That is a correctness hammer, not the #17213 design (replicate
indeterminate values the way we already replicate NULLs, on both
probe and build: null-replication of the build alone is not enough
for `ROW(1, null) IN (SELECT ROW(1, 2))`). @martint — keep the
broadcast, or switch to replicate-indeterminate?

Standalone tests cannot prove cross-worker hashing. Planner tests
lock the REPLICATED choice.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Engine
* Fix `IN` for rows with null fields to use three-valued logic. ({issue}`7798`)
```
