### PR TITLE
Support CAST(varchar/char AS INTERVAL DAY TO SECOND)

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/IntervalDayTimeOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/IntervalDayTimeOperators.java
@@ -20,7 +20,12 @@ import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
+import io.trino.sql.tree.IntervalField;
 
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static io.airlift.slice.SliceUtf8.trim;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.client.IntervalDayTime.formatMillis;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
@@ -32,6 +37,7 @@ import static io.trino.spi.function.OperatorType.DIVIDE;
 import static io.trino.spi.function.OperatorType.MULTIPLY;
 import static io.trino.spi.function.OperatorType.NEGATION;
 import static io.trino.spi.function.OperatorType.SUBTRACT;
+import static io.trino.util.DateTimeUtils.parseDayTimeInterval;
 import static java.lang.Math.addExact;
 import static java.lang.Math.multiplyExact;
 import static java.lang.Math.negateExact;
@@ -152,5 +158,38 @@ public final class IntervalDayTimeOperators
             return slice;
         }
         throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to varchar(%s)", slice.toStringUtf8(), x));
+    }
+
+    // fallible
+    @ScalarOperator(CAST)
+    @LiteralParameters("x")
+    @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND)
+    public static long castFromVarchar(@SqlType("varchar(x)") Slice value)
+    {
+        return parse(value);
+    }
+
+    // fallible
+    @ScalarOperator(CAST)
+    @LiteralParameters("x")
+    @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND)
+    public static long castFromChar(@SqlType("char(x)") Slice value)
+    {
+        return parse(value);
+    }
+
+    // Reuses the same day-to-second literal grammar as the `INTERVAL '...' DAY TO SECOND` SQL
+    // literal (DateTimeUtils.parseDayTimeInterval), since IntervalDayTimeType is always the
+    // DAY TO SECOND precision at runtime; there is no separate qualifier to track on the value.
+    private static long parse(Slice value)
+    {
+        String trimmed = trim(value).toStringUtf8();
+        IntervalField endField = new IntervalField.Second(OptionalInt.empty());
+        try {
+            return parseDayTimeInterval(trimmed, new IntervalField.Day(), Optional.of(endField));
+        }
+        catch (TrinoException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to interval day to second", trimmed), e);
+        }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestIntervalDayTime.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntervalDayTime.java
@@ -577,6 +577,57 @@ public class TestIntervalDayTime
     }
 
     @Test
+    public void testCastFromVarchar()
+    {
+        assertThat(assertions.expression("CAST(a AS INTERVAL DAY TO SECOND)")
+                .binding("a", "VARCHAR '12 10:45:32.123'"))
+                .matches("INTERVAL '12 10:45:32.123' DAY TO SECOND");
+
+        assertThat(assertions.expression("CAST(a AS INTERVAL DAY TO SECOND)")
+                .binding("a", "VARCHAR '12 10:45:32'"))
+                .matches("INTERVAL '12 10:45:32' DAY TO SECOND");
+
+        assertThat(assertions.expression("CAST(a AS INTERVAL DAY TO SECOND)")
+                .binding("a", "VARCHAR '12 10:45'"))
+                .matches("INTERVAL '12 10:45' DAY TO SECOND");
+
+        assertThat(assertions.expression("CAST(a AS INTERVAL DAY TO SECOND)")
+                .binding("a", "VARCHAR '12 10'"))
+                .matches("INTERVAL '12 10' DAY TO SECOND");
+
+        assertThat(assertions.expression("CAST(a AS INTERVAL DAY TO SECOND)")
+                .binding("a", "VARCHAR '12'"))
+                .matches("INTERVAL '12' DAY TO SECOND");
+
+        assertThat(assertions.expression("CAST(a AS INTERVAL DAY TO SECOND)")
+                .binding("a", "VARCHAR '-12 10:45:32.123'"))
+                .matches("INTERVAL '-12 10:45:32.123' DAY TO SECOND");
+
+        // round trip
+        assertThat(assertions.expression("CAST(CAST(a AS varchar) AS INTERVAL DAY TO SECOND)")
+                .binding("a", "INTERVAL '12 10:45:32.123' DAY TO SECOND"))
+                .matches("INTERVAL '12 10:45:32.123' DAY TO SECOND");
+
+        // leading/trailing whitespace is trimmed, matching other varchar-to-X casts
+        assertThat(assertions.expression("CAST(a AS INTERVAL DAY TO SECOND)")
+                .binding("a", "VARCHAR '  12 10:45:32.123  '"))
+                .matches("INTERVAL '12 10:45:32.123' DAY TO SECOND");
+
+        // CHAR source, not just VARCHAR
+        assertThat(assertions.expression("CAST(a AS INTERVAL DAY TO SECOND)")
+                .binding("a", "CAST('12 10:45:32.123' AS CHAR(20))"))
+                .matches("INTERVAL '12 10:45:32.123' DAY TO SECOND");
+
+        assertTrinoExceptionThrownBy(assertions.expression("CAST(a AS INTERVAL DAY TO SECOND)")
+                .binding("a", "VARCHAR 'not an interval'")::evaluate)
+                .hasErrorCode(INVALID_CAST_ARGUMENT);
+
+        assertTrinoExceptionThrownBy(assertions.expression("CAST(a AS INTERVAL DAY TO SECOND)")
+                .binding("a", "VARCHAR '12 25:00'")::evaluate)
+                .hasErrorCode(INVALID_CAST_ARGUMENT);
+    }
+
+    @Test
     public void testIndeterminate()
     {
         assertThat(assertions.operator(INDETERMINATE, "CAST(NULL AS INTERVAL DAY TO SECOND)"))

--- a/core/trino-main/src/test/java/io/trino/type/TestIntervalDayTime.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntervalDayTime.java
@@ -622,9 +622,12 @@ public class TestIntervalDayTime
                 .binding("a", "VARCHAR 'not an interval'")::evaluate)
                 .hasErrorCode(INVALID_CAST_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(assertions.expression("CAST(a AS INTERVAL DAY TO SECOND)")
-                .binding("a", "VARCHAR '12 25:00'")::evaluate)
-                .hasErrorCode(INVALID_CAST_ARGUMENT);
+        // field components beyond their nominal range (e.g. 25 hours) are normalized rather than
+        // rejected, since this reuses the same parser as the INTERVAL '...' DAY TO SECOND literal
+        // grammar, which already accepts the same input the same way
+        assertThat(assertions.expression("CAST(a AS INTERVAL DAY TO SECOND)")
+                .binding("a", "VARCHAR '12 25:00'"))
+                .matches("INTERVAL '12 25:00' DAY TO SECOND");
     }
 
     @Test


### PR DESCRIPTION
## Description

`IntervalDayTimeType` (`INTERVAL DAY TO SECOND`) is missing a `CAST` from `VARCHAR`/`CHAR`. Casting the other direction (`INTERVAL DAY TO SECOND` -> `VARCHAR`) is already supported via `castToVarchar`, but there was no way back, so round-tripping the type through text was not possible.

This adds `castFromVarchar` and `castFromChar` operators to `IntervalDayTimeOperators`, reusing the existing day-to-second literal grammar in `DateTimeUtils#parseDayTimeInterval` (the same parser backing the `INTERVAL '...' DAY TO SECOND` SQL literal), since `IntervalDayTimeType` only ever represents the `DAY TO SECOND` precision at runtime. Invalid input throws `INVALID_CAST_ARGUMENT`, consistent with other varchar-to-X cast failures. Leading/trailing whitespace is trimmed, matching other varchar casts.

Addresses #4697.

## Additional context and related issues

N/A

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add support for `CAST` from `VARCHAR`/`CHAR` to `INTERVAL DAY TO SECOND`. ({issue}`4697`)
```