### PR TITLE
Add dry_run parameter to Iceberg remove_orphan_files procedure

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -1045,6 +1045,14 @@ procedure fails with a similar message: `Retention specified (1.00d) is shorter
 than the minimum retention configured in the system (7.00d)`. The default value
 for this property is `7d`.
 
+The command accepts an optional `dry_run` parameter (defaults to false). When
+true, the procedure reports the files it would remove in the
+`deleted_files_count` and `deleted_bytes` metrics without deleting them:
+
+```sql
+ALTER TABLE test_table EXECUTE remove_orphan_files(retention_threshold => '7d', dry_run => true);
+```
+
 The output of the query has the following metrics:
 
 :::{list-table} Output
@@ -1060,9 +1068,11 @@ The output of the query has the following metrics:
 * - `scanned_files_count`
   - The count of files scanned from the file system.
 * - `deleted_files_count`
-  - The count of files deleted by remove_orphan_files.
+  - The count of files deleted by remove_orphan_files, or that would be deleted
+    when `dry_run` is true.
 * - `deleted_bytes`
-  - The total size in bytes of files deleted by remove_orphan_files.
+  - The total size in bytes of files deleted by remove_orphan_files, or that
+    would be deleted when `dry_run` is true.
 :::
 
 (drop-extended-stats)=

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1869,12 +1869,13 @@ public class IcebergMetadata
     private Optional<ConnectorTableExecuteHandle> getTableHandleForRemoveOrphanFiles(ConnectorSession session, IcebergTableHandle tableHandle, Map<String, Object> executeProperties)
     {
         Duration retentionThreshold = (Duration) executeProperties.get(RETENTION_THRESHOLD);
+        boolean dryRun = (boolean) executeProperties.get("dry_run");
         Table icebergTable = catalog.loadTable(session, tableHandle.getSchemaTableName());
 
         return Optional.of(new IcebergTableExecuteHandle(
                 tableHandle.getSchemaTableName(),
                 REMOVE_ORPHAN_FILES,
-                new IcebergRemoveOrphanFilesHandle(retentionThreshold),
+                new IcebergRemoveOrphanFilesHandle(retentionThreshold, dryRun),
                 icebergTable.location()));
     }
 
@@ -2416,7 +2417,8 @@ public class IcebergMetadata
                 icebergScanExecutor,
                 icebergFileDeleteExecutor,
                 executeHandle.schemaTableName(),
-                expiration);
+                expiration,
+                removeOrphanFilesHandle.dryRun());
     }
 
     public Map<String, Long> executeAddFiles(ConnectorSession session, IcebergTableExecuteHandle executeHandle)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergRemoveOrphanFilesHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergRemoveOrphanFilesHandle.java
@@ -17,7 +17,7 @@ import io.airlift.units.Duration;
 
 import static java.util.Objects.requireNonNull;
 
-public record IcebergRemoveOrphanFilesHandle(Duration retentionThreshold)
+public record IcebergRemoveOrphanFilesHandle(Duration retentionThreshold, boolean dryRun)
         implements IcebergProcedureHandle
 {
     public IcebergRemoveOrphanFilesHandle

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RemoveOrphanFiles.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RemoveOrphanFiles.java
@@ -65,7 +65,8 @@ public final class RemoveOrphanFiles
             ExecutorService icebergScanExecutor,
             ExecutorService icebergFileDeleteExecutor,
             SchemaTableName schemaTableName,
-            Instant expiration)
+            Instant expiration,
+            boolean dryRun)
     {
         Set<String> processedManifestFilePaths = new HashSet<>();
         // Similarly to issues like https://github.com/trinodb/trino/issues/13759, equivalent paths may have different String
@@ -128,12 +129,13 @@ public final class RemoveOrphanFiles
             // Ensure any futures still running are canceled in case of failure
             manifestScanFutures.forEach(future -> future.cancel(true));
         }
-        ScanAndDeleteResult result = scanAndDeleteInvalidFiles(table, fileSystem, icebergFileDeleteExecutor, schemaTableName, expiration, validFileNames);
-        log.info("remove_orphan_files for table %s processed %d manifest files, found %d active files, scanned %d files, deleted %d files (%d bytes)",
+        ScanAndDeleteResult result = scanAndDeleteInvalidFiles(table, fileSystem, icebergFileDeleteExecutor, schemaTableName, expiration, validFileNames, dryRun);
+        log.info("remove_orphan_files for table %s processed %d manifest files, found %d active files, scanned %d files, %s %d files (%d bytes)",
                 schemaTableName,
                 processedManifestFilePaths.size(),
                 validFileNames.size() - 1, // excluding version-hint.text
                 result.scannedFilesCount(),
+                dryRun ? "would delete" : "deleted",
                 result.deletedFilesCount(),
                 result.deletedBytes());
         return ImmutableMap.of(
@@ -150,7 +152,8 @@ public final class RemoveOrphanFiles
             ExecutorService icebergFileDeleteExecutor,
             SchemaTableName schemaTableName,
             Instant expiration,
-            Set<String> validFiles)
+            Set<String> validFiles,
+            boolean dryRun)
     {
         List<Future<?>> deleteFutures = new ArrayList<>();
         long scannedFilesCount = 0;
@@ -163,9 +166,13 @@ public final class RemoveOrphanFiles
                 FileEntry entry = allFiles.next();
                 scannedFilesCount++;
                 if (entry.lastModified().isBefore(expiration) && !validFiles.contains(entry.location().fileName())) {
-                    filesToDelete.add(entry.location());
                     deletedFilesCount++;
                     deletedBytes += entry.length();
+                    if (dryRun) {
+                        log.debug("%s file would be deleted while removing orphan files %s", entry.location(), schemaTableName.getTableName());
+                        continue;
+                    }
+                    filesToDelete.add(entry.location());
                     if (filesToDelete.size() >= DELETE_BATCH_SIZE) {
                         List<Location> finalFilesToDelete = filesToDelete;
                         deleteFutures.add(icebergFileDeleteExecutor.submit(() -> deleteFiles(finalFilesToDelete, schemaTableName, fileSystem)));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RemoveOrphanFilesTableProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RemoveOrphanFilesTableProcedure.java
@@ -21,6 +21,7 @@ import io.trino.spi.connector.TableProcedureMetadata;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty;
 import static io.trino.plugin.iceberg.procedure.IcebergTableProcedureId.REMOVE_ORPHAN_FILES;
 import static io.trino.spi.connector.TableProcedureExecutionMode.coordinatorOnly;
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 
 public class RemoveOrphanFilesTableProcedure
         implements Provider<TableProcedureMetadata>
@@ -36,6 +37,11 @@ public class RemoveOrphanFilesTableProcedure
                                 "retention_threshold",
                                 "Files older than threshold should be removed",
                                 Duration.valueOf("7d"),
+                                false),
+                        booleanProperty(
+                                "dry_run",
+                                "When true, report the files that would be removed without deleting them",
+                                false,
                                 false)));
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -7200,6 +7200,45 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testRemoveOrphanFilesDryRun()
+            throws Exception
+    {
+        String tableName = "test_removing_orphan_files_dry_run_" + randomNameSuffix();
+        Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
+        assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer)");
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2), ('three', 3)", 2);
+        assertUpdate("DELETE FROM " + tableName + " WHERE key = 'two'", 1);
+        String location = getTableLocation(tableName);
+        String orphanFile1 = getIcebergTableDataPath(location) + "/invalidData1." + format;
+        String orphanFile2 = getIcebergTableDataPath(location) + "/invalidData2." + format;
+        int orphanFile1Bytes = 123;
+        int orphanFile2Bytes = 456;
+        int totalOrphanBytes = orphanFile1Bytes + orphanFile2Bytes;
+        createFile(orphanFile1, new byte[orphanFile1Bytes]);
+        createFile(orphanFile2, new byte[orphanFile2Bytes]);
+        List<String> initialDataFiles = getAllDataFilesFromTableDirectory(tableName);
+        assertThat(initialDataFiles).contains(orphanFile1, orphanFile2);
+
+        @Language("SQL") String expectedMetrics = "VALUES ('processed_manifests_count', 3), ('active_files_count', 16), ('scanned_files_count', 18), ('deleted_files_count', 2), ('deleted_bytes', " + totalOrphanBytes + ")";
+
+        // A dry run reports the files it would remove, but leaves them in place
+        assertUpdate(
+                sessionWithShortRetentionUnlocked,
+                "ALTER TABLE " + tableName + " EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s', dry_run => true)",
+                expectedMetrics);
+        assertThat(getAllDataFilesFromTableDirectory(tableName)).containsExactlyInAnyOrderElementsOf(initialDataFiles);
+
+        // Running the procedure without dry run reports the same metrics and removes the files
+        assertUpdate(
+                sessionWithShortRetentionUnlocked,
+                "ALTER TABLE " + tableName + " EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')",
+                expectedMetrics);
+        assertQuery("SELECT * FROM " + tableName, "VALUES ('one', 1), ('three', 3)");
+        assertThat(getAllDataFilesFromTableDirectory(tableName)).doesNotContain(orphanFile1, orphanFile2);
+    }
+
+    @Test
     public void testIfRemoveOrphanFilesCleansUnnecessaryDataFilesInPartitionedTable()
             throws Exception
     {
@@ -7293,7 +7332,7 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2)", 1);
 
         assertExplain("EXPLAIN ALTER TABLE " + tableName + " EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')",
-                "SimpleTableExecute\\[table = iceberg:schemaTableName:tpch.test_remove_orphan_files.*\\[retentionThreshold=0\\.00s].*");
+                "SimpleTableExecute\\[table = iceberg:schemaTableName:tpch.test_remove_orphan_files.*\\[retentionThreshold=0\\.00s, dryRun=false].*");
     }
 
     @Test


### PR DESCRIPTION
## Description
`remove_orphan_files` deletes files irreversibly, and there was no way to tell what it would remove before running it. This adds an optional `dry_run` parameter (defaults to `false`) to the procedure:                                                                                                                                                                            
                                                                                                                                                                                                        
```sql                                                                                                                                                                                                
  ALTER TABLE test_table EXECUTE remove_orphan_files(retention_threshold => '7d', dry_run => true);     
```                                                                                                
                                                                                                                                                                                                        
When enabled, the procedure performs the same scan and reports the same metrics as a regular run, but leaves the files in place:                                                                                                                                                           
          
```                                                                                                                                                                                              
        metric_name         | metric_value
----------------------------+--------------
 processed_manifests_count  |            3
 active_files_count         |           16
 scanned_files_count        |           18
 deleted_files_count        |            2
 deleted_bytes              |          579     
```                                                                                                                                                
                                                                                
Iceberg's Spark `remove_orphan_files` procedure offers the same dry_run argument.   


## Additional context and related issues

closed #16514 

Only metrics are reported, not file locations. Spark's implementation returns an `orphan_file_location` column listing each candidate. That is not possible here: the output schema of ALTER TABLE ... EXECUTE is fixed to (metric_name varchar, metric_value bigint) in StatementAnalyzer, so file paths cannot be returned through it. 


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Add a `dry_run` argument to the `remove_orphan_files` procedure to report the files that would be removed without deleting them. ({issue}`16514`)
```
