### PR TITLE
Add timestamp support to DuckDB connector

### DIFF
--- a/docs/src/main/sphinx/connector/duckdb.md
+++ b/docs/src/main/sphinx/connector/duckdb.md
@@ -111,6 +111,15 @@ this table:
 * - `DATE`
   - `DATE`
   -
+* - `TIMESTAMP_S`
+  - `TIMESTAMP(0)`
+  -
+* - `TIMESTAMP_MS`
+  - `TIMESTAMP(3)`
+  -
+* - `TIMESTAMP`
+  - `TIMESTAMP(6)`
+  -
 :::
 
 No other types are supported.
@@ -159,6 +168,15 @@ this table:
   -
 * - `DATE`
   - `DATE`
+  -
+* - `TIMESTAMP(0)`
+  - `TIMESTAMP_S`
+  -
+* - `TIMESTAMP(1)`, `TIMESTAMP(2)`, `TIMESTAMP(3)`
+  - `TIMESTAMP_MS`
+  -
+* - `TIMESTAMP(4)`, `TIMESTAMP(5)`, `TIMESTAMP(6)`
+  - `TIMESTAMP`
   -
 :::
 

--- a/plugin/trino-duckdb/src/main/java/io/trino/plugin/duckdb/DuckDbClient.java
+++ b/plugin/trino-duckdb/src/main/java/io/trino/plugin/duckdb/DuckDbClient.java
@@ -34,6 +34,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
@@ -45,6 +46,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -67,6 +69,8 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.realWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.shortDecimalWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.smallintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.smallintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.timestampColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.timestampWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharColumnMapping;
@@ -82,6 +86,9 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_SECONDS;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoField.EPOCH_DAY;
@@ -210,7 +217,13 @@ public final class DuckDbClient
                     DATE,
                     (resultSet, columnIndex) -> DATE_FORMATTER.parse(resultSet.getString(columnIndex)).getLong(EPOCH_DAY),
                     dateWriteFunction()));
+            case Types.TIMESTAMP -> Optional.of(timestampColumnMapping(toTrinoTimestampType(typeHandle).orElse(TIMESTAMP_MICROS)));
             default -> {
+                // DuckDB reports TIMESTAMP_S / TIMESTAMP_MS as Types.OTHER
+                Optional<TimestampType> timestampType = toTrinoTimestampType(typeHandle);
+                if (timestampType.isPresent()) {
+                    yield Optional.of(timestampColumnMapping(timestampType.get()));
+                }
                 if (getUnsupportedTypeHandling(session) == CONVERT_TO_VARCHAR) {
                     yield mapToUnboundedVarchar(typeHandle);
                 }
@@ -261,7 +274,36 @@ public final class DuckDbClient
         if (type == DATE) {
             return WriteMapping.longMapping("date", dateWriteFunction());
         }
+        if (type instanceof TimestampType timestampType) {
+            return WriteMapping.longMapping(toDuckDbTimestampType(timestampType), timestampWriteFunction(timestampType));
+        }
         throw new TrinoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
+    }
+
+    private static Optional<TimestampType> toTrinoTimestampType(JdbcTypeHandle typeHandle)
+    {
+        String typeName = typeHandle.jdbcTypeName().orElse("").toUpperCase(Locale.ENGLISH);
+        return switch (typeName) {
+            case "TIMESTAMP_S" -> Optional.of(TIMESTAMP_SECONDS);
+            case "TIMESTAMP_MS" -> Optional.of(TIMESTAMP_MILLIS);
+            case "TIMESTAMP", "TIMESTAMP WITHOUT TIME ZONE", "DATETIME" -> Optional.of(TIMESTAMP_MICROS);
+            default -> Optional.empty();
+        };
+    }
+
+    private static String toDuckDbTimestampType(TimestampType timestampType)
+    {
+        int precision = timestampType.getPrecision();
+        if (precision == 0) {
+            return "timestamp_s";
+        }
+        if (precision <= 3) {
+            return "timestamp_ms";
+        }
+        if (precision <= 6) {
+            return "timestamp";
+        }
+        throw new TrinoException(NOT_SUPPORTED, "Unsupported column type: " + timestampType.getDisplayName());
     }
 
     private static LongWriteFunction dateWriteFunction()

--- a/plugin/trino-duckdb/src/test/java/io/trino/plugin/duckdb/TestDuckDbConnectorTest.java
+++ b/plugin/trino-duckdb/src/test/java/io/trino/plugin/duckdb/TestDuckDbConnectorTest.java
@@ -86,7 +86,7 @@ final class TestDuckDbConnectorTest
 
         if (type.equals("time") ||
                 type.startsWith("time(") ||
-                type.startsWith("timestamp") ||
+                type.contains("with time zone") ||
                 type.equals("varbinary") ||
                 type.startsWith("array") ||
                 type.startsWith("row")) {
@@ -193,6 +193,10 @@ final class TestDuckDbConnectorTest
     @Override
     protected Optional<SetColumnTypeSetup> filterSetColumnTypesDataProvider(SetColumnTypeSetup setup)
     {
+        if (setup.sourceColumnType().startsWith("timestamp") || setup.newColumnType().startsWith("timestamp")) {
+            return Optional.empty();
+        }
+
         return switch ("%s -> %s".formatted(setup.sourceColumnType(), setup.newColumnType())) {
             case "varchar(100) -> varchar(50)" -> Optional.of(setup.withNewColumnType("varchar"));
             case "char(25) -> char(20)",

--- a/plugin/trino-duckdb/src/test/java/io/trino/plugin/duckdb/TestDuckDbTypeMapping.java
+++ b/plugin/trino-duckdb/src/test/java/io/trino/plugin/duckdb/TestDuckDbTypeMapping.java
@@ -42,6 +42,9 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_SECONDS;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.time.ZoneOffset.UTC;
@@ -298,6 +301,108 @@ final class TestDuckDbTypeMapping
                 .execute(getQueryRunner(), session, duckDbCreateAndInsert("test_date"))
                 .execute(getQueryRunner(), session, trinoCreateAsSelect("test_date"))
                 .execute(getQueryRunner(), session, trinoCreateAndInsert("test_date"));
+    }
+
+    @Test
+    void testTimestamp()
+    {
+        testTimestamp(UTC);
+        testTimestamp(jvmZone);
+        testTimestamp(vilnius);
+        testTimestamp(kathmandu);
+        testTimestamp(TestingSession.DEFAULT_TIME_ZONE_KEY.getZoneId());
+    }
+
+    private void testTimestamp(ZoneId sessionZone)
+    {
+        Session session = Session.builder(getSession())
+                .setTimeZoneKey(TimeZoneKey.getTimeZoneKey(sessionZone.getId()))
+                .build();
+
+        timestampSecondsTests("timestamp_s")
+                .execute(getQueryRunner(), session, duckDbCreateAndInsert("test_timestamp_s"));
+        timestampMillisTests("timestamp_ms")
+                .execute(getQueryRunner(), session, duckDbCreateAndInsert("test_timestamp_ms"));
+        timestampMicrosTests("timestamp")
+                .execute(getQueryRunner(), session, duckDbCreateAndInsert("test_timestamp"));
+
+        timestampSecondsTests("timestamp(0)")
+                .execute(getQueryRunner(), session, trinoCreateAsSelect("test_timestamp_s"))
+                .execute(getQueryRunner(), session, trinoCreateAndInsert("test_timestamp_s"));
+        timestampMillisTests("timestamp(3)")
+                .execute(getQueryRunner(), session, trinoCreateAsSelect("test_timestamp_ms"))
+                .execute(getQueryRunner(), session, trinoCreateAndInsert("test_timestamp_ms"));
+        timestampMicrosTests("timestamp(6)")
+                .execute(getQueryRunner(), session, trinoCreateAsSelect("test_timestamp"))
+                .execute(getQueryRunner(), session, trinoCreateAndInsert("test_timestamp"));
+    }
+
+    @Test
+    void testTimestampPrecisionMapping()
+    {
+        // DuckDB has TIMESTAMP_S / TIMESTAMP_MS / TIMESTAMP, so Trino precisions collapse onto those three types.
+        SqlDataTypeTest.create()
+                .addRoundTrip("timestamp(0)", "TIMESTAMP '1970-01-01 00:00:00'", TIMESTAMP_SECONDS, "TIMESTAMP '1970-01-01 00:00:00'")
+                .addRoundTrip("timestamp(1)", "TIMESTAMP '1970-01-01 00:00:00.1'", TIMESTAMP_MILLIS, "TIMESTAMP '1970-01-01 00:00:00.100'")
+                .addRoundTrip("timestamp(2)", "TIMESTAMP '1970-01-01 00:00:00.12'", TIMESTAMP_MILLIS, "TIMESTAMP '1970-01-01 00:00:00.120'")
+                .addRoundTrip("timestamp(3)", "TIMESTAMP '1970-01-01 00:00:00.123'", TIMESTAMP_MILLIS, "TIMESTAMP '1970-01-01 00:00:00.123'")
+                .addRoundTrip("timestamp(4)", "TIMESTAMP '1970-01-01 00:00:00.1234'", TIMESTAMP_MICROS, "TIMESTAMP '1970-01-01 00:00:00.123400'")
+                .addRoundTrip("timestamp(5)", "TIMESTAMP '1970-01-01 00:00:00.12345'", TIMESTAMP_MICROS, "TIMESTAMP '1970-01-01 00:00:00.123450'")
+                .addRoundTrip("timestamp(6)", "TIMESTAMP '1970-01-01 00:00:00.123456'", TIMESTAMP_MICROS, "TIMESTAMP '1970-01-01 00:00:00.123456'")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_timestamp_precision"))
+                .execute(getQueryRunner(), trinoCreateAndInsert("test_timestamp_precision"));
+    }
+
+    private static SqlDataTypeTest timestampSecondsTests(String inputType)
+    {
+        return SqlDataTypeTest.create()
+                .addRoundTrip(inputType, "TIMESTAMP '1970-01-01 00:00:00'", TIMESTAMP_SECONDS, "TIMESTAMP '1970-01-01 00:00:00'")
+                .addRoundTrip(inputType, "TIMESTAMP '1582-10-04 23:59:59'", TIMESTAMP_SECONDS, "TIMESTAMP '1582-10-04 23:59:59'") // before julian->gregorian switch
+                .addRoundTrip(inputType, "TIMESTAMP '1582-10-05 00:00:00'", TIMESTAMP_SECONDS, "TIMESTAMP '1582-10-05 00:00:00'") // begin julian->gregorian switch
+                .addRoundTrip(inputType, "TIMESTAMP '1582-10-14 23:59:59'", TIMESTAMP_SECONDS, "TIMESTAMP '1582-10-14 23:59:59'") // end julian->gregorian switch
+                .addRoundTrip(inputType, "TIMESTAMP '1932-04-01 00:13:42'", TIMESTAMP_SECONDS, "TIMESTAMP '1932-04-01 00:13:42'") // time gap in JVM zone
+                .addRoundTrip(inputType, "TIMESTAMP '1986-01-01 00:13:07'", TIMESTAMP_SECONDS, "TIMESTAMP '1986-01-01 00:13:07'") // time gap in Kathmandu
+                .addRoundTrip(inputType, "TIMESTAMP '2018-03-25 03:17:17'", TIMESTAMP_SECONDS, "TIMESTAMP '2018-03-25 03:17:17'") // time gap in Vilnius
+                .addRoundTrip(inputType, "TIMESTAMP '2018-10-28 01:33:17'", TIMESTAMP_SECONDS, "TIMESTAMP '2018-10-28 01:33:17'") // time doubled in JVM zone
+                .addRoundTrip(inputType, "TIMESTAMP '2018-10-28 03:33:33'", TIMESTAMP_SECONDS, "TIMESTAMP '2018-10-28 03:33:33'") // time doubled in Vilnius
+                .addRoundTrip(inputType, "TIMESTAMP '0001-01-01 00:00:00'", TIMESTAMP_SECONDS, "TIMESTAMP '0001-01-01 00:00:00'")
+                .addRoundTrip(inputType, "TIMESTAMP '9999-12-31 23:59:59'", TIMESTAMP_SECONDS, "TIMESTAMP '9999-12-31 23:59:59'")
+                .addRoundTrip(inputType, "NULL", TIMESTAMP_SECONDS, "CAST(NULL AS TIMESTAMP(0))");
+    }
+
+    private static SqlDataTypeTest timestampMillisTests(String inputType)
+    {
+        return SqlDataTypeTest.create()
+                .addRoundTrip(inputType, "TIMESTAMP '1970-01-01 00:00:00.000'", TIMESTAMP_MILLIS, "TIMESTAMP '1970-01-01 00:00:00.000'")
+                .addRoundTrip(inputType, "TIMESTAMP '1582-10-04 23:59:59.999'", TIMESTAMP_MILLIS, "TIMESTAMP '1582-10-04 23:59:59.999'") // before julian->gregorian switch
+                .addRoundTrip(inputType, "TIMESTAMP '1582-10-05 00:00:00.000'", TIMESTAMP_MILLIS, "TIMESTAMP '1582-10-05 00:00:00.000'") // begin julian->gregorian switch
+                .addRoundTrip(inputType, "TIMESTAMP '1582-10-14 23:59:59.999'", TIMESTAMP_MILLIS, "TIMESTAMP '1582-10-14 23:59:59.999'") // end julian->gregorian switch
+                .addRoundTrip(inputType, "TIMESTAMP '1932-04-01 00:13:42.123'", TIMESTAMP_MILLIS, "TIMESTAMP '1932-04-01 00:13:42.123'") // time gap in JVM zone
+                .addRoundTrip(inputType, "TIMESTAMP '1986-01-01 00:13:07.123'", TIMESTAMP_MILLIS, "TIMESTAMP '1986-01-01 00:13:07.123'") // time gap in Kathmandu
+                .addRoundTrip(inputType, "TIMESTAMP '2018-03-25 03:17:17.123'", TIMESTAMP_MILLIS, "TIMESTAMP '2018-03-25 03:17:17.123'") // time gap in Vilnius
+                .addRoundTrip(inputType, "TIMESTAMP '2018-10-28 01:33:17.456'", TIMESTAMP_MILLIS, "TIMESTAMP '2018-10-28 01:33:17.456'") // time doubled in JVM zone
+                .addRoundTrip(inputType, "TIMESTAMP '2018-10-28 03:33:33.333'", TIMESTAMP_MILLIS, "TIMESTAMP '2018-10-28 03:33:33.333'") // time doubled in Vilnius
+                .addRoundTrip(inputType, "TIMESTAMP '0001-01-01 00:00:00.000'", TIMESTAMP_MILLIS, "TIMESTAMP '0001-01-01 00:00:00.000'")
+                .addRoundTrip(inputType, "TIMESTAMP '9999-12-31 23:59:59.999'", TIMESTAMP_MILLIS, "TIMESTAMP '9999-12-31 23:59:59.999'")
+                .addRoundTrip(inputType, "NULL", TIMESTAMP_MILLIS, "CAST(NULL AS TIMESTAMP(3))");
+    }
+
+    private static SqlDataTypeTest timestampMicrosTests(String inputType)
+    {
+        return SqlDataTypeTest.create()
+                .addRoundTrip(inputType, "TIMESTAMP '1970-01-01 00:00:00.000000'", TIMESTAMP_MICROS, "TIMESTAMP '1970-01-01 00:00:00.000000'")
+                .addRoundTrip(inputType, "TIMESTAMP '1970-01-01 00:00:00.000001'", TIMESTAMP_MICROS, "TIMESTAMP '1970-01-01 00:00:00.000001'")
+                .addRoundTrip(inputType, "TIMESTAMP '1582-10-04 23:59:59.999999'", TIMESTAMP_MICROS, "TIMESTAMP '1582-10-04 23:59:59.999999'") // before julian->gregorian switch
+                .addRoundTrip(inputType, "TIMESTAMP '1582-10-05 00:00:00.000000'", TIMESTAMP_MICROS, "TIMESTAMP '1582-10-05 00:00:00.000000'") // begin julian->gregorian switch
+                .addRoundTrip(inputType, "TIMESTAMP '1582-10-14 23:59:59.999999'", TIMESTAMP_MICROS, "TIMESTAMP '1582-10-14 23:59:59.999999'") // end julian->gregorian switch
+                .addRoundTrip(inputType, "TIMESTAMP '1932-04-01 00:13:42.123000'", TIMESTAMP_MICROS, "TIMESTAMP '1932-04-01 00:13:42.123000'") // time gap in JVM zone
+                .addRoundTrip(inputType, "TIMESTAMP '1986-01-01 00:13:07.123000'", TIMESTAMP_MICROS, "TIMESTAMP '1986-01-01 00:13:07.123000'") // time gap in Kathmandu
+                .addRoundTrip(inputType, "TIMESTAMP '2018-03-25 03:17:17.000000'", TIMESTAMP_MICROS, "TIMESTAMP '2018-03-25 03:17:17.000000'") // time gap in Vilnius
+                .addRoundTrip(inputType, "TIMESTAMP '2018-10-28 01:33:17.456789'", TIMESTAMP_MICROS, "TIMESTAMP '2018-10-28 01:33:17.456789'") // time doubled in JVM zone
+                .addRoundTrip(inputType, "TIMESTAMP '2018-10-28 03:33:33.333333'", TIMESTAMP_MICROS, "TIMESTAMP '2018-10-28 03:33:33.333333'") // time doubled in Vilnius
+                .addRoundTrip(inputType, "TIMESTAMP '0001-01-01 00:00:00.000000'", TIMESTAMP_MICROS, "TIMESTAMP '0001-01-01 00:00:00.000000'")
+                .addRoundTrip(inputType, "TIMESTAMP '9999-12-31 23:59:59.999999'", TIMESTAMP_MICROS, "TIMESTAMP '9999-12-31 23:59:59.999999'")
+                .addRoundTrip(inputType, "NULL", TIMESTAMP_MICROS, "CAST(NULL AS TIMESTAMP(6))");
     }
 
     private DataSetup duckDbCreateAndInsert(String tableNamePrefix)


### PR DESCRIPTION
## Description

Add TIMESTAMP read and write mapping for the DuckDB connector.

DuckDB JDBC reports `TIMESTAMP_S` / `TIMESTAMP_MS` as `Types.OTHER`, not
`Types.TIMESTAMP`. Map those plus `TIMESTAMP` onto Trino `TIMESTAMP(0/3/6)`,
and write Trino timestamps to `TIMESTAMP_S` / `TIMESTAMP_MS` / `TIMESTAMP` by
precision, as requested on #28995.

This revives stale-closed #28995. The dedicated `TestDuckDbConnectorTest.testCreateTableWithTimestamp` from that PR is omitted; type mapping covers it.

## Additional context and related issues

Fixes #28060

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## DuckDB
* Add support for the `timestamp` type. ({issue}`28060`)
```
