### PR TITLE
Allow vacuum on Delta tables with deletion vectors

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -597,6 +597,10 @@ measure to ensure that files are retained as expected. The minimum value for
 this property is `0s`. There is a minimum retention session property as well,
 `vacuum_min_retention`.
 
+Tables that use deletion vectors are supported. A deletion vector file is kept
+while any add action still references it. After the retention period,
+unreferenced deletion vector files are removed like other data files.
+
 (delta-lake-data-management)=
 ### Data management
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/VacuumProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/VacuumProcedure.java
@@ -32,6 +32,7 @@ import io.trino.plugin.deltalake.DeltaLakeSessionProperties;
 import io.trino.plugin.deltalake.DeltaLakeTableCredentials;
 import io.trino.plugin.deltalake.DeltaLakeTableHandle;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
+import io.trino.plugin.deltalake.transactionlog.DeletionVectorEntry;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.deltalake.transactionlog.RemoveFileEntry;
@@ -69,7 +70,7 @@ import static io.trino.plugin.deltalake.DeltaLakeMetadata.checkUnsupportedUniver
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.checkValidTableHandle;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.toUriFormat;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getVacuumMinRetention;
-import static io.trino.plugin.deltalake.transactionlog.DeltaLakeTableFeatures.DELETION_VECTORS_FEATURE_NAME;
+import static io.trino.plugin.deltalake.delete.DeletionVectors.toFileName;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeTableFeatures.unsupportedWriterFeatures;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.TRANSACTION_LOG_DIRECTORY;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogDir;
@@ -85,6 +86,8 @@ public class VacuumProcedure
 {
     private static final Logger log = Logger.get(VacuumProcedure.class);
     private static final int DELETE_BATCH_SIZE = 1000;
+    // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#deletion-vector-descriptor-schema
+    private static final String UUID_DELETION_VECTOR_STORAGE_TYPE = "u";
 
     private static final MethodHandle VACUUM;
 
@@ -196,14 +199,9 @@ public class VacuumProcedure
             if (protocolEntry.minWriterVersion() > MAX_WRITER_VERSION) {
                 throw new TrinoException(NOT_SUPPORTED, "Cannot execute vacuum procedure with %d writer version".formatted(protocolEntry.minWriterVersion()));
             }
-            Set<String> writerFeatures = protocolEntry.writerFeatures().orElse(ImmutableSet.of());
             Set<String> unsupportedWriterFeatures = unsupportedWriterFeatures(protocolEntry.writerFeatures().orElse(ImmutableSet.of()));
             if (!unsupportedWriterFeatures.isEmpty()) {
                 throw new TrinoException(NOT_SUPPORTED, "Cannot execute vacuum procedure with %s writer features".formatted(unsupportedWriterFeatures));
-            }
-            if (writerFeatures.contains(DELETION_VECTORS_FEATURE_NAME)) {
-                // TODO https://github.com/trinodb/trino/issues/22809 Add support for vacuuming tables with deletion vectors
-                throw new TrinoException(NOT_SUPPORTED, "Cannot execute vacuum procedure with %s writer features".formatted(DELETION_VECTORS_FEATURE_NAME));
             }
 
             TableSnapshot tableSnapshot = metadata.getSnapshot(session, handle, Optional.of(handle.getReadVersion()));
@@ -229,7 +227,7 @@ public class VacuumProcedure
                         activeAddEntries
                                 // paths can be absolute as well in case of shallow-cloned tables, and they shouldn't be deleted as part of vacuum because according to
                                 // delta-protocol absolute paths are inherited from base table and the vacuum procedure should only list and delete local file references
-                                .map(AddFileEntry::getPath),
+                                .flatMap(VacuumProcedure::retainedFilePaths),
                         transactionLogAccess.getJsonEntries(
                                         fileSystem,
                                         transactionLogDir,
@@ -240,7 +238,7 @@ public class VacuumProcedure
                                                 .collect(toImmutableList()))
                                 .map(DeltaLakeTransactionLogEntry::getRemove)
                                 .filter(Objects::nonNull)
-                                .map(RemoveFileEntry::path))) {
+                                .flatMap(VacuumProcedure::retainedFilePaths))) {
                     retainedPaths = pathEntries
                             .peek(path -> checkState(!path.startsWith(tableLocation), "Unexpected absolute path in transaction log: %s", path))
                             .collect(toImmutableSet());
@@ -328,5 +326,25 @@ public class VacuumProcedure
                     retainedUnknownFiles,
                     removedFiles);
         }
+    }
+
+    private static Stream<String> retainedFilePaths(AddFileEntry add)
+    {
+        return retainedFilePaths(add.getPath(), add.getDeletionVector());
+    }
+
+    private static Stream<String> retainedFilePaths(RemoveFileEntry remove)
+    {
+        return retainedFilePaths(remove.path(), remove.deletionVector());
+    }
+
+    private static Stream<String> retainedFilePaths(String dataPath, Optional<DeletionVectorEntry> deletionVector)
+    {
+        return Stream.concat(
+                Stream.of(dataPath),
+                deletionVector
+                        .filter(entry -> UUID_DELETION_VECTOR_STORAGE_TYPE.equals(entry.storageType()))
+                        .map(entry -> toUriFormat(toFileName(entry.pathOrInlineDv())))
+                        .stream());
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -1824,6 +1824,101 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     }
 
     @Test
+    public void testVacuumAfterDeleteWithDeletionVectors()
+            throws Exception
+    {
+        String catalog = getSession().getCatalog().orElseThrow();
+        String tableName = "test_vacuum_dv_delete_" + randomNameSuffix();
+        Session sessionWithShortRetentionUnlocked = Session.builder(getSession())
+                .setCatalogSessionProperty(catalog, "vacuum_min_retention", "0s")
+                .build();
+        assertUpdate(
+                format("CREATE TABLE %s (x int) WITH (location = '%s', deletion_vectors_enabled = true)",
+                        tableName,
+                        getLocationForTable(bucketName, tableName)));
+        try {
+            assertUpdate("INSERT INTO " + tableName + " VALUES 1, 2, 3", 3);
+            assertUpdate("DELETE FROM " + tableName + " WHERE x = 2", 1);
+            Set<String> filesAfterFirstDelete = getAllDataFilesFromTableDirectory(tableName);
+            Set<String> firstDeletionVectors = deletionVectorFiles(filesAfterFirstDelete);
+            assertThat(firstDeletionVectors).hasSize(1);
+            assertThat(query("SELECT * FROM " + tableName)).matches("VALUES 1, 3");
+
+            assertUpdate("DELETE FROM " + tableName + " WHERE x = 3", 1);
+            Stopwatch timeSinceSecondDelete = Stopwatch.createStarted();
+            Set<String> filesAfterSecondDelete = getAllDataFilesFromTableDirectory(tableName);
+            Set<String> secondDeletionVectors = deletionVectorFiles(filesAfterSecondDelete);
+            assertThat(secondDeletionVectors).hasSize(2).containsAll(firstDeletionVectors);
+            assertThat(query("SELECT * FROM " + tableName)).matches("VALUES 1");
+            assertThat(query("SELECT count(*) FROM " + tableName)).matches("VALUES BIGINT '1'");
+
+            assertUpdate(sessionWithShortRetentionUnlocked, "CALL system.vacuum(schema_name => CURRENT_SCHEMA, table_name => '" + tableName + "', retention => '10m')");
+            assertThat(getAllDataFilesFromTableDirectory(tableName)).isEqualTo(filesAfterSecondDelete);
+            assertThat(query("SELECT * FROM " + tableName)).matches("VALUES 1");
+
+            MILLISECONDS.sleep(2_000 - timeSinceSecondDelete.elapsed(MILLISECONDS) + 1);
+            assertUpdate(sessionWithShortRetentionUnlocked, "CALL system.vacuum(schema_name => CURRENT_SCHEMA, table_name => '" + tableName + "', retention => '1s')");
+
+            Set<String> filesAfterVacuum = getAllDataFilesFromTableDirectory(tableName);
+            Set<String> activeFiles = getActiveFiles(tableName);
+            assertThat(filesAfterVacuum).containsAll(activeFiles);
+            assertThat(filesAfterVacuum).doesNotContainAnyElementsOf(firstDeletionVectors);
+            assertThat(deletionVectorFiles(filesAfterVacuum)).hasSize(1);
+            assertThat(query("SELECT * FROM " + tableName)).matches("VALUES 1");
+            assertThat(query("SELECT count(*) FROM " + tableName)).matches("VALUES BIGINT '1'");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
+    public void testVacuumAfterMergeWithDeletionVectors()
+            throws Exception
+    {
+        String catalog = getSession().getCatalog().orElseThrow();
+        String tableName = "test_vacuum_dv_merge_" + randomNameSuffix();
+        Session sessionWithShortRetentionUnlocked = Session.builder(getSession())
+                .setCatalogSessionProperty(catalog, "vacuum_min_retention", "0s")
+                .build();
+        assertUpdate(
+                format("CREATE TABLE %s (id int, v varchar) WITH (location = '%s', deletion_vectors_enabled = true)",
+                        tableName,
+                        getLocationForTable(bucketName, tableName)));
+        try {
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'a'), (2, 'b'), (3, 'c')", 3);
+            assertUpdate(
+                    "MERGE INTO " + tableName + " t USING (VALUES 2) AS s(id) ON (t.id = s.id) WHEN MATCHED THEN DELETE",
+                    1);
+            Stopwatch timeSinceMerge = Stopwatch.createStarted();
+            Set<String> filesAfterMerge = getAllDataFilesFromTableDirectory(tableName);
+            Set<String> activeFiles = getActiveFiles(tableName);
+            assertThat(activeFiles).isNotEmpty();
+            assertThat(filesAfterMerge).containsAll(activeFiles);
+            assertThat(deletionVectorFiles(filesAfterMerge)).hasSize(1);
+            assertThat(query("SELECT * FROM " + tableName)).matches("VALUES (1, VARCHAR 'a'), (3, VARCHAR 'c')");
+            assertThat(query("SELECT count(*) FROM " + tableName)).matches("VALUES BIGINT '2'");
+
+            assertUpdate(sessionWithShortRetentionUnlocked, "CALL system.vacuum(schema_name => CURRENT_SCHEMA, table_name => '" + tableName + "', retention => '10m')");
+            assertThat(getAllDataFilesFromTableDirectory(tableName)).isEqualTo(filesAfterMerge);
+            assertThat(query("SELECT * FROM " + tableName)).matches("VALUES (1, VARCHAR 'a'), (3, VARCHAR 'c')");
+
+            MILLISECONDS.sleep(2_000 - timeSinceMerge.elapsed(MILLISECONDS) + 1);
+            assertUpdate(sessionWithShortRetentionUnlocked, "CALL system.vacuum(schema_name => CURRENT_SCHEMA, table_name => '" + tableName + "', retention => '1s')");
+
+            Set<String> filesAfterVacuum = getAllDataFilesFromTableDirectory(tableName);
+            assertThat(filesAfterVacuum).isEqualTo(filesAfterMerge);
+            assertThat(filesAfterVacuum).containsAll(activeFiles);
+            assertThat(deletionVectorFiles(filesAfterVacuum)).hasSize(1);
+            assertThat(query("SELECT * FROM " + tableName)).matches("VALUES (1, VARCHAR 'a'), (3, VARCHAR 'c')");
+            assertThat(query("SELECT count(*) FROM " + tableName)).matches("VALUES BIGINT '2'");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
     public void testVacuumWithTrailingSlash()
             throws Exception
     {
@@ -2915,6 +3010,13 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     {
         return getTableFiles(tableName).stream()
                 .filter(path -> !path.contains("/" + TRANSACTION_LOG_DIRECTORY))
+                .collect(toImmutableSet());
+    }
+
+    private static Set<String> deletionVectorFiles(Set<String> files)
+    {
+        return files.stream()
+                .filter(path -> path.matches(".*deletion_vector_[0-9a-f-]+\\.bin"))
                 .collect(toImmutableSet());
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -1751,13 +1751,41 @@ public class TestDeltaLakeBasic
     public void testVacuumAfterDeleteWithDeletionVectors()
             throws Exception
     {
+        Session sessionWithShortRetentionUnlocked = Session.builder(getSession())
+                .setCatalogSessionProperty(getSession().getCatalog().orElseThrow(), "vacuum_min_retention", "0s")
+                .build();
+
         try (TestTable table = newTrinoTable("test_vacuum_dv_delete", "(x int) WITH (deletion_vectors_enabled = true)")) {
             assertUpdate("INSERT INTO " + table.getName() + " VALUES 1, 2, 3", 3);
             assertUpdate("DELETE FROM " + table.getName() + " WHERE x = 2", 1);
-            vacuumDeletionVectorTableAndAssertRetention(
-                    table.getName(),
-                    "VALUES 1, 3",
-                    2);
+            Set<String> filesAfterFirstDelete = dataAndDeletionVectorFiles(table.getName());
+            Set<String> firstDeletionVectors = deletionVectorFiles(filesAfterFirstDelete);
+            assertThat(firstDeletionVectors).hasSize(1);
+            assertThat(query("SELECT * FROM " + table.getName())).matches("VALUES 1, 3");
+
+            assertUpdate("DELETE FROM " + table.getName() + " WHERE x = 3", 1);
+            Stopwatch timeSinceSecondDelete = Stopwatch.createStarted();
+            Set<String> filesAfterSecondDelete = dataAndDeletionVectorFiles(table.getName());
+            Set<String> secondDeletionVectors = deletionVectorFiles(filesAfterSecondDelete);
+            assertThat(secondDeletionVectors).hasSize(2).containsAll(firstDeletionVectors);
+            assertThat(query("SELECT * FROM " + table.getName())).matches("VALUES 1");
+            assertThat(query("SELECT count(*) FROM " + table.getName())).matches("VALUES BIGINT '1'");
+
+            // High retention keeps the superseded DV so recent snapshots still apply it
+            assertUpdate(sessionWithShortRetentionUnlocked, "CALL system.vacuum(schema_name => CURRENT_SCHEMA, table_name => '" + table.getName() + "', retention => '10m')");
+            assertThat(dataAndDeletionVectorFiles(table.getName())).isEqualTo(filesAfterSecondDelete);
+            assertThat(query("SELECT * FROM " + table.getName())).matches("VALUES 1");
+
+            MILLISECONDS.sleep(2_000 - timeSinceSecondDelete.elapsed(MILLISECONDS) + 1);
+            assertUpdate(sessionWithShortRetentionUnlocked, "CALL system.vacuum(schema_name => CURRENT_SCHEMA, table_name => '" + table.getName() + "', retention => '1s')");
+
+            Set<String> filesAfterVacuum = dataAndDeletionVectorFiles(table.getName());
+            Set<String> activeFiles = activeDataFiles(table.getName());
+            assertThat(filesAfterVacuum).containsAll(activeFiles);
+            assertThat(filesAfterVacuum).doesNotContainAnyElementsOf(firstDeletionVectors);
+            assertThat(deletionVectorFiles(filesAfterVacuum)).hasSize(1);
+            assertThat(query("SELECT * FROM " + table.getName())).matches("VALUES 1");
+            assertThat(query("SELECT count(*) FROM " + table.getName())).matches("VALUES BIGINT '1'");
         }
     }
 
@@ -1829,6 +1857,13 @@ public class TestDeltaLakeBasic
         return computeActual("SELECT DISTINCT \"$path\" FROM " + tableName).getOnlyColumnAsSet().stream()
                 .map(String.class::cast)
                 .map(path -> Path.of(URI.create(path)).toString())
+                .collect(toImmutableSet());
+    }
+
+    private static Set<String> deletionVectorFiles(Set<String> files)
+    {
+        return files.stream()
+                .filter(path -> path.matches(".*deletion_vector_[0-9a-f-]+\\.bin"))
                 .collect(toImmutableSet());
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -16,6 +16,7 @@ package io.trino.plugin.deltalake;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -91,6 +92,7 @@ import java.util.stream.Stream;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.alwaysTrue;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterators.getOnlyElement;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -113,6 +115,7 @@ import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.lang.String.format;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.time.ZoneOffset.UTC;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
@@ -1745,21 +1748,88 @@ public class TestDeltaLakeBasic
     }
 
     @Test
-    public void testUnsupportedVacuumDeletionVectors()
+    public void testVacuumAfterDeleteWithDeletionVectors()
             throws Exception
     {
-        String tableName = "deletion_vectors" + randomNameSuffix();
+        try (TestTable table = newTrinoTable("test_vacuum_dv_delete", "(x int) WITH (deletion_vectors_enabled = true)")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 1, 2, 3", 3);
+            assertUpdate("DELETE FROM " + table.getName() + " WHERE x = 2", 1);
+            vacuumDeletionVectorTableAndAssertRetention(
+                    table.getName(),
+                    "VALUES 1, 3",
+                    2);
+        }
+    }
 
-        Path tableLocation = catalogDir.resolve(tableName);
-        copyDirectoryContents(new File(Resources.getResource("databricks122/deletion_vectors_empty").toURI()).toPath(), tableLocation);
-        assertUpdate("CALL system.register_table('%s', '%s', '%s')".formatted(getSession().getSchema().orElseThrow(), tableName, tableLocation.toUri()));
+    @Test
+    public void testVacuumAfterMergeWithDeletionVectors()
+            throws Exception
+    {
+        try (TestTable table = newTrinoTable("test_vacuum_dv_merge", "(id int, v varchar) WITH (deletion_vectors_enabled = true)")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (1, 'a'), (2, 'b'), (3, 'c')", 3);
+            assertUpdate(
+                    "MERGE INTO " + table.getName() + " t USING (VALUES 2) AS s(id) ON (t.id = s.id) WHEN MATCHED THEN DELETE",
+                    1);
+            vacuumDeletionVectorTableAndAssertRetention(
+                    table.getName(),
+                    "VALUES (1, VARCHAR 'a'), (3, VARCHAR 'c')",
+                    2);
+        }
+    }
 
-        // TODO https://github.com/trinodb/trino/issues/22809 Add support for vacuuming tables with deletion vectors
-        assertQueryFails(
-                "CALL delta.system.vacuum('tpch', '" + tableName + "', '7d')",
-                "Cannot execute vacuum procedure with deletionVectors writer features");
+    private void vacuumDeletionVectorTableAndAssertRetention(String tableName, @Language("SQL") String expectedRows, long expectedCount)
+            throws Exception
+    {
+        Session sessionWithShortRetentionUnlocked = Session.builder(getSession())
+                .setCatalogSessionProperty(getSession().getCatalog().orElseThrow(), "vacuum_min_retention", "0s")
+                .build();
 
-        assertUpdate("DROP TABLE " + tableName);
+        Stopwatch timeSinceMutation = Stopwatch.createStarted();
+        Set<String> filesAfterMutation = dataAndDeletionVectorFiles(tableName);
+        Set<String> activeFiles = activeDataFiles(tableName);
+        assertThat(activeFiles).isNotEmpty();
+        assertThat(filesAfterMutation).containsAll(activeFiles);
+        assertThat(filesAfterMutation).anyMatch(path -> path.matches(".*deletion_vector_[0-9a-f-]+\\.bin"));
+        assertThat(query("SELECT * FROM " + tableName)).matches(expectedRows);
+        assertThat(query("SELECT count(*) FROM " + tableName)).matches("VALUES BIGINT '" + expectedCount + "'");
+
+        // High retention must not drop the live data file or the DV it still references
+        assertUpdate(sessionWithShortRetentionUnlocked, "CALL system.vacuum(schema_name => CURRENT_SCHEMA, table_name => '" + tableName + "', retention => '10m')");
+        assertThat(dataAndDeletionVectorFiles(tableName)).isEqualTo(filesAfterMutation);
+        assertThat(query("SELECT * FROM " + tableName)).matches(expectedRows);
+
+        MILLISECONDS.sleep(2_000 - timeSinceMutation.elapsed(MILLISECONDS) + 1);
+        assertUpdate(sessionWithShortRetentionUnlocked, "CALL system.vacuum(schema_name => CURRENT_SCHEMA, table_name => '" + tableName + "', retention => '1s')");
+
+        // A live add still points at the DV; deleting it would resurrect the removed rows
+        Set<String> filesAfterVacuum = dataAndDeletionVectorFiles(tableName);
+        assertThat(filesAfterVacuum).isEqualTo(filesAfterMutation);
+        assertThat(filesAfterVacuum).containsAll(activeFiles);
+        assertThat(filesAfterVacuum).anyMatch(path -> path.matches(".*deletion_vector_[0-9a-f-]+\\.bin"));
+        assertThat(query("SELECT * FROM " + tableName)).matches(expectedRows);
+        assertThat(query("SELECT count(*) FROM " + tableName)).matches("VALUES BIGINT '" + expectedCount + "'");
+    }
+
+    private Set<String> dataAndDeletionVectorFiles(String tableName)
+            throws Exception
+    {
+        Path tablePath = Path.of(new URI(getTableLocation(tableName)));
+        try (Stream<Path> walk = Files.walk(tablePath)) {
+            return walk
+                    .filter(Files::isRegularFile)
+                    .filter(path -> !path.toString().contains("/_delta_log/"))
+                    .filter(path -> !path.getFileName().toString().startsWith("."))
+                    .map(Path::toString)
+                    .collect(toImmutableSet());
+        }
+    }
+
+    private Set<String> activeDataFiles(String tableName)
+    {
+        return computeActual("SELECT DISTINCT \"$path\" FROM " + tableName).getOnlyColumnAsSet().stream()
+                .map(String.class::cast)
+                .map(path -> Path.of(URI.create(path)).toString())
+                .collect(toImmutableSet());
     }
 
     @Test // regression test for https://github.com/trinodb/trino/issues/28885


### PR DESCRIPTION
## Description

VACUUM on a Delta Lake table with the deletionVectors writer feature currently throws, even though Trino writes deletion vectors on MERGE and DELETE. Users who set deletion_vectors_enabled cannot reclaim storage.

This change keeps a UUID deletion vector file while any live add action still references it, using the same transaction log walk as today's vacuum. An unreferenced deletion vector from an older DELETE is removed after the retention window. Tests assert the surviving file set, not only row counts. Smoke tests cover the same DELETE then VACUUM and MERGE then VACUUM checks on object storage. Docs record that VACUUM supports deletion vector tables.

Unsupported writer features and min writer version checks stay.

## Additional context and related issues

Related to #22809.

OPTIMIZE skipping a lone DV-backed file (#29087) and metadata deletes with DVs (#30343) stay out of this change. The #12005 operationMetrics TODO is left alone.

Smoke tests from #30742 and docs from #30743 are now in this PR.

CLA for this GitHub account is already submitted via #30729. `cla-signed` may still be red until `cla@trino.io` processes it.

@ebyhr

### How to test

The two new methods in `TestDeltaLakeBasic` failed before the production change with `Cannot execute vacuum procedure with deletionVectors writer features`.

```
./mvnw -pl plugin/trino-delta-lake test -Dtest=TestDeltaLakeBasic
```

85 passed, including `testVacuumAfterDeleteWithDeletionVectors` and `testVacuumAfterMergeWithDeletionVectors`.

```
./mvnw -pl plugin/trino-delta-lake test -Dtest=TestDeltaLakeFlociAndHmsConnectorSmokeTest
```

150 passed, 1 skipped. Includes `testVacuumAfterDeleteWithDeletionVectors` and `testVacuumAfterMergeWithDeletionVectors`.

```
./mvnw validate -pl plugin/trino-delta-lake,docs
```

BUILD SUCCESS.

Secret-gated `cloud-tests`, `Test*FailureRecoveryTest`, and Databricks product tests were not run.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake connector
* Add support for `VACUUM` on tables with deletion vectors. ({issue}`22809`)
```
