### PR TITLE
Analyze REFRESH MATERIALIZED VIEW as owner

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -148,6 +148,7 @@ public class Analysis
     private Optional<Boolean> tableExecuteReadsData;
 
     private final Map<NodeRef<Table>, Query> namedQueries = new LinkedHashMap<>();
+    private final Map<NodeRef<Table>, Session> namedQuerySessions = new LinkedHashMap<>();
 
     private final Map<NodeRef<Pivot>, PivotAnalysis> pivotAnalyses = new LinkedHashMap<>();
 
@@ -953,6 +954,19 @@ public class Analysis
         requireNonNull(query, "query is null");
 
         namedQueries.put(NodeRef.of(tableReference), query);
+    }
+
+    public void registerNamedQuerySession(Table tableReference, Session querySession)
+    {
+        requireNonNull(tableReference, "tableReference is null");
+        requireNonNull(querySession, "querySession is null");
+
+        namedQuerySessions.put(NodeRef.of(tableReference), querySession);
+    }
+
+    public Optional<Session> getNamedQuerySession(Table table)
+    {
+        return Optional.ofNullable(namedQuerySessions.get(NodeRef.of(table)));
     }
 
     public void registerPivotAnalysis(Pivot pivot, PivotAnalysis analysis)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Multiset;
 import com.google.common.collect.Streams;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.annotations.Immutable;
+import io.trino.Session;
 import io.trino.connector.CatalogHandle;
 import io.trino.metadata.AnalyzeMetadata;
 import io.trino.metadata.QualifiedObjectName;
@@ -1752,13 +1753,15 @@ public class Analysis
         private final TableHandle target;
         private final Query query;
         private final List<ColumnHandle> columns;
+        private final Session querySession;
 
-        public RefreshMaterializedViewAnalysis(Table table, TableHandle target, Query query, List<ColumnHandle> columns)
+        public RefreshMaterializedViewAnalysis(Table table, TableHandle target, Query query, List<ColumnHandle> columns, Session querySession)
         {
             this.table = requireNonNull(table, "table is null");
             this.target = requireNonNull(target, "target is null");
             this.query = query;
             this.columns = requireNonNull(columns, "columns is null");
+            this.querySession = requireNonNull(querySession, "querySession is null");
             checkArgument(columns.size() > 0, "No columns given to refresh materialized view");
         }
 
@@ -1780,6 +1783,11 @@ public class Analysis
         public Table getTable()
         {
             return table;
+        }
+
+        public Session getQuerySession()
+        {
+            return querySession;
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -758,9 +758,20 @@ class StatementAnalyzer
             QualifiedObjectName targetTable = createQualifiedObjectName(session, refreshMaterializedView, storageName);
             checkStorageTableNotRedirected(targetTable);
 
-            // analyze the query that creates the data
+            // Analyze the definition query with the stored owner session, matching
+            // analyzeView. The delegated path above does not analyze the definition.
             Query query = parseView(view.getOriginalSql(), name, refreshMaterializedView);
-            Scope queryScope = process(query, scope);
+            ViewOwnerContext ownerContext = viewOwnerContext(view.getRunAsIdentity(), view.getCatalog(), view.getSchema(), view.getPath());
+            Scope queryScope;
+            try {
+                StatementAnalyzer analyzer = statementAnalyzerFactory
+                        .withSpecializedAccessControl(ownerContext.accessControl())
+                        .createStatementAnalyzer(analysis, ownerContext.session(), warningCollector, CorrelationSupport.ALLOWED);
+                queryScope = analyzer.analyze(query);
+            }
+            catch (RuntimeException e) {
+                throw semanticException(INVALID_VIEW, refreshMaterializedView, e, "Failed analyzing stored view '%s': %s", name, e.getMessage());
+            }
 
             // verify the insert destination columns match the query
             TableHandle targetTableHandle = metadata.getTableHandle(session, targetTable)
@@ -780,7 +791,8 @@ class StatementAnalyzer
                     refreshMaterializedView.getTable(),
                     targetTableHandle,
                     query,
-                    insertColumns.stream().map(columnHandles::get).collect(toImmutableList())));
+                    insertColumns.stream().map(columnHandles::get).collect(toImmutableList()),
+                    ownerContext.session()));
 
             List<Type> tableTypes = insertColumns.stream()
                     .map(insertColumn -> tableMetadata.column(insertColumn).getType())
@@ -5723,31 +5735,10 @@ class StatementAnalyzer
                 Table node)
         {
             try {
-                // run view as view owner if set; otherwise, run as session user
-                Identity identity;
-                AccessControl viewAccessControl;
-                if (owner.isPresent()) {
-                    identity = Identity.from(owner.get())
-                            .withGroups(groupProvider.getGroups(owner.get().getUser()))
-                            .build();
-                    if (owner.get().getUser().equals(session.getIdentity().getUser())) {
-                        // View owner does not need GRANT OPTION to grant access themselves
-                        viewAccessControl = accessControl;
-                    }
-                    else {
-                        viewAccessControl = new ViewAccessControl(accessControl);
-                    }
-                }
-                else {
-                    identity = session.getIdentity();
-                    viewAccessControl = accessControl;
-                }
-
-                Session viewSession = session.createViewSession(catalog, schema, identity, path);
-
+                ViewOwnerContext ownerContext = viewOwnerContext(owner, catalog, schema, path);
                 StatementAnalyzer analyzer = statementAnalyzerFactory
-                        .withSpecializedAccessControl(viewAccessControl)
-                        .createStatementAnalyzer(analysis, viewSession, warningCollector, CorrelationSupport.ALLOWED);
+                        .withSpecializedAccessControl(ownerContext.accessControl())
+                        .createStatementAnalyzer(analysis, ownerContext.session(), warningCollector, CorrelationSupport.ALLOWED);
                 Scope queryScope = analyzer.analyze(query);
                 return queryScope.getRelationType().withAlias(name.objectName(), null);
             }
@@ -5755,6 +5746,36 @@ class StatementAnalyzer
                 throw semanticException(INVALID_VIEW, node, e, "Failed analyzing stored view '%s': %s", name, e.getMessage());
             }
         }
+
+        private ViewOwnerContext viewOwnerContext(
+                Optional<Identity> owner,
+                Optional<String> catalog,
+                Optional<String> schema,
+                List<CatalogSchemaName> path)
+        {
+            // run view as view owner if set; otherwise, run as session user
+            Identity identity;
+            AccessControl viewAccessControl;
+            if (owner.isPresent()) {
+                identity = Identity.from(owner.get())
+                        .withGroups(groupProvider.getGroups(owner.get().getUser()))
+                        .build();
+                if (owner.get().getUser().equals(session.getIdentity().getUser())) {
+                    // View owner does not need GRANT OPTION to grant access themselves
+                    viewAccessControl = accessControl;
+                }
+                else {
+                    viewAccessControl = new ViewAccessControl(accessControl);
+                }
+            }
+            else {
+                identity = session.getIdentity();
+                viewAccessControl = accessControl;
+            }
+            return new ViewOwnerContext(session.createViewSession(catalog, schema, identity, path), viewAccessControl);
+        }
+
+        private record ViewOwnerContext(Session session, AccessControl accessControl) {}
 
         private Query parseView(String view, QualifiedObjectName name, Node node)
         {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2801,13 +2801,18 @@ class StatementAnalyzer
                 }
 
                 analysis.registerTableForView(table, name, isMaterializedView);
-                RelationType descriptor = analyzeView(query, name, catalog, schema, owner, path, table);
+                ViewOwnerContext ownerContext = viewOwnerContext(owner, catalog, schema, path);
+                RelationType descriptor = analyzeView(query, name, ownerContext, table);
                 analysis.unregisterTableForView();
 
                 checkViewStaleness(columns, descriptor.getVisibleFields(), name, table)
                         .ifPresent(explanation -> { throw semanticException(VIEW_IS_STALE, table, "View '%s' is stale or in invalid state: %s", name, explanation); });
 
                 analysis.registerNamedQuery(table, query);
+                if (isMaterializedView) {
+                    // Plan the inlined definition as the owner. Regular views keep the caller session so current_user is the invoker.
+                    analysis.registerNamedQuerySession(table, ownerContext.session());
+                }
             }
 
             Scope accessControlScope = Scope.builder()
@@ -5728,14 +5733,10 @@ class StatementAnalyzer
         private RelationType analyzeView(
                 Query query,
                 QualifiedObjectName name,
-                Optional<String> catalog,
-                Optional<String> schema,
-                Optional<Identity> owner,
-                List<CatalogSchemaName> path,
+                ViewOwnerContext ownerContext,
                 Table node)
         {
             try {
-                ViewOwnerContext ownerContext = viewOwnerContext(owner, catalog, schema, path);
                 StatementAnalyzer analyzer = statementAnalyzerFactory
                         .withSpecializedAccessControl(ownerContext.accessControl())
                         .createStatementAnalyzer(analysis, ownerContext.session(), warningCollector, CorrelationSupport.ALLOWED);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -527,7 +527,11 @@ public class LogicalPlanner
         TableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle);
 
         Map<NodeRef<LambdaArgumentDeclaration>, Symbol> lambdaDeclarationToSymbolMap = buildLambdaDeclarationToSymbolMap(analysis, symbolAllocator);
-        RelationPlanner planner = new RelationPlanner(analysis, symbolAllocator, idAllocator, lambdaDeclarationToSymbolMap, plannerContext, Optional.empty(), session, ImmutableMap.of());
+        Session querySession = session;
+        if (materializedViewRefreshWriterTarget.isPresent()) {
+            querySession = analysis.getRefreshMaterializedView().orElseThrow().getQuerySession();
+        }
+        RelationPlanner planner = new RelationPlanner(analysis, symbolAllocator, idAllocator, lambdaDeclarationToSymbolMap, plannerContext, Optional.empty(), querySession, ImmutableMap.of());
         RelationPlan plan = planner.process(query, null);
 
         List<Symbol> visibleFieldMappings = visibleFields(plan);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -306,13 +306,17 @@ class RelationPlanner
 
         RelationPlan plan;
         if (namedQuery != null) {
+            Session querySession = analysis.getNamedQuerySession(node).orElse(session);
+            RelationPlanner queryPlanner = querySession == session
+                    ? this
+                    : new RelationPlanner(analysis, symbolAllocator, idAllocator, lambdaDeclarationToSymbolMap, plannerContext, outerContext, querySession, recursiveSubqueries);
             RelationPlan subPlan;
             if (analysis.isExpandableQuery(namedQuery)) {
-                subPlan = new QueryPlanner(analysis, symbolAllocator, idAllocator, lambdaDeclarationToSymbolMap, plannerContext, outerContext, session, recursiveSubqueries)
+                subPlan = new QueryPlanner(analysis, symbolAllocator, idAllocator, lambdaDeclarationToSymbolMap, plannerContext, outerContext, querySession, recursiveSubqueries)
                         .planExpand(namedQuery);
             }
             else {
-                subPlan = process(namedQuery, null);
+                subPlan = queryPlanner.process(namedQuery, null);
             }
 
             // Add implicit coercions if view query produces types that don't match the declared output types

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -151,10 +151,6 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.SystemSessionProperties.getCharVarcharCoercion;
 import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
 import static io.trino.operator.scalar.FormatFunction.FORMAT_FUNCTION_NAME;
-import static io.trino.operator.scalar.SessionFunctions.CURRENT_CATALOG_FUNCTION_NAME;
-import static io.trino.operator.scalar.SessionFunctions.CURRENT_PATH_FUNCTION_NAME;
-import static io.trino.operator.scalar.SessionFunctions.CURRENT_SCHEMA_FUNCTION_NAME;
-import static io.trino.operator.scalar.SessionFunctions.CURRENT_USER_FUNCTION_NAME;
 import static io.trino.operator.scalar.TryCastFunction.TRY_CAST_FUNCTION_NAME;
 import static io.trino.operator.scalar.TryFunction.TRY_FUNCTION_NAME;
 import static io.trino.operator.scalar.time.LocalTimeFunction.LOCALTIME_FUNCTION_NAME;
@@ -1060,34 +1056,26 @@ public class TranslationMap
 
     private io.trino.sql.ir.Expression translate(CurrentCatalog unused)
     {
-        return new Call(
-                plannerContext.getMetadata()
-                        .resolveBuiltinFunction(getCharVarcharCoercion(session), CURRENT_CATALOG_FUNCTION_NAME, ImmutableList.of()),
-                ImmutableList.of());
+        return session.getCatalog()
+                .map(catalog -> (io.trino.sql.ir.Expression) new Constant(VARCHAR, utf8Slice(catalog)))
+                .orElseGet(() -> new Constant(VARCHAR, null));
     }
 
     private io.trino.sql.ir.Expression translate(CurrentSchema unused)
     {
-        return new Call(
-                plannerContext.getMetadata()
-                        .resolveBuiltinFunction(getCharVarcharCoercion(session), CURRENT_SCHEMA_FUNCTION_NAME, ImmutableList.of()),
-                ImmutableList.of());
+        return session.getSchema()
+                .map(schema -> (io.trino.sql.ir.Expression) new Constant(VARCHAR, utf8Slice(schema)))
+                .orElseGet(() -> new Constant(VARCHAR, null));
     }
 
     private io.trino.sql.ir.Expression translate(CurrentPath unused)
     {
-        return new Call(
-                plannerContext.getMetadata()
-                        .resolveBuiltinFunction(getCharVarcharCoercion(session), CURRENT_PATH_FUNCTION_NAME, ImmutableList.of()),
-                ImmutableList.of());
+        return new Constant(VARCHAR, utf8Slice(session.getPath().toString()));
     }
 
     private io.trino.sql.ir.Expression translate(CurrentUser unused)
     {
-        return new Call(
-                plannerContext.getMetadata()
-                        .resolveBuiltinFunction(getCharVarcharCoercion(session), CURRENT_USER_FUNCTION_NAME, ImmutableList.of()),
-                ImmutableList.of());
+        return new Constant(VARCHAR, utf8Slice(session.getUser()));
     }
 
     private io.trino.sql.ir.Expression translate(CurrentDate unused)

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -6384,8 +6384,8 @@ public class TestAnalyzer
         analyze("SELECT * FROM fresh_materialized_view" + suffix);
         analyze("SELECT * FROM fresh_materialized_view_non_existent_table" + suffix);
         assertFails("REFRESH MATERIALIZED VIEW fresh_materialized_view_non_existent_table" + suffix)
-                .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("line 1:18: Table 'tpch.s1.non_existent_table' does not exist");
+                .hasErrorCode(INVALID_VIEW)
+                .hasMessage("line 1:1: Failed analyzing stored view 'tpch.s1.fresh_materialized_view_non_existent_table" + suffix + "': line 1:18: Table 'tpch.s1.non_existent_table' does not exist");
     }
 
     @Test
@@ -6400,8 +6400,8 @@ public class TestAnalyzer
                 .hasErrorCode(VIEW_IS_STALE)
                 .hasMessage("line 1:15: Materialized view 'tpch.s1.stale_materialized_view_non_existent_table_when_stale_fail' is stale");
         assertFails("REFRESH MATERIALIZED VIEW stale_materialized_view_non_existent_table_when_stale_fail")
-                .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("line 1:18: Table 'tpch.s1.non_existent_table' does not exist");
+                .hasErrorCode(INVALID_VIEW)
+                .hasMessage("line 1:1: Failed analyzing stored view 'tpch.s1.stale_materialized_view_non_existent_table_when_stale_fail': line 1:18: Table 'tpch.s1.non_existent_table' does not exist");
     }
 
     public void testAnalyzeStaleMaterializedViewWithWhenStaleInline(WhenStaleBehavior whenStaleBehavior)
@@ -6413,8 +6413,8 @@ public class TestAnalyzer
                 .hasErrorCode(INVALID_VIEW)
                 .hasMessage("line 1:15: Failed analyzing stored view 'tpch.s1.stale_materialized_view_non_existent_table" + suffix + "': line 1:18: Table 'tpch.s1.non_existent_table' does not exist");
         assertFails("REFRESH MATERIALIZED VIEW stale_materialized_view_non_existent_table" + suffix)
-                .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("line 1:18: Table 'tpch.s1.non_existent_table' does not exist");
+                .hasErrorCode(INVALID_VIEW)
+                .hasMessage("line 1:1: Failed analyzing stored view 'tpch.s1.stale_materialized_view_non_existent_table" + suffix + "': line 1:18: Table 'tpch.s1.non_existent_table' does not exist");
     }
 
     @Test
@@ -6475,7 +6475,7 @@ public class TestAnalyzer
         analyze(CLIENT_SESSION, "SELECT * FROM fresh_materialized_view" + suffix, accessControlManager);
         assertFails(CLIENT_SESSION, "REFRESH MATERIALIZED VIEW fresh_materialized_view" + suffix, accessControlManager)
                 .hasErrorCode(PERMISSION_DENIED)
-                .hasMessage("Access Denied: Cannot select from columns [a, b] in table or view tpch.s1.t1");
+                .hasMessage("Access Denied: View owner does not have sufficient privileges: View owner 'some user' cannot create view that selects from tpch.s1.t1");
         if (whenStaleBehavior == INLINE) {
             // Now we check that when the MV is stale, access to the underlying tables is checked.
             assertFails(CLIENT_SESSION, "SELECT * FROM stale_materialized_view" + suffix, accessControlManager)
@@ -6490,7 +6490,7 @@ public class TestAnalyzer
 
         assertFails(CLIENT_SESSION, "REFRESH MATERIALIZED VIEW stale_materialized_view" + suffix, accessControlManager)
                 .hasErrorCode(PERMISSION_DENIED)
-                .hasMessage("Access Denied: Cannot select from columns [a, b] in table or view tpch.s1.t1");
+                .hasMessage("Access Denied: View owner does not have sufficient privileges: View owner 'some user' cannot create view that selects from tpch.s1.t1");
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -1270,11 +1270,9 @@ public abstract class BaseIcebergMaterializedViewTest
         // Refresh by a different user picks up the new row
         assertUpdate(otherUserSession, "REFRESH MATERIALIZED VIEW " + mvName, 1);
         assertFreshness(mvName, "FRESH");
-        // TODO https://github.com/trinodb/trino/issues/28738 session-scoped expressions should resolve using
-        // the MV owner's identity during refresh (like the stale inline path does via analyzeView), but currently
-        // the refresh path resolves them from the refreshing user's session.
-        // When fixed, this should be: VALUES ('user'), ('user')
-        assertQuery("SELECT created_by FROM " + mvName, "VALUES ('user'), ('other_user')");
+        // current_user should resolve to 'user' (the MV owner) for all rows,
+        // regardless of who triggered the refresh
+        assertQuery("SELECT created_by FROM " + mvName, "VALUES ('user'), ('user')");
 
         assertUpdate("DROP MATERIALIZED VIEW " + mvName);
         assertUpdate("DROP TABLE " + sourceTableName);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -1246,10 +1246,11 @@ public abstract class BaseIcebergMaterializedViewTest
         assertUpdate("CREATE TABLE " + sourceTableName + " (value INTEGER)");
         assertUpdate("INSERT INTO " + sourceTableName + " VALUES 1", 1);
 
-        // Session-scoped expressions (current_user, current_catalog, current_schema, current_path)
-        // are constants for materialized views (fixed at creation time), so the MV should be FRESH after refresh
+        // Session-scoped expressions are constants for materialized views, fixed at creation.
+        // GRACE PERIOD 0 makes a stale SELECT inline the definition.
         String mvName = "mv_session_scoped_" + randomNameSuffix();
-        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT *, current_user AS created_by FROM " + sourceTableName);
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName +
+                " GRACE PERIOD INTERVAL '0' SECOND AS SELECT *, current_user AS created_by FROM " + sourceTableName);
 
         assertFreshness(mvName, "STALE");
         assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
@@ -1265,8 +1266,8 @@ public abstract class BaseIcebergMaterializedViewTest
 
         assertUpdate("INSERT INTO " + sourceTableName + " VALUES 2", 1);
         assertFreshness(mvName, "STALE");
-        // Stale MV still serves cached data from storage
-        assertQuery(otherUserSession, "SELECT created_by FROM " + mvName, "VALUES 'user'");
+        // Stale MV is inlined using the owner's identity, so current_user = 'user' for all rows
+        assertQuery(otherUserSession, "SELECT created_by FROM " + mvName, "VALUES ('user'), ('user')");
         // Refresh by a different user picks up the new row
         assertUpdate(otherUserSession, "REFRESH MATERIALIZED VIEW " + mvName, 1);
         assertFreshness(mvName, "FRESH");

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -679,7 +679,7 @@ public class TestEventListenerBasic
         TableInfo table = tables.get(0);
         assertThat(table)
                 .hasCatalogSchemaTable("tpch", "tiny", "nation")
-                .hasAuthorization("user")
+                .hasAuthorization("alice")
                 .isDirectlyReferenced()
                 .hasColumnsWithoutMasking("nationkey")
                 .hasNoRowFilters()


### PR DESCRIPTION
## Description

REFRESH MATERIALIZED VIEW analyzed the stored definition on the caller session. Session functions such as `current_user` therefore resolved to the refresher, not the owner. Stale SELECT already used `analyzeView`'s owner session. After the delegated connector early return, reuse that owner session for analysis and planning of the definition query. Storage writes still use the caller session so Iceberg catalog session properties are not dropped.

* Fixes #28738

## Additional context and related issues

hashhar named this fix on the issue. #28731 (`current_date` freshness) is separate and is not in this PR. Delegated connector refresh is unchanged. Iceberg still returns false there.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix ``REFRESH MATERIALIZED VIEW`` to evaluate session functions such as ``current_user`` as the view owner. ({issue}`28738`)
```

## How to test

JAVA_HOME must be Temurin 25. Quote `-Dtest` in zsh.

```
./mvnw -pl plugin/trino-iceberg test -Dtest=TestIcebergMaterializedView
```

Tests run: 47, Failures: 0.

```
./mvnw -pl core/trino-main test -Dtest=TestAnalyzer,TestLogicalPlanner,TestSessionFunctions,TestMaterializedViews
```

Tests run: 397, Failures: 0, Skipped: 1. `TestAnalyzer` 295/0 (1 skip). `TestLogicalPlanner` 91/0. `TestSessionFunctions` 5/0. `TestMaterializedViews` 6/0.

```
./mvnw -pl core/trino-main test
```

Tests run: 9844, Failures: 0, Errors: 3, Skipped: 5. The 3 errors are OAuth2 Hydra tests with no Docker environment. Unrelated.

```
./mvnw validate -pl core/trino-main,plugin/trino-iceberg,testing/trino-tests -am
```

BUILD SUCCESS

```
./mvnw -pl testing/trino-tests test -Dtest=TestEventListenerBasic
```

Tests run: 64, Failures: 0. `testReferencedTablesInRefreshMaterializedView` expects owner `alice` for the referenced table, matching SELECT from a stale MV.

