### PR TITLE
Fix REST catalog case-insensitive name mapping cache

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -243,8 +243,10 @@ public class TrinoRestCatalog
         catch (RESTException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to drop namespace '%s'".formatted(namespace), e);
         }
-        if (caseInsensitiveNameMatching) {
-            remoteNamespaceMappingCache.invalidate(toNamespace(namespace));
+        finally {
+            if (caseInsensitiveNameMatching) {
+                remoteNamespaceMappingCache.invalidate(toNamespace(namespace));
+            }
         }
     }
 
@@ -496,21 +498,27 @@ public class TrinoRestCatalog
         catch (RESTException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to unregister table '%s'".formatted(tableName.getTableName()), e);
         }
-        invalidateTableCache(tableName);
-        invalidateTableMappingCache(tableName);
+        finally {
+            invalidateTableCache(tableName);
+            invalidateTableMappingCache(tableName);
+        }
     }
 
     @Override
     public void dropTable(ConnectorSession session, SchemaTableName schemaTableName)
     {
-        if (security == Security.GOOGLE) {
-            purgeBigLakeTable(session, schemaTableName);
+        try {
+            if (security == Security.GOOGLE) {
+                purgeBigLakeTable(session, schemaTableName);
+            }
+            else {
+                purgeTable(session, schemaTableName);
+            }
         }
-        else {
-            purgeTable(session, schemaTableName);
+        finally {
+            invalidateTableCache(schemaTableName);
+            invalidateTableMappingCache(schemaTableName);
         }
-        invalidateTableCache(schemaTableName);
-        invalidateTableMappingCache(schemaTableName);
     }
 
     private void purgeBigLakeTable(ConnectorSession session, SchemaTableName schemaTableName)
@@ -568,8 +576,10 @@ public class TrinoRestCatalog
         catch (RESTException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, format("Failed to rename table %s to %s", from, to), e);
         }
-        invalidateTableCache(from);
-        invalidateTableMappingCache(from);
+        finally {
+            invalidateTableCache(from);
+            invalidateTableMappingCache(from);
+        }
     }
 
     @Override
@@ -633,13 +643,17 @@ public class TrinoRestCatalog
         catch (RESTException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to load table '%s'".formatted(schemaTableName.getTableName()), e);
         }
-        if (comment.isEmpty()) {
-            icebergTable.updateProperties().remove(TABLE_COMMENT).commit();
+        try {
+            if (comment.isEmpty()) {
+                icebergTable.updateProperties().remove(TABLE_COMMENT).commit();
+            }
+            else {
+                icebergTable.updateProperties().set(TABLE_COMMENT, comment.get()).commit();
+            }
         }
-        else {
-            icebergTable.updateProperties().set(TABLE_COMMENT, comment.get()).commit();
+        finally {
+            invalidateTableCache(schemaTableName);
         }
-        invalidateTableCache(schemaTableName);
     }
 
     @Override
@@ -724,7 +738,9 @@ public class TrinoRestCatalog
         catch (RESTException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to rename view '%s' to '%s'".formatted(source, target), e);
         }
-        invalidateTableMappingCache(source);
+        finally {
+            invalidateTableMappingCache(source);
+        }
     }
 
     @Override
@@ -742,7 +758,9 @@ public class TrinoRestCatalog
         catch (RESTException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to drop view '%s'".formatted(schemaViewName.getTableName()), e);
         }
-        invalidateTableMappingCache(schemaViewName);
+        finally {
+            invalidateTableMappingCache(schemaViewName);
+        }
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -91,6 +91,7 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.cache.CacheUtils.uncheckedCacheGet;
@@ -612,19 +613,10 @@ public class TrinoRestCatalog
 
     private TableIdentifier toRemoteObject(ConnectorSession session, SchemaTableName schemaTableName)
     {
-        TableIdentifier remoteTable = toRemoteTable(session, schemaTableName, false);
-        if (!remoteTable.name().equals(schemaTableName.getTableName())) {
-            return remoteTable;
-        }
-
-        TableIdentifier remoteView = toRemoteView(session, schemaTableName, false);
-        if (!remoteView.name().equals(schemaTableName.getTableName())) {
-            return remoteView;
-        }
-        if (remoteView.name().equals(schemaTableName.getTableName()) && remoteTable.name().equals(schemaTableName.getTableName())) {
-            return remoteTable;
-        }
-        throw new RuntimeException("Unable to find remote object");
+        TableIdentifier tableIdentifier = toIdentifier(schemaTableName);
+        return toRemoteTableIfExists(session, tableIdentifier, false)
+                .orElseGet(() -> toRemoteViewIfExists(session, tableIdentifier, false)
+                        .orElseGet(() -> toRemoteIdentifier(session, tableIdentifier)));
     }
 
     @Override
@@ -1024,6 +1016,12 @@ public class TrinoRestCatalog
     private TableIdentifier toRemoteTable(ConnectorSession session, SchemaTableName schemaTableName, boolean getCached)
     {
         TableIdentifier tableIdentifier = toIdentifier(schemaTableName);
+        return toRemoteTableIfExists(session, tableIdentifier, getCached)
+                .orElseGet(() -> toRemoteIdentifier(session, tableIdentifier));
+    }
+
+    private Optional<TableIdentifier> toRemoteTableIfExists(ConnectorSession session, TableIdentifier tableIdentifier, boolean getCached)
+    {
         return toRemoteObject(tableIdentifier, () -> findRemoteTable(session, tableIdentifier), getCached);
     }
 
@@ -1047,21 +1045,29 @@ public class TrinoRestCatalog
                 matchingTable = identifier;
             }
         }
-        return matchingTable == null ? TableIdentifier.of(remoteNamespace, tableIdentifier.name()) : matchingTable;
+        if (matchingTable == null) {
+            throw new RemoteObjectNotFoundException();
+        }
+        return matchingTable;
     }
 
     private TableIdentifier toRemoteView(ConnectorSession session, SchemaTableName schemaViewName, boolean getCached)
     {
         TableIdentifier tableIdentifier = toIdentifier(schemaViewName);
+        return toRemoteViewIfExists(session, tableIdentifier, getCached)
+                .orElseGet(() -> toRemoteIdentifier(session, tableIdentifier));
+    }
+
+    private Optional<TableIdentifier> toRemoteViewIfExists(ConnectorSession session, TableIdentifier tableIdentifier, boolean getCached)
+    {
+        if (!viewEndpointsEnabled) {
+            return Optional.empty();
+        }
         return toRemoteObject(tableIdentifier, () -> findRemoteView(session, tableIdentifier), getCached);
     }
 
     private TableIdentifier findRemoteView(ConnectorSession session, TableIdentifier tableIdentifier)
     {
-        if (!viewEndpointsEnabled) {
-            return tableIdentifier;
-        }
-
         Namespace remoteNamespace = toRemoteNamespace(session, tableIdentifier.namespace());
         List<TableIdentifier> tableIdentifiers;
         try {
@@ -1080,18 +1086,42 @@ public class TrinoRestCatalog
                 matchingView = identifier;
             }
         }
-        return matchingView == null ? TableIdentifier.of(remoteNamespace, tableIdentifier.name()) : matchingView;
+        if (matchingView == null) {
+            throw new RemoteObjectNotFoundException();
+        }
+        return matchingView;
     }
 
-    private TableIdentifier toRemoteObject(TableIdentifier tableIdentifier, Supplier<TableIdentifier> remoteObjectProvider, boolean getCached)
+    private Optional<TableIdentifier> toRemoteObject(TableIdentifier tableIdentifier, Supplier<TableIdentifier> remoteObjectProvider, boolean getCached)
     {
         if (caseInsensitiveNameMatching) {
-            if (getCached) {
-                return uncheckedCacheGet(remoteTableMappingCache, tableIdentifier, remoteObjectProvider);
+            try {
+                if (getCached) {
+                    return Optional.of(getAndCache(tableIdentifier, remoteObjectProvider));
+                }
+                return Optional.of(remoteObjectProvider.get());
             }
-            return remoteObjectProvider.get();
+            catch (RemoteObjectNotFoundException e) {
+                return Optional.empty();
+            }
         }
-        return tableIdentifier;
+        return Optional.of(tableIdentifier);
+    }
+
+    private TableIdentifier getAndCache(TableIdentifier tableIdentifier, Supplier<TableIdentifier> remoteObjectProvider)
+    {
+        try {
+            return uncheckedCacheGet(remoteTableMappingCache, tableIdentifier, remoteObjectProvider);
+        }
+        catch (UncheckedExecutionException e) {
+            throwIfUnchecked(e.getCause());
+            throw e;
+        }
+    }
+
+    private TableIdentifier toRemoteIdentifier(ConnectorSession session, TableIdentifier tableIdentifier)
+    {
+        return TableIdentifier.of(toRemoteNamespace(session, tableIdentifier.namespace()), tableIdentifier.name());
     }
 
     private Namespace toRemoteNamespace(ConnectorSession session, Namespace trinoNamespace)
@@ -1143,5 +1173,16 @@ public class TrinoRestCatalog
     private static Namespace toTrinoNamespace(Namespace namespace)
     {
         return Namespace.of(Arrays.stream(namespace.levels()).map(level -> level.toLowerCase(ENGLISH)).toArray(String[]::new));
+    }
+
+    private static class RemoteObjectNotFoundException
+            extends RuntimeException
+    {
+        public RemoteObjectNotFoundException()
+        {
+            // This exception is a sentinel used only to signal a cache miss to the enclosing catch;
+            // it never escapes and is never logged, so the stack trace is pointless overhead and is suppressed.
+            super(null, null, false, false);
+        }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogCaseInsensitiveMapping.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogCaseInsensitiveMapping.java
@@ -244,6 +244,40 @@ final class TestIcebergRestCatalogCaseInsensitiveMapping
     }
 
     @Test
+    void testCachedTableMappingHidesExternallyRecreatedTable()
+    {
+        Map<String, String> namespaceMetadata = backend.loadNamespaceMetadata(NAMESPACE);
+        String namespaceLocation = namespaceMetadata.get(LOCATION_PROPERTY);
+        createDir(namespaceLocation);
+
+        String tableName = "MiXeD_CaSe_ReCrEaTeD_" + randomNameSuffix();
+        String lowercaseTableName = tableName.toLowerCase(ENGLISH);
+
+        // Creating the table resolves its name through the mapping cache while it
+        // does not yet exist remotely, populating the cache with the requested name as-is.
+        String initialLocation = namespaceLocation + "/" + lowercaseTableName + "_initial";
+        assertUpdate("CREATE TABLE " + lowercaseTableName + " (a integer) WITH (location = '" + initialLocation + "')");
+
+        // Drop it on the backend and recreate it under a mixed-case remote name, so the remote name
+        // no longer matches what the cached entry points at.
+        assertThat(backend.dropTable(TableIdentifier.of(NAMESPACE, lowercaseTableName), true)).isTrue();
+
+        String recreatedLocation = namespaceLocation + "/" + lowercaseTableName + "_recreated";
+        createDir(recreatedLocation);
+        createDir(recreatedLocation + "/data");
+        createDir(recreatedLocation + "/metadata");
+        backend.buildTable(TableIdentifier.of(NAMESPACE, tableName), new Schema(required(1, "a", Types.IntegerType.get())))
+                .withLocation(recreatedLocation)
+                .createTransaction()
+                .commitTransaction();
+
+        // TODO: This asserts buggy behavior. The mapping cache retains the entry populated on the
+        //  earlier miss (lowercase name -> itself); it hides the externally recreated mixed-case
+        //  table, so the drop fails even though the table exists.
+        assertQueryFails("DROP TABLE " + lowercaseTableName, "Failed to drop table .*");
+    }
+
+    @Test
     void testLoadTableProbeDoesNotPolluteViewMapping()
     {
         Map<String, String> namespaceMetadata = backend.loadNamespaceMetadata(NAMESPACE);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogCaseInsensitiveMapping.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogCaseInsensitiveMapping.java
@@ -271,10 +271,9 @@ final class TestIcebergRestCatalogCaseInsensitiveMapping
                 .createTransaction()
                 .commitTransaction();
 
-        // TODO: This asserts buggy behavior. The mapping cache retains the entry populated on the
-        //  earlier miss (lowercase name -> itself); it hides the externally recreated mixed-case
-        //  table, so the drop fails even though the table exists.
-        assertQueryFails("DROP TABLE " + lowercaseTableName, "Failed to drop table .*");
+        // A stale mapping would still point at the old lowercase remote name and hide the
+        // externally recreated table; resolution must find the mixed-case table instead.
+        assertUpdate("DROP TABLE " + lowercaseTableName);
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogCaseInsensitiveMapping.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogCaseInsensitiveMapping.java
@@ -307,6 +307,54 @@ final class TestIcebergRestCatalogCaseInsensitiveMapping
         backend.dropView(TableIdentifier.of(NAMESPACE, viewName));
     }
 
+    @Test
+    void testCaseInsensitiveCollisionBetweenTableAndView()
+    {
+        // A remote backend that is case-sensitive can hold a table and a view whose names differ
+        // only by case (the Iceberg spec forbids a table and view sharing the *same* name, but not
+        // case-variants). With case-insensitive matching enabled, both collapse to a single Trino
+        // name and Trino cannot address them separately.
+        Map<String, String> namespaceMetadata = backend.loadNamespaceMetadata(NAMESPACE);
+        String namespaceLocation = namespaceMetadata.get(LOCATION_PROPERTY);
+        createDir(namespaceLocation);
+
+        String suffix = randomNameSuffix();
+        String lowercaseName = "cross_type_collision_" + suffix;
+        TableIdentifier remoteTable = TableIdentifier.of(NAMESPACE, "CROSS_TYPE_COLLISION_" + suffix);
+        TableIdentifier remoteView = TableIdentifier.of(NAMESPACE, lowercaseName);
+
+        String tableLocation = namespaceLocation + "/" + lowercaseName + "_table";
+        createDir(tableLocation);
+        createDir(tableLocation + "/data");
+        createDir(tableLocation + "/metadata");
+        backend.buildTable(remoteTable, new Schema(required(1, "t_val", Types.LongType.get())))
+                .withLocation(tableLocation)
+                .createTransaction()
+                .commitTransaction();
+
+        String viewLocation = namespaceLocation + "/" + lowercaseName + "_view";
+        createDir(viewLocation);
+        createDir(viewLocation + "/data");
+        createDir(viewLocation + "/metadata");
+        backend.buildView(remoteView)
+                .withQuery("trino", "SELECT BIGINT '7' AS v_val")
+                .withSchema(new Schema(required(1, "v_val", Types.LongType.get())))
+                .withDefaultNamespace(NAMESPACE)
+                .withLocation(viewLocation)
+                .createOrReplace();
+
+        // The analyzer resolves views before tables (StatementAnalyzer resolves
+        // materialized view -> view -> table), so the query binds to the view and the
+        // colliding table is unreachable: it returns the view's column/value, not the table's.
+        assertThat(computeActual("DESCRIBE " + lowercaseName).getMaterializedRows())
+                .singleElement()
+                .satisfies(row -> assertThat(row.getField(0)).isEqualTo("v_val"));
+        assertQuery("SELECT * FROM " + lowercaseName, "VALUES CAST(7 AS BIGINT)");
+
+        assertUpdate("DROP VIEW " + lowercaseName);
+        assertUpdate("DROP TABLE " + lowercaseName);
+    }
+
     private String getColumnComment(String tableName, String columnName)
     {
         return (String) computeScalar("SELECT comment FROM information_schema.columns " +

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogCaseInsensitiveMapping.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogCaseInsensitiveMapping.java
@@ -243,6 +243,32 @@ final class TestIcebergRestCatalogCaseInsensitiveMapping
         assertQueryFails("SELECT * FROM " + viewName2, ".*'iceberg.%s.%s' does not exist".formatted(LOWERCASE_SCHEMA, lowercaseViewName2));
     }
 
+    @Test
+    void testLoadTableProbeDoesNotPolluteViewMapping()
+    {
+        Map<String, String> namespaceMetadata = backend.loadNamespaceMetadata(NAMESPACE);
+        String namespaceLocation = namespaceMetadata.get(LOCATION_PROPERTY);
+        createDir(namespaceLocation);
+
+        String viewName = "MiXed_CaSe_LoAd_TaBlE_PrObE_vIeW_" + randomNameSuffix();
+        String lowercaseViewName = viewName.toLowerCase(ENGLISH);
+        String viewLocation = namespaceLocation + "/" + lowercaseViewName;
+        createDir(viewLocation);
+        createDir(viewLocation + "/data");
+        createDir(viewLocation + "/metadata");
+        backend.buildView(TableIdentifier.of(NAMESPACE, viewName))
+                .withQuery("trino", "SELECT BIGINT '92' value")
+                .withSchema(new Schema(required(1, "value", Types.LongType.get())))
+                .withDefaultNamespace(NAMESPACE)
+                .withLocation(viewLocation)
+                .createOrReplace();
+
+        assertQueryFails("SELECT * FROM \"" + lowercaseViewName + "$history\"", ".*does not exist");
+        assertQuery("SELECT * FROM " + lowercaseViewName, "VALUES (92)");
+
+        assertUpdate("DROP VIEW " + lowercaseViewName);
+    }
+
     private String getColumnComment(String tableName, String columnName)
     {
         return (String) computeScalar("SELECT comment FROM information_schema.columns " +

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogCaseInsensitiveMapping.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogCaseInsensitiveMapping.java
@@ -269,6 +269,44 @@ final class TestIcebergRestCatalogCaseInsensitiveMapping
         assertUpdate("DROP VIEW " + lowercaseViewName);
     }
 
+    @Test
+    void testViewPropertiesIgnoreStaleNameMapping()
+    {
+        Map<String, String> namespaceMetadata = backend.loadNamespaceMetadata(NAMESPACE);
+        String namespaceLocation = namespaceMetadata.get(LOCATION_PROPERTY);
+        createDir(namespaceLocation);
+
+        String viewName = "MiXed_CaSe_ViEw_PrOpErTiEs_" + randomNameSuffix();
+        String lowercaseViewName = viewName.toLowerCase(ENGLISH);
+
+        // Creating the view resolves its name through the mapping cache (getCached=true) while it does
+        // not yet exist remotely, caching the name as-is. This entry is never invalidated.
+        assertUpdate("CREATE VIEW " + lowercaseViewName + " AS SELECT BIGINT '67' value");
+
+        // Drop it on the backend and recreate it under a mixed-case remote name, so the cached entry
+        // now points at a lowercase remote view that no longer exists.
+        backend.dropView(TableIdentifier.of(NAMESPACE, lowercaseViewName));
+
+        String recreatedLocation = namespaceLocation + "/" + lowercaseViewName + "_recreated";
+        createDir(recreatedLocation);
+        createDir(recreatedLocation + "/data");
+        createDir(recreatedLocation + "/metadata");
+        backend.buildView(TableIdentifier.of(NAMESPACE, viewName))
+                .withQuery("trino", "SELECT BIGINT '67' value")
+                .withSchema(new Schema(required(1, "value", Types.LongType.get())))
+                .withDefaultNamespace(NAMESPACE)
+                .withLocation(recreatedLocation)
+                .createOrReplace();
+
+        // getViewProperties must resolve the view name with getCached=false. If it trusted the cache,
+        // it would load the stale lowercase mapping, miss the recreated mixed-case view, and fail to
+        // report its location.
+        assertThat((String) computeScalar("SHOW CREATE VIEW " + lowercaseViewName))
+                .contains("location = '" + recreatedLocation + "'");
+
+        backend.dropView(TableIdentifier.of(NAMESPACE, viewName));
+    }
+
     private String getColumnComment(String tableName, String columnName)
     {
         return (String) computeScalar("SELECT comment FROM information_schema.columns " +


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The REST catalog's case-insensitive name mapping had three bugs that could cause queries to silently resolve to the wrong object or fail to find objects that exist:

1. Cache misses hid later-created objects. When no remote match was found, the cache stored the requested identifier as-is — making a miss look identical to an exact-case hit. A mixed-case table created externally after such a miss stayed invisible until TTL expiry.
2. Table and view lookups shared one cache and polluted each other. A table lookup miss could populate the shared mapping cache, and a subsequent view resolution for the same name would trust that stale entry instead of querying the remote catalog.
3. Mutation failures left stale cache entries. Cache invalidation ran only after successful returns. When a REST call failed ambiguously (remote side applied the change, client saw an error), Trino kept the old mapping until TTL expiry.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Fix case-insensitive name matching in REST catalogs incorrectly resolving tables and views. ({issue}`30747`)
```
