### PR TITLE
Support returning metrics in `CALL` syntax and Iceberg `migrate` procedure

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CallTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CallTask.java
@@ -207,7 +207,14 @@ public class CallTask
         stateMachine.setRoutines(ImmutableList.of(new RoutineInfo(procedureName.objectName(), session.getUser())));
 
         try {
-            procedure.getMethodHandle().invokeWithArguments(arguments);
+            Object result = procedure.getMethodHandle().invokeWithArguments(arguments);
+            if (procedure.getMethodHandle().type().returnType() == Map.class && result != null) {
+                @SuppressWarnings("unchecked")
+                Map<String, Long> metrics = (Map<String, Long>) result;
+                if (!metrics.isEmpty()) {
+                    stateMachine.setCallResult(metrics);
+                }
+            }
         }
         catch (Throwable t) {
             if (t instanceof InterruptedException) {

--- a/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
@@ -287,6 +287,12 @@ public class DataDefinitionExecution<T extends Statement>
     }
 
     @Override
+    public Optional<Map<String, Long>> callResult()
+    {
+        return stateMachine.callResult();
+    }
+
+    @Override
     public QueryState getState()
     {
         return stateMachine.getQueryState();

--- a/core/trino-main/src/main/java/io/trino/execution/QueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryExecution.java
@@ -30,6 +30,7 @@ import io.trino.spi.type.Type;
 import io.trino.sql.planner.Plan;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.function.Consumer;
@@ -85,6 +86,11 @@ public interface QueryExecution
      * be taken to avoid leaking {@code this} when adding a listener in a constructor.
      */
     void addFinalQueryInfoListener(StateChangeListener<QueryInfo> stateChangeListener);
+
+    default Optional<Map<String, Long>> callResult()
+    {
+        return Optional.empty();
+    }
 
     interface QueryExecutionFactory<T extends QueryExecution>
     {

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManager.java
@@ -42,6 +42,7 @@ import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
@@ -264,6 +265,11 @@ public class QueryManager
     public Optional<Plan> getQueryPlan(QueryId queryId)
     {
         return queryTracker.getQuery(queryId).getQueryPlan();
+    }
+
+    public Optional<Map<String, Long>> getCallResult(QueryId queryId)
+    {
+        return queryTracker.getQuery(queryId).callResult();
     }
 
     public void addFinalQueryInfoListener(QueryId queryId, StateChangeListener<QueryInfo> stateChangeListener)

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -192,6 +192,7 @@ public class QueryStateMachine
     private final AtomicReference<List<RoutineInfo>> routines = new AtomicReference<>(ImmutableList.of());
     private final AtomicReference<Map<String, Metrics>> catalogMetadataMetrics = new AtomicReference<>(ImmutableMap.of());
     private final AtomicReference<Map<String, Metrics>> exchangeMetrics = new AtomicReference<>(ImmutableMap.of());
+    private final AtomicReference<Map<String, Long>> callResult = new AtomicReference<>();
     private final StateMachine<Optional<QueryInfo>> finalQueryInfo;
 
     private final WarningCollector warningCollector;
@@ -1081,6 +1082,16 @@ public class QueryStateMachine
     {
         requireNonNull(routines, "routines is null");
         this.routines.set(ImmutableList.copyOf(routines));
+    }
+
+    public void setCallResult(Map<String, Long> metrics)
+    {
+        callResult.set(ImmutableMap.copyOf(metrics));
+    }
+
+    public Optional<Map<String, Long>> callResult()
+    {
+        return Optional.ofNullable(callResult.get());
     }
 
     private DynamicFiltersStats getDynamicFiltersStats()

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -52,6 +52,7 @@ import io.trino.server.GoneException;
 import io.trino.server.ResultQueryInfo;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
 import io.trino.spi.QueryId;
 import io.trino.spi.block.ArrayBlock;
 import io.trino.spi.block.Block;
@@ -72,6 +73,7 @@ import java.io.EOFException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -86,6 +88,7 @@ import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.addTimeout;
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.SystemSessionProperties.getRetryPolicy;
 import static io.trino.execution.QueryState.FAILED;
@@ -99,6 +102,8 @@ import static io.trino.server.protocol.QueryResultRows.empty;
 import static io.trino.server.protocol.QueryResultRows.queryResultRowsBuilder;
 import static io.trino.server.protocol.Slug.Context.EXECUTING_QUERY;
 import static io.trino.spi.StandardErrorCode.SERIALIZATION_ERROR;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.util.Failures.toFailure;
 import static io.trino.util.MoreLists.mappedCopy;
 import static java.util.Objects.requireNonNull;
@@ -578,6 +583,29 @@ class Query
     {
         if (!resultsConsumed && queryInfo.stages().isEmpty()) {
             if (columns == null) {
+                String updateType = queryInfo.updateType();
+                if ("CALL".equals(updateType)) {
+                    types = ImmutableList.of(VARCHAR, BIGINT);
+                    columns = ImmutableList.of(
+                            createColumn("metric_name", VARCHAR, supportsParametricDateTime, supportsNumberType, supportsVariant, supportsVariantBinary),
+                            createColumn("metric_value", BIGINT, supportsParametricDateTime, supportsNumberType, supportsVariant, supportsVariantBinary));
+                    queryDataProducer = QueryDataProducerFactory.create(session, types);
+                    Optional<Map<String, Long>> callResult = queryManager.getCallResult(queryId);
+                    if (callResult.isPresent() && !callResult.get().isEmpty()) {
+                        Map<String, Long> metrics = callResult.get();
+                        PageBuilder pageBuilder = new PageBuilder(types);
+                        for (Entry<String, Long> entry : metrics.entrySet()) {
+                            pageBuilder.declarePosition();
+                            VARCHAR.writeSlice(pageBuilder.getBlockBuilder(0), utf8Slice(entry.getKey()));
+                            BIGINT.writeLong(pageBuilder.getBlockBuilder(1), entry.getValue());
+                        }
+                        return queryResultRowsBuilder()
+                                .withTypes(types)
+                                .addPage(pageBuilder.build())
+                                .build();
+                    }
+                    return QueryResultRows.empty();
+                }
                 columns = ImmutableList.of();
                 types = ImmutableList.of();
             }

--- a/core/trino-spi/src/main/java/io/trino/spi/procedure/Procedure.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/procedure/Procedure.java
@@ -21,6 +21,7 @@ import jakarta.annotation.Nullable;
 import java.lang.invoke.MethodHandle;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static java.lang.String.format;
@@ -61,7 +62,7 @@ public class Procedure
         }
 
         checkArgument(!methodHandle.isVarargsCollector(), "Method must have fixed arity");
-        checkArgument(methodHandle.type().returnType() == void.class, "Method must return void");
+        checkArgument(methodHandle.type().returnType() == void.class || methodHandle.type().returnType() == Map.class, "Method must return void or Map<String, Long>");
 
         long parameterCount = methodHandle.type().parameterList().stream()
                 .filter(type -> !ConnectorSession.class.equals(type))

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
@@ -162,17 +162,17 @@ public class MigrateProcedure
                 MIGRATE.bindTo(this));
     }
 
-    public void migrate(ConnectorSession session, String schemaName, String tableName, String recursiveDirectory)
+    public Map<String, Long> migrate(ConnectorSession session, String schemaName, String tableName, String recursiveDirectory)
     {
         // this line guarantees that classLoader that we stored in the field will be used inside try/catch
         // as we captured reference to PluginClassLoader during initialization of this class
         // we can use it now to correctly execute the procedure
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(getClass().getClassLoader())) {
-            doMigrate(session, schemaName, tableName, recursiveDirectory);
+            return doMigrate(session, schemaName, tableName, recursiveDirectory);
         }
     }
 
-    public void doMigrate(ConnectorSession session, String schemaName, String tableName, String recursiveDirectory)
+    public Map<String, Long> doMigrate(ConnectorSession session, String schemaName, String tableName, String recursiveDirectory)
     {
         SchemaTableName sourceTableName = new SchemaTableName(schemaName, tableName);
         TrinoCatalog catalog = catalogFactory.create(session.getIdentity());
@@ -251,6 +251,10 @@ public class MigrateProcedure
 
             transaction.commitTransaction();
             log.debug("Successfully migrated %s table to Iceberg format", sourceTableName);
+
+            return ImmutableMap.<String, Long>builder()
+                    .put("added_data_files_count", (long) dataFiles.size())
+                    .buildOrThrow();
         }
         catch (Exception e) {
             throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to migrate table", e);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergMigrateProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergMigrateProcedure.java
@@ -94,7 +94,8 @@ public class TestIcebergMigrateProcedure
         assertUpdate("INSERT INTO " + hiveTableName + " VALUES NULL", 1);
         assertQueryFails("SELECT * FROM " + icebergTableName, "Not an Iceberg table: .*");
 
-        assertUpdate("CALL iceberg.system.migrate('tpch', '" + tableName + "')");
+        assertThat(query("CALL iceberg.system.migrate('tpch', '" + tableName + "')"))
+                .matches("VALUES (VARCHAR 'added_data_files_count', BIGINT '2')");
 
         assertThat((String) computeScalar("SHOW CREATE TABLE " + icebergTableName))
                 .contains("format = '%s'".formatted(fileFormat));

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestProcedureCreation.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestProcedureCreation.java
@@ -56,7 +56,7 @@ public class TestProcedureCreation
     }
 
     @Test
-    public void shouldThrowExceptionWhenProcedureIsNonVoid()
+    public void shouldThrowExceptionWhenReturnTypeIsInvalid()
     {
         assertThatThrownBy(() -> new Procedure(
                 "schema",
@@ -64,7 +64,7 @@ public class TestProcedureCreation
                 ImmutableList.of(),
                 methodHandle(Procedures.class, "funWithoutArguments")))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Method must return void");
+                .hasMessage("Method must return void or Map<String, Long>");
     }
 
     @Test


### PR DESCRIPTION
## Description

The first commit adds support for returning metrics in the engine. 
The second commit updates Iceberg `migrate` procedure to return its metrics. 

- Similar to https://github.com/trinodb/trino/pull/26661

## Release notes

```markdown
## General
* Add support for returning metrics in {doc}`/sql/call`. ({issue}`30749`)

## Iceberg
* Add support for returning metrics in the `migrate` procedure. ({issue}`30749`)

## SPI
* Deprecate `void` return type for the `Procedure` class. Return `Map<String, Long>` instead. ({issue}`30749`)
```
