### PR TITLE
Add optional LOCATION parameter to create_empty_partition

### DIFF
--- a/docs/src/main/sphinx/connector/hive.md
+++ b/docs/src/main/sphinx/connector/hive.md
@@ -714,6 +714,17 @@ CALL system.create_empty_partition(
     partition_values => ARRAY['2016-08-09', 'US']);
 ```
 
+Add an empty partition at an explicit location:
+
+```
+CALL system.create_empty_partition(
+    schema_name => 'web',
+    table_name => 'page_views',
+    partition_columns => ARRAY['ds', 'country'],
+    partition_values => ARRAY['2016-08-09', 'US'],
+    location => 's3://web-bucket/page_views/custom/ds=2016-08-09/country=US');
+```
+
 Drop stats for a partition of the `page_views` table:
 
 ```
@@ -749,9 +760,13 @@ CALL web.system.example_procedure()
 
 The following procedures are available:
 
-- `system.create_empty_partition(schema_name, table_name, partition_columns, partition_values)`
+- `system.create_empty_partition(schema_name, table_name, partition_columns, partition_values, location)`
 
-  Create an empty partition in the specified table.
+  Create an empty partition in the specified table. The `location` argument is
+  optional; when provided, the partition is created at the given location
+  instead of the default location computed by the connector. Note that some
+  metastores restrict which partition locations are allowed, for example for
+  managed tables.
 
 - `system.sync_partition_metadata(schema_name, table_name, mode, case_sensitive)`
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/CreateEmptyPartitionProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/CreateEmptyPartitionProcedure.java
@@ -19,10 +19,12 @@ import com.google.inject.Provider;
 import io.airlift.json.JsonCodec;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.trino.filesystem.Location;
 import io.trino.metastore.HiveMetastore;
 import io.trino.plugin.base.util.UncheckedCloseable;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HiveInsertTableHandle;
+import io.trino.plugin.hive.LocationHandle.WriteMode;
 import io.trino.plugin.hive.LocationService;
 import io.trino.plugin.hive.LocationService.WriteInfo;
 import io.trino.plugin.hive.PartitionUpdate;
@@ -62,7 +64,7 @@ public class CreateEmptyPartitionProcedure
 
     static {
         try {
-            CREATE_EMPTY_PARTITION = lookup().unreflect(CreateEmptyPartitionProcedure.class.getMethod("createEmptyPartition", ConnectorSession.class, ConnectorAccessControl.class, String.class, String.class, List.class, List.class));
+            CREATE_EMPTY_PARTITION = lookup().unreflect(CreateEmptyPartitionProcedure.class.getMethod("createEmptyPartition", ConnectorSession.class, ConnectorAccessControl.class, String.class, String.class, List.class, List.class, String.class));
         }
         catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
@@ -91,18 +93,19 @@ public class CreateEmptyPartitionProcedure
                         new Argument("SCHEMA_NAME", VARCHAR),
                         new Argument("TABLE_NAME", VARCHAR),
                         new Argument("PARTITION_COLUMNS", new ArrayType(VARCHAR)),
-                        new Argument("PARTITION_VALUES", new ArrayType(VARCHAR))),
+                        new Argument("PARTITION_VALUES", new ArrayType(VARCHAR)),
+                        new Argument("LOCATION", VARCHAR, false, null)),
                 CREATE_EMPTY_PARTITION.bindTo(this));
     }
 
-    public void createEmptyPartition(ConnectorSession session, ConnectorAccessControl accessControl, String schema, String table, List<String> partitionColumnNames, List<String> partitionValues)
+    public void createEmptyPartition(ConnectorSession session, ConnectorAccessControl accessControl, String schema, String table, List<String> partitionColumnNames, List<String> partitionValues, String location)
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(getClass().getClassLoader())) {
-            doCreateEmptyPartition(session, accessControl, schema, table, partitionColumnNames, partitionValues);
+            doCreateEmptyPartition(session, accessControl, schema, table, partitionColumnNames, partitionValues, location);
         }
     }
 
-    private void doCreateEmptyPartition(ConnectorSession session, ConnectorAccessControl accessControl, String schemaName, String tableName, List<String> partitionColumnNames, List<String> partitionValues)
+    private void doCreateEmptyPartition(ConnectorSession session, ConnectorAccessControl accessControl, String schemaName, String tableName, List<String> partitionColumnNames, List<String> partitionValues, String location)
     {
         checkProcedureArgument(schemaName != null, "schema_name cannot be null");
         checkProcedureArgument(tableName != null, "table_name cannot be null");
@@ -136,7 +139,9 @@ public class CreateEmptyPartitionProcedure
             HiveInsertTableHandle hiveInsertTableHandle = (HiveInsertTableHandle) hiveMetadata.beginInsert(session, tableHandle, ImmutableList.of(), NO_RETRIES);
             String partitionName = makePartName(actualPartitionColumnNames, partitionValues);
 
-            WriteInfo writeInfo = locationService.getPartitionWriteInfo(hiveInsertTableHandle.getLocationHandle(), Optional.empty(), partitionName);
+            WriteInfo writeInfo = location == null
+                    ? locationService.getPartitionWriteInfo(hiveInsertTableHandle.getLocationHandle(), Optional.empty(), partitionName)
+                    : new WriteInfo(parseLocation(location), parseLocation(location), WriteMode.DIRECT_TO_TARGET_NEW_DIRECTORY);
             Slice serializedPartitionUpdate = Slices.wrappedBuffer(
                     partitionUpdateJsonCodec.toJsonBytes(
                             new PartitionUpdate(
@@ -156,6 +161,16 @@ public class CreateEmptyPartitionProcedure
                     ImmutableList.of(serializedPartitionUpdate),
                     ImmutableList.of());
             hiveMetadata.commit();
+        }
+    }
+
+    private static Location parseLocation(String location)
+    {
+        try {
+            return Location.of(location);
+        }
+        catch (IllegalArgumentException e) {
+            throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, "Invalid partition location: " + location, e);
         }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/CreateEmptyPartitionProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/CreateEmptyPartitionProcedure.java
@@ -40,6 +40,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.procedure.Procedure;
 import io.trino.spi.procedure.Procedure.Argument;
 import io.trino.spi.type.ArrayType;
+import jakarta.annotation.Nullable;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
@@ -98,14 +99,14 @@ public class CreateEmptyPartitionProcedure
                 CREATE_EMPTY_PARTITION.bindTo(this));
     }
 
-    public void createEmptyPartition(ConnectorSession session, ConnectorAccessControl accessControl, String schema, String table, List<String> partitionColumnNames, List<String> partitionValues, String location)
+    public void createEmptyPartition(ConnectorSession session, ConnectorAccessControl accessControl, String schema, String table, List<String> partitionColumnNames, List<String> partitionValues, @Nullable String location)
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(getClass().getClassLoader())) {
             doCreateEmptyPartition(session, accessControl, schema, table, partitionColumnNames, partitionValues, location);
         }
     }
 
-    private void doCreateEmptyPartition(ConnectorSession session, ConnectorAccessControl accessControl, String schemaName, String tableName, List<String> partitionColumnNames, List<String> partitionValues, String location)
+    private void doCreateEmptyPartition(ConnectorSession session, ConnectorAccessControl accessControl, String schemaName, String tableName, List<String> partitionColumnNames, List<String> partitionValues, @Nullable String location)
     {
         checkProcedureArgument(schemaName != null, "schema_name cannot be null");
         checkProcedureArgument(tableName != null, "table_name cannot be null");

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -2991,39 +2991,32 @@ public abstract class BaseHiveConnectorTest
     }
 
     @Test
-    public void testCreateEmptyPartitionWithCustomLocation()
+    public void testCreateEmptyPartitionWithExplicitLocation()
     {
-        String tableName = "test_create_empty_partition_with_custom_location" + randomNameSuffix();
-        assertUpdate("" +
-                "CREATE TABLE " + tableName + " (" +
-                "  dummy_col bigint," +
-                "  part varchar)" +
-                "WITH (" +
-                "  format = 'ORC', " +
-                "  partitioned_by = ARRAY[ 'part' ] " +
-                ")");
+        try (TestTable table = new TestTable(
+                new TrinoSqlExecutor(getQueryRunner()),
+                "test_create_empty_partition_with_location_",
+                "(dummy_col bigint, part varchar) WITH (partitioned_by = ARRAY['part'])")) {
+            // seed a partition with real data so the table's root location can be derived from a file path
+            assertUpdate("INSERT INTO %s (dummy_col, part) VALUES (1, 'seed')".formatted(table.getName()), 1);
+            String seededPath = (String) computeScalar("SELECT \"$path\" FROM %s WHERE part = 'seed'".formatted(table.getName()));
+            // strip the file name and the "part=seed" directory to get the table's root location
+            String tableLocation = Location.of(seededPath).parentDirectory().parentDirectory().toString();
+            String explicitLocation = tableLocation + "/part=empty";
 
-        // seed a partition with real data so the table's root location can be derived from a file path
-        assertUpdate("INSERT INTO " + tableName + " (dummy_col, part) VALUES (1, 'seed')", 1);
-        String seededPath = (String) computeScalar(format("SELECT \"$path\" FROM %s WHERE part = 'seed'", tableName));
-        // strip the file name and the "part=seed" partition directory to get the table's root location
-        String tableLocation = Location.of(seededPath).parentDirectory().parentDirectory().toString();
-        String customLocation = tableLocation + "/custom_location_for_empty";
+            // create an empty partition, passing its location explicitly instead of relying on the default location computation
+            assertUpdate("CALL system.create_empty_partition('%s', '%s', ARRAY['part'], ARRAY['empty'], '%s')".formatted(TPCH_SCHEMA, table.getName(), explicitLocation));
+            assertQuery("SELECT count(*) FROM \"%s$partitions\"".formatted(table.getName()), "SELECT 2");
 
-        // create an empty partition at an explicit, non-default location
-        assertUpdate(format("CALL system.create_empty_partition('%s', '%s', ARRAY['part'], ARRAY['%s'], '%s')", TPCH_SCHEMA, tableName, "empty", customLocation));
-        assertQuery(format("SELECT count(*) FROM \"%s$partitions\"", tableName), "SELECT 2");
+            // data inserted into that partition afterwards lands under the explicitly provided location
+            assertUpdate("INSERT INTO %s (dummy_col, part) VALUES (2, 'empty')".formatted(table.getName()), 1);
+            assertThat((String) computeScalar("SELECT \"$path\" FROM %s WHERE part = 'empty'".formatted(table.getName())))
+                    .startsWith(explicitLocation);
 
-        // data inserted into that partition afterwards should land under the custom location
-        assertUpdate(format("INSERT INTO %s (dummy_col, part) VALUES (2, 'empty')", tableName), 1);
-        assertThat((String) computeScalar(format("SELECT \"$path\" FROM %s WHERE part = 'empty'", tableName)))
-                .startsWith(customLocation);
-
-        assertQueryFails(
-                format("CALL system.create_empty_partition('%s', '%s', ARRAY['part'], ARRAY['%s'], '%s')", TPCH_SCHEMA, tableName, "empty", customLocation),
-                "Partition already exists.*");
-
-        assertUpdate("DROP TABLE " + tableName);
+            assertQueryFails(
+                    "CALL system.create_empty_partition('%s', '%s', ARRAY['part'], ARRAY['empty'], '%s')".formatted(TPCH_SCHEMA, table.getName(), explicitLocation),
+                    "Partition already exists.*");
+        }
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -2991,6 +2991,42 @@ public abstract class BaseHiveConnectorTest
     }
 
     @Test
+    public void testCreateEmptyPartitionWithCustomLocation()
+    {
+        String tableName = "test_create_empty_partition_with_custom_location" + randomNameSuffix();
+        assertUpdate("" +
+                "CREATE TABLE " + tableName + " (" +
+                "  dummy_col bigint," +
+                "  part varchar)" +
+                "WITH (" +
+                "  format = 'ORC', " +
+                "  partitioned_by = ARRAY[ 'part' ] " +
+                ")");
+
+        // seed a partition with real data so the table's root location can be derived from a file path
+        assertUpdate("INSERT INTO " + tableName + " (dummy_col, part) VALUES (1, 'seed')", 1);
+        String seededPath = (String) computeScalar(format("SELECT \"$path\" FROM %s WHERE part = 'seed'", tableName));
+        // strip the file name and the "part=seed" partition directory to get the table's root location
+        String tableLocation = Location.of(seededPath).parentDirectory().parentDirectory().toString();
+        String customLocation = tableLocation + "/custom_location_for_empty";
+
+        // create an empty partition at an explicit, non-default location
+        assertUpdate(format("CALL system.create_empty_partition('%s', '%s', ARRAY['part'], ARRAY['%s'], '%s')", TPCH_SCHEMA, tableName, "empty", customLocation));
+        assertQuery(format("SELECT count(*) FROM \"%s$partitions\"", tableName), "SELECT 2");
+
+        // data inserted into that partition afterwards should land under the custom location
+        assertUpdate(format("INSERT INTO %s (dummy_col, part) VALUES (2, 'empty')", tableName), 1);
+        assertThat((String) computeScalar(format("SELECT \"$path\" FROM %s WHERE part = 'empty'", tableName)))
+                .startsWith(customLocation);
+
+        assertQueryFails(
+                format("CALL system.create_empty_partition('%s', '%s', ARRAY['part'], ARRAY['%s'], '%s')", TPCH_SCHEMA, tableName, "empty", customLocation),
+                "Partition already exists.*");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
     public void testUnregisterRegisterPartition()
     {
         String tableName = "test_register_partition_for_table" + randomNameSuffix();


### PR DESCRIPTION
## Description

Adds an optional `LOCATION` argument to the `system.create_empty_partition` procedure, addressing #5137. When supplied, the given location is used directly as both the write path and target path for the new partition (`DIRECT_TO_TARGET_NEW_DIRECTORY` mode) instead of going through the connector's default location computation. This follows the same optional-argument pattern already used by `register_partition`.

No changes were needed to `LocationService` or the metastore commit path: `SemiTransactionalHiveMetastore.prepareAddPartition` already creates the target directory on commit if it does not exist.

Note: `FileHiveMetastore` restricts managed-table partition locations to the computed default, so with the file metastore a divergent location is only usable for external tables; Thrift and Glue do not enforce this restriction.

## Additional context and related issues

Fixes #5137. `testCreateEmptyPartitionWithExplicitLocation` in `BaseHiveConnectorTest` exercises the explicit-location code path end to end; the location is kept equal to the conventional partition directory so the test stays metastore-portable (see review discussion). Documentation updated in `docs/src/main/sphinx/connector/hive.md`.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive
* Add optional `location` argument to the `system.create_empty_partition` procedure. ({issue}`5137`)
```