### PR TITLE
Finalize task info on worker restart

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/RemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RemoteTask.java
@@ -76,6 +76,13 @@ public interface RemoteTask
      */
     void failRemotely(Throwable cause);
 
+    /**
+     * Forces the task info to a done state using the current task status,
+     * so that finalTaskInfo listeners fire even if the remote worker never delivered
+     * the final TaskInfo.
+     */
+    void forceFinalizationUsingTaskStatus();
+
     PartitionedSplitsInfo getQueuedPartitionedSplitsInfo();
 
     int getUnacknowledgedPartitionedSplitCount();

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -1729,8 +1729,9 @@ public class EventDrivenFaultTolerantQueryScheduler
                         }, NO_FINAL_TASK_INFO_CHECK_INTERVAL.toMillis(), MILLISECONDS);
                         case CANCELED, ABORTED, FAILED -> scheduledExecutorService.schedule(() -> {
                             if (!finalTaskInfoReceived.get()) {
+                                log.error("Did not receive final task info for task %s after it %s; internal inconsistency; finalizing task info locally and marking task failed in scheduler", task.getTaskId(), taskStatus.state());
+                                task.forceFinalizationUsingTaskStatus();
                                 if (taskCompletedEventSent.compareAndSet(false, true)) {
-                                    log.error("Did not receive final task info for task %s after it %s; internal inconsistency; marking task failed in scheduler to unblock query progression", task.getTaskId(), taskStatus.state());
                                     eventQueue.add(new RemoteTaskCompletedEvent(taskStatus));
                                 }
                             }

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -929,7 +929,13 @@ public final class HttpRemoteTask
                 if (currentTimeNanos == 0) {
                     currentTimeNanos = 1;
                 }
-                this.terminationStartedNanos.compareAndSet(0, currentTimeNanos);
+                if (this.terminationStartedNanos.compareAndSet(0, currentTimeNanos)) {
+                    errorScheduledExecutor.schedule(() -> {
+                        if (!getTaskStatus().state().isDone()) {
+                            fatalUnacknowledgedFailure(new TrinoException(REMOTE_TASK_ERROR, format("Task %s failed to terminate after %s, last known state: %s", taskId, taskTerminationTimeout, getTaskStatus().state())));
+                        }
+                    }, taskTerminationTimeout.roundTo(NANOSECONDS), NANOSECONDS);
+                }
             }
             else {
                 Duration terminatingTime = nanosSince(terminationStartedNanos);
@@ -1153,6 +1159,13 @@ public final class HttpRemoteTask
                 }
             }
         }
+    }
+
+    @Override
+    public void forceFinalizationUsingTaskStatus()
+    {
+        checkState(getTaskStatus().state().isDone(), "task status is not terminal");
+        taskInfoFetcher.updateTaskInfo(getTaskInfo().withTaskStatus(getTaskStatus()));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
@@ -65,6 +65,7 @@ public class TaskInfoFetcher
     private static final SpoolingOutputStats.Snapshot ALREADY_RETRIEVED_MARKER = new SpoolingOutputStats.Snapshot(Slices.EMPTY_SLICE, 0);
 
     private final TaskId taskId;
+    private final AtomicLong expectedTaskInstanceId = new AtomicLong();
     private final Consumer<Throwable> onFail;
     private final ContinuousTaskStatusFetcher taskStatusFetcher;
     private final StateMachine<TaskInfo> taskInfo;
@@ -118,6 +119,7 @@ public class TaskInfoFetcher
         requireNonNull(errorScheduledExecutor, "errorScheduledExecutor is null");
 
         this.taskId = initialTask.taskStatus().taskId();
+        this.expectedTaskInstanceId.set(initialTask.taskStatus().taskInstanceId());
         this.onFail = requireNonNull(onFail, "onFail is null");
         this.taskStatusFetcher = requireNonNull(taskStatusFetcher, "taskStatusFetcher is null");
         this.taskInfo = new StateMachine<>("task " + taskId, executor, initialTask);
@@ -256,7 +258,33 @@ public class TaskInfoFetcher
 
     synchronized void updateTaskInfo(TaskInfo newTaskInfo)
     {
+        updateTaskInfo(newTaskInfo, isTaskInstanceMismatch(newTaskInfo));
+    }
+
+    private synchronized void updateTaskInfo(TaskInfo newTaskInfo, boolean taskInstanceMismatch)
+    {
         TaskStatus localTaskStatus = taskStatusFetcher.getTaskStatus();
+
+        if (taskInstanceMismatch) {
+            // Defer until TaskStatusFetcher (running in loop) detects the mismatch and marks the task done (FAILED) locally.
+            // Finalizing now would use task info from the restarted worker's task instance.
+            if (!localTaskStatus.state().isDone()) {
+                log.debug(
+                        "Task %s received TaskInfo with mismatched instance id (expected %s, observed %s) but local status is %s; deferring finalization",
+                        taskId,
+                        expectedTaskInstanceId.get(),
+                        newTaskInfo.taskStatus().taskInstanceId(),
+                        localTaskStatus.state());
+                return;
+            }
+            log.warn(
+                    "Task %s received a TaskInfo from a different task instance (expected %s, observed %s); worker at %s likely restarted. Finalizing task info locally.",
+                    taskId,
+                    expectedTaskInstanceId.get(),
+                    newTaskInfo.taskStatus().taskInstanceId(),
+                    newTaskInfo.taskStatus().self());
+            newTaskInfo = getTaskInfo().withTaskStatus(localTaskStatus);
+        }
         TaskStatus newRemoteTaskStatus = newTaskInfo.taskStatus();
 
         if (!newRemoteTaskStatus.taskId().equals(taskId)) {
@@ -321,8 +349,11 @@ public class TaskInfoFetcher
                 lastUpdateNanos.set(System.nanoTime());
 
                 updateStats(requestStartNanos);
-                errorTracker.requestSucceeded();
-                updateTaskInfo(newValue);
+                boolean taskInstanceMismatch = isTaskInstanceMismatch(newValue);
+                if (!taskInstanceMismatch) {
+                    errorTracker.requestSucceeded();
+                }
+                updateTaskInfo(newValue, taskInstanceMismatch);
             }
             finally {
                 cleanupRequest();
@@ -362,6 +393,29 @@ public class TaskInfoFetcher
                 cleanupRequest();
             }
         }
+    }
+
+    /**
+     * Checks whether the given {@code TaskInfo} was produced by a different task instance
+     * than the one this fetcher was created for. This happens when a worker container
+     * restarts at the same address: the replacement JVM creates a new task on demand
+     * ({@code SqlTaskManager#getTask}) with a different {@code taskInstanceId}.
+     *
+     * <p>The first non-zero instance id observed is latched as the expected value; any
+     * later response carrying a different non-zero instance id is a mismatch.
+     */
+    boolean isTaskInstanceMismatch(TaskInfo newTaskInfo)
+    {
+        long remoteInstanceId = newTaskInfo.taskStatus().taskInstanceId();
+        if (remoteInstanceId == 0) {
+            return false;
+        }
+        long expected = expectedTaskInstanceId.get();
+        if (expected == 0) {
+            expectedTaskInstanceId.compareAndSet(0, remoteInstanceId);
+            return false;
+        }
+        return expected != remoteInstanceId;
     }
 
     private synchronized void cleanupRequest()

--- a/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
@@ -479,6 +479,9 @@ public class MockRemoteTaskFactory
         }
 
         @Override
+        public void forceFinalizationUsingTaskStatus() {}
+
+        @Override
         public synchronized PartitionedSplitsInfo getPartitionedSplitsInfo()
         {
             if (taskStateMachine.getState().isDone()) {

--- a/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestingRemoteTaskFactory.java
@@ -309,6 +309,9 @@ public class TestingRemoteTaskFactory
         }
 
         @Override
+        public void forceFinalizationUsingTaskStatus() {}
+
+        @Override
         public PartitionedSplitsInfo getQueuedPartitionedSplitsInfo()
         {
             return PartitionedSplitsInfo.forZeroSplits();

--- a/core/trino-main/src/test/java/io/trino/server/remotetask/TestTaskInfoFetcherInstanceMismatch.java
+++ b/core/trino-main/src/test/java/io/trino/server/remotetask/TestTaskInfoFetcherInstanceMismatch.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.remotetask;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.http.client.testing.TestingHttpClient;
+import io.airlift.json.JsonCodec;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.trino.execution.DynamicFilterConfig;
+import io.trino.execution.DynamicFiltersCollector.VersionedDynamicFilterDomains;
+import io.trino.execution.StageId;
+import io.trino.execution.TaskId;
+import io.trino.execution.TaskInfo;
+import io.trino.execution.TaskState;
+import io.trino.execution.TaskStatus;
+import io.trino.execution.buffer.BufferState;
+import io.trino.execution.buffer.OutputBufferInfo;
+import io.trino.execution.buffer.OutputBufferStatus;
+import io.trino.operator.RetryPolicy;
+import io.trino.operator.TaskStats;
+import io.trino.server.DynamicFilterService;
+import io.trino.spi.type.TypeOperators;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static io.airlift.tracing.Tracing.noopTracer;
+import static io.trino.execution.TaskState.FAILED;
+import static io.trino.execution.TaskState.RUNNING;
+import static io.trino.execution.TaskStatus.STARTING_VERSION;
+import static io.trino.metadata.TestingMetadataManager.createTestingMetadataManager;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestTaskInfoFetcherInstanceMismatch
+{
+    private static final TaskId TASK_ID = new TaskId(new StageId("test", 1), 0, 0);
+    private static final URI TASK_URI = URI.create("http://fake.invalid/task/node/test.1.0.0");
+
+    @Test
+    @Timeout(10)
+    public void testInstanceMismatchFinalizesTaskInfo()
+            throws Exception
+    {
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(2);
+        try {
+            long originalInstanceId = 42L;
+            TaskInfo initialTaskInfo = createTaskInfo(originalInstanceId, STARTING_VERSION, RUNNING);
+
+            ContinuousTaskStatusFetcher statusFetcher = createStatusFetcher(
+                    initialTaskInfo.taskStatus(), executor);
+            TaskInfoFetcher fetcher = createFetcher(initialTaskInfo, statusFetcher, executor);
+
+            // Simulate coordinator force-failing the status (as failLocallyImmediately does)
+            TaskStatus failedStatus = TaskStatus.failWith(
+                    statusFetcher.getTaskStatus(), FAILED, ImmutableList.of());
+            statusFetcher.updateTaskStatus(failedStatus);
+
+            CompletableFuture<TaskInfo> finalTaskInfoFuture = new CompletableFuture<>();
+            fetcher.addFinalTaskInfoListener(finalTaskInfoFuture::complete);
+
+            // Feed a response with a different instance id and low version
+            fetcher.updateTaskInfo(createTaskInfo(999L, 1, RUNNING));
+
+            // finalTaskInfo must be set promptly using the authoritative local FAILED status
+            TaskInfo finalTaskInfo = finalTaskInfoFuture.get(5, SECONDS);
+            assertThat(finalTaskInfo.taskStatus().state()).isEqualTo(FAILED);
+            assertThat(finalTaskInfo.taskStatus().taskInstanceId()).isEqualTo(originalInstanceId);
+        }
+        finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    public void testMismatchWithLowVersionStillFinalizes()
+            throws Exception
+    {
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(2);
+        try {
+            long originalInstanceId = 42L;
+            long highVersion = 50L;
+            TaskInfo initialTaskInfo = createTaskInfo(originalInstanceId, highVersion, RUNNING);
+
+            ContinuousTaskStatusFetcher statusFetcher = createStatusFetcher(
+                    initialTaskInfo.taskStatus(), executor);
+            TaskInfoFetcher fetcher = createFetcher(initialTaskInfo, statusFetcher, executor);
+
+            // Force status to FAILED
+            TaskStatus failedStatus = TaskStatus.failWith(
+                    statusFetcher.getTaskStatus(), FAILED, ImmutableList.of());
+            statusFetcher.updateTaskStatus(failedStatus);
+
+            CompletableFuture<TaskInfo> finalTaskInfoFuture = new CompletableFuture<>();
+            fetcher.addFinalTaskInfoListener(finalTaskInfoFuture::complete);
+
+            // Mismatched instance with version=1, much lower than held version=50
+            // Without the fix, updateTaskInfo silently rejects this (version too low)
+            // and finalTaskInfo stays empty.
+            fetcher.updateTaskInfo(createTaskInfo(999L, 1, RUNNING));
+
+            TaskInfo finalTaskInfo = finalTaskInfoFuture.get(5, SECONDS);
+            assertThat(finalTaskInfo.taskStatus().state()).isEqualTo(FAILED);
+        }
+        finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    public void testNormalResponseIsNotMismatch()
+            throws Exception
+    {
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(2);
+        try {
+            long originalInstanceId = 42L;
+            TaskInfo initialTaskInfo = createTaskInfo(originalInstanceId, STARTING_VERSION, RUNNING);
+
+            ContinuousTaskStatusFetcher statusFetcher = createStatusFetcher(
+                    initialTaskInfo.taskStatus(), executor);
+            TaskInfoFetcher fetcher = createFetcher(initialTaskInfo, statusFetcher, executor);
+
+            CompletableFuture<TaskInfo> finalTaskInfoFuture = new CompletableFuture<>();
+            fetcher.addFinalTaskInfoListener(finalTaskInfoFuture::complete);
+
+            // Normal done response from the same instance — must finalize
+            fetcher.updateTaskInfo(createTaskInfo(originalInstanceId, STARTING_VERSION + 1, TaskState.FINISHED));
+
+            TaskInfo finalTaskInfo = finalTaskInfoFuture.get(5, SECONDS);
+            assertThat(finalTaskInfo.taskStatus().state()).isEqualTo(TaskState.FINISHED);
+        }
+        finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static TaskInfo createTaskInfo(long taskInstanceId, long version, TaskState state)
+    {
+        TaskStatus status = new TaskStatus(
+                TASK_ID,
+                taskInstanceId,
+                version,
+                state,
+                TASK_URI,
+                "node-id",
+                false,
+                ImmutableList.of(),
+                0,
+                0,
+                OutputBufferStatus.initial(),
+                DataSize.ofBytes(0),
+                DataSize.ofBytes(0),
+                DataSize.ofBytes(0),
+                OptionalInt.empty(),
+                DataSize.ofBytes(0),
+                DataSize.ofBytes(0),
+                DataSize.ofBytes(0),
+                0,
+                new Duration(0, MILLISECONDS),
+                0,
+                0,
+                0);
+
+        return new TaskInfo(
+                status,
+                Instant.now(),
+                new OutputBufferInfo(
+                        "UNINITIALIZED",
+                        BufferState.OPEN,
+                        true,
+                        true,
+                        0,
+                        0,
+                        0,
+                        0,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
+                ImmutableSet.of(),
+                new TaskStats(Instant.now(), null),
+                Optional.empty(),
+                false);
+    }
+
+    private static ContinuousTaskStatusFetcher createStatusFetcher(
+            TaskStatus initialStatus,
+            ScheduledExecutorService executor)
+    {
+        DynamicFiltersFetcher dynamicFiltersFetcher = new DynamicFiltersFetcher(
+                _ -> {},
+                TASK_ID,
+                TASK_URI,
+                new Duration(10, SECONDS),
+                JsonCodec.jsonCodec(VersionedDynamicFilterDomains.class),
+                executor,
+                new TestingHttpClient(_ -> { throw new UnsupportedOperationException(); }),
+                () -> noopTracer().spanBuilder("test"),
+                new Duration(10, SECONDS),
+                executor,
+                new RemoteTaskStats(),
+                new DynamicFilterService(
+                        createTestingMetadataManager(),
+                        PLANNER_CONTEXT.getFunctionManager(),
+                        new TypeOperators(),
+                        new DynamicFilterConfig()));
+
+        return new ContinuousTaskStatusFetcher(
+                _ -> {},
+                initialStatus,
+                new Duration(10, SECONDS),
+                JsonCodec.jsonCodec(TaskStatus.class),
+                dynamicFiltersFetcher,
+                executor,
+                new TestingHttpClient(_ -> { throw new UnsupportedOperationException(); }),
+                () -> noopTracer().spanBuilder("test"),
+                new Duration(10, SECONDS),
+                executor,
+                new RemoteTaskStats());
+    }
+
+    private static TaskInfoFetcher createFetcher(
+            TaskInfo initialTask,
+            ContinuousTaskStatusFetcher statusFetcher,
+            ScheduledExecutorService executor)
+    {
+        return new TaskInfoFetcher(
+                _ -> {},
+                statusFetcher,
+                initialTask,
+                new TestingHttpClient(_ -> { throw new UnsupportedOperationException(); }),
+                () -> noopTracer().spanBuilder("test"),
+                new Duration(10, SECONDS),
+                JsonCodec.jsonCodec(TaskInfo.class),
+                new Duration(10, SECONDS),
+                false,
+                executor,
+                executor,
+                executor,
+                new RemoteTaskStats(),
+                Optional.empty(),
+                RetryPolicy.NONE);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
When a worker restarts at the same address while a task is running, the coordinator's `TaskInfoFetcher` can receive `TaskInfo` responses from the replacement JVM referring to a task the new JVM instantiated on demand. Those responses carry a different taskInstanceId and a fresh version. The current fetcher accepts them: it calls `errorTracker.requestSucceeded()` (so the fetcher never gives up) and the low version is silently rejected by the version predicate (so finalTaskInfo is never set). As a result `SqlStage.updateFinalTaskInfo` never fires, `QueryCompletedEvent` is not emitted, and the query info is retained forever.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Manually reproducing the exact race on a live cluster requires a worker to restart within a few seconds of a task entering a done-but-not-finalized state. The unit test exercises the race directly by constructing `TaskInfoFetcher `against `TestingHttpClient` and feeding a mismatched-instance response after forcing the local status to FAILED.

### Timeline from the logs:
  - T+0s – FTE INSERT query dispatched, tasks scheduled on multiple workers including worker at IP W.X.Y.Z                                                                                                       
  - T+14s – Worker at W.X.Y.Z restarts. Coordinator sees connection failures on all tasks at that IP:                                                                                                            
  WARN `RequestErrorTracker: Error getting task status: Failed communicating with server`                                                                                                       
  - T+14s–T+45s – New pod boots at same IP, returns SERVICE_UNAVAILABLE (503) on all task requests (~1500 occurrences across running queries)                                                                    
  - T+~45s – New pod fully up. ContinuousTaskStatusFetcher detects taskInstanceId mismatch for tasks still in RUNNING state → those tasks fail with `REMOTE_TASK_MISMATCH`, FTE retries them (attempt .1)          
  - T+~45s – Tasks already in cleanup (abort sent before restart) receive 404/503 from new pod. `doScheduleAsyncCleanupRequest` treats these as transient failures and retries with backoff. Tasks stay stuck in   
    ABORTING – new pod has no record of them, will never acknowledge.                                                                                                                                            
  - T+1m45s – ERROR EventDrivenFaultTolerantQueryScheduler: Did not receive final task info for task <id> after it FAILED - fires for the REMOTE_TASK_MISMATCH-failed tasks (1-min timer after FAILED): FTE retries those partitions. This not fires for **ABORTING** as it is not a done state, listener exits early.                                                                        
  - T+4m33s – All required partitions complete via retried tasks (.1 attempts). QueryStateMachine transitions to FINISHED. Query visible as FINISHED in UI.                                                      
  - T+4m33s → `finalQueryInfo` never set:                                                                                                                                                                      
  // QueryStateMachine.getQueryInfo()                                                                                                                                                                            
  boolean finalInfo = state.isDone() && allStages.stream().allMatch(StageInfo::isFinalStageInfo);                                                                                                                
    3 tasks permanently stuck in ABORTING → stage never isFinalStageInfo → finalQueryInfo StateMachine never fires → queryCompletedEvent never called → no completed_queries write, no TIMELINE log (in the coordinator logs there is no `queryid : FINISHED` entries).                                                                                                                                                                                                       
                                                                                                                                                            
### With the fix: 
Commit 1: The fix detects the instance ID mismatch in TaskInfoFetcher and defers finalization until ContinuousTaskStatusFetcher marks the task FAILED (which it already did independently in the loop). At that point, TaskInfoFetcher synthesizes a final TaskInfo from the last known good cached info and the local terminal status, unblocking stage finalization and allowing FTE to retry the task normally.
Commit 2: When worker dies and never comes back then ContinuousTaskStatusFetcher error tracker fires → onFail → local status = FAILED. However TaskInfoFetcher never gets HTTP response at all, so updateTaskInfo is not called. Commit adds explicit forceFinalTaskInfo() call to set finalTaskInfo and fire all listeners. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
