### PR TITLE
Support repeated --file option in CLI

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -227,7 +227,7 @@ public class ClientOptions
     public List<String> path = ImmutableList.of();
 
     @Option(names = {"-f", "--file"}, paramLabel = "<file>", description = "Execute statements from file and exit")
-    public String file;
+    public List<String> file = new ArrayList<>();
 
     @Option(names = DEBUG_OPTION_NAME, paramLabel = "<debug>", description = "Enable debug information")
     public boolean debug;

--- a/client/trino-cli/src/main/java/io/trino/cli/Console.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Console.java
@@ -122,7 +122,7 @@ public class Console
         TrinoUri uri = clientOptions.getTrinoUri(restrictedOptions);
         ClientSession session = clientOptions.toClientSession(uri);
         boolean hasQuery = clientOptions.execute != null;
-        boolean isFromFile = !isNullOrEmpty(clientOptions.file);
+        boolean isFromFile = !clientOptions.file.isEmpty();
 
         String query = clientOptions.execute;
         if (hasQuery) {
@@ -134,11 +134,16 @@ public class Console
                 throw new RuntimeException("both --execute and --file specified");
             }
             try {
-                query = asCharSource(new File(clientOptions.file), UTF_8).read();
+                StringBuilder queryBuilder = new StringBuilder();
+                for (String fileName : clientOptions.file) {
+                    queryBuilder.append(asCharSource(new File(fileName), UTF_8).read());
+                    queryBuilder.append("\n");
+                }
+                query = queryBuilder.toString();
                 hasQuery = true;
             }
             catch (IOException e) {
-                throw new RuntimeException(format("Error reading from file %s: %s", clientOptions.file, e.getMessage()));
+                throw new RuntimeException(format("Error reading from file: %s", e.getMessage()));
             }
         }
 


### PR DESCRIPTION
## Purpose

Allow passing `--file` multiple times to execute SQL from multiple files sequentially.

## Changes

- Changed `ClientOptions.file` from `String` to `List<String>` to accept repeated options
- Updated `Console.java` to iterate over all files and concatenate their contents

## Usage

```bash
trino --catalog iceberg --schema default --file ddls.sql --file inserts.sql
```

Closes #27532