### PR TITLE
Add S3 keystore secrets via RuntimeSecretResolver

### DIFF
--- a/.github/bin/build-pt-matrix.py
+++ b/.github/bin/build-pt-matrix.py
@@ -74,6 +74,7 @@ BUCKETS = [
     ("cloud-object-store", [
         "SuiteGcs",
         "SuiteAzure",
+        "SuiteS3KeystoreSecrets",
     ]),
     ("databricks-133", [
         "SuiteDeltaLakeDatabricks133",

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorContextInstance.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorContextInstance.java
@@ -25,7 +25,10 @@ import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorExpressionEvaluator;
 import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.function.FunctionBundleFactory;
+import io.trino.spi.secrets.RuntimeSecretResolver;
 import io.trino.spi.type.TypeManager;
+
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -44,6 +47,7 @@ public class ConnectorContextInstance
     private final BlocksHashFactory blocksHashFactory;
     private final ConnectorExpressionEvaluator evaluator;
     private final ConnectorCacheFactory cacheFactory;
+    private final Optional<RuntimeSecretResolver> runtimeSecretResolver;
 
     public ConnectorContextInstance(
             OpenTelemetry openTelemetry,
@@ -57,7 +61,8 @@ public class ConnectorContextInstance
             FunctionBundleFactory functionBundleFactory,
             BlocksHashFactory blocksHashFactory,
             ConnectorExpressionEvaluator evaluator,
-            ConnectorCacheFactory cacheFactory)
+            ConnectorCacheFactory cacheFactory,
+            Optional<RuntimeSecretResolver> runtimeSecretResolver)
     {
         this.openTelemetry = requireNonNull(openTelemetry, "openTelemetry is null");
         this.tracer = requireNonNull(tracer, "tracer is null");
@@ -71,6 +76,7 @@ public class ConnectorContextInstance
         this.blocksHashFactory = requireNonNull(blocksHashFactory, "blocksHashFactory is null");
         this.evaluator = requireNonNull(evaluator, "evaluator is null");
         this.cacheFactory = requireNonNull(cacheFactory, "cacheFactory is null");
+        this.runtimeSecretResolver = requireNonNull(runtimeSecretResolver, "runtimeSecretResolver is null");
     }
 
     @Override
@@ -143,5 +149,11 @@ public class ConnectorContextInstance
     public ConnectorCacheFactory getCacheFactory()
     {
         return cacheFactory;
+    }
+
+    @Override
+    public Optional<RuntimeSecretResolver> getRuntimeSecretResolver()
+    {
+        return runtimeSecretResolver;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
@@ -211,7 +211,8 @@ public class DefaultCatalogFactory
                 new InternalFunctionBundleFactory(),
                 blocksHashFactory,
                 evaluator,
-                cacheManagerRegistry.createConnectorCacheFactory(catalogName));
+                cacheManagerRegistry.createConnectorCacheFactory(catalogName),
+                Optional.of(secretsResolver::resolveSecret));
 
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(connectorFactory.getClass().getClassLoader())) {
             // TODO: connector factory should take CatalogName

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
@@ -24,6 +24,7 @@ import io.trino.spi.Unstable;
 import io.trino.spi.VersionEmbedder;
 import io.trino.spi.cache.ConnectorCacheFactory;
 import io.trino.spi.function.FunctionBundleFactory;
+import io.trino.spi.secrets.RuntimeSecretResolver;
 import io.trino.spi.type.TypeManager;
 
 import java.util.Optional;
@@ -108,5 +109,11 @@ public interface ConnectorContext
     default ConnectorCacheFactory getCacheFactory()
     {
         return _ -> Optional.empty();
+    }
+
+    @Unstable
+    default Optional<RuntimeSecretResolver> getRuntimeSecretResolver()
+    {
+        return Optional.empty();
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/secrets/RuntimeSecretResolver.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/secrets/RuntimeSecretResolver.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.secrets;
+
+import io.trino.spi.Unstable;
+
+@Unstable
+public interface RuntimeSecretResolver
+{
+    String resolveSecret(String secretProviderName, String keyName);
+}

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
@@ -44,6 +44,7 @@ import io.trino.filesystem.tracking.TrackingFileSystemFactory;
 import io.trino.spi.cache.BlobCache;
 import io.trino.spi.cache.CacheRequirements;
 import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.secrets.RuntimeSecretResolver;
 
 import java.util.Map;
 import java.util.Optional;
@@ -106,6 +107,8 @@ public class FileSystemModule
         }
 
         if (config.isS3Enabled()) {
+            context.getRuntimeSecretResolver().ifPresent(resolver ->
+                    binder.bind(RuntimeSecretResolver.class).toInstance(resolver));
             install(new S3FileSystemModule());
             factories.addBinding("s3").to(Key.get(TrinoFileSystemFactory.class, FileSystemS3.class));
             factories.addBinding("s3a").to(Key.get(TrinoFileSystemFactory.class, FileSystemS3.class));

--- a/lib/trino-filesystem-s3/pom.xml
+++ b/lib/trino-filesystem-s3/pom.xml
@@ -221,6 +221,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>configuration-testing</artifactId>
             <scope>test</scope>
         </dependency>
@@ -234,6 +240,20 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>secrets-keystore-plugin</artifactId>
+            <version>445-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>secrets-spi</artifactId>
+            <version>445-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
@@ -259,6 +279,12 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.hadoop</groupId>
+            <artifactId>hadoop-apache</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3BucketCredentialFileSystemLoader.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3BucketCredentialFileSystemLoader.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import com.google.inject.Inject;
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.spi.security.ConnectorIdentity;
+import jakarta.annotation.PreDestroy;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+final class S3BucketCredentialFileSystemLoader
+        implements Function<Location, TrinoFileSystemFactory>
+{
+    private final S3FileSystemLoader delegate;
+    private final Map<String, BucketFileSystemFactory> factoriesByBucket = new ConcurrentHashMap<>();
+
+    @Inject
+    S3BucketCredentialFileSystemLoader(OpenTelemetry openTelemetry, S3FileSystemConfig config, S3FileSystemStats stats, S3SecretsCredentialResolver secretsCredentialResolver)
+    {
+        this.delegate = new S3FileSystemLoader(openTelemetry, config, stats, secretsCredentialResolver);
+    }
+
+    @Override
+    public TrinoFileSystemFactory apply(Location location)
+    {
+        String bucket = new S3Location(location).bucket();
+        return factoriesByBucket.computeIfAbsent(bucket, delegate::createFactoryForBucket);
+    }
+
+    @PreDestroy
+    public void destroy()
+    {
+        factoriesByBucket.values().forEach(BucketFileSystemFactory::destroy);
+        delegate.destroy();
+    }
+
+    static final class BucketFileSystemFactory
+            implements TrinoFileSystemFactory
+    {
+        private final S3Client client;
+        private final S3Presigner preSigner;
+        private final S3Context context;
+        private final Executor uploadExecutor;
+
+        BucketFileSystemFactory(S3Client client, S3Presigner preSigner, S3Context context, Executor uploadExecutor)
+        {
+            this.client = requireNonNull(client, "client is null");
+            this.preSigner = requireNonNull(preSigner, "preSigner is null");
+            this.context = requireNonNull(context, "context is null");
+            this.uploadExecutor = requireNonNull(uploadExecutor, "uploadExecutor is null");
+        }
+
+        @Override
+        public TrinoFileSystem create(ConnectorIdentity identity)
+        {
+            return new S3FileSystem(uploadExecutor, client, preSigner, context.withCredentials(identity));
+        }
+
+        void destroy()
+        {
+            try (client) {
+                preSigner.close();
+            }
+        }
+    }
+}

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -144,6 +144,8 @@ public class S3FileSystemConfig
 
     private String awsAccessKey;
     private String awsSecretKey;
+    private String secretsBucketKeyPrefix;
+    private String secretsProvider = "keystore";
     private String endpoint;
     private String region;
     private boolean pathStyleAccess;
@@ -201,6 +203,37 @@ public class S3FileSystemConfig
     public S3FileSystemConfig setAwsSecretKey(String awsSecretKey)
     {
         this.awsSecretKey = awsSecretKey;
+        return this;
+    }
+
+    public String getSecretsBucketKeyPrefix()
+    {
+        return secretsBucketKeyPrefix;
+    }
+
+    @Config("s3.secrets.bucket-key-prefix")
+    @ConfigDescription("Prefix for per-bucket keystore aliases resolved at query time via the configured secrets provider (for example, fs.s3a.bucket.)")
+    public S3FileSystemConfig setSecretsBucketKeyPrefix(String secretsBucketKeyPrefix)
+    {
+        this.secretsBucketKeyPrefix = secretsBucketKeyPrefix;
+        return this;
+    }
+
+    public boolean isSecretsBucketPrefixConfigured()
+    {
+        return secretsBucketKeyPrefix != null;
+    }
+
+    public String getSecretsProvider()
+    {
+        return secretsProvider;
+    }
+
+    @Config("s3.secrets.provider")
+    @ConfigDescription("Secrets provider name from secrets.toml used for query-time alias resolution when s3.secrets.bucket-key-prefix is set")
+    public S3FileSystemConfig setSecretsProvider(String secretsProvider)
+    {
+        this.secretsProvider = secretsProvider;
         return this;
     }
 

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemLoader.java
@@ -56,8 +56,8 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.filesystem.s3.S3FileSystemConfig.RetryMode.getRetryStrategy;
+import static io.trino.filesystem.s3.S3FileSystemUtils.createCredentialsProvider;
 import static io.trino.filesystem.s3.S3FileSystemUtils.createS3PreSigner;
-import static io.trino.filesystem.s3.S3FileSystemUtils.createStaticCredentialsProvider;
 import static io.trino.filesystem.s3.S3FileSystemUtils.createStsClient;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -68,8 +68,10 @@ final class S3FileSystemLoader
         implements Function<Location, TrinoFileSystemFactory>
 {
     private final Optional<S3SecurityMappingProvider> mappingProvider;
+    private final Optional<S3SecretsCredentialResolver> secretsCredentialResolver;
     private final SdkHttpClient httpClient;
-    private final S3ClientFactory clientFactory;
+    private final OpenTelemetry openTelemetry;
+    private final MetricPublisher metricPublisher;
     private final S3FileSystemConfig config;
     private final S3Context context;
     private final ExecutorService uploadExecutor = newCachedThreadPool(daemonThreadsNamed("s3-upload-%s"));
@@ -79,23 +81,32 @@ final class S3FileSystemLoader
     @Inject
     public S3FileSystemLoader(S3SecurityMappingProvider mappingProvider, OpenTelemetry openTelemetry, S3FileSystemConfig config, S3FileSystemStats stats)
     {
-        this(Optional.of(mappingProvider), openTelemetry, config, stats);
+        this(Optional.of(mappingProvider), openTelemetry, config, stats, Optional.empty());
     }
 
     S3FileSystemLoader(OpenTelemetry openTelemetry, S3FileSystemConfig config, S3FileSystemStats stats)
     {
-        this(Optional.empty(), openTelemetry, config, stats);
+        this(Optional.empty(), openTelemetry, config, stats, Optional.empty());
     }
 
-    private S3FileSystemLoader(Optional<S3SecurityMappingProvider> mappingProvider, OpenTelemetry openTelemetry, S3FileSystemConfig config, S3FileSystemStats stats)
+    S3FileSystemLoader(OpenTelemetry openTelemetry, S3FileSystemConfig config, S3FileSystemStats stats, S3SecretsCredentialResolver secretsCredentialResolver)
+    {
+        this(Optional.empty(), openTelemetry, config, stats, Optional.of(secretsCredentialResolver));
+    }
+
+    private S3FileSystemLoader(
+            Optional<S3SecurityMappingProvider> mappingProvider,
+            OpenTelemetry openTelemetry,
+            S3FileSystemConfig config,
+            S3FileSystemStats stats,
+            Optional<S3SecretsCredentialResolver> secretsCredentialResolver)
     {
         this.mappingProvider = requireNonNull(mappingProvider, "mappingProvider is null");
+        this.secretsCredentialResolver = requireNonNull(secretsCredentialResolver, "secretsCredentialResolver is null");
         this.httpClient = createHttpClient(config);
-
+        this.openTelemetry = requireNonNull(openTelemetry, "openTelemetry is null");
         requireNonNull(stats, "stats is null");
-
-        MetricPublisher metricPublisher = stats.newMetricPublisher();
-        this.clientFactory = s3ClientFactory(httpClient, openTelemetry, config, metricPublisher);
+        this.metricPublisher = stats.newMetricPublisher();
         this.config = requireNonNull(config, "config is null");
         this.context = new S3Context(
                 toIntExact(config.getStreamingPartSize().toBytes()),
@@ -109,14 +120,19 @@ final class S3FileSystemLoader
                 config.getCannedAcl());
     }
 
+    private S3ClientFactory clientFactory(Optional<String> bucket)
+    {
+        return s3ClientFactory(httpClient, openTelemetry, config, metricPublisher, secretsCredentialResolver, bucket);
+    }
+
     @Override
     public TrinoFileSystemFactory apply(Location location)
     {
         return identity -> {
             Optional<S3SecurityMappingResult> mapping = mappingProvider.orElseThrow().getMapping(identity, location);
 
-            S3Client client = clients.computeIfAbsent(mapping, _ -> clientFactory.create(mapping));
-            S3Presigner preSigner = preSigners.computeIfAbsent(mapping, _ -> createS3PreSigner(config, client));
+            S3Client client = clients.computeIfAbsent(mapping, _ -> clientFactory(Optional.empty()).create(mapping));
+            S3Presigner preSigner = preSigners.computeIfAbsent(mapping, _ -> createS3PreSigner(config, client, secretsCredentialResolver, Optional.empty()));
             S3Context context = this.context.withCredentials(identity);
 
             if (mapping.isPresent() && mapping.get().kmsKeyId().isPresent()) {
@@ -142,7 +158,15 @@ final class S3FileSystemLoader
 
     S3Client createClient()
     {
-        return clientFactory.create(Optional.empty());
+        return clientFactory(Optional.empty()).create(Optional.empty());
+    }
+
+    S3BucketCredentialFileSystemLoader.BucketFileSystemFactory createFactoryForBucket(String bucket)
+    {
+        Optional<String> bucketName = Optional.of(bucket);
+        S3Client client = clientFactory(bucketName).create(Optional.empty());
+        S3Presigner preSigner = createS3PreSigner(config, client, secretsCredentialResolver, bucketName);
+        return new S3BucketCredentialFileSystemLoader.BucketFileSystemFactory(client, preSigner, context, uploadExecutor);
     }
 
     S3Context context()
@@ -155,11 +179,17 @@ final class S3FileSystemLoader
         return uploadExecutor;
     }
 
-    private static S3ClientFactory s3ClientFactory(SdkHttpClient httpClient, OpenTelemetry openTelemetry, S3FileSystemConfig config, MetricPublisher metricPublisher)
+    private static S3ClientFactory s3ClientFactory(
+            SdkHttpClient httpClient,
+            OpenTelemetry openTelemetry,
+            S3FileSystemConfig config,
+            MetricPublisher metricPublisher,
+            Optional<S3SecretsCredentialResolver> secretsCredentialResolver,
+            Optional<String> bucket)
     {
         ClientOverrideConfiguration overrideConfiguration = createOverrideConfiguration(openTelemetry, config, metricPublisher);
 
-        Optional<AwsCredentialsProvider> staticCredentialsProvider = createStaticCredentialsProvider(config);
+        Optional<AwsCredentialsProvider> staticCredentialsProvider = createCredentialsProvider(config, secretsCredentialResolver, bucket);
         Optional<String> staticRegion = Optional.ofNullable(config.getRegion());
         Optional<String> staticEndpoint = Optional.ofNullable(config.getEndpoint());
         boolean pathStyleAccess = config.isPathStyleAccess();

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemModule.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemModule.java
@@ -46,8 +46,16 @@ public class S3FileSystemModule
     {
         configBinder(binder).bindConfig(S3FileSystemConfig.class);
 
+        S3FileSystemConfig config = buildConfigObject(S3FileSystemConfig.class);
+
         if (buildConfigObject(S3SecurityMappingEnabledConfig.class).isEnabled()) {
+            if (config.isSecretsBucketPrefixConfigured()) {
+                throw new VerifyException("s3.secrets.bucket-key-prefix cannot be used with s3.security-mapping.enabled");
+            }
             install(new S3SecurityMappingModule());
+        }
+        else if (config.isSecretsBucketPrefixConfigured()) {
+            install(new S3SecretsBucketCredentialModule());
         }
         else {
             binder.bind(TrinoFileSystemFactory.class).annotatedWith(FileSystemS3.class)
@@ -90,6 +98,25 @@ public class S3FileSystemModule
         @Singleton
         @FileSystemS3
         static TrinoFileSystemFactory createFileSystemFactory(S3FileSystemLoader loader)
+        {
+            return new SwitchingFileSystemFactory(loader);
+        }
+    }
+
+    public static class S3SecretsBucketCredentialModule
+            extends AbstractConfigurationAwareModule
+    {
+        @Override
+        protected void setup(Binder binder)
+        {
+            binder.bind(S3SecretsCredentialResolver.class).in(SINGLETON);
+            binder.bind(S3BucketCredentialFileSystemLoader.class).in(SINGLETON);
+        }
+
+        @Provides
+        @Singleton
+        @FileSystemS3
+        static TrinoFileSystemFactory createFileSystemFactory(S3BucketCredentialFileSystemLoader loader)
         {
             return new SwitchingFileSystemFactory(loader);
         }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemUtils.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemUtils.java
@@ -14,6 +14,7 @@
 package io.trino.filesystem.s3;
 
 import io.trino.filesystem.s3.S3FileSystemConfig.S3AuthType;
+import io.trino.spi.TrinoException;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -30,13 +31,24 @@ import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import java.net.URI;
 import java.util.Optional;
 
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+
 final class S3FileSystemUtils
 {
     private S3FileSystemUtils() {}
 
     public static S3Presigner createS3PreSigner(S3FileSystemConfig config, S3Client s3Client)
     {
-        Optional<AwsCredentialsProvider> staticCredentialsProvider = createStaticCredentialsProvider(config);
+        return createS3PreSigner(config, s3Client, Optional.empty(), Optional.empty());
+    }
+
+    public static S3Presigner createS3PreSigner(
+            S3FileSystemConfig config,
+            S3Client s3Client,
+            Optional<S3SecretsCredentialResolver> secretsCredentialResolver,
+            Optional<String> bucket)
+    {
+        Optional<AwsCredentialsProvider> staticCredentialsProvider = createCredentialsProvider(config, secretsCredentialResolver, bucket);
         Optional<String> staticRegion = Optional.ofNullable(config.getRegion());
         Optional<String> staticEndpoint = Optional.ofNullable(config.getEndpoint());
         boolean pathStyleAccess = config.isPathStyleAccess();
@@ -86,9 +98,30 @@ final class S3FileSystemUtils
 
     static Optional<AwsCredentialsProvider> createStaticCredentialsProvider(S3FileSystemConfig config)
     {
-        if ((config.getAwsAccessKey() != null) || (config.getAwsSecretKey() != null)) {
+        return createCredentialsProvider(config, Optional.empty(), Optional.empty());
+    }
+
+    static Optional<AwsCredentialsProvider> createCredentialsProvider(
+            S3FileSystemConfig config,
+            Optional<S3SecretsCredentialResolver> secretsCredentialResolver,
+            Optional<String> bucket)
+    {
+        Optional<String> accessKey = Optional.ofNullable(config.getAwsAccessKey());
+        Optional<String> secretKey = Optional.ofNullable(config.getAwsSecretKey());
+
+        if (accessKey.isEmpty() && secretKey.isEmpty() && secretsCredentialResolver.isPresent() && bucket.isPresent()) {
+            S3SecretsCredentialResolver.BucketCredentials bucketCredentials = secretsCredentialResolver.get()
+                    .resolveBucketCredentials(bucket.get());
+            accessKey = Optional.of(bucketCredentials.accessKey());
+            secretKey = Optional.of(bucketCredentials.secretKey());
+        }
+
+        if (accessKey.isPresent() && secretKey.isPresent()) {
             return Optional.of(StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create(config.getAwsAccessKey(), config.getAwsSecretKey())));
+                    AwsBasicCredentials.create(accessKey.get(), secretKey.get())));
+        }
+        if (accessKey.isPresent() || secretKey.isPresent()) {
+            throw new TrinoException(CONFIGURATION_INVALID, "Both S3 access key and secret key must be configured");
         }
         return Optional.empty();
     }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3SecretsCredentialResolver.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3SecretsCredentialResolver.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import com.google.inject.Inject;
+import io.trino.spi.TrinoException;
+import io.trino.spi.secrets.RuntimeSecretResolver;
+
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+import static java.util.Objects.requireNonNull;
+
+final class S3SecretsCredentialResolver
+{
+    private final RuntimeSecretResolver secretResolver;
+    private final String secretProvider;
+    private final String bucketKeyPrefix;
+
+    @Inject
+    S3SecretsCredentialResolver(RuntimeSecretResolver secretResolver, S3FileSystemConfig config)
+    {
+        this.secretResolver = requireNonNull(secretResolver, "secretResolver is null");
+        requireNonNull(config, "config is null");
+        this.secretProvider = requireNonNull(config.getSecretsProvider(), "secretsProvider is null");
+        this.bucketKeyPrefix = requireNonNull(config.getSecretsBucketKeyPrefix(), "secretsBucketKeyPrefix is null");
+    }
+
+    BucketCredentials resolveBucketCredentials(String bucket)
+    {
+        requireNonNull(bucket, "bucket is null");
+        try {
+            String accessKeyAlias = bucketKeyPrefix + bucket + ".access.key";
+            String secretKeyAlias = bucketKeyPrefix + bucket + ".secret.key";
+            return new BucketCredentials(
+                    secretResolver.resolveSecret(secretProvider, accessKeyAlias),
+                    secretResolver.resolveSecret(secretProvider, secretKeyAlias));
+        }
+        catch (RuntimeException e) {
+            throw new TrinoException(CONFIGURATION_INVALID, "Failed to resolve S3 credentials for bucket: " + bucket, e);
+        }
+    }
+
+    record BucketCredentials(String accessKey, String secretKey) {}
+}

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3SecretsBucketCredentials.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3SecretsBucketCredentials.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import io.airlift.secrets.keystore.KeystoreSecretProvider;
+import io.airlift.secrets.keystore.KeystoreSecretProviderConfig;
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.filesystem.s3.secrets.KeyStoreTestFixture;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.filesystem.s3.S3FileSystemUtils.createCredentialsProvider;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestS3SecretsBucketCredentials
+{
+    @Test
+    public void testBucketPrefixLoaderWiring()
+            throws Exception
+    {
+        Path keystorePath = KeyStoreTestFixture.createHadoopKeyStore(
+                Map.of(
+                        "fs.s3a.bucket.orders.access.key", "bucket-access",
+                        "fs.s3a.bucket.orders.secret.key", "bucket-secret"),
+                "none");
+
+        KeystoreSecretProvider keystoreProvider = new KeystoreSecretProvider(new KeystoreSecretProviderConfig()
+                .setKeyStoreFilePath(keystorePath.toString())
+                .setKeyStoreType("JCEKS")
+                .setKeyStorePassword("none"));
+
+        S3FileSystemConfig config = new S3FileSystemConfig()
+                .setRegion("us-east-1")
+                .setSecretsBucketKeyPrefix("fs.s3a.bucket.")
+                .setSecretsProvider("keystore");
+
+        S3SecretsCredentialResolver secretsCredentialResolver = new S3SecretsCredentialResolver(
+                (_, key) -> keystoreProvider.resolveSecretValue(key),
+                config);
+
+        S3FileSystemLoader loader = new S3FileSystemLoader(OpenTelemetry.noop(), config, new S3FileSystemStats(), secretsCredentialResolver);
+        S3BucketCredentialFileSystemLoader.BucketFileSystemFactory bucketFactory = loader.createFactoryForBucket("orders");
+
+        Optional<AwsCredentialsProvider> credentialsProvider = createCredentialsProvider(
+                config,
+                Optional.of(secretsCredentialResolver),
+                Optional.of("orders"));
+
+        assertThat(credentialsProvider).isPresent();
+        AwsBasicCredentials credentials = (AwsBasicCredentials) credentialsProvider.get().resolveCredentials();
+        assertThat(credentials.accessKeyId()).isEqualTo("bucket-access");
+        assertThat(credentials.secretAccessKey()).isEqualTo("bucket-secret");
+        assertThat(bucketFactory).isNotNull();
+    }
+}

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/secrets/KeyStoreTestFixture.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/secrets/KeyStoreTestFixture.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3.secrets;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.alias.CredentialProvider;
+import org.apache.hadoop.security.alias.CredentialProviderFactory;
+
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public final class KeyStoreTestFixture
+{
+    private KeyStoreTestFixture() {}
+
+    public static Path createKeyStore(Map<String, String> aliases, String password)
+            throws Exception
+    {
+        KeyStore keyStore = KeyStore.getInstance("JCEKS");
+        keyStore.load(null, password.toCharArray());
+
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
+        for (Map.Entry<String, String> entry : aliases.entrySet()) {
+            String alias = entry.getKey().toLowerCase(Locale.US);
+            PBEKeySpec keySpec = new PBEKeySpec(entry.getValue().toCharArray());
+            SecretKey key = factory.generateSecret(keySpec);
+            keyStore.setEntry(alias, new KeyStore.SecretKeyEntry(key), new KeyStore.PasswordProtection(password.toCharArray()));
+        }
+
+        return writeKeyStore(keyStore, password);
+    }
+
+    public static Path createHadoopKeyStore(Map<String, String> aliases, String password)
+            throws IOException
+    {
+        Path keystorePath = Files.createTempFile("hadoop-credentials", ".jceks");
+        keystorePath.toFile().deleteOnExit();
+
+        String providerPath = "localjceks://file" + keystorePath.toAbsolutePath();
+        Configuration configuration = new Configuration(false);
+        configuration.set(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH, providerPath);
+        configuration.set("hadoop.security.credential.provider.password", password);
+
+        List<CredentialProvider> providers = CredentialProviderFactory.getProviders(configuration);
+        CredentialProvider provider = providers.getFirst();
+        for (Map.Entry<String, String> entry : aliases.entrySet()) {
+            provider.createCredentialEntry(entry.getKey(), entry.getValue().toCharArray());
+        }
+        provider.flush();
+
+        return keystorePath;
+    }
+
+    private static Path writeKeyStore(KeyStore keyStore, String password)
+            throws Exception
+    {
+        Path keystorePath = Files.createTempFile("credentials", ".jceks");
+        keystorePath.toFile().deleteOnExit();
+        try (OutputStream out = Files.newOutputStream(keystorePath)) {
+            keyStore.store(out, password.toCharArray());
+        }
+        return keystorePath;
+    }
+}

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/secrets/TestKeystoreSecretsComparison.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/secrets/TestKeystoreSecretsComparison.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3.secrets;
+
+import io.airlift.configuration.secrets.SecretsResolver;
+import io.airlift.secrets.keystore.KeystoreSecretProvider;
+import io.airlift.secrets.keystore.KeystoreSecretProviderConfig;
+import io.airlift.spi.secrets.SecretProvider;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Validates approach 3: enhanced {@link KeystoreSecretProvider} reads both PBE and Hadoop JCEKS formats.
+ */
+public class TestKeystoreSecretsComparison
+{
+    private static final String ACCESS_ALIAS = "fs.s3a.bucket.test-bucket.access.key";
+    private static final String SECRET_ALIAS = "fs.s3a.bucket.test-bucket.secret.key";
+    private static final String ACCESS_VALUE = "AKIATEST";
+    private static final String SECRET_VALUE = "SECRETTEST";
+    private static final String PASSWORD = "none";
+
+    @Test
+    public void testAirliftKeystoreProviderReadsPbeJceks()
+            throws Exception
+    {
+        Path keystore = KeyStoreTestFixture.createKeyStore(
+                Map.of(ACCESS_ALIAS, ACCESS_VALUE, SECRET_ALIAS, SECRET_VALUE),
+                PASSWORD);
+
+        KeystoreSecretProvider provider = new KeystoreSecretProvider(keystoreConfig(keystore));
+        assertThat(provider.resolveSecretValue(ACCESS_ALIAS)).isEqualTo(ACCESS_VALUE);
+        assertThat(provider.resolveSecretValue(SECRET_ALIAS)).isEqualTo(SECRET_VALUE);
+    }
+
+    @Test
+    public void testSecretsResolverInterpolatesPbeJceksIntoCatalogProperties()
+            throws Exception
+    {
+        Path keystore = KeyStoreTestFixture.createKeyStore(
+                Map.of(ACCESS_ALIAS, ACCESS_VALUE, SECRET_ALIAS, SECRET_VALUE),
+                PASSWORD);
+
+        SecretProvider keystoreProvider = new KeystoreSecretProvider(keystoreConfig(keystore));
+        SecretsResolver resolver = new SecretsResolver(Map.of("keystore", keystoreProvider));
+
+        Map<String, String> resolved = resolver.getResolvedConfiguration(Map.of(
+                "s3.aws-access-key", "${keystore:" + ACCESS_ALIAS + "}",
+                "s3.aws-secret-key", "${keystore:" + SECRET_ALIAS + "}"));
+
+        assertThat(resolved.get("s3.aws-access-key")).isEqualTo(ACCESS_VALUE);
+        assertThat(resolved.get("s3.aws-secret-key")).isEqualTo(SECRET_VALUE);
+    }
+
+    @Test
+    public void testAirliftKeystoreProviderReadsHadoopJceks()
+            throws Exception
+    {
+        Path keystore = KeyStoreTestFixture.createHadoopKeyStore(
+                Map.of(ACCESS_ALIAS, ACCESS_VALUE, SECRET_ALIAS, SECRET_VALUE),
+                PASSWORD);
+
+        KeystoreSecretProvider provider = new KeystoreSecretProvider(keystoreConfig(keystore));
+
+        assertThat(provider.resolveSecretValue(ACCESS_ALIAS)).isEqualTo(ACCESS_VALUE);
+        assertThat(provider.resolveSecretValue(SECRET_ALIAS)).isEqualTo(SECRET_VALUE);
+    }
+
+    private static KeystoreSecretProviderConfig keystoreConfig(Path keystore)
+    {
+        return new KeystoreSecretProviderConfig()
+                .setKeyStoreFilePath(keystore.toString())
+                .setKeyStoreType("JCEKS")
+                .setKeyStorePassword(PASSWORD);
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ConnectorContextModule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ConnectorContextModule.java
@@ -28,6 +28,7 @@ import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorExpressionEvaluator;
 import io.trino.spi.connector.MetadataProvider;
+import io.trino.spi.secrets.RuntimeSecretResolver;
 import io.trino.spi.type.TypeManager;
 
 import static java.util.Objects.requireNonNull;
@@ -61,5 +62,7 @@ public class ConnectorContextModule
         binder.bind(PageIndexerFactory.class).toInstance(context.getPageIndexerFactory());
         binder.bind(BlocksHashFactory.class).toInstance(context.getBlocksHashFactory());
         binder.bind(ConnectorExpressionEvaluator.class).toInstance(context.getExpressionEvaluator());
+        context.getRuntimeSecretResolver().ifPresent(resolver ->
+                binder.bind(RuntimeSecretResolver.class).toInstance(resolver));
     }
 }

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/TestGroup.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/TestGroup.java
@@ -183,6 +183,11 @@ public @interface TestGroup
 
     @Target({TYPE, METHOD})
     @Retention(RUNTIME)
+    @Tag("s3_keystore_secrets")
+    @interface S3KeystoreSecrets {}
+
+    @Target({TYPE, METHOD})
+    @Retention(RUNTIME)
     @Tag("postgresql_postgis")
     @interface PostgresqlPostgis {}
 

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/KeystoreSecretsProductTestFixture.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/KeystoreSecretsProductTestFixture.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Creates JCEKS fixtures for keystore-backed secrets product tests.
+ * Mirrors {@code io.trino.filesystem.s3.secrets.KeyStoreTestFixture} without a test-module dependency.
+ */
+public final class KeystoreSecretsProductTestFixture
+{
+    public static final String KEYSTORE_PASSWORD = "none";
+
+    private KeystoreSecretsProductTestFixture() {}
+
+    public static Path createKeyStore(Map<String, String> aliases)
+            throws Exception
+    {
+        KeyStore keyStore = KeyStore.getInstance("JCEKS");
+        keyStore.load(null, KEYSTORE_PASSWORD.toCharArray());
+
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
+        for (Map.Entry<String, String> entry : aliases.entrySet()) {
+            String alias = entry.getKey().toLowerCase(Locale.US);
+            PBEKeySpec keySpec = new PBEKeySpec(entry.getValue().toCharArray());
+            SecretKey key = factory.generateSecret(keySpec);
+            keyStore.setEntry(alias, new KeyStore.SecretKeyEntry(key), new KeyStore.PasswordProtection(KEYSTORE_PASSWORD.toCharArray()));
+        }
+
+        Path keystorePath = Files.createTempFile("keystore-secrets-pt-", ".jceks");
+        keystorePath.toFile().deleteOnExit();
+        try (OutputStream out = Files.newOutputStream(keystorePath)) {
+            keyStore.store(out, KEYSTORE_PASSWORD.toCharArray());
+        }
+        return keystorePath;
+    }
+
+    public static void deleteIfExists(Path keystorePath)
+    {
+        if (keystorePath == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(keystorePath);
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to delete temporary keystore: " + keystorePath, e);
+        }
+    }
+}

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/S3KeystoreSecretsEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/S3KeystoreSecretsEnvironment.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+import io.trino.testing.containers.Minio;
+import io.trino.testing.containers.TrinoProductTestContainer;
+import io.trino.testing.containers.environment.ProductTestEnvironment;
+import org.testcontainers.containers.Network;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.trino.TrinoContainer;
+import org.testcontainers.utility.MountableFile;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
+import static io.trino.tests.product.hive.KeystoreSecretsProductTestFixture.KEYSTORE_PASSWORD;
+import static io.trino.tests.product.hive.KeystoreSecretsProductTestFixture.createKeyStore;
+import static io.trino.tests.product.hive.KeystoreSecretsProductTestFixture.deleteIfExists;
+
+/**
+ * Hive file metastore with MinIO storage and keystore-resolved S3 credentials.
+ */
+public class S3KeystoreSecretsEnvironment
+        extends ProductTestEnvironment
+{
+    public static final String BUCKET_NAME = "orders";
+    public static final String SCHEMA_LOCATION = "s3://" + BUCKET_NAME + "/keystore-pt/";
+    private static final String ACCESS_ALIAS = "fs.s3a.bucket." + BUCKET_NAME + ".access.key";
+    private static final String SECRET_ALIAS = "fs.s3a.bucket." + BUCKET_NAME + ".secret.key";
+    private static final String HIVE_METASTORE_DIR = "file:///var/trino/hive-data";
+
+    private Network network;
+    private Minio minio;
+    private TrinoContainer trino;
+    private Path credentialStore;
+
+    @Override
+    public void start()
+            throws SQLException, InterruptedException
+    {
+        if (isRunning()) {
+            return;
+        }
+
+        try {
+            startEnvironment();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to start S3 keystore secrets environment", e);
+        }
+    }
+
+    private void startEnvironment()
+            throws Exception
+    {
+        network = Network.newNetwork();
+
+        minio = Minio.builder()
+                .withNetwork(network)
+                .build();
+        minio.start();
+        minio.createBucket(BUCKET_NAME);
+
+        credentialStore = createKeyStore(Map.of(
+                ACCESS_ALIAS, MINIO_ROOT_USER,
+                SECRET_ALIAS, MINIO_ROOT_PASSWORD));
+
+        Map<String, String> hiveCatalog = new LinkedHashMap<>();
+        hiveCatalog.put("connector.name", "hive");
+        hiveCatalog.put("hive.metastore", "file");
+        hiveCatalog.put("hive.metastore.catalog.dir", HIVE_METASTORE_DIR);
+        hiveCatalog.put("fs.local.enabled", "true");
+        hiveCatalog.put("fs.native-s3.enabled", "true");
+        hiveCatalog.put("s3.region", Minio.MINIO_REGION);
+        hiveCatalog.put("s3.endpoint", "http://" + Minio.DEFAULT_HOST_NAME + ":" + Minio.MINIO_API_PORT);
+        hiveCatalog.put("s3.path-style-access", "true");
+        hiveCatalog.put("s3.aws-access-key", "${keystore:" + ACCESS_ALIAS + "}");
+        hiveCatalog.put("s3.aws-secret-key", "${keystore:" + SECRET_ALIAS + "}");
+        hiveCatalog.put("s3.secrets.bucket-key-prefix", "fs.s3a.bucket.");
+        hiveCatalog.put("s3.secrets.provider", "keystore");
+        hiveCatalog.put("hive.non-managed-table-writes-enabled", "true");
+
+        trino = TrinoProductTestContainer.builder()
+                .withNetwork(network)
+                .withCatalog("hive", hiveCatalog)
+                .withCatalog("tpch", Map.of("connector.name", "tpch"))
+                .build();
+        trino.withCopyToContainer(Transferable.of(secretsConfiguration()), "/etc/trino/secrets.toml");
+        trino.withCopyFileToContainer(MountableFile.forHostPath(credentialStore), "/etc/trino/credentials.jceks");
+        trino.withCopyToContainer(Transferable.of(""), "/var/trino/hive-data/.keep");
+        TrinoProductTestContainer.startAndWait(trino);
+    }
+
+    @Override
+    public Connection createTrinoConnection()
+            throws SQLException
+    {
+        return createTrinoConnection("test");
+    }
+
+    @Override
+    public Connection createTrinoConnection(String user)
+            throws SQLException
+    {
+        Connection connection = TrinoProductTestContainer.createConnection(trino, user);
+        connection.setCatalog("hive");
+        connection.setSchema("default");
+        return connection;
+    }
+
+    @Override
+    public String getTrinoJdbcUrl()
+    {
+        return trino != null ? trino.getJdbcUrl() : null;
+    }
+
+    @Override
+    public boolean isRunning()
+    {
+        return trino != null && trino.isRunning();
+    }
+
+    @Override
+    protected void doClose()
+    {
+        if (trino != null) {
+            trino.close();
+            trino = null;
+        }
+        if (minio != null) {
+            minio.close();
+            minio = null;
+        }
+        if (network != null) {
+            network.close();
+            network = null;
+        }
+        deleteIfExists(credentialStore);
+        credentialStore = null;
+    }
+
+    private static String secretsConfiguration()
+    {
+        return """
+               [env]
+               secrets-provider.name = "env"
+
+               [keystore]
+               secrets-provider.name = "keystore"
+               keystore-file-path = "/etc/trino/credentials.jceks"
+               keystore-type = "JCEKS"
+               keystore-password = "%s"
+               """.formatted(KEYSTORE_PASSWORD);
+    }
+}

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TestS3KeystoreSecretsSqlTests.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TestS3KeystoreSecretsSqlTests.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+import io.trino.testing.containers.environment.ProductTest;
+import io.trino.testing.containers.environment.QueryResult;
+import io.trino.testing.containers.environment.RequiresEnvironment;
+import io.trino.tests.product.TestGroup;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.testing.containers.environment.QueryResultAssert.assertThat;
+import static io.trino.testing.containers.environment.Row.row;
+
+/**
+ * End-to-end validation that keystore-resolved S3 credentials work for Hive DML against MinIO.
+ */
+@ProductTest
+@RequiresEnvironment(S3KeystoreSecretsEnvironment.class)
+@TestGroup.S3KeystoreSecrets
+@TestGroup.ProfileSpecificTests
+class TestS3KeystoreSecretsSqlTests
+{
+    private static final String SCHEMA = "hive.test_keystore";
+    private static final String TABLE = SCHEMA + ".orders";
+    private static final String TABLE_LOCATION = S3KeystoreSecretsEnvironment.SCHEMA_LOCATION + "orders/";
+
+    @Test
+    void testKeystoreBackedS3ReadWrite(S3KeystoreSecretsEnvironment env)
+    {
+        env.executeTrinoUpdate("DROP TABLE IF EXISTS " + TABLE);
+        env.executeTrinoUpdate("DROP SCHEMA IF EXISTS " + SCHEMA);
+        env.executeTrinoUpdate("CREATE SCHEMA " + SCHEMA);
+        env.executeTrinoUpdate("CREATE TABLE " + TABLE + " (id bigint, name varchar) WITH (external_location = '" + TABLE_LOCATION + "', format = 'PARQUET')");
+        env.executeTrinoUpdate("INSERT INTO " + TABLE + " VALUES (1, 'keystore-ok'), (2, 'minio-rw')");
+
+        QueryResult result = env.executeTrino("SELECT id, name FROM " + TABLE + " ORDER BY id");
+        assertThat(result).containsOnly(
+                row(1L, "keystore-ok"),
+                row(2L, "minio-rw"));
+    }
+}

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteS3KeystoreSecrets.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteS3KeystoreSecrets.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.suite;
+
+import io.trino.tests.product.TestGroup;
+import io.trino.tests.product.hive.S3KeystoreSecretsEnvironment;
+import io.trino.tests.product.suite.SuiteRunner.TestRunResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Product tests for keystore-backed S3 credentials with Hive and MinIO.
+ * <p>
+ * Run standalone:
+ * <pre>
+ * mvn exec:java -Dexec.mainClass="io.trino.tests.product.suite.SuiteS3KeystoreSecrets"
+ * </pre>
+ */
+public final class SuiteS3KeystoreSecrets
+{
+    private SuiteS3KeystoreSecrets() {}
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        System.setProperty("trino.product-test.environment-mode", "STRICT");
+
+        List<TestRunResult> results = new ArrayList<>();
+        results.add(SuiteRunner.forEnvironment(S3KeystoreSecretsEnvironment.class)
+                .includeTag(TestGroup.S3KeystoreSecrets.class)
+                .run());
+
+        SuiteRunner.printSummary(results);
+        System.exit(SuiteRunner.hasFailures(results) ? 1 : 0);
+    }
+}


### PR DESCRIPTION
## Summary
Implement approach based on the feedback on #30638: resolve S3 credentials
from Airlift keystore secrets at query time via RuntimeSecretResolver, including
per-bucket prefix support for multi-bucket catalogs.

## Dependency
Requires Airlift: https://github.com/airlift/airlift/pull/2100

After Airlift merges, Trino needs an Airlift version bump (currently
dep.airlift.version 444).

## Commits
1. Add RuntimeSecretResolver for query-time keystore secrets
2. Add per-bucket S3 credentials via keystore secrets prefix
3. Add tests for JCEKS keystore and S3 bucket secrets
4. Add product test for S3 keystore secrets

## Test plan
- [x] Unit: TestKeystoreSecretsComparison, TestS3SecretsBucketCredentials
- [x] PT tests: SuiteS3KeystoreSecrets 
