### PR TITLE
Add test for Ignite decimal type with negative scale

### DIFF
--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
@@ -230,7 +230,7 @@ public class IgniteClient
             case Types.FLOAT -> Optional.of(realColumnMapping());
             case Types.DOUBLE -> Optional.of(doubleColumnMapping());
             case Types.DECIMAL -> {
-                int decimalDigits = typeHandle.requiredDecimalDigits();
+                int decimalDigits = typeHandle.decimalDigits().orElse(0);
                 int precision = typeHandle.requiredColumnSize();
                 if (getDecimalRounding(session) == ALLOW_OVERFLOW && precision > Decimals.MAX_PRECISION) {
                     int scale = min(decimalDigits, getDecimalDefaultScale(session));

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
@@ -264,9 +264,9 @@ public class TestIgniteTypeMapping
         // Ignite supports decimal with negative scale internally, but the JDBC driver
         // reports the scale as 0, so Trino sees decimal(p, 0) for decimal(p, -s).
         SqlDataTypeTest.create()
-                .addRoundTrip("decimal(3, -1)", "CAST('10' AS decimal(3, -1))", createDecimalType(3, 0), "CAST('10' AS decimal(3, 0))")
-                .addRoundTrip("decimal(3, -1)", "CAST('0' AS decimal(3, -1))", createDecimalType(3, 0), "CAST('0' AS decimal(3, 0))")
-                .addRoundTrip("decimal(3, -2)", "CAST('100' AS decimal(3, -2))", createDecimalType(3, 0), "CAST('100' AS decimal(3, 0))")
+                .addRoundTrip("decimal(3, -1)", "CAST('10' AS decimal(3, -1))", createDecimalType(4, 0), "CAST('10' AS decimal(4, 0))")
+                .addRoundTrip("decimal(3, -1)", "CAST('0' AS decimal(3, -1))", createDecimalType(4, 0), "CAST('0' AS decimal(4, 0))")
+                .addRoundTrip("decimal(3, -2)", "CAST('100' AS decimal(3, -2))", createDecimalType(5, 0), "CAST('100' AS decimal(5, 0))")
                 .execute(getQueryRunner(), igniteCreateAndInsert("test_decimal_negative_scale"));
     }
 

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
@@ -259,6 +259,18 @@ public class TestIgniteTypeMapping
     }
 
     @Test
+    public void testDecimalNegativeScale()
+    {
+        // Ignite supports decimal with negative scale internally, but the JDBC driver
+        // reports the scale as 0, so Trino sees decimal(p, 0) for decimal(p, -s).
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(3, -1)", "CAST('10' AS decimal(3, -1))", createDecimalType(3, 0), "CAST('10' AS decimal(3, 0))")
+                .addRoundTrip("decimal(3, -1)", "CAST('0' AS decimal(3, -1))", createDecimalType(3, 0), "CAST('0' AS decimal(3, 0))")
+                .addRoundTrip("decimal(3, -2)", "CAST('100' AS decimal(3, -2))", createDecimalType(3, 0), "CAST('100' AS decimal(3, 0))")
+                .execute(getQueryRunner(), igniteCreateAndInsert("test_decimal_negative_scale"));
+    }
+
+    @Test
     public void testBinary()
     {
         binaryTest("binary")


### PR DESCRIPTION
Add round-trip test for Ignite decimal with negative scale. Closes #28416.