### PR TITLE
Report removed statistics count in Iceberg drop_extended_stats

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -1077,6 +1077,18 @@ from the table.
 ALTER TABLE test_table EXECUTE drop_extended_stats;
 ```
 
+The output of the query has the following metrics:
+
+:::{list-table} Output
+:widths: 40, 60
+:header-rows: 1
+
+* - Property name
+  - Description
+* - `removed_statistics_count`
+  - The count of statistics files removed by drop_extended_stats.
+:::
+
 (iceberg-alter-table-set-properties)=
 #### ALTER TABLE SET PROPERTIES
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2249,10 +2249,7 @@ public class IcebergMetadata
         IcebergTableExecuteHandle executeHandle = (IcebergTableExecuteHandle) tableExecuteHandle;
         return switch (executeHandle.procedureId()) {
             case OPTIMIZE_MANIFESTS -> executeOptimizeManifests(session, executeHandle);
-            case DROP_EXTENDED_STATS -> {
-                executeDropExtendedStats(session, executeHandle);
-                yield ImmutableMap.of();
-            }
+            case DROP_EXTENDED_STATS -> executeDropExtendedStats(session, executeHandle);
             case ROLLBACK_TO_SNAPSHOT -> {
                 executeRollbackToSnapshot(session, executeHandle);
                 yield ImmutableMap.of();
@@ -2282,7 +2279,7 @@ public class IcebergMetadata
         return optimizeManifests(icebergTable, icebergScanExecutor);
     }
 
-    private void executeDropExtendedStats(ConnectorSession session, IcebergTableExecuteHandle executeHandle)
+    private Map<String, Long> executeDropExtendedStats(ConnectorSession session, IcebergTableExecuteHandle executeHandle)
     {
         checkArgument(executeHandle.procedureHandle() instanceof IcebergDropExtendedStatsHandle, "Unexpected procedure handle %s", executeHandle.procedureHandle());
 
@@ -2290,17 +2287,18 @@ public class IcebergMetadata
             Table icebergTable = catalog.loadTable(session, executeHandle.schemaTableName());
             beginTransaction(icebergTable);
             UpdateStatistics updateStatistics = transaction.updateStatistics();
-            for (StatisticsFile statisticsFile : icebergTable.statisticsFiles()) {
+            List<StatisticsFile> statisticsFiles = icebergTable.statisticsFiles();
+            for (StatisticsFile statisticsFile : statisticsFiles) {
                 updateStatistics.removeStatistics(statisticsFile.snapshotId());
             }
             updateStatistics.commit();
             commitTransaction(transaction, "drop extended stats");
+            transaction = null;
+            return ImmutableMap.of("removed_statistics_count", (long) statisticsFiles.size());
         }
         catch (NotFoundException e) {
             throw new TrinoException(ICEBERG_INVALID_METADATA, e);
         }
-
-        transaction = null;
     }
 
     private void executeRollbackToSnapshot(ConnectorSession session, IcebergTableExecuteHandle executeHandle)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergStatistics.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergStatistics.java
@@ -716,7 +716,8 @@ public class TestIcebergStatistics
         assertQuery("SHOW STATS FOR " + tableName, extendedStats);
 
         // Dropping extended stats clears distinct count and leaves other stats alone
-        assertUpdate("ALTER TABLE " + tableName + " EXECUTE DROP_EXTENDED_STATS");
+        assertThat(query("ALTER TABLE " + tableName + " EXECUTE DROP_EXTENDED_STATS"))
+                .matches("VALUES (VARCHAR 'removed_statistics_count', BIGINT '1')");
         assertQuery("SHOW STATS FOR " + tableName, baseStats);
 
         // Re-analyzing should work


### PR DESCRIPTION
## Release notes

```markdown
## Iceberg
* Report removed statistics count in Iceberg `drop_extended_stats`. ({issue}`30768`)
```
