### PR TITLE
Support gcs.json-key property for Iceberg Google security

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -584,7 +584,7 @@ fs.gcs.enabled=true
 gcs.json-key-file-path=/path/to/gcs_keyfile.json
 ```
 
-`gcs.json-key-file-path` is optional. When omitted, [Application Default
+`gcs.json-key` and `gcs.json-key-file-path` are optional. When omitted, [Application Default
 Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
 (ADC) are used, which supports GKE Workload Identity and other
 environment-based credential sources.

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleAuthProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleAuthProperties.java
@@ -18,6 +18,7 @@ import com.google.inject.Inject;
 
 import java.util.Map;
 
+import static org.apache.iceberg.gcp.auth.GoogleAuthManager.GCP_CREDENTIALS_JSON_PROPERTY;
 import static org.apache.iceberg.gcp.auth.GoogleAuthManager.GCP_CREDENTIALS_PATH_PROPERTY;
 import static org.apache.iceberg.rest.auth.AuthProperties.AUTH_TYPE;
 import static org.apache.iceberg.rest.auth.AuthProperties.AUTH_TYPE_GOOGLE;
@@ -33,6 +34,7 @@ public class GoogleAuthProperties
         ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String>builder()
                 .put(AUTH_TYPE, AUTH_TYPE_GOOGLE)
                 .put("header.x-goog-user-project", config.getProjectId());
+        config.getJsonKey().ifPresent(key -> builder.put(GCP_CREDENTIALS_JSON_PROPERTY, key));
         config.getJsonKeyFilePath().ifPresent(path -> builder.put(GCP_CREDENTIALS_PATH_PROPERTY, path));
         properties = builder.buildOrThrow();
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleSecurityConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/GoogleSecurityConfig.java
@@ -15,7 +15,9 @@ package io.trino.plugin.iceberg.catalog.rest;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.validation.FileExists;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.Optional;
@@ -23,6 +25,7 @@ import java.util.Optional;
 public class GoogleSecurityConfig
 {
     private String projectId;
+    private String jsonKey;
     private String jsonKeyFilePath;
 
     @NotNull
@@ -39,8 +42,21 @@ public class GoogleSecurityConfig
         return this;
     }
 
-    // Duplicated from GcsFileSystemConfig. When absent, Application Default Credentials (ADC) are used,
-    // which enables GKE Workload Identity and environment-based credential sources.
+    @NotNull
+    public Optional<String> getJsonKey()
+    {
+        return Optional.ofNullable(jsonKey);
+    }
+
+    @Config("gcs.json-key")
+    @ConfigSecuritySensitive
+    @ConfigDescription("Google Cloud service account key in JSON format")
+    public GoogleSecurityConfig setJsonKey(String jsonKey)
+    {
+        this.jsonKey = jsonKey;
+        return this;
+    }
+
     public Optional<@FileExists String> getJsonKeyFilePath()
     {
         return Optional.ofNullable(jsonKeyFilePath);
@@ -52,5 +68,13 @@ public class GoogleSecurityConfig
     {
         this.jsonKeyFilePath = jsonKeyFilePath;
         return this;
+    }
+
+    // Duplicated from GcsServiceAccountAuthConfig. When absent, Application Default Credentials (ADC) are used,
+    // which enables GKE Workload Identity and environment-based credential sources.
+    @AssertTrue(message = "gcs.json-key and gcs.json-key-file-path cannot be set at the same time")
+    public boolean isAuthMethodValid()
+    {
+        return !(jsonKey != null && jsonKeyFilePath != null);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestGoogleSecurityConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestGoogleSecurityConfig.java
@@ -14,6 +14,8 @@
 package io.trino.plugin.iceberg.catalog.rest;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import jakarta.validation.constraints.AssertTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -23,6 +25,7 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
 
 final class TestGoogleSecurityConfig
 {
@@ -31,6 +34,7 @@ final class TestGoogleSecurityConfig
     {
         assertRecordedDefaults(recordDefaults(GoogleSecurityConfig.class)
                 .setProjectId(null)
+                .setJsonKey(null)
                 .setJsonKeyFilePath(null));
     }
 
@@ -46,6 +50,33 @@ final class TestGoogleSecurityConfig
                 .setProjectId("gcp")
                 .setJsonKeyFilePath(config.toString());
 
-        assertFullMapping(properties, expected);
+        assertFullMapping(properties, expected, ImmutableSet.of("gcs.json-key"));
+    }
+
+    @Test
+    void testJsonKeyExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("iceberg.rest-catalog.google-project-id", "gcp")
+                .put("gcs.json-key", "{}")
+                .buildOrThrow();
+
+        GoogleSecurityConfig expected = new GoogleSecurityConfig()
+                .setProjectId("gcp")
+                .setJsonKey("{}");
+
+        assertFullMapping(properties, expected, ImmutableSet.of("gcs.json-key-file-path"));
+    }
+
+    @Test
+    void testValidation()
+    {
+        assertFailsValidation(
+                new GoogleSecurityConfig()
+                        .setJsonKey("{}")
+                        .setJsonKeyFilePath("file.json"),
+                "authMethodValid",
+                "gcs.json-key and gcs.json-key-file-path cannot be set at the same time",
+                AssertTrue.class);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergBigLakeMetastoreConnectorSmokeTest.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg.catalog.rest;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonMapperProvider;
@@ -34,8 +35,6 @@ import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Base64;
 
 import static io.trino.testing.SystemEnvironmentUtils.requireEnv;
@@ -76,10 +75,8 @@ final class TestIcebergBigLakeMetastoreConnectorSmokeTest
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        Path gcpCredentialsFile = Files.createTempFile("gcp-credentials", ".json");
-        gcpCredentialsFile.toFile().deleteOnExit();
-        Files.write(gcpCredentialsFile, GCS_JSON_KEY_BYTES);
-        String projectId = JSON_MAPPER.readTree(GCS_JSON_KEY_BYTES).get("project_id").asText();
+        JsonNode gcsJson = JSON_MAPPER.readTree(GCS_JSON_KEY_BYTES);
+        String projectId = gcsJson.get("project_id").asText();
 
         return IcebergQueryRunner.builder(SCHEMA)
                 .addIcebergProperty("iceberg.file-format", format.name())
@@ -95,7 +92,7 @@ final class TestIcebergBigLakeMetastoreConnectorSmokeTest
                 .addIcebergProperty("iceberg.writer-sort-buffer-size", "1MB")
                 .addIcebergProperty("iceberg.allowed-extra-properties", "write.metadata.delete-after-commit.enabled,write.metadata.previous-versions-max")
                 .addIcebergProperty("fs.gcs.enabled", "true")
-                .addIcebergProperty("gcs.json-key-file-path", gcpCredentialsFile.toString())
+                .addIcebergProperty("gcs.json-key", gcsJson.toString())
                 .setSchemaInitializer(SchemaInitializer.builder()
                         .withSchemaName(SCHEMA)
                         .withClonedTpchTables(REQUIRED_TPCH_TABLES)


### PR DESCRIPTION
## Description

- Relates to https://github.com/apache/iceberg/pull/14713

## Release notes

```markdown
## Iceberg
* Support `gcs.json-key` property for Google security. ({issue}`issuenumber`)
```
