### PR TITLE
Improve memory accounting and footprint of ORC dictionary writer

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/DictionaryBuilder.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/DictionaryBuilder.java
@@ -29,7 +29,6 @@ import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.block.Bitmap.allocateWords;
-import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static it.unimi.dsi.fastutil.HashCommon.arraySize;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
@@ -44,7 +43,7 @@ public class DictionaryBuilder
     private static final float FILL_RATIO = 0.75f;
     private static final int EMPTY_SLOT = -1;
     private static final int NULL_POSITION = 0;
-    private static final int EXPECTED_BYTES_PER_ENTRY = 32;
+    private static final int INITIAL_SLICE_OUTPUT_SIZE = 64;
 
     private final IntBigArray blockPositionByHash = new IntBigArray();
 
@@ -59,11 +58,7 @@ public class DictionaryBuilder
     {
         checkArgument(expectedSize >= 0, "expectedSize must not be negative");
 
-        // todo we can do better
-        int expectedEntries = min(expectedSize, DEFAULT_MAX_PAGE_SIZE_IN_BYTES / EXPECTED_BYTES_PER_ENTRY);
-        // it is guaranteed expectedEntries * EXPECTED_BYTES_PER_ENTRY will not overflow
-        int expectedBytes = expectedEntries * EXPECTED_BYTES_PER_ENTRY;
-        sliceOutput = new DynamicSliceOutput(min(expectedBytes, MAX_ARRAY_SIZE));
+        sliceOutput = new DynamicSliceOutput(INITIAL_SLICE_OUTPUT_SIZE);
 
         int hashSize = arraySize(expectedSize, FILL_RATIO);
         this.maxFill = calculateMaxFill(hashSize);

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
@@ -82,7 +82,7 @@ public class SliceDictionaryColumnWriter
     private final ByteArrayOutputStream dictionaryDataStream;
     private final LongOutputStream dictionaryLengthStream;
 
-    private final DictionaryBuilder dictionary = new DictionaryBuilder(10000);
+    private final DictionaryBuilder dictionary = new DictionaryBuilder(1024);
 
     private final List<DictionaryRowGroup> rowGroups = new ArrayList<>();
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
@@ -540,6 +540,7 @@ public class SliceDictionaryColumnWriter
                 (directColumnWriter == null ? 0 : directColumnWriter.getRetainedBytes());
 
         for (DictionaryRowGroup rowGroup : rowGroups) {
+            retainedBytes += rowGroup.getDictionaryIndexes().sizeOf();
             retainedBytes += rowGroup.getColumnStatistics().getRetainedSizeInBytes();
         }
         return retainedBytes;

--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
@@ -55,12 +55,14 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.SizeOf.instanceSize;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.orc.DictionaryCompressionOptimizer.estimateIndexBytesPerValue;
 import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DICTIONARY_V2;
 import static io.trino.orc.metadata.CompressionKind.NONE;
 import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static io.trino.orc.stream.LongOutputStream.createLengthOutputStream;
+import static java.lang.Math.multiplyExact;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -217,35 +219,45 @@ public class SliceDictionaryColumnWriter
         for (int i = 0; valueCount > 0 && i < segments.length; i++) {
             int[] segment = segments[i];
             int positionCount = Math.min(valueCount, segment.length);
-            Block block = DictionaryBlock.create(positionCount, dictionary, segment);
-
-            while (block != null) {
-                int chunkPositionCount = block.getPositionCount();
-                Block chunk = block.getRegion(0, chunkPositionCount);
-
-                // avoid chunk with huge logical size
-                while (chunkPositionCount > 1 && chunk.getSizeInBytes() > DIRECT_CONVERSION_CHUNK_MAX_BYTES) {
-                    chunkPositionCount /= 2;
-                    chunk = chunk.getRegion(0, chunkPositionCount);
-                }
-
-                directColumnWriter.writeBlock(chunk);
-                if (directColumnWriter.getBufferedBytes() > maxDirectBytes) {
-                    return false;
-                }
-
-                // slice block to only unconverted rows
-                if (chunkPositionCount < block.getPositionCount()) {
-                    block = block.getRegion(chunkPositionCount, block.getPositionCount() - chunkPositionCount);
-                }
-                else {
-                    block = null;
-                }
+            if (!writeDictionaryRowGroup(dictionary, positionCount, segment, maxDirectBytes)) {
+                return false;
             }
-
             valueCount -= positionCount;
         }
         checkState(valueCount == 0);
+        return true;
+    }
+
+    private boolean writeDictionaryRowGroup(Block dictionary, int positionCount, int[] dictionaryIndexes, int maxDirectBytes)
+    {
+        if (positionCount == 0) {
+            return true;
+        }
+        Block block = DictionaryBlock.create(positionCount, dictionary, dictionaryIndexes);
+
+        while (block != null) {
+            int chunkPositionCount = block.getPositionCount();
+            Block chunk = block.getRegion(0, chunkPositionCount);
+
+            // avoid chunk with huge logical size
+            while (chunkPositionCount > 1 && chunk.getSizeInBytes() > DIRECT_CONVERSION_CHUNK_MAX_BYTES) {
+                chunkPositionCount /= 2;
+                chunk = chunk.getRegion(0, chunkPositionCount);
+            }
+
+            directColumnWriter.writeBlock(chunk);
+            if (directColumnWriter.getBufferedBytes() > maxDirectBytes) {
+                return false;
+            }
+
+            // slice block to only unconverted rows
+            if (chunkPositionCount < block.getPositionCount()) {
+                block = block.getRegion(chunkPositionCount, block.getPositionCount() - chunkPositionCount);
+            }
+            else {
+                block = null;
+            }
+        }
         return true;
     }
 
@@ -313,10 +325,9 @@ public class SliceDictionaryColumnWriter
         }
 
         ColumnStatistics statistics = statisticsBuilder.buildColumnStatistics();
-        rowGroups.add(new DictionaryRowGroup(values, rowGroupValueCount, statistics));
+        rowGroups.add(new DictionaryRowGroup(values, rowGroupValueCount, dictionary.getEntryCount(), statistics));
         rowGroupValueCount = 0;
         statisticsBuilder = statisticsBuilderSupplier.get();
-        values = new IntBigArray();
         return ImmutableMap.of(columnId, statistics);
     }
 
@@ -377,12 +388,12 @@ public class SliceDictionaryColumnWriter
             dataStream.recordCheckpoint();
         }
         for (DictionaryRowGroup rowGroup : rowGroups) {
-            IntBigArray dictionaryIndexes = rowGroup.getDictionaryIndexes();
+            int[] dictionaryIndexes = rowGroup.getDictionaryIndexes();
             for (int position = 0; position < rowGroup.getValueCount(); position++) {
-                presentStream.writeBoolean(dictionaryIndexes.get(position) != 0);
+                presentStream.writeBoolean(dictionaryIndexes[position] != 0);
             }
             for (int position = 0; position < rowGroup.getValueCount(); position++) {
-                int originalDictionaryIndex = dictionaryIndexes.get(position);
+                int originalDictionaryIndex = dictionaryIndexes[position];
                 // index zero in original dictionary is reserved for null
                 if (originalDictionaryIndex != 0) {
                     int sortedIndex = originalDictionaryToSortedIndex[originalDictionaryIndex];
@@ -540,8 +551,7 @@ public class SliceDictionaryColumnWriter
                 (directColumnWriter == null ? 0 : directColumnWriter.getRetainedBytes());
 
         for (DictionaryRowGroup rowGroup : rowGroups) {
-            retainedBytes += rowGroup.getDictionaryIndexes().sizeOf();
-            retainedBytes += rowGroup.getColumnStatistics().getRetainedSizeInBytes();
+            retainedBytes += rowGroup.getRetainedSizeInBytes();
         }
         return retainedBytes;
     }
@@ -573,24 +583,47 @@ public class SliceDictionaryColumnWriter
 
     private static class DictionaryRowGroup
     {
-        private final IntBigArray dictionaryIndexes;
+        private static final int INSTANCE_SIZE = instanceSize(DictionaryRowGroup.class);
+
+        // indexes are packed to the smallest byte width that fits the dictionary size at seal time
+        private final byte[] packedIndexes;
+        private final int bytesPerValue;
         private final int valueCount;
         private final ColumnStatistics columnStatistics;
 
-        public DictionaryRowGroup(IntBigArray dictionaryIndexes, int valueCount, ColumnStatistics columnStatistics)
+        public DictionaryRowGroup(IntBigArray dictionaryIndexes, int valueCount, int dictionaryEntryCount, ColumnStatistics columnStatistics)
         {
             requireNonNull(dictionaryIndexes, "dictionaryIndexes is null");
             checkArgument(valueCount >= 0, "valueCount is negative");
-            requireNonNull(columnStatistics, "columnStatistics is null");
+            checkArgument(dictionaryEntryCount >= 0, "dictionaryEntryCount is negative");
+            this.columnStatistics = requireNonNull(columnStatistics, "columnStatistics is null");
 
-            this.dictionaryIndexes = dictionaryIndexes;
+            this.bytesPerValue = estimateIndexBytesPerValue(dictionaryEntryCount);
             this.valueCount = valueCount;
-            this.columnStatistics = columnStatistics;
+            this.packedIndexes = new byte[multiplyExact(valueCount, bytesPerValue)];
+            int offset = 0;
+            for (int position = 0; position < valueCount; position++) {
+                int index = dictionaryIndexes.get(position);
+                for (int indexByte = 0; indexByte < bytesPerValue; indexByte++) {
+                    packedIndexes[offset] = (byte) (index >>> (8 * indexByte));
+                    offset++;
+                }
+            }
         }
 
-        public IntBigArray getDictionaryIndexes()
+        public int[] getDictionaryIndexes()
         {
-            return dictionaryIndexes;
+            int[] indexes = new int[valueCount];
+            int offset = 0;
+            for (int position = 0; position < valueCount; position++) {
+                int index = 0;
+                for (int indexByte = 0; indexByte < bytesPerValue; indexByte++) {
+                    index |= (packedIndexes[offset] & 0xFF) << (8 * indexByte);
+                    offset++;
+                }
+                indexes[position] = index;
+            }
+            return indexes;
         }
 
         public int getValueCount()
@@ -601,6 +634,13 @@ public class SliceDictionaryColumnWriter
         public ColumnStatistics getColumnStatistics()
         {
             return columnStatistics;
+        }
+
+        public long getRetainedSizeInBytes()
+        {
+            return INSTANCE_SIZE +
+                    sizeOf(packedIndexes) +
+                    columnStatistics.getRetainedSizeInBytes();
         }
     }
 }

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestSliceDictionaryColumnWriter.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestSliceDictionaryColumnWriter.java
@@ -45,6 +45,7 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.orc.OrcWriterOptions.DEFAULT_MAX_COMPRESSION_BUFFER_SIZE;
 import static io.trino.orc.OrcWriterOptions.DEFAULT_MAX_STRING_STATISTICS_LIMIT;
+import static io.trino.orc.metadata.ColumnEncoding.ColumnEncodingKind.DICTIONARY_V2;
 import static io.trino.orc.metadata.OrcColumnId.ROOT_COLUMN;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.Character.MAX_CODE_POINT;
@@ -74,6 +75,29 @@ public class TestSliceDictionaryColumnWriter
         writer.finishRowGroup();
 
         assertThat(writer.tryConvertToDirect(megabytes(64))).isEmpty();
+    }
+
+    @Test
+    public void testDirectConversionWithEmptyRowGroup()
+    {
+        SliceDictionaryColumnWriter writer = new SliceDictionaryColumnWriter(
+                ROOT_COLUMN,
+                VARCHAR,
+                CompressionKind.NONE,
+                toIntExact(DEFAULT_MAX_COMPRESSION_BUFFER_SIZE.toBytes()),
+                () -> new StringStatisticsBuilder(toIntExact(DEFAULT_MAX_STRING_STATISTICS_LIMIT.toBytes()), new NoOpBloomFilterBuilder()));
+
+        writer.beginRowGroup();
+        writer.finishRowGroup();
+
+        writer.beginRowGroup();
+        VariableWidthBlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, 2, 16);
+        blockBuilder.writeEntry(utf8Slice("a"));
+        blockBuilder.writeEntry(utf8Slice("b"));
+        writer.writeBlock(blockBuilder.build());
+        writer.finishRowGroup();
+
+        assertThat(writer.tryConvertToDirect(megabytes(64))).isPresent();
     }
 
     @Test
@@ -123,6 +147,55 @@ public class TestSliceDictionaryColumnWriter
             hits += contains ? 1 : 0;
         }
         assertThat((double) hits / valuesCount).isBetween(0.1, 0.115);
+    }
+
+    @Test
+    public void testHighCardinalityDictionaryRoundTrip()
+            throws Exception
+    {
+        // over 65536 dictionary entries exercises multi-byte packed row group indexes
+        // four copies per value keeps the compression ratio above the dictionary conversion threshold
+        List<String> values = new ArrayList<>();
+        for (int i = 0; i < 70_000; i++) {
+            String value = "value_" + i;
+            for (int copy = 0; copy < 4; copy++) {
+                values.add(value);
+            }
+        }
+        OrcTester.quickOrcTester().testRoundTrip(VARCHAR, values);
+    }
+
+    @Test
+    public void testPackedRowGroupIndexWidths()
+    {
+        SliceDictionaryColumnWriter writer = new SliceDictionaryColumnWriter(
+                ROOT_COLUMN,
+                VARCHAR,
+                CompressionKind.NONE,
+                toIntExact(DEFAULT_MAX_COMPRESSION_BUFFER_SIZE.toBytes()),
+                () -> new StringStatisticsBuilder(toIntExact(DEFAULT_MAX_STRING_STATISTICS_LIMIT.toBytes()), new NoOpBloomFilterBuilder()));
+
+        // dictionary reserves entry 0 for null, so 255 values seal exactly at the 256 entry boundary
+        writeDistinctValues(writer, 0, 255, 1);
+        writeDistinctValues(writer, 255, 65_280, 2);
+        writeDistinctValues(writer, 65_535, 10_000, 3);
+
+        writer.close();
+        assertThat(writer.getColumnEncodings().get(ROOT_COLUMN).getColumnEncodingKind()).isEqualTo(DICTIONARY_V2);
+    }
+
+    private static void writeDistinctValues(SliceDictionaryColumnWriter writer, int firstValue, int count, int expectedIndexBytesPerValue)
+    {
+        VariableWidthBlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, count, count * 16);
+        for (int i = firstValue; i < firstValue + count; i++) {
+            blockBuilder.writeEntry(utf8Slice("value_" + i));
+        }
+        writer.beginRowGroup();
+        writer.writeBlock(blockBuilder.build());
+        long retainedBeforeSeal = writer.getRetainedBytes();
+        writer.finishRowGroup();
+        assertThat(writer.getRetainedBytes() - retainedBeforeSeal)
+                .isGreaterThanOrEqualTo((long) count * expectedIndexBytesPerValue);
     }
 
     public static Slice createRandomUtf8Slice(int[] codePointSet, int lengthInBytes)


### PR DESCRIPTION
## Description

Root caused from an 88GB worker heap dump taken during a partitioned Iceberg ORC write with over a thousand open writers. Three fixes:

1. `SliceDictionaryColumnWriter.getRetainedBytes()` did not count the dictionary index arrays of sealed row groups. In the dump this was ~23GiB of heap invisible to memory accounting, so the writer never hit memory limits and the worker died with OOM.
2. Sealed row groups retained indexes as `IntBigArray` (4 bytes per value plus segment and spine overhead). They are now packed into a single `byte[]` at the smallest fixed byte width that fits the dictionary size, cutting retained heap up to 4x and matching the index size `DictionaryCompressionOptimizer` already assumes via `estimateIndexBytesPerValue`. The scratch `IntBigArray` is also reused across row groups instead of reallocated.
3. `DictionaryBuilder` preallocated ~440KB per column writer before seeing any data (10000 expected entries at 32 bytes each). With thousands of open partition writers this alone was a ~16GiB floor. It now starts at 1024 entries and 64 data bytes, matching the Parquet writer's `PlainBinaryDictionaryValuesWriter`, and keeps the existing adaptive resizing on reset.

## Additional context and related issues

Heap dump breakdown: 64 page sinks retained 71.45GB (81.5% of heap), 1112 open ORC writers, 38920 dictionary column writers.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg, Hive
* Fix worker crashes due to under accounting of memory usage in ORC writer. ({issue}`30771`)
```