### PR TITLE
Set Snowflake log level as WARN in Iceberg tests

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -87,6 +87,7 @@ public final class IcebergQueryRunner
     static {
         Logging logging = Logging.initialize();
         logging.setLevel("org.apache.iceberg", Level.OFF);
+        logging.setLevel("net.snowflake.client.internal.core", Level.WARN);
     }
 
     public static Builder builder()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Same as Snowflake connector:

https://github.com/trinodb/trino/blob/365fd00d3b6b0b1553960a81a709d1012eda3c2f/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/SnowflakeQueryRunner.java#L37-L40

The INFO message is too verbose:
```
2026-08-17T23:28:50.469-0600	INFO	ForkJoinPool-1-worker-5	net.snowflake.client.internal.core.SFSession	Opening session with server: https://if05012.us-east-2.aws.snowflakecomputing.com:443/, account: if05012, user: trino_snowflake_testing, password is provided, role: TRINO_SNOWFLAKE_CONNECTOR_TESTING_ROLE, database: TRINO_CONNECTOR_TEST_DATA, schema: first_schema_i30sa5n3fp, warehouse: TRINO_TESTING, validate default parameters: null, authenticator: null, ocsp mode: FAIL_OPEN, passcode in password: null, passcode is not provided, private key is not provided, disable socks proxy: null, application: null, app id: JDBC, app version: 4.3.2, login timeout: null, retry timeout: null, network timeout: null, query timeout: null, connection timeout: null, socket timeout: null, tracing: null, private key file: null, private key base 64: not provided, private key pwd is not provided, enable_diagnostics: null, diagnostics_allowlist_path: null, session parameters: client store temporary credential: null, gzip disabled: null, browser response timeout: null
```
https://github.com/trinodb/trino/actions/runs/32102605854/job/95606209475?pr=30770


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
