### PR TITLE
Fix broken DefaultDeltaLakeQueryRunnerMain

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -195,6 +195,7 @@ public final class DeltaLakeQueryRunner
                     .addCoordinatorProperty("http-server.http.port", "8080")
                     .addDeltaProperty("delta.enable-non-concurrent-writes", "true")
                     .addDeltaProperty("hive.metastore.catalog.dir", metastoreDir.toURI().toString())
+                    .addDeltaProperty("fs.hadoop.enabled", "true")
                     .setInitialTables(TpchTable.getTables())
                     .build();
 


### PR DESCRIPTION
## Description

```
2026-08-18T16:23:52.847+0900	INFO	main	io.trino.testing.DistributedQueryRunner	Created DistributedQueryRunner in 4.75s (unclosed instances = 1)
2026-08-18T16:23:53.326+0900	INFO	main	stderr	Exception in thread "main"
2026-08-18T16:23:53.326+0900	INFO	main	stderr	io.trino.testing.QueryFailedException: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: No factory for location: file:/var/folders/9s/_zwn4r_n2_9bp0krllp1pl3c0000gp/T/delta_query_runner11364300867127351625/
2026-08-18T16:23:53.326+0900	INFO	main	stderr		at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
2026-08-18T16:23:53.326+0900	INFO	main	stderr		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:597)
2026-08-18T16:23:53.326+0900	INFO	main	stderr		at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:580)
2026-08-18T16:23:53.326+0900	INFO	main	stderr		at io.trino.testing.QueryRunner.execute(QueryRunner.java:82)
2026-08-18T16:23:53.326+0900	INFO	main	stderr		at io.trino.plugin.deltalake.DeltaLakeQueryRunner$Builder.build(DeltaLakeQueryRunner.java:171)
2026-08-18T16:23:53.326+0900	INFO	main	stderr		at io.trino.plugin.deltalake.DeltaLakeQueryRunner$DefaultDeltaLakeQueryRunnerMain.main(DeltaLakeQueryRunner.java:199)
2026-08-18T16:23:53.326+0900	INFO	main	stderr		Suppressed: java.lang.Exception: SQL: CREATE SCHEMA IF NOT EXISTS tpch
2026-08-18T16:23:53.326+0900	INFO	main	stderr			at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:604)
2026-08-18T16:23:53.326+0900	INFO	main	stderr			... 4 more
...
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.