### PR TITLE
Add Web UI login migration message

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ui/LoginResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/LoginResource.java
@@ -32,12 +32,16 @@ import jakarta.ws.rs.core.SecurityContext;
 import java.util.Optional;
 
 import static com.google.common.base.Strings.emptyToNull;
+import static io.trino.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static io.trino.server.security.ResourceSecurity.AccessType.WEB_UI;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_AUTH_INFO;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_LOGIN_FORM;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_LOGOUT;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.getDeleteCookies;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.Response.Status.METHOD_NOT_ALLOWED;
 import static java.util.Objects.requireNonNull;
 
 @Path("")
@@ -46,6 +50,8 @@ import static java.util.Objects.requireNonNull;
 @Produces(APPLICATION_JSON)
 public class LoginResource
 {
+    private static final String DEPRECATED_UI_LOGIN = "/ui/login";
+
     private final FormWebUiAuthenticationFilter formWebUiAuthenticationManager;
 
     @Inject
@@ -61,6 +67,20 @@ public class LoginResource
         boolean isPasswordAllowed = formWebUiAuthenticationManager.isPasswordAllowed(securityContext.isSecure());
         Optional<String> username = formWebUiAuthenticationManager.getAuthenticatedUsername(request);
         return new AuthInfo("form", isPasswordAllowed, username.isPresent(), username);
+    }
+
+    @ResourceSecurity(PUBLIC)
+    @POST
+    @Path(DEPRECATED_UI_LOGIN)
+    @Consumes(APPLICATION_FORM_URLENCODED)
+    @Produces(TEXT_PLAIN)
+    public Response deprecatedLogin()
+    {
+        return Response.status(METHOD_NOT_ALLOWED)
+                .allow("GET", "HEAD", "OPTIONS")
+                .type(TEXT_PLAIN)
+                .entity("Web UI form login moved to POST /ui/auth/login in Trino 483. The new endpoint expects an application/json request.")
+                .build();
     }
 
     @POST

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
@@ -88,7 +88,9 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.net.HttpHeaders.ALLOW;
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.HttpHeaders.LOCATION;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_HOST;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_PORT;
@@ -112,6 +114,7 @@ import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_DISABLED;
 import static io.trino.server.ui.OAuthIdTokenCookie.ID_TOKEN_COOKIE;
 import static io.trino.server.ui.OAuthWebUiCookie.OAUTH2_COOKIE;
 import static io.trino.testing.assertions.Assert.assertEventually;
+import static jakarta.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED;
 import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static jakarta.servlet.http.HttpServletResponse.SC_SEE_OTHER;
@@ -268,6 +271,9 @@ public class TestWebUi
         testLoggedOut(httpServerInfo.getHttpUri());
         testLoggedOut(httpServerInfo.getHttpsUri());
 
+        testDeprecatedLogin(httpServerInfo.getHttpUri());
+        testDeprecatedLogin(httpServerInfo.getHttpsUri());
+
         testLogIn(httpServerInfo.getHttpUri(), username, password, false);
         testLogIn(httpServerInfo.getHttpsUri(), username, password, sendPasswordForHttps);
 
@@ -334,6 +340,30 @@ public class TestWebUi
         assertResponseCode(client, getLocation(baseUri, "/ui/api/unknown"), SC_NOT_FOUND);
         assertRedirect(client, getLogoutLocation(baseUri), getLoginHtmlLocation(baseUri), false);
         assertThat(cookieManager.getCookieStore().getCookies()).isEmpty();
+    }
+
+    private void testDeprecatedLogin(URI baseUri)
+            throws IOException
+    {
+        CookieManager cookieManager = new CookieManager();
+        OkHttpClient client = this.client.newBuilder()
+                .cookieJar(new JavaNetCookieJar(cookieManager))
+                .build();
+        Request request = new Request.Builder()
+                .url(getLocation(baseUri, "/ui/login"))
+                .post(new FormBody.Builder()
+                        .add("username", "test")
+                        .add("password", "test")
+                        .build())
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            assertThat(response.code()).isEqualTo(SC_METHOD_NOT_ALLOWED);
+            assertThat(response.header(CONTENT_TYPE)).startsWith("text/plain");
+            assertThat(response.header(ALLOW)).contains("GET", "HEAD", "OPTIONS");
+            assertThat(requireNonNull(response.body()).string())
+                    .isEqualTo("Web UI form login moved to POST /ui/auth/login in Trino 483. The new endpoint expects an application/json request.");
+            assertThat(cookieManager.getCookieStore().getCookies()).isEmpty();
+        }
     }
 
     private void testFailedLogin(URI uri, boolean passwordAllowed, String password)


### PR DESCRIPTION
## Description

Trino 483 moved Web UI form login from `POST /ui/login` to `POST /ui/auth/login`. The new endpoint expects a JSON request while `POST /ui/login` currently returns a `405 Method Not Allowed` response without explaining the change.

This PR is to keep the `405` response but include an actionable plain-text message directing clients to the new endpoint. 

The currently known affected client is Trino Gateway. Its `UI_API` cluster monitor uses the previous form login endpoint and no longer works with Trino 483 and later. The problem and the migration to `POST /ui/auth/login` are discussed in [trinodb/trino#30591](https://github.com/trinodb/trino/issues/30591).

The new response can be verified with:

```shell
curl -i \
    -X POST --data 'username=test&password=test' \
    http://localhost:8080/ui/login

HTTP/1.1 405 Method Not Allowed
Content-Type: text/plain
Allow: GET,HEAD,OPTIONS

Web UI form login moved to POST /ui/auth/login in Trino 483. The new endpoint expects an application/json request.
```

## Additional context and related issues

This does not restore the previous form login endpoint or provide a compatibility alias. Clients must migrate to the JSON login endpoint.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

## Web UI
* Return an actionable error when clients use the Web UI form login endpoint moved in Trino 483. ({issue}`30591`)