### PR TITLE
Handle negative decimal scale in Ignite connector

### DIFF
--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
@@ -230,7 +230,7 @@ public class IgniteClient
             case Types.FLOAT -> Optional.of(realColumnMapping());
             case Types.DOUBLE -> Optional.of(doubleColumnMapping());
             case Types.DECIMAL -> {
-                int decimalDigits = typeHandle.requiredDecimalDigits();
+                int decimalDigits = typeHandle.decimalDigits().orElse(0);
                 int precision = typeHandle.requiredColumnSize();
                 if (getDecimalRounding(session) == ALLOW_OVERFLOW && precision > Decimals.MAX_PRECISION) {
                     int scale = min(decimalDigits, getDecimalDefaultScale(session));

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
@@ -259,6 +259,19 @@ public class TestIgniteTypeMapping
     }
 
     @Test
+    public void testDecimalNegativeScale()
+    {
+        // Ignite supports decimal with negative scale internally. The JDBC driver
+        // reports the actual negative scale, so Trino adjusts precision accordingly:
+        // decimal(p, -s) is mapped to decimal(p+s, 0).
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(3, -1)", "CAST('10' AS decimal(3, -1))", createDecimalType(4, 0), "CAST('10' AS decimal(4, 0))")
+                .addRoundTrip("decimal(3, -1)", "CAST('0' AS decimal(3, -1))", createDecimalType(4, 0), "CAST('0' AS decimal(4, 0))")
+                .addRoundTrip("decimal(3, -2)", "CAST('100' AS decimal(3, -2))", createDecimalType(5, 0), "CAST('100' AS decimal(5, 0))")
+                .execute(getQueryRunner(), igniteCreateAndInsert("test_decimal_negative_scale"));
+    }
+
+    @Test
     public void testBinary()
     {
         binaryTest("binary")


### PR DESCRIPTION
## Description

Handle negative decimal scale in the Ignite connector. Ignite supports decimal columns with negative scale internally, and its JDBC driver reports the scale as 0 while expanding the precision: `decimal(3, -1)` is reported as `decimal(3, 0)` and `decimal(3, -2)` as `decimal(5, 0)`.

### Changes
- `IgniteClient.java`: fall back to `decimalDigits().orElse(0)` instead of `requiredDecimalDigits()` so mapping no longer fails when the driver reports a NULL scale
- `TestIgniteTypeMapping.java`: add a round-trip test pinning the driver-reported type for negative scale columns

## Additional context and related issues

- Relates to #28770
- Relates to #28418

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: