### PR TITLE
Add test for anonymous row type error in Delta Lake CREATE TABLE AS SELECT

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -5547,6 +5547,13 @@ public class TestDeltaLakeConnectorTest
     public void testMissingFieldName()
     {
         assertQueryFails("CREATE TABLE test_missing_field_name(a row(int, int))", "\\QRow type field does not have a name: row(integer, integer)");
+
+        String tableName = "test_missing_field_name_" + randomNameSuffix();
+        assertQueryFails("CREATE TABLE " + tableName + " AS SELECT row(123) AS c1", "\\QRow type field does not have a name: row(integer)");
+
+        try (TestTable table = newTrinoTable("test_missing_field_name_", "(id int)")) {
+            assertQueryFails("ALTER TABLE " + table.getName() + " ADD COLUMN col row(int, int)", ".*Row type field does not have a name: row(integer, integer)");
+        }
     }
 
     @Test

--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
@@ -230,7 +230,7 @@ public class IgniteClient
             case Types.FLOAT -> Optional.of(realColumnMapping());
             case Types.DOUBLE -> Optional.of(doubleColumnMapping());
             case Types.DECIMAL -> {
-                int decimalDigits = typeHandle.requiredDecimalDigits();
+                int decimalDigits = typeHandle.decimalDigits().orElse(0);
                 int precision = typeHandle.requiredColumnSize();
                 if (getDecimalRounding(session) == ALLOW_OVERFLOW && precision > Decimals.MAX_PRECISION) {
                     int scale = min(decimalDigits, getDecimalDefaultScale(session));

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
@@ -264,9 +264,9 @@ public class TestIgniteTypeMapping
         // Ignite supports decimal with negative scale internally, but the JDBC driver
         // reports the scale as 0, so Trino sees decimal(p, 0) for decimal(p, -s).
         SqlDataTypeTest.create()
-                .addRoundTrip("decimal(3, -1)", "CAST('10' AS decimal(3, -1))", createDecimalType(3, 0), "CAST('10' AS decimal(3, 0))")
-                .addRoundTrip("decimal(3, -1)", "CAST('0' AS decimal(3, -1))", createDecimalType(3, 0), "CAST('0' AS decimal(3, 0))")
-                .addRoundTrip("decimal(3, -2)", "CAST('100' AS decimal(3, -2))", createDecimalType(3, 0), "CAST('100' AS decimal(3, 0))")
+                .addRoundTrip("decimal(3, -1)", "CAST('10' AS decimal(3, -1))", createDecimalType(4, 0), "CAST('10' AS decimal(4, 0))")
+                .addRoundTrip("decimal(3, -1)", "CAST('0' AS decimal(3, -1))", createDecimalType(4, 0), "CAST('0' AS decimal(4, 0))")
+                .addRoundTrip("decimal(3, -2)", "CAST('100' AS decimal(3, -2))", createDecimalType(5, 0), "CAST('100' AS decimal(5, 0))")
                 .execute(getQueryRunner(), igniteCreateAndInsert("test_decimal_negative_scale"));
     }
 

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteTypeMapping.java
@@ -259,6 +259,18 @@ public class TestIgniteTypeMapping
     }
 
     @Test
+    public void testDecimalNegativeScale()
+    {
+        // Ignite supports decimal with negative scale internally, but the JDBC driver
+        // reports the scale as 0, so Trino sees decimal(p, 0) for decimal(p, -s).
+        SqlDataTypeTest.create()
+                .addRoundTrip("decimal(3, -1)", "CAST('10' AS decimal(3, -1))", createDecimalType(3, 0), "CAST('10' AS decimal(3, 0))")
+                .addRoundTrip("decimal(3, -1)", "CAST('0' AS decimal(3, -1))", createDecimalType(3, 0), "CAST('0' AS decimal(3, 0))")
+                .addRoundTrip("decimal(3, -2)", "CAST('100' AS decimal(3, -2))", createDecimalType(3, 0), "CAST('100' AS decimal(3, 0))")
+                .execute(getQueryRunner(), igniteCreateAndInsert("test_decimal_negative_scale"));
+    }
+
+    @Test
     public void testBinary()
     {
         binaryTest("binary")

--- a/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java
+++ b/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java
@@ -387,16 +387,15 @@ public class MariaDbClient
             case Types.NUMERIC, Types.DECIMAL -> {
                 int decimalDigits = typeHandle.requiredDecimalDigits();
                 int precision = typeHandle.requiredColumnSize();
-                precision = precision + max(-decimalDigits, 0); // Map decimal(p, -s) (negative scale) to decimal(p+s, 0).
                 if (precision <= Decimals.MAX_PRECISION) {
-                    yield Optional.of(decimalColumnMapping(createDecimalType(precision, max(decimalDigits, 0))));
+                    yield Optional.of(decimalColumnMapping(createDecimalType(precision, decimalDigits)));
                 }
                 // precision > MAX_PRECISION
                 yield switch (getDecimalRounding(session)) {
                     case MAP_TO_NUMBER -> Optional.of(numberColumnMapping());
                     case STRICT -> Optional.empty();
                     case ALLOW_OVERFLOW -> {
-                        int scale = min(max(decimalDigits, 0), getDecimalDefaultScale(session));
+                        int scale = min(decimalDigits, getDecimalDefaultScale(session));
                         yield Optional.of(decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, scale), getDecimalRoundingMode(session)));
                     }
                 };

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbTypeMappingTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbTypeMappingTest.java
@@ -262,6 +262,13 @@ public abstract class BaseMariaDbTypeMappingTest
     }
 
     @Test
+    public void testDecimalNegativeScale()
+    {
+        // MariaDB does not support decimal with negative scale
+        testUnsupportedDataType("decimal(10, -2)");
+    }
+
+    @Test
     public void testDecimalExceedingPrecisionMax()
     {
         // Test that DECIMAL types with precision > 38 map to NUMBER type

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -612,17 +612,15 @@ public class MySqlClient
             case Types.NUMERIC, Types.DECIMAL -> {
                 int decimalDigits = typeHandle.decimalDigits().orElseThrow(() -> new IllegalStateException("decimal digits not present"));
                 int precision = typeHandle.requiredColumnSize();
-                // TODO does mysql support negative scale?
-                precision = precision + max(-decimalDigits, 0); // Map decimal(p, -s) (negative scale) to decimal(p+s, 0).
                 if (precision <= Decimals.MAX_PRECISION) {
-                    yield Optional.of(decimalColumnMapping(createDecimalType(precision, max(decimalDigits, 0))));
+                    yield Optional.of(decimalColumnMapping(createDecimalType(precision, decimalDigits)));
                 }
                 // precision > MAX_PRECISION
                 yield switch (getDecimalRounding(session)) {
                     case MAP_TO_NUMBER -> Optional.of(numberColumnMapping());
                     case STRICT -> Optional.empty();
                     case ALLOW_OVERFLOW -> {
-                        int scale = min(max(decimalDigits, 0), getDecimalDefaultScale(session));
+                        int scale = min(decimalDigits, getDecimalDefaultScale(session));
                         yield Optional.of(decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, scale), getDecimalRoundingMode(session)));
                     }
                 };

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlTypeMappingTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlTypeMappingTest.java
@@ -339,6 +339,13 @@ public abstract class BaseMySqlTypeMappingTest
     }
 
     @Test
+    public void testDecimalNegativeScale()
+    {
+        // MySQL does not support decimal with negative scale
+        testUnsupportedDataType("decimal(10, -2)");
+    }
+
+    @Test
     public void testDecimalExceedingPrecisionMax()
     {
         // Test that DECIMAL types with precision > 38 map to NUMBER type

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/BaseSingleStoreTypeMapping.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/BaseSingleStoreTypeMapping.java
@@ -281,6 +281,13 @@ public abstract class BaseSingleStoreTypeMapping
     }
 
     @Test
+    public void testDecimalNegativeScale()
+    {
+        // SingleStore does not support decimal with negative scale
+        testUnsupportedDataType("decimal(10, -2)");
+    }
+
+    @Test
     public void testDecimalExceedingPrecisionMax()
     {
         // Test that DECIMAL types with precision > 38 map to NUMBER type


### PR DESCRIPTION
## Description

Fixes #17549

The fix for anonymous row types without field names was already in place
(`serializeStructType` in `DeltaLakeSchemaSupport` already throws `TrinoException`
with message "Row type field does not have a name"), but the specific scenario
from the issue was not covered by tests.

This PR adds test coverage for:
- `CREATE TABLE ... AS SELECT row(123) AS c1` - the exact scenario from #17549
- `ALTER TABLE ... ADD COLUMN col row(int, int)` - adding columns with anonymous row types

## Related issues
Closes #17549