### PR TITLE
Wait for ClickHouse mutations in execute test

### DIFF
--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -52,6 +52,7 @@ import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.assertions.Assert.assertEventually;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1118,10 +1119,10 @@ public class TestClickHouseConnectorTest
             assertQuery("SELECT * FROM " + schemaTableName, "VALUES (1, 10)");
 
             assertUpdate("CALL system.execute('ALTER TABLE " + schemaTableName + " UPDATE data = 100 WHERE true')");
-            assertQuery("SELECT * FROM " + schemaTableName, "VALUES (1, 100)");
+            assertEventually(() -> assertQuery("SELECT * FROM " + schemaTableName, "VALUES (1, 100)"));
 
             assertUpdate("CALL system.execute('ALTER TABLE " + schemaTableName + " DELETE WHERE true')");
-            assertQueryReturnsEmptyResult("SELECT * FROM " + schemaTableName);
+            assertEventually(() -> assertQueryReturnsEmptyResult("SELECT * FROM " + schemaTableName));
 
             assertUpdate("CALL system.execute('DROP TABLE " + schemaTableName + "')");
             assertThat(getQueryRunner().tableExists(getSession(), tableName)).isFalse();


### PR DESCRIPTION
## Description

`testExecuteProcedure` reads immediately after `CALL system.execute` of ClickHouse `ALTER TABLE ... UPDATE` and `ALTER DELETE`. Those MergeTree mutations are asynchronous, so the next `SELECT` can still see the old rows. Wait with `assertEventually` until the mutation is visible. The native ALTER SQL is unchanged.

Fixes #30787

## Additional context and related issues

Showed up on #30744 CI (`plugin/trino-clickhouse` on run 32138340060). That PR does not change ClickHouse. This wait is a separate test fix. Reviewer requested: ebyhr.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
