### PR TITLE
Fix Parquet predicate evaluation on type-widened columns

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -434,12 +434,14 @@ public class TupleDomainParquetPredicate
                     // Ignore statistics that cannot be converted exactly to DOUBLE
                     return Domain.create(ValueSet.all(type), hasNullValue);
                 }
+                double minValue = min.orElseThrow();
+                double maxValue = max.orElseThrow();
 
-                if (Double.isNaN(min.getAsDouble()) || Double.isNaN(max.getAsDouble())) {
+                if (Double.isNaN(minValue) || Double.isNaN(maxValue)) {
                     return Domain.create(ValueSet.all(type), hasNullValue);
                 }
 
-                rangesBuilder.addRangeInclusive(min.getAsDouble(), max.getAsDouble());
+                rangesBuilder.addRangeInclusive(minValue, maxValue);
             }
             return Domain.create(rangesBuilder.build(), hasNullValue);
         }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -62,6 +62,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -406,14 +407,20 @@ public class TupleDomainParquetPredicate
         if (type.equals(REAL)) {
             SortedRangeSet.Builder rangesBuilder = SortedRangeSet.builder(type, minimums.size());
             for (int i = 0; i < minimums.size(); i++) {
-                Float min = (Float) minimums.get(i);
-                Float max = (Float) maximums.get(i);
+                Optional<Float> min = toExactFloat(minimums.get(i));
+                Optional<Float> max = toExactFloat(maximums.get(i));
+                if (min.isEmpty() || max.isEmpty()) {
+                    // Ignore statistics that cannot be converted exactly to REAL
+                    return Domain.create(ValueSet.all(type), hasNullValue);
+                }
+                float minValue = min.orElseThrow();
+                float maxValue = max.orElseThrow();
 
-                if (min.isNaN() || max.isNaN()) {
+                if (Float.isNaN(minValue) || Float.isNaN(maxValue)) {
                     return Domain.create(ValueSet.all(type), hasNullValue);
                 }
 
-                rangesBuilder.addRangeInclusive((long) floatToRawIntBits(min), (long) floatToRawIntBits(max));
+                rangesBuilder.addRangeInclusive((long) floatToRawIntBits(minValue), (long) floatToRawIntBits(maxValue));
             }
             return Domain.create(rangesBuilder.build(), hasNullValue);
         }
@@ -421,14 +428,18 @@ public class TupleDomainParquetPredicate
         if (type.equals(DOUBLE)) {
             SortedRangeSet.Builder rangesBuilder = SortedRangeSet.builder(type, minimums.size());
             for (int i = 0; i < minimums.size(); i++) {
-                double min = asDouble(minimums.get(i));
-                double max = asDouble(maximums.get(i));
-
-                if (Double.isNaN(min) || Double.isNaN(max)) {
+                OptionalDouble min = toExactDouble(minimums.get(i));
+                OptionalDouble max = toExactDouble(maximums.get(i));
+                if (min.isEmpty() || max.isEmpty()) {
+                    // Ignore statistics that cannot be converted exactly to DOUBLE
                     return Domain.create(ValueSet.all(type), hasNullValue);
                 }
 
-                rangesBuilder.addRangeInclusive(min, max);
+                if (Double.isNaN(min.getAsDouble()) || Double.isNaN(max.getAsDouble())) {
+                    return Domain.create(ValueSet.all(type), hasNullValue);
+                }
+
+                rangesBuilder.addRangeInclusive(min.getAsDouble(), max.getAsDouble());
             }
             return Domain.create(rangesBuilder.build(), hasNullValue);
         }
@@ -692,11 +703,51 @@ public class TupleDomainParquetPredicate
 
     public static double asDouble(Object value)
     {
-        if (value instanceof Float || value instanceof Double) {
-            return ((Number) value).doubleValue();
-        }
+        return toExactDouble(value).orElseThrow(() -> new IllegalArgumentException("Can't convert value to double: " + value.getClass().getName()));
+    }
 
-        throw new IllegalArgumentException("Can't convert value to double: " + value.getClass().getName());
+    /**
+     * Convert a Parquet statistics value to {@code double} when the conversion is exact and order-preserving.
+     * FLOAT and INT32 always convert; INT64 converts only when the value fits in a double mantissa.
+     */
+    private static OptionalDouble toExactDouble(Object value)
+    {
+        if (value instanceof Double doubleValue) {
+            return OptionalDouble.of(doubleValue);
+        }
+        if (value instanceof Float floatValue) {
+            return OptionalDouble.of(floatValue.doubleValue());
+        }
+        if (value instanceof Byte || value instanceof Short || value instanceof Integer) {
+            return OptionalDouble.of(((Number) value).doubleValue());
+        }
+        if (value instanceof Long longValue) {
+            double converted = longValue.doubleValue();
+            if ((long) converted == longValue) {
+                return OptionalDouble.of(converted);
+            }
+            return OptionalDouble.empty();
+        }
+        return OptionalDouble.empty();
+    }
+
+    /**
+     * Convert a Parquet statistics value to {@code float} when the conversion is exact.
+     * FLOAT converts directly; DOUBLE converts only when the value is representable in float.
+     */
+    private static Optional<Float> toExactFloat(Object value)
+    {
+        if (value instanceof Float floatValue) {
+            return Optional.of(floatValue);
+        }
+        if (value instanceof Double doubleValue) {
+            float converted = doubleValue.floatValue();
+            if (Double.isNaN(doubleValue) || (double) converted == doubleValue) {
+                return Optional.of(converted);
+            }
+            return Optional.empty();
+        }
+        return Optional.empty();
     }
 
     /**
@@ -753,10 +804,21 @@ public class TupleDomainParquetPredicate
                 }
                 return false;
             }
+            if (sqlType == DOUBLE) {
+                return checkIntegerBloomFilter(((Double) predicateValue).doubleValue(), bloomFilter);
+            }
         }
         else if (primitiveTypeName == PrimitiveType.PrimitiveTypeName.INT64) {
             if (sqlType == BIGINT || sqlType == INTEGER || sqlType == SMALLINT || sqlType == TINYINT || sqlType == DATE) {
                 return bloomFilter.findHash(bloomFilter.hash(((Number) predicateValue).longValue()));
+            }
+            if (sqlType == DOUBLE) {
+                double doubleValue = ((Double) predicateValue).doubleValue();
+                long longValue = (long) doubleValue;
+                if ((double) longValue == doubleValue) {
+                    return bloomFilter.findHash(bloomFilter.hash(longValue));
+                }
+                return false;
             }
         }
         else {
@@ -782,6 +844,15 @@ public class TupleDomainParquetPredicate
         }
 
         return true;
+    }
+
+    private static boolean checkIntegerBloomFilter(double doubleValue, BloomFilter bloomFilter)
+    {
+        long longValue = (long) doubleValue;
+        if ((double) longValue != doubleValue || longValue < Integer.MIN_VALUE || longValue > Integer.MAX_VALUE) {
+            return false;
+        }
+        return bloomFilter.findHash(bloomFilter.hash((int) longValue));
     }
 
     private static Optional<Collection<Object>> extractDiscreteValues(int domainCompactionThreshold, ValueSet valueSet)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -269,7 +269,7 @@ public class TupleDomainParquetPredicate
                 continue;
             }
             BloomFilter bloomFilter = bloomFilterOptional.get();
-            if (discreteValues.get().stream().noneMatch(value -> checkInBloomFilter(bloomFilter, value, effectivePredicateDomain.getType()))) {
+            if (discreteValues.get().stream().noneMatch(value -> checkInBloomFilter(bloomFilter, value, effectivePredicateDomain.getType(), column.getPrimitiveType()))) {
                 return false;
             }
         }
@@ -421,10 +421,10 @@ public class TupleDomainParquetPredicate
         if (type.equals(DOUBLE)) {
             SortedRangeSet.Builder rangesBuilder = SortedRangeSet.builder(type, minimums.size());
             for (int i = 0; i < minimums.size(); i++) {
-                Double min = (Double) minimums.get(i);
-                Double max = (Double) maximums.get(i);
+                double min = asDouble(minimums.get(i));
+                double max = asDouble(maximums.get(i));
 
-                if (min.isNaN() || max.isNaN()) {
+                if (Double.isNaN(min) || Double.isNaN(max)) {
                     return Domain.create(ValueSet.all(type), hasNullValue);
                 }
 
@@ -690,6 +690,15 @@ public class TupleDomainParquetPredicate
         throw new IllegalArgumentException("Can't convert value to long: " + value.getClass().getName());
     }
 
+    public static double asDouble(Object value)
+    {
+        if (value instanceof Float || value instanceof Double) {
+            return ((Number) value).doubleValue();
+        }
+
+        throw new IllegalArgumentException("Can't convert value to double: " + value.getClass().getName());
+    }
+
     /**
      * Check if the predicateValue might be in the bloomfilter
      *
@@ -701,20 +710,71 @@ public class TupleDomainParquetPredicate
     @VisibleForTesting
     public static boolean checkInBloomFilter(BloomFilter bloomFilter, Object predicateValue, Type sqlType)
     {
+        return checkInBloomFilter(bloomFilter, predicateValue, sqlType, null);
+    }
+
+    @VisibleForTesting
+    public static boolean checkInBloomFilter(BloomFilter bloomFilter, Object predicateValue, Type sqlType, PrimitiveType primitiveType)
+    {
         // TODO: Support TIMESTAMP, CHAR and DECIMAL
-        if (sqlType == TINYINT || sqlType == SMALLINT || sqlType == INTEGER || sqlType == DATE) {
-            return bloomFilter.findHash(bloomFilter.hash(toIntExact(((Number) predicateValue).longValue())));
+        PrimitiveType.PrimitiveTypeName primitiveTypeName = primitiveType != null ? primitiveType.getPrimitiveTypeName() : null;
+
+        if (primitiveTypeName == PrimitiveType.PrimitiveTypeName.FLOAT) {
+            if (sqlType == REAL) {
+                return bloomFilter.findHash(bloomFilter.hash(intBitsToFloat(toIntExact(((Number) predicateValue).longValue()))));
+            }
+            if (sqlType == DOUBLE) {
+                double doubleValue = ((Double) predicateValue).doubleValue();
+                float floatValue = (float) doubleValue;
+                if ((double) floatValue == doubleValue) {
+                    return bloomFilter.findHash(bloomFilter.hash(floatValue));
+                }
+                return false;
+            }
         }
-        if (sqlType == BIGINT) {
-            return bloomFilter.findHash(bloomFilter.hash(((Number) predicateValue).longValue()));
+        else if (primitiveTypeName == PrimitiveType.PrimitiveTypeName.DOUBLE) {
+            if (sqlType == DOUBLE) {
+                return bloomFilter.findHash(bloomFilter.hash(((Double) predicateValue).doubleValue()));
+            }
+            if (sqlType == REAL) {
+                float floatValue = intBitsToFloat(toIntExact(((Number) predicateValue).longValue()));
+                return bloomFilter.findHash(bloomFilter.hash((double) floatValue));
+            }
         }
-        else if (sqlType == DOUBLE) {
-            return bloomFilter.findHash(bloomFilter.hash(((Double) predicateValue).doubleValue()));
+        else if (primitiveTypeName == PrimitiveType.PrimitiveTypeName.INT32) {
+            if (sqlType == TINYINT || sqlType == SMALLINT || sqlType == INTEGER || sqlType == DATE) {
+                return bloomFilter.findHash(bloomFilter.hash(toIntExact(((Number) predicateValue).longValue())));
+            }
+            if (sqlType == BIGINT) {
+                long longValue = ((Number) predicateValue).longValue();
+                int intValue = (int) longValue;
+                if ((long) intValue == longValue) {
+                    return bloomFilter.findHash(bloomFilter.hash(intValue));
+                }
+                return false;
+            }
         }
-        else if (sqlType == REAL) {
-            return bloomFilter.findHash(bloomFilter.hash(intBitsToFloat(toIntExact(((Number) predicateValue).longValue()))));
+        else if (primitiveTypeName == PrimitiveType.PrimitiveTypeName.INT64) {
+            if (sqlType == BIGINT || sqlType == INTEGER || sqlType == SMALLINT || sqlType == TINYINT || sqlType == DATE) {
+                return bloomFilter.findHash(bloomFilter.hash(((Number) predicateValue).longValue()));
+            }
         }
-        else if (sqlType instanceof VarcharType || sqlType instanceof VarbinaryType) {
+        else {
+            if (sqlType == TINYINT || sqlType == SMALLINT || sqlType == INTEGER || sqlType == DATE) {
+                return bloomFilter.findHash(bloomFilter.hash(toIntExact(((Number) predicateValue).longValue())));
+            }
+            if (sqlType == BIGINT) {
+                return bloomFilter.findHash(bloomFilter.hash(((Number) predicateValue).longValue()));
+            }
+            else if (sqlType == DOUBLE) {
+                return bloomFilter.findHash(bloomFilter.hash(((Double) predicateValue).doubleValue()));
+            }
+            else if (sqlType == REAL) {
+                return bloomFilter.findHash(bloomFilter.hash(intBitsToFloat(toIntExact(((Number) predicateValue).longValue()))));
+            }
+        }
+
+        if (sqlType instanceof VarcharType || sqlType instanceof VarbinaryType) {
             return bloomFilter.findHash(bloomFilter.hash(Binary.fromConstantByteBuffer(((Slice) predicateValue).toByteBuffer())));
         }
         else if (sqlType instanceof UuidType) {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -701,11 +701,6 @@ public class TupleDomainParquetPredicate
         throw new IllegalArgumentException("Can't convert value to long: " + value.getClass().getName());
     }
 
-    public static double asDouble(Object value)
-    {
-        return toExactDouble(value).orElseThrow(() -> new IllegalArgumentException("Can't convert value to double: " + value.getClass().getName()));
-    }
-
     /**
      * Convert a Parquet statistics value to {@code double} when the conversion is exact and order-preserving.
      * FLOAT and INT32 always convert; INT64 converts only when the value fits in a double mantissa.

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
@@ -40,6 +40,7 @@ import org.apache.parquet.column.statistics.FloatStatistics;
 import org.apache.parquet.column.statistics.IntStatistics;
 import org.apache.parquet.column.statistics.LongStatistics;
 import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.column.values.bloomfilter.BlockSplitBloomFilter;
 import org.apache.parquet.internal.column.columnindex.BoundaryOrder;
 import org.apache.parquet.internal.column.columnindex.ColumnIndex;
 import org.apache.parquet.internal.column.columnindex.ColumnIndexBuilder;
@@ -495,6 +496,63 @@ public class TestTupleDomainParquetPredicate
         assertThatExceptionOfType(ParquetCorruptionException.class)
                 .isThrownBy(() -> getDomain(columnDescriptor, REAL, 10, floatColumnStats(maximum, minimum), ID, UTC))
                 .withMessage("Malformed Parquet file. Corrupted statistics for column \"[] required float FloatColumn\": [min: 40.3, max: 4.3, num_nulls: 0] [testFile]");
+    }
+
+    @Test
+    public void testFloatWidenedToDouble()
+            throws Exception
+    {
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(FLOAT, "FloatColumn");
+        assertThat(getDomain(columnDescriptor, DOUBLE, 0, null, ID, UTC)).isEqualTo(all(DOUBLE));
+
+        float minimum = 4.3f;
+        float maximum = 40.3f;
+
+        assertThat(getDomain(columnDescriptor, DOUBLE, 10, floatColumnStats(minimum, minimum), ID, UTC))
+                .isEqualTo(singleValue(DOUBLE, (double) minimum));
+
+        assertThat(getDomain(columnDescriptor, DOUBLE, 10, floatColumnStats(minimum, maximum), ID, UTC))
+                .isEqualTo(create(ValueSet.ofRanges(range(DOUBLE, (double) minimum, true, (double) maximum, true)), false));
+
+        assertThat(getDomain(columnDescriptor, DOUBLE, 10, floatColumnStats(NaN, NaN), ID, UTC)).isEqualTo(notNull(DOUBLE));
+        assertThat(getDomain(columnDescriptor, DOUBLE, 10, floatColumnStats(NaN, NaN, true), ID, UTC)).isEqualTo(all(DOUBLE));
+        assertThat(getDomain(DOUBLE, floatDictionaryDescriptor(NaN))).isEqualTo(all(DOUBLE));
+        assertThat(getDomain(DOUBLE, floatDictionaryDescriptor(minimum, NaN))).isEqualTo(all(DOUBLE));
+
+        // fail on corrupted statistics
+        assertThatExceptionOfType(ParquetCorruptionException.class)
+                .isThrownBy(() -> getDomain(columnDescriptor, DOUBLE, 10, floatColumnStats(maximum, minimum), ID, UTC))
+                .withMessage("Malformed Parquet file. Corrupted statistics for column \"[] required float FloatColumn\": [min: 40.3, max: 4.3, num_nulls: 0] [testFile]");
+    }
+
+    @Test
+    public void testBloomFilterTypeWidening()
+    {
+        BlockSplitBloomFilter floatBloomFilter = new BlockSplitBloomFilter(1024);
+        floatBloomFilter.insertHash(floatBloomFilter.hash(1.5f));
+        floatBloomFilter.insertHash(floatBloomFilter.hash(42.0f));
+
+        PrimitiveType floatPrimitive = Types.optional(FLOAT).named("col");
+
+        // When queried as DOUBLE
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(floatBloomFilter, 1.5d, DOUBLE, floatPrimitive)).isTrue();
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(floatBloomFilter, 42.0d, DOUBLE, floatPrimitive)).isTrue();
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(floatBloomFilter, 100.0d, DOUBLE, floatPrimitive)).isFalse();
+        // A double value not representable as float exactly
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(floatBloomFilter, 1.50000000001d, DOUBLE, floatPrimitive)).isFalse();
+
+        // When queried as REAL
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(floatBloomFilter, (long) floatToRawIntBits(1.5f), REAL, floatPrimitive)).isTrue();
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(floatBloomFilter, (long) floatToRawIntBits(99.0f), REAL, floatPrimitive)).isFalse();
+
+        // INT32 widened to BIGINT
+        BlockSplitBloomFilter intBloomFilter = new BlockSplitBloomFilter(1024);
+        intBloomFilter.insertHash(intBloomFilter.hash(123));
+
+        PrimitiveType intPrimitive = Types.optional(INT32).named("int_col");
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(intBloomFilter, 123L, BIGINT, intPrimitive)).isTrue();
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(intBloomFilter, 456L, BIGINT, intPrimitive)).isFalse();
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(intBloomFilter, 1000000000000L, BIGINT, intPrimitive)).isFalse();
     }
 
     @Test

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
@@ -553,6 +553,57 @@ public class TestTupleDomainParquetPredicate
         assertThat(TupleDomainParquetPredicate.checkInBloomFilter(intBloomFilter, 123L, BIGINT, intPrimitive)).isTrue();
         assertThat(TupleDomainParquetPredicate.checkInBloomFilter(intBloomFilter, 456L, BIGINT, intPrimitive)).isFalse();
         assertThat(TupleDomainParquetPredicate.checkInBloomFilter(intBloomFilter, 1000000000000L, BIGINT, intPrimitive)).isFalse();
+
+        // INT32 widened to DOUBLE (Hive integer → double coercion)
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(intBloomFilter, 123.0d, DOUBLE, intPrimitive)).isTrue();
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(intBloomFilter, 123.5d, DOUBLE, intPrimitive)).isFalse();
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(intBloomFilter, 456.0d, DOUBLE, intPrimitive)).isFalse();
+    }
+
+    @Test
+    public void testIntegerWidenedToDouble()
+            throws Exception
+    {
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(INT32, "IntColumn");
+        assertThat(getDomain(columnDescriptor, DOUBLE, 10, intColumnStats(1, 100), ID, UTC))
+                .isEqualTo(create(ValueSet.ofRanges(range(DOUBLE, 1.0d, true, 100.0d, true)), false));
+
+        ColumnIndex columnIndex = ColumnIndexBuilder.build(
+                Types.required(INT32).named("test_int32"),
+                BoundaryOrder.UNORDERED,
+                asList(false),
+                asList(0L),
+                toIntByteBufferList(1),
+                toIntByteBufferList(100));
+        ColumnDescriptor column = new ColumnDescriptor(new String[] {"c"}, Types.optional(INT32).named("c"), 0, 0);
+        assertThat(getDomain(DOUBLE, 10, columnIndex, ID, column, UTC))
+                .isEqualTo(create(ValueSet.ofRanges(range(DOUBLE, 1.0d, true, 100.0d, true)), false));
+    }
+
+    @Test
+    public void testFloatColumnIndexWidenedToDouble()
+            throws Exception
+    {
+        ColumnIndex columnIndex = ColumnIndexBuilder.build(
+                Types.required(FLOAT).named("test_float"),
+                BoundaryOrder.UNORDERED,
+                asList(false),
+                asList(0L),
+                toFloatByteBufferList(1.5f),
+                toFloatByteBufferList(2.5f));
+        ColumnDescriptor column = new ColumnDescriptor(new String[] {"c"}, Types.optional(FLOAT).named("c"), 0, 0);
+        assertThat(getDomain(DOUBLE, 10, columnIndex, ID, column, UTC))
+                .isEqualTo(create(ValueSet.ofRanges(range(DOUBLE, (double) 1.5f, true, (double) 2.5f, true)), false));
+    }
+
+    @Test
+    public void testInexactLongStatisticsIgnoredForDouble()
+            throws Exception
+    {
+        ColumnDescriptor columnDescriptor = createColumnDescriptor(INT64, "LongColumn");
+        long inexact = (1L << 53) + 1;
+        assertThat(getDomain(columnDescriptor, DOUBLE, 10, longColumnStats(inexact, inexact), ID, UTC))
+                .isEqualTo(notNull(DOUBLE));
     }
 
     @Test
@@ -1009,6 +1060,24 @@ public class TestTupleDomainParquetPredicate
             else {
                 buffers.add(ByteBuffer.wrap(BytesUtils.longToBytes(value)));
             }
+        }
+        return buffers;
+    }
+
+    private static List<ByteBuffer> toIntByteBufferList(Integer... values)
+    {
+        List<ByteBuffer> buffers = new ArrayList<>(values.length);
+        for (Integer value : values) {
+            buffers.add(ByteBuffer.wrap(BytesUtils.intToBytes(value)));
+        }
+        return buffers;
+    }
+
+    private static List<ByteBuffer> toFloatByteBufferList(Float... values)
+    {
+        List<ByteBuffer> buffers = new ArrayList<>(values.length);
+        for (Float value : values) {
+            buffers.add(ByteBuffer.wrap(BytesUtils.intToBytes(Float.floatToIntBits(value))));
         }
         return buffers;
     }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
@@ -558,6 +558,13 @@ public class TestTupleDomainParquetPredicate
         assertThat(TupleDomainParquetPredicate.checkInBloomFilter(intBloomFilter, 123.0d, DOUBLE, intPrimitive)).isTrue();
         assertThat(TupleDomainParquetPredicate.checkInBloomFilter(intBloomFilter, 123.5d, DOUBLE, intPrimitive)).isFalse();
         assertThat(TupleDomainParquetPredicate.checkInBloomFilter(intBloomFilter, 456.0d, DOUBLE, intPrimitive)).isFalse();
+
+        BlockSplitBloomFilter longBloomFilter = new BlockSplitBloomFilter(1024);
+        longBloomFilter.insertHash(longBloomFilter.hash(123L));
+        PrimitiveType longPrimitive = Types.optional(INT64).named("long_col");
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(longBloomFilter, 123.0d, DOUBLE, longPrimitive)).isTrue();
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(longBloomFilter, 123.5d, DOUBLE, longPrimitive)).isFalse();
+        assertThat(TupleDomainParquetPredicate.checkInBloomFilter(longBloomFilter, 456.0d, DOUBLE, longPrimitive)).isFalse();
     }
 
     @Test

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetTypeWidenedPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetTypeWidenedPredicate.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.parquet.ParquetDataSource;
+import io.trino.parquet.ParquetReaderOptions;
+import io.trino.parquet.metadata.ParquetMetadata;
+import io.trino.parquet.writer.ParquetWriterOptions;
+import io.trino.spi.Page;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.parquet.ParquetTestUtils.createParquetReader;
+import static io.trino.parquet.ParquetTestUtils.writeParquetFile;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static java.lang.Float.floatToRawIntBits;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestParquetTypeWidenedPredicate
+{
+    @Test
+    public void testFloatFileQueriedAsDouble()
+            throws IOException
+    {
+        List<String> columnNames = ImmutableList.of("c");
+        BlockBuilder realValues = REAL.createFixedSizeBlockBuilder(2);
+        REAL.writeLong(realValues, floatToRawIntBits(1.5f));
+        REAL.writeLong(realValues, floatToRawIntBits(2.5f));
+
+        ParquetDataSource dataSource = new TestingParquetDataSource(
+                writeParquetFile(
+                        ParquetWriterOptions.builder().build(),
+                        ImmutableList.of(REAL),
+                        columnNames,
+                        ImmutableList.of(new Page(2, realValues.build()))),
+                ParquetReaderOptions.defaultOptions());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+
+        assertThat(readMatchingRows(dataSource, parquetMetadata, DOUBLE, columnNames, Domain.singleValue(DOUBLE, 1.5d)))
+                .containsExactly(1.5d);
+        assertThat(readMatchingRows(dataSource, parquetMetadata, DOUBLE, columnNames, Domain.singleValue(DOUBLE, 9.9d)))
+                .isEmpty();
+    }
+
+    @Test
+    public void testInt32FileQueriedAsBigint()
+            throws IOException
+    {
+        List<String> columnNames = ImmutableList.of("c");
+        BlockBuilder intValues = INTEGER.createFixedSizeBlockBuilder(2);
+        INTEGER.writeLong(intValues, 123);
+        INTEGER.writeLong(intValues, 456);
+
+        ParquetDataSource dataSource = new TestingParquetDataSource(
+                writeParquetFile(
+                        ParquetWriterOptions.builder().build(),
+                        ImmutableList.of(INTEGER),
+                        columnNames,
+                        ImmutableList.of(new Page(2, intValues.build()))),
+                ParquetReaderOptions.defaultOptions());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+
+        assertThat(readMatchingLongs(dataSource, parquetMetadata, BIGINT, columnNames, Domain.singleValue(BIGINT, 123L)))
+                .containsExactly(123L);
+        assertThat(readMatchingLongs(dataSource, parquetMetadata, BIGINT, columnNames, Domain.singleValue(BIGINT, 999L)))
+                .isEmpty();
+    }
+
+    @Test
+    public void testFloatBloomFilterQueriedAsDouble()
+            throws IOException
+    {
+        List<String> columnNames = ImmutableList.of("c");
+        BlockBuilder first = REAL.createFixedSizeBlockBuilder(1);
+        REAL.writeLong(first, floatToRawIntBits(1.5f));
+        BlockBuilder second = REAL.createFixedSizeBlockBuilder(1);
+        REAL.writeLong(second, floatToRawIntBits(2.5f));
+
+        ParquetDataSource dataSource = new TestingParquetDataSource(
+                writeParquetFile(
+                        ParquetWriterOptions.builder()
+                                .setMaxRowGroupRowCount(1)
+                                .setBloomFilterColumns(ImmutableSet.copyOf(columnNames))
+                                .build(),
+                        ImmutableList.of(REAL),
+                        columnNames,
+                        ImmutableList.of(new Page(1, first.build()), new Page(1, second.build()))),
+                ParquetReaderOptions.defaultOptions());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        assertThat(parquetMetadata.getBlocks()).hasSize(2);
+
+        ParquetReaderOptions bloomOptions = ParquetReaderOptions.builder().withBloomFilter(true).build();
+        assertThat(readMatchingRows(dataSource, parquetMetadata, bloomOptions, DOUBLE, columnNames, Domain.singleValue(DOUBLE, 1.5d)))
+                .containsExactly(1.5d);
+        assertThat(readMatchingRows(dataSource, parquetMetadata, bloomOptions, DOUBLE, columnNames, Domain.singleValue(DOUBLE, 9.9d)))
+                .isEmpty();
+    }
+
+    private static List<Double> readMatchingRows(
+            ParquetDataSource dataSource,
+            ParquetMetadata parquetMetadata,
+            Type readType,
+            List<String> columnNames,
+            Domain predicate)
+            throws IOException
+    {
+        return readMatchingRows(dataSource, parquetMetadata, ParquetReaderOptions.defaultOptions(), readType, columnNames, predicate);
+    }
+
+    private static List<Double> readMatchingRows(
+            ParquetDataSource dataSource,
+            ParquetMetadata parquetMetadata,
+            ParquetReaderOptions options,
+            Type readType,
+            List<String> columnNames,
+            Domain predicate)
+            throws IOException
+    {
+        TupleDomain<String> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of("c", predicate));
+        List<Double> values = new ArrayList<>();
+        try (ParquetReader reader = createParquetReader(
+                dataSource,
+                parquetMetadata,
+                options,
+                newSimpleAggregatedMemoryContext(),
+                ImmutableList.of(readType),
+                columnNames,
+                tupleDomain)) {
+            SourcePage page = reader.nextPage();
+            while (page != null) {
+                for (int i = 0; i < page.getPositionCount(); i++) {
+                    values.add(DOUBLE.getDouble(page.getBlock(0), i));
+                }
+                page = reader.nextPage();
+            }
+        }
+        return values;
+    }
+
+    private static List<Long> readMatchingLongs(
+            ParquetDataSource dataSource,
+            ParquetMetadata parquetMetadata,
+            Type readType,
+            List<String> columnNames,
+            Domain predicate)
+            throws IOException
+    {
+        TupleDomain<String> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of("c", predicate));
+        List<Long> values = new ArrayList<>();
+        try (ParquetReader reader = createParquetReader(
+                dataSource,
+                parquetMetadata,
+                ParquetReaderOptions.defaultOptions(),
+                newSimpleAggregatedMemoryContext(),
+                ImmutableList.of(readType),
+                columnNames,
+                tupleDomain)) {
+            SourcePage page = reader.nextPage();
+            while (page != null) {
+                for (int i = 0; i < page.getPositionCount(); i++) {
+                    values.add(BIGINT.getLong(page.getBlock(0), i));
+                }
+                page = reader.nextPage();
+            }
+        }
+        return values;
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetTypeWidenedPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetTypeWidenedPredicate.java
@@ -50,18 +50,22 @@ public class TestParquetTypeWidenedPredicate
             throws IOException
     {
         List<String> columnNames = ImmutableList.of("c");
-        BlockBuilder realValues = REAL.createFixedSizeBlockBuilder(2);
-        REAL.writeLong(realValues, floatToRawIntBits(1.5f));
-        REAL.writeLong(realValues, floatToRawIntBits(2.5f));
+        BlockBuilder first = REAL.createFixedSizeBlockBuilder(1);
+        REAL.writeLong(first, floatToRawIntBits(1.5f));
+        BlockBuilder second = REAL.createFixedSizeBlockBuilder(1);
+        REAL.writeLong(second, floatToRawIntBits(2.5f));
 
         ParquetDataSource dataSource = new TestingParquetDataSource(
                 writeParquetFile(
-                        ParquetWriterOptions.builder().build(),
+                        ParquetWriterOptions.builder()
+                                .setMaxRowGroupRowCount(1)
+                                .build(),
                         ImmutableList.of(REAL),
                         columnNames,
-                        ImmutableList.of(new Page(2, realValues.build()))),
+                        ImmutableList.of(new Page(1, first.build()), new Page(1, second.build()))),
                 ParquetReaderOptions.defaultOptions());
         ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        assertThat(parquetMetadata.getBlocks()).hasSize(2);
 
         assertThat(readMatchingRows(dataSource, parquetMetadata, DOUBLE, columnNames, Domain.singleValue(DOUBLE, 1.5d)))
                 .containsExactly(1.5d);
@@ -74,18 +78,22 @@ public class TestParquetTypeWidenedPredicate
             throws IOException
     {
         List<String> columnNames = ImmutableList.of("c");
-        BlockBuilder intValues = INTEGER.createFixedSizeBlockBuilder(2);
-        INTEGER.writeLong(intValues, 123);
-        INTEGER.writeLong(intValues, 456);
+        BlockBuilder first = INTEGER.createFixedSizeBlockBuilder(1);
+        INTEGER.writeLong(first, 123);
+        BlockBuilder second = INTEGER.createFixedSizeBlockBuilder(1);
+        INTEGER.writeLong(second, 456);
 
         ParquetDataSource dataSource = new TestingParquetDataSource(
                 writeParquetFile(
-                        ParquetWriterOptions.builder().build(),
+                        ParquetWriterOptions.builder()
+                                .setMaxRowGroupRowCount(1)
+                                .build(),
                         ImmutableList.of(INTEGER),
                         columnNames,
-                        ImmutableList.of(new Page(2, intValues.build()))),
+                        ImmutableList.of(new Page(1, first.build()), new Page(1, second.build()))),
                 ParquetReaderOptions.defaultOptions());
         ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        assertThat(parquetMetadata.getBlocks()).hasSize(2);
 
         assertThat(readMatchingLongs(dataSource, parquetMetadata, BIGINT, columnNames, Domain.singleValue(BIGINT, 123L)))
                 .containsExactly(123L);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestHiveParquetTypeWidenedPredicate.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestHiveParquetTypeWidenedPredicate.java
@@ -60,7 +60,7 @@ public class TestHiveParquetTypeWidenedPredicate
     {
         String source = "source_int_double_" + randomNameSuffix();
         String widened = "widened_int_double_" + randomNameSuffix();
-        assertUpdate("CREATE TABLE " + source + " (c integer) WITH (format = 'PARQUET')");
+        assertUpdate("CREATE TABLE " + source + " (c integer) WITH (format = 'PARQUET', parquet_bloom_filter_columns = ARRAY['c'])");
         try {
             assertUpdate("INSERT INTO " + source + " VALUES 1, 2", 2);
             String location = (String) computeScalar("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*$', '') FROM " + source);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestHiveParquetTypeWidenedPredicate.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestHiveParquetTypeWidenedPredicate.java
@@ -101,4 +101,28 @@ public class TestHiveParquetTypeWidenedPredicate
             assertUpdate("DROP TABLE IF EXISTS " + source);
         }
     }
+
+    @Test
+    public void testPredicateOnBigintColumnWidenedToDouble()
+    {
+        String source = "source_bigint_double_" + randomNameSuffix();
+        String widened = "widened_bigint_double_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + source + " (c bigint) WITH (format = 'PARQUET', parquet_bloom_filter_columns = ARRAY['c'])");
+        try {
+            assertUpdate("INSERT INTO " + source + " VALUES BIGINT '1', BIGINT '2'", 2);
+            String location = (String) computeScalar("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*$', '') FROM " + source);
+            assertUpdate(format("CREATE TABLE %s (c double) WITH (format = 'PARQUET', external_location = '%s')", widened, location));
+            try {
+                assertQuery("SELECT count(*) FROM " + widened, "VALUES 2");
+                assertQuery("SELECT count(*) FROM " + widened + " WHERE c = DOUBLE '1'", "VALUES 1");
+                assertQuery("SELECT count(*) FROM " + widened + " WHERE c = DOUBLE '9'", "VALUES 0");
+            }
+            finally {
+                assertUpdate("DROP TABLE IF EXISTS " + widened);
+            }
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + source);
+        }
+    }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestHiveParquetTypeWidenedPredicate.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestHiveParquetTypeWidenedPredicate.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.parquet;
+
+import io.trino.plugin.hive.HiveQueryRunner;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
+
+public class TestHiveParquetTypeWidenedPredicate
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.builder().build();
+    }
+
+    @Test
+    public void testPredicateOnFloatColumnWidenedToDouble()
+    {
+        String source = "source_float_" + randomNameSuffix();
+        String widened = "widened_double_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + source + " (c real) WITH (format = 'PARQUET')");
+        try {
+            assertUpdate("INSERT INTO " + source + " VALUES REAL '1.5', REAL '2.5'", 2);
+            String location = (String) computeScalar("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*$', '') FROM " + source);
+            assertUpdate(format("CREATE TABLE %s (c double) WITH (format = 'PARQUET', external_location = '%s')", widened, location));
+            try {
+                assertQuery("SELECT count(*) FROM " + widened, "VALUES 2");
+                assertQuery("SELECT count(*) FROM " + widened + " WHERE c = DOUBLE '1.5'", "VALUES 1");
+                assertQuery("SELECT count(*) FROM " + widened + " WHERE c = DOUBLE '9.9'", "VALUES 0");
+            }
+            finally {
+                assertUpdate("DROP TABLE IF EXISTS " + widened);
+            }
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + source);
+        }
+    }
+
+    @Test
+    public void testPredicateOnIntColumnWidenedToBigintWithBloomFilter()
+    {
+        String source = "source_int_" + randomNameSuffix();
+        String widened = "widened_bigint_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + source + " (c integer) WITH (format = 'PARQUET', parquet_bloom_filter_columns = ARRAY['c'])");
+        try {
+            assertUpdate("INSERT INTO " + source + " VALUES 123, 456", 2);
+            String location = (String) computeScalar("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*$', '') FROM " + source);
+            assertUpdate(format("CREATE TABLE %s (c bigint) WITH (format = 'PARQUET', external_location = '%s')", widened, location));
+            try {
+                assertQuery("SELECT count(*) FROM " + widened + " WHERE c = BIGINT '123'", "VALUES 1");
+                assertQuery("SELECT count(*) FROM " + widened + " WHERE c = BIGINT '999'", "VALUES 0");
+            }
+            finally {
+                assertUpdate("DROP TABLE IF EXISTS " + widened);
+            }
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + source);
+        }
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestHiveParquetTypeWidenedPredicate.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestHiveParquetTypeWidenedPredicate.java
@@ -36,7 +36,7 @@ public class TestHiveParquetTypeWidenedPredicate
     {
         String source = "source_float_" + randomNameSuffix();
         String widened = "widened_double_" + randomNameSuffix();
-        assertUpdate("CREATE TABLE " + source + " (c real) WITH (format = 'PARQUET')");
+        assertUpdate("CREATE TABLE " + source + " (c real) WITH (format = 'PARQUET', parquet_bloom_filter_columns = ARRAY['c'])");
         try {
             assertUpdate("INSERT INTO " + source + " VALUES REAL '1.5', REAL '2.5'", 2);
             String location = (String) computeScalar("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*$', '') FROM " + source);
@@ -45,6 +45,30 @@ public class TestHiveParquetTypeWidenedPredicate
                 assertQuery("SELECT count(*) FROM " + widened, "VALUES 2");
                 assertQuery("SELECT count(*) FROM " + widened + " WHERE c = DOUBLE '1.5'", "VALUES 1");
                 assertQuery("SELECT count(*) FROM " + widened + " WHERE c = DOUBLE '9.9'", "VALUES 0");
+            }
+            finally {
+                assertUpdate("DROP TABLE IF EXISTS " + widened);
+            }
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + source);
+        }
+    }
+
+    @Test
+    public void testPredicateOnIntColumnWidenedToDouble()
+    {
+        String source = "source_int_double_" + randomNameSuffix();
+        String widened = "widened_int_double_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + source + " (c integer) WITH (format = 'PARQUET')");
+        try {
+            assertUpdate("INSERT INTO " + source + " VALUES 1, 2", 2);
+            String location = (String) computeScalar("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*$', '') FROM " + source);
+            assertUpdate(format("CREATE TABLE %s (c double) WITH (format = 'PARQUET', external_location = '%s')", widened, location));
+            try {
+                assertQuery("SELECT count(*) FROM " + widened, "VALUES 2");
+                assertQuery("SELECT count(*) FROM " + widened + " WHERE c = DOUBLE '1'", "VALUES 1");
+                assertQuery("SELECT count(*) FROM " + widened + " WHERE c = DOUBLE '9'", "VALUES 0");
             }
             finally {
                 assertUpdate("DROP TABLE IF EXISTS " + widened);


### PR DESCRIPTION
## Summary
- Decode Parquet min/max using the physical file type when the Trino schema is a widening (`FLOAT`/`INT32` → `DOUBLE`, `INT32` → `BIGINT`) instead of throwing `ClassCastException` as corrupted statistics (#30544).
- Hash Bloom filters at the physical width (lossless narrowing only), so a predicate on a promoted column cannot silently drop row groups.
- Ignore INT64 statistics that are not exactly representable as `DOUBLE` rather than failing the query.
- Add unit, reader, and Hive external-table tests for the reported `REAL` file / `DOUBLE` table predicate, including Bloom filters.

## Test plan
- [ ] `./mvnw -pl lib/trino-parquet -Dtest=TestTupleDomainParquetPredicate,TestParquetTypeWidenedPredicate test`
- [ ] `./mvnw -pl plugin/trino-hive -Dtest=TestHiveParquetTypeWidenedPredicate test`
- [ ] Hive repro from #30544: `CREATE TABLE widened (c double) ... external_location` over a FLOAT Parquet file, then `SELECT ... WHERE c = DOUBLE '1.5'`


Made with [Cursor](https://cursor.com)