### PR TITLE
Account for outer join visited-position flags in hash builder

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/HashBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/HashBuilderOperator.java
@@ -317,16 +317,17 @@ public class HashBuilderOperator
         }
 
         checkState(index != null, "index is null");
+        long outerPositionTrackerSizeInBytes = lookupSourceFactory.getOuterPositionTrackerSizeInBytes(index.getPositionCount());
         ListenableFuture<Void> reserved = localUserMemoryContext.setBytes(index.getEstimatedMemoryRequiredToCreateLookupSource(
                 hashArraySizeSupplier,
                 sortChannel,
-                hashChannels));
+                hashChannels) + outerPositionTrackerSizeInBytes);
         if (!reserved.isDone() || !operatorContext.isWaitingForMemory().isDone()) {
             // Yield when not enough memory is available to proceed, finish is expected to be called again when some memory is freed
             return;
         }
         LookupSourceSupplier partition = buildLookupSource();
-        localUserMemoryContext.setBytes(partition.get().getInMemorySizeInBytes());
+        localUserMemoryContext.setBytes(partition.get().getInMemorySizeInBytes() + outerPositionTrackerSizeInBytes);
         lookupSourceNotNeeded = Optional.of(lookupSourceFactory.lendPartitionLookupSource(partitionIndex, partition));
 
         index = null;

--- a/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/PartitionedLookupSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/nonspilling/PartitionedLookupSourceFactory.java
@@ -36,6 +36,7 @@ import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
 import static com.google.common.util.concurrent.Futures.transform;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.slice.SizeOf.sizeOfBooleanArray;
 import static io.trino.operator.join.OuterLookupSource.createOuterLookupSourceSupplier;
 import static io.trino.operator.join.nonspilling.PartitionedLookupSource.createPartitionedLookupSourceSupplier;
 import static java.util.Objects.requireNonNull;
@@ -95,6 +96,16 @@ public final class PartitionedLookupSourceFactory
     public int partitions()
     {
         return partitions.length;
+    }
+
+    // The factory allocates the outer join visited-position flags when the last partition is lent,
+    // so each HashBuilderOperator accounts its partition's share through this method.
+    public long getOuterPositionTrackerSizeInBytes(int positionCount)
+    {
+        if (!outer) {
+            return 0;
+        }
+        return sizeOfBooleanArray(positionCount);
     }
 
     public synchronized ListenableFuture<LookupSource> createLookupSource()

--- a/core/trino-main/src/main/java/io/trino/operator/join/spilling/HashBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/spilling/HashBuilderOperator.java
@@ -498,10 +498,13 @@ public class HashBuilderOperator
             return;
         }
 
+        long outerPositionTrackerSizeInBytes = lookupSourceFactory.getOuterPositionTrackerSizeInBytes(index.getPositionCount());
+        // Outer join does not support spill, so the tracker bytes never land in revocable memory
+        verify(outerPositionTrackerSizeInBytes == 0 || !spillEnabled);
         long memoryRequired = index.getEstimatedMemoryRequiredToCreateLookupSource(
                 hashArraySizeSupplier,
                 sortChannel,
-                hashChannels);
+                hashChannels) + outerPositionTrackerSizeInBytes;
 
         ListenableFuture<Void> reserved;
         if (spillEnabled) {
@@ -518,10 +521,10 @@ public class HashBuilderOperator
 
         LookupSourceSupplier partition = buildLookupSource();
         if (spillEnabled) {
-            localRevocableMemoryContext.setBytes(partition.get().getInMemorySizeInBytes() + index.getExtraPagesIndexMemoryWithLookupSourceBuild());
+            localRevocableMemoryContext.setBytes(partition.get().getInMemorySizeInBytes() + index.getExtraPagesIndexMemoryWithLookupSourceBuild() + outerPositionTrackerSizeInBytes);
         }
         else {
-            localUserMemoryContext.setBytes(partition.get().getInMemorySizeInBytes() + index.getExtraPagesIndexMemoryWithLookupSourceBuild());
+            localUserMemoryContext.setBytes(partition.get().getInMemorySizeInBytes() + index.getExtraPagesIndexMemoryWithLookupSourceBuild() + outerPositionTrackerSizeInBytes);
         }
         lookupSourceNotNeeded = Optional.of(lookupSourceFactory.lendPartitionLookupSource(partitionIndex, partition));
 

--- a/core/trino-main/src/main/java/io/trino/operator/join/spilling/PartitionedLookupSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/spilling/PartitionedLookupSourceFactory.java
@@ -52,6 +52,7 @@ import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
 import static com.google.common.util.concurrent.Futures.transform;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.slice.SizeOf.sizeOfBooleanArray;
 import static io.trino.operator.join.OuterLookupSource.createOuterLookupSourceSupplier;
 import static io.trino.operator.join.spilling.PartitionedLookupSource.createPartitionedLookupSourceSupplier;
 import static java.util.Collections.emptyList;
@@ -145,6 +146,16 @@ public final class PartitionedLookupSourceFactory
     public int partitions()
     {
         return partitions.length;
+    }
+
+    // The factory allocates the outer join visited-position flags when the last partition is lent,
+    // so each HashBuilderOperator accounts its partition's share through this method.
+    public long getOuterPositionTrackerSizeInBytes(int positionCount)
+    {
+        if (!outer) {
+            return 0;
+        }
+        return sizeOfBooleanArray(positionCount);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/operator/join/nonspilling/TestHashBuilderOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/nonspilling/TestHashBuilderOperator.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.slice.SizeOf.sizeOfBooleanArray;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.SequencePageBuilder.createSequencePage;
 import static io.trino.SessionTestUtils.TEST_SESSION;
@@ -51,6 +52,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
@@ -172,10 +174,73 @@ public class TestHashBuilderOperator
         }
     }
 
+    // Outer join build reserves memory for the visited-position flags of its partition.
+    @Test
+    public void testOuterJoinAccountsForOuterPositionTracker()
+    {
+        int pageCount = 100;
+        int positionsPerPage = 1024;
+        long innerJoinReservation = userMemoryReservationAfterBuild(false, pageCount, positionsPerPage);
+        long outerJoinReservation = userMemoryReservationAfterBuild(true, pageCount, positionsPerPage);
+        assertThat(outerJoinReservation - innerJoinReservation)
+                .isCloseTo(sizeOfBooleanArray(pageCount * positionsPerPage), offset(4096L));
+    }
+
+    private long userMemoryReservationAfterBuild(boolean outer, int pageCount, int positionsPerPage)
+    {
+        TaskContext taskContext = TestingTaskContext.builder(executor, scheduledExecutor, TEST_SESSION)
+                .setMemoryPoolSize(DataSize.of(64, MEGABYTE))
+                .build();
+        DriverContext driverContext = taskContext
+                .addPipelineContext(0, false, false, false)
+                .addDriverContext();
+        OperatorContext operatorContext = driverContext
+                .addOperatorContext(0, new PlanNodeId("0"), HashBuilderOperator.class.getName());
+        List<Type> types = ImmutableList.of(BIGINT, BIGINT);
+        PartitionedLookupSourceFactory lookupSourceFactory = new PartitionedLookupSourceFactory(
+                types,
+                ImmutableList.of(BIGINT),
+                ImmutableList.of(BIGINT),
+                1,
+                outer,
+                new NullSafeHashCompiler(new TypeOperators()));
+        try (HashBuilderOperator operator = new HashBuilderOperator(
+                operatorContext,
+                lookupSourceFactory,
+                0,
+                ImmutableList.of(0),
+                ImmutableList.of(1),
+                Optional.empty(),
+                OptionalInt.empty(),
+                ImmutableList.of(),
+                10_000,
+                new PagesIndex.TestingFactory(false),
+                defaultHashArraySizeSupplier(),
+                4096)) {
+            for (int i = 0; i < pageCount; i++) {
+                operator.addInput(somePage(types, positionsPerPage));
+            }
+            operator.finish();
+            assertThat(operator.getState()).isEqualTo(LOOKUP_SOURCE_BUILT);
+            long reservation = operatorContext.getOperatorMemoryContext().getUserMemory();
+            lookupSourceFactory.destroy();
+            operator.finish();
+            return reservation;
+        }
+        finally {
+            operatorContext.destroy();
+        }
+    }
+
     private static Page somePage(List<Type> types)
+    {
+        return somePage(types, 7);
+    }
+
+    private static Page somePage(List<Type> types, int positionCount)
     {
         int[] initialValues = new int[types.size()];
         Arrays.setAll(initialValues, i -> 100 * i);
-        return createSequencePage(types, 7, initialValues);
+        return createSequencePage(types, positionCount, initialValues);
     }
 }


### PR DESCRIPTION
## Description

The visited-position flags for outer joins (`boolean[]` per partition, allocated by `PartitionedLookupSourceFactory` when the last partition is lent) cost one byte per build-side position but were not tracked in any memory context. On large right or full outer join builds this untracked memory can be significant, e.g. 150MB per query for a 150M row build side, and it grows after the build reservation is settled, so a worker can exceed its memory pool headroom without any query being charged for it.

Each `HashBuilderOperator` now accounts its partition's share of the flags through a new `getOuterPositionTrackerSizeInBytes(positionCount)` method on both the nonspilling and spilling factories. The size is included in the pre-build memory reservation and in the post-build `setBytes`, matching the lifetime of the arrays (held until `partitionsNoLongerNeeded`). Outer joins do not support spill, so in the spilling operator the bytes always land in user memory; a `verify` documents that invariant.

## Additional context and related issues

Found while investigating a worker JVM OOM where concurrent large right-outer-join builds exceeded the heap. The tracker arrays were the only build-side structure absent from `JoinHash.getInMemorySizeInBytes` and the build reservation.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix missing memory accounting for outer join hash builds.
```