### PR TITLE
Support AWS default credentials chain for SigV4 REST catalog

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -489,6 +489,9 @@ following properties:
 * - `iceberg.rest-catalog.security`
   - The type of security to use (default: `NONE`). Possible values are `NONE`, 
     `SIGV4`, `GOOGLE` or `OAUTH2`. `OAUTH2` requires either a `token` or a `credential`.
+    `SIGV4` signs requests with credentials from `s3.iam-role` if configured,
+    otherwise from `s3.aws-access-key` and `s3.aws-secret-key` if set,
+    and otherwise from the AWS default credentials provider chain.
 * - `iceberg.rest-catalog.session`
   - Session information included when communicating with the REST Catalog.
     Options are `NONE` or `USER` (default: `NONE`).

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/SigV4AwsProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/SigV4AwsProperties.java
@@ -76,11 +76,13 @@ public class SigV4AwsProperties
             Optional.ofNullable(s3Config.getAwsSecretKey()).ifPresent(secretAccessKey -> builder.put(CLIENT_CREDENTIAL_AWS_SECRET_ACCESS_KEY, secretAccessKey));
             Optional.ofNullable(s3Config.getStsEndpoint()).ifPresent(endpoint -> builder.put(CLIENT_CREDENTIAL_AWS_STS_ENDPOINT, endpoint));
         }
-        else {
+        else if (s3Config.getAwsAccessKey() != null || s3Config.getAwsSecretKey() != null) {
             builder
                     .put(REST_ACCESS_KEY_ID, requireNonNull(s3Config.getAwsAccessKey(), "s3.aws-access-key is null"))
                     .put(REST_SECRET_ACCESS_KEY, requireNonNull(s3Config.getAwsSecretKey(), "s3.aws-secret-key is null"));
         }
+        // when neither an IAM role nor static keys are configured, the Iceberg REST client
+        // signs requests with credentials from the AWS default credentials provider chain
 
         properties = builder.buildOrThrow();
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestSigV4AwsProperties.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestSigV4AwsProperties.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import io.trino.filesystem.s3.S3FileSystemConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.apache.iceberg.aws.AwsClientProperties.CLIENT_CREDENTIALS_PROVIDER;
+import static org.apache.iceberg.aws.AwsProperties.REST_ACCESS_KEY_ID;
+import static org.apache.iceberg.aws.AwsProperties.REST_SECRET_ACCESS_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestSigV4AwsProperties
+{
+    @Test
+    void testStaticCredentials()
+    {
+        Map<String, String> properties = new SigV4AwsProperties(
+                new IcebergRestCatalogSigV4Config(),
+                new S3FileSystemConfig()
+                        .setRegion("us-east-2")
+                        .setAwsAccessKey("access-key")
+                        .setAwsSecretKey("secret-key"))
+                .get();
+        assertThat(properties)
+                .containsEntry(REST_ACCESS_KEY_ID, "access-key")
+                .containsEntry(REST_SECRET_ACCESS_KEY, "secret-key");
+    }
+
+    @Test
+    void testDefaultCredentialsProviderChain()
+    {
+        Map<String, String> properties = new SigV4AwsProperties(
+                new IcebergRestCatalogSigV4Config(),
+                new S3FileSystemConfig().setRegion("us-east-2"))
+                .get();
+        assertThat(properties)
+                .doesNotContainKeys(REST_ACCESS_KEY_ID, REST_SECRET_ACCESS_KEY, CLIENT_CREDENTIALS_PROVIDER);
+    }
+
+    @Test
+    void testPartialStaticCredentials()
+    {
+        assertThatThrownBy(() -> new SigV4AwsProperties(
+                new IcebergRestCatalogSigV4Config(),
+                new S3FileSystemConfig()
+                        .setRegion("us-east-2")
+                        .setAwsAccessKey("access-key")))
+                .hasMessage("s3.aws-secret-key is null");
+        assertThatThrownBy(() -> new SigV4AwsProperties(
+                new IcebergRestCatalogSigV4Config(),
+                new S3FileSystemConfig()
+                        .setRegion("us-east-2")
+                        .setAwsSecretKey("secret-key")))
+                .hasMessage("s3.aws-access-key is null");
+    }
+
+    @Test
+    void testIamRole()
+    {
+        Map<String, String> properties = new SigV4AwsProperties(
+                new IcebergRestCatalogSigV4Config(),
+                new S3FileSystemConfig()
+                        .setRegion("us-east-2")
+                        .setIamRole("arn:aws:iam::123456789012:role/example"))
+                .get();
+        assertThat(properties)
+                .containsEntry(CLIENT_CREDENTIALS_PROVIDER, "io.trino.plugin.iceberg.StsAwsCredentialProvider")
+                .doesNotContainKeys(REST_ACCESS_KEY_ID, REST_SECRET_ACCESS_KEY);
+    }
+}


### PR DESCRIPTION
## Description

Configure the Iceberg REST client to sign SigV4 requests with the AWS default credentials provider chain when neither `s3.iam-role` nor static access keys are configured. This allows using session, SSO, and instance profile credentials with SigV4 secured REST catalogs such as the AWS Glue Iceberg REST endpoint.

## Additional context and related issues

Fixes #25257

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Support the AWS default credentials provider chain for SigV4 authentication with REST catalogs. ({issue}`25257`)
```
