### PR TITLE
Fix bogus `isImplicitCoercion` in `DomainTranslator`

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -463,7 +463,7 @@ public final class DomainTranslator
                         return result.get();
                     }
                 }
-                if (!isImplicitCoercion(castExpression)) {
+                if (!isOrderPreserving(castExpression)) {
                     //
                     // we cannot use non-coercion cast to literal_type on symbol side to build tuple domain
                     //
@@ -519,7 +519,7 @@ public final class DomainTranslator
             }
         }
 
-        private boolean isImplicitCoercion(Cast cast)
+        private boolean isOrderPreserving(Cast cast)
         {
             if (cast.expression().type() instanceof CharType && cast.type() instanceof VarcharType) {
                 // CHAR -> VARCHAR trims trailing spaces, so it has no inverse on the value side: a VARCHAR constant
@@ -528,6 +528,11 @@ public final class DomainTranslator
                 // (e.g. CAST(c AS varchar) = 'a ' is unsatisfiable, but would be rewritten to c = CHAR 'a'). Leave it.
                 return false;
             }
+            // Implicit coercions are typically order-preserving and injective.
+            // TODO this, like UnwrapCastInComparison, should determine whether cast is injective.
+            //  For example, bigint -> double is implicit coercion and injective for values up to 2^53.
+            //  For injective and order-preserving cast we can convert equality comparison on cast values into equality comparison on source type values
+            //  For non-injective but still order-preserving cast, we can create a wider domain to capture the range of all the source type values that produce given target type value.
             return typeCoercion.canCoerce(cast.expression().type(), cast.type());
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
@@ -362,7 +362,7 @@ public class UnwrapCastInComparison
                 return unwrapCharToVarcharCast(charType, varcharType, operator, cast.expression(), (Slice) rightValue);
             }
 
-            if (!hasInjectiveImplicitCoercion(sourceType, targetType, rightValue)) {
+            if (!isInjectiveOrderPreservingCastAtValue(sourceType, targetType, rightValue)) {
                 return Optional.empty();
             }
 
@@ -612,7 +612,11 @@ public class UnwrapCastInComparison
                     || isCastOverTrivial(cast.expression()));
         }
 
-        private boolean hasInjectiveImplicitCoercion(Type source, Type target, Object value)
+        /// Determines whether the cast from `source` to `target` is order-preserving and
+        /// injective at `value` — i.e. at most one value of the source type casts to `value`.
+        ///
+        /// @param value a value of the target type
+        private boolean isInjectiveOrderPreservingCastAtValue(Type source, Type target, Object value)
         {
             if ((source.equals(BIGINT) && target.equals(DOUBLE)) ||
                     (source.equals(BIGINT) && target.equals(REAL)) ||


### PR DESCRIPTION
The `isImplicitCoercion` method should return true for CHAR/VARCHAR
pair because CHAR coerces to VARCHAR.  Fix this by renaming method and
thus changing semantics. Monotonicity is, indeed, needed by the caller
and violated by CHAR -> VARCHAR cast.

This also improves naming of similar method in `UnwrapCastInComparison`.