### PR TITLE
Add tests for PBE and Hadoop JCEKS global S3 credentials

### DIFF
--- a/.github/bin/build-pt-matrix.py
+++ b/.github/bin/build-pt-matrix.py
@@ -74,6 +74,7 @@ BUCKETS = [
     ("cloud-object-store", [
         "SuiteGcs",
         "SuiteAzure",
+        "SuiteS3KeystoreSecrets",
     ]),
     ("databricks-133", [
         "SuiteDeltaLakeDatabricks133",

--- a/lib/trino-filesystem-s3/pom.xml
+++ b/lib/trino-filesystem-s3/pom.xml
@@ -221,6 +221,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>configuration-testing</artifactId>
             <scope>test</scope>
         </dependency>
@@ -234,6 +240,20 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>secrets-keystore-plugin</artifactId>
+            <version>445-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>secrets-spi</artifactId>
+            <version>445-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
@@ -259,6 +279,12 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-testing-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.hadoop</groupId>
+            <artifactId>hadoop-apache</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/secrets/KeyStoreTestFixture.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/secrets/KeyStoreTestFixture.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3.secrets;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.alias.CredentialProvider;
+import org.apache.hadoop.security.alias.CredentialProviderFactory;
+
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public final class KeyStoreTestFixture
+{
+    private KeyStoreTestFixture() {}
+
+    public static Path createKeyStore(Map<String, String> aliases, String password)
+            throws Exception
+    {
+        KeyStore keyStore = KeyStore.getInstance("JCEKS");
+        keyStore.load(null, password.toCharArray());
+
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
+        for (Map.Entry<String, String> entry : aliases.entrySet()) {
+            String alias = entry.getKey().toLowerCase(Locale.US);
+            PBEKeySpec keySpec = new PBEKeySpec(entry.getValue().toCharArray());
+            SecretKey key = factory.generateSecret(keySpec);
+            keyStore.setEntry(alias, new KeyStore.SecretKeyEntry(key), new KeyStore.PasswordProtection(password.toCharArray()));
+        }
+
+        return writeKeyStore(keyStore, password);
+    }
+
+    /**
+     * Creates a Hadoop-format JCEKS via {@code CredentialProviderFactory} — entries are
+     * {@code SecretKeySpec} via {@code setKeyEntry}, matching production Hadoop-format JCEKS.
+     * Requires enhanced Airlift reader: <a href="https://github.com/airlift/airlift/pull/2100">#2100</a>.
+     */
+    public static Path createHadoopKeyStore(Map<String, String> aliases, String password)
+            throws IOException
+    {
+        Path keystorePath = Files.createTempFile("hadoop-credentials", ".jceks");
+        keystorePath.toFile().deleteOnExit();
+
+        String providerPath = "localjceks://file" + keystorePath.toAbsolutePath();
+        Configuration configuration = new Configuration(false);
+        configuration.set(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH, providerPath);
+        configuration.set("hadoop.security.credential.provider.password", password);
+
+        List<CredentialProvider> providers = CredentialProviderFactory.getProviders(configuration);
+        CredentialProvider provider = providers.getFirst();
+        for (Map.Entry<String, String> entry : aliases.entrySet()) {
+            provider.createCredentialEntry(entry.getKey(), entry.getValue().toCharArray());
+        }
+        provider.flush();
+
+        return keystorePath;
+    }
+
+    private static Path writeKeyStore(KeyStore keyStore, String password)
+            throws Exception
+    {
+        Path keystorePath = Files.createTempFile("credentials", ".jceks");
+        keystorePath.toFile().deleteOnExit();
+        try (OutputStream out = Files.newOutputStream(keystorePath)) {
+            keyStore.store(out, password.toCharArray());
+        }
+        return keystorePath;
+    }
+}

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/secrets/TestKeystoreSecretProvider.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/secrets/TestKeystoreSecretProvider.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3.secrets;
+
+import io.airlift.configuration.secrets.SecretsResolver;
+import io.airlift.secrets.keystore.KeystoreSecretProvider;
+import io.airlift.secrets.keystore.KeystoreSecretProviderConfig;
+import io.airlift.spi.secrets.SecretProvider;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link KeystoreSecretProvider} and {@link SecretsResolver} with
+ * global {@code fs.s3a.access.key} / {@code fs.s3a.secret.key} aliases.
+ * <p>
+ * JCEKS format matrix:
+ * <table>
+ *   <caption>Keystore formats exercised by PR1</caption>
+ *   <tr><th>Format</th><th>Entry type</th><th>Fixture</th><th>Where tested</th><th>Airlift version</th></tr>
+ *   <tr><td>PBE</td><td>{@code PBEKeySpec} + {@code SecretKeyEntry}</td>
+ *       <td>{@link KeyStoreTestFixture#createKeyStore}</td>
+ *       <td>Unit + product tests</td><td>444 (bundled)</td></tr>
+ *   <tr><td>Hadoop</td><td>{@code SecretKeySpec} via {@code setKeyEntry}</td>
+ *       <td>{@link KeyStoreTestFixture#createHadoopKeyStore}</td>
+ *       <td>Unit only ({@link #testAirliftKeystoreProviderReadsHadoopJceks})</td>
+ *       <td>445-SNAPSHOT (test scope)</td></tr>
+ * </table>
+ * Product tests use PBE because Trino bundles Airlift 444, whose stock keystore plugin
+ * reads PBE entries only. Production Hadoop-format keystores from
+ * {@code CredentialProviderFactory} require enhanced reader support in
+ * <a href="https://github.com/airlift/airlift/pull/2100">airlift/airlift#2100</a>
+ * plus a subsequent Trino Airlift version bump — not a merge blocker for this test-only PR.
+ * No negative test asserts that stock Airlift 444 fails on Hadoop JCEKS because
+ * 445-SNAPSHOT on the test classpath would make such an assertion fragile and not
+ * meaningful in CI.
+ */
+public class TestKeystoreSecretProvider
+{
+    // Global aliases: one static credential pair resolved at catalog load.
+    private static final String ACCESS_ALIAS = "fs.s3a.access.key";
+    private static final String SECRET_ALIAS = "fs.s3a.secret.key";
+    private static final String ACCESS_VALUE = "AKIATEST";
+    private static final String SECRET_VALUE = "SECRETTEST";
+    private static final String PASSWORD = "none";
+
+    /**
+     * Airlift {@link KeystoreSecretProvider} reads PBE {@code SecretKeyEntry} aliases
+     * from a JCEKS file — the format used by {@code KeystoreSecretsProductTestFixture}
+     * and compatible with Trino's bundled Airlift 444.
+     */
+    @Test
+    public void testAirliftKeystoreProviderReadsPbeJceks()
+            throws Exception
+    {
+        Path keystore = KeyStoreTestFixture.createKeyStore(
+                Map.of(ACCESS_ALIAS, ACCESS_VALUE, SECRET_ALIAS, SECRET_VALUE),
+                PASSWORD);
+
+        KeystoreSecretProvider provider = new KeystoreSecretProvider(keystoreConfig(keystore));
+        assertThat(provider.resolveSecretValue(ACCESS_ALIAS)).isEqualTo(ACCESS_VALUE);
+        assertThat(provider.resolveSecretValue(SECRET_ALIAS)).isEqualTo(SECRET_VALUE);
+    }
+
+    /**
+     * {@link SecretsResolver} interpolates {@code ${keystore:alias}} placeholders into
+     * catalog properties using a PBE JCEKS keystore — the end-to-end global credential path.
+     */
+    @Test
+    public void testSecretsResolverInterpolatesPbeJceksIntoCatalogProperties()
+            throws Exception
+    {
+        Path keystore = KeyStoreTestFixture.createKeyStore(
+                Map.of(ACCESS_ALIAS, ACCESS_VALUE, SECRET_ALIAS, SECRET_VALUE),
+                PASSWORD);
+
+        SecretProvider keystoreProvider = new KeystoreSecretProvider(keystoreConfig(keystore));
+        SecretsResolver resolver = new SecretsResolver(Map.of("keystore", keystoreProvider));
+
+        Map<String, String> resolved = resolver.getResolvedConfiguration(Map.of(
+                "s3.aws-access-key", "${keystore:" + ACCESS_ALIAS + "}",
+                "s3.aws-secret-key", "${keystore:" + SECRET_ALIAS + "}"));
+
+        assertThat(resolved.get("s3.aws-access-key")).isEqualTo(ACCESS_VALUE);
+        assertThat(resolved.get("s3.aws-secret-key")).isEqualTo(SECRET_VALUE);
+    }
+
+    /**
+     * Hadoop-format JCEKS: {@link KeyStoreTestFixture#createHadoopKeyStore} writes entries
+     * via {@code CredentialProviderFactory} / {@code setKeyEntry(SecretKeySpec)} — the
+     * same layout as Hadoop-format JCEKS from {@code hadoop credential create}.
+     * <p>
+     * Requires {@code secrets-keystore-plugin} 445-SNAPSHOT on the test classpath (see
+     * {@code lib/trino-filesystem-s3/pom.xml}); enhanced reader from
+     * <a href="https://github.com/airlift/airlift/pull/2100">airlift/airlift#2100</a>.
+     * Stock Airlift 444 cannot read this format — product tests intentionally use PBE instead.
+     */
+    @Test
+    public void testAirliftKeystoreProviderReadsHadoopJceks()
+            throws Exception
+    {
+        Path keystore = KeyStoreTestFixture.createHadoopKeyStore(
+                Map.of(ACCESS_ALIAS, ACCESS_VALUE, SECRET_ALIAS, SECRET_VALUE),
+                PASSWORD);
+
+        KeystoreSecretProvider provider = new KeystoreSecretProvider(keystoreConfig(keystore));
+
+        assertThat(provider.resolveSecretValue(ACCESS_ALIAS)).isEqualTo(ACCESS_VALUE);
+        assertThat(provider.resolveSecretValue(SECRET_ALIAS)).isEqualTo(SECRET_VALUE);
+    }
+
+    private static KeystoreSecretProviderConfig keystoreConfig(Path keystore)
+    {
+        return new KeystoreSecretProviderConfig()
+                .setKeyStoreFilePath(keystore.toString())
+                .setKeyStoreType("JCEKS")
+                .setKeyStorePassword(PASSWORD);
+    }
+}

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/TestGroup.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/TestGroup.java
@@ -183,6 +183,11 @@ public @interface TestGroup
 
     @Target({TYPE, METHOD})
     @Retention(RUNTIME)
+    @Tag("s3_keystore_secrets")
+    @interface S3KeystoreSecrets {}
+
+    @Target({TYPE, METHOD})
+    @Retention(RUNTIME)
     @Tag("postgresql_postgis")
     @interface PostgresqlPostgis {}
 

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/KeystoreSecretsProductTestFixture.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/KeystoreSecretsProductTestFixture.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Creates PBE JCEKS fixtures for keystore-backed secrets product tests.
+ * Uses PBE (not Hadoop {@code SecretKeySpec}) because Trino bundles Airlift 444;
+ * Hadoop-format coverage is in {@code TestKeystoreSecretProvider} with 445-SNAPSHOT — see
+ * <a href="https://github.com/airlift/airlift/pull/2100">airlift/airlift#2100</a>.
+ */
+public final class KeystoreSecretsProductTestFixture
+{
+    public static final String KEYSTORE_PASSWORD = "none";
+
+    private KeystoreSecretsProductTestFixture() {}
+
+    public static Path createKeyStore(Map<String, String> aliases)
+            throws Exception
+    {
+        KeyStore keyStore = KeyStore.getInstance("JCEKS");
+        keyStore.load(null, KEYSTORE_PASSWORD.toCharArray());
+
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
+        for (Map.Entry<String, String> entry : aliases.entrySet()) {
+            String alias = entry.getKey().toLowerCase(Locale.US);
+            PBEKeySpec keySpec = new PBEKeySpec(entry.getValue().toCharArray());
+            SecretKey key = factory.generateSecret(keySpec);
+            keyStore.setEntry(alias, new KeyStore.SecretKeyEntry(key), new KeyStore.PasswordProtection(KEYSTORE_PASSWORD.toCharArray()));
+        }
+
+        Path keystorePath = Files.createTempFile("keystore-secrets-pt-", ".jceks");
+        keystorePath.toFile().deleteOnExit();
+        try (OutputStream out = Files.newOutputStream(keystorePath)) {
+            keyStore.store(out, KEYSTORE_PASSWORD.toCharArray());
+        }
+        return keystorePath;
+    }
+
+    public static void deleteIfExists(Path keystorePath)
+    {
+        if (keystorePath == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(keystorePath);
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to delete temporary keystore: " + keystorePath, e);
+        }
+    }
+}

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/S3KeystoreSecretsEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/S3KeystoreSecretsEnvironment.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+import io.trino.testing.containers.Minio;
+import io.trino.testing.containers.TrinoProductTestContainer;
+import io.trino.testing.containers.environment.ProductTestEnvironment;
+import org.testcontainers.containers.Network;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.trino.TrinoContainer;
+import org.testcontainers.utility.MountableFile;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static io.trino.testing.containers.Minio.MINIO_ROOT_PASSWORD;
+import static io.trino.testing.containers.Minio.MINIO_ROOT_USER;
+import static io.trino.tests.product.hive.KeystoreSecretsProductTestFixture.KEYSTORE_PASSWORD;
+import static io.trino.tests.product.hive.KeystoreSecretsProductTestFixture.createKeyStore;
+import static io.trino.tests.product.hive.KeystoreSecretsProductTestFixture.deleteIfExists;
+
+/**
+ * Hive file metastore with MinIO storage and keystore-resolved S3 credentials.
+ */
+public class S3KeystoreSecretsEnvironment
+        extends ProductTestEnvironment
+{
+    public static final String BUCKET_NAME = "orders";
+    public static final String SCHEMA_LOCATION = "s3://" + BUCKET_NAME + "/keystore-pt/";
+    private static final String ACCESS_ALIAS = "fs.s3a.access.key";
+    private static final String SECRET_ALIAS = "fs.s3a.secret.key";
+    private static final String HIVE_METASTORE_DIR = "file:///var/trino/hive-data";
+
+    private Network network;
+    private Minio minio;
+    private TrinoContainer trino;
+    private Path credentialStore;
+
+    @Override
+    public void start()
+            throws SQLException, InterruptedException
+    {
+        if (isRunning()) {
+            return;
+        }
+
+        try {
+            startEnvironment();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to start S3 keystore secrets environment", e);
+        }
+    }
+
+    private void startEnvironment()
+            throws Exception
+    {
+        network = Network.newNetwork();
+
+        minio = Minio.builder()
+                .withNetwork(network)
+                .build();
+        minio.start();
+        minio.createBucket(BUCKET_NAME);
+
+        credentialStore = createKeyStore(Map.of(
+                ACCESS_ALIAS, MINIO_ROOT_USER,
+                SECRET_ALIAS, MINIO_ROOT_PASSWORD));
+
+        Map<String, String> hiveCatalog = new LinkedHashMap<>();
+        hiveCatalog.put("connector.name", "hive");
+        hiveCatalog.put("hive.metastore", "file");
+        hiveCatalog.put("hive.metastore.catalog.dir", HIVE_METASTORE_DIR);
+        hiveCatalog.put("fs.local.enabled", "true");
+        hiveCatalog.put("fs.native-s3.enabled", "true");
+        hiveCatalog.put("s3.region", Minio.MINIO_REGION);
+        hiveCatalog.put("s3.endpoint", "http://" + Minio.DEFAULT_HOST_NAME + ":" + Minio.MINIO_API_PORT);
+        hiveCatalog.put("s3.path-style-access", "true");
+        hiveCatalog.put("s3.aws-access-key", "${keystore:" + ACCESS_ALIAS + "}");
+        hiveCatalog.put("s3.aws-secret-key", "${keystore:" + SECRET_ALIAS + "}");
+        hiveCatalog.put("hive.non-managed-table-writes-enabled", "true");
+
+        trino = TrinoProductTestContainer.builder()
+                .withNetwork(network)
+                .withCatalog("hive", hiveCatalog)
+                .withCatalog("tpch", Map.of("connector.name", "tpch"))
+                .build();
+        trino.withCopyToContainer(Transferable.of(secretsConfiguration()), "/etc/trino/secrets.toml");
+        trino.withCopyFileToContainer(MountableFile.forHostPath(credentialStore), "/etc/trino/credentials.jceks");
+        trino.withCopyToContainer(Transferable.of(""), "/var/trino/hive-data/.keep");
+        TrinoProductTestContainer.startAndWait(trino);
+    }
+
+    @Override
+    public Connection createTrinoConnection()
+            throws SQLException
+    {
+        return createTrinoConnection("test");
+    }
+
+    @Override
+    public Connection createTrinoConnection(String user)
+            throws SQLException
+    {
+        Connection connection = TrinoProductTestContainer.createConnection(trino, user);
+        connection.setCatalog("hive");
+        connection.setSchema("default");
+        return connection;
+    }
+
+    @Override
+    public String getTrinoJdbcUrl()
+    {
+        return trino != null ? trino.getJdbcUrl() : null;
+    }
+
+    @Override
+    public boolean isRunning()
+    {
+        return trino != null && trino.isRunning();
+    }
+
+    @Override
+    protected void doClose()
+    {
+        if (trino != null) {
+            trino.close();
+            trino = null;
+        }
+        if (minio != null) {
+            minio.close();
+            minio = null;
+        }
+        if (network != null) {
+            network.close();
+            network = null;
+        }
+        deleteIfExists(credentialStore);
+        credentialStore = null;
+    }
+
+    private static String secretsConfiguration()
+    {
+        return """
+               [env]
+               secrets-provider.name = "env"
+
+               [keystore]
+               secrets-provider.name = "keystore"
+               keystore-file-path = "/etc/trino/credentials.jceks"
+               keystore-type = "JCEKS"
+               keystore-password = "%s"
+               """.formatted(KEYSTORE_PASSWORD);
+    }
+}

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TestS3KeystoreSecretsSqlTests.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TestS3KeystoreSecretsSqlTests.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+import io.trino.testing.containers.environment.ProductTest;
+import io.trino.testing.containers.environment.QueryResult;
+import io.trino.testing.containers.environment.RequiresEnvironment;
+import io.trino.tests.product.TestGroup;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.testing.containers.environment.QueryResultAssert.assertThat;
+import static io.trino.testing.containers.environment.Row.row;
+
+/**
+ * End-to-end validation that keystore-resolved S3 credentials work for Hive DML against MinIO.
+ */
+@ProductTest
+@RequiresEnvironment(S3KeystoreSecretsEnvironment.class)
+@TestGroup.S3KeystoreSecrets
+@TestGroup.ProfileSpecificTests
+class TestS3KeystoreSecretsSqlTests
+{
+    private static final String SCHEMA = "hive.test_keystore";
+    private static final String TABLE = SCHEMA + ".orders";
+    private static final String TABLE_LOCATION = S3KeystoreSecretsEnvironment.SCHEMA_LOCATION + "orders/";
+
+    @Test
+    void testKeystoreBackedS3ReadWrite(S3KeystoreSecretsEnvironment env)
+    {
+        env.executeTrinoUpdate("DROP TABLE IF EXISTS " + TABLE);
+        env.executeTrinoUpdate("DROP SCHEMA IF EXISTS " + SCHEMA);
+        env.executeTrinoUpdate("CREATE SCHEMA " + SCHEMA);
+        env.executeTrinoUpdate("CREATE TABLE " + TABLE + " (id bigint, name varchar) WITH (external_location = '" + TABLE_LOCATION + "', format = 'PARQUET')");
+        env.executeTrinoUpdate("INSERT INTO " + TABLE + " VALUES (1, 'keystore-ok'), (2, 'minio-rw')");
+
+        QueryResult result = env.executeTrino("SELECT id, name FROM " + TABLE + " ORDER BY id");
+        assertThat(result).containsOnly(
+                row(1L, "keystore-ok"),
+                row(2L, "minio-rw"));
+    }
+}

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteS3KeystoreSecrets.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteS3KeystoreSecrets.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.suite;
+
+import io.trino.tests.product.TestGroup;
+import io.trino.tests.product.hive.S3KeystoreSecretsEnvironment;
+import io.trino.tests.product.suite.SuiteRunner.TestRunResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Product tests for keystore-backed S3 credentials with Hive and MinIO.
+ * <p>
+ * Run standalone:
+ * <pre>
+ * mvn exec:java -Dexec.mainClass="io.trino.tests.product.suite.SuiteS3KeystoreSecrets"
+ * </pre>
+ */
+public final class SuiteS3KeystoreSecrets
+{
+    private SuiteS3KeystoreSecrets() {}
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        System.setProperty("trino.product-test.environment-mode", "STRICT");
+
+        List<TestRunResult> results = new ArrayList<>();
+        results.add(SuiteRunner.forEnvironment(S3KeystoreSecretsEnvironment.class)
+                .includeTag(TestGroup.S3KeystoreSecrets.class)
+                .run());
+
+        SuiteRunner.printSummary(results);
+        System.exit(SuiteRunner.hasFailures(results) ? 1 : 0);
+    }
+}


### PR DESCRIPTION
## Description

Test-only change covering both JCEKS entry layouts for global fs.s3a.access.key and fs.s3a.secret.key aliases:

- PBE JCEKS (SecretKeyEntry via PBEKeySpec): unit tests for KeystoreSecretProvider and SecretsResolver, plus Hive DML product tests against MinIO with keystore-backed catalog credentials. Compatible with Trino's bundled Airlift 444.

- Hadoop-format JCEKS (SecretKeySpec via CredentialProviderFactory setKeyEntry): unit test via KeyStoreTestFixture.createHadoopKeyStore, validated with secrets-keystore-plugin 445-SNAPSHOT (test scope only).

Production Hadoop-format keystores require enhanced reader support in airlift/airlift#2100 and a subsequent Trino Airlift version bump — not a merge blocker for this test-only PR.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Thanks for feedback by @dain @electrum in https://github.com/trinodb/trino/pull/30638#issuecomment-5274282803. Added this https://github.com/airlift/airlift/pull/2100 in Airlift. This PR is the follow-up to the discussion on #30638

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

