### PR TITLE
Fix BIGINT overflow in array and string scalar functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayElementAtFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayElementAtFunction.java
@@ -66,7 +66,8 @@ public final class ArrayElementAtFunction
         if (index == 0) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "SQL array indices start at 1");
         }
-        if (Math.abs(index) > arrayLength) {
+        // the bounds are compared without Math.abs, because Math.abs(Long.MIN_VALUE) is negative and would let the index through
+        if (index > arrayLength || index < -arrayLength) {
             return -1; // -1 indicates that the element is out of range and "ELEMENT_AT" should return null
         }
         if (index > 0) {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArraySliceFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArraySliceFunction.java
@@ -21,8 +21,10 @@ import io.trino.spi.function.TypeParameter;
 import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.Type;
 
+import static com.google.common.math.LongMath.saturatedAdd;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.util.Failures.checkCondition;
+import static java.lang.Math.min;
 
 @ScalarFunction("slice")
 @Description("Subsets an array given an offset (1-indexed) and length")
@@ -50,7 +52,9 @@ public final class ArraySliceFunction
             fromIndex = size + fromIndex + 1;
         }
 
-        long toIndex = Math.min(fromIndex + length, size + 1);
+        // fromIndex + length can overflow for a large length, which would make toIndex wrap around to a
+        // negative value and produce an empty result instead of the trailing part of the array
+        long toIndex = min(saturatedAdd(fromIndex, length), size + 1);
 
         if (fromIndex >= toIndex || fromIndex < 1) {
             return type.createBlockBuilder(null, 0).build();

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
@@ -41,6 +41,7 @@ import java.text.Normalizer;
 import java.util.OptionalInt;
 
 import static com.google.common.math.LongMath.saturatedAdd;
+import static com.google.common.math.LongMath.saturatedSubtract;
 import static io.airlift.slice.SliceUtf8.countCodePoints;
 import static io.airlift.slice.SliceUtf8.getCodePointAt;
 import static io.airlift.slice.SliceUtf8.lengthOfCodePoint;
@@ -59,7 +60,6 @@ import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.util.Failures.checkCondition;
 import static java.lang.Character.MAX_CODE_POINT;
 import static java.lang.Character.SURROGATE;
-import static java.lang.Math.abs;
 import static java.lang.Math.max;
 import static java.lang.Math.toIntExact;
 
@@ -233,7 +233,9 @@ public final class StringFunctions
     public static long stringPosition(@SqlType("varchar(x)") Slice string, @SqlType("varchar(y)") Slice substring, @SqlType(StandardTypes.BIGINT) long instance)
     {
         if (instance < 0) {
-            return stringPositionFromEnd(string, substring, abs(instance));
+            // abs(Long.MIN_VALUE) is negative, which stringPositionFromEnd would reject as a non-negative instance.
+            // Negating with saturation keeps the count positive, so the search simply runs out of matches and returns 0.
+            return stringPositionFromEnd(string, substring, saturatedSubtract(0, instance));
         }
         return stringPositionFromStart(string, substring, instance);
     }
@@ -478,7 +480,9 @@ public final class StringFunctions
         checkCondition(index > 0, INVALID_FUNCTION_ARGUMENT, "Index must be greater than zero");
         // Empty delimiter? Then every character will be a split
         if (delimiter.length() == 0) {
-            int startCodePoint = toIntExact(index);
+            // an index beyond Integer.MAX_VALUE is past the end of any string, and saturating keeps it out of range
+            // rather than overflowing, so it is reported as a missing part like any other too large index
+            int startCodePoint = Ints.saturatedCast(index);
 
             int indexStart = offsetOfCodePoint(string, startCodePoint - 1);
             if (indexStart < 0) {

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
@@ -881,6 +881,13 @@ public class TestStringFunctions
         assertThat(assertions.function("strpos", "'abc/xyz/foo/bar'", "'/'", "-4"))
                 .isEqualTo(0L);
 
+        // an instance count that cannot be negated without overflowing is simply more occurrences than the string has
+        assertThat(assertions.function("strpos", "'abc/xyz/foo/bar'", "'/'", "-9223372036854775808"))
+                .isEqualTo(0L);
+
+        assertThat(assertions.function("strpos", "'abc/xyz/foo/bar'", "'/'", "9223372036854775807"))
+                .isEqualTo(0L);
+
         assertThat(assertions.function("strpos", "'highhigh'", "'ig'", "-1"))
                 .isEqualTo(6L);
 
@@ -1511,6 +1518,13 @@ public class TestStringFunctions
                 .isNull(createVarcharType(3));
 
         assertThat(assertions.function("split_part", "'abc'", "''", "99"))
+                .isNull(createVarcharType(3));
+
+        // an index that does not fit in an int is past the end of the string, like any other too large index
+        assertThat(assertions.function("split_part", "'abc'", "''", "3000000000"))
+                .isNull(createVarcharType(3));
+
+        assertThat(assertions.function("split_part", "'abc'", "''", "9223372036854775807"))
                 .isNull(createVarcharType(3));
 
         assertThat(assertions.function("split_part", "'abc'", "'abcd'", "1"))

--- a/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
@@ -3113,6 +3113,13 @@ public class TestArrayOperators
         assertThat(assertions.function("element_at", "ARRAY[1, 2, 3]", "-4"))
                 .isNull(INTEGER);
 
+        // an index that cannot be negated without overflowing is out of range like any other index past the array bounds
+        assertThat(assertions.function("element_at", "ARRAY[1, 2, 3]", "-9223372036854775808"))
+                .isNull(INTEGER);
+
+        assertThat(assertions.function("element_at", "ARRAY[1, 2, 3]", "9223372036854775807"))
+                .isNull(INTEGER);
+
         assertThat(assertions.function("element_at", "ARRAY[NULL]", "1"))
                 .isNull(UNKNOWN);
 
@@ -3829,6 +3836,23 @@ public class TestArrayOperators
 
         assertTrinoExceptionThrownBy(assertions.function("slice", "ARRAY[1, 2, 3, 4]", "0", "1")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
+
+        // a length large enough to overflow the end index must still return everything from the start index onwards
+        assertThat(assertions.function("slice", "ARRAY[1, 2, 3, 4]", "1", "9223372036854775807"))
+                .hasType(new ArrayType(INTEGER))
+                .isEqualTo(ImmutableList.of(1, 2, 3, 4));
+
+        assertThat(assertions.function("slice", "ARRAY[1, 2, 3, 4]", "3", "9223372036854775807"))
+                .hasType(new ArrayType(INTEGER))
+                .isEqualTo(ImmutableList.of(3, 4));
+
+        assertThat(assertions.function("slice", "ARRAY[1, 2, 3, 4]", "-1", "9223372036854775807"))
+                .hasType(new ArrayType(INTEGER))
+                .isEqualTo(ImmutableList.of(4));
+
+        assertThat(assertions.function("slice", "ARRAY[1, 2, 3, 4]", "-9223372036854775808", "9223372036854775807"))
+                .hasType(new ArrayType(INTEGER))
+                .isEqualTo(ImmutableList.of());
     }
 
     @Test


### PR DESCRIPTION
## Description

Four scalar functions do unchecked 64-bit arithmetic on their user-supplied `BIGINT`
arguments. When a caller passes a value near `Long.MIN_VALUE` / `Long.MAX_VALUE`, the
arithmetic overflows and the function either returns a wrong result or fails with a raw
`ArithmeticException` instead of the documented `NULL`/`0`.

| Query | Before | After |
| --- | --- | --- |
| `SELECT slice(ARRAY[1, 2, 3, 4], 1, 9223372036854775807)` | `[]` | `[1, 2, 3, 4]` |
| `SELECT element_at(ARRAY[1, 2, 3], -9223372036854775808)` | `ArithmeticException: integer overflow` | `NULL` |
| `SELECT split_part('abc', '', 3000000000)` | `ArithmeticException: integer overflow` | `NULL` |
| `SELECT strpos('abc/xyz', '/', -9223372036854775808)` | `Index must be greater than zero`-style failure: `'instance' must be a positive or negative number.` | `0` |

The `slice` case is the most serious: it silently returns an empty array rather than
failing, so a query that asks for "everything from position N onwards" using a large
sentinel length quietly loses all its rows.

The array fixes and the string fixes are in separate commits.

### slice

`fromIndex + length` overflows to a negative `toIndex`, which then loses the
`min(..., size + 1)` comparison, so the `fromIndex >= toIndex` guard treats a fully
in-range slice as empty. Replaced with `LongMath.saturatedAdd`.

### element_at

`Math.abs(Long.MIN_VALUE)` is negative, so the out-of-range guard
`Math.abs(index) > arrayLength` does not fire. Execution falls through to
`toIntExact(arrayLength + index)`, which throws. Replaced the `abs` with an explicit
two-sided bounds check, so the index is reported out of range and the function returns
`NULL` as documented.

### split_part

With an empty delimiter, `toIntExact(index)` throws for any index above
`Integer.MAX_VALUE`, even though such an index is simply past the end of the string and
the function already returns `NULL` for that case (`split_part('abc', '', 99)`).
Switched to `Ints.saturatedCast`, matching what `substring` in the same file already
does.

### strpos

`abs(instance)` is negative for `Long.MIN_VALUE`, so `stringPositionFromEnd` hits its
`instance <= 0` guard and raises "'instance' must be a positive or negative number." for
a value that is, in fact, negative. The `@ScalarFunction(value = "strpos", neverFails =
false /* for instance==0 */)` annotation documents `instance == 0` as the only failure
mode, so this was an unintended second one. Negating with saturation makes the search
run to the end of the string and return `0`, consistent with
`strpos('abc/xyz/foo/bar', '/', -4)`.

## Additional context and related issues

- Fixes #30803

`json_array_get` already special-cases `Long.MIN_VALUE` and returns `NULL`
(`JsonFunctions.java`), and `substring`/`overlay` already use `Ints.saturatedCast` and
`LongMath.saturatedAdd` respectively. These four functions are the remaining places
where the same class of input was not handled; the fixes reuse those existing idioms
rather than introducing a new one.

No behavior changes for any argument that did not previously overflow.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix `slice` returning an empty array when the `length` argument is large enough to
  overflow the end index. ({issue}`30804`)
* Fix `element_at`, `split_part`, and `strpos` failing with an `integer overflow` error
  for index arguments near the `BIGINT` bounds, instead of returning `NULL` or `0`. ({issue}`30804`)
```
