### PR TITLE
Remove redundant BigQueryClient.getTable call

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -328,11 +328,11 @@ public class BigQueryClient
         }
     }
 
-    public TableInfo getCachedTable(Duration viewExpiration, TableInfo remoteTableId, List<BigQueryColumnHandle> requiredColumns, Optional<String> filter)
+    public TableInfo getCachedTable(Duration viewExpiration, TableId tableId, List<BigQueryColumnHandle> requiredColumns, Optional<String> filter)
     {
-        String query = selectSql(remoteTableId.getTableId(), requiredColumns, filter, OptionalLong.empty());
+        String query = selectSql(tableId, requiredColumns, filter, OptionalLong.empty());
         log.debug("query is %s", query);
-        return materializationCache.getCachedTable(this, query, viewExpiration, remoteTableId);
+        return materializationCache.getCachedTable(this, query, viewExpiration, tableId);
     }
 
     /**

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitSource.java
@@ -208,7 +208,7 @@ public class BigQuerySplitSource
                     .filter(column -> !projectedColumnsNames.contains(column.name()))
                     .forEach(projectedColumnHandles::add));
         }
-        ReadSession readSession = createReadSession(session, remoteTableId, ImmutableList.copyOf(projectedColumnHandles.build()), filter);
+        ReadSession readSession = createReadSession(session, type, remoteTableId, ImmutableList.copyOf(projectedColumnHandles.build()), filter);
 
         String schemaString = getSchemaAsString(readSession);
         return readSession.getStreamsList().stream()
@@ -217,10 +217,10 @@ public class BigQuerySplitSource
     }
 
     @VisibleForTesting
-    ReadSession createReadSession(ConnectorSession session, TableId remoteTableId, List<BigQueryColumnHandle> columns, Optional<String> filter)
+    ReadSession createReadSession(ConnectorSession session, TableDefinition.Type type, TableId remoteTableId, List<BigQueryColumnHandle> columns, Optional<String> filter)
     {
         ReadSessionCreator readSessionCreator = new ReadSessionCreator(bigQueryClientFactory, bigQueryReadClientFactory, viewEnabled, arrowSerializationEnabled, viewExpiration, maxReadRowsRetries, getMaxParallelism(session));
-        return readSessionCreator.create(session, remoteTableId, columns, filter, workerCountSupplier.getAsInt());
+        return readSessionCreator.create(session, type, remoteTableId, columns, filter, workerCountSupplier.getAsInt());
     }
 
     private static List<String> getProjectedColumnNames(List<BigQueryColumnHandle> columns)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
@@ -16,7 +16,6 @@ package io.trino.plugin.bigquery;
 import com.google.api.gax.rpc.ApiException;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
-import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
@@ -28,8 +27,6 @@ import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.TableNotFoundException;
 
 import java.util.List;
 import java.util.Optional;
@@ -79,13 +76,16 @@ public class ReadSessionCreator
         this.maxParallelism = maxParallelism;
     }
 
-    public ReadSession create(ConnectorSession session, TableId remoteTable, List<BigQueryColumnHandle> selectedFields, Optional<String> filter, int currentWorkerCount)
+    public ReadSession create(
+            ConnectorSession session,
+            TableDefinition.Type type,
+            TableId tableId,
+            List<BigQueryColumnHandle> selectedFields,
+            Optional<String> filter,
+            int currentWorkerCount)
     {
         BigQueryClient client = bigQueryClientFactory.create(session);
-        TableInfo tableDetails = client.getTable(remoteTable)
-                .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(remoteTable.getDataset(), remoteTable.getTable())));
-
-        TableInfo actualTable = getActualTable(client, tableDetails, selectedFields, isViewMaterializationWithFilter(session) ? filter : Optional.empty());
+        TableId actualTableId = getActualTableId(client, type, tableId, selectedFields, isViewMaterializationWithFilter(session) ? filter : Optional.empty());
 
         List<String> filteredSelectedFields = selectedFields.stream()
                 .map(BigQueryColumnHandle::getQualifiedName)
@@ -109,7 +109,7 @@ public class ReadSessionCreator
                     .setParent("projects/" + client.getParentProjectId())
                     .setReadSession(ReadSession.newBuilder()
                             .setDataFormat(format)
-                            .setTable(toTableResourceName(actualTable.getTableId()))
+                            .setTable(toTableResourceName(actualTableId))
                             .setReadOptions(readOptions));
             if (maxParallelism.isPresent()) {
                 int maxStreamCount = maxParallelism.get();
@@ -141,16 +141,15 @@ public class ReadSessionCreator
         return format("projects/%s/datasets/%s/tables/%s", tableId.getProject(), tableId.getDataset(), tableId.getTable());
     }
 
-    private TableInfo getActualTable(
+    private TableId getActualTableId(
             BigQueryClient client,
-            TableInfo remoteTable,
+            TableDefinition.Type tableType,
+            TableId tableId,
             List<BigQueryColumnHandle> requiredColumns,
             Optional<String> filter)
     {
-        TableDefinition tableDefinition = remoteTable.getDefinition();
-        TableDefinition.Type tableType = tableDefinition.getType();
         if (tableType == TABLE || tableType == SNAPSHOT || tableType == EXTERNAL) {
-            return remoteTable;
+            return tableId;
         }
         if (tableType == VIEW || tableType == MATERIALIZED_VIEW) {
             if (!viewEnabled) {
@@ -159,13 +158,13 @@ public class ReadSessionCreator
                         BigQueryConfig.VIEWS_ENABLED));
             }
             // get it from the view
-            return client.getCachedTable(viewExpiration, remoteTable, requiredColumns, filter);
+            return client.getCachedTable(viewExpiration, tableId, requiredColumns, filter).getTableId();
         }
         // Storage API doesn't support reading other table types (materialized views, non-biglake external tables)
         throw new TrinoException(NOT_SUPPORTED, format(
                 "Table type '%s' of table '%s.%s' is not supported",
                 tableType,
-                remoteTable.getTableId().getDataset(),
-                remoteTable.getTableId().getTable()));
+                tableId.getDataset(),
+                tableId.getTable()));
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ViewMaterializationCache.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ViewMaterializationCache.java
@@ -61,9 +61,9 @@ public class ViewMaterializationCache
         this.viewMaterializationDataset = config.getViewMaterializationDataset();
     }
 
-    public TableInfo getCachedTable(BigQueryClient client, String query, Duration viewExpiration, TableInfo remoteTableId)
+    public TableInfo getCachedTable(BigQueryClient client, String query, Duration viewExpiration, TableId tableId)
     {
-        return uncheckedCacheGet(destinationTableCache, query, new DestinationTableBuilder(client, viewExpiration, query, buildDestinationTable(remoteTableId.getTableId())));
+        return uncheckedCacheGet(destinationTableCache, query, new DestinationTableBuilder(client, viewExpiration, query, buildDestinationTable(tableId)));
     }
 
     private TableId buildDestinationTable(TableId remoteTableId)

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQuerySplitManager.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -118,6 +119,7 @@ public class TestBigQuerySplitManager
         BigQueryTableHandle bigQueryTable = (BigQueryTableHandle) table;
         return splitSource.createReadSession(
                 session,
+                TableDefinition.Type.MATERIALIZED_VIEW,
                 bigQueryTable.asPlainTable().getRemoteTableName().toTableId(),
                 bigQueryTable.projectedColumns().orElseThrow(),
                 buildFilter(bigQueryTable.constraint()));


### PR DESCRIPTION
## Description

- Closes #30619

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
