### PR TITLE
Retry maven resolver dependency downloads on CI more robustly

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -146,6 +146,11 @@ runs:
         if: ${{ inputs.java-version != '' }}
         shell: bash
         run: .github/bin/retry ./mvnw -v
+      - name: Preload Maven core extensions
+        # Load maven core extensions with retry.
+        if: ${{ inputs.java-version != '' }}
+        shell: bash
+        run: .github/bin/retry ./mvnw -N -B -U -e --no-transfer-progress help:evaluate -Dexpression=maven.version -DforceStdout
       - name: Configure Problem Matchers
         if: ${{ inputs.java-version != '' }}
         shell: bash

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -3,6 +3,8 @@
 -Daether.syncContext.named.nameMapper=file-hgav
 -Daether.syncContext.named.retry=5
 -Daether.dependencyCollector.impl=bf
+-Daether.connector.http.retryHandler.count=6
+-Daether.connector.http.retryHandler.serviceUnavailable=429,500,502,503,504
 -Daether.remoteRepositoryFilter.prefixes=true
 -Daether.remoteRepositoryFilter.prefixes.basedir=${session.rootDirectory}/.mvn/rrf/
 -Daether.remoteRepositoryFilter.groupId=true


### PR DESCRIPTION
- relates to https://github.com/trinodb/trino/issues/30807