### PR TITLE
Fix int overflow in ngrams result size

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayNgramsFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayNgramsFunction.java
@@ -32,6 +32,10 @@ import static java.lang.StrictMath.toIntExact;
 @Description("Return N-grams for the input")
 public final class ArrayNgramsFunction
 {
+    // the result holds one position id per element in an int array, so this bounds that array at about 4 MB,
+    // in line with the 4 MB result budget the repeat function applies
+    private static final int MAX_RESULT_ELEMENTS = 1_000_000;
+
     private ArrayNgramsFunction() {}
 
     @TypeParameter("T")
@@ -43,7 +47,16 @@ public final class ArrayNgramsFunction
         // n should not be larger than the array length
         int elementsPerRecord = toIntExact(min(array.getPositionCount(), n));
         int totalRecords = array.getPositionCount() - elementsPerRecord + 1;
-        int[] ids = new int[totalRecords * elementsPerRecord];
+        // the element count peaks near arrayLength^2 / 4, so it is computed as a long: for arrays of about
+        // 92000 entries and upwards it overflows an int, which would leave the allocation with a negative size
+        long totalElements = (long) totalRecords * elementsPerRecord;
+        checkCondition(
+                totalElements <= MAX_RESULT_ELEMENTS,
+                INVALID_FUNCTION_ARGUMENT,
+                "ngrams result would have %s elements, which exceeds the maximum of %s",
+                totalElements,
+                MAX_RESULT_ELEMENTS);
+        int[] ids = new int[(int) totalElements];
         int[] offset = new int[totalRecords + 1];
         for (int recordIndex = 0; recordIndex < totalRecords; recordIndex++) {
             for (int elementIndex = 0; elementIndex < elementsPerRecord; elementIndex++) {
@@ -52,6 +65,6 @@ public final class ArrayNgramsFunction
             offset[recordIndex + 1] = (recordIndex + 1) * elementsPerRecord;
         }
 
-        return ArrayBlock.fromElementBlock(totalRecords, Optional.empty(), offset, array.getPositions(ids, 0, totalRecords * elementsPerRecord));
+        return ArrayBlock.fromElementBlock(totalRecords, Optional.empty(), offset, array.getPositions(ids, 0, ids.length));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayNgramsFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayNgramsFunction.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -165,5 +166,23 @@ public class TestArrayNgramsFunction
 
         assertTrinoExceptionThrownBy(assertions.function("ngrams", "ARRAY['foo','bar']", "0")::evaluate)
                 .hasMessage("N must be positive");
+
+        // an element count that does not fit in an int must be rejected rather than wrapping to a negative allocation
+        assertTrinoExceptionThrownBy(assertions.function("ngrams", "repeat(1, 100000)", "50000")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("ngrams result would have 2500050000 elements, which exceeds the maximum of 1000000");
+
+        // an element count that fits in an int but exceeds the maximum is rejected too
+        assertTrinoExceptionThrownBy(assertions.function("ngrams", "repeat(1, 100000)", "20")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("ngrams result would have 1999620 elements, which exceeds the maximum of 1000000");
+    }
+
+    @Test
+    public void testLargeResultWithinLimit()
+    {
+        // the largest array repeat can produce still works for the small n values ngrams is typically used with
+        assertThat(assertions.query("SELECT cardinality(ngrams(repeat(1, 100000), 10))"))
+                .matches("VALUES BIGINT '99991'");
     }
 }


### PR DESCRIPTION
## Description

`ngrams` sized its result array with int arithmetic:

```java
int[] ids = new int[totalRecords * elementsPerRecord];
```

The element count peaks near `arrayLength^2 / 4`, so the product overflows an int once the array reaches roughly 92,000 entries and the allocation gets a negative size. The `NegativeArraySizeException` message then leaked through as the query failure text.

| Query | Before | After |
| --- | --- | --- |
| `SELECT ngrams(repeat(1, 100000), 50000)` | `Query failed: -1794917296` | `ngrams result would have 2500050000 elements, which exceeds the maximum of 1000000` |

A 100,000-element array is reachable through ordinary SQL, since `repeat` permits up to `MAX_RESULT_ENTRIES = 100_000`.

The count is now computed as a `long` and rejected with `INVALID_FUNCTION_ARGUMENT` when it exceeds `MAX_RESULT_ELEMENTS = 1_000_000`, which bounds the position id array at about 4 MB. The size is computed once and reused via `ids.length`, rather than recomputing the same expression for `getPositions`.

## Additional context and related issues

Fixes #30806

The sibling functions all guard their result size and fail with a categorized error; `ngrams` was the only one without such a guard:

- `combinations` — `MAX_RESULT_ELEMENTS = 100_000`
- `repeat` — `MAX_RESULT_ENTRIES = 100_000`, plus a 4 MB `MAX_SIZE_IN_BYTES` budget
- `sequence` — `MAX_RESULT_ENTRIES = 10_000`

### On the choice of limit

The first revision of this PR only guarded against the int overflow, at `Integer.MAX_VALUE`. As @findepi pointed out in review, that still permits an 8 GB allocation and may fail outright on some JVMs, so a real limit was needed.

`MAX_RESULT_ELEMENTS = 100_000`, matching `combinations`, turns out to be too tight for this function. The element count is roughly `arrayLength * n`, and `repeat` permits arrays of exactly 100,000 elements, so a 100k limit would reject `ngrams` over the largest array `repeat` can build even at `n = 2`:

| Query | Result elements | vs. a 100k limit |
| --- | --- | --- |
| `ngrams(repeat(1, 100000), 2)` | 199,998 | rejected |
| `ngrams(repeat(1, 100000), 5)` | 499,980 | rejected |
| `ngrams(repeat(1, 100000), 10)` | 999,910 | rejected |

1,000,000 admits all of those and still rejects the 8 GB case by three orders of magnitude. It was chosen against `repeat`'s 4 MB byte budget, since there is no existing constant for an element count that fits this function. Happy to use a different value if maintainers prefer one.

Tests cover three cases: a count that overflows an int, a count that fits in an int but exceeds the limit, and `ngrams(repeat(1, 100000), 10)` succeeding, to confirm the limit does not break ordinary use at small `n`.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix `ngrams` failing with an uninformative error message when the number of
  elements in the result is too large. ({issue}`30811`)
```
