### PR TITLE
Add node groups to restrict queries to a subset of workers

### DIFF
--- a/core/trino-main/src/main/java/io/trino/Session.java
+++ b/core/trino-main/src/main/java/io/trino/Session.java
@@ -91,6 +91,7 @@ public final class Session
     private final ProtocolHeaders protocolHeaders;
     private final Optional<Slice> exchangeEncryptionKey;
     private final Optional<String> queryDataEncoding;
+    private final Optional<String> nodeGroup;
 
     public Session(
             QueryId queryId,
@@ -119,7 +120,8 @@ public final class Session
             Map<String, String> preparedStatements,
             ProtocolHeaders protocolHeaders,
             Optional<Slice> exchangeEncryptionKey,
-            Optional<String> queryDataEncoding)
+            Optional<String> queryDataEncoding,
+            Optional<String> nodeGroup)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.querySpan = requireNonNull(querySpan, "querySpan is null");
@@ -147,6 +149,7 @@ public final class Session
         this.protocolHeaders = requireNonNull(protocolHeaders, "protocolHeaders is null");
         this.exchangeEncryptionKey = requireNonNull(exchangeEncryptionKey, "exchangeEncryptionKey is null");
         this.queryDataEncoding = requireNonNull(queryDataEncoding, "queryDataEncoding is null");
+        this.nodeGroup = requireNonNull(nodeGroup, "nodeGroup is null");
 
         requireNonNull(catalogProperties, "catalogProperties is null");
         ImmutableMap.Builder<String, Map<String, String>> catalogPropertiesBuilder = ImmutableMap.builder();
@@ -324,6 +327,15 @@ public final class Session
         return queryDataEncoding;
     }
 
+    /**
+     * Node group that this query is restricted to, if any. Resolved from the query's resource group
+     * on the coordinator, so it is deliberately absent from {@link SessionRepresentation}.
+     */
+    public Optional<String> getNodeGroup()
+    {
+        return nodeGroup;
+    }
+
     public SessionPropertyManager getSessionPropertyManager()
     {
         return sessionPropertyManager;
@@ -395,7 +407,8 @@ public final class Session
                 preparedStatements,
                 protocolHeaders,
                 exchangeEncryptionKey,
-                queryDataEncoding);
+                queryDataEncoding,
+                nodeGroup);
     }
 
     public Session withDefaultProperties(Map<String, String> systemPropertyDefaults, Map<String, Map<String, String>> catalogPropertyDefaults, AccessControl accessControl)
@@ -450,7 +463,8 @@ public final class Session
                 preparedStatements,
                 protocolHeaders,
                 exchangeEncryptionKey,
-                queryDataEncoding);
+                queryDataEncoding,
+                nodeGroup);
     }
 
     public Session withExchangeEncryption(Slice encryptionKey)
@@ -483,7 +497,8 @@ public final class Session
                 preparedStatements,
                 protocolHeaders,
                 Optional.of(encryptionKey),
-                queryDataEncoding);
+                queryDataEncoding,
+                nodeGroup);
     }
 
     public Session withoutSpooling()
@@ -515,7 +530,8 @@ public final class Session
                 preparedStatements,
                 protocolHeaders,
                 exchangeEncryptionKey,
-                Optional.empty());
+                Optional.empty(),
+                nodeGroup);
     }
 
     public ConnectorSession toConnectorSession()
@@ -702,6 +718,7 @@ public final class Session
         private Set<String> clientTags = ImmutableSet.of();
         private Set<String> clientCapabilities = ImmutableSet.of();
         private Optional<String> queryDataEncoding = Optional.empty();
+        private Optional<String> nodeGroup = Optional.empty();
         private ResourceEstimates resourceEstimates;
         private Instant start = Instant.now();
         private final Map<String, String> systemProperties = new HashMap<>();
@@ -737,6 +754,7 @@ public final class Session
             this.clientInfo = session.clientInfo.orElse(null);
             this.clientCapabilities = ImmutableSet.copyOf(session.clientCapabilities);
             this.queryDataEncoding = session.queryDataEncoding;
+            this.nodeGroup = session.nodeGroup;
             this.clientTags = ImmutableSet.copyOf(session.clientTags);
             this.start = session.start;
             this.systemProperties.putAll(session.systemProperties);
@@ -991,6 +1009,12 @@ public final class Session
             return this;
         }
 
+        public SessionBuilder setNodeGroup(Optional<String> nodeGroup)
+        {
+            this.nodeGroup = requireNonNull(nodeGroup, "nodeGroup is null");
+            return this;
+        }
+
         public Session build()
         {
             return new Session(
@@ -1020,7 +1044,8 @@ public final class Session
                     preparedStatements,
                     protocolHeaders,
                     Optional.empty(),
-                    queryDataEncoding);
+                    queryDataEncoding,
+                    nodeGroup);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/SessionRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/SessionRepresentation.java
@@ -398,6 +398,7 @@ public final class SessionRepresentation
                 preparedStatements,
                 createProtocolHeaders(protocolName),
                 exchangeEncryptionKey,
-                queryDataEncoding);
+                queryDataEncoding,
+                Optional.empty());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/system/NodeSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/NodeSystemTable.java
@@ -18,6 +18,8 @@ import io.trino.node.AllNodes;
 import io.trino.node.InternalNode;
 import io.trino.node.InternalNodeManager;
 import io.trino.node.NodeState;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
@@ -27,10 +29,12 @@ import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.ArrayType;
 
 import java.util.Locale;
 import java.util.Set;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.node.NodeState.ACTIVE;
 import static io.trino.node.NodeState.DRAINED;
@@ -53,6 +57,7 @@ public class NodeSystemTable
             .column("node_version", createUnboundedVarcharType())
             .column("coordinator", BOOLEAN)
             .column("state", createUnboundedVarcharType())
+            .column("node_groups", new ArrayType(createUnboundedVarcharType()))
             .build();
 
     private final InternalNodeManager nodeManager;
@@ -92,8 +97,24 @@ public class NodeSystemTable
     private void addRows(Builder table, Set<InternalNode> nodes, NodeState state)
     {
         for (InternalNode node : nodes) {
-            table.addRow(node.getNodeIdentifier(), node.getInternalUri().toString(), getNodeVersion(node), isCoordinator(node), state.toString().toLowerCase(Locale.ENGLISH));
+            table.addRow(
+                    node.getNodeIdentifier(),
+                    node.getInternalUri().toString(),
+                    getNodeVersion(node),
+                    isCoordinator(node),
+                    state.toString().toLowerCase(Locale.ENGLISH),
+                    nodeGroupsToBlock(node));
         }
+    }
+
+    private static Block nodeGroupsToBlock(InternalNode node)
+    {
+        Set<String> nodeGroups = node.getNodeGroups();
+        BlockBuilder blockBuilder = createUnboundedVarcharType().createBlockBuilder(null, nodeGroups.size());
+        for (String nodeGroup : nodeGroups) {
+            createUnboundedVarcharType().writeSlice(blockBuilder, utf8Slice(nodeGroup));
+        }
+        return blockBuilder.build();
     }
 
     private static String getNodeVersion(InternalNode node)

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemSplitManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemSplitManager.java
@@ -15,6 +15,7 @@ package io.trino.connector.system;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import io.trino.FullConnectorSession;
 import io.trino.node.InternalNode;
 import io.trino.node.InternalNodeManager;
 import io.trino.spi.HostAddress;
@@ -35,6 +36,7 @@ import io.trino.spi.predicate.TupleDomain;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.node.NodeState.ACTIVE;
 import static io.trino.spi.connector.SystemTable.Distribution.ALL_COORDINATORS;
 import static io.trino.spi.connector.SystemTable.Distribution.ALL_NODES;
@@ -88,12 +90,29 @@ public class SystemSplitManager
             nodes.addAll(nodeManager.getCoordinators());
         }
         else if (tableDistributionMode == ALL_NODES) {
-            nodes.addAll(nodeManager.getNodes(ACTIVE));
+            nodes.addAll(activeNodesForQuery(session));
         }
         Set<InternalNode> nodeSet = nodes.build();
         for (InternalNode node : nodeSet) {
             splits.add(new SystemSplit(node.getHostAndPort(), tableConstraint, Optional.empty()));
         }
         return new FixedSplitSource(splits.build());
+    }
+
+    /**
+     * System splits are not remotely accessible, so they must be addressed at nodes the query is allowed
+     * to run on. Addressing one at a node outside the query's node group would leave it unschedulable.
+     */
+    private Set<InternalNode> activeNodesForQuery(ConnectorSession session)
+    {
+        Optional<String> nodeGroup = ((FullConnectorSession) session).getSession().getNodeGroup();
+        if (nodeGroup.isEmpty()) {
+            return nodeManager.getNodes(ACTIVE);
+        }
+        // matches the node selector: coordinators are never excluded by a node group
+        Set<InternalNode> coordinators = nodeManager.getCoordinators();
+        return nodeManager.getNodes(ACTIVE).stream()
+                .filter(node -> node.getNodeGroups().contains(nodeGroup.get()) || coordinators.contains(node))
+                .collect(toImmutableSet());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/cost/TaskCountEstimator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/TaskCountEstimator.java
@@ -22,6 +22,7 @@ import io.trino.operator.RetryPolicy;
 
 import java.util.Set;
 import java.util.function.IntSupplier;
+import java.util.function.ToIntFunction;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.SystemSessionProperties.getCostEstimationWorkerCount;
@@ -34,15 +35,17 @@ import static java.util.Objects.requireNonNull;
 
 public class TaskCountEstimator
 {
-    private final IntSupplier numberOfNodes;
+    private final ToIntFunction<Session> numberOfNodes;
 
     @Inject
     public TaskCountEstimator(NodeSchedulerConfig nodeSchedulerConfig, InternalNodeManager nodeManager)
     {
         boolean schedulerIncludeCoordinator = nodeSchedulerConfig.isIncludeCoordinator();
         requireNonNull(nodeManager, "nodeManager is null");
-        this.numberOfNodes = () -> {
-            Set<InternalNode> activeNodes = nodeManager.getAllNodes().activeNodes();
+        this.numberOfNodes = session -> {
+            // a query restricted to a node group only runs on that group, so costing it against the whole
+            // cluster would over-estimate the parallelism available to it
+            Set<InternalNode> activeNodes = nodeManager.getActiveNodesInGroup(session.getNodeGroup());
             int count;
             if (schedulerIncludeCoordinator) {
                 count = activeNodes.size();
@@ -59,7 +62,8 @@ public class TaskCountEstimator
 
     public TaskCountEstimator(IntSupplier numberOfNodes)
     {
-        this.numberOfNodes = requireNonNull(numberOfNodes, "numberOfNodes is null");
+        requireNonNull(numberOfNodes, "numberOfNodes is null");
+        this.numberOfNodes = _ -> numberOfNodes.getAsInt();
     }
 
     public int estimateSourceDistributedTaskCount(Session session)
@@ -69,7 +73,7 @@ public class TaskCountEstimator
             // validated to be at least 1
             return costEstimationWorkerCount;
         }
-        int count = numberOfNodes.getAsInt();
+        int count = numberOfNodes.applyAsInt(session);
         checkState(count > 0, "%s should return positive number of nodes: %s", numberOfNodes, count);
         return count;
     }

--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
@@ -242,6 +242,15 @@ public class DispatchManager
             // apply system default session properties (does not override user set properties)
             session = sessionPropertyDefaults.newSessionWithDefaultProperties(session, queryType, selectionContext.getResourceGroupId());
 
+            // restrict the query to the node group of its resource group, if it declares one. This is resolved
+            // from the resource group rather than the session so that a user cannot choose their own node group.
+            Optional<String> nodeGroup = resourceGroupManager.getNodeGroup(selectionContext);
+            if (nodeGroup.isPresent()) {
+                session = Session.builder(session)
+                        .setNodeGroup(nodeGroup)
+                        .build();
+            }
+
             DispatchQuery dispatchQuery = dispatchQueryFactory.createDispatchQuery(
                     session,
                     sessionContext.getTransactionId(),

--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java
@@ -130,7 +130,8 @@ public class LocalDispatchQuery
             if (queryExecution.shouldWaitForMinWorkers()) {
                 executionMinCount = getRequiredWorkers(session);
             }
-            ListenableFuture<Void> minimumWorkerFuture = clusterSizeMonitor.waitForMinimumWorkers(executionMinCount, getRequiredWorkersMaxWait(session));
+            // wait on the query's own node group, so it is not held up by, or admitted on the strength of, workers it cannot use
+            ListenableFuture<Void> minimumWorkerFuture = clusterSizeMonitor.waitForMinimumWorkers(session.getNodeGroup(), executionMinCount, getRequiredWorkersMaxWait(session));
             // when worker requirement is met, start the execution
             addSuccessCallback(minimumWorkerFuture, () -> startExecution(queryExecution), queryExecutor);
             addExceptionCallback(minimumWorkerFuture, stateMachine::transitionToFailed, queryExecutor);

--- a/core/trino-main/src/main/java/io/trino/execution/ClusterSizeMonitor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/ClusterSizeMonitor.java
@@ -14,6 +14,7 @@
 package io.trino.execution;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -22,25 +23,28 @@ import com.google.inject.Inject;
 import io.airlift.units.Duration;
 import io.trino.execution.scheduler.NodeSchedulerConfig;
 import io.trino.node.AllNodes;
+import io.trino.node.InternalNode;
 import io.trino.node.InternalNodeManager;
 import io.trino.spi.TrinoException;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import org.weakref.jmx.Managed;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.PriorityQueue;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static java.lang.String.format;
-import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -53,11 +57,12 @@ public class ClusterSizeMonitor
 
     private final Consumer<AllNodes> listener = this::updateAllNodes;
 
+    // keyed by node group, with an empty key for queries that are not restricted to one
     @GuardedBy("this")
-    private int currentCount;
+    private Map<Optional<String>, Integer> currentCounts = ImmutableMap.of();
 
     @GuardedBy("this")
-    private final PriorityQueue<MinNodesFuture> futuresQueue = new PriorityQueue<>(comparing(MinNodesFuture::executionMinCount));
+    private final Set<MinNodesFuture> futures = new HashSet<>();
 
     @Inject
     public ClusterSizeMonitor(InternalNodeManager nodeManager, NodeSchedulerConfig nodeSchedulerConfig)
@@ -94,18 +99,19 @@ public class ClusterSizeMonitor
      * Note: caller should not add a listener using the direct executor, as this can delay the
      * notifications for other listeners.
      */
-    public synchronized ListenableFuture<Void> waitForMinimumWorkers(int executionMinCount, Duration executionMaxWait)
+    public synchronized ListenableFuture<Void> waitForMinimumWorkers(Optional<String> nodeGroup, int executionMinCount, Duration executionMaxWait)
     {
         checkArgument(executionMinCount > 0, "executionMinCount should be greater than 0");
+        requireNonNull(nodeGroup, "nodeGroup is null");
         requireNonNull(executionMaxWait, "executionMaxWait is null");
 
-        if (currentCount >= executionMinCount) {
+        if (currentCount(nodeGroup) >= executionMinCount) {
             return immediateVoidFuture();
         }
 
         SettableFuture<Void> future = SettableFuture.create();
-        MinNodesFuture minNodesFuture = new MinNodesFuture(executionMinCount, future);
-        futuresQueue.add(minNodesFuture);
+        MinNodesFuture minNodesFuture = new MinNodesFuture(nodeGroup, executionMinCount, future);
+        futures.add(minNodesFuture);
 
         // if future does not finish in wait period, complete with an exception
         ScheduledFuture<?> timeoutTask = executor.schedule(
@@ -113,7 +119,12 @@ public class ClusterSizeMonitor
                     synchronized (this) {
                         future.setException(new TrinoException(
                                 GENERIC_INSUFFICIENT_RESOURCES,
-                                format("Insufficient active worker nodes. Waited %s for at least %s workers, but only %s workers are active", executionMaxWait, executionMinCount, currentCount)));
+                                format(
+                                        "Insufficient active worker nodes%s. Waited %s for at least %s workers, but only %s workers are active",
+                                        nodeGroup.map(" in node group '%s'"::formatted).orElse(""),
+                                        executionMaxWait,
+                                        executionMinCount,
+                                        currentCount(nodeGroup))));
                     }
                 },
                 executionMaxWait.toMillis(),
@@ -128,47 +139,64 @@ public class ClusterSizeMonitor
         return future;
     }
 
+    @GuardedBy("this")
+    private int currentCount(Optional<String> nodeGroup)
+    {
+        return currentCounts.getOrDefault(nodeGroup, 0);
+    }
+
     private synchronized void removeFuture(MinNodesFuture minNodesFuture)
     {
-        futuresQueue.remove(minNodesFuture);
+        futures.remove(minNodesFuture);
     }
 
     private synchronized void updateAllNodes(AllNodes allNodes)
     {
-        if (includeCoordinator) {
-            currentCount = allNodes.activeNodes().size();
+        // recomputed from the whole snapshot: node change listeners run on a pool, so snapshots can
+        // arrive out of order, and start() delivers one twice
+        Set<InternalNode> schedulableNodes = includeCoordinator
+                ? allNodes.activeNodes()
+                : Sets.difference(allNodes.activeNodes(), allNodes.activeCoordinators());
+
+        Map<Optional<String>, Integer> counts = new HashMap<>();
+        counts.put(Optional.empty(), schedulableNodes.size());
+        for (InternalNode node : schedulableNodes) {
+            for (String nodeGroup : node.getNodeGroups()) {
+                counts.merge(Optional.of(nodeGroup), 1, Integer::sum);
+            }
         }
-        else {
-            currentCount = Sets.difference(allNodes.activeNodes(), allNodes.activeCoordinators()).size();
-        }
+        currentCounts = ImmutableMap.copyOf(counts);
 
         ImmutableList.Builder<SettableFuture<Void>> listenersBuilder = ImmutableList.builder();
-        while (!futuresQueue.isEmpty()) {
-            MinNodesFuture minNodesFuture = futuresQueue.peek();
-            if (minNodesFuture.executionMinCount() > currentCount) {
-                break;
+        futures.removeIf(minNodesFuture -> {
+            if (minNodesFuture.executionMinCount() > currentCount(minNodesFuture.nodeGroup())) {
+                return false;
             }
             listenersBuilder.add(minNodesFuture.future());
-            // this should not happen since we have a lock
-            checkState(futuresQueue.poll() == minNodesFuture, "Unexpected modifications to MinNodesFuture queue");
-        }
+            return true;
+        });
         List<SettableFuture<Void>> listeners = listenersBuilder.build();
         executor.submit(() -> listeners.forEach(listener -> listener.set(null)));
     }
 
+    /**
+     * Highest worker count any query is currently waiting for, across all node groups. With node groups in
+     * use this is an upper bound rather than a count of workers the cluster as a whole is missing.
+     */
     @Managed
     public synchronized int getRequiredWorkers()
     {
-        return futuresQueue.stream()
-                .map(MinNodesFuture::executionMinCount)
-                .max(Integer::compareTo)
+        return futures.stream()
+                .mapToInt(MinNodesFuture::executionMinCount)
+                .max()
                 .orElse(0);
     }
 
-    private record MinNodesFuture(int executionMinCount, SettableFuture<Void> future)
+    private record MinNodesFuture(Optional<String> nodeGroup, int executionMinCount, SettableFuture<Void> future)
     {
         MinNodesFuture
         {
+            requireNonNull(nodeGroup, "nodeGroup is null");
             requireNonNull(future, "future is null");
         }
     }

--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroupManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroupManager.java
@@ -122,6 +122,12 @@ public final class InternalResourceGroupManager<C>
     }
 
     @Override
+    public Optional<String> getNodeGroup(SelectionContext<C> selectionContext)
+    {
+        return configurationManager.get().getNodeGroup(selectionContext);
+    }
+
+    @Override
     public void addConfigurationManagerFactory(ResourceGroupConfigurationManagerFactory factory)
     {
         if (configurationManagerFactories.putIfAbsent(factory.getName(), factory) != null) {

--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/NoOpResourceGroupManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/NoOpResourceGroupManager.java
@@ -54,6 +54,12 @@ public final class NoOpResourceGroupManager
     }
 
     @Override
+    public Optional<String> getNodeGroup(SelectionContext<Void> selectionContext)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public SelectionContext<Void> selectGroup(SelectionCriteria criteria)
     {
         throw new UnsupportedOperationException();

--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/ResourceGroupManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/ResourceGroupManager.java
@@ -19,6 +19,7 @@ import io.trino.spi.resourcegroups.ResourceGroupConfigurationManagerFactory;
 import io.trino.spi.resourcegroups.SelectionContext;
 import io.trino.spi.resourcegroups.SelectionCriteria;
 
+import java.util.Optional;
 import java.util.concurrent.Executor;
 
 /**
@@ -32,6 +33,12 @@ public interface ResourceGroupManager<C>
     void submit(ManagedQueryExecution queryExecution, SelectionContext<C> selectionContext, Executor executor);
 
     SelectionContext<C> selectGroup(SelectionCriteria criteria);
+
+    /**
+     * Node group that queries in the selected resource group must run on, restricting them to the
+     * workers declaring membership of that group. Empty places no restriction on where the query runs.
+     */
+    Optional<String> getNodeGroup(SelectionContext<C> selectionContext);
 
     void addConfigurationManagerFactory(ResourceGroupConfigurationManagerFactory factory);
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeScheduler.java
@@ -27,6 +27,7 @@ import io.trino.metadata.Split;
 import io.trino.node.InternalNode;
 import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
+import io.trino.spi.TrinoException;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -38,6 +39,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -45,7 +47,10 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.whenAnyCompleteCancelOthers;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static java.lang.Math.addExact;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class NodeScheduler
@@ -148,6 +153,24 @@ public class NodeScheduler
         }
 
         return ImmutableList.copyOf(chosen);
+    }
+
+    /**
+     * A split that is not remotely accessible must run on the node it is addressed to. Connectors choose
+     * those nodes from the cluster-wide node list, without knowing about node groups, so a query restricted
+     * to a group cannot run them and is refused rather than left unschedulable.
+     */
+    public static TrinoException noNodesAvailable(Split split, Optional<String> nodeGroup)
+    {
+        if (nodeGroup.isPresent() && !split.isRemotelyAccessible()) {
+            return new TrinoException(NOT_SUPPORTED, format(
+                    "Catalog '%s' addresses splits to specific nodes, which is not supported for a query restricted to node group '%s'",
+                    split.getCatalogHandle().getCatalogName(),
+                    nodeGroup.get()));
+        }
+        return new TrinoException(NO_NODES_AVAILABLE, nodeGroup
+                .map("No nodes available to run query in node group '%s'"::formatted)
+                .orElse("No nodes available to run query"));
     }
 
     public static SplitPlacementResult selectDistributionNodes(

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelector.java
@@ -25,12 +25,12 @@ import io.trino.metadata.Split;
 import io.trino.node.InternalNode;
 import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
-import io.trino.spi.TrinoException;
 import jakarta.annotation.Nullable;
 
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -40,12 +40,12 @@ import static io.trino.execution.scheduler.NetworkLocation.ROOT_LOCATION;
 import static io.trino.execution.scheduler.NodeScheduler.calculateLowWatermark;
 import static io.trino.execution.scheduler.NodeScheduler.canAssignSplitBasedOnWeight;
 import static io.trino.execution.scheduler.NodeScheduler.getAllNodes;
+import static io.trino.execution.scheduler.NodeScheduler.noNodesAvailable;
 import static io.trino.execution.scheduler.NodeScheduler.randomizedNodes;
 import static io.trino.execution.scheduler.NodeScheduler.selectDistributionNodes;
 import static io.trino.execution.scheduler.NodeScheduler.selectExactNodes;
 import static io.trino.execution.scheduler.NodeScheduler.selectNodes;
 import static io.trino.execution.scheduler.NodeScheduler.toWhenHasSplitQueueSpaceFuture;
-import static io.trino.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static java.util.Objects.requireNonNull;
 
 public class TopologyAwareNodeSelector
@@ -64,6 +64,7 @@ public class TopologyAwareNodeSelector
     private final List<CounterStat> topologicalSplitCounters;
     private final NetworkTopology networkTopology;
     private final StableHostAddressProvider stableHostAddressProvider;
+    private final Optional<String> nodeGroup;
 
     public TopologyAwareNodeSelector(
             InternalNode currentNode,
@@ -76,7 +77,8 @@ public class TopologyAwareNodeSelector
             int maxUnacknowledgedSplitsPerTask,
             List<CounterStat> topologicalSplitCounters,
             NetworkTopology networkTopology,
-            StableHostAddressProvider stableHostAddressProvider)
+            StableHostAddressProvider stableHostAddressProvider,
+            Optional<String> nodeGroup)
     {
         this.currentNode = requireNonNull(currentNode, "currentNode is null");
         this.nodeTaskMap = requireNonNull(nodeTaskMap, "nodeTaskMap is null");
@@ -90,6 +92,7 @@ public class TopologyAwareNodeSelector
         this.topologicalSplitCounters = requireNonNull(topologicalSplitCounters, "topologicalSplitCounters is null");
         this.networkTopology = requireNonNull(networkTopology, "networkTopology is null");
         this.stableHostAddressProvider = requireNonNull(stableHostAddressProvider, "stableHostAddressProvider is null");
+        this.nodeGroup = requireNonNull(nodeGroup, "nodeGroup is null");
     }
 
     @Override
@@ -134,7 +137,7 @@ public class TopologyAwareNodeSelector
                 List<InternalNode> candidateNodes = selectExactNodes(nodeMap, split.getAddresses(), includeCoordinator);
                 if (candidateNodes.isEmpty()) {
                     log.debug("No nodes available to schedule %s. Available nodes %s", split, nodeMap.getNodesByHost().keys());
-                    throw new TrinoException(NO_NODES_AVAILABLE, "No nodes available to run query");
+                    throw noNodesAvailable(split, nodeGroup);
                 }
                 InternalNode chosenNode = bestNodeSplitCount(splitWeight, candidateNodes.iterator(), minCandidates, maxPendingSplitsWeightPerTask, assignmentStats);
                 if (chosenNode != null) {

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelectorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelectorFactory.java
@@ -34,6 +34,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -125,8 +126,9 @@ public class TopologyAwareNodeSelectorFactory
     {
         // this supplier is thread-safe. TODO: this logic should probably move to the scheduler since the choice of which node to run in should be
         // done as close to when the split is about to be scheduled
+        Optional<String> nodeGroup = session.getNodeGroup();
         Supplier<NodeMap> nodeMap = Suppliers.memoizeWithExpiration(
-                this::createNodeMap,
+                () -> createNodeMap(nodeGroup),
                 5,
                 TimeUnit.SECONDS);
 
@@ -141,16 +143,25 @@ public class TopologyAwareNodeSelectorFactory
                 getMaxUnacknowledgedSplitsPerTask(session),
                 placementCounters,
                 networkTopology,
-                stableHostAddressProvider);
+                stableHostAddressProvider,
+                nodeGroup);
     }
 
-    private NodeMap createNodeMap()
+    private NodeMap createNodeMap(Optional<String> nodeGroup)
     {
         Set<InternalNode> nodes = nodeManager.getNodes(ACTIVE);
 
         Set<String> coordinatorNodeIds = nodeManager.getCoordinators().stream()
                 .map(InternalNode::getNodeIdentifier)
                 .collect(toImmutableSet());
+
+        if (nodeGroup.isPresent()) {
+            // coordinators are exempt so that coordinator-only stages keep working; whether they are
+            // given worker splits is still decided by node-scheduler.include-coordinator
+            nodes = nodes.stream()
+                    .filter(node -> node.getNodeGroups().contains(nodeGroup.get()) || coordinatorNodeIds.contains(node.getNodeIdentifier()))
+                    .collect(toImmutableSet());
+        }
 
         ImmutableSetMultimap.Builder<HostAddress, InternalNode> byHostAndPort = ImmutableSetMultimap.builder();
         ImmutableSetMultimap.Builder<InetAddress, InternalNode> byHost = ImmutableSetMultimap.builder();

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java
@@ -28,7 +28,6 @@ import io.trino.execution.scheduler.NodeSchedulerConfig.SplitsBalancingPolicy;
 import io.trino.metadata.Split;
 import io.trino.node.InternalNode;
 import io.trino.spi.HostAddress;
-import io.trino.spi.TrinoException;
 import jakarta.annotation.Nullable;
 
 import java.util.HashMap;
@@ -44,12 +43,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.execution.scheduler.NodeScheduler.calculateLowWatermark;
 import static io.trino.execution.scheduler.NodeScheduler.filterNodes;
 import static io.trino.execution.scheduler.NodeScheduler.getAllNodes;
+import static io.trino.execution.scheduler.NodeScheduler.noNodesAvailable;
 import static io.trino.execution.scheduler.NodeScheduler.randomizedNodes;
 import static io.trino.execution.scheduler.NodeScheduler.selectDistributionNodes;
 import static io.trino.execution.scheduler.NodeScheduler.selectExactNodes;
 import static io.trino.execution.scheduler.NodeScheduler.selectNodes;
 import static io.trino.execution.scheduler.NodeScheduler.toWhenHasSplitQueueSpaceFuture;
-import static io.trino.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -70,6 +69,7 @@ public class UniformNodeSelector
     private final boolean optimizedLocalScheduling;
     private final QueueSizeAdjuster queueSizeAdjuster;
     private final StableHostAddressProvider stableHostAddressProvider;
+    private final Optional<String> nodeGroup;
 
     public UniformNodeSelector(
             InternalNode currentNode,
@@ -83,7 +83,8 @@ public class UniformNodeSelector
             int maxUnacknowledgedSplitsPerTask,
             SplitsBalancingPolicy splitsBalancingPolicy,
             boolean optimizedLocalScheduling,
-            StableHostAddressProvider stableHostAddressProvider)
+            StableHostAddressProvider stableHostAddressProvider,
+            Optional<String> nodeGroup)
     {
         this(currentNode,
                 nodeTaskMap,
@@ -96,7 +97,8 @@ public class UniformNodeSelector
                 splitsBalancingPolicy,
                 optimizedLocalScheduling,
                 new QueueSizeAdjuster(minPendingSplitsWeightPerTask, maxAdjustedPendingSplitsWeightPerTask),
-                stableHostAddressProvider);
+                stableHostAddressProvider,
+                nodeGroup);
     }
 
     @VisibleForTesting
@@ -112,7 +114,8 @@ public class UniformNodeSelector
             SplitsBalancingPolicy splitsBalancingPolicy,
             boolean optimizedLocalScheduling,
             QueueSizeAdjuster queueSizeAdjuster,
-            StableHostAddressProvider stableHostAddressProvider)
+            StableHostAddressProvider stableHostAddressProvider,
+            Optional<String> nodeGroup)
     {
         this.currentNode = requireNonNull(currentNode, "currentNode is null");
         this.nodeTaskMap = requireNonNull(nodeTaskMap, "nodeTaskMap is null");
@@ -127,6 +130,7 @@ public class UniformNodeSelector
         this.optimizedLocalScheduling = optimizedLocalScheduling;
         this.queueSizeAdjuster = queueSizeAdjuster;
         this.stableHostAddressProvider = requireNonNull(stableHostAddressProvider, "stableHostAddressProvider is null");
+        this.nodeGroup = requireNonNull(nodeGroup, "nodeGroup is null");
     }
 
     @Override
@@ -200,7 +204,7 @@ public class UniformNodeSelector
             }
             if (candidateNodes.isEmpty()) {
                 log.debug("No nodes available to schedule %s. Available nodes %s", split, nodeMap.getNodesByHost().keys());
-                throw new TrinoException(NO_NODES_AVAILABLE, "No nodes available to run query");
+                throw noNodesAvailable(split, nodeGroup);
             }
 
             InternalNode chosenNode = chooseNodeForSplit(assignmentStats, candidateNodes);

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelectorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelectorFactory.java
@@ -31,6 +31,7 @@ import io.trino.spi.SplitWeight;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -111,15 +112,16 @@ public class UniformNodeSelectorFactory
     {
         // this supplier is thread-safe. TODO: this logic should probably move to the scheduler since the choice of which node to run in should be
         // done as close to when the split is about to be scheduled
+        Optional<String> nodeGroup = session.getNodeGroup();
         Supplier<NodeMap> nodeMap;
         if (nodeMapMemoizationDuration.toMillis() > 0) {
             nodeMap = Suppliers.memoizeWithExpiration(
-                    this::createNodeMap,
+                    () -> createNodeMap(nodeGroup),
                     nodeMapMemoizationDuration.toMillis(),
                     MILLISECONDS);
         }
         else {
-            nodeMap = this::createNodeMap;
+            nodeMap = () -> createNodeMap(nodeGroup);
         }
 
         return new UniformNodeSelector(
@@ -134,16 +136,25 @@ public class UniformNodeSelectorFactory
                 getMaxUnacknowledgedSplitsPerTask(session),
                 splitsBalancingPolicy,
                 optimizedLocalScheduling,
-                stableHostAddressProvider);
+                stableHostAddressProvider,
+                nodeGroup);
     }
 
-    private NodeMap createNodeMap()
+    private NodeMap createNodeMap(Optional<String> nodeGroup)
     {
         Set<InternalNode> nodes = nodeManager.getNodes(ACTIVE);
 
         Set<String> coordinatorNodeIds = nodeManager.getCoordinators().stream()
                 .map(InternalNode::getNodeIdentifier)
                 .collect(toImmutableSet());
+
+        if (nodeGroup.isPresent()) {
+            // coordinators are exempt so that coordinator-only stages keep working; whether they are
+            // given worker splits is still decided by node-scheduler.include-coordinator
+            nodes = nodes.stream()
+                    .filter(node -> node.getNodeGroups().contains(nodeGroup.get()) || coordinatorNodeIds.contains(node.getNodeIdentifier()))
+                    .collect(toImmutableSet());
+        }
 
         ImmutableSetMultimap.Builder<HostAddress, InternalNode> byHostAndPort = ImmutableSetMultimap.builder();
         ImmutableSetMultimap.Builder<InetAddress, InternalNode> byHost = ImmutableSetMultimap.builder();

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/BinPackingNodeAllocatorService.java
@@ -313,7 +313,11 @@ public class BinPackingNodeAllocatorService
                         break;
                     }
 
-                    pendingAcquire.getFuture().setException(new TrinoException(NO_NODES_AVAILABLE, "No nodes available to run query"));
+                    pendingAcquire.getFuture().setException(new TrinoException(
+                            NO_NODES_AVAILABLE,
+                            pendingAcquire.getNodeGroup()
+                                    .map("No nodes available to run query in node group '%s'"::formatted)
+                                    .orElse("No nodes available to run query")));
                     iterator.remove();
                 }
                 case NOT_ENOUGH_RESOURCES_NOW -> {
@@ -433,7 +437,7 @@ public class BinPackingNodeAllocatorService
             @Override
             public NodeLease acquire(NodeRequirements nodeRequirements, DataSize memoryRequirement, TaskExecutionClass executionClass)
             {
-                return BinPackingNodeAllocatorService.this.acquire(nodeRequirements, memoryRequirement, executionClass, session.getQueryId());
+                return BinPackingNodeAllocatorService.this.acquire(nodeRequirements, memoryRequirement, executionClass, session.getQueryId(), session.getNodeGroup());
             }
 
             @Override
@@ -446,8 +450,13 @@ public class BinPackingNodeAllocatorService
 
     public NodeAllocator.NodeLease acquire(NodeRequirements nodeRequirements, DataSize memoryRequirement, TaskExecutionClass executionClass, QueryId queryId)
     {
+        return acquire(nodeRequirements, memoryRequirement, executionClass, queryId, Optional.empty());
+    }
+
+    public NodeAllocator.NodeLease acquire(NodeRequirements nodeRequirements, DataSize memoryRequirement, TaskExecutionClass executionClass, QueryId queryId, Optional<String> nodeGroup)
+    {
         BinPackingNodeLease nodeLease = new BinPackingNodeLease(memoryRequirement.toBytes(), executionClass, nodeRequirements);
-        PendingAcquire pendingAcquire = new PendingAcquire(nodeRequirements, nodeLease, queryId, ticker);
+        PendingAcquire pendingAcquire = new PendingAcquire(nodeRequirements, nodeLease, queryId, nodeGroup, ticker);
         Deque<PendingAcquire> requesterPendingAcquires = pendingAcquires.computeIfAbsent(queryId, _ -> new ConcurrentLinkedDeque<>());
         requesterPendingAcquires.add(pendingAcquire);
         wakeupProcessPendingAcquires();
@@ -561,16 +570,18 @@ public class BinPackingNodeAllocatorService
         private final NodeRequirements nodeRequirements;
         private final BinPackingNodeLease lease;
         private final QueryId queryId;
+        private final Optional<String> nodeGroup;
         private final Stopwatch noMatchingNodeStopwatch;
         private final Stopwatch notEnoughResourcesStopwatch;
 
         private volatile BinPackingSimulation.ReservationStatus lastReservationStatus = BinPackingSimulation.ReservationStatus.UNKNOWN;
 
-        private PendingAcquire(NodeRequirements nodeRequirements, BinPackingNodeLease lease, QueryId queryId, Ticker ticker)
+        private PendingAcquire(NodeRequirements nodeRequirements, BinPackingNodeLease lease, QueryId queryId, Optional<String> nodeGroup, Ticker ticker)
         {
             this.nodeRequirements = requireNonNull(nodeRequirements, "nodeRequirements is null");
             this.lease = requireNonNull(lease, "lease is null");
             this.queryId = requireNonNull(queryId, "queryId is null");
+            this.nodeGroup = requireNonNull(nodeGroup, "nodeGroup is null");
             this.noMatchingNodeStopwatch = Stopwatch.createUnstarted(ticker);
             this.notEnoughResourcesStopwatch = Stopwatch.createStarted(ticker);
         }
@@ -588,6 +599,11 @@ public class BinPackingNodeAllocatorService
         public QueryId getQueryId()
         {
             return queryId;
+        }
+
+        public Optional<String> getNodeGroup()
+        {
+            return nodeGroup;
         }
 
         public SettableFuture<InternalNode> getFuture()
@@ -762,6 +778,8 @@ public class BinPackingNodeAllocatorService
     private static class BinPackingSimulation
     {
         private final List<InternalNode> allNodesSorted;
+        private final Map<String, List<InternalNode>> candidatesWithCoordinatorByNodeGroup = new HashMap<>();
+        private final Map<String, List<InternalNode>> candidatesExceptCoordinatorByNodeGroup = new HashMap<>();
         private final List<InternalNode> workerNodesSorted;
         private final Multimap<HostAddress, InternalNode> allNodesByAddress;
         private final boolean ignoreAcquiredSpeculative;
@@ -879,22 +897,28 @@ public class BinPackingNodeAllocatorService
         {
             NodeRequirements requirements = acquire.getNodeRequirements();
 
+            Optional<String> nodeGroup = acquire.getNodeGroup();
             List<InternalNode> candidates;
             Optional<HostAddress> address = requirements.getAddress();
             if (address.isPresent() && (optimizedLocalScheduling || !requirements.isRemotelyAccessible())) {
                 Collection<InternalNode> preferred = allNodesByAddress.get(address.get());
                 if ((!preferred.isEmpty() && acquire.getNotEnoughResourcesPeriod().compareTo(exhaustedNodeWaitPeriod) < 0) || !requirements.isRemotelyAccessible()) {
                     // use preferred node if available
-                    candidates = getCandidatesWithCoordinator().stream().filter(preferred::contains).collect(toImmutableList());
+                    candidates = getCandidatesWithCoordinator(nodeGroup).stream().filter(preferred::contains).collect(toImmutableList());
+                    if (candidates.isEmpty() && requirements.isRemotelyAccessible()) {
+                        // the preferred node is outside the query's node group, so fall back to any allowed node
+                        // rather than waiting out allowedNoMatchingNodePeriod and failing the query
+                        candidates = scheduleOnCoordinator ? getCandidatesWithCoordinator(nodeGroup) : getCandidatesExceptCoordinator(nodeGroup);
+                    }
                 }
                 else {
                     // use all nodes if we do not have preferences or waited to long
-                    candidates = scheduleOnCoordinator ? getCandidatesWithCoordinator() : getCandidatesExceptCoordinator();
+                    candidates = scheduleOnCoordinator ? getCandidatesWithCoordinator(nodeGroup) : getCandidatesExceptCoordinator(nodeGroup);
                 }
             }
             else {
                 // standard candidates
-                candidates = scheduleOnCoordinator ? getCandidatesWithCoordinator() : getCandidatesExceptCoordinator();
+                candidates = scheduleOnCoordinator ? getCandidatesWithCoordinator(nodeGroup) : getCandidatesExceptCoordinator(nodeGroup);
             }
 
             if (candidates.isEmpty()) {
@@ -955,14 +979,30 @@ public class BinPackingNodeAllocatorService
             return ReserveResult.NOT_ENOUGH_RESOURCES_NOW;
         }
 
-        private List<InternalNode> getCandidatesExceptCoordinator()
+        private List<InternalNode> getCandidatesExceptCoordinator(Optional<String> nodeGroup)
         {
-            return workerNodesSorted;
+            return candidatesForNodeGroup(candidatesExceptCoordinatorByNodeGroup, workerNodesSorted, nodeGroup);
         }
 
-        private List<InternalNode> getCandidatesWithCoordinator()
+        private List<InternalNode> getCandidatesWithCoordinator(Optional<String> nodeGroup)
         {
-            return allNodesSorted;
+            return candidatesForNodeGroup(candidatesWithCoordinatorByNodeGroup, allNodesSorted, nodeGroup);
+        }
+
+        /**
+         * Filters the already sorted candidates, rather than reading a node group index, so that ties between
+         * equally loaded nodes keep resolving the same way from one simulation to the next. Built on demand
+         * because most clusters use no node groups at all, and a simulation is built several times per pass.
+         */
+        private static List<InternalNode> candidatesForNodeGroup(Map<String, List<InternalNode>> cache, List<InternalNode> candidatesSorted, Optional<String> nodeGroup)
+        {
+            if (nodeGroup.isEmpty()) {
+                return candidatesSorted;
+            }
+            return cache.computeIfAbsent(nodeGroup.get(), group -> candidatesSorted.stream()
+                    // coordinators are exempt, matching the node selector used by pipelined execution
+                    .filter(node -> node.getNodeGroups().contains(group) || node.isCoordinator())
+                    .collect(toImmutableList()));
         }
 
         private Comparator<InternalNode> resolveTiesWithSpeculativeMemory(Comparator<InternalNode> comparator)

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenTaskSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenTaskSourceFactory.java
@@ -156,6 +156,15 @@ public class EventDrivenTaskSourceFactory
                 metricsRecorder);
     }
 
+    /**
+     * Number of nodes the query may be scheduled on, which is fewer than the cluster when it is
+     * restricted to a node group.
+     */
+    private int schedulableNodeCount(Session session)
+    {
+        return nodeManager.getActiveNodesInGroup(session.getNodeGroup()).size();
+    }
+
     private SplitAssigner createSplitAssigner(
             Session session,
             PlanFragment fragment,
@@ -248,7 +257,7 @@ public class EventDrivenTaskSourceFactory
                     outputDataSizeEstimates,
                     fragment,
                     getFaultTolerantExecutionHashDistributionComputeTaskTargetSize(session).toBytes(),
-                    toIntExact(round(getFaultTolerantExecutionHashDistributionComputeTasksToNodesMinRatio(session) * nodeManager.getAllNodes().activeNodes().size())),
+                    toIntExact(round(getFaultTolerantExecutionHashDistributionComputeTasksToNodesMinRatio(session) * schedulableNodeCount(session))),
                     Integer.MAX_VALUE); // compute tasks are bounded by the number of partitions anyways
         }
         if (partitioning.equals(SCALED_WRITER_HASH_DISTRIBUTION)
@@ -262,7 +271,7 @@ public class EventDrivenTaskSourceFactory
                     outputDataSizeEstimates,
                     fragment,
                     getFaultTolerantExecutionHashDistributionWriteTaskTargetSize(session).toBytes(),
-                    toIntExact(round(getFaultTolerantExecutionHashDistributionWriteTasksToNodesMinRatio(session) * nodeManager.getAllNodes().activeNodes().size())),
+                    toIntExact(round(getFaultTolerantExecutionHashDistributionWriteTasksToNodesMinRatio(session) * schedulableNodeCount(session))),
                     getFaultTolerantExecutionHashDistributionWriteTaskTargetMaxCount(session));
         }
 

--- a/core/trino-main/src/main/java/io/trino/node/CoordinatorNodeManager.java
+++ b/core/trino-main/src/main/java/io/trino/node/CoordinatorNodeManager.java
@@ -14,6 +14,7 @@
 package io.trino.node;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -36,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -51,6 +53,8 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
 
 @ThreadSafe
 public final class CoordinatorNodeManager
@@ -294,6 +298,19 @@ public final class CoordinatorNodeManager
     {
         AllNodes allNodes = getAllNodes();
         return allNodes.activeNodes().size() - allNodes.activeCoordinators().size();
+    }
+
+    /**
+     * Number of active nodes declaring each node group, so that an operator can alert before a group empties
+     * and its queries start failing. Nodes may declare several groups, so these do not sum to the node count.
+     */
+    @Managed
+    public String getActiveNodeCountByNodeGroup()
+    {
+        Map<String, Long> countByNodeGroup = getAllNodes().activeNodes().stream()
+                .flatMap(node -> node.getNodeGroups().stream())
+                .collect(groupingBy(identity(), TreeMap::new, counting()));
+        return Joiner.on(", ").withKeyValueSeparator("=").join(countByNodeGroup);
     }
 
     @VisibleForTesting

--- a/core/trino-main/src/main/java/io/trino/node/InternalNode.java
+++ b/core/trino-main/src/main/java/io/trino/node/InternalNode.java
@@ -13,6 +13,7 @@
  */
 package io.trino.node;
 
+import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.XxHash64;
 import io.trino.spi.HostAddress;
 import io.trino.spi.Node;
@@ -23,6 +24,7 @@ import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Strings.emptyToNull;
@@ -41,15 +43,24 @@ public class InternalNode
     private final URI internalUri;
     private final NodeVersion nodeVersion;
     private final boolean coordinator;
+    private final Set<String> nodeGroups;
     private final long longHashCode;
 
     public InternalNode(String nodeIdentifier, URI internalUri, NodeVersion nodeVersion, boolean coordinator)
+    {
+        this(nodeIdentifier, internalUri, nodeVersion, coordinator, ImmutableSet.of());
+    }
+
+    public InternalNode(String nodeIdentifier, URI internalUri, NodeVersion nodeVersion, boolean coordinator, Set<String> nodeGroups)
     {
         nodeIdentifier = emptyToNull(nullToEmpty(nodeIdentifier).trim());
         this.nodeIdentifier = requireNonNull(nodeIdentifier, "nodeIdentifier is null or empty");
         this.internalUri = requireNonNull(internalUri, "internalUri is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.coordinator = coordinator;
+        this.nodeGroups = ImmutableSet.copyOf(requireNonNull(nodeGroups, "nodeGroups is null"));
+        // nodeGroups is deliberately excluded so that changing a node's groups does not reshuffle
+        // rendezvous hashing of splits, which is keyed on this value
         this.longHashCode = new XxHash64(coordinator ? 1 : 0)
                 .update(nodeIdentifier.getBytes(UTF_8))
                 .update(internalUri.toString().getBytes(UTF_8))
@@ -107,6 +118,11 @@ public class InternalNode
         return nodeVersion;
     }
 
+    public Set<String> getNodeGroups()
+    {
+        return nodeGroups;
+    }
+
     @Override
     public boolean equals(Object obj)
     {
@@ -120,7 +136,8 @@ public class InternalNode
         return coordinator == o.coordinator &&
                 Objects.equals(nodeIdentifier, o.nodeIdentifier) &&
                 Objects.equals(internalUri, o.internalUri) &&
-                Objects.equals(nodeVersion, o.nodeVersion);
+                Objects.equals(nodeVersion, o.nodeVersion) &&
+                Objects.equals(nodeGroups, o.nodeGroups);
     }
 
     public long longHashCode()
@@ -142,6 +159,7 @@ public class InternalNode
                 .add("internalUri", internalUri)
                 .add("nodeVersion", nodeVersion)
                 .add("coordinator", coordinator)
+                .add("nodeGroups", nodeGroups)
                 .toString();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/node/InternalNodeManager.java
+++ b/core/trino-main/src/main/java/io/trino/node/InternalNodeManager.java
@@ -13,13 +13,21 @@
  */
 package io.trino.node;
 
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.SetMultimap;
 import io.trino.spi.HostAddress;
 
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Suppliers.memoize;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.ImmutableSetMultimap.toImmutableSetMultimap;
 import static java.util.Objects.requireNonNull;
 
 public interface InternalNodeManager
@@ -46,6 +54,21 @@ public interface InternalNodeManager
         return getAllNodes().activeCoordinators();
     }
 
+    /**
+     * Active nodes belonging to the given node group, or all active nodes when the group is empty,
+     * meaning execution is not restricted to a group.
+     */
+    default Set<InternalNode> getActiveNodesInGroup(Optional<String> nodeGroup)
+    {
+        Set<InternalNode> activeNodes = getAllNodes().activeNodes();
+        if (nodeGroup.isEmpty()) {
+            return activeNodes;
+        }
+        return activeNodes.stream()
+                .filter(node -> node.getNodeGroups().contains(nodeGroup.get()))
+                .collect(toImmutableSet());
+    }
+
     AllNodes getAllNodes();
 
     boolean isGone(HostAddress hostAddress);
@@ -59,16 +82,32 @@ public interface InternalNodeManager
     class NodesSnapshot
     {
         private final Set<InternalNode> allNodes;
+        private final Supplier<SetMultimap<String, InternalNode>> nodesByGroup;
 
         public NodesSnapshot(Set<InternalNode> allActiveNodes)
         {
             requireNonNull(allActiveNodes, "allActiveNodes is null");
             this.allNodes = ImmutableSet.copyOf(allActiveNodes);
+            this.nodesByGroup = memoize(() -> allNodes.stream()
+                    .flatMap(node -> node.getNodeGroups().stream().map(group -> Map.entry(group, node)))
+                    .collect(toImmutableSetMultimap(Entry::getKey, Entry::getValue)));
         }
 
         public Set<InternalNode> getAllNodes()
         {
             return allNodes;
+        }
+
+        /**
+         * Nodes belonging to the given node group, or all nodes when the group is empty,
+         * meaning execution is not restricted to a group.
+         */
+        public Set<InternalNode> getNodesInGroup(Optional<String> nodeGroup)
+        {
+            if (nodeGroup.isEmpty()) {
+                return allNodes;
+            }
+            return nodesByGroup.get().get(nodeGroup.get());
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/node/RemoteNodeState.java
+++ b/core/trino-main/src/main/java/io/trino/node/RemoteNodeState.java
@@ -156,7 +156,8 @@ public class RemoteNodeState
                                     serverInfo.nodeId(),
                                     serverUri,
                                     serverInfo.nodeVersion(),
-                                    serverInfo.coordinator()));
+                                    serverInfo.coordinator(),
+                                    serverInfo.nodeGroups()));
                         }
 
                         RemoteNodeState.this.nodeState.set(nodeState);

--- a/core/trino-main/src/main/java/io/trino/server/ServerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerConfig.java
@@ -13,12 +13,15 @@
  */
 package io.trino.server;
 
+import com.google.common.collect.ImmutableSet;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.Duration;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 
@@ -30,6 +33,7 @@ public class ServerConfig
     private Duration gracePeriod = new Duration(2, MINUTES);
     private boolean queryResultsCompressionEnabled = true;
     private Optional<String> queryInfoUrlTemplate = Optional.empty();
+    private Set<String> nodeGroups = ImmutableSet.of();
 
     public boolean isCoordinator()
     {
@@ -102,6 +106,20 @@ public class ServerConfig
     public ServerConfig setQueryInfoUrlTemplate(String queryInfoUrlTemplate)
     {
         this.queryInfoUrlTemplate = Optional.ofNullable(queryInfoUrlTemplate);
+        return this;
+    }
+
+    @NotNull
+    public Set<@Pattern(regexp = "[A-Za-z0-9][_A-Za-z0-9-]*") String> getNodeGroups()
+    {
+        return nodeGroups;
+    }
+
+    @Config("node.groups")
+    @ConfigDescription("Names of the node groups this server belongs to")
+    public ServerConfig setNodeGroups(Set<String> nodeGroups)
+    {
+        this.nodeGroups = ImmutableSet.copyOf(nodeGroups);
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ServerInfo.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerInfo.java
@@ -13,11 +13,13 @@
  */
 package io.trino.server;
 
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
 import io.trino.node.NodeState;
 import io.trino.spi.NodeVersion;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -29,7 +31,8 @@ public record ServerInfo(
         boolean coordinator,
         Optional<String> coordinatorId,
         boolean starting,
-        Duration uptime)
+        Duration uptime,
+        Set<String> nodeGroups)
 {
     public ServerInfo
     {
@@ -39,5 +42,7 @@ public record ServerInfo(
         requireNonNull(environment, "environment is null");
         requireNonNull(coordinatorId, "coordinatorId is null");
         requireNonNull(uptime, "uptime is null");
+        // absent in JSON from a server that predates node groups; unlike Optional, a Set deserializes to null
+        nodeGroups = nodeGroups == null ? ImmutableSet.of() : ImmutableSet.copyOf(nodeGroups);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ServerInfoResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerInfoResource.java
@@ -30,6 +30,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static io.airlift.units.Duration.nanosSince;
 import static io.trino.server.security.ResourceSecurity.AccessType.MANAGEMENT_WRITE;
@@ -48,6 +49,7 @@ public class ServerInfoResource
     private final NodeVersion version;
     private final String environment;
     private final boolean coordinator;
+    private final Set<String> nodeGroups;
     private final NodeStateManager nodeStateManager;
     private final StartupStatus startupStatus;
     private final Optional<QueryIdGenerator> queryIdGenerator;
@@ -66,6 +68,7 @@ public class ServerInfoResource
         this.version = requireNonNull(nodeVersion, "nodeVersion is null");
         this.environment = nodeInfo.getEnvironment();
         this.coordinator = serverConfig.isCoordinator();
+        this.nodeGroups = serverConfig.getNodeGroups();
         this.nodeStateManager = requireNonNull(nodeStateManager, "nodeStateManager is null");
         this.startupStatus = requireNonNull(startupStatus, "startupStatus is null");
         this.queryIdGenerator = requireNonNull(queryIdGenerator, "queryIdGenerator is null");
@@ -85,7 +88,8 @@ public class ServerInfoResource
                 coordinator,
                 queryIdGenerator.map(QueryIdGenerator::getCoordinatorId),
                 starting,
-                nanosSince(startTime));
+                nanosSince(startTime),
+                nodeGroups);
     }
 
     @ResourceSecurity(MANAGEMENT_WRITE)

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -504,7 +504,8 @@ public class ServerMainModule
                 nodeInfo.getNodeId(),
                 internalCommunicationConfig.isHttpsRequired() ? httpServerInfo.getHttpsUri() : httpServerInfo.getHttpUri(),
                 nodeVersion,
-                serverConfig.isCoordinator());
+                serverConfig.isCoordinator(),
+                serverConfig.getNodeGroups());
     }
 
     private static class RegisterFunctionBundles

--- a/core/trino-main/src/main/java/io/trino/sql/planner/NodePartitioningManager.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/NodePartitioningManager.java
@@ -27,6 +27,7 @@ import io.trino.execution.scheduler.NodeSelector;
 import io.trino.metadata.Split;
 import io.trino.node.InternalNode;
 import io.trino.operator.RetryPolicy;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorBucketNodeMap;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPartitioningHandle;
@@ -52,10 +53,12 @@ import static io.trino.SystemSessionProperties.getFaultTolerantExecutionMaxParti
 import static io.trino.SystemSessionProperties.getRetryPolicy;
 import static io.trino.execution.TaskManagerConfig.MAX_WRITER_COUNT;
 import static io.trino.operator.exchange.LocalExchange.SCALE_WRITERS_MAX_PARTITIONS_PER_WRITER;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static io.trino.util.Failures.checkCondition;
 import static java.lang.Math.max;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class NodePartitioningManager
@@ -114,6 +117,7 @@ public class NodePartitioningManager
             checkArgument(connectorBucketNodeMap.getBucketCount() < 1_000_000, "Too many buckets in partitioning: %s", connectorBucketNodeMap.getBucketCount());
 
             if (connectorBucketNodeMap.hasFixedMapping()) {
+                checkNodeGroupSupported(session, partitioningHandle);
                 bucketToNode = getFixedMapping(connectorBucketNodeMap);
                 verify(bucketToNode.size() == connectorBucketNodeMap.getBucketCount(), "Fixed mapping size does not match bucket count");
             }
@@ -202,6 +206,7 @@ public class NodePartitioningManager
         ToIntFunction<Split> splitToBucket = getSplitToBucket(session, partitioningHandle, bucketCount);
 
         if (bucketNodeMap.map(ConnectorBucketNodeMap::hasFixedMapping).orElse(false)) {
+            checkNodeGroupSupported(session, partitioningHandle);
             return new BucketNodeMap(splitToBucket, getFixedMapping(bucketNodeMap.get()));
         }
 
@@ -252,6 +257,20 @@ public class NodePartitioningManager
     private List<InternalNode> getAllNodes(Session session)
     {
         return nodeScheduler.createNodeSelector(session).allNodes();
+    }
+
+    /**
+     * A connector that pins buckets to specific nodes chooses them from the cluster-wide node list, which
+     * is not aware of the query's node group, so the query would silently escape the restriction.
+     */
+    private static void checkNodeGroupSupported(Session session, PartitioningHandle partitioningHandle)
+    {
+        if (session.getNodeGroup().isPresent()) {
+            throw new TrinoException(NOT_SUPPORTED, format(
+                    "Catalog '%s' assigns partitions to specific nodes, which is not supported for a query restricted to node group '%s'",
+                    requiredCatalogHandle(partitioningHandle).getCatalogName(),
+                    session.getNodeGroup().get()));
+        }
     }
 
     private static List<InternalNode> getFixedMapping(ConnectorBucketNodeMap connectorBucketNodeMap)

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -583,7 +583,8 @@ public class PlanTester
                 defaultSession.getPreparedStatements(),
                 defaultSession.getProtocolHeaders(),
                 defaultSession.getExchangeEncryptionKey(),
-                defaultSession.getQueryDataEncoding());
+                defaultSession.getQueryDataEncoding(),
+                defaultSession.getNodeGroup());
     }
 
     private static SessionPropertyManager createSessionPropertyManager(

--- a/core/trino-main/src/test/java/io/trino/connector/system/TestSystemSplitManager.java
+++ b/core/trino-main/src/test/java/io/trino/connector/system/TestSystemSplitManager.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector.system;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.FullConnectorSession;
+import io.trino.Session;
+import io.trino.metadata.MetadataUtil.TableMetadataBuilder;
+import io.trino.node.InternalNode;
+import io.trino.node.TestingInternalNodeManager;
+import io.trino.spi.HostAddress;
+import io.trino.spi.NodeVersion;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.connector.DynamicFilterSnapshot;
+import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SystemTable;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.testing.TestingSession;
+import io.trino.testing.TestingTransactionHandle;
+import io.trino.transaction.TestingTransactionManager;
+import io.trino.transaction.TransactionId;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.trino.metadata.AbstractMockMetadata.dummyMetadata;
+import static io.trino.node.TestingInternalNodeManager.CURRENT_NODE;
+import static io.trino.spi.connector.SystemTable.Distribution.ALL_NODES;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestSystemSplitManager
+{
+    private static final SchemaTableName TABLE_NAME = new SchemaTableName("runtime", "test_table");
+
+    private static final InternalNode ETL_NODE = new InternalNode("etl1", URI.create("http://10.0.0.1:21"), NodeVersion.UNKNOWN, false, ImmutableSet.of("etl"));
+    private static final InternalNode ADHOC_NODE = new InternalNode("adhoc1", URI.create("http://10.0.0.1:22"), NodeVersion.UNKNOWN, false, ImmutableSet.of("adhoc"));
+
+    @Test
+    void testAllNodesSplitsAreRestrictedToNodeGroup()
+    {
+        // System splits are not remotely accessible, so a split addressed at a node outside the query's
+        // node group could not be scheduled anywhere and the query would fail with NO_NODES_AVAILABLE.
+        assertThat(splitAddresses(sessionWithNodeGroup("etl")))
+                .containsExactlyInAnyOrder(ETL_NODE.getHostAndPort(), CURRENT_NODE.getHostAndPort());
+        assertThat(splitAddresses(sessionWithNodeGroup("adhoc")))
+                .containsExactlyInAnyOrder(ADHOC_NODE.getHostAndPort(), CURRENT_NODE.getHostAndPort());
+    }
+
+    @Test
+    void testAllNodesSplitsCoverEveryNodeWithoutNodeGroup()
+    {
+        assertThat(splitAddresses(TestingSession.testSessionBuilder().build()))
+                .containsExactlyInAnyOrder(ETL_NODE.getHostAndPort(), ADHOC_NODE.getHostAndPort(), CURRENT_NODE.getHostAndPort());
+    }
+
+    @Test
+    void testUnmatchedNodeGroupStillLeavesTheCoordinator()
+    {
+        // the coordinator is never excluded by a node group, so there is always something to schedule on
+        assertThat(splitAddresses(sessionWithNodeGroup("missing")))
+                .containsExactly(CURRENT_NODE.getHostAndPort());
+    }
+
+    private static List<HostAddress> splitAddresses(Session session)
+    {
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault(ETL_NODE, ADHOC_NODE);
+        SystemSplitManager splitManager = new SystemSplitManager(
+                CURRENT_NODE,
+                nodeManager,
+                new SystemTablesProvider(new TestingTransactionManager(), dummyMetadata(), TEST_CATALOG_NAME, ImmutableSet.of(new AllNodesSystemTable())));
+
+        ConnectorSession connectorSession = new FullConnectorSession(session, session.getIdentity().toConnectorIdentity());
+        ConnectorSplitSource splitSource = splitManager.getSplits(
+                new SystemTransactionHandle(TransactionId.create(), TestingTransactionHandle.create()),
+                connectorSession,
+                new SystemTableHandle(TABLE_NAME.getSchemaName(), TABLE_NAME.getTableName(), TupleDomain.all()),
+                Set.<ColumnHandle>of(),
+                Constraint.alwaysTrue());
+
+        return splitSource.getNextBatch(1000, DynamicFilterSnapshot.EMPTY).join().stream()
+                .flatMap(split -> split.getAddresses().stream())
+                .toList();
+    }
+
+    private static Session sessionWithNodeGroup(String nodeGroup)
+    {
+        return TestingSession.testSessionBuilder()
+                .setNodeGroup(Optional.of(nodeGroup))
+                .build();
+    }
+
+    private static class AllNodesSystemTable
+            implements SystemTable
+    {
+        @Override
+        public Distribution getDistribution()
+        {
+            return ALL_NODES;
+        }
+
+        @Override
+        public ConnectorTableMetadata getTableMetadata()
+        {
+            return TableMetadataBuilder.tableMetadataBuilder(TABLE_NAME)
+                    .column("value", BIGINT)
+                    .build();
+        }
+
+        @Override
+        public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/cost/TestTaskCountEstimator.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestTaskCountEstimator.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.cost;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.execution.scheduler.NodeSchedulerConfig;
+import io.trino.node.InternalNode;
+import io.trino.node.TestingInternalNodeManager;
+import io.trino.spi.NodeVersion;
+import io.trino.testing.TestingSession;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestTaskCountEstimator
+{
+    private static final InternalNode ETL_NODE_1 = new InternalNode("etl1", URI.create("http://10.0.0.1:21"), NodeVersion.UNKNOWN, false, ImmutableSet.of("etl", "shared"));
+    private static final InternalNode ETL_NODE_2 = new InternalNode("etl2", URI.create("http://10.0.0.1:22"), NodeVersion.UNKNOWN, false, ImmutableSet.of("etl", "shared"));
+    private static final InternalNode ADHOC_NODE = new InternalNode("adhoc1", URI.create("http://10.0.0.1:23"), NodeVersion.UNKNOWN, false, ImmutableSet.of("adhoc", "shared"));
+    private static final InternalNode UNGROUPED_NODE = new InternalNode("plain1", URI.create("http://10.0.0.1:24"), NodeVersion.UNKNOWN, false);
+
+    @Test
+    void testTaskCountIsScopedToTheNodeGroup()
+    {
+        TaskCountEstimator estimator = new TaskCountEstimator(
+                new NodeSchedulerConfig().setIncludeCoordinator(false),
+                TestingInternalNodeManager.createDefault(ETL_NODE_1, ETL_NODE_2, ADHOC_NODE, UNGROUPED_NODE));
+
+        assertThat(estimator.estimateSourceDistributedTaskCount(sessionWithNodeGroup("etl"))).isEqualTo(2);
+        assertThat(estimator.estimateSourceDistributedTaskCount(sessionWithNodeGroup("adhoc"))).isEqualTo(1);
+        assertThat(estimator.estimateSourceDistributedTaskCount(sessionWithNodeGroup("shared"))).isEqualTo(3);
+        assertThat(estimator.estimateSourceDistributedTaskCount(TestingSession.testSessionBuilder().build())).isEqualTo(4);
+    }
+
+    @Test
+    void testEmptyNodeGroupStillEstimatesAtLeastOneTask()
+    {
+        TaskCountEstimator estimator = new TaskCountEstimator(
+                new NodeSchedulerConfig().setIncludeCoordinator(false),
+                TestingInternalNodeManager.createDefault(ADHOC_NODE));
+
+        // the floor prevents underflow elsewhere in costing; the query fails later on node selection
+        assertThat(estimator.estimateSourceDistributedTaskCount(sessionWithNodeGroup("etl"))).isEqualTo(1);
+    }
+
+    private static Session sessionWithNodeGroup(String nodeGroup)
+    {
+        return TestingSession.testSessionBuilder()
+                .setNodeGroup(Optional.of(nodeGroup))
+                .build();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/dispatcher/TestLocalDispatchQuery.java
+++ b/core/trino-main/src/test/java/io/trino/dispatcher/TestLocalDispatchQuery.java
@@ -236,7 +236,7 @@ public class TestLocalDispatchQuery
         }
 
         @Override
-        public synchronized ListenableFuture<Void> waitForMinimumWorkers(int executionMinCount, Duration executionMaxWait)
+        public synchronized ListenableFuture<Void> waitForMinimumWorkers(Optional<String> nodeGroup, int executionMinCount, Duration executionMaxWait)
         {
             return immediateVoidFuture();
         }

--- a/core/trino-main/src/test/java/io/trino/execution/TestClusterSizeMonitor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestClusterSizeMonitor.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.Duration;
+import io.trino.node.InternalNode;
+import io.trino.node.TestingInternalNodeManager;
+import io.trino.spi.NodeVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestClusterSizeMonitor
+{
+    private static final Duration WAIT = new Duration(1, MINUTES);
+
+    private static final InternalNode ETL_NODE = new InternalNode("etl1", URI.create("http://10.0.0.1:21"), NodeVersion.UNKNOWN, false, ImmutableSet.of("etl", "shared"));
+    private static final InternalNode SECOND_ETL_NODE = new InternalNode("etl2", URI.create("http://10.0.0.1:24"), NodeVersion.UNKNOWN, false, ImmutableSet.of("etl"));
+    private static final InternalNode ADHOC_NODE = new InternalNode("adhoc1", URI.create("http://10.0.0.1:22"), NodeVersion.UNKNOWN, false, ImmutableSet.of("adhoc", "shared"));
+    private static final InternalNode UNGROUPED_NODE = new InternalNode("plain1", URI.create("http://10.0.0.1:23"), NodeVersion.UNKNOWN, false);
+
+    @Test
+    @Timeout(30)
+    void testWaitsOnTheNodeGroupRatherThanTheCluster()
+            throws Exception
+    {
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault(ADHOC_NODE, UNGROUPED_NODE);
+        ClusterSizeMonitor monitor = new ClusterSizeMonitor(nodeManager, false);
+        monitor.start();
+        try {
+            // two workers are active, but neither is in the "etl" group
+            ListenableFuture<Void> etlFuture = monitor.waitForMinimumWorkers(Optional.of("etl"), 1, WAIT);
+            assertThat(etlFuture.isDone()).isFalse();
+
+            // an unrestricted query is satisfied by the same two workers
+            assertThat(monitor.waitForMinimumWorkers(Optional.empty(), 2, WAIT).isDone()).isTrue();
+
+            nodeManager.addNodes(ETL_NODE);
+            etlFuture.get(10, SECONDS);
+        }
+        finally {
+            monitor.stop();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void testOneNodeSatisfiesWaitersInEachOfItsGroups()
+            throws Exception
+    {
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault();
+        ClusterSizeMonitor monitor = new ClusterSizeMonitor(nodeManager, false);
+        monitor.start();
+        try {
+            ListenableFuture<Void> etlFuture = monitor.waitForMinimumWorkers(Optional.of("etl"), 1, WAIT);
+            ListenableFuture<Void> sharedFuture = monitor.waitForMinimumWorkers(Optional.of("shared"), 1, WAIT);
+            ListenableFuture<Void> anyFuture = monitor.waitForMinimumWorkers(Optional.empty(), 1, WAIT);
+            assertThat(etlFuture.isDone()).isFalse();
+
+            // a single node declaring both groups must release the waiters of each of them, not just one
+            nodeManager.addNodes(ETL_NODE);
+            etlFuture.get(10, SECONDS);
+            sharedFuture.get(10, SECONDS);
+            anyFuture.get(10, SECONDS);
+        }
+        finally {
+            monitor.stop();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void testTimeoutNamesTheNodeGroupAndItsCount()
+    {
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault(ETL_NODE, ADHOC_NODE);
+        ClusterSizeMonitor monitor = new ClusterSizeMonitor(nodeManager, false);
+        monitor.start();
+        try {
+            ListenableFuture<Void> future = monitor.waitForMinimumWorkers(Optional.of("etl"), 2, new Duration(1, MILLISECONDS));
+            assertThatThrownBy(future::get)
+                    .hasMessageContaining("in node group 'etl'")
+                    // one node declares "etl", not the two active workers
+                    .hasMessageContaining("only 1 workers are active");
+        }
+        finally {
+            monitor.stop();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void testCoordinatorExclusionIsAppliedWithinTheNodeGroup()
+    {
+        // the coordinator declares "etl", but with include-coordinator disabled it cannot run the query,
+        // so it must not count towards the group either
+        InternalNode coordinator = new InternalNode("local", URI.create("local://127.0.0.1:8080"), NodeVersion.UNKNOWN, true, ImmutableSet.of("etl"));
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault(coordinator);
+        ClusterSizeMonitor monitor = new ClusterSizeMonitor(nodeManager, false);
+        monitor.start();
+        try {
+            assertThat(monitor.waitForMinimumWorkers(Optional.of("etl"), 1, WAIT).isDone()).isFalse();
+        }
+        finally {
+            monitor.stop();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void testRepeatedSnapshotsDoNotDoubleCount()
+            throws Exception
+    {
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault(ETL_NODE);
+        ClusterSizeMonitor monitor = new ClusterSizeMonitor(nodeManager, false);
+        // start() delivers the snapshot both directly and through the listener
+        monitor.start();
+        try {
+            assertThat(monitor.waitForMinimumWorkers(Optional.of("etl"), 1, WAIT).isDone()).isTrue();
+            assertThat(monitor.waitForMinimumWorkers(Optional.of("etl"), 2, WAIT).isDone()).isFalse();
+        }
+        finally {
+            monitor.stop();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void testOnlyWaitersWhoseThresholdIsMetAreReleased()
+            throws Exception
+    {
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault();
+        ClusterSizeMonitor monitor = new ClusterSizeMonitor(nodeManager, false);
+        monitor.start();
+        try {
+            ListenableFuture<Void> needsOne = monitor.waitForMinimumWorkers(Optional.of("etl"), 1, WAIT);
+            ListenableFuture<Void> needsTwo = monitor.waitForMinimumWorkers(Optional.of("etl"), 2, WAIT);
+
+            nodeManager.addNodes(ETL_NODE);
+            needsOne.get(10, SECONDS);
+            assertThat(needsTwo.isDone()).isFalse();
+
+            nodeManager.addNodes(SECOND_ETL_NODE);
+            needsTwo.get(10, SECONDS);
+        }
+        finally {
+            monitor.stop();
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
@@ -62,6 +62,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -76,6 +77,7 @@ import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.node.NodeState.ACTIVE;
 import static io.trino.node.TestingInternalNodeManager.CURRENT_NODE;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
@@ -628,6 +630,115 @@ public class TestNodeScheduler
     private Multimap<InternalNode, Split> computeSingleAssignment(NodeSelector nodeSelector, Split split)
     {
         return nodeSelector.computeAssignments(ImmutableSet.of(split), ImmutableList.copyOf(taskMap.values())).getAssignments();
+    }
+
+    @Test
+    public void testNodeGroupRestrictsNodeSelection()
+    {
+        nodeManager.addNodes(
+                new InternalNode("etl1", URI.create("http://10.0.0.1:21"), NodeVersion.UNKNOWN, false, ImmutableSet.of("etl", "shared")),
+                new InternalNode("adhoc1", URI.create("http://10.0.0.1:22"), NodeVersion.UNKNOWN, false, ImmutableSet.of("adhoc", "shared")),
+                new InternalNode("ungrouped", URI.create("http://10.0.0.1:23"), NodeVersion.UNKNOWN, false));
+
+        assertThat(selectableNodes(nodeScheduler, "etl")).containsExactly("etl1");
+        assertThat(selectableNodes(nodeScheduler, "adhoc")).containsExactly("adhoc1");
+        // a node declaring several groups is selectable for each of them
+        assertThat(selectableNodes(nodeScheduler, "shared")).containsExactlyInAnyOrder("etl1", "adhoc1");
+        // a group no node declares leaves nothing to schedule on
+        assertThat(selectableNodes(nodeScheduler, "missing")).isEmpty();
+        // an unrestricted query is not limited to grouped nodes
+        assertThat(selectableNodes(nodeScheduler.createNodeSelector(session)))
+                .containsExactlyInAnyOrder("etl1", "adhoc1", "ungrouped");
+    }
+
+    @Test
+    public void testNodeGroupRestrictsTopologyAwareNodeSelection()
+    {
+        nodeManager.addNodes(
+                new InternalNode("etl1", URI.create("http://host1.rack1:21"), NodeVersion.UNKNOWN, false, ImmutableSet.of("etl")),
+                new InternalNode("adhoc1", URI.create("http://host2.rack1:22"), NodeVersion.UNKNOWN, false, ImmutableSet.of("adhoc")));
+
+        NodeScheduler topologyAwareScheduler = new NodeScheduler(new TopologyAwareNodeSelectorFactory(
+                new TestNetworkTopology(),
+                CURRENT_NODE,
+                nodeManager,
+                nodeSchedulerConfig,
+                nodeTaskMap,
+                getNetworkTopologyConfig(),
+                new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig())));
+
+        assertThat(selectableNodes(topologyAwareScheduler, "etl")).containsExactly("etl1");
+        assertThat(selectableNodes(topologyAwareScheduler, "adhoc")).containsExactly("adhoc1");
+    }
+
+    @Test
+    public void testNodeGroupDoesNotExcludeCoordinator()
+    {
+        nodeManager.addNodes(new InternalNode("etl1", URI.create("http://10.0.0.1:21"), NodeVersion.UNKNOWN, false, ImmutableSet.of("etl")));
+
+        // the coordinator declares no node group, but must stay available so that coordinator-only stages
+        // and the coordinator fallback in selectExactNodes keep working
+        NodeScheduler schedulerWithCoordinator = new NodeScheduler(new UniformNodeSelectorFactory(
+                CURRENT_NODE,
+                nodeManager,
+                new NodeSchedulerConfig().setIncludeCoordinator(true),
+                nodeTaskMap,
+                new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, true), new StableHostAddressProviderConfig())));
+
+        assertThat(selectableNodes(schedulerWithCoordinator, "etl"))
+                .containsExactlyInAnyOrder("etl1", CURRENT_NODE.getNodeIdentifier());
+        assertThat(schedulerWithCoordinator.createNodeSelector(sessionWithNodeGroup("missing")).selectCurrentNode())
+                .isEqualTo(CURRENT_NODE);
+    }
+
+    @Test
+    public void testNodeAddressedSplitOutsideNodeGroupIsRejected()
+    {
+        // the split can only run on the node it is addressed to, and that node is not in the query's group.
+        // The connector chose it from the cluster wide node list, so refuse the query rather than leave it
+        // unschedulable, matching how a connector that pins partitions to nodes is handled.
+        setUpNodes();
+        nodeManager.addNodes(new InternalNode("etl1", URI.create("http://10.0.0.1:21"), NodeVersion.UNKNOWN, false, ImmutableSet.of("etl")));
+        Split split = new Split(TEST_CATALOG_HANDLE, new TestSplitLocal());
+
+        NodeSelector restricted = nodeScheduler.createNodeSelector(sessionWithNodeGroup("etl"));
+        assertTrinoExceptionThrownBy(() -> computeSingleAssignment(restricted, split))
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessageContaining("addresses splits to specific nodes")
+                .hasMessageContaining("node group 'etl'");
+
+        // the same split is fine for a query that is not restricted to a node group
+        assertThat(getOnlyElement(computeSingleAssignment(nodeScheduler.createNodeSelector(session), split).entries()).getKey().getHostAndPort())
+                .isEqualTo(split.getAddresses().get(0));
+    }
+
+    @Test
+    public void testEmptyNodeGroupNamesTheGroup()
+    {
+        setUpNodes();
+        NodeSelector restricted = nodeScheduler.createNodeSelector(sessionWithNodeGroup("missing"));
+        assertTrinoExceptionThrownBy(() -> computeSingleAssignment(restricted, new Split(TEST_CATALOG_HANDLE, new TestSplitRemote())))
+                .hasErrorCode(NO_NODES_AVAILABLE)
+                .hasMessageContaining("node group 'missing'");
+    }
+
+    private static Set<String> selectableNodes(NodeScheduler nodeScheduler, String nodeGroup)
+    {
+        return selectableNodes(nodeScheduler.createNodeSelector(sessionWithNodeGroup(nodeGroup)));
+    }
+
+    private static Set<String> selectableNodes(NodeSelector nodeSelector)
+    {
+        return nodeSelector.allNodes().stream()
+                .map(InternalNode::getNodeIdentifier)
+                .collect(toImmutableSet());
+    }
+
+    private static Session sessionWithNodeGroup(String nodeGroup)
+    {
+        return TestingSession.testSessionBuilder()
+                .setNodeGroup(Optional.of(nodeGroup))
+                .build();
     }
 
     private static Session sessionWithMaxUnacknowledgedSplitsPerTask(int maxUnacknowledgedSplitsPerTask)

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestUniformNodeSelector.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestUniformNodeSelector.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -141,7 +142,8 @@ public class TestUniformNodeSelector
                 NodeSchedulerConfig.SplitsBalancingPolicy.STAGE,
                 false,
                 queueSizeAdjuster,
-                new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig()));
+                new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig()),
+                Optional.empty());
 
         for (int i = 0; i < 20; i++) {
             splits.add(new Split(TEST_CATALOG_HANDLE, TestingSplit.createRemoteSplit()));
@@ -314,7 +316,8 @@ public class TestUniformNodeSelector
                 NodeSchedulerConfig.SplitsBalancingPolicy.STAGE,
                 true,
                 new UniformNodeSelector.QueueSizeAdjuster(1000, 10000, new TestingTicker()),
-                new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig()));
+                new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig()),
+                Optional.empty());
 
         Split rigidSplit = new Split(TEST_CATALOG_HANDLE, new TestingSplit(false, ImmutableList.of(node1.getHostAndPort())));
         splits.add(rigidSplit);

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestBinPackingNodeAllocator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestBinPackingNodeAllocator.java
@@ -14,6 +14,7 @@
 package io.trino.execution.scheduler.faulttolerant;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import io.airlift.testing.TestingTicker;
 import io.airlift.units.DataSize;
@@ -78,6 +79,14 @@ public class TestBinPackingNodeAllocator
     private static final InternalNode NODE_4 = new InternalNode("node-4", URI.create("local://" + NODE_4_ADDRESS), NodeVersion.UNKNOWN, false);
 
     private static final CatalogHandle CATALOG_1 = createTestCatalogHandle("catalog1");
+
+    // NODE_ETL and NODE_ADHOC both belong to "shared", so a shared query contends with each of them
+    // same identities as NODE_1/NODE_2 so the fixture's per-node memory info applies
+    private static final InternalNode NODE_ETL = new InternalNode("node-1", URI.create("local://" + NODE_1_ADDRESS), NodeVersion.UNKNOWN, false, ImmutableSet.of("etl", "shared"));
+    private static final InternalNode NODE_ADHOC = new InternalNode("node-2", URI.create("local://" + NODE_2_ADDRESS), NodeVersion.UNKNOWN, false, ImmutableSet.of("adhoc", "shared"));
+
+    private static final Session SESSION_ETL = sessionWithNodeGroup("query_etl", "etl");
+    private static final Session SESSION_SHARED = sessionWithNodeGroup("query_shared", "shared");
 
     private static final NodeRequirements REQ_NONE = new NodeRequirements(Optional.empty(), Optional.empty(), true);
     private static final NodeRequirements REQ_NODE_1 = new NodeRequirements(Optional.empty(), Optional.of(NODE_1_ADDRESS), true);
@@ -1094,6 +1103,93 @@ public class TestBinPackingNodeAllocator
     private TaskId taskId(int partition)
     {
         return new TaskId(new StageId("test_query", 0), partition, 0);
+    }
+
+    @Test
+    @Timeout(value = TEST_TIMEOUT, unit = MILLISECONDS)
+    public void testNodeGroupRestrictsAcquires()
+    {
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault(NODE_ETL, NODE_ADHOC);
+        setupNodeAllocatorService(nodeManager);
+
+        try (NodeAllocator etlAllocator = nodeAllocatorService.getNodeAllocator(SESSION_ETL)) {
+            // only one of the two nodes declares "etl", so both acquires land there
+            NodeAllocator.NodeLease etlAcquire1 = etlAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
+            NodeAllocator.NodeLease etlAcquire2 = etlAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
+            assertAcquired(etlAcquire1, NODE_ETL);
+            assertAcquired(etlAcquire2, NODE_ETL);
+            etlAcquire1.release();
+            etlAcquire2.release();
+        }
+
+        try (NodeAllocator sharedAllocator = nodeAllocatorService.getNodeAllocator(SESSION_SHARED)) {
+            // "shared" spans both nodes, so acquires spread across them
+            assertAcquired(sharedAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD), NODE_ETL);
+            assertAcquired(sharedAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD), NODE_ADHOC);
+        }
+    }
+
+    @Test
+    @Timeout(value = TEST_TIMEOUT, unit = MILLISECONDS)
+    public void testOverlappingNodeGroupsShareNodeMemory()
+    {
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault(NODE_ETL, NODE_ADHOC);
+        setupNodeAllocatorService(nodeManager);
+
+        // Groups overlap on a physical node, so memory reserved through one group must be visible to the
+        // other. This is what breaks if the simulation is ever split per node group.
+        try (NodeAllocator etlAllocator = nodeAllocatorService.getNodeAllocator(SESSION_ETL);
+                NodeAllocator sharedAllocator = nodeAllocatorService.getNodeAllocator(SESSION_SHARED)) {
+            assertAcquired(etlAllocator.acquire(REQ_NONE, DataSize.of(64, GIGABYTE), STANDARD), NODE_ETL);
+
+            // a "shared" acquire too big for what is left on NODE_ETL must go to NODE_ADHOC
+            assertAcquired(sharedAllocator.acquire(REQ_NONE, DataSize.of(64, GIGABYTE), STANDARD), NODE_ADHOC);
+
+            assertNotAcquired(sharedAllocator.acquire(REQ_NONE, DataSize.of(64, GIGABYTE), STANDARD));
+            assertNotAcquired(etlAllocator.acquire(REQ_NONE, DataSize.of(64, GIGABYTE), STANDARD));
+        }
+    }
+
+    @Test
+    @Timeout(value = TEST_TIMEOUT, unit = MILLISECONDS)
+    public void testNoNodeInNodeGroupFailsNamingTheGroup()
+    {
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault(NODE_ADHOC);
+        setupNodeAllocatorService(nodeManager);
+
+        try (NodeAllocator etlAllocator = nodeAllocatorService.getNodeAllocator(SESSION_ETL)) {
+            NodeAllocator.NodeLease acquire = etlAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
+            assertNotAcquired(acquire);
+
+            ticker.increment(1, TimeUnit.MINUTES);
+            ticker.increment(2, TimeUnit.SECONDS); // past the no matching node timeout
+            nodeAllocatorService.processPendingAcquires();
+
+            assertThatThrownBy(() -> Futures.getUnchecked(acquire.getNode()))
+                    .hasMessageContaining("node group 'etl'");
+        }
+    }
+
+    @Test
+    @Timeout(value = TEST_TIMEOUT, unit = MILLISECONDS)
+    public void testPreferredAddressOutsideNodeGroupFallsBack()
+    {
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault(NODE_ETL, NODE_ADHOC);
+        setupNodeAllocatorService(nodeManager);
+
+        try (NodeAllocator etlAllocator = nodeAllocatorService.getNodeAllocator(SESSION_ETL)) {
+            // the preferred node is outside the query's group; a remotely accessible split should still be
+            // placed on an allowed node rather than waiting out the timeout and failing
+            assertAcquired(etlAllocator.acquire(REQ_NODE_2, DataSize.of(16, GIGABYTE), STANDARD), NODE_ETL);
+        }
+    }
+
+    private static Session sessionWithNodeGroup(String queryId, String nodeGroup)
+    {
+        return testSessionBuilder()
+                .setQueryId(new QueryId(queryId))
+                .setNodeGroup(Optional.of(nodeGroup))
+                .build();
     }
 
     private void assertAcquired(NodeAllocator.NodeLease lease, InternalNode node)

--- a/core/trino-main/src/test/java/io/trino/node/TestCoordinatorNodeManager.java
+++ b/core/trino-main/src/test/java/io/trino/node/TestCoordinatorNodeManager.java
@@ -22,6 +22,7 @@ import io.airlift.http.client.testing.TestingResponse;
 import io.airlift.json.JsonCodec;
 import io.airlift.testing.TestingTicker;
 import io.airlift.units.Duration;
+import io.trino.node.InternalNodeManager.NodesSnapshot;
 import io.trino.server.ServerInfo;
 import io.trino.spi.NodeVersion;
 import org.junit.jupiter.api.Test;
@@ -34,14 +35,18 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.net.MediaType.JSON_UTF_8;
 import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
 import static io.airlift.http.client.HttpStatus.OK;
 import static io.trino.node.NodeState.ACTIVE;
 import static io.trino.node.NodeState.INACTIVE;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TestCoordinatorNodeManager
@@ -213,6 +218,90 @@ class TestCoordinatorNodeManager
         }
     }
 
+    @Test
+    @Timeout(60)
+    void testNodeGroups()
+            throws Exception
+    {
+        NodeVersion version = new NodeVersion("1");
+        InternalNode current = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.9.1"), version, false);
+        InternalNode etl = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.9.2"), version, false, ImmutableSet.of("etl", "shared"));
+        InternalNode adhoc = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.9.3"), version, false, ImmutableSet.of("adhoc", "shared"));
+
+        AtomicReference<Set<String>> etlGroups = new AtomicReference<>(etl.getNodeGroups());
+        Map<String, InternalNode> nodesByHost = Stream.of(current, etl, adhoc)
+                .collect(toImmutableMap(InternalNode::getHost, identity()));
+        TestingHttpClient httpClient = new TestingHttpClient(request -> {
+            InternalNode node = nodesByHost.get(request.getUri().getHost());
+            ServerInfo serverInfo = new ServerInfo(
+                    node.getNodeIdentifier(),
+                    ACTIVE,
+                    node.getNodeVersion(),
+                    EXPECTED_ENVIRONMENT,
+                    node.isCoordinator(),
+                    Optional.empty(),
+                    false,
+                    Duration.ZERO,
+                    node.equals(etl) ? etlGroups.get() : node.getNodeGroups());
+            return new TestingResponse(
+                    OK,
+                    ImmutableListMultimap.of(CONTENT_TYPE, JSON_UTF_8.toString()),
+                    SERVER_INFO_JSON_CODEC.toJsonBytes(serverInfo));
+        });
+
+        Set<URI> announced = nodesByHost.values().stream()
+                .map(InternalNode::getInternalUri)
+                .collect(toImmutableSet());
+        CoordinatorNodeManager manager = new CoordinatorNodeManager(
+                () -> announced,
+                copy(current),
+                () -> ACTIVE,
+                EXPECTED_ENVIRONMENT,
+                httpClient,
+                new TestingTicker());
+        try {
+            BlockingQueue<AllNodes> notifications = new ArrayBlockingQueue<>(100);
+            manager.addNodeChangeListener(notifications::add);
+            notifications.take();
+
+            manager.refreshNodes(true);
+            assertThat(manager.getNodes(ACTIVE)).containsExactlyInAnyOrder(current, etl, adhoc);
+
+            // a node belonging to several groups is returned for each of them
+            assertThat(manager.getActiveNodesInGroup(Optional.of("etl"))).containsExactly(etl);
+            assertThat(manager.getActiveNodesInGroup(Optional.of("adhoc"))).containsExactly(adhoc);
+            assertThat(manager.getActiveNodesInGroup(Optional.of("shared"))).containsExactlyInAnyOrder(etl, adhoc);
+            assertThat(manager.getActiveNodesInGroup(Optional.of("missing"))).isEmpty();
+            // an empty group means unrestricted, not "nodes without a group"
+            assertThat(manager.getActiveNodesInGroup(Optional.empty())).containsExactlyInAnyOrder(current, etl, adhoc);
+
+            // the snapshot index must resolve every group of a node, not just whichever one iterates first
+            NodesSnapshot snapshot = manager.getActiveNodesSnapshot();
+            assertThat(snapshot.getNodesInGroup(Optional.of("etl"))).containsExactly(etl);
+            assertThat(snapshot.getNodesInGroup(Optional.of("adhoc"))).containsExactly(adhoc);
+            assertThat(snapshot.getNodesInGroup(Optional.of("shared"))).containsExactlyInAnyOrder(etl, adhoc);
+            assertThat(snapshot.getNodesInGroup(Optional.of("missing"))).isEmpty();
+            assertThat(snapshot.getNodesInGroup(Optional.empty())).containsExactlyInAnyOrder(current, etl, adhoc);
+
+            // a node returning with different groups is observed as a node change
+            notifications.clear();
+            etlGroups.set(ImmutableSet.of("adhoc"));
+            manager.refreshNodes(true);
+            AllNodes allNodes = notifications.take();
+            assertThat(allNodes.activeNodes()).contains(new InternalNode(
+                    etl.getNodeIdentifier(),
+                    etl.getInternalUri(),
+                    version,
+                    false,
+                    ImmutableSet.of("adhoc")));
+            assertThat(manager.getActiveNodesInGroup(Optional.of("etl"))).isEmpty();
+            assertThat(manager.getActiveNodesInGroup(Optional.of("shared"))).containsExactly(adhoc);
+        }
+        finally {
+            manager.stop();
+        }
+    }
+
     private final class TestingNodeInventory
             implements NodeInventory
     {
@@ -254,7 +343,8 @@ class TestCoordinatorNodeManager
                 node.getNodeIdentifier(),
                 node.getInternalUri(),
                 node.getNodeVersion(),
-                node.isCoordinator());
+                node.isCoordinator(),
+                node.getNodeGroups());
     }
 
     private static ServerInfo toServerInfo(InternalNode inactiveNode, NodeState nodeState, String environment)
@@ -267,6 +357,7 @@ class TestCoordinatorNodeManager
                 inactiveNode.isCoordinator(),
                 Optional.empty(),
                 false,
-                Duration.ZERO);
+                Duration.ZERO,
+                inactiveNode.getNodeGroups());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/server/TestServerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestServerConfig.java
@@ -14,6 +14,7 @@
 package io.trino.server;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +36,8 @@ public class TestServerConfig
                 .setIncludeExceptionInResponse(true)
                 .setGracePeriod(new Duration(2, MINUTES))
                 .setQueryResultsCompressionEnabled(true)
-                .setQueryInfoUrlTemplate(null));
+                .setQueryInfoUrlTemplate(null)
+                .setNodeGroups(ImmutableSet.of()));
     }
 
     @Test
@@ -48,6 +50,7 @@ public class TestServerConfig
                 .put("shutdown.grace-period", "5m")
                 .put("query-results.compression-enabled", "false")
                 .put("query.info-url-template", "https://example.com/query/${QUERY_ID}")
+                .put("node.groups", "etl,shared")
                 .buildOrThrow();
 
         ServerConfig expected = new ServerConfig()
@@ -56,7 +59,8 @@ public class TestServerConfig
                 .setIncludeExceptionInResponse(false)
                 .setGracePeriod(new Duration(5, MINUTES))
                 .setQueryResultsCompressionEnabled(false)
-                .setQueryInfoUrlTemplate("https://example.com/query/${QUERY_ID}");
+                .setQueryInfoUrlTemplate("https://example.com/query/${QUERY_ID}")
+                .setNodeGroups(ImmutableSet.of("etl", "shared"));
 
         assertFullMapping(properties, expected);
     }

--- a/core/trino-main/src/test/java/io/trino/server/TestServerInfoSerialization.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestServerInfoSerialization.java
@@ -13,6 +13,7 @@
  */
 package io.trino.server;
 
+import com.google.common.collect.ImmutableSet;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.Duration;
 import io.trino.client.NodeVersion;
@@ -32,8 +33,31 @@ public class TestServerInfoSerialization
     @Test
     void testServerInfoSerialization()
     {
-        io.trino.server.ServerInfo serverServerInfo = new io.trino.server.ServerInfo("some-node-id", NodeState.ACTIVE, new io.trino.spi.NodeVersion("some-version"), "some-env", true, Optional.of("some-coordinator-id"), true, Duration.valueOf("1h"));
+        io.trino.server.ServerInfo serverServerInfo = new io.trino.server.ServerInfo("some-node-id", NodeState.ACTIVE, new io.trino.spi.NodeVersion("some-version"), "some-env", true, Optional.of("some-coordinator-id"), true, Duration.valueOf("1h"), ImmutableSet.of("some-node-group"));
         io.trino.client.ServerInfo clientServerInfo = new io.trino.client.ServerInfo(new NodeVersion("some-version"), "some-env", true, true, Optional.of(Duration.valueOf("1h")), Optional.of("some-coordinator-id"), Optional.of("some-node-id"));
         assertThat(CLIENT_SERVER_INFO_CODEC.fromJson(SERVER_SERVER_INFO_CODEC.toJson(serverServerInfo))).isEqualTo(clientServerInfo);
+    }
+
+    @Test
+    void testMissingNodeGroupsDeserializesToEmpty()
+    {
+        // a server that predates node groups omits the property; unlike Optional, a Set deserializes to null,
+        // which would fail the constructor and make the coordinator mark the node INACTIVE
+        String json =
+                """
+                {
+                  "nodeId": "some-node-id",
+                  "state": "ACTIVE",
+                  "nodeVersion": {"version": "some-version"},
+                  "environment": "some-env",
+                  "coordinator": true,
+                  "starting": false,
+                  "uptime": "1h"
+                }
+                """;
+
+        io.trino.server.ServerInfo serverInfo = SERVER_SERVER_INFO_CODEC.fromJson(json);
+        assertThat(serverInfo.nodeGroups()).isEmpty();
+        assertThat(serverInfo.state()).isEqualTo(NodeState.ACTIVE);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestNodePartitioningManager.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestNodePartitioningManager.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.connector.CatalogServiceProvider;
+import io.trino.connector.DefaultNodeManager;
+import io.trino.execution.NodeTaskMap;
+import io.trino.execution.scheduler.NodeScheduler;
+import io.trino.execution.scheduler.NodeSchedulerConfig;
+import io.trino.execution.scheduler.StableHostAddressProvider;
+import io.trino.execution.scheduler.StableHostAddressProviderConfig;
+import io.trino.execution.scheduler.UniformNodeSelectorFactory;
+import io.trino.node.InternalNode;
+import io.trino.node.TestingInternalNodeManager;
+import io.trino.spi.NodeVersion;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.BucketFunction;
+import io.trino.spi.connector.ConnectorBucketNodeMap;
+import io.trino.spi.connector.ConnectorNodePartitioningProvider;
+import io.trino.spi.connector.ConnectorPartitioningHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.type.Type;
+import io.trino.testing.TestingSession;
+import io.trino.testing.TestingTransactionHandle;
+import io.trino.util.FinalizerService;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.ToIntFunction;
+
+import static io.trino.node.TestingInternalNodeManager.CURRENT_NODE;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.connector.ConnectorBucketNodeMap.createBucketNodeMap;
+import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestNodePartitioningManager
+{
+    private static final ConnectorPartitioningHandle FIXED_MAPPING_HANDLE = new ConnectorPartitioningHandle() {};
+    private static final ConnectorPartitioningHandle BUCKET_COUNT_HANDLE = new ConnectorPartitioningHandle() {};
+
+    private static final InternalNode ETL_NODE = new InternalNode("etl1", URI.create("http://10.0.0.1:21"), NodeVersion.UNKNOWN, false, ImmutableSet.of("etl"));
+
+    private static final PartitioningHandle FIXED_MAPPING_PARTITIONING = partitioning(FIXED_MAPPING_HANDLE);
+    private static final PartitioningHandle BUCKET_COUNT_PARTITIONING = partitioning(BUCKET_COUNT_HANDLE);
+
+    @Test
+    void testFixedBucketMappingIsRejectedForNodeGroup()
+    {
+        NodePartitioningManager manager = createNodePartitioningManager();
+
+        // a connector that pins buckets to nodes picks them without knowing about the node group, so the
+        // query would silently run outside its group. It must be refused rather than escape the restriction.
+        assertThatThrownBy(() -> manager.getNodePartitioningMap(sessionWithNodeGroup("etl"), FIXED_MAPPING_PARTITIONING, 2))
+                .isInstanceOf(TrinoException.class)
+                .hasMessageContaining("node group 'etl'")
+                .extracting(e -> ((TrinoException) e).getErrorCode())
+                .isEqualTo(NOT_SUPPORTED.toErrorCode());
+
+        assertThatThrownBy(() -> manager.getBucketNodeMap(sessionWithNodeGroup("etl"), FIXED_MAPPING_PARTITIONING, 2))
+                .isInstanceOf(TrinoException.class)
+                .extracting(e -> ((TrinoException) e).getErrorCode())
+                .isEqualTo(NOT_SUPPORTED.toErrorCode());
+    }
+
+    @Test
+    void testFixedBucketMappingIsAllowedWithoutNodeGroup()
+    {
+        NodePartitioningManager manager = createNodePartitioningManager();
+        Session session = TestingSession.testSessionBuilder().build();
+
+        assertThat(manager.getNodePartitioningMap(session, FIXED_MAPPING_PARTITIONING, 2).getPartitionToNode())
+                .containsExactly(CURRENT_NODE);
+    }
+
+    @Test
+    void testBucketCountPartitioningHonoursNodeGroup()
+    {
+        NodePartitioningManager manager = createNodePartitioningManager();
+
+        // a connector that only declares a bucket count leaves node choice to the engine, so it is restricted
+        assertThat(manager.getNodePartitioningMap(sessionWithNodeGroup("etl"), BUCKET_COUNT_PARTITIONING, 2).getPartitionToNode())
+                .containsExactly(ETL_NODE);
+    }
+
+    private static NodePartitioningManager createNodePartitioningManager()
+    {
+        TestingInternalNodeManager nodeManager = TestingInternalNodeManager.createDefault(ETL_NODE);
+        NodeSchedulerConfig config = new NodeSchedulerConfig().setIncludeCoordinator(false);
+        NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(
+                CURRENT_NODE,
+                nodeManager,
+                config,
+                new NodeTaskMap(new FinalizerService()),
+                new StableHostAddressProvider(new DefaultNodeManager(CURRENT_NODE, nodeManager, false), new StableHostAddressProviderConfig())));
+        return new NodePartitioningManager(nodeScheduler, CatalogServiceProvider.singleton(TEST_CATALOG_HANDLE, new TestPartitioningProvider()));
+    }
+
+    private static Session sessionWithNodeGroup(String nodeGroup)
+    {
+        return TestingSession.testSessionBuilder()
+                .setNodeGroup(Optional.of(nodeGroup))
+                .build();
+    }
+
+    private static PartitioningHandle partitioning(ConnectorPartitioningHandle connectorHandle)
+    {
+        return new PartitioningHandle(
+                Optional.of(TEST_CATALOG_HANDLE),
+                Optional.of(TestingTransactionHandle.create()),
+                connectorHandle);
+    }
+
+    private static class TestPartitioningProvider
+            implements ConnectorNodePartitioningProvider
+    {
+        @Override
+        public Optional<ConnectorBucketNodeMap> getBucketNodeMapping(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
+        {
+            if (partitioningHandle.equals(FIXED_MAPPING_HANDLE)) {
+                return Optional.of(createBucketNodeMap(ImmutableList.of(CURRENT_NODE)));
+            }
+            return Optional.of(createBucketNodeMap(4));
+        }
+
+        @Override
+        public BucketFunction getBucketFunction(
+                ConnectorTransactionHandle transactionHandle,
+                ConnectorSession session,
+                ConnectorPartitioningHandle partitioningHandle,
+                List<Type> partitionChannelTypes,
+                int bucketCount)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ToIntFunction<ConnectorSplit> getSplitBucketFunction(
+                ConnectorTransactionHandle transactionHandle,
+                ConnectorSession session,
+                ConnectorPartitioningHandle partitioningHandle,
+                int bucketCount)
+        {
+            return _ -> 0;
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
@@ -254,7 +254,8 @@ public class TestShowQueries
         assertThat(assertions.query("SHOW COLUMNS FROM system.runtime.nodes LIKE 'node%'"))
                 .matches("VALUES " +
                         "(VARCHAR 'node_id', VARCHAR 'varchar' , VARCHAR '', VARCHAR '')," +
-                        "(VARCHAR 'node_version', VARCHAR 'varchar' , VARCHAR '', VARCHAR '')");
+                        "(VARCHAR 'node_version', VARCHAR 'varchar' , VARCHAR '', VARCHAR '')," +
+                        "(VARCHAR 'node_groups', VARCHAR 'array(varchar)' , VARCHAR '', VARCHAR '')");
         assertThat(assertions.query("SHOW COLUMNS FROM system.runtime.nodes LIKE 'node_id'"))
                 .matches("VALUES (VARCHAR 'node_id', VARCHAR 'varchar' , VARCHAR '', VARCHAR '')");
         assertThat(assertions.execute("SHOW COLUMNS FROM system.runtime.nodes LIKE ''").getRowCount()).isEqualTo(0);

--- a/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/ResourceGroupConfigurationManager.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/ResourceGroupConfigurationManager.java
@@ -55,5 +55,17 @@ public interface ResourceGroupConfigurationManager<C>
      */
     SelectionContext<C> parentGroupContext(SelectionContext<C> context);
 
+    /**
+     * Name of the node group that queries assigned to the group specified by {@link #match(SelectionCriteria)}'s
+     * {@link SelectionContext#getResourceGroupId()} must run on, restricting them to the workers that declare
+     * membership of that group. An empty result places no restriction on where the query runs.
+     *
+     * @param context a selection context returned from {@link #match(SelectionCriteria)}
+     */
+    default Optional<String> getNodeGroup(SelectionContext<C> context)
+    {
+        return Optional.empty();
+    }
+
     void shutdown();
 }

--- a/docs/src/main/sphinx/admin/graceful-shutdown.md
+++ b/docs/src/main/sphinx/admin/graceful-shutdown.md
@@ -36,6 +36,15 @@ Keep the following aspects in mind:
   Ranger this permission can be found under
   _"System Information - Write System Information"_. 
 
+
+If the cluster uses node groups, take care when shutting down the last node of a
+group. A query assigned to a node group with no active nodes waits for
+`query.required-workers-max-wait` and then fails, so drain the nodes of a group
+only while another node of that group remains active, or after the workloads
+assigned to it have been repointed. The active node count of each group is
+exported by the node manager as `ActiveNodeCountByNodeGroup`. See
+[](node-properties) for `node.groups`.
+
 ## Shutdown behavior
 
 Once the API is called, the worker performs the following steps:

--- a/docs/src/main/sphinx/admin/properties-resource-management.md
+++ b/docs/src/main/sphinx/admin/properties-resource-management.md
@@ -45,6 +45,12 @@ by the hash tables built during execution, memory used during sorting, etc.
 When the user memory allocation of a query across all workers hits this limit
 it is killed.
 
+If a resource group confines its queries to a node group, this cluster-wide
+limit still counts every node, so a query restricted to a small group can hold
+a far larger share of the workers available to it than intended. Pair the node
+group with a lower `query_max_memory` for that resource group, applied through
+a {doc}`session property manager </admin/session-property-managers>`.
+
 :::{warning}
 {ref}`prop-resource-query-max-total-memory` must be greater than
 {ref}`prop-resource-query-max-memory`.
@@ -55,6 +61,7 @@ Does not apply for queries with task level retries enabled (`retry-policy=TASK`)
 :::
 
 (prop-resource-query-max-total-memory)=
+
 ## `query.max-total-memory`
 
 - **Type:** {ref}`prop-type-data-size`

--- a/docs/src/main/sphinx/admin/resource-groups.md
+++ b/docs/src/main/sphinx/admin/resource-groups.md
@@ -138,6 +138,11 @@ are reflected automatically for incoming queries.
 - `jmxExport` (optional): If true, group statistics are exported to JMX for monitoring.
   Defaults to `false`.
 
+- `nodeGroup` (optional): name of the node group that queries in this group must run
+  on. Queries only run on workers that declare membership of that group with the
+  `node.groups` property, see [](node-properties). A sub-group that does not specify
+  `nodeGroup` inherits it from the nearest ancestor that does. See {ref}`node-groups`.
+
 - `subGroups` (optional): list of sub-groups.
 
 (scheduleweight-example)=
@@ -159,6 +164,43 @@ evenly and each receive 50% of the queries in a given timeframe.
 ```{literalinclude} schedule-weight-example.json
 :language: text
 ```
+
+(node-groups)=
+### Node groups
+
+A node group restricts the workers that queries in a resource group run on, so that an
+expensive workload does not compete for CPU and memory with the rest of the cluster.
+Workers declare the groups they belong to with the `node.groups` property, and may belong
+to more than one, see [](node-properties).
+
+A node group constrains where queries run, it does not reserve capacity for them. A worker
+shared between two node groups can be fully occupied by queries from either one. Use
+`hardConcurrencyLimit` and `softMemoryLimit` to limit how much of the cluster a group
+occupies, and give workers non-overlapping membership to keep queries strictly apart.
+
+Both memory limits are measured against the whole cluster. A percentage `softMemoryLimit`
+is a share of total cluster memory, so a group restricted to a tenth of the workers never
+reaches a limit higher than about ten percent and the limit has no effect. Use an absolute
+value sized to the workers of the group instead, and set `query_max_memory` for the group
+with a {doc}`session property manager </admin/session-property-managers>` for the same
+reason.
+
+When workers run out of memory, the query that is terminated is the largest consumer of
+memory on those workers, so a query restricted to a different node group is not considered.
+There are two exceptions. The `query.low-memory-killer.policy=total-reservation` policy
+selects the largest query in the cluster wherever its memory is held, and a query that sets
+`resource_overcommit` is terminated whenever any worker in the cluster runs out of memory.
+
+Some catalogs cannot be read from a query that is restricted to a node group. Connectors
+that assign work to specific nodes choose them from the cluster-wide list of workers and
+are not aware of node groups, so such a query is rejected instead of running outside its
+group. This applies to `jmx`, `memory`, `tpch` and `tpcds`.
+
+A node group is only as reliable as the selector that chooses the resource group. The
+`source` and client tags of a query are set by the client, so a selector that matches on
+them lets a user choose their own resource group, and with it their node group, in the same
+way that it already lets them choose that group's concurrency and memory limits. Match on
+`user`, `userGroup`, `originalUser` or `authenticatedUser` where placement must be enforced.
 
 ## Selector rules
 

--- a/docs/src/main/sphinx/connector/system.md
+++ b/docs/src/main/sphinx/connector/system.md
@@ -100,7 +100,14 @@ The table comments table contains the list of table comment.
 ### `runtime.nodes`
 
 The nodes table contains the list of visible nodes in the Trino
-cluster along with their status.
+cluster along with their status. The `node_groups` column contains the node
+group names each node declares through the `node.groups` property, and is empty
+when the node belongs to no group. See [](node-properties). For example, to list
+the nodes serving the `etl` group:
+
+```sql
+SELECT node_id, state FROM system.runtime.nodes WHERE contains(node_groups, 'etl');
+```
 
 (optimizer-rule-stats)=
 ### `runtime.optimizer_rule_stats`

--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -111,6 +111,19 @@ The above properties are described below:
 - `node.data-dir`:
   The location (filesystem path) of the data directory. Trino stores
   logs and other data here.
+- `node.groups`:
+  Optional comma-separated list of node group names this node belongs to, for
+  example `node.groups=etl,shared`. A node may belong to any number of groups,
+  and groups may overlap. Each name must start with an alphanumeric character
+  and only contain alphanumeric, `-`, or `_` characters. When unset, the node
+  belongs to no group. Membership is visible in the `node_groups` column of
+  [](/connector/system).
+
+  Node groups constrain *where* a query may run; they do not *reserve*
+  capacity. A node listed in two groups can be fully occupied by queries from
+  either one. Use non-overlapping membership if you need hard isolation, and
+  resource group concurrency and memory limits to bound how much of the cluster
+  a workload occupies.
 
 (jvm-config)=
 ### JVM config

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
@@ -36,7 +36,7 @@ import java.util.Queue;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Verify.verifyNotNull;
+import static com.google.common.base.Verify.verify;
 import static io.trino.spi.StandardErrorCode.INVALID_RESOURCE_GROUP;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -168,18 +168,41 @@ public abstract class AbstractResourceConfigurationManager
 
     protected ResourceGroupSpec getMatchingSpec(ResourceGroup group, SelectionContext<ResourceGroupIdTemplate> context)
     {
+        List<ResourceGroupSpec> path = getMatchingSpecPath(group.getId(), context.getContext());
+        verify(!path.isEmpty(), "path is empty");
+        return path.getLast();
+    }
+
+    @Override
+    public Optional<String> getNodeGroup(SelectionContext<ResourceGroupIdTemplate> context)
+    {
+        // Unlike the resource limits, which are enforced by combining the limits of every ancestor, a node group
+        // cannot be combined, so the nearest ancestor that declares one wins unless the group overrides it.
+        Optional<String> nodeGroup = Optional.empty();
+        for (ResourceGroupSpec spec : getMatchingSpecPath(context.getResourceGroupId(), context.getContext())) {
+            if (spec.getNodeGroup().isPresent()) {
+                nodeGroup = spec.getNodeGroup();
+            }
+        }
+        return nodeGroup;
+    }
+
+    /**
+     * The specs matching each segment of the group id template, from the root group down to the group itself.
+     */
+    private List<ResourceGroupSpec> getMatchingSpecPath(ResourceGroupId groupId, ResourceGroupIdTemplate groupIdTemplate)
+    {
+        ImmutableList.Builder<ResourceGroupSpec> path = ImmutableList.builder();
         List<ResourceGroupSpec> candidates = getRootGroups();
-        ResourceGroupIdTemplate groupIdTemplate = context.getContext();
-        ResourceGroupSpec match = null;
 
         for (ResourceGroupNameTemplate segment : groupIdTemplate.getSegments()) {
-            match = null;
+            ResourceGroupSpec match = null;
             for (ResourceGroupSpec candidate : candidates) {
                 if (candidate.getName().equals(segment)) {
                     if (match != null) {
                         throw new TrinoException(INVALID_RESOURCE_GROUP, format(
                                 "Ambiguous configuration for [%s] using [%s]. Matches [%s] and [%s]",
-                                group.getId(),
+                                groupId,
                                 groupIdTemplate,
                                 match.getName(),
                                 candidate.getName()));
@@ -188,12 +211,12 @@ public abstract class AbstractResourceConfigurationManager
                 }
             }
 
-            checkState(match != null, "No matching configuration found for [%s] using [%s]", group.getId(), groupIdTemplate);
+            checkState(match != null, "No matching configuration found for [%s] using [%s]", groupId, groupIdTemplate);
+            path.add(match);
             candidates = match.getSubGroups();
         }
 
-        verifyNotNull(match, "match is null");
-        return match;
+        return path.build();
     }
 
     @SuppressWarnings("NumericCastThatLosesPrecision")

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/ResourceGroupSpec.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/ResourceGroupSpec.java
@@ -51,6 +51,7 @@ public class ResourceGroupSpec
     private final Optional<Duration> softCpuLimit;
     private final Optional<Duration> hardCpuLimit;
     private final Optional<DataSize> hardPhysicalDataScanLimit;
+    private final Optional<String> nodeGroup;
 
     @JsonCreator
     public ResourceGroupSpec(
@@ -66,7 +67,8 @@ public class ResourceGroupSpec
             @JsonProperty("jmxExport") Optional<Boolean> jmxExport,
             @JsonProperty("softCpuLimit") Optional<Duration> softCpuLimit,
             @JsonProperty("hardCpuLimit") Optional<Duration> hardCpuLimit,
-            @JsonProperty("hardPhysicalDataScanLimit") Optional<DataSize> hardPhysicalDataScanLimit)
+            @JsonProperty("hardPhysicalDataScanLimit") Optional<DataSize> hardPhysicalDataScanLimit,
+            @JsonProperty("nodeGroup") Optional<String> nodeGroup)
     {
         this.softCpuLimit = requireNonNull(softCpuLimit, "softCpuLimit is null");
         this.hardCpuLimit = requireNonNull(hardCpuLimit, "hardCpuLimit is null");
@@ -76,6 +78,7 @@ public class ResourceGroupSpec
         this.maxQueued = maxQueued;
         this.softConcurrencyLimit = softConcurrencyLimit;
         this.hardPhysicalDataScanLimit = requireNonNull(hardPhysicalDataScanLimit, "hardPhysicalDataScanLimit is null");
+        this.nodeGroup = requireNonNull(nodeGroup, "nodeGroup is null");
 
         checkArgument(hardConcurrencyLimit.isPresent() || maxRunning.isPresent(), "Missing required property: hardConcurrencyLimit");
         this.hardConcurrencyLimit = hardConcurrencyLimit.orElseGet(maxRunning::get);
@@ -109,6 +112,11 @@ public class ResourceGroupSpec
         for (ResourceGroupSpec subGroup : this.subGroups) {
             checkArgument(names.add(subGroup.getName()), "Duplicated sub group: %s", subGroup.getName());
         }
+    }
+
+    public Optional<String> getNodeGroup()
+    {
+        return nodeGroup;
     }
 
     public Optional<DataSize> getSoftMemoryLimit()
@@ -197,7 +205,8 @@ public class ResourceGroupSpec
                 jmxExport.equals(that.jmxExport) &&
                 softCpuLimit.equals(that.softCpuLimit) &&
                 hardCpuLimit.equals(that.hardCpuLimit) &&
-                hardPhysicalDataScanLimit.equals(that.hardPhysicalDataScanLimit));
+                hardPhysicalDataScanLimit.equals(that.hardPhysicalDataScanLimit) &&
+                nodeGroup.equals(that.nodeGroup));
     }
 
     // Subgroups not included, used to determine whether a group needs to be reconfigured
@@ -216,7 +225,8 @@ public class ResourceGroupSpec
                 jmxExport.equals(other.jmxExport) &&
                 softCpuLimit.equals(other.softCpuLimit) &&
                 hardCpuLimit.equals(other.hardCpuLimit) &&
-                hardPhysicalDataScanLimit.equals(other.hardPhysicalDataScanLimit));
+                hardPhysicalDataScanLimit.equals(other.hardPhysicalDataScanLimit) &&
+                nodeGroup.equals(other.nodeGroup));
     }
 
     @Override
@@ -234,7 +244,8 @@ public class ResourceGroupSpec
                 jmxExport,
                 softCpuLimit,
                 hardCpuLimit,
-                hardPhysicalDataScanLimit);
+                hardPhysicalDataScanLimit,
+                nodeGroup);
     }
 
     @Override
@@ -252,6 +263,7 @@ public class ResourceGroupSpec
                 .add("softCpuLimit", softCpuLimit)
                 .add("hardCpuLimit", hardCpuLimit)
                 .add("hardPhysicalDataScanLimit", hardPhysicalDataScanLimit)
+                .add("nodeGroup", nodeGroup)
                 .toString();
     }
 }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupSpecBuilder.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupSpecBuilder.java
@@ -41,6 +41,7 @@ public class ResourceGroupSpecBuilder
     private final Optional<Duration> softCpuLimit;
     private final Optional<Duration> hardCpuLimit;
     private final Optional<DataSize> hardPhysicalDataScanLimit;
+    private final Optional<String> nodeGroup;
     private final Optional<Long> parentId;
     private final ImmutableList.Builder<ResourceGroupSpec> subGroups = ImmutableList.builder();
 
@@ -57,6 +58,7 @@ public class ResourceGroupSpecBuilder
             Optional<String> softCpuLimit,
             Optional<String> hardCpuLimit,
             Optional<String> hardPhysicalDataScanLimit,
+            Optional<String> nodeGroup,
             Optional<Long> parentId)
     {
         this.id = id;
@@ -71,6 +73,7 @@ public class ResourceGroupSpecBuilder
         this.softCpuLimit = softCpuLimit.map(Duration::valueOf);
         this.hardCpuLimit = hardCpuLimit.map(Duration::valueOf);
         this.hardPhysicalDataScanLimit = hardPhysicalDataScanLimit.map(DataSize::valueOf);
+        this.nodeGroup = requireNonNull(nodeGroup, "nodeGroup is null");
         this.parentId = parentId;
     }
 
@@ -119,7 +122,8 @@ public class ResourceGroupSpecBuilder
                 jmxExport,
                 softCpuLimit,
                 hardCpuLimit,
-                hardPhysicalDataScanLimit);
+                hardPhysicalDataScanLimit,
+                nodeGroup);
     }
 
     public static class Mapper
@@ -150,6 +154,7 @@ public class ResourceGroupSpecBuilder
             Optional<String> softCpuLimit = Optional.ofNullable(resultSet.getString("soft_cpu_limit"));
             Optional<String> hardCpuLimit = Optional.ofNullable(resultSet.getString("hard_cpu_limit"));
             Optional<String> hardPhysicalDataScanLimit = Optional.ofNullable(resultSet.getString("hard_physical_data_scan_limit"));
+            Optional<String> nodeGroup = Optional.ofNullable(resultSet.getString("node_group"));
             Optional<Long> parentId = Optional.of(resultSet.getLong("parent"));
             if (resultSet.wasNull()) {
                 parentId = Optional.empty();
@@ -167,6 +172,7 @@ public class ResourceGroupSpecBuilder
                     softCpuLimit,
                     hardCpuLimit,
                     hardPhysicalDataScanLimit,
+                    nodeGroup,
                     parentId);
         }
     }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupsDao.java
@@ -47,6 +47,7 @@ public interface ResourceGroupsDao
             "  soft_cpu_limit VARCHAR(128) NULL,\n" +
             "  hard_cpu_limit VARCHAR(128) NULL,\n" +
             "  hard_physical_data_scan_limit VARCHAR(128) NULL,\n" +
+            "  node_group VARCHAR(250) NULL,\n" +
             "  parent BIGINT NULL,\n" +
             "  environment VARCHAR(128) NULL,\n" +
             "  PRIMARY KEY (resource_group_id),\n" +
@@ -56,7 +57,7 @@ public interface ResourceGroupsDao
 
     @SqlQuery("SELECT resource_group_id, name, soft_memory_limit, max_queued, soft_concurrency_limit, " +
             "  hard_concurrency_limit, scheduling_policy, scheduling_weight, jmx_export, soft_cpu_limit, " +
-            "  hard_cpu_limit, hard_physical_data_scan_limit, parent\n" +
+            "  hard_cpu_limit, hard_physical_data_scan_limit, node_group, parent\n" +
             "FROM resource_groups\n" +
             "WHERE environment = :environment\n")
     @UseRowMapper(ResourceGroupSpecBuilder.Mapper.class)

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/mysql/V11__add_node_group_to_resource_groups.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/mysql/V11__add_node_group_to_resource_groups.sql
@@ -1,0 +1,1 @@
+ALTER TABLE resource_groups ADD COLUMN node_group VARCHAR(250);

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/oracle/V11__add_node_group_to_resource_groups.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/oracle/V11__add_node_group_to_resource_groups.sql
@@ -1,0 +1,1 @@
+ALTER TABLE resource_groups ADD node_group VARCHAR(250);

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/postgresql/V11__add_node_group_to_resource_groups.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/postgresql/V11__add_node_group_to_resource_groups.sql
@@ -1,0 +1,1 @@
+ALTER TABLE resource_groups ADD COLUMN node_group VARCHAR(250);

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestFileResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestFileResourceGroupConfigurationManager.java
@@ -341,6 +341,25 @@ public class TestFileResourceGroupConfigurationManager
         assertThatThrownBy(() -> parse(fileName)).hasMessageMatching(expectedPattern);
     }
 
+    @Test
+    public void testNodeGroup()
+    {
+        FileResourceGroupConfigurationManager manager = parse("resource_groups_config_node_group.json");
+
+        assertThat(nodeGroup(manager, "etl")).contains("batch");
+        // a sub group without its own node group inherits the nearest ancestor that declares one
+        assertThat(nodeGroup(manager, "etl.inherits")).contains("batch");
+        assertThat(nodeGroup(manager, "etl.overrides")).contains("batch_large");
+        // a group under a root that declares no node group is unrestricted
+        assertThat(nodeGroup(manager, "adhoc")).isEmpty();
+        assertThat(nodeGroup(manager, "adhoc.unrestricted")).isEmpty();
+    }
+
+    private static Optional<String> nodeGroup(FileResourceGroupConfigurationManager manager, String groupId)
+    {
+        return manager.getNodeGroup(new SelectionContext<>(ResourceGroupId.valueOf(groupId), new ResourceGroupIdTemplate(groupId)));
+    }
+
     private static FileResourceGroupConfigurationManager parse(String fileName)
     {
         FileResourceGroupConfig config = new FileResourceGroupConfig();

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroups.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroups.java
@@ -62,6 +62,7 @@ final class TestingResourceGroups
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/H2ResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/H2ResourceGroupsDao.java
@@ -29,8 +29,8 @@ public interface H2ResourceGroupsDao
     void updateResourceGroupsGlobalProperties(@Bind("name") String name);
 
     @SqlUpdate("INSERT INTO resource_groups\n" +
-            "(resource_group_id, name, soft_memory_limit, max_queued, soft_concurrency_limit, hard_concurrency_limit, scheduling_policy, scheduling_weight, jmx_export, soft_cpu_limit, hard_cpu_limit, hard_physical_data_scan_limit, parent, environment)\n" +
-            "VALUES (:resource_group_id, :name, :soft_memory_limit, :max_queued, :soft_concurrency_limit, :hard_concurrency_limit, :scheduling_policy, :scheduling_weight, :jmx_export, :soft_cpu_limit, :hard_cpu_limit, :hard_physical_data_scan_limit, :parent, :environment)")
+            "(resource_group_id, name, soft_memory_limit, max_queued, soft_concurrency_limit, hard_concurrency_limit, scheduling_policy, scheduling_weight, jmx_export, soft_cpu_limit, hard_cpu_limit, hard_physical_data_scan_limit, node_group, parent, environment)\n" +
+            "VALUES (:resource_group_id, :name, :soft_memory_limit, :max_queued, :soft_concurrency_limit, :hard_concurrency_limit, :scheduling_policy, :scheduling_weight, :jmx_export, :soft_cpu_limit, :hard_cpu_limit, :hard_physical_data_scan_limit, :node_group, :parent, :environment)")
     void insertResourceGroup(
             @Bind("resource_group_id") long resourceGroupId,
             @Bind("name") String name,
@@ -44,6 +44,7 @@ public interface H2ResourceGroupsDao
             @Bind("soft_cpu_limit") String softCpuLimit,
             @Bind("hard_cpu_limit") String hardCpuLimit,
             @Bind("hard_physical_data_scan_limit") String hardPhysicalDataScanLimit,
+            @Bind("node_group") String nodeGroup,
             @Bind("parent") Long parent,
             @Bind("environment") String environment);
 
@@ -60,6 +61,7 @@ public interface H2ResourceGroupsDao
             ", soft_cpu_limit = :soft_cpu_limit\n" +
             ", hard_cpu_limit = :hard_cpu_limit\n" +
             ", hard_physical_data_scan_limit = :hard_physical_data_scan_limit\n" +
+            ", node_group = :node_group\n" +
             ", parent = :parent\n" +
             ", environment = :environment\n" +
             "WHERE resource_group_id = :resource_group_id")
@@ -76,6 +78,7 @@ public interface H2ResourceGroupsDao
             @Bind("soft_cpu_limit") String softCpuLimit,
             @Bind("hard_cpu_limit") String hardCpuLimit,
             @Bind("hard_physical_data_scan_limit") String hardPhysicalDataScanLimit,
+            @Bind("node_group") String nodeGroup,
             @Bind("parent") Long parent,
             @Bind("environment") String environment);
 

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
@@ -77,8 +77,8 @@ public class TestDbResourceGroupConfigurationManager
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         dao.insertResourceGroupsGlobalProperties("physical_data_scan_quota_period", "1h");
         // two resource groups are the same except the group for the prod environment has a larger softMemoryLimit
-        dao.insertResourceGroup(1, "prod_global", "10MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "5MB", null, prodEnvironment);
-        dao.insertResourceGroup(2, "dev_global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "5MB", null, devEnvironment);
+        dao.insertResourceGroup(1, "prod_global", "10MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "5MB", null, null, prodEnvironment);
+        dao.insertResourceGroup(2, "dev_global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "5MB", null, null, devEnvironment);
         dao.insertSelector(1, 1, ".*prod_user.*", null, null, null, null, null, null, null, null);
         dao.insertSelector(2, 2, ".*dev_user.*", null, null, null, null, null, null, null, null);
 
@@ -116,8 +116,8 @@ public class TestDbResourceGroupConfigurationManager
         dao.createSelectorsTable();
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         dao.insertResourceGroupsGlobalProperties("physical_data_scan_quota_period", "1h");
-        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1TB", null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, "10GB", 1L, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1TB", null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, "10GB", null, 1L, ENVIRONMENT);
         dao.insertSelector(2, 1, null, null, null, null, null, null, null, null, null);
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(_ -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
         InternalResourceGroup global = new InternalResourceGroup("global", (_, _) -> {}, directExecutor());
@@ -136,8 +136,8 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, ENVIRONMENT);
-        assertThatThrownBy(() -> dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, ENVIRONMENT))
+        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
+        assertThatThrownBy(() -> dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT))
                 .isInstanceOfSatisfying(UnableToExecuteStatementException.class, ex -> {
                     assertThat(ex.getCause()).isInstanceOf(JdbcException.class);
                     assertThat(ex.getCause().getMessage()).startsWith("Unique index or primary key violation");
@@ -153,9 +153,9 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "sub", "1MB", 1000, 100, 100, null, null, null, null, null, null, 1L, ENVIRONMENT);
-        assertThatThrownBy(() -> dao.insertResourceGroup(2, "sub", "1MB", 1000, 100, 100, null, null, null, null, null, null, 1L, ENVIRONMENT))
+        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "sub", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        assertThatThrownBy(() -> dao.insertResourceGroup(2, "sub", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, 1L, ENVIRONMENT))
                 .isInstanceOfSatisfying(UnableToExecuteStatementException.class, ex -> {
                     assertThat(ex.getCause()).isInstanceOf(JdbcException.class);
                     assertThat(ex.getCause().getMessage()).startsWith("Unique index or primary key violation");
@@ -171,8 +171,8 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         dao.insertSelector(2, 1, null, null, null, null, null, null, null, null, null);
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(_ -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
@@ -193,8 +193,8 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1GB", null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, "100MB", 1L, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1GB", null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, "100MB", null, 1L, ENVIRONMENT);
         dao.insertSelector(2, 1, null, null, null, null, null, null, null, null, null);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         dao.insertResourceGroupsGlobalProperties("physical_data_scan_quota_period", "1h");
@@ -206,7 +206,7 @@ public class TestDbResourceGroupConfigurationManager
         manager.configure(globalSub, new SelectionContext<>(globalSub.getId(), new ResourceGroupIdTemplate("global.sub")));
         // Verify record exists
         assertEqualsResourceGroup(globalSub, "2MB", 4, 3, 3, FAIR, 5, false, Duration.ofMillis(Long.MAX_VALUE), Duration.ofMillis(Long.MAX_VALUE), "100MB");
-        dao.updateResourceGroup(2, "sub", "3MB", 2, 1, 1, "weighted", 6, true, "1h", "1d", "10MB", 1L, ENVIRONMENT);
+        dao.updateResourceGroup(2, "sub", "3MB", 2, 1, 1, "weighted", 6, true, "1h", "1d", "10MB", null, 1L, ENVIRONMENT);
         do {
             MILLISECONDS.sleep(500);
         }
@@ -231,8 +231,8 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
         dao.createExactMatchSelectorsTable();
-        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertSelector(2, 1, null, null, null, null, null, null, null, null, null);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         DbResourceGroupConfig config = new DbResourceGroupConfig();
@@ -257,7 +257,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
 
         final int numberOfUsers = 100;
         List<String> expectedUsers = new ArrayList<>();
@@ -300,7 +300,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
 
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(
                 _ -> {},
@@ -320,7 +320,7 @@ public class TestDbResourceGroupConfigurationManager
         H2ResourceGroupsDao dao = daoProvider.get();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
 
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(
                 _ -> {},
@@ -348,7 +348,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
         dao.insertSelector(1, 1, null, "first matching|second matching", null, null, null, null, null, null, null);
 
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(
@@ -371,7 +371,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
         dao.insertSelector(1, 1, "Matching user", "Matching group", null, null, null, null, null, null, null);
 
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(
@@ -395,7 +395,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
         dao.insertSelector(1, 1, null, null, "foo.+", null, null, null, null, null, null);
 
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(
@@ -419,7 +419,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
         dao.insertSelector(1, 1, null, null, null, "foo.+", null, null, null, null, null);
 
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(
@@ -443,7 +443,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
         dao.insertSelector(1, 1, null, null, null, null, null, "(?s).+FROM tableX.*", null, null, null);
 
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(
@@ -479,7 +479,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "80%", 10, null, 1, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "80%", 10, null, 1, null, null, null, null, null, null, null, null, ENVIRONMENT);
         dao.insertSelector(1, 1, null, "userGroup", null, null, null, null, null, null, null);
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(_ -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
 
@@ -490,7 +490,7 @@ public class TestDbResourceGroupConfigurationManager
         InternalResourceGroup resourceGroup = new InternalResourceGroup("global", (_, _) -> {}, directExecutor());
 
         try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
-            dao.updateResourceGroup(1, "global", "80%", 10, null, 10, null, null, null, null, null, null, null, ENVIRONMENT);
+            dao.updateResourceGroup(1, "global", "80%", 10, null, 10, null, null, null, null, null, null, null, null, ENVIRONMENT);
 
             executor.submit(() -> {
                 synchronized (resourceGroup) {

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestResourceGroupsDao.java
@@ -79,19 +79,19 @@ public class TestResourceGroupsDao
 
     private static void testResourceGroupInsert(H2ResourceGroupsDao dao, Map<Long, ResourceGroupSpecBuilder> map)
     {
-        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "bi", "50%", 50, 50, 50, null, null, null, null, null, "5MB", 1L, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "bi", "50%", 50, 50, 50, null, null, null, null, null, "5MB", "batch", 1L, ENVIRONMENT);
         List<ResourceGroupSpecBuilder> records = dao.getResourceGroups(ENVIRONMENT);
         assertThat(records).hasSize(2);
-        map.put(1L, new ResourceGroupSpecBuilder(1, new ResourceGroupNameTemplate("global"), Optional.of("100%"), 100, Optional.of(100), 100, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
-        map.put(2L, new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), Optional.of("50%"), 50, Optional.of(50), 50, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of("5MB"), Optional.of(1L)));
+        map.put(1L, new ResourceGroupSpecBuilder(1, new ResourceGroupNameTemplate("global"), Optional.of("100%"), 100, Optional.of(100), 100, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
+        map.put(2L, new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), Optional.of("50%"), 50, Optional.of(50), 50, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of("5MB"), Optional.of("batch"), Optional.of(1L)));
         compareResourceGroups(map, records);
     }
 
     private static void testResourceGroupUpdate(H2ResourceGroupsDao dao, Map<Long, ResourceGroupSpecBuilder> map)
     {
-        dao.updateResourceGroup(2, "bi", null, 40, 30, 30, null, null, true, null, null, null, 1L, ENVIRONMENT);
-        ResourceGroupSpecBuilder updated = new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), Optional.empty(), 40, Optional.of(30), 30, Optional.empty(), Optional.empty(), Optional.of(true), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(1L));
+        dao.updateResourceGroup(2, "bi", null, 40, 30, 30, null, null, true, null, null, null, null, 1L, ENVIRONMENT);
+        ResourceGroupSpecBuilder updated = new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), Optional.empty(), 40, Optional.of(30), 30, Optional.empty(), Optional.empty(), Optional.of(true), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(1L));
         map.put(2L, updated);
         compareResourceGroups(map, dao.getResourceGroups(ENVIRONMENT));
     }
@@ -160,10 +160,10 @@ public class TestResourceGroupsDao
                         Optional.empty(),
                         Optional.of(SELECTOR_RESOURCE_ESTIMATE)));
 
-        dao.insertResourceGroup(1, "admin", "100%", 100, 100, 100, null, null, null, null, null, null, null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "ping_query", "50%", 50, 50, 50, null, null, null, null, null, null, 1L, ENVIRONMENT);
-        dao.insertResourceGroup(3, "config", "50%", 50, 50, 50, null, null, null, null, null, null, 1L, ENVIRONMENT);
-        dao.insertResourceGroup(4, "config", "50%", 50, 50, 50, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(1, "admin", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "ping_query", "50%", 50, 50, 50, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(3, "config", "50%", 50, 50, 50, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(4, "config", "50%", 50, 50, 50, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
 
         dao.insertSelector(2, 1, "ping_user", "ping_group", "ping_original_user", "ping_auth_user", ".*", "ping_query_text", null, null, null);
         dao.insertSelector(3, 2, "admin_user", "admin_group", "admin_original_user", "admin_auth_user", ".*", "admin_query_text", EXPLAIN.name(), LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null);

--- a/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config_node_group.json
+++ b/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config_node_group.json
@@ -1,0 +1,40 @@
+{
+  "rootGroups": [
+    {
+      "name": "etl",
+      "hardConcurrencyLimit": 10,
+      "maxQueued": 100,
+      "nodeGroup": "batch",
+      "subGroups": [
+        {
+          "name": "inherits",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 4
+        },
+        {
+          "name": "overrides",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 4,
+          "nodeGroup": "batch_large"
+        }
+      ]
+    },
+    {
+      "name": "adhoc",
+      "hardConcurrencyLimit": 10,
+      "maxQueued": 100,
+      "subGroups": [
+        {
+          "name": "unrestricted",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 4
+        }
+      ]
+    }
+  ],
+  "selectors": [
+    {
+      "group": "etl"
+    }
+  ]
+}

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -5555,7 +5555,8 @@ public abstract class AbstractTestEngineOnlyQueries
                 getSession().getPreparedStatements(),
                 getSession().getProtocolHeaders(),
                 getSession().getExchangeEncryptionKey(),
-                getSession().getQueryDataEncoding());
+                getSession().getQueryDataEncoding(),
+                getSession().getNodeGroup());
         MaterializedResult result = computeActual(session, "SHOW SESSION");
 
         Map<String, MaterializedRow> properties = Maps.uniqueIndex(result.getMaterializedRows(), input -> {

--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -138,6 +138,7 @@ public final class DistributedQueryRunner
     private DistributedQueryRunner(
             Session defaultSession,
             int workerCount,
+            List<Map<String, String>> workerProperties,
             Map<String, String> extraProperties,
             Map<String, String> coordinatorProperties,
             String environment,
@@ -201,7 +202,7 @@ public final class DistributedQueryRunner
                     ImmutableList.of());
 
             for (int i = 0; i < workerCount; i++) {
-                createNewWorker.accept(Map.of());
+                createNewWorker.accept(i < workerProperties.size() ? workerProperties.get(i) : Map.of());
             }
             refreshNodes();
         }
@@ -756,6 +757,7 @@ public final class DistributedQueryRunner
         private Optional<Map<String, String>> blobCacheProperties = Optional.empty();
         private final ImmutableList.Builder<Plugin> plugins = ImmutableList.builder();
         private int workerCount = 2;
+        private List<Map<String, String>> workerProperties = ImmutableList.of();
         private Map<String, String> extraProperties = ImmutableMap.of();
         private Map<String, String> coordinatorProperties = ImmutableMap.of();
         private Consumer<QueryRunner> additionalSetup = _ -> {};
@@ -788,6 +790,18 @@ public final class DistributedQueryRunner
         public SELF setWorkerCount(int workerCount)
         {
             this.workerCount = workerCount;
+            return self();
+        }
+
+        /**
+         * Configuration for each worker separately, for tests that need workers to differ, such as
+         * belonging to different node groups. Sets the worker count to the number of entries.
+         */
+        @CanIgnoreReturnValue
+        public SELF setWorkerProperties(List<Map<String, String>> workerProperties)
+        {
+            this.workerProperties = ImmutableList.copyOf(workerProperties);
+            this.workerCount = this.workerProperties.size();
             return self();
         }
 
@@ -1015,6 +1029,7 @@ public final class DistributedQueryRunner
             DistributedQueryRunner queryRunner = new DistributedQueryRunner(
                     defaultSession,
                     workerCount,
+                    workerProperties,
                     extraProperties,
                     coordinatorProperties,
                     environment,

--- a/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/H2TestUtil.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/H2TestUtil.java
@@ -160,13 +160,13 @@ final class H2TestUtil
     {
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         dao.insertResourceGroupsGlobalProperties("physical_data_scan_quota_period", "1h");
-        dao.insertResourceGroup(1, "global", "1MB", 100, 1000, 1000, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(2, "bi-${USER}", "1MB", 3, 2, 2, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(3, "user-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(4, "adhoc-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(6, "no-queueing", "1MB", 0, 1, 1, null, null, null, null, null, null, null, TEST_ENVIRONMENT_2);
-        dao.insertResourceGroup(7, "explain", "1MB", 0, 1, 1, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "1MB", 100, 1000, 1000, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(2, "bi-${USER}", "1MB", 3, 2, 2, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(3, "user-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(4, "adhoc-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(6, "no-queueing", "1MB", 0, 1, 1, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT_2);
+        dao.insertResourceGroup(7, "explain", "1MB", 0, 1, 1, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertSelector(2, 10_000, "user.*", null, null, null, "test", null, null, null, null);
         dao.insertSelector(4, 1_000, "user.*", null, null, null, "(?i).*adhoc.*", null, null, null, null);
         dao.insertSelector(5, 100, "user.*", null, null, null, "(?i).*dashboard.*", null, null, null, null);

--- a/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/TestQueuesDb.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/TestQueuesDb.java
@@ -131,8 +131,8 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
         waitForRunningQueryCount(queryRunner, 1);
         // Update db to allow for 1 more running query in dashboard resource group
-        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         waitForQueryState(queryRunner, secondDashboardQuery, RUNNING);
         QueryId thirdDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
@@ -181,8 +181,8 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, thirdDashboardQuery, FAILED);
 
         // Allow one more query to run and resubmit third query
-        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
 
         InternalResourceGroupManager<?> manager = queryRunner.getCoordinator().getResourceGroupManager().get();
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
@@ -194,7 +194,7 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
 
         // Lower running queries in dashboard resource groups and reload the config
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
 
         // Cancel query and verify that third query is still queued
@@ -258,7 +258,7 @@ public class TestQueuesDb
         assertThat(resourceGroup.get().toString()).isEqualTo("global.user-user.dashboard-user");
 
         // create a new resource group that rejects all queries submitted to it
-        dao.insertResourceGroup(8, "reject-all-queries", "1MB", 0, 0, 0, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(8, "reject-all-queries", "1MB", 0, 0, 0, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
 
         // add a new selector that has a higher priority than the existing dashboard selector and that routes queries to the "reject-all-queries" resource group
         dao.insertSelector(8, 200, "user.*", null, null, null, "(?i).*dashboard.*", null, null, null, null);
@@ -302,7 +302,7 @@ public class TestQueuesDb
         assertThat(queryManager.getFullQueryInfo(firstQuery).getErrorCode()).isEqualTo(EXCEEDED_TIME_LIMIT.toErrorCode());
         assertThat(queryManager.getFullQueryInfo(firstQuery).getFailureInfo().message()).contains("Query exceeded the maximum execution time limit of 1.00ms");
         // set max running queries to 0 for the dashboard resource group so that new queries get queued immediately
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, null, 0, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, null, 0, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
         QueryId secondQuery = createQuery(
                 queryRunner,
@@ -320,7 +320,7 @@ public class TestQueuesDb
         DispatchManager dispatchManager = queryRunner.getCoordinator().getDispatchManager();
         assertThat(dispatchManager.getQueryInfo(secondQuery).getState()).isEqualTo(QUEUED);
         // reconfigure the resource group to run the second query
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, null, 1, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, null, 1, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
         // cancel the first one and let the second one start
         dispatchManager.cancelQuery(firstQuery);
@@ -390,14 +390,14 @@ public class TestQueuesDb
         InternalResourceGroupManager<?> manager = queryRunner.getCoordinator().getResourceGroupManager().orElseThrow();
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
 
-        dao.updateResourceGroup(2, "bi-${USER}", "100%", 3, 2, 2, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(2, "bi-${USER}", "100%", 3, 2, 2, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
         assertThat(manager.tryGetResourceGroupInfo(new ResourceGroupId(new ResourceGroupId("global"), "bi-user"))
                 .orElseThrow(() -> new IllegalStateException("Resource group not found"))
                 .softMemoryLimit()
                 .toBytes()).isEqualTo(queryRunner.getCoordinator().getClusterMemoryManager().getClusterMemoryBytes());
 
-        dao.updateResourceGroup(2, "bi-${USER}", "123MB", 3, 2, 2, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(2, "bi-${USER}", "123MB", 3, 2, 2, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
 
         // wait for SqlQueryManager which enforce memory limits per second
@@ -416,9 +416,9 @@ public class TestQueuesDb
     {
         InternalResourceGroupManager<?> manager = queryRunner.getCoordinator().getResourceGroupManager().orElseThrow();
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
-        dao.insertResourceGroup(10, "queued", "80%", 10, null, 1, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(10, "queued", "80%", 10, null, 1, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertSelector(10, 1, null, null, null, null, null, null, null, "[\"queued\"]", null);
-        dao.insertResourceGroup(11, "running", "80%", 10, null, 2, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(11, "running", "80%", 10, null, 2, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertSelector(11, 1, null, null, null, null, null, null, null, "[\"running\"]", null);
         dbConfigurationManager.load();
 
@@ -431,10 +431,10 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, firstQueryFromRunningGroup, RUNNING);
 
         dao.deleteSelectors(10);
-        dao.insertResourceGroup(12, "subgroup", "80%", 10, null, 1, null, null, null, null, null, null, 10L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(12, "subgroup", "80%", 10, null, 1, null, null, null, null, null, null, null, 10L, TEST_ENVIRONMENT);
         dao.insertSelector(12, 1, null, null, null, null, null, null, null, "[\"queued\"]", null);
         dao.deleteSelectors(11);
-        dao.insertResourceGroup(13, "subgroup", "80%", 10, null, 1, null, null, null, null, null, null, 11L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(13, "subgroup", "80%", 10, null, 1, null, null, null, null, null, null, null, 11L, TEST_ENVIRONMENT);
         dao.insertSelector(13, 1, null, null, null, null, null, null, null, "[\"running\"]", null);
         dbConfigurationManager.load();
 
@@ -456,11 +456,11 @@ public class TestQueuesDb
         InternalResourceGroupManager<?> manager = queryRunner.getCoordinator().getResourceGroupManager().orElseThrow();
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
 
-        dao.insertResourceGroup(10, "queued", "80%", 10, null, 3, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(11, "subgroup", "80%", 10, null, 1, null, null, null, null, null, null, 10L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(10, "queued", "80%", 10, null, 3, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(11, "subgroup", "80%", 10, null, 1, null, null, null, null, null, null, null, 10L, TEST_ENVIRONMENT);
         dao.insertSelector(11, 1, null, null, null, null, null, null, null, "[\"queued\"]", null);
-        dao.insertResourceGroup(12, "running", "80%", 10, null, 3, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(13, "subgroup", "80%", 10, null, 1, null, null, null, null, null, null, 12L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(12, "running", "80%", 10, null, 3, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(13, "subgroup", "80%", 10, null, 1, null, null, null, null, null, null, null, 12L, TEST_ENVIRONMENT);
         dao.insertSelector(13, 1, null, null, null, null, null, null, null, "[\"running\"]", null);
         dbConfigurationManager.load();
 
@@ -497,7 +497,7 @@ public class TestQueuesDb
     {
         InternalResourceGroupManager<?> manager = queryRunner.getCoordinator().getResourceGroupManager().orElseThrow();
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
-        dao.insertResourceGroup(10, "${USER}", "80%", 0, null, 0, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(10, "${USER}", "80%", 0, null, 0, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertSelector(10, 1, null, null, null, null, null, null, null, "[\"tag\"]", null);
         dbConfigurationManager.load();
 
@@ -505,13 +505,13 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, firstQuery, FAILED);
         assertFailureMessage(firstQuery, "Too many queued queries for \"admin\"");
 
-        dao.updateResourceGroup(10, "admin", "80%", 1, null, 0, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(10, "admin", "80%", 1, null, 0, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
 
         QueryId secondQuery = createQuery(queryRunner, session("admin", "tag"), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, secondQuery, QUEUED);
 
-        dao.updateResourceGroup(10, "${USER}", "80%", 1, null, 2, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(10, "${USER}", "80%", 1, null, 2, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
 
         QueryId thirdQuery = createQuery(queryRunner, session("admin", "tag"), LONG_LASTING_QUERY);
@@ -527,7 +527,7 @@ public class TestQueuesDb
         InternalResourceGroupManager<?> manager = queryRunner.getCoordinator().getResourceGroupManager().orElseThrow();
         DbResourceGroupConfigurationManager dbConfigurationManager = (DbResourceGroupConfigurationManager) manager.getConfigurationManager();
 
-        dao.insertResourceGroup(10, "${USER}", "80%", 100, null, 100, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(10, "${USER}", "80%", 100, null, 100, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertSelector(10, 100, null, null, null, null, null, null, null, "[\"tag\"]", null);
         dbConfigurationManager.load();
 
@@ -535,14 +535,14 @@ public class TestQueuesDb
         QueryId firstQuery = createQuery(queryRunner, session("admin", "tag"), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, firstQuery, RUNNING);
 
-        dao.updateResourceGroup(10, "admin", "80%", 100, null, 100, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(10, "admin", "80%", 100, null, 100, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dbConfigurationManager.load();
 
         // associate the resource group with config 'admin'
         QueryId secondQuery = createQuery(queryRunner, session("admin", "tag"), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, secondQuery, RUNNING);
 
-        dao.insertResourceGroup(11, "${USER}", "80%", 0, null, 0, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(11, "${USER}", "80%", 0, null, 0, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertSelector(11, 101, null, null, null, null, null, null, null, "[\"tag\"]", null);
         dbConfigurationManager.load();
 

--- a/testing/trino-tests/src/test/java/io/trino/execution/scheduler/TestNodeGroupIsolation.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/scheduler/TestNodeGroupIsolation.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.scheduler;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import io.trino.Session;
+import io.trino.execution.QueryInfo;
+import io.trino.execution.StageInfo;
+import io.trino.execution.resourcegroups.InternalResourceGroupManager;
+import io.trino.plugin.blackhole.BlackHolePlugin;
+import io.trino.plugin.resourcegroups.ResourceGroupManagerPlugin;
+import io.trino.spi.security.Identity;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.QueryRunner.MaterializedResultWithPlan;
+import io.trino.tests.tpch.TpchQueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+final class TestNodeGroupIsolation
+{
+    private static final String ETL_GROUP = "etl";
+    private static final String ADHOC_GROUP = "adhoc";
+
+    private QueryRunner queryRunner;
+
+    @BeforeAll
+    public void setUp()
+            throws Exception
+    {
+        queryRunner = TpchQueryRunner.builder()
+                .setWorkerProperties(ImmutableList.of(
+                        ImmutableMap.of("node.groups", ETL_GROUP),
+                        ImmutableMap.of("node.groups", ETL_GROUP),
+                        ImmutableMap.of("node.groups", ADHOC_GROUP),
+                        ImmutableMap.of("node.groups", ADHOC_GROUP),
+                        // a worker that declares no group, as during a partial rollout
+                        ImmutableMap.of()))
+                // node groups give no isolation from the coordinator while it also takes worker splits
+                .addExtraProperty("node-scheduler.include-coordinator", "false")
+                .build();
+        queryRunner.installPlugin(new BlackHolePlugin());
+        queryRunner.createCatalog("blackhole", "blackhole");
+        queryRunner.installPlugin(new ResourceGroupManagerPlugin());
+        resourceGroupManager().setConfigurationManager("file", ImmutableMap.of(
+                "resource-groups.config-file", getClass().getClassLoader().getResource("resource_groups_node_group.json").getPath()));
+
+        // enough splits that an unrestricted query reaches every worker
+        queryRunner.execute(session("other_user"), "CREATE TABLE blackhole.default.test_table (value bigint) " +
+                "WITH (split_count = 40, pages_per_split = 1, rows_per_page = 1)");
+    }
+
+    @AfterAll
+    public void tearDown()
+    {
+        if (queryRunner != null) {
+            queryRunner.close();
+            queryRunner = null;
+        }
+    }
+
+    @Test
+    public void testQueriesRunOnlyOnTheNodesOfTheirGroup()
+    {
+        Set<String> etlNodes = nodesInGroup(ETL_GROUP);
+        Set<String> adhocNodes = nodesInGroup(ADHOC_GROUP);
+        assertThat(etlNodes).hasSize(2);
+        assertThat(adhocNodes).hasSize(2);
+
+        assertThat(nodesUsedByQuery("etl_user")).isEqualTo(etlNodes);
+        assertThat(nodesUsedByQuery("adhoc_user")).isEqualTo(adhocNodes);
+
+        // a resource group that declares no node group is not restricted to any of them, and reaches
+        // the worker that declares no group as well
+        assertThat(nodesUsedByQuery("other_user")).isEqualTo(allWorkers());
+        assertThat(allWorkers()).hasSize(5);
+    }
+
+    @Test
+    public void testWorkerWithoutANodeGroupServesOnlyUnrestrictedQueries()
+    {
+        Set<String> ungrouped = Sets.difference(allWorkers(), union(nodesInGroup(ETL_GROUP), nodesInGroup(ADHOC_GROUP)));
+        assertThat(ungrouped).hasSize(1);
+
+        // it is reachable by a query that is not restricted to a node group
+        assertThat(nodesUsedByQuery("other_user")).containsAll(ungrouped);
+        // but declaring no group means belonging to none, so no restricted query can use it
+        assertThat(nodesUsedByQuery("etl_user")).doesNotContainAnyElementsOf(ungrouped);
+        assertThat(nodesUsedByQuery("adhoc_user")).doesNotContainAnyElementsOf(ungrouped);
+    }
+
+    @Test
+    public void testConnectorPinningPartitionsToNodesIsRejected()
+    {
+        // tpch assigns its partitions to specific nodes without knowing about node groups, so a restricted
+        // query is refused rather than allowed to silently run outside its group
+        assertThatThrownBy(() -> queryRunner.execute(session("etl_user"), "SELECT count(*) FROM tpch.tiny.lineitem"))
+                .hasMessageContaining("assigns partitions to specific nodes")
+                .hasMessageContaining("node group 'etl'");
+
+        // the same query is fine when the resource group declares no node group
+        assertThat(queryRunner.execute(session("other_user"), "SELECT count(*) FROM tpch.tiny.lineitem").getRowCount())
+                .isEqualTo(1);
+    }
+
+    private Set<String> nodesUsedByQuery(String user)
+    {
+        MaterializedResultWithPlan result = queryRunner.executeWithPlan(session(user), "SELECT count(*) FROM blackhole.default.test_table");
+        QueryInfo queryInfo = queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(result.queryId());
+        return queryInfo.getStages().orElseThrow().getStages().stream()
+                .filter(stage -> !stage.coordinatorOnly())
+                .map(StageInfo::tasks)
+                .flatMap(List::stream)
+                .map(taskInfo -> taskInfo.taskStatus().nodeId())
+                .collect(toImmutableSet());
+    }
+
+    private Set<String> allWorkers()
+    {
+        return queryRunner.execute("SELECT node_id FROM system.runtime.nodes WHERE NOT coordinator")
+                .getOnlyColumnAsSet().stream()
+                .map(String.class::cast)
+                .collect(toImmutableSet());
+    }
+
+    private Set<String> nodesInGroup(String nodeGroup)
+    {
+        return queryRunner.execute("SELECT node_id FROM system.runtime.nodes WHERE contains(node_groups, '" + nodeGroup + "')")
+                .getOnlyColumnAsSet().stream()
+                .map(String.class::cast)
+                .collect(toImmutableSet());
+    }
+
+    private static Set<String> union(Set<String> left, Set<String> right)
+    {
+        return ImmutableList.<String>builder().addAll(left).addAll(right).build().stream().collect(toImmutableSet());
+    }
+
+    private static Session session(String user)
+    {
+        return testSessionBuilder()
+                .setIdentity(Identity.ofUser(user))
+                .build();
+    }
+
+    private InternalResourceGroupManager<?> resourceGroupManager()
+    {
+        return queryRunner.getCoordinator().getResourceGroupManager()
+                .orElseThrow(() -> new IllegalArgumentException("no resource group manager"));
+    }
+}

--- a/testing/trino-tests/src/test/resources/resource_groups_node_group.json
+++ b/testing/trino-tests/src/test/resources/resource_groups_node_group.json
@@ -1,0 +1,34 @@
+{
+  "rootGroups": [
+    {
+      "name": "etl",
+      "hardConcurrencyLimit": 10,
+      "maxQueued": 100,
+      "nodeGroup": "etl"
+    },
+    {
+      "name": "adhoc",
+      "hardConcurrencyLimit": 10,
+      "maxQueued": 100,
+      "nodeGroup": "adhoc"
+    },
+    {
+      "name": "anywhere",
+      "hardConcurrencyLimit": 10,
+      "maxQueued": 100
+    }
+  ],
+  "selectors": [
+    {
+      "user": "etl_user",
+      "group": "etl"
+    },
+    {
+      "user": "adhoc_user",
+      "group": "adhoc"
+    },
+    {
+      "group": "anywhere"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

### Problem

Trino spreads every query across all workers, so a heavy ETL job and a short interactive query
compete for the same CPU and memory. Resource groups bound how much of the cluster a workload
consumes, but not where it runs.

The usual workaround is a separate cluster per workload. That does isolate them, but it duplicates
coordinators, catalog and security configuration, and client routing, and it strands capacity, since
each cluster has to be sized for its own peak. Node groups give the same placement separation inside
one cluster, and membership may overlap where pools should share machines.

### Solution

Workers declare which groups they belong to in `node.properties`. A resource group names the node
group its queries must run on with a `nodeGroup` property.

A cluster with six ETL workers, two of them larger and belonging to a second pool:

```properties
# node.properties -- four general ETL workers
node.groups=etl

# node.properties -- two larger ETL workers, in both pools
node.groups=etl,etl_large
```

```json
{
  "rootGroups": [
    {"name": "adhoc", "hardConcurrencyLimit": 20, "maxQueued": 100},
    {
      "name": "pipelines",
      "hardConcurrencyLimit": 10,
      "maxQueued": 100,
      "nodeGroup": "etl",
      "subGroups": [
        {"name": "reports",  "hardConcurrencyLimit": 3, "maxQueued": 20},
        {"name": "backfill", "hardConcurrencyLimit": 2, "maxQueued": 20, "nodeGroup": "etl_large"}
      ]
    }
  ]
}
```

**The basic behaviour:**

- `adhoc` names no node group, so its queries are unrestricted and use every worker in the cluster,
  including any that declare no group at all.
- `pipelines` names `etl`, so its queries run on the six ETL workers and nowhere else.

**Inheritance and overrides:**

- `pipelines.reports` names no node group of its own, so it inherits `etl` from its parent and runs
  on all six.
- `pipelines.backfill` names `etl_large`, which **replaces** the inherited name rather than
  intersecting with it, so it runs on the two larger workers only.
- Those two workers declare both names, so they serve both subgroups — membership is a set and pools
  overlap freely. The override lands on a smaller pool only because `etl_large` was made a subset of
  `etl`; drop `etl` from those two and `backfill` and `reports` would run on entirely separate
  machines.

At dispatch the coordinator resolves the name from the selected resource group — never from a
session property, so a user cannot choose their own placement — and pins it to the session. Every
scheduling decision for that query is then made against the workers declaring that name.

## Additional context and related issues

An alternative approach to #28374, which bounds what each query may consume rather than where it runs.

### Interaction with existing settings

| Setting or feature | Interaction |
| --- | --- |
| `node.groups` | A worker may declare several groups, and groups may overlap. Declaring none means the worker serves unrestricted queries only, so membership can roll out gradually. Changes take effect at the next node refresh; running tasks are not migrated. |
| `nodeGroup` | Resolved at dispatch from the selected resource group. Names must match `[A-Za-z0-9][_A-Za-z0-9-]*`, enforced here and on `node.groups`, so an unusable name fails at config load rather than as a query that waits and then dies. |
| `node-scheduler.include-coordinator` | Coordinators are never removed by the group filter, so coordinator-only and output stages keep working. With `true` the coordinator takes worker splits from every group and the groups are not isolated on that machine — run `false`, the multi-node default, where isolation matters. |
| `query.required-workers`<br>`query.required-workers-max-wait` | Counted within the query's group rather than the cluster. A cluster-wide value larger than the smallest group leaves that group's queries failing after the wait. Clusters using no node groups are unaffected. |
| `query.max-memory`<br>percentage `softMemoryLimit` | Stay cluster-wide. A group holding a tenth of the workers never approaches a limit above about a tenth; use an absolute `softMemoryLimit` sized to the group and a per-group `query_max_memory`. |
| `query.low-memory-killer.policy` | The default policy kills the largest consumer on the affected workers, so it stays within a group. `total-reservation` picks the largest query cluster-wide, and `resource_overcommit` is killed whenever any worker runs out. |
| `hardConcurrencyLimit` and other group limits | Unchanged. Node groups constrain placement, not capacity — a worker shared by two groups can be fully occupied by either. |
| `retry-policy=TASK` | Same filter, applied to the bin-packing candidate list instead of the node map. |
| Connectors that pin work to nodes | `jmx`, `memory`, `tpch` and `tpcds` are rejected with `NOT_SUPPORTED` naming the catalog, in both execution modes, rather than silently escaping the group. |
| Empty or unknown group | Queues, then fails with `GENERIC_INSUFFICIENT_RESOURCES` naming the group and its live worker count. |
| Graceful shutdown | Draining the last worker of a group makes that group's queries fail. Drain only while another member stays active. |
| `system.runtime.nodes` | New `node_groups array(varchar)` column. |
| JMX | `ClusterSizeMonitor.ActiveWorkerCountByNodeGroup` reports schedulable workers per group, honouring `include-coordinator`. Alert on this rather than a raw node count, which can read healthy while nothing in the group can run a query. |
| Database resource group manager | New `node_group` column. Migration `V11` for MySQL, PostgreSQL and Oracle, applied automatically by the existing Flyway migration on startup. |

### Limitations

- **Split affinity stays cluster-wide.** Cache-affinity hosts come from a rendezvous hash over all
  workers, so a grouped query's preferred host is usually outside the group and placement falls back
  to random, losing warm-cache locality. Not addressed here.
- **A node group is only as trustworthy as the selector that chose the resource group.** `source` and
  client tags are client-set, so a selector matching on those lets a user pick their own group, as it
  already does for that group's limits. Match on `user`, `userGroup`, `originalUser` or
  `authenticatedUser` where placement must be enforced.

Docs are included for `node.groups`, the `nodeGroup` resource group property, the `node_groups`
system table column, and the graceful-shutdown implications of draining a group.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add support for restricting a resource group's queries to a subset of workers with the new `node.groups` node property and `nodeGroup` resource group property. ({issue}`30815`)
* Add `node_groups` column to the `system.runtime.nodes` table. ({issue}`30815`)
* Add `node_group` column to the `resource_groups` table for the database resource group manager. The column is added automatically on startup. ({issue}`30815`)

## SPI
* Add `ResourceGroupConfigurationManager.getNodeGroup` for a configuration manager to declare the node group that a resource group's queries must run on. ({issue}`30815`)
```
