### PR TITLE
Reuse catalog OAuth2 session for REST catalog operations

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OAuth2SecurityProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/OAuth2SecurityProperties.java
@@ -28,12 +28,12 @@ public class OAuth2SecurityProperties
     private final Map<String, String> securityProperties;
 
     @Inject
-    public OAuth2SecurityProperties(OAuth2SecurityConfig securityConfig)
+    public OAuth2SecurityProperties(OAuth2SecurityConfig securityConfig, IcebergRestCatalogConfig catalogConfig)
     {
         requireNonNull(securityConfig, "securityConfig is null");
 
         ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builder();
-        propertiesBuilder.put(AuthProperties.AUTH_TYPE, AuthProperties.AUTH_TYPE_OAUTH2);
+        propertiesBuilder.put(AuthProperties.AUTH_TYPE, resolveAuthType(catalogConfig));
         securityConfig.getCredential().ifPresent(
                 credential -> {
                     propertiesBuilder.put(OAuth2Properties.CREDENTIAL, credential);
@@ -54,5 +54,13 @@ public class OAuth2SecurityProperties
     public Map<String, String> get()
     {
         return securityProperties;
+    }
+
+    private static String resolveAuthType(IcebergRestCatalogConfig catalogConfig)
+    {
+        return switch (catalogConfig.getSessionType()) {
+            case NONE -> SharedSessionOAuth2Manager.class.getName();
+            case USER -> AuthProperties.AUTH_TYPE_OAUTH2;
+        };
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/SharedSessionOAuth2Manager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/SharedSessionOAuth2Manager.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.rest.auth.AuthSession;
+import org.apache.iceberg.rest.auth.OAuth2Manager;
+import org.apache.iceberg.rest.auth.OAuth2Util;
+
+import java.time.Duration;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/// OAuth2 auth manager for REST catalogs configured with session type NONE.
+///
+/// With session type NONE, Trino does not propagate the end-user identity to the REST server: the
+/// catalog authenticates as a single service principal via the configured credential, and a fresh
+/// random `sessionId` is generated for every catalog operation. The upstream [OAuth2Manager] keys
+/// its auth session cache on that `sessionId`, so every operation is a cache miss that fetches a new
+/// token. Because all operations share one identity, they can instead share the catalog session,
+/// avoiding the per-operation token fetch (and the associated cached sessions and scheduled refresh
+/// tasks).
+///
+/// Sharing only kicks in while the catalog session's token expiry is known and comfortably ahead of
+/// now. When the expiry is unknown or token refresh is disabled and the token is near expiry, this
+/// falls back to the upstream per-operation behavior.
+public class SharedSessionOAuth2Manager
+        extends OAuth2Manager
+{
+    private static final long REFRESH_SAFETY_MARGIN_MILLIS = Duration.ofMinutes(1).toMillis();
+
+    public SharedSessionOAuth2Manager(String managerName)
+    {
+        super(managerName);
+    }
+
+    @Override
+    public OAuth2Util.AuthSession contextualSession(SessionCatalog.SessionContext context, AuthSession parent)
+    {
+        checkArgument(context.identity() == null, "expected shared session");
+
+        OAuth2Util.AuthSession oauthParent = (OAuth2Util.AuthSession) parent;
+        if (isFreshEnoughToShare(oauthParent)) {
+            return oauthParent;
+        }
+
+        return super.contextualSession(context, parent);
+    }
+
+    private static boolean isFreshEnoughToShare(OAuth2Util.AuthSession parent)
+    {
+        // A null expiry means the token lifetime is unknown, so we cannot tell whether the shared
+        // session is still valid; fall back to the upstream per-operation session in that case.
+        Long expiresAt = parent.expiresAtMillis();
+        return expiresAt != null && expiresAt > System.currentTimeMillis() + REFRESH_SAFETY_MARGIN_MILLIS;
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestOAuth2TokenFetch.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestOAuth2TokenFetch.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.http.server.HttpConfig;
+import io.airlift.http.server.HttpServerConfig;
+import io.airlift.http.server.HttpServerInfo;
+import io.airlift.http.server.ServerFeature;
+import io.airlift.http.server.testing.TestingHttpServer;
+import io.airlift.node.NodeInfo;
+import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.testing.DistributedQueryRunner;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.QuotedETagRestCatalogServlet;
+import org.apache.iceberg.rest.RESTCatalogAdapter;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.OAuthTokenResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static io.trino.plugin.iceberg.catalog.rest.RestCatalogTestUtils.backendCatalog;
+import static java.lang.Math.toIntExact;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestOAuth2TokenFetch
+{
+    @Test
+    void testTokenFetchCountForSessionNone(@TempDir Path warehouseLocation)
+            throws Exception
+    {
+        Catalog backend = backendCatalog(warehouseLocation);
+        ExpiringTokenRestCatalogAdapter adapter = new ExpiringTokenRestCatalogAdapter(backend, Duration.ofHours(1));
+        TestingHttpServer testServer = createTestServer(adapter);
+        testServer.start();
+
+        try (DistributedQueryRunner queryRunner = IcebergQueryRunner.builder()
+                .setIcebergProperties(
+                        ImmutableMap.<String, String>builder()
+                                .put("iceberg.catalog.type", "rest")
+                                .put("iceberg.rest-catalog.uri", testServer.getBaseUrl().toString())
+                                .put("iceberg.rest-catalog.security", "OAUTH2")
+                                .put("iceberg.rest-catalog.oauth2.credential", "client_id:client_secret")
+                                .put("iceberg.rest-catalog.oauth2.token-refresh-enabled", "true")
+                                .put("iceberg.rest-catalog.session", "NONE")
+                                .buildOrThrow())
+                .addIcebergProperty("fs.hadoop.enabled", "true")
+                .disableSchemaInitializer()
+                .build()) {
+            assertThat(adapter.tokenFetchCount()).isEqualTo(0);
+
+            queryRunner.execute("CREATE SCHEMA test_schema");
+            queryRunner.execute("CREATE TABLE test_schema.test_table (id INTEGER, name VARCHAR)");
+            queryRunner.execute("INSERT INTO test_schema.test_table VALUES (1, 'alice'), (2, 'bob')");
+            queryRunner.execute("SELECT * FROM test_schema.test_table");
+            queryRunner.execute("SELECT count(*) FROM test_schema.test_table");
+            queryRunner.execute("DROP TABLE test_schema.test_table");
+            queryRunner.execute("DROP SCHEMA test_schema");
+
+            assertThat(adapter.tokenFetchCount()).isEqualTo(19);
+        }
+        finally {
+            testServer.stop();
+        }
+    }
+
+    private static TestingHttpServer createTestServer(ExpiringTokenRestCatalogAdapter adapter)
+            throws Exception
+    {
+        NodeInfo nodeInfo = new NodeInfo("test");
+        HttpServerConfig config = new HttpServerConfig()
+                .setHttpEnabled(true);
+        HttpServerInfo httpServerInfo = new HttpServerInfo(config, Optional.of(new HttpConfig().setHttpPort(0)), Optional.empty(), nodeInfo);
+        return new TestingHttpServer("rest-catalog", httpServerInfo, nodeInfo, config, new QuotedETagRestCatalogServlet(adapter), ServerFeature.builder()
+                .withLegacyUriCompliance(true)
+                .build());
+    }
+
+    private static final class ExpiringTokenRestCatalogAdapter
+            extends RESTCatalogAdapter
+    {
+        private final AtomicInteger tokenFetchCount = new AtomicInteger();
+        private final int tokenExpiresInSeconds;
+
+        public ExpiringTokenRestCatalogAdapter(Catalog delegate, Duration tokenExpiresIn)
+        {
+            super(delegate);
+            this.tokenExpiresInSeconds = toIntExact(tokenExpiresIn.toSeconds());
+        }
+
+        @Override
+        protected <T extends RESTResponse> T execute(
+                HTTPRequest request,
+                Class<T> responseType,
+                Consumer<ErrorResponse> errorHandler,
+                Consumer<Map<String, String>> responseHeaders)
+        {
+            T response = super.execute(request, responseType, errorHandler, responseHeaders);
+            if (response instanceof OAuthTokenResponse tokenResponse) {
+                tokenFetchCount.incrementAndGet();
+                return responseType.cast(OAuthTokenResponse.builder()
+                        .withToken(jwtEncodingExpiry(tokenExpiresInSeconds))
+                        .withTokenType(tokenResponse.tokenType())
+                        .withIssuedTokenType(tokenResponse.issuedTokenType())
+                        .addScopes(tokenResponse.scopes())
+                        .setExpirationInSeconds(tokenExpiresInSeconds)
+                        .build());
+            }
+            return response;
+        }
+
+        public int tokenFetchCount()
+        {
+            return tokenFetchCount.get();
+        }
+
+        private static String jwtEncodingExpiry(long expiresInSeconds)
+        {
+            long expiresAtEpochSeconds = System.currentTimeMillis() / 1000 + expiresInSeconds;
+            return base64Url("{\"alg\":\"none\"}") + "." + base64Url("{\"exp\":" + expiresAtEpochSeconds + "}") + "." + base64Url("signature");
+        }
+
+        private static String base64Url(String value)
+        {
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(UTF_8));
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestOAuth2TokenFetch.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestOAuth2TokenFetch.java
@@ -79,7 +79,7 @@ final class TestOAuth2TokenFetch
             queryRunner.execute("DROP TABLE test_schema.test_table");
             queryRunner.execute("DROP SCHEMA test_schema");
 
-            assertThat(adapter.tokenFetchCount()).isEqualTo(19);
+            assertThat(adapter.tokenFetchCount()).isEqualTo(1);
         }
         finally {
             testServer.stop();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

With an Iceberg REST catalog using OAuth2 and session type `NONE`, every catalog operation fetches a new OAuth2 token. Under `NONE`, Trino authenticates as a single service principal but still generates a random `SessionContext.sessionId()` per operation. Upstream `OAuth2Manager` caches auth sessions by that id, so each operation is a cache miss that runs the client-credentials flow — and leaves behind a cached session (retained for the auth session timeout) plus a scheduled refresh task.

### Alternatives considered

Using a constant `sessionId` for `NONE` (so the upstream cache hits instead of missing) is not viable, because sessionId is not only the OAuth2 session cache key. Iceberg also keys other per-session state on it (e.g. `RESTTableCache`), and each `SessionContext` carries a per-query `wrappedIdentity` — the Trino end-user `ConnectorIdentity` — that the catalog's `ioBuilder` uses to construct the `FileIO` for storage access. A constant `sessionId` would let that per-query, identity-scoped state collide across operations run by different users.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Avoid fetching a new OAuth2 token on every operation for REST catalogs configured with `iceberg.rest-catalog.session=NONE`. ({issue}`30816`)
```
