### PR TITLE
Activate Google Maven Central mirror earlier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ env:
   MAVEN: ./mvnw
   MAVEN_OPTS: "-Xmx512M -XX:+ExitOnOutOfMemoryError"
   MAVEN_INSTALL_OPTS: "-Xmx3G -XX:+ExitOnOutOfMemoryError"
+  MAVEN_ARGS: "--global-settings ${{ github.workspace }}/.mvn/settings-ci.xml"
   MAVEN_FAST_INSTALL: "-B -V -T 1C -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all"
   MAVEN_COMPILE_COMMITS: "-B --quiet -T 1C -DskipTests -Dmaven.source.skip=true -Dair.check.skip-all=true -Dmaven.javadoc.skip=true --no-snapshot-updates --no-transfer-progress"
   MAVEN_GIB: "-P gib -Dgib.referenceBranch=refs/remotes/origin/${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.event.repository.default_branch }}"

--- a/.mvn/settings-ci.xml
+++ b/.mvn/settings-ci.xml
@@ -1,0 +1,11 @@
+<settings>
+    <!--
+        CI-only settings, merged in as the global-settings file via MAVEN_ARGS in ci.yml
+
+        Activating the profile here is necessary to make the Google Maven Central mirror apply
+        before extensions (.mvn/extensions.xml) are loaded.
+    -->
+    <activeProfiles>
+        <activeProfile>ci-google-maven-central</activeProfile>
+    </activeProfiles>
+</settings>

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -16,12 +16,6 @@
     <profiles>
         <profile>
             <id>ci-google-maven-central</id>
-            <activation>
-                <property>
-                    <name>env.CONTINUOUS_INTEGRATION</name>
-                    <value>true</value>
-                </property>
-            </activation>
             <repositories>
                 <repository>
                     <id>google-maven-central</id>


### PR DESCRIPTION
The profile auto-activation happens after maven extensions are loaded, so does not apply to loading the extensions themselves.

- hopefully fixes https://github.com/trinodb/trino/issues/30807