### PR TITLE
Add tunable max standard error to approx_set

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -24,6 +24,7 @@ import io.trino.operator.aggregation.ApproximateRealPercentileAggregations;
 import io.trino.operator.aggregation.ApproximateRealPercentileArrayAggregations;
 import io.trino.operator.aggregation.ApproximateSetAggregation;
 import io.trino.operator.aggregation.ApproximateSetGenericAggregation;
+import io.trino.operator.aggregation.ApproximateSetWithMaxErrorAggregation;
 import io.trino.operator.aggregation.ArbitraryAggregationFunction;
 import io.trino.operator.aggregation.BigintApproximateMostFrequent;
 import io.trino.operator.aggregation.BigintAverageAggregations;
@@ -436,6 +437,7 @@ public final class SystemFunctionBundle
                 .aggregates(RealGeometricMeanAggregations.class)
                 .aggregates(MergeHyperLogLogAggregation.class)
                 .aggregates(ApproximateSetAggregation.class)
+                .aggregates(ApproximateSetWithMaxErrorAggregation.class)
                 .aggregates(ApproximateSetGenericAggregation.class)
                 .aggregates(TDigestAggregationFunction.class)
                 .aggregates(DoubleQuantileDigestAggregationFunction.class)

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ApproximateSetWithMaxErrorAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ApproximateSetWithMaxErrorAggregation.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation;
+
+import io.airlift.slice.Slice;
+import io.airlift.stats.cardinality.HyperLogLog;
+import io.trino.operator.aggregation.state.HyperLogLogState;
+import io.trino.operator.aggregation.state.StateCompiler;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AccumulatorStateSerializer;
+import io.trino.spi.function.AggregationFunction;
+import io.trino.spi.function.AggregationState;
+import io.trino.spi.function.CombineFunction;
+import io.trino.spi.function.InputFunction;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.OutputFunction;
+import io.trino.spi.function.SqlNullable;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+
+import static io.trino.operator.aggregation.ApproximateCountDistinctAggregation.standardErrorToBuckets;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+
+/**
+ * Variant of {@code approx_set} that accepts an explicit {@code maxStandardError}, controlling the
+ * precision (the number of buckets) of the produced {@link HyperLogLog} sketch. A smaller
+ * {@code maxStandardError} yields a more accurate sketch at the cost of more memory during
+ * aggregation and a larger serialized size. The permitted range is enforced by
+ * {@link ApproximateCountDistinctAggregation#standardErrorToBuckets(double)}, matching
+ * {@code approx_distinct}.
+ * <p>
+ * Caveats, which are surfaced in the user-facing documentation as well:
+ * <ul>
+ *     <li>The single-argument {@code approx_set(x)} uses a fixed precision that differs from most
+ *     explicit {@code maxStandardError} values, so sketches produced by the two forms are generally
+ *     not mergeable with each other.</li>
+ *     <li>{@code merge()} and combining partial sketches require all inputs to share the same
+ *     precision; merging sketches created with different {@code maxStandardError} values fails at
+ *     runtime (the underlying HyperLogLog rejects merges across different bucket counts). Every
+ *     sketch intended to be merged together must be produced with the same {@code maxStandardError}.</li>
+ * </ul>
+ */
+@AggregationFunction("approx_set")
+public final class ApproximateSetWithMaxErrorAggregation
+{
+    private static final AccumulatorStateSerializer<HyperLogLogState> SERIALIZER = StateCompiler.generateStateSerializer(HyperLogLogState.class);
+
+    private ApproximateSetWithMaxErrorAggregation() {}
+
+    @InputFunction
+    public static void input(@AggregationState HyperLogLogState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double maxStandardError)
+    {
+        HyperLogLog hll = getOrCreateHyperLogLog(state, maxStandardError);
+        state.addMemoryUsage(-hll.estimatedInMemorySize());
+        hll.add(Double.doubleToLongBits(value));
+        state.addMemoryUsage(hll.estimatedInMemorySize());
+    }
+
+    @InputFunction
+    @LiteralParameters("x")
+    public static void input(@AggregationState HyperLogLogState state, @SqlType("varchar(x)") Slice value, @SqlType(StandardTypes.DOUBLE) double maxStandardError)
+    {
+        HyperLogLog hll = getOrCreateHyperLogLog(state, maxStandardError);
+        state.addMemoryUsage(-hll.estimatedInMemorySize());
+        hll.add(value);
+        state.addMemoryUsage(hll.estimatedInMemorySize());
+    }
+
+    @InputFunction
+    public static void input(@AggregationState HyperLogLogState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.DOUBLE) double maxStandardError)
+    {
+        HyperLogLog hll = getOrCreateHyperLogLog(state, maxStandardError);
+        state.addMemoryUsage(-hll.estimatedInMemorySize());
+        hll.add(value);
+        state.addMemoryUsage(hll.estimatedInMemorySize());
+    }
+
+    private static HyperLogLog getOrCreateHyperLogLog(HyperLogLogState state, double maxStandardError)
+    {
+        HyperLogLog hll = state.getHyperLogLog();
+        if (hll == null) {
+            hll = HyperLogLog.newInstance(standardErrorToBuckets(maxStandardError));
+            state.setHyperLogLog(hll);
+            state.addMemoryUsage(hll.estimatedInMemorySize());
+        }
+        return hll;
+    }
+
+    @CombineFunction
+    public static void combineState(@AggregationState HyperLogLogState state, @AggregationState HyperLogLogState otherState)
+    {
+        HyperLogLog input = otherState.getHyperLogLog();
+
+        HyperLogLog previous = state.getHyperLogLog();
+        if (previous == null) {
+            state.setHyperLogLog(input);
+            state.addMemoryUsage(input.estimatedInMemorySize());
+        }
+        else {
+            state.addMemoryUsage(-previous.estimatedInMemorySize());
+            try {
+                previous.mergeWith(input);
+            }
+            catch (IllegalArgumentException e) {
+                // Partial sketches can only be combined when they share the same precision (bucket count).
+                // This happens when maxStandardError is a non-constant expression that yields different
+                // precisions across splits, which is a user error rather than an internal failure.
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+            }
+            state.addMemoryUsage(previous.estimatedInMemorySize());
+        }
+    }
+
+    @SqlNullable
+    @OutputFunction(StandardTypes.HYPER_LOG_LOG)
+    public static void evaluateFinal(@AggregationState HyperLogLogState state, BlockBuilder out)
+    {
+        SERIALIZER.serialize(state, out);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/MergeHyperLogLogAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/MergeHyperLogLogAggregation.java
@@ -17,6 +17,7 @@ import io.airlift.slice.Slice;
 import io.airlift.stats.cardinality.HyperLogLog;
 import io.trino.operator.aggregation.state.HyperLogLogState;
 import io.trino.operator.aggregation.state.StateCompiler;
+import io.trino.spi.TrinoException;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.AccumulatorStateSerializer;
 import io.trino.spi.function.AggregationFunction;
@@ -27,6 +28,8 @@ import io.trino.spi.function.OutputFunction;
 import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 
 @AggregationFunction("merge")
 public final class MergeHyperLogLogAggregation
@@ -57,7 +60,14 @@ public final class MergeHyperLogLogAggregation
         }
         else {
             state.addMemoryUsage(-previous.estimatedInMemorySize());
-            previous.mergeWith(input);
+            try {
+                previous.mergeWith(input);
+            }
+            catch (IllegalArgumentException e) {
+                // HyperLogLog sketches can only be merged when they share the same precision (bucket count).
+                // Mixing sketches produced with different approx_set maxStandardError values is a user error.
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+            }
             state.addMemoryUsage(previous.estimatedInMemorySize());
         }
     }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestApproximateSetWithMaxError.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestApproximateSetWithMaxError.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import io.airlift.stats.cardinality.HyperLogLog;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.spi.Page;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.SqlVarbinary;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestApproximateSetWithMaxError
+{
+    private static final TestingFunctionResolution FUNCTION_RESOLUTION = new TestingFunctionResolution();
+
+    private static final double LOWEST_MAX_STANDARD_ERROR = 0.0040625;
+    private static final double HIGHEST_MAX_STANDARD_ERROR = 0.26;
+
+    @Test
+    public void testCustomMaxStandardErrorProducesAccurateEstimate()
+    {
+        int uniques = 20000;
+        HyperLogLog hll = approxSet(sequence(uniques), LOWEST_MAX_STANDARD_ERROR);
+
+        double relativeError = Math.abs(hll.cardinality() - uniques) / (double) uniques;
+        // The finest permitted precision targets ~0.4% standard error; allow generous slack to avoid flakiness.
+        assertThat(relativeError).isLessThan(0.02);
+    }
+
+    @Test
+    public void testSmallerErrorProducesLargerSketch()
+    {
+        List<Long> values = sequence(20000);
+
+        HyperLogLog preciseSketch = approxSet(values, LOWEST_MAX_STANDARD_ERROR);
+        HyperLogLog coarseSketch = approxSet(values, HIGHEST_MAX_STANDARD_ERROR);
+
+        // A smaller maxStandardError allocates more buckets, so the serialized sketch is larger.
+        assertThat(preciseSketch.serialize().length()).isGreaterThan(coarseSketch.serialize().length());
+    }
+
+    @Test
+    public void testMaxStandardErrorOutOfRangeFailsQuery()
+    {
+        assertTrinoExceptionThrownBy(() -> approxSet(ImmutableList.of(1L), LOWEST_MAX_STANDARD_ERROR - 0.0001))
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
+        assertTrinoExceptionThrownBy(() -> approxSet(ImmutableList.of(1L), HIGHEST_MAX_STANDARD_ERROR + 0.0001))
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
+    }
+
+    @Test
+    public void testSketchesWithDifferentErrorCannotBeMerged()
+    {
+        List<Long> values = sequence(20000);
+
+        HyperLogLog preciseSketch = approxSet(values, LOWEST_MAX_STANDARD_ERROR);
+        HyperLogLog coarseSketch = approxSet(values, HIGHEST_MAX_STANDARD_ERROR);
+
+        assertThatThrownBy(() -> preciseSketch.mergeWith(coarseSketch))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot merge HLLs with different number of buckets");
+    }
+
+    private static HyperLogLog approxSet(List<Long> values, double maxStandardError)
+    {
+        SqlVarbinary serialized = (SqlVarbinary) AggregationTestUtils.aggregation(
+                FUNCTION_RESOLUTION.getAggregateFunction("approx_set", fromTypes(BIGINT, DOUBLE)),
+                createPage(values, maxStandardError));
+        if (serialized == null) {
+            return null;
+        }
+        return HyperLogLog.newInstance(Slices.wrappedBuffer(serialized.getBytes()));
+    }
+
+    private static Page createPage(List<Long> values, double maxStandardError)
+    {
+        if (values.isEmpty()) {
+            return new Page(0);
+        }
+        BlockBuilder valueBuilder = BIGINT.createBlockBuilder(null, values.size());
+        BlockBuilder errorBuilder = DOUBLE.createBlockBuilder(null, values.size());
+        for (long value : values) {
+            BIGINT.writeLong(valueBuilder, value);
+            DOUBLE.writeDouble(errorBuilder, maxStandardError);
+        }
+        return new Page(values.size(), valueBuilder.build(), errorBuilder.build());
+    }
+
+    private static List<Long> sequence(int count)
+    {
+        List<Long> values = new ArrayList<>(count);
+        for (long i = 0; i < count; i++) {
+            values.add(i);
+        }
+        return values;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestMergeHyperLogLogAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestMergeHyperLogLogAggregation.java
@@ -15,14 +15,20 @@ package io.trino.operator.aggregation;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.stats.cardinality.HyperLogLog;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.SqlVarbinary;
 import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.type.HyperLogLogType.HYPER_LOG_LOG;
+import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 
 public class TestMergeHyperLogLogAggregation
         extends AbstractTestAggregationFunction
@@ -69,5 +75,32 @@ public class TestMergeHyperLogLogAggregation
         }
         hll.makeDense();
         return new SqlVarbinary(hll.serialize().getBytes());
+    }
+
+    @Test
+    public void testMergeSketchesWithDifferentPrecisionFailsAsUserError()
+    {
+        TestingFunctionResolution functionResolution = new TestingFunctionResolution();
+
+        // Dense sketches are required to trigger the bucket-count check; sparse sketches of different
+        // precision can still be combined by the underlying HyperLogLog.
+        HyperLogLog coarse = HyperLogLog.newInstance(16);
+        coarse.add(1);
+        coarse.makeDense();
+        HyperLogLog fine = HyperLogLog.newInstance(64);
+        fine.add(2);
+        fine.makeDense();
+
+        BlockBuilder blockBuilder = HYPER_LOG_LOG.createBlockBuilder(null, 2);
+        HYPER_LOG_LOG.writeSlice(blockBuilder, coarse.serialize());
+        HYPER_LOG_LOG.writeSlice(blockBuilder, fine.serialize());
+        Page page = new Page(2, blockBuilder.build());
+
+        // Merging sketches of different precision is a user error, not an internal failure.
+        assertTrinoExceptionThrownBy(() -> AggregationTestUtils.aggregation(
+                functionResolution.getAggregateFunction("merge", fromTypes(HYPER_LOG_LOG)),
+                page))
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageContaining("Cannot merge HLLs with different number of buckets");
     }
 }

--- a/docs/src/main/sphinx/functions/hyperloglog.md
+++ b/docs/src/main/sphinx/functions/hyperloglog.md
@@ -51,11 +51,44 @@ WHERE visit_date >= current_date - interval '7' day;
 
 ## Functions
 
-:::{function} approx_set(x) -> HyperLogLog
-Returns the `HyperLogLog` sketch of the input data set of `x`. This
-data sketch underlies {func}`approx_distinct` and can be stored and
-used later by calling `cardinality()`.
+::::{function} approx_set(x) -> HyperLogLog
+Returns the `HyperLogLog` sketch of the input data set of `x`, using a fixed
+default precision. This data sketch underlies {func}`approx_distinct` and can
+be stored and used later by calling `cardinality()`.
+
+:::{note}
+The fixed default precision uses 4096 buckets, which corresponds to a standard
+error of approximately 1.6% (`1.04 / sqrt(4096)`). To produce a sketch with this
+same precision using the two-argument form, and thus one that can be merged with
+sketches from `approx_set(x)`, pass a `maxStandardError` of `0.01625`.
 :::
+::::
+
+::::{function} approx_set(x, maxStandardError) -> HyperLogLog
+:noindex: true
+
+Returns the `HyperLogLog` sketch of the input data set of `x`, with the
+precision of the sketch controlled by `maxStandardError`. This is the desired
+maximum standard error as a `double` between `0.0040625` and `0.26`, matching
+{func}`approx_distinct`. A smaller value produces a more accurate sketch at the
+cost of more memory during aggregation and a larger serialized size. Values
+outside the permitted range fail the query.
+
+:::{note}
+Sketches can only be merged with, and produce a correct `cardinality()` union
+for, other sketches of the **same** precision:
+
+* Sketches produced with different `maxStandardError` values cannot be merged
+  with each other. Every sketch that you intend to combine with {func}`merge`
+  must be produced with the same `maxStandardError`.
+* The single-argument `approx_set(x)` uses a fixed precision that generally
+  differs from any explicit `maxStandardError`, so sketches from the two forms
+  are generally not mergeable with each other.
+
+Attempting to {func}`merge` sketches of different precision fails the query.
+Reading a single stored sketch with `cardinality()` is unaffected.
+:::
+::::
 
 :::{function} cardinality(hll) -> bigint
 :noindex: true
@@ -68,7 +101,16 @@ This will perform {func}`approx_distinct` on the data summarized by the
 Returns an empty `HyperLogLog`.
 :::
 
-:::{function} merge(HyperLogLog) -> HyperLogLog
+::::{function} merge(HyperLogLog) -> HyperLogLog
 Returns the `HyperLogLog` of the aggregate union of the individual `hll`
 HyperLogLog structures.
+
+:::{note}
+All sketches passed to a single `merge` must share the same precision (the same
+number of buckets). This precision is determined by how each sketch was created:
+`approx_set(x)` uses a fixed default precision, while `approx_set(x,
+maxStandardError)` uses a precision derived from `maxStandardError`. Merging
+sketches of different precision fails the query. Ensure every sketch you intend
+to combine is produced the same way, with the same `maxStandardError`.
 :::
+::::


### PR DESCRIPTION
## Description

Add a two-argument aggregation `approx_set(x, maxStandardError)` that lets users control the precision (number of buckets) of the produced `HyperLogLog` sketch, mirroring the `maxStandardError` argument already available on `approx_distinct`. A smaller `maxStandardError` yields a more accurate sketch at the cost of more memory during aggregation and a larger serialized size. The permitted range `[0.0040625, 0.26]` and the error-to-buckets mapping are shared with `approx_distinct` via `ApproximateCountDistinctAggregation.standardErrorToBuckets`.

The single-argument `approx_set(x)` is unchanged: it keeps its fixed default precision of 4096 buckets (~1.6% standard error), so existing stored sketches and their merges are unaffected.

Because `HyperLogLog` sketches can only be merged when they share the same precision, this change also reclassifies the "Cannot merge HLLs with different number of buckets" failure from `GENERIC_INTERNAL_ERROR` to `INVALID_FUNCTION_ARGUMENT` in both the `merge` aggregation and the new aggregation's combine path — mixing precisions is a user mistake, not an internal invariant violation.

Documentation for the HyperLogLog functions is updated to:
* state the default precision (4096 buckets, ~1.6% standard error) and how to reproduce it with the two-argument form (`maxStandardError = 0.01625`),
* document the new `approx_set(x, maxStandardError)` form, and
* note on `merge` that all combined sketches must share the same precision.

## Additional context and related issues

Fixes #30819.

The single- and two-argument forms are intentionally not mergeable unless they resolve to the same bucket count; this is documented and enforced with a user-facing error.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add a `maxStandardError` argument to `approx_set` to control the precision of the produced `HyperLogLog` sketch. ({issue}`30819`)
```