### PR TITLE
Skip checkCanSetUser() in RangerAccessControl

### DIFF
--- a/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java
+++ b/plugin/trino-ranger/src/main/java/io/trino/plugin/ranger/RangerSystemAccessControl.java
@@ -118,7 +118,6 @@ import static io.trino.spi.security.AccessDeniedException.denySetEntityAuthoriza
 import static io.trino.spi.security.AccessDeniedException.denySetMaterializedViewProperties;
 import static io.trino.spi.security.AccessDeniedException.denySetSystemSessionProperty;
 import static io.trino.spi.security.AccessDeniedException.denySetTableProperties;
-import static io.trino.spi.security.AccessDeniedException.denySetUser;
 import static io.trino.spi.security.AccessDeniedException.denyShowColumns;
 import static io.trino.spi.security.AccessDeniedException.denyShowCreateFunction;
 import static io.trino.spi.security.AccessDeniedException.denyShowCreateSchema;
@@ -178,9 +177,8 @@ public class RangerSystemAccessControl
     @Override
     public void checkCanSetUser(Optional<Principal> principal, String userName)
     {
-        if (!hasPermission(RangerTrinoResource.forUser(userName), principal, null, IMPERSONATE, "SetUser")) {
-            denySetUser(principal, userName);
-        }
+        // Skip because this method doesn't work in Ranger with Kerberos: https://github.com/trinodb/trino/issues/29342
+        // It's safe to skip because impersonation itself is checked by checkCanImpersonateUser().
     }
 
     @Override

--- a/plugin/trino-ranger/src/test/java/io/trino/plugin/ranger/TestRangerSystemAccessControl.java
+++ b/plugin/trino-ranger/src/test/java/io/trino/plugin/ranger/TestRangerSystemAccessControl.java
@@ -117,13 +117,13 @@ final class TestRangerSystemAccessControl
     @Test
     void testCanSetUserOperations()
     {
-        accessControlManager.checkCanSetUser(ADMIN.getPrincipal(), BOB.getUser());
+        accessControlManager.checkCanSetUser(ADMIN.getPrincipal(), BOB.getUser()); // ignored
         accessControlManager.checkCanImpersonateUser(ADMIN, BOB.getUser());
         accessControlManager.checkCanViewQueryOwnedBy(ADMIN, BOB);
         accessControlManager.checkCanKillQueryOwnedBy(ADMIN, BOB);
         assertThat(accessControlManager.filterViewQueryOwnedBy(ALICE, QUERY_OWNERS)).isEmpty();
 
-        assertThatThrownBy(() -> accessControlManager.checkCanSetUser(ALICE.getPrincipal(), BOB.getUser())).isInstanceOf(AccessDeniedException.class);
+        accessControlManager.checkCanSetUser(ALICE.getPrincipal(), BOB.getUser()); // ignored
         assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(ALICE, BOB.getUser())).isInstanceOf(AccessDeniedException.class);
         assertThatThrownBy(() -> accessControlManager.checkCanViewQueryOwnedBy(ALICE, BOB)).isInstanceOf(AccessDeniedException.class);
         assertThatThrownBy(() -> accessControlManager.checkCanKillQueryOwnedBy(ALICE, BOB)).isInstanceOf(AccessDeniedException.class);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Skip `checkCanSetUser()` in `RangerAccessControl` because it doesn't work with Kerberos (https://github.com/trinodb/trino/issues/29342). It's safe to skip because impersonation itself is checked by `checkCanImpersonateUser()`.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/29342

This has been originally proposed at https://github.com/trinodb/trino/issues/29342#issuecomment-4581333923 by me and the PR (https://github.com/trinodb/trino/pull/30416) created by @mneethiraj but I took over the PR with [author's agreement](https://github.com/trinodb/trino/pull/30416#issuecomment-5330472828).

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
