### PR TITLE
Update MongoDB image versions in tests

### DIFF
--- a/docs/src/main/sphinx/connector/mongodb.md
+++ b/docs/src/main/sphinx/connector/mongodb.md
@@ -10,7 +10,7 @@ The `mongodb` connector allows the use of [MongoDB](https://www.mongodb.com/) co
 
 To connect to MongoDB, you need:
 
-- MongoDB 4.2 or higher.
+- MongoDB 6.0 or higher.
 - Network access from the Trino coordinator and workers to MongoDB.
   Port 27017 is the default port.
 - Write access to the {ref}`schema information collection <table-definition-label>`

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -258,7 +258,11 @@ public class MongoMetadata
         if (saveMode == REPLACE) {
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support replacing tables");
         }
-        RemoteTableName remoteTableName = mongoSession.toRemoteSchemaTableName(tableMetadata.getTable());
+        SchemaTableName tableName = tableMetadata.getTable();
+        if (tableName.toString().getBytes(UTF_8).length > MAX_QUALIFIED_IDENTIFIER_BYTE_LENGTH) {
+            throw new TrinoException(NOT_SUPPORTED, format("Qualified identifier name must be shorter than or equal to '%s' bytes: '%s'", MAX_QUALIFIED_IDENTIFIER_BYTE_LENGTH, tableName));
+        }
+        RemoteTableName remoteTableName = mongoSession.toRemoteSchemaTableName(tableName);
         mongoSession.createTable(remoteTableName, buildColumnHandles(tableMetadata), tableMetadata.getComment());
     }
 
@@ -402,7 +406,11 @@ public class MongoMetadata
         if (replace) {
             throw new TrinoException(NOT_SUPPORTED, "This connector does not support replacing tables");
         }
-        RemoteTableName remoteTableName = mongoSession.toRemoteSchemaTableName(tableMetadata.getTable());
+        SchemaTableName tableName = tableMetadata.getTable();
+        if (tableName.toString().getBytes(UTF_8).length > MAX_QUALIFIED_IDENTIFIER_BYTE_LENGTH) {
+            throw new TrinoException(NOT_SUPPORTED, format("Qualified identifier name must be shorter than or equal to '%s' bytes: '%s'", MAX_QUALIFIED_IDENTIFIER_BYTE_LENGTH, tableName));
+        }
+        RemoteTableName remoteTableName = mongoSession.toRemoteSchemaTableName(tableName);
 
         List<MongoColumnHandle> columns = buildColumnHandles(tableMetadata);
 

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/AuthenticatedMongoServer.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/AuthenticatedMongoServer.java
@@ -36,7 +36,7 @@ public class AuthenticatedMongoServer
     {
         dockerContainer = new GenericContainer<>("mongo:" + requireNonNull(mongoVersion, "mongoVersion is null"))
                 .withStartupAttempts(3)
-                .waitingFor(Wait.forLogMessage(".*Listening on 0\\.0\\.0\\.0.*", 1))
+                .waitingFor(Wait.forListeningPort())
                 .withEnv("MONGO_INITDB_ROOT_USERNAME", ROOT_USER)
                 .withEnv("MONGO_INITDB_ROOT_PASSWORD", ROOT_PASSWORD)
                 .withEnv("MONGO_INITDB_DATABASE", "admin")

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoServer.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoServer.java
@@ -25,7 +25,7 @@ public class MongoServer
 
     public MongoServer()
     {
-        this("4.2.0");
+        this("6.0.14");
     }
 
     public MongoServer(String mongoVersion)

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -1896,7 +1896,7 @@ public class TestMongoConnectorTest
     @Override
     protected void verifySchemaNameLengthFailurePermissible(Throwable e)
     {
-        assertThat(e).hasMessageContaining("Invalid database name");
+        assertThat(e).hasMessageContaining("Invalid namespace specified");
     }
 
     @Override

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoLatestConnectorSmokeTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoLatestConnectorSmokeTest.java
@@ -15,14 +15,14 @@ package io.trino.plugin.mongodb;
 
 import io.trino.testing.QueryRunner;
 
-public class TestMongo4LatestConnectorSmokeTest
+public class TestMongoLatestConnectorSmokeTest
         extends BaseMongoConnectorSmokeTest
 {
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        MongoServer server = closeAfterClass(new MongoServer("4.4.1"));
+        MongoServer server = closeAfterClass(new MongoServer("8.0.4"));
         return MongoQueryRunner.builder(server)
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoPrivileges.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoPrivileges.java
@@ -95,7 +95,7 @@ public class TestMongoPrivileges
 
     private static AuthenticatedMongoServer setupMongoServer()
     {
-        AuthenticatedMongoServer mongoServer = new AuthenticatedMongoServer("4.2.0");
+        AuthenticatedMongoServer mongoServer = new AuthenticatedMongoServer("6.0.14");
         try (MongoClient client = MongoClients.create(mongoServer.rootUserConnectionString())) {
             DATABASES.forEach(database -> createDatabase(client, database));
             client.getDatabase("another").createCollection("_schema"); // this database/schema should not be visible


### PR DESCRIPTION
## Description

Update MongoDB test infrastructure to use supported versions and improve container readiness checks.

- Bump default `MongoServer` to MongoDB 6.0.14.
- Update `TestMongoLatestConnectorSmokeTest` to use MongoDB 8.0.4.
- Rename `TestMongo4LatestConnectorSmokeTest` to `TestMongoLatestConnectorSmokeTest`.
- Change `AuthenticatedMongoServer` readiness from log-string wait to `Wait.forListeningPort()` to avoid dependence on TLS/log format changes.

- Fixes #26526

## Additional context

- Previous MongoDB versions used in tests are EOL per MongoDB lifecycle: https://www.mongodb.com/legal/support-policy/lifecycles
- Align tests with supported versions: 6.x for general tests, 8.x for latest smoke coverage.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.