### PR TITLE
Delete old Redshift clusters

### DIFF
--- a/.github/bin/redshift/delete-stale-aws-redshift.sh
+++ b/.github/bin/redshift/delete-stale-aws-redshift.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+delete_cluster() {
+    local cluster_id="$1"
+    echo "Deleting Amazon Redshift cluster ${cluster_id}"
+    local output
+    output=$(aws redshift delete-cluster --cluster-identifier "${cluster_id}" --skip-final-cluster-snapshot)
+    if [ -z "${output}" ]; then
+        echo "${output}"
+        # Don't fail the build because of cleanup issues
+        return 0
+    fi
+    echo "Waiting for the Amazon Redshift cluster ${cluster_id} to be deleted"
+    aws redshift wait cluster-deleted \
+      --cluster-identifier "${cluster_id}"
+    if [ "$?" -ne 0 ]; then
+        echo "Amazon Redshift cluster ${cluster_id} deletion has timed out"
+    else
+        echo "Amazon Redshift cluster ${cluster_id} has been deleted"
+    fi
+}
+
+# 60m comes from 'test' job in ci.yml
+echo "Checking for stale Amazon Redshift clusters older than 60 minutes..."
+CUTOFF_EPOCH=$(( $(date -u +%s) - 3600 ))
+STALE_CLUSTERS=$(aws redshift describe-clusters \
+    --query "Clusters[?Tags[?Key=='project' && Value=='trino-redshift']].{Id:ClusterIdentifier,Created:ClusterCreateTime}" \
+    --output json \
+  | jq -r --argjson cutoff "${CUTOFF_EPOCH}" \
+    '.[] | select((.Created | sub("\\.[0-9]+\\+.*$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime) < $cutoff) | .Id')
+for stale_cluster_id in ${STALE_CLUSTERS}; do
+    delete_cluster "${stale_cluster_id}"
+done
+
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,6 +693,13 @@ jobs:
         run: |
           $MAVEN test ${MAVEN_TEST} -pl :trino-google-sheets -Pcloud-tests \
             -Dtesting.gsheets.credentials-key="${SHEETS_CREDENTIALS_KEY}"
+      - name: Cleanup stale Redshift Clusters
+        env:
+          AWS_REGION: ${{ vars.REDSHIFT_AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ vars.REDSHIFT_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.REDSHIFT_AWS_SECRET_ACCESS_KEY }}
+        if: always()
+        run: .github/bin/redshift/delete-stale-aws-redshift.sh
       - name: Cloud Redshift Tests ${{ matrix.profile }}
         id: tests-redshift
         env:


### PR DESCRIPTION
## Description

We observed that our CI account has ~60 Redshift clusters for some reason. 
This PR updates `delete-stale-aws-redshift.sh` so we can delete such clusters. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.