### PR TITLE
Close BigQuery read client if page source construction fails

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSourceProvider.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSourceProvider.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.trino.spi.connector.ColumnHandle;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.base.util.Closables.closeAllSuppress;
 import static java.util.Objects.requireNonNull;
 
 public class BigQueryPageSourceProvider
@@ -109,23 +111,30 @@ public class BigQueryPageSourceProvider
 
     private ConnectorPageSource createStoragePageSource(ConnectorSession session, BigQuerySplit split, List<BigQueryColumnHandle> columnHandles)
     {
-        if (arrowSerializationEnabled) {
-            return new BigQueryStorageArrowPageSource(
-                    typeManager,
-                    bigQueryReadClientFactory.create(session),
+        BigQueryReadClient bigQueryReadClient = bigQueryReadClientFactory.create(session);
+        try {
+            if (arrowSerializationEnabled) {
+                return new BigQueryStorageArrowPageSource(
+                        typeManager,
+                        bigQueryReadClient,
+                        executor,
+                        arrowBufferAllocator.orElseThrow(() -> new IllegalStateException("ArrowBufferAllocator was not bound")),
+                        maxReadRowsRetries,
+                        split,
+                        columnHandles);
+            }
+            return new BigQueryStorageAvroPageSource(
+                    bigQueryReadClient,
                     executor,
-                    arrowBufferAllocator.orElseThrow(() -> new IllegalStateException("ArrowBufferAllocator was not bound")),
+                    typeManager,
                     maxReadRowsRetries,
                     split,
                     columnHandles);
         }
-        return new BigQueryStorageAvroPageSource(
-                bigQueryReadClientFactory.create(session),
-                executor,
-                typeManager,
-                maxReadRowsRetries,
-                split,
-                columnHandles);
+        catch (Throwable t) {
+            closeAllSuppress(t, bigQueryReadClient);
+            throw t;
+        }
     }
 
     private ConnectorPageSource createQueryPageSource(ConnectorSession session, BigQueryTableHandle table, List<BigQueryColumnHandle> columnHandles, Optional<String> filter)


### PR DESCRIPTION
The storage page source constructor issues the initial ReadRows RPC, so it can throw. When it did, the just-created BigQueryReadClient was never handed to the engine and never closed, leaking its gRPC channel.
