### PR TITLE
Fix memory blob cache caching partial content with stale length

### DIFF
--- a/core/trino-main/src/test/java/io/trino/cache/TestCacheManagerRegistry.java
+++ b/core/trino-main/src/test/java/io/trino/cache/TestCacheManagerRegistry.java
@@ -31,6 +31,7 @@ import io.trino.spi.cache.NoopBlob;
 import io.trino.spi.catalog.CatalogName;
 import org.junit.jupiter.api.Test;
 
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -264,5 +265,11 @@ class TestCacheManagerRegistry
 
         @Override
         public void readFully(long position, byte[] buffer, int offset, int length) {}
+
+        @Override
+        public InputStream openStream()
+        {
+            return InputStream.nullInputStream();
+        }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/cache/BlobSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/cache/BlobSource.java
@@ -15,6 +15,7 @@ package io.trino.spi.cache;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Lazy source of bytes backing a cached blob. Used by {@link BlobCache} to
@@ -41,6 +42,20 @@ public interface BlobSource
      * not fully available.
      */
     void readFully(long position, byte[] buffer, int offset, int length)
+            throws IOException;
+
+    /**
+     * Opens a stream over the entire content backing this source, starting at its first byte
+     * and ending at the actual end of the content on storage. {@link #length()} may come from
+     * metadata a caller declared without a storage round trip, so when that metadata is stale
+     * the stream can end before or after {@code length()} bytes. Caches that copy the whole
+     * content into an entry populate it from this stream, so a stale declared length can never
+     * truncate the entry.
+     * <p>
+     * The returned stream is owned by the caller and must be closed by it; closing the stream
+     * does not close this source.
+     */
+    InputStream openStream()
             throws IOException;
 
     /**

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/BlobCacheSource.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/BlobCacheSource.java
@@ -19,7 +19,11 @@ import io.trino.spi.cache.BlobSource;
 import io.trino.spi.cache.CacheKey;
 
 import java.io.IOException;
+import java.io.InputStream;
 
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.checkFromIndexSize;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -54,6 +58,50 @@ final class BlobCacheSource
             throws IOException
     {
         blob().read(position, buffer, offset, length);
+    }
+
+    @Override
+    public InputStream openStream()
+            throws IOException
+    {
+        // Streams the blob served by the tier below, so populating a cache from this source
+        // still populates that one on the way. The extent is that tier's view of the content:
+        // a whole-file tier below serves the actual content, a positional tier is bounded by
+        // the length the file was opened with
+        Blob blob = blob();
+        long length = blob.length();
+        return new InputStream()
+        {
+            private long position;
+
+            @Override
+            public int read()
+                    throws IOException
+            {
+                byte[] buffer = new byte[1];
+                if (read(buffer, 0, 1) == -1) {
+                    return -1;
+                }
+                return buffer[0] & 0xFF;
+            }
+
+            @Override
+            public int read(byte[] buffer, int offset, int count)
+                    throws IOException
+            {
+                checkFromIndexSize(offset, count, buffer.length);
+                if (count == 0) {
+                    return 0;
+                }
+                if (position >= length) {
+                    return -1;
+                }
+                int toRead = toIntExact(min(count, length - position));
+                blob.read(position, buffer, offset, toRead);
+                position += toRead;
+                return toRead;
+            }
+        };
     }
 
     // The blob is held open across reads for the same reason the underlying source is: reads

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/TrinoInputFileBlobSource.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/TrinoInputFileBlobSource.java
@@ -18,6 +18,7 @@ import io.trino.filesystem.TrinoInputFile;
 import io.trino.spi.cache.BlobSource;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 import static java.util.Objects.requireNonNull;
 
@@ -45,6 +46,19 @@ public final class TrinoInputFileBlobSource
             throws IOException
     {
         input().readFully(position, buffer, offset, length);
+    }
+
+    @Override
+    public InputStream openStream()
+            throws IOException
+    {
+        if (closed) {
+            throw new IOException("Blob source is closed: " + this);
+        }
+        // The raw stream ends at the actual end of the object, not at the possibly stale
+        // length the input file was opened with, so a whole-content cache populating from
+        // it never caches a truncated copy
+        return delegate.newStream();
     }
 
     // The input is held open across reads: pass-through blobs (uncached or oversized files)

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/cache/TestTieredBlobCache.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/cache/TestTieredBlobCache.java
@@ -19,8 +19,10 @@ import io.trino.spi.cache.BlobSource;
 import io.trino.spi.cache.CacheKey;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -249,6 +251,12 @@ final class TestTieredBlobCache
             }
             reads++;
             System.arraycopy(CONTENT, toIntExact(position), buffer, offset, length);
+        }
+
+        @Override
+        public InputStream openStream()
+        {
+            return new ByteArrayInputStream(CONTENT);
         }
 
         @Override

--- a/plugin/trino-blob-cache-memory/src/main/java/io/trino/blob/cache/memory/MemoryBlobCache.java
+++ b/plugin/trino-blob-cache-memory/src/main/java/io/trino/blob/cache/memory/MemoryBlobCache.java
@@ -31,6 +31,7 @@ import io.trino.spi.cache.NoopBlob;
 import org.weakref.jmx.Managed;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -174,8 +175,9 @@ public final class MemoryBlobCache
             stats.recordHit();
             return new CachedContent(cached, false);
         }
-        long length = source.length();
-        if (length > maxContentLengthBytes) {
+        // The length may be declared by the caller from stale metadata, so it is only a cheap
+        // pre-filter here; the load below reads the content to its actual end and re-checks
+        if (source.length() > maxContentLengthBytes) {
             largeFileSkippedCount.incrementAndGet();
             stats.recordLargeFileSkipped();
             return null;
@@ -186,12 +188,17 @@ public final class MemoryBlobCache
             boolean[] loaded = new boolean[1];
             Slice data = cache.get(key, () -> {
                 loaded[0] = true;
-                return load(source, length);
+                return load(source);
             });
             return new CachedContent(data, loaded[0]);
         }
         catch (ExecutionException e) {
             Throwable cause = e.getCause();
+            if (cause instanceof ContentExceedsMaxLengthException) {
+                largeFileSkippedCount.incrementAndGet();
+                stats.recordLargeFileSkipped();
+                return null;
+            }
             if (cause instanceof IOException io) {
                 throw io;
             }
@@ -202,11 +209,22 @@ public final class MemoryBlobCache
         }
     }
 
-    private static Slice load(BlobSource source, long length)
+    private Slice load(BlobSource source)
             throws IOException
     {
-        byte[] buffer = new byte[toIntExact(length)];
-        source.readFully(0, buffer, 0, buffer.length);
-        return Slices.wrappedBuffer(buffer);
+        // Read from the start of the content to its actual end, rather than the declared
+        // number of bytes: a caller may open a file with a stale, smaller length, and caching
+        // only that many bytes would serve a truncated copy to every subsequent reader. The
+        // extra byte detects content that outgrows the limit despite passing the pre-filter
+        try (InputStream stream = source.openStream()) {
+            byte[] content = stream.readNBytes(maxContentLengthBytes + 1);
+            if (content.length > maxContentLengthBytes) {
+                throw new ContentExceedsMaxLengthException();
+            }
+            return Slices.wrappedBuffer(content);
+        }
     }
+
+    private static final class ContentExceedsMaxLengthException
+            extends IOException {}
 }

--- a/plugin/trino-blob-cache-memory/src/test/java/io/trino/blob/cache/memory/TestCacheFileSystemAccessOperations.java
+++ b/plugin/trino-blob-cache-memory/src/test/java/io/trino/blob/cache/memory/TestCacheFileSystemAccessOperations.java
@@ -81,7 +81,7 @@ public class TestCacheFileSystemAccessOperations
         assertReadOperations(location, content,
                 ImmutableMultiset.<FileOperation>builder()
                         .add(new FileOperation(location, "InputFile.length"))
-                        .add(new FileOperation(location, "InputFile.newInput"))
+                        .add(new FileOperation(location, "InputFile.newStream"))
                         .add(new FileOperation(location, "InputFile.lastModified"))
                         .build());
         assertReadOperations(location, content,
@@ -96,7 +96,7 @@ public class TestCacheFileSystemAccessOperations
         assertReadOperations(location, modifiedContent,
                 ImmutableMultiset.<FileOperation>builder()
                         .add(new FileOperation(location, "InputFile.length"))
-                        .add(new FileOperation(location, "InputFile.newInput"))
+                        .add(new FileOperation(location, "InputFile.newStream"))
                         .add(new FileOperation(location, "InputFile.lastModified"))
                         .build());
     }

--- a/plugin/trino-blob-cache-memory/src/test/java/io/trino/blob/cache/memory/TestMemoryBlobCache.java
+++ b/plugin/trino-blob-cache-memory/src/test/java/io/trino/blob/cache/memory/TestMemoryBlobCache.java
@@ -174,6 +174,46 @@ public class TestMemoryBlobCache
         assertThat(source.isClosed()).isTrue();
     }
 
+    @Test
+    public void testStaleDeclaredLengthDoesNotTruncateEntry()
+            throws IOException
+    {
+        CacheKey key = CacheKey.of("testStaleDeclaredLengthDoesNotTruncateEntry", UUID.randomUUID().toString());
+        byte[] content = content(1024);
+        byte[] buffer = new byte[content.length];
+
+        // A caller may declare the length from stale metadata; the entry must still hold the
+        // content to its actual end, or every subsequent reader would see a truncated copy
+        TestingBlobSource source = new TestingBlobSource(content, 100);
+        try (Blob blob = cache.get(key, source)) {
+            assertThat(blob.length()).isEqualTo(content.length);
+            blob.read(0, buffer, 0, buffer.length);
+            assertThat(buffer).isEqualTo(content);
+        }
+        assertThat(cache.isCached(key)).isTrue();
+    }
+
+    @Test
+    public void testStaleDeclaredLengthWithOversizedContentReadsThroughToSource()
+            throws IOException
+    {
+        CacheKey key = CacheKey.of("testStaleDeclaredLengthWithOversizedContentReadsThroughToSource", UUID.randomUUID().toString());
+        byte[] content = content(MAX_CONTENT_LENGTH + 200);
+        byte[] buffer = new byte[100];
+
+        // The declared length passes the pre-filter, but the actual content exceeds the
+        // limit: the entry must be skipped, not cached truncated
+        TestingBlobSource source = new TestingBlobSource(content, 100);
+        long largeFileSkippedCount = cache.getLargeFileSkippedCount();
+        try (Blob blob = cache.get(key, source)) {
+            assertThat(cache.getLargeFileSkippedCount()).isEqualTo(largeFileSkippedCount + 1);
+            assertThat(cache.isCached(key)).isFalse();
+            blob.read(0, buffer, 0, buffer.length);
+            assertThat(buffer).isEqualTo(Arrays.copyOf(content, buffer.length));
+        }
+        assertThat(source.isClosed()).isTrue();
+    }
+
     private static byte[] content(int size)
     {
         byte[] content = new byte[size];
@@ -187,18 +227,25 @@ public class TestMemoryBlobCache
             implements BlobSource
     {
         private final byte[] content;
+        private final long declaredLength;
         private long readBytes;
         private boolean closed;
 
         public TestingBlobSource(byte[] content)
         {
+            this(content, content.length);
+        }
+
+        public TestingBlobSource(byte[] content, long declaredLength)
+        {
             this.content = content;
+            this.declaredLength = declaredLength;
         }
 
         @Override
         public long length()
         {
-            return content.length;
+            return declaredLength;
         }
 
         @Override

--- a/plugin/trino-blob-cache-memory/src/test/java/io/trino/blob/cache/memory/TestMemoryBlobCache.java
+++ b/plugin/trino-blob-cache-memory/src/test/java/io/trino/blob/cache/memory/TestMemoryBlobCache.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.UUID;
@@ -198,6 +199,40 @@ public class TestMemoryBlobCache
         public long length()
         {
             return content.length;
+        }
+
+        @Override
+        public InputStream openStream()
+        {
+            // Like a file system source: the stream ends at the actual end of the content,
+            // regardless of the declared length
+            return new InputStream()
+            {
+                private int position;
+
+                @Override
+                public int read()
+                {
+                    byte[] buffer = new byte[1];
+                    if (read(buffer, 0, 1) == -1) {
+                        return -1;
+                    }
+                    return buffer[0] & 0xFF;
+                }
+
+                @Override
+                public int read(byte[] buffer, int offset, int count)
+                {
+                    if (position >= content.length) {
+                        return -1;
+                    }
+                    int toRead = min(count, content.length - position);
+                    System.arraycopy(content, position, buffer, offset, toRead);
+                    position += toRead;
+                    readBytes += toRead;
+                    return toRead;
+                }
+            };
         }
 
         @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMemoryCacheFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMemoryCacheFileOperations.java
@@ -82,11 +82,11 @@ public class TestIcebergMemoryCacheFileOperations
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
                 ImmutableMultiset.<CacheOperation>builder()
-                        .addCopies(new CacheOperation("Input.readFully", DATA), 2)
+                        .addCopies(new CacheOperation("InputFile.newStream", DATA), 2)
                         .addCopies(new CacheOperation("BlobCache.get", DATA), 2)
                         .add(new CacheOperation("BlobCache.get", METADATA_JSON))
                         .addCopies(new CacheOperation("BlobCache.get", SNAPSHOT), 2)
-                        .addCopies(new CacheOperation("Input.readFully", MANIFEST), 2)
+                        .addCopies(new CacheOperation("InputFile.newStream", MANIFEST), 2)
                         .addCopies(new CacheOperation("BlobCache.get", MANIFEST), 2)
                         .build());
 
@@ -106,11 +106,11 @@ public class TestIcebergMemoryCacheFileOperations
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
                 ImmutableMultiset.<CacheOperation>builder()
-                        .addCopies(new CacheOperation("Input.readFully", DATA), 3)
+                        .addCopies(new CacheOperation("InputFile.newStream", DATA), 3)
                         .addCopies(new CacheOperation("BlobCache.get", DATA), 5)
                         .add(new CacheOperation("BlobCache.get", METADATA_JSON))
                         .addCopies(new CacheOperation("BlobCache.get", SNAPSHOT), 2)
-                        .addCopies(new CacheOperation("Input.readFully", MANIFEST), 3)
+                        .addCopies(new CacheOperation("InputFile.newStream", MANIFEST), 3)
                         .addCopies(new CacheOperation("BlobCache.get", MANIFEST), 5)
                         .build());
 
@@ -132,13 +132,13 @@ public class TestIcebergMemoryCacheFileOperations
                 "SELECT * FROM test_select_with_filter WHERE col_name = 1",
                 ImmutableMultiset.<CacheOperation>builder()
                         .add(new CacheOperation("BlobCache.get", METADATA_JSON))
-                        .add(new CacheOperation("Input.readFully", METADATA_JSON))
+                        .add(new CacheOperation("InputFile.newStream", METADATA_JSON))
                         .add(new CacheOperation("InputFile.length", METADATA_JSON))
                         .addCopies(new CacheOperation("BlobCache.get", SNAPSHOT), 2)
                         .add(new CacheOperation("BlobCache.get", MANIFEST))
-                        .add(new CacheOperation("Input.readFully", MANIFEST))
+                        .add(new CacheOperation("InputFile.newStream", MANIFEST))
                         .add(new CacheOperation("BlobCache.get", DATA))
-                        .add(new CacheOperation("Input.readFully", DATA))
+                        .add(new CacheOperation("InputFile.newStream", DATA))
                         .build());
 
         assertFileSystemAccesses(
@@ -159,13 +159,13 @@ public class TestIcebergMemoryCacheFileOperations
 
         assertFileSystemAccesses("SELECT name, age FROM test_join_t1 JOIN test_join_t2 ON test_join_t2.id = test_join_t1.id",
                 ImmutableMultiset.<CacheOperation>builder()
-                        .addCopies(new CacheOperation("Input.readFully", METADATA_JSON), 2)
+                        .addCopies(new CacheOperation("InputFile.newStream", METADATA_JSON), 2)
                         .addCopies(new CacheOperation("InputFile.length", METADATA_JSON), 2)
                         .addCopies(new CacheOperation("BlobCache.get", METADATA_JSON), 2)
                         .addCopies(new CacheOperation("BlobCache.get", SNAPSHOT), 4)
-                        .addCopies(new CacheOperation("Input.readFully", MANIFEST), 2)
+                        .addCopies(new CacheOperation("InputFile.newStream", MANIFEST), 2)
                         .addCopies(new CacheOperation("BlobCache.get", MANIFEST), 4)
-                        .addCopies(new CacheOperation("Input.readFully", DATA), 2)
+                        .addCopies(new CacheOperation("InputFile.newStream", DATA), 2)
                         .addCopies(new CacheOperation("BlobCache.get", DATA), 2)
                         .build());
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/cache/TestCachedManifestStaleLength.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/cache/TestCachedManifestStaleLength.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.cache;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.blob.cache.memory.MemoryBlobCache;
+import io.trino.blob.cache.memory.MemoryBlobCacheConfig;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+import io.trino.filesystem.cache.CacheFileSystem;
+import io.trino.filesystem.memory.MemoryFileSystem;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.file.FileReader;
+import org.apache.avro.file.SeekableByteArrayInput;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestCachedManifestStaleLength
+{
+    private static final Schema SCHEMA = SchemaBuilder.record("Test").namespace("test").fields().requiredString("value").endRecord();
+
+    /**
+     * Regression test for <a href="https://github.com/trinodb/trino/issues/25702">#25702</a>.
+     * <p>
+     * An iceberg manifest list may record a manifest length that is smaller than the actual
+     * on-storage size. Uncached, this is harmless: the raw input stream reads to the actual
+     * end of the object, so the Avro reader still sees the whole manifest. The blob cache must
+     * preserve those semantics — it must not populate the entry with only the declared number
+     * of bytes, and it must not serve such a truncated entry to readers that never declared
+     * a length.
+     */
+    @Test
+    void testStaleDeclaredLengthReadsFullManifest()
+            throws IOException
+    {
+        MemoryFileSystem delegate = new MemoryFileSystem();
+        MemoryBlobCache cache = new MemoryBlobCache(new MemoryBlobCacheConfig());
+        TrinoFileSystem fileSystem = new CacheFileSystem(delegate, cache, new IcebergCacheKeyProvider());
+
+        Location location = Location.of("memory:///stale-length-%s-m0.avro".formatted(UUID.randomUUID()));
+        AvroFile avroFile = writeTwoBlockAvroFile("first", "second");
+        fileSystem.newOutputFile(location).createOrOverwrite(avroFile.content());
+
+        // A stale length that falls exactly on the first Avro block boundary: a truncated
+        // read then loses the second record silently instead of failing
+        long staleLength = avroFile.firstBlockEnd();
+        assertThat(staleLength).isLessThan(avroFile.content().length);
+
+        // Uncached baseline: the raw stream ignores the declared length and reads to the
+        // actual end of the file, so both records come back
+        assertThat(readValues(delegate.newInputFile(location, staleLength)))
+                .containsExactly("first", "second");
+
+        // The same read through the cache must return the same records
+        assertThat(readValues(fileSystem.newInputFile(location, staleLength)))
+                .containsExactly("first", "second");
+
+        // The populated entry must not poison readers that never declared a length
+        assertThat(fileSystem.newInputFile(location).length()).isEqualTo(avroFile.content().length);
+        assertThat(readValues(fileSystem.newInputFile(location)))
+                .containsExactly("first", "second");
+    }
+
+    private static List<String> readValues(TrinoInputFile inputFile)
+            throws IOException
+    {
+        byte[] bytes;
+        try (TrinoInputStream stream = inputFile.newStream()) {
+            bytes = stream.readAllBytes();
+        }
+        ImmutableList.Builder<String> values = ImmutableList.builder();
+        try (FileReader<GenericRecord> reader = DataFileReader.openReader(new SeekableByteArrayInput(bytes), new GenericDatumReader<GenericRecord>())) {
+            while (reader.hasNext()) {
+                values.add(reader.next().get("value").toString());
+            }
+        }
+        return values.build();
+    }
+
+    private record AvroFile(byte[] content, long firstBlockEnd) {}
+
+    private static AvroFile writeTwoBlockAvroFile(String firstValue, String secondValue)
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        long firstBlockEnd;
+        try (DataFileWriter<GenericRecord> writer = new DataFileWriter<>(new GenericDatumWriter<GenericRecord>(SCHEMA))) {
+            writer.create(SCHEMA, out);
+            writer.append(record(firstValue));
+            // Force a block boundary, so that the file truncated at this position is still a
+            // well-formed Avro file that just misses the second record
+            firstBlockEnd = writer.sync();
+            writer.append(record(secondValue));
+        }
+        return new AvroFile(out.toByteArray(), firstBlockEnd);
+    }
+
+    private static GenericRecord record(String value)
+    {
+        GenericRecord record = new GenericData.Record(SCHEMA);
+        record.put("value", value);
+        return record;
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/cache/TestIcebergStaleManifestLength.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/cache/TestIcebergStaleManifestLength.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.cache;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.testing.MaterializedRow;
+import io.trino.testing.QueryRunner;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.file.SeekableFileInput;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestIcebergStaleManifestLength
+{
+    private static final String SCHEMA = "stale_len";
+
+    /**
+     * A manifest list may record a {@code manifest_length} smaller than the manifest's actual
+     * size on storage when the manifest list was written by a buggy writer, such as iceberg-go
+     * before <a href="https://github.com/apache/iceberg-go/pull/439">apache/iceberg-go#439</a>
+     * (see <a href="https://github.com/apache/iceberg-go/issues/438">apache/iceberg-go#438</a>).
+     * Such metadata is permanent until the manifests are rewritten, so reads of the table must
+     * not be corrupted by it: trino itself always records exact lengths (asserted first), and
+     * a table with undersized recorded lengths must return the same correct rows with the
+     * metadata cache enabled (the default) as without it.
+     */
+    @Test
+    void testUndersizedManifestLengthFromForeignWriter()
+            throws Exception
+    {
+        Path metastoreDirectory = Files.createTempDirectory(SCHEMA);
+        try {
+            try (QueryRunner writer = queryRunner(metastoreDirectory, true)) {
+                writer.execute("CREATE TABLE %s.t AS SELECT * FROM (VALUES 1, 2) AS v(x)".formatted(SCHEMA));
+                writer.execute("INSERT INTO %s.t VALUES 3".formatted(SCHEMA));
+
+                // Trino records the exact manifest sizes, so tables written by trino are not
+                // affected: only foreign writers introduce undersized lengths
+                for (MaterializedRow manifest : writer.execute("SELECT path, length FROM %s.\"t$manifests\"".formatted(SCHEMA)).getMaterializedRows()) {
+                    Path manifestFile = Paths.get(URI.create((String) manifest.getField(0)));
+                    assertThat((long) manifest.getField(1))
+                            .as("recorded manifest_length of %s", manifestFile)
+                            .isEqualTo(Files.size(manifestFile));
+                }
+            }
+
+            // Rewrite the manifest lists the way a buggy foreign writer would have written
+            // them: same manifests, but with a recorded length smaller than the actual size
+            try (Stream<Path> files = Files.walk(metastoreDirectory)) {
+                List<Path> manifestLists = files.filter(file -> file.getFileName().toString().startsWith("snap-")).toList();
+                assertThat(manifestLists).isNotEmpty();
+                for (Path manifestList : manifestLists) {
+                    shrinkRecordedManifestLengths(manifestList, 40);
+                }
+            }
+
+            // A fresh coordinator with default configuration, metadata caching included, must
+            // read all rows: the recorded length must not truncate what is actually read
+            try (QueryRunner reader = queryRunner(metastoreDirectory, true)) {
+                assertThat(reader.execute("SELECT x FROM %s.t ORDER BY x".formatted(SCHEMA)).getOnlyColumnAsSet())
+                        .containsExactlyInAnyOrder(1, 2, 3);
+            }
+
+            // Reference behavior with the metadata cache disabled
+            try (QueryRunner reader = queryRunner(metastoreDirectory, false)) {
+                assertThat(reader.execute("SELECT x FROM %s.t ORDER BY x".formatted(SCHEMA)).getOnlyColumnAsSet())
+                        .containsExactlyInAnyOrder(1, 2, 3);
+            }
+        }
+        finally {
+            deleteRecursively(metastoreDirectory, ALLOW_INSECURE);
+        }
+    }
+
+    private static QueryRunner queryRunner(Path metastoreDirectory, boolean metadataCacheEnabled)
+            throws Exception
+    {
+        QueryRunner queryRunner = IcebergQueryRunner.builder()
+                .setIcebergProperties(ImmutableMap.<String, String>builder()
+                        .put("iceberg.metadata-cache.enabled", String.valueOf(metadataCacheEnabled))
+                        .put("hive.metastore.catalog.dir", metastoreDirectory.toUri().toString())
+                        .put("fs.hadoop.enabled", "true")
+                        .buildOrThrow())
+                .setWorkerCount(0)
+                .build();
+        queryRunner.execute("CREATE SCHEMA IF NOT EXISTS " + SCHEMA);
+        return queryRunner;
+    }
+
+    private static void shrinkRecordedManifestLengths(Path manifestList, long shrinkBy)
+            throws IOException
+    {
+        Schema schema;
+        Map<String, byte[]> metadata = new LinkedHashMap<>();
+        List<GenericRecord> entries = new ArrayList<>();
+        try (DataFileReader<GenericRecord> reader = new DataFileReader<>(new SeekableFileInput(manifestList.toFile()), new GenericDatumReader<>())) {
+            schema = reader.getSchema();
+            for (String key : reader.getMetaKeys()) {
+                if (!key.startsWith("avro.")) {
+                    metadata.put(key, reader.getMeta(key));
+                }
+            }
+            reader.forEach(entries::add);
+        }
+        assertThat(entries).isNotEmpty();
+
+        ByteArrayOutputStream rewritten = new ByteArrayOutputStream();
+        try (DataFileWriter<GenericRecord> writer = new DataFileWriter<>(new GenericDatumWriter<GenericRecord>(schema))) {
+            metadata.forEach(writer::setMeta);
+            writer.create(schema, rewritten);
+            for (GenericRecord entry : entries) {
+                entry.put("manifest_length", (long) entry.get("manifest_length") - shrinkBy);
+                writer.append(entry);
+            }
+        }
+        Files.write(manifestList, rewritten.toByteArray());
+        // The hadoop local file system keeps a checksum sidecar that no longer matches the
+        // rewritten content
+        Files.deleteIfExists(manifestList.resolveSibling("." + manifestList.getFileName() + ".crc"));
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
@@ -558,7 +558,7 @@ public class TestIcebergGlueCatalogAccessOperations
                                 .build(),
                         ImmutableMultiset.<FileOperation>builder()
                                 .add(new FileOperation(METADATA_JSON, "InputFile.length"))
-                                .add(new FileOperation(METADATA_JSON, "InputFile.newInput"))
+                                .add(new FileOperation(METADATA_JSON, "InputFile.newStream"))
                                 .build());
 
                 // Pointed columns lookup via DESCRIBE (which does some additional things before delegating to information_schema.columns)
@@ -571,7 +571,7 @@ public class TestIcebergGlueCatalogAccessOperations
                                 .build(),
                         ImmutableMultiset.<FileOperation>builder()
                                 .add(new FileOperation(METADATA_JSON, "InputFile.length"))
-                                .add(new FileOperation(METADATA_JSON, "InputFile.newInput"))
+                                .add(new FileOperation(METADATA_JSON, "InputFile.newStream"))
                                 .build());
             }
             finally {
@@ -631,7 +631,7 @@ public class TestIcebergGlueCatalogAccessOperations
                                 .build(),
                         ImmutableMultiset.<FileOperation>builder()
                                 .add(new FileOperation(METADATA_JSON, "InputFile.length"))
-                                .add(new FileOperation(METADATA_JSON, "InputFile.newInput"))
+                                .add(new FileOperation(METADATA_JSON, "InputFile.newStream"))
                                 .build());
             }
             finally {


### PR DESCRIPTION
## Description

- Fixes #25702

Iceberg opens manifest files with the length recorded in its metadata. When that length is stale (smaller than the actual file size), `MemoryBlobCache` populates the entry with only the declared number of bytes, caching a truncated copy of the file. With location-only cache keys the truncated entry is then served to every reader, silently dropping manifest entries or failing the read — while the uncached path works, because the raw input stream reads to the actual end of the object.

The whole-file cache cannot read past the declared length through the current `BlobSource` surface (`length()` + positional `readFully`), so 
* The first commit adds `BlobSource.openStream()`. This restores the stream access cache implementations had before the migration to the blob cache SPI (`TrinoFileSystemCache.cacheStream(TrinoInputFile delegate, String key)`), in narrowed form. 
* The second commit populates `MemoryBlobCache` entries from that stream, reading to its actual end and using the declared length only as a pre-filter for the max content length check. Request count per cache miss is unchanged: one GET, as before.

## Additional context and related issues

- Supersedes #29606, which fixed the same issue in the since-removed `MemoryFileSystemCache`.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix file system metadata cache serving truncated content when the file length
  recorded in table metadata is stale. ({issue}`25702`)
```
