### PR TITLE
Cancel Redshift UNLOAD statement when split source is closed

### DIFF
--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftUnloadSplitSource.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftUnloadSplitSource.java
@@ -51,6 +51,8 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -72,6 +74,8 @@ public class RedshiftUnloadSplitSource
     private final String unloadOutputPath;
     private final TrinoFileSystem fileSystem;
     private final CompletableFuture<Void> resultSetFuture;
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private final AtomicReference<PreparedStatement> activeStatement = new AtomicReference<>();
 
     private List<FileInfo> unloadedFilePaths = ImmutableList.of();
     private boolean finished;
@@ -105,12 +109,21 @@ public class RedshiftUnloadSplitSource
             try (Connection connection = jdbcClient.getConnection(session)) {
                 String redshiftSelectSql = buildRedshiftSelectSql(session, connection, jdbcTableHandle, columns);
                 try (PreparedStatement statement = buildRedshiftUnloadSql(session, connection, columns, redshiftSelectSql, unloadOutputPath)) {
-                    // Exclusively set readOnly to false to avoid query failing with "ERROR: transaction is read-only".
-                    connection.setReadOnly(false);
-                    log.debug("Executing: %s", statement);
-                    long start = System.nanoTime();
-                    statement.execute(); // Return value of `statement.execute()` is not useful to determine whether UNLOAD command produced any result as it always return false.
-                    log.info("Redshift UNLOAD command for %s query took %s", queryFragmentId, nanosSince(start));
+                    activeStatement.set(statement);
+                    try {
+                        if (closed.get()) {
+                            return;
+                        }
+                        // Exclusively set readOnly to false to avoid query failing with "ERROR: transaction is read-only".
+                        connection.setReadOnly(false);
+                        log.debug("Executing: %s", statement);
+                        long start = System.nanoTime();
+                        statement.execute(); // Return value of `statement.execute()` is not useful to determine whether UNLOAD command produced any result as it always return false.
+                        log.info("Redshift UNLOAD command for %s query took %s", queryFragmentId, nanosSince(start));
+                    }
+                    finally {
+                        activeStatement.set(null);
+                    }
                 }
             }
             catch (SQLException e) {
@@ -139,6 +152,17 @@ public class RedshiftUnloadSplitSource
     @Override
     public void close()
     {
+        if (closed.compareAndSet(false, true)) {
+            PreparedStatement statement = activeStatement.get();
+            if (statement != null) {
+                try {
+                    statement.cancel();
+                }
+                catch (SQLException e) {
+                    log.debug(e, "Failed to cancel Redshift UNLOAD statement");
+                }
+            }
+        }
         resultSetFuture.cancel(true);
     }
 

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftRemoteDatabaseEventMonitor.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftRemoteDatabaseEventMonitor.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.redshift;
+
+import io.airlift.log.Logger;
+import io.trino.plugin.jdbc.RemoteDatabaseEvent;
+import io.trino.plugin.jdbc.RemoteDatabaseEvent.Status;
+import io.trino.plugin.jdbc.RemoteLogTracingEvent;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.plugin.redshift.TestingRedshiftServer.JDBC_PASSWORD;
+import static io.trino.plugin.redshift.TestingRedshiftServer.JDBC_URL;
+import static io.trino.plugin.redshift.TestingRedshiftServer.JDBC_USER;
+import static io.trino.plugin.redshift.TestingRedshiftServer.TEST_DATABASE;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Periodically polls {@code SYS_QUERY_HISTORY} for recent queries of the given type issued by the test user
+ * and feeds them to the registered {@link RemoteLogTracingEvent}s.
+ */
+public final class RedshiftRemoteDatabaseEventMonitor
+        implements Runnable
+{
+    private static final Logger log = Logger.get(RedshiftRemoteDatabaseEventMonitor.class);
+    private static final String LOG_CANCELLATION_EVENT = "cancelled on user's request";
+
+    private final Jdbi jdbi = Jdbi.create(JDBC_URL, JDBC_USER, JDBC_PASSWORD);
+    private final Set<RemoteLogTracingEvent> tracingEvents = ConcurrentHashMap.newKeySet();
+    private final String queryType;
+    private ScheduledThreadPoolExecutor executor;
+
+    /**
+     * @param queryType value of the {@code query_type} column in {@code SYS_QUERY_HISTORY} to monitor, e.g. {@code SELECT} or {@code UNLOAD}
+     */
+    public RedshiftRemoteDatabaseEventMonitor(String queryType)
+    {
+        this.queryType = requireNonNull(queryType, "queryType is null");
+    }
+
+    public synchronized void startTracingDatabaseEvent(RemoteLogTracingEvent event)
+    {
+        if (tracingEvents.isEmpty()) {
+            executor = new ScheduledThreadPoolExecutor(1, daemonThreadsNamed("redshift-database-event-monitor"));
+            executor.scheduleWithFixedDelay(this, 0, 5, SECONDS);
+        }
+        tracingEvents.add(event);
+    }
+
+    public synchronized void stopTracingDatabaseEvent(RemoteLogTracingEvent event)
+    {
+        tracingEvents.remove(event);
+        if (tracingEvents.isEmpty()) {
+            executor.shutdown();
+        }
+    }
+
+    @Override
+    public void run()
+    {
+        if (tracingEvents.isEmpty()) {
+            return;
+        }
+
+        try {
+            recentQueries()
+                    .forEach(remoteDatabaseEvent -> tracingEvents.forEach(tracingEvent -> tracingEvent.accept(remoteDatabaseEvent)));
+        }
+        catch (Exception e) {
+            // ignore exceptions to keep scheduled executions going
+            log.warn(e, "Encountered error while gathering Redshift remote database events");
+        }
+    }
+
+    private List<RemoteDatabaseEvent> recentQueries()
+    {
+        try (Handle handle = jdbi.open()) {
+            return handle.createQuery(
+                            """
+                            SELECT query_text, status, error_message
+                            FROM SYS_QUERY_HISTORY
+                            WHERE database_name = :db_name
+                            AND query_type = :query_type
+                            AND user_id = current_user_id
+                            AND start_time > GETDATE() - INTERVAL '15 minutes'
+                            """)
+                    .bind("db_name", TEST_DATABASE)
+                    .bind("query_type", queryType)
+                    .map((rs, _) -> new RemoteDatabaseEvent(
+                            rs.getString("query_text"),
+                            switch (requireNonNull(rs.getString("status"), "status is null").trim()) {
+                                case "failed" -> Optional.ofNullable(rs.getString("error_message"))
+                                        .flatMap(message -> message.contains(LOG_CANCELLATION_EVENT) ? Optional.of(Status.CANCELLED) : Optional.empty())
+                                        .orElse(Status.DONE);
+                                case "success" -> Status.DONE;
+                                case "canceled" -> Status.CANCELLED;
+                                default -> Status.RUNNING;
+                            }))
+                    .list();
+        }
+    }
+}

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
@@ -15,15 +15,12 @@ package io.trino.plugin.redshift;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
-import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import io.trino.Session;
 import io.trino.plugin.jdbc.BaseJdbcConnectorTest;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
-import io.trino.plugin.jdbc.RemoteDatabaseEvent;
-import io.trino.plugin.jdbc.RemoteDatabaseEvent.Status;
 import io.trino.plugin.jdbc.RemoteLogTracingEvent;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
@@ -32,8 +29,6 @@ import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
-import org.jdbi.v3.core.Handle;
-import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
@@ -45,19 +40,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.SystemSessionProperties.DISTINCT_AGGREGATIONS_STRATEGY;
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.UNSUPPORTED_TYPE_HANDLING;
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
-import static io.trino.plugin.redshift.RedshiftQueryRunner.IAM_ROLE;
 import static io.trino.plugin.redshift.TestingRedshiftServer.JDBC_PASSWORD;
 import static io.trino.plugin.redshift.TestingRedshiftServer.JDBC_URL;
 import static io.trino.plugin.redshift.TestingRedshiftServer.JDBC_USER;
@@ -72,7 +62,6 @@ import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.Math.round;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
-import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -81,9 +70,7 @@ import static org.junit.jupiter.api.Assumptions.abort;
 public class TestRedshiftConnectorTest
         extends BaseJdbcConnectorTest
 {
-    private static final String LOG_CANCELLATION_EVENT = "cancelled on user's request";
-
-    private final RemoteDatabaseEventMonitor remoteDatabaseEventMonitor = new RemoteDatabaseEventMonitor();
+    private final RedshiftRemoteDatabaseEventMonitor remoteDatabaseEventMonitor = new RedshiftRemoteDatabaseEventMonitor("SELECT");
 
     @Override
     protected QueryRunner createQueryRunner()
@@ -880,11 +867,6 @@ public class TestRedshiftConnectorTest
         return TestingRedshiftServer::executeInRedshiftWithRetry;
     }
 
-    private SqlExecutor onRemoteDatabaseWithSchema(String schema)
-    {
-        return sql -> executeInRedshift("SET search_path TO %s; %s".formatted(schema, sql));
-    }
-
     @Override
     protected void startTracingDatabaseEvent(RemoteLogTracingEvent event)
     {
@@ -900,20 +882,7 @@ public class TestRedshiftConnectorTest
     @Override
     protected io.trino.testing.sql.TestView createSleepingView(Duration minimalQueryDuration)
     {
-        long secondsToSleep = round(minimalQueryDuration.convertTo(SECONDS).getValue() + 1);
-        // pg_sleep unsupported: https://docs.aws.amazon.com/redshift/latest/dg/c_unsupported-postgresql-functions.html,
-        // Using a predefined AWS lambda replacement
-        onRemoteDatabaseWithSchema(TEST_SCHEMA).execute(
-                """
-                CREATE OR REPLACE EXTERNAL FUNCTION\s
-                        janky_sleep(x int) returns int
-                        lambda 'trino-redshift-ci-sleep' IAM_ROLE '%s'
-                STABLE
-                """.formatted(IAM_ROLE));
-        return new io.trino.testing.sql.TestView(
-                onRemoteDatabaseWithSchema(TEST_SCHEMA),
-                "test_sleeping_view",
-                format("SELECT 1 FROM janky_sleep(%d)", secondsToSleep));
+        return TestingRedshiftServer.createSleepingView(round(minimalQueryDuration.convertTo(SECONDS).getValue() + 1));
     }
 
     @Test
@@ -977,83 +946,6 @@ public class TestRedshiftConnectorTest
         public String getName()
         {
             return name;
-        }
-    }
-
-    private static class RemoteDatabaseEventMonitor
-            implements Runnable
-    {
-        private static final Logger log = Logger.get(RemoteDatabaseEventMonitor.class);
-
-        private final Jdbi jdbi;
-        private final Set<RemoteLogTracingEvent> tracingEvents;
-        private ScheduledThreadPoolExecutor executor;
-
-        private RemoteDatabaseEventMonitor()
-        {
-            jdbi = Jdbi.create(JDBC_URL, JDBC_USER, JDBC_PASSWORD);
-            tracingEvents = ConcurrentHashMap.newKeySet();
-        }
-
-        public void startTracingDatabaseEvent(RemoteLogTracingEvent event)
-        {
-            if (tracingEvents.isEmpty()) {
-                executor = new ScheduledThreadPoolExecutor(1, daemonThreadsNamed("redshift-database-event-monitor"));
-                executor.scheduleWithFixedDelay(this, 0, 5, SECONDS);
-            }
-            tracingEvents.add(event);
-        }
-
-        public void stopTracingDatabaseEvent(RemoteLogTracingEvent event)
-        {
-            tracingEvents.remove(event);
-            if (tracingEvents.isEmpty()) {
-                executor.shutdown();
-            }
-        }
-
-        @Override
-        public void run()
-        {
-            if (tracingEvents.isEmpty()) {
-                return;
-            }
-
-            try {
-                getRecentQueries()
-                        .forEach(remoteDatabaseEvent -> tracingEvents.forEach(tracingEvent -> tracingEvent.accept(remoteDatabaseEvent)));
-            }
-            catch (Exception e) {
-                // ignore exceptions to keep scheduled executions going
-                log.warn(e, "Encountered error while gathering Redshift remote database events");
-            }
-        }
-
-        private List<RemoteDatabaseEvent> getRecentQueries()
-        {
-            try (Handle handle = jdbi.open()) {
-                return handle.createQuery(
-                                """
-                                SELECT query_text, status, error_message
-                                FROM SYS_QUERY_HISTORY
-                                WHERE database_name = :db_name
-                                AND query_type = 'SELECT'
-                                AND user_id = current_user_id
-                                AND start_time > GETDATE() - INTERVAL '15 minutes'
-                                """)
-                        .bind("db_name", TEST_DATABASE)
-                        .map((rs, _) -> new RemoteDatabaseEvent(
-                                rs.getString("query_text"),
-                                switch (requireNonNull(rs.getString("status"), "status is null").trim()) {
-                                    case "failed" -> Optional.ofNullable(rs.getString("error_message"))
-                                            .flatMap(message -> message.contains(LOG_CANCELLATION_EVENT) ? Optional.of(Status.CANCELLED) : Optional.empty())
-                                            .orElse(Status.DONE);
-                                    case "success" -> Status.DONE;
-                                    case "canceled" -> Status.CANCELLED;
-                                    default -> Status.RUNNING;
-                                }))
-                        .list();
-            }
         }
     }
 }

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftUnload.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftUnload.java
@@ -16,11 +16,16 @@ package io.trino.plugin.redshift;
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.operator.OperatorInfo;
+import io.trino.plugin.jdbc.RemoteDatabaseEvent.Status;
+import io.trino.plugin.jdbc.RemoteLogTracingEvent;
+import io.trino.spi.QueryId;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.QueryRunner.MaterializedResultWithPlan;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
+import io.trino.testing.sql.TestView;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
@@ -32,17 +37,26 @@ import software.amazon.awssdk.services.s3.S3Client;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.onlyElement;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
+import static io.trino.plugin.jdbc.BaseJdbcConnectorTest.getQueryId;
 import static io.trino.plugin.redshift.RedshiftQueryRunner.IAM_ROLE;
 import static io.trino.plugin.redshift.TestingRedshiftServer.TEST_SCHEMA;
+import static io.trino.plugin.redshift.TestingRedshiftServer.createSleepingView;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.testing.assertions.Assert.assertEventually;
 import static io.trino.tpch.TpchTable.NATION;
+import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -56,6 +70,15 @@ final class TestRedshiftUnload
     private static final String AWS_REGION = requiredNonEmptySystemProperty("test.redshift.aws.region");
     private static final String AWS_ACCESS_KEY = requiredNonEmptySystemProperty("test.redshift.aws.access-key");
     private static final String AWS_SECRET_KEY = requiredNonEmptySystemProperty("test.redshift.aws.secret-key");
+
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getName() + "-%s"));
+    private final RedshiftRemoteDatabaseEventMonitor remoteDatabaseEventMonitor = new RedshiftRemoteDatabaseEventMonitor("UNLOAD");
+
+    @AfterAll
+    void tearDown()
+    {
+        executor.shutdownNow();
+    }
 
     @Override
     protected QueryRunner createQueryRunner()
@@ -197,6 +220,31 @@ final class TestRedshiftUnload
                     assertThat(operatorInfo).isNull();
                 },
                 results -> assertThat(results.getRowCount()).isEqualTo(1));
+    }
+
+    @Test
+    void testUnloadCancellation()
+            throws Exception
+    {
+        try (TestView sleepingView = createSleepingView(MINUTES.toSeconds(1) + 1)) {
+            String viewName = sleepingView.getName().toLowerCase(ENGLISH);
+
+            RemoteLogTracingEvent runningEvent = new RemoteLogTracingEvent(event -> event.getQuery().toLowerCase(ENGLISH).contains(viewName) && event.getStatus() == Status.RUNNING);
+            remoteDatabaseEventMonitor.startTracingDatabaseEvent(runningEvent);
+
+            String query = "SELECT * FROM " + sleepingView.getName();
+            Future<?> future = executor.submit(() -> assertQueryFails(query, "Query killed. Message: Killed by test"));
+            QueryId queryId = getQueryId(getQueryRunner(), query);
+            assertEventually(() -> assertThat(runningEvent.hasHappened()).isTrue());
+            remoteDatabaseEventMonitor.stopTracingDatabaseEvent(runningEvent);
+
+            RemoteLogTracingEvent cancelledEvent = new RemoteLogTracingEvent(event -> event.getQuery().toLowerCase(ENGLISH).contains(viewName) && event.getStatus() == Status.CANCELLED);
+            remoteDatabaseEventMonitor.startTracingDatabaseEvent(cancelledEvent);
+            assertUpdate(format("CALL system.runtime.kill_query(query_id => '%s', message => '%s')", queryId, "Killed by test"));
+            future.get();
+            assertEventually(() -> assertThat(cancelledEvent.hasHappened()).isTrue());
+            remoteDatabaseEventMonitor.stopTracingDatabaseEvent(cancelledEvent);
+        }
     }
 
     @Test

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestingRedshiftServer.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestingRedshiftServer.java
@@ -13,8 +13,11 @@
  */
 package io.trino.plugin.redshift;
 
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
+import io.trino.testing.sql.SqlExecutor;
+import io.trino.testing.sql.TestView;
 import org.jdbi.v3.core.HandleCallback;
 import org.jdbi.v3.core.HandleConsumer;
 import org.jdbi.v3.core.Jdbi;
@@ -25,6 +28,7 @@ import java.time.Duration;
 
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.base.Throwables.getCausalChain;
+import static io.trino.plugin.redshift.RedshiftQueryRunner.IAM_ROLE;
 import static io.trino.testing.TestingProperties.requiredNonEmptySystemProperty;
 
 public final class TestingRedshiftServer
@@ -39,6 +43,9 @@ public final class TestingRedshiftServer
     public static final String TEST_SCHEMA = "test_schema";
 
     public static final String JDBC_URL = "jdbc:redshift://" + JDBC_ENDPOINT + TEST_DATABASE + "?connectTimeout=0";
+
+    @GuardedBy("TestingRedshiftServer.class")
+    private static boolean sleepFunctionCreated;
 
     public static void executeInRedshiftWithRetry(String sql, Object... parameters)
     {
@@ -73,6 +80,47 @@ public final class TestingRedshiftServer
             throws E
     {
         return Jdbi.create(JDBC_URL, JDBC_USER, JDBC_PASSWORD).withHandle(callback);
+    }
+
+    public static SqlExecutor onRemoteDatabaseWithSchema(String schema)
+    {
+        return sql -> executeInRedshift("SET search_path TO %s; %s".formatted(schema, sql));
+    }
+
+    /**
+     * Creates a view in {@link #TEST_SCHEMA} whose scan blocks for at least {@code secondsToSleep} seconds,
+     * for tests that need a long-running remote query.
+     */
+    public static TestView createSleepingView(long secondsToSleep)
+    {
+        ensureSleepFunctionExists();
+        // Select from a real table so the query runs on the compute nodes, where Lambda UDFs are evaluated.
+        // A query without a table reference runs only on the leader node, and Redshift UNLOAD completes it immediately without sleeping.
+        // Filter to a single row as the Lambda sleeps once per input row.
+        return new TestView(
+                onRemoteDatabaseWithSchema(TEST_SCHEMA),
+                "test_sleeping_view",
+                "SELECT janky_sleep(%d) AS value FROM %s.nation WHERE nationkey = 0".formatted(secondsToSleep, TEST_SCHEMA));
+    }
+
+    // Created once per JVM under a lock: concurrent CREATE OR REPLACE of the same function fails in Redshift
+    // with "could not complete because of conflict with concurrent transaction"
+    private static synchronized void ensureSleepFunctionExists()
+    {
+        if (sleepFunctionCreated) {
+            return;
+        }
+        // pg_sleep unsupported: https://docs.aws.amazon.com/redshift/latest/dg/c_unsupported-postgresql-functions.html,
+        // Using a predefined AWS lambda replacement
+        executeInRedshiftWithRetry(
+                """
+                SET search_path TO %s;
+                CREATE OR REPLACE EXTERNAL FUNCTION\s
+                        janky_sleep(x int) returns int
+                        lambda 'trino-redshift-ci-sleep' IAM_ROLE '%s'
+                STABLE
+                """.formatted(TEST_SCHEMA, IAM_ROLE));
+        sleepFunctionCreated = true;
     }
 
     public static boolean isExceptionRecoverable(Throwable exception)


### PR DESCRIPTION
When a query using Redshift UNLOAD is cancelled or closed, RedshiftUnloadSplitSource now cancels the active JDBC PreparedStatement executing the UNLOAD, propagating cancellation to Redshift instead of only cancelling the local future.

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
When a query that Trino issues is cancelled or timed out, the database the query was issued to should also cancel it. I noticed this at my org mostly with Redshift UNLOAD statements.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- Closes #29514 and supersedes #29670 


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Redshift
* Reduce resource usage on Redshift when query is cancelled and for queries involving LIMIT. (`#29514`)
```
