### PR TITLE
Reapply BigQuery read timeout default

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ProxyTransportFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ProxyTransportFactory.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.bigquery;
 
 import com.google.api.client.http.apache.v2.ApacheHttpTransport;
+import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.http.HttpTransportOptions;
 import com.google.inject.Inject;
 import io.grpc.HttpConnectProxiedSocketAddress;
@@ -128,6 +129,7 @@ public interface ProxyTransportFactory
             HttpClient client = httpClientBuilder.build(); // TODO: close http client on catalog deregistration
             return HttpTransportOptions.newBuilder()
                     .setHttpTransportFactory(() -> new ApacheHttpTransport(client))
+                    .setReadTimeout(BigQueryOptions.getDefaultHttpTransportOptions().getReadTimeout())
                     .build();
         }
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/TracingOptionsConfigurer.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/TracingOptionsConfigurer.java
@@ -45,6 +45,7 @@ public class TracingOptionsConfigurer
     {
         return builder.setTransportOptions(HttpTransportOptions.newBuilder()
                 .setHttpTransportFactory(() -> new ApacheHttpTransport(ApacheHttpClientTelemetry.create(openTelemetry).createHttpClient()))
+                .setReadTimeout(BigQueryOptions.getDefaultHttpTransportOptions().getReadTimeout())
                 .build());
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This reapply 60s read timeout in BigQuery. When setting  `setTransportOptions` it was actually override default 60s with 20s default from `com.google.api.client.http.HttpRequest`


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## BigQuery connector
* BigQuery read timeout fixed to google cloud BigQuery sdk default (60s)
```
