### PR TITLE
Retry HiveServer2 communication failures

### DIFF
--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/compatibility/CompatibilityEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/compatibility/CompatibilityEnvironment.java
@@ -31,6 +31,7 @@ import java.sql.Statement;
 import java.time.Duration;
 import java.util.Map;
 
+import static io.trino.testing.containers.environment.ConnectionRetry.createWithRetry;
 import static io.trino.tests.product.hive.HiveCatalogPropertiesBuilder.hadoopMetastoreUri;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
@@ -132,7 +133,7 @@ public class CompatibilityEnvironment
                 "jdbc:hive2://%s:%s/default",
                 hadoop.getHost(),
                 hadoop.getMappedPort(HadoopContainer.HIVESERVER2_PORT));
-        try (Connection connection = DriverManager.getConnection(jdbcUrl, "hive", "");
+        try (Connection connection = createWithRetry(() -> DriverManager.getConnection(jdbcUrl, "hive", ""));
                 Statement statement = connection.createStatement()) {
             return statement.executeUpdate(sql);
         }

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/environment/ConnectionRetry.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/environment/ConnectionRetry.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.containers.environment;
+
+import com.google.common.base.Throwables;
+import dev.failsafe.Failsafe;
+import dev.failsafe.FailsafeException;
+import dev.failsafe.RetryPolicy;
+import io.airlift.log.Logger;
+
+import java.net.SocketException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+/// Creates JDBC connections with retries for transient socket failures.
+public final class ConnectionRetry
+{
+    private static final Logger log = Logger.get(ConnectionRetry.class);
+
+    private static final RetryPolicy<Object> RETRY_POLICY = RetryPolicy.builder()
+            .handleIf(failure -> Throwables.getRootCause(failure) instanceof SocketException)
+            .withBackoff(1, 10, SECONDS)
+            .withMaxRetries(30)
+            .onRetry(event -> log.warn(event.getLastException(), "Connection failed on attempt %d, will retry.", event.getAttemptCount()))
+            .build();
+
+    private ConnectionRetry() {}
+
+    public static Connection createWithRetry(ConnectionFactory connectionFactory)
+            throws SQLException
+    {
+        try {
+            return Failsafe.with(RETRY_POLICY).get(connectionFactory::create);
+        }
+        catch (FailsafeException failure) {
+            if (failure.getCause() instanceof SQLException sqlException) {
+                throw sqlException;
+            }
+            throw failure;
+        }
+    }
+
+    @FunctionalInterface
+    public interface ConnectionFactory
+    {
+        Connection create()
+                throws SQLException;
+    }
+}


### PR DESCRIPTION
## Description

Prevent transient HiveServer2 connection failures from failing compatibility product tests.

## Additional context and related issues

Fixes #30839.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```