### PR TITLE
Fix worker lock convoy in the thread-per-driver task executor

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/TaskEntry.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/TaskEntry.java
@@ -108,24 +108,50 @@ class TaskEntry
     }
 
     /**
-     * @return true if a split was scheduled; false if no splits are pending
+     * Claim the next pending leaf split and account for it as running. The claimed split must be
+     * handed to {@link #startLeafSplit} to actually run; the two steps are separate so that the
+     * caller can start the split without holding any lock.
+     *
+     * @return null if no splits are pending
      */
-    public synchronized boolean dequeueAndRunLeafSplit(Runnable doneCallback)
+    public synchronized QueuedSplit claimLeafSplit()
     {
         QueuedSplit split = pending.poll();
         if (split == null) {
-            return false;
+            return null;
         }
 
-        runSplit(split.split())
+        runningLeafSplits++;
+        running.add(split.split());
+
+        return split;
+    }
+
+    /// Start a split claimed via [#claimLeafSplit()]. Must be called without holding a lock.
+    /// If this throws, the claim was not consumed and must be given back via
+    /// [#releaseLeafSplit(QueuedSplit,Throwable)].
+    public void startLeafSplit(QueuedSplit split, Runnable doneCallback)
+    {
+        submit(split.split())
                 .addListener(() -> {
                     leafSplitDone(split);
                     doneCallback.run();
                 }, directExecutor());
+    }
 
-        runningLeafSplits++;
-
-        return true;
+    /// Give back a split claimed via [#claimLeafSplit()] that could not be started. The split's
+    /// work is lost, so the task is failed rather than told that the split finished.
+    ///
+    /// Completes the split's future while holding this monitor, as does the normal completion
+    /// path. That is only safe because `SqlTaskExecution` registers its callback on the task
+    /// notification executor: the callback reaches `removeTask`, and so the task executor
+    /// monitor, which is always acquired before this one. Running it inline would close a cycle.
+    public synchronized void releaseLeafSplit(QueuedSplit split, Throwable cause)
+    {
+        runningLeafSplits--;
+        running.remove(split.split());
+        split.split().close();
+        split.done().setException(cause);
     }
 
     private synchronized void leafSplitDone(QueuedSplit split)
@@ -134,7 +160,19 @@ class TaskEntry
         split.done().set(null);
     }
 
-    public synchronized ListenableFuture<Void> runSplit(SplitRunner split)
+    public ListenableFuture<Void> runSplit(SplitRunner split)
+    {
+        synchronized (this) {
+            running.add(split);
+        }
+
+        return submit(split);
+    }
+
+    /// Hand a split that is already accounted for in `running` to the scheduler. Must be called
+    /// without holding a lock: the scheduler creates the thread that runs the split, which on a
+    /// loaded worker is slow enough to stall every other operation on the lock.
+    private ListenableFuture<Void> submit(SplitRunner split)
     {
         int splitId = nextSplitId();
         ListenableFuture<Void> done = scheduler.submit(
@@ -142,7 +180,6 @@ class TaskEntry
                 splitId,
                 new VersionEmbedderBridge(versionEmbedder, new SplitProcessor(taskId, splitId, split, tracer)));
         done.addListener(() -> splitDone(split), directExecutor());
-        running.add(split);
 
         return done;
     }
@@ -194,7 +231,7 @@ class TaskEntry
         return concurrency.targetConcurrency();
     }
 
-    private record QueuedSplit(SplitRunner split, SettableFuture<Void> done) {}
+    record QueuedSplit(SplitRunner split, SettableFuture<Void> done) {}
 
     private record VersionEmbedderBridge(VersionEmbedder versionEmbedder, Schedulable delegate)
             implements Schedulable

--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/TaskEntry.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/TaskEntry.java
@@ -25,14 +25,19 @@ import io.trino.execution.executor.scheduler.Group;
 import io.trino.execution.executor.scheduler.Schedulable;
 import io.trino.execution.executor.scheduler.SchedulerContext;
 import io.trino.spi.VersionEmbedder;
+import jakarta.annotation.Nullable;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.Queue;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.function.DoubleSupplier;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Objects.requireNonNull;
 
@@ -53,13 +58,13 @@ class TaskEntry
     private volatile boolean destroyed;
 
     @GuardedBy("this")
-    private int runningLeafSplits;
-
-    @GuardedBy("this")
-    private final Queue<QueuedSplit> pending = new LinkedList<>();
+    private final Deque<QueuedSplit> pending = new ArrayDeque<>();
 
     @GuardedBy("this")
     private final Set<SplitRunner> running = new HashSet<>();
+
+    @GuardedBy("this")
+    private final Set<QueuedSplit> runningLeafSplits = new HashSet<>();
 
     public TaskEntry(TaskId taskId, FairScheduler scheduler, VersionEmbedder versionEmbedder, Tracer tracer, int initialConcurrency, DoubleSupplier utilization)
     {
@@ -78,79 +83,197 @@ class TaskEntry
         return taskId;
     }
 
-    public synchronized void destroy()
+    public void destroy()
     {
-        if (destroyed) {
-            return;
+        List<SplitRunner> runningSplits;
+        List<QueuedSplit> pendingSplits;
+        List<QueuedSplit> claimedSplits;
+        synchronized (this) {
+            if (destroyed) {
+                return;
+            }
+
+            destroyed = true;
+            runningSplits = new ArrayList<>(running);
+            pendingSplits = new ArrayList<>(pending);
+            claimedSplits = new ArrayList<>(runningLeafSplits);
+            running.clear();
+            pending.clear();
+            runningLeafSplits.clear();
         }
 
-        scheduler.removeGroup(group);
+        // Complete futures before closing. Driver.close() can rethrow operator close failures, and
+        // no such failure may strand another split or prevent its task from finishing.
+        pendingSplits.forEach(split -> split.done().set(null));
+        claimedSplits.forEach(split -> split.done().set(null));
 
-        destroyed = true;
-
-        for (SplitRunner split : running) {
-            split.close();
+        Throwable failure = null;
+        try {
+            scheduler.removeGroup(group);
         }
-        running.clear();
-
-        for (QueuedSplit split : pending) {
-            split.split().close();
-            split.done.set(null);
+        catch (Throwable t) {
+            failure = t;
         }
-        pending.clear();
+
+        for (SplitRunner split : runningSplits) {
+            failure = closeSplit(split, failure);
+        }
+        for (QueuedSplit split : pendingSplits) {
+            failure = closeSplit(split.split(), failure);
+        }
+
+        if (failure != null) {
+            throwIfUnchecked(failure);
+            throw new RuntimeException(failure);
+        }
     }
 
-    public synchronized ListenableFuture<Void> enqueueLeafSplit(SplitRunner split)
+    public ListenableFuture<Void> enqueueLeafSplit(SplitRunner split)
     {
         SettableFuture<Void> done = SettableFuture.create();
-        pending.add(new QueuedSplit(split, done));
+        synchronized (this) {
+            if (!destroyed) {
+                pending.addLast(new QueuedSplit(split, done));
+                return done;
+            }
+        }
+
+        // The task was removed concurrently with enqueueSplits. There is nobody left to claim the
+        // split, so finish it immediately rather than leaving its future in a destroyed queue.
+        done.set(null);
+        split.close();
         return done;
     }
 
-    /**
-     * @return true if a split was scheduled; false if no splits are pending
-     */
-    public synchronized boolean dequeueAndRunLeafSplit(Runnable doneCallback)
+    /// Claim the next pending leaf split and account for it as running. The claimed split must be
+    /// handed to [#startLeafSplit] to actually run; the two steps are separate so the caller can
+    /// start the split without holding any lock.
+    ///
+    /// The task can be destroyed between claiming and starting. A production `SplitRunner`
+    /// tolerates being started after close, and the scheduler rejects work for the removed group.
+    ///
+    /// @return null if no splits are pending or the task has been destroyed
+    @Nullable
+    public synchronized QueuedSplit claimLeafSplit()
     {
-        QueuedSplit split = pending.poll();
-        if (split == null) {
-            return false;
+        if (destroyed) {
+            return null;
         }
 
-        runSplit(split.split())
-                .addListener(() -> {
-                    leafSplitDone(split);
-                    doneCallback.run();
-                }, directExecutor());
+        QueuedSplit split = pending.poll();
+        if (split == null) {
+            return null;
+        }
 
-        runningLeafSplits++;
+        runningLeafSplits.add(split);
+        running.add(split.split());
 
-        return true;
+        return split;
     }
 
-    private synchronized void leafSplitDone(QueuedSplit split)
+    /// Start a split claimed via [#claimLeafSplit()]. Must be called without holding a lock.
+    /// If this throws, the claim was not consumed and must be requeued via [#releaseLeafSplit].
+    public void startLeafSplit(QueuedSplit split, Consumer<TaskEntry> doneCallback)
     {
-        runningLeafSplits--;
-        split.done().set(null);
+        submit(split.split())
+                .addListener(() -> {
+                    finishLeafSplit(split, doneCallback);
+                }, directExecutor());
     }
 
-    public synchronized ListenableFuture<Void> runSplit(SplitRunner split)
+    /// Requeue a claimed split that could not be started. Thread creation can fail temporarily on
+    /// an overloaded worker, and the periodic scheduling pass will retry it after capacity clears.
+    public void releaseLeafSplit(QueuedSplit split)
+    {
+        boolean destroyed;
+        synchronized (this) {
+            runningLeafSplits.remove(split);
+            running.remove(split.split());
+            destroyed = this.destroyed;
+            if (!destroyed) {
+                pending.addFirst(split);
+            }
+        }
+
+        if (destroyed) {
+            split.done().set(null);
+        }
+    }
+
+    private void finishLeafSplit(QueuedSplit split, Consumer<TaskEntry> doneCallback)
+    {
+        boolean close;
+        synchronized (this) {
+            runningLeafSplits.remove(split);
+            close = running.remove(split.split());
+        }
+
+        // Complete the future and notify the executor even when Driver.close() fails.
+        split.done().set(null);
+        try {
+            if (close) {
+                split.split().close();
+            }
+        }
+        finally {
+            doneCallback.accept(this);
+        }
+    }
+
+    public ListenableFuture<Void> runSplit(SplitRunner split)
+    {
+        boolean destroyed;
+        synchronized (this) {
+            destroyed = this.destroyed;
+            if (!destroyed) {
+                running.add(split);
+            }
+        }
+
+        if (destroyed) {
+            SettableFuture<Void> done = SettableFuture.create();
+            done.set(null);
+            split.close();
+            return done;
+        }
+
+        try {
+            ListenableFuture<Void> done = submit(split);
+            done.addListener(() -> splitDone(split), directExecutor());
+            return done;
+        }
+        catch (Throwable t) {
+            try {
+                splitDone(split);
+            }
+            catch (Throwable closeFailure) {
+                t.addSuppressed(closeFailure);
+            }
+            throw t;
+        }
+    }
+
+    /// Hand a split that is already accounted for in `running` to the scheduler. Must be called
+    /// without holding a lock: the scheduler creates the thread that runs the split, which on a
+    /// loaded worker is slow enough to stall every other operation on the lock.
+    private ListenableFuture<Void> submit(SplitRunner split)
     {
         int splitId = nextSplitId();
-        ListenableFuture<Void> done = scheduler.submit(
+        return scheduler.submit(
                 group,
                 splitId,
                 new VersionEmbedderBridge(versionEmbedder, new SplitProcessor(taskId, splitId, split, tracer)));
-        done.addListener(() -> splitDone(split), directExecutor());
-        running.add(split);
-
-        return done;
     }
 
-    private synchronized void splitDone(SplitRunner split)
+    private void splitDone(SplitRunner split)
     {
-        split.close();
-        running.remove(split);
+        boolean close;
+        synchronized (this) {
+            close = running.remove(split);
+        }
+        if (close) {
+            split.close();
+        }
     }
 
     private int nextSplitId()
@@ -160,7 +283,7 @@ class TaskEntry
 
     public synchronized int runningLeafSplits()
     {
-        return runningLeafSplits;
+        return runningLeafSplits.size();
     }
 
     @Override
@@ -171,7 +294,7 @@ class TaskEntry
 
     public synchronized void updateConcurrency()
     {
-        concurrency.update(utilization.getAsDouble(), runningLeafSplits);
+        concurrency.update(utilization.getAsDouble(), runningLeafSplits.size());
     }
 
     public synchronized int pendingLeafSplitCount()
@@ -194,7 +317,21 @@ class TaskEntry
         return concurrency.targetConcurrency();
     }
 
-    private record QueuedSplit(SplitRunner split, SettableFuture<Void> done) {}
+    record QueuedSplit(SplitRunner split, SettableFuture<Void> done) {}
+
+    private static Throwable closeSplit(SplitRunner split, @Nullable Throwable failure)
+    {
+        try {
+            split.close();
+        }
+        catch (Throwable t) {
+            if (failure == null) {
+                return t;
+            }
+            failure.addSuppressed(t);
+        }
+        return failure;
+    }
 
     private record VersionEmbedderBridge(VersionEmbedder versionEmbedder, Schedulable delegate)
             implements Schedulable

--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
@@ -15,6 +15,7 @@ package io.trino.execution.executor.dedicated;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ticker;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.ThreadSafe;
@@ -30,6 +31,7 @@ import io.trino.execution.TaskManagerConfig;
 import io.trino.execution.executor.RunningSplitInfo;
 import io.trino.execution.executor.TaskExecutor;
 import io.trino.execution.executor.TaskHandle;
+import io.trino.execution.executor.dedicated.TaskEntry.QueuedSplit;
 import io.trino.execution.executor.scheduler.FairScheduler;
 import io.trino.spi.VersionEmbedder;
 import jakarta.annotation.PostConstruct;
@@ -73,8 +75,7 @@ public class ThreadPerDriverTaskExecutor
     @GuardedBy("this")
     private final Map<TaskId, TaskEntry> tasks = new HashMap<>();
 
-    @GuardedBy("this")
-    private boolean closed;
+    private volatile boolean closed;
 
     @GuardedBy("this")
     private int runningLeafDrivers;
@@ -157,13 +158,13 @@ public class ThreadPerDriverTaskExecutor
     }
 
     @Override
-    public synchronized List<ListenableFuture<Void>> enqueueSplits(TaskHandle handle, boolean intermediate, List<? extends SplitRunner> splits)
+    public List<ListenableFuture<Void>> enqueueSplits(TaskHandle handle, boolean intermediate, List<? extends SplitRunner> splits)
     {
         checkArgument(!closed, "Executor is already closed");
 
         TaskEntry entry = (TaskEntry) handle;
 
-        List<ListenableFuture<Void>> futures = new ArrayList<>();
+        List<ListenableFuture<Void>> futures = new ArrayList<>(splits.size());
         for (SplitRunner split : splits) {
             if (intermediate) {
                 futures.add(entry.runSplit(split));
@@ -177,47 +178,94 @@ public class ThreadPerDriverTaskExecutor
         return futures;
     }
 
-    private boolean scheduleLeafSplit(TaskEntry task)
+    private void leafSplitDone()
     {
-        boolean scheduled = task.dequeueAndRunLeafSplit(leafSplitDoneCallback);
-        if (scheduled) {
-            runningLeafDrivers++;
+        synchronized (this) {
+            runningLeafDrivers--;
         }
-
-        return scheduled;
-    }
-
-    private synchronized void leafSplitDone()
-    {
-        runningLeafDrivers--;
         scheduleMoreLeafSplits();
     }
 
-    private synchronized void scheduleMoreLeafSplits()
+    private void scheduleMoreLeafSplits()
     {
-        // schedule minimum guaranteed leaf drivers for each task
+        // Start the splits outside the lock. The scheduler creates a thread per split, which on a
+        // loaded worker takes long enough that holding the lock across it stalls task registration,
+        // task removal and split completion for every task on the worker.
+        List<ClaimedLeafSplit> claimed = claimMoreLeafSplits();
+        for (int i = 0; i < claimed.size(); i++) {
+            ClaimedLeafSplit split = claimed.get(i);
+            try {
+                split.task().startLeafSplit(split.split(), leafSplitDoneCallback);
+            }
+            catch (Throwable e) {
+                // A claim is only given back by the listener that starting the split installs, so
+                // give back this claim and the ones behind it that never got one.
+                releaseClaims(claimed.subList(i, claimed.size()), e);
+                throw e;
+            }
+        }
+    }
+
+    private void releaseClaims(List<ClaimedLeafSplit> claimed, Throwable cause)
+    {
+        synchronized (this) {
+            runningLeafDrivers -= claimed.size();
+        }
+
+        for (ClaimedLeafSplit split : claimed) {
+            split.task().releaseLeafSplit(split.split(), cause);
+        }
+    }
+
+    private synchronized List<ClaimedLeafSplit> claimMoreLeafSplits()
+    {
+        if (closed) {
+            return ImmutableList.of();
+        }
+
+        List<ClaimedLeafSplit> claimed = new ArrayList<>();
+
+        // claim minimum guaranteed leaf drivers for each task
         for (TaskEntry task : tasks.values()) {
             int target = max(0, minDriversPerTask - task.runningLeafSplits());
             for (int i = 0; i < target; i++) {
-                if (!scheduleLeafSplit(task)) {
+                if (!claimLeafSplit(task, claimed)) {
                     break;
                 }
             }
         }
 
-        // schedule additional drivers up to the target global leaf drivers
+        // claim additional drivers up to the target global leaf drivers
         Queue<TaskEntry> queue = new ArrayDeque<>(tasks.values());
         int target = targetGlobalLeafDrivers - runningLeafDrivers;
         for (int i = 0; i < target && !queue.isEmpty(); i++) {
             TaskEntry task = queue.poll();
             if (task.runningLeafSplits() < min(task.targetConcurrency(), maxDriversPerTask)) {
-                scheduleLeafSplit(task);
+                claimLeafSplit(task, claimed);
                 if (task.hasPendingLeafSplits()) {
                     queue.add(task);
                 }
             }
         }
+
+        return claimed;
     }
+
+    @GuardedBy("this")
+    private boolean claimLeafSplit(TaskEntry task, List<ClaimedLeafSplit> claimed)
+    {
+        QueuedSplit split = task.claimLeafSplit();
+        if (split == null) {
+            return false;
+        }
+
+        runningLeafDrivers++;
+        claimed.add(new ClaimedLeafSplit(task, split));
+
+        return true;
+    }
+
+    private record ClaimedLeafSplit(TaskEntry task, QueuedSplit split) {}
 
     private void adjustConcurrency()
     {

--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
@@ -269,9 +269,14 @@ public class ThreadPerDriverTaskExecutor
 
     private void adjustConcurrency()
     {
-        for (TaskEntry task : tasks.values()) {
+        for (TaskEntry task : activeTasks()) {
             task.updateConcurrency();
         }
+    }
+
+    private synchronized List<TaskEntry> activeTasks()
+    {
+        return ImmutableList.copyOf(tasks.values());
     }
 
     private void logDiagnostics()
@@ -282,7 +287,7 @@ public class ThreadPerDriverTaskExecutor
             builder.append(scheduler.diagnostics().indent(4));
 
             builder.append("Query tasks:\n");
-            for (TaskEntry task : tasks.values()) {
+            for (TaskEntry task : activeTasks()) {
                 builder.append("%s: [total running = %s, leaf running = %s, leaf pending = %s, target concurrency = %s]\n".formatted(
                         task.taskId(),
                         task.totalRunningSplits(),

--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
@@ -82,6 +82,7 @@ public class ThreadPerDriverTaskExecutor
 
     // Do not inline this field to avoid creating lambdas that cannot be cached by JVM.
     private final Runnable leafSplitDoneCallback = this::leafSplitDone;
+    private final Runnable scheduleMoreLeafSplitsQuietly = maintenance(this::scheduleMoreLeafSplits, "Error scheduling leaf splits");
 
     @Inject
     public ThreadPerDriverTaskExecutor(TaskManagerConfig config, Tracer tracer, VersionEmbedder versionEmbedder)
@@ -110,9 +111,9 @@ public class ThreadPerDriverTaskExecutor
     public synchronized void start()
     {
         scheduler.start();
-        backgroundTasks.scheduleWithFixedDelay(this::scheduleMoreLeafSplits, 0, 100, TimeUnit.MILLISECONDS);
-        backgroundTasks.scheduleWithFixedDelay(this::adjustConcurrency, 0, 10, TimeUnit.MILLISECONDS);
-        backgroundTasks.scheduleWithFixedDelay(this::logDiagnostics, 0, 30, TimeUnit.SECONDS);
+        backgroundTasks.scheduleWithFixedDelay(scheduleMoreLeafSplitsQuietly, 0, 100, TimeUnit.MILLISECONDS);
+        backgroundTasks.scheduleWithFixedDelay(maintenance(this::adjustConcurrency, "Error adjusting task concurrency"), 0, 10, TimeUnit.MILLISECONDS);
+        backgroundTasks.scheduleWithFixedDelay(maintenance(this::logDiagnostics, "Error logging diagnostics"), 0, 30, TimeUnit.SECONDS);
     }
 
     @PreDestroy
@@ -178,12 +179,15 @@ public class ThreadPerDriverTaskExecutor
         return futures;
     }
 
-    private void leafSplitDone()
+    @VisibleForTesting
+    void leafSplitDone()
     {
         synchronized (this) {
             runningLeafDrivers--;
         }
-        scheduleMoreLeafSplits();
+        // Must be the wrapped form: this runs on the thread of a split that just finished, which
+        // is in no position to handle another task's split failing to start.
+        scheduleMoreLeafSplitsQuietly.run();
     }
 
     private void scheduleMoreLeafSplits()
@@ -266,6 +270,24 @@ public class ThreadPerDriverTaskExecutor
     }
 
     private record ClaimedLeafSplit(TaskEntry task, QueuedSplit split) {}
+
+    /// Wrap a task so that a failure does not take its caller down with it.
+    /// [ScheduledThreadPoolExecutor#scheduleWithFixedDelay] silently stops rescheduling a task
+    /// that throws, which would leave the worker permanently without leaf split scheduling or
+    /// concurrency adjustment. Failures here are typically symptoms of an overloaded worker,
+    /// such as being unable to create a thread, and it is expected to recover once load subsides.
+    @VisibleForTesting
+    static Runnable maintenance(Runnable task, String errorMessage)
+    {
+        return () -> {
+            try {
+                task.run();
+            }
+            catch (Throwable e) {
+                LOG.warn(e, "%s", errorMessage);
+            }
+        };
+    }
 
     private void adjustConcurrency()
     {

--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
@@ -39,14 +39,12 @@ import jakarta.annotation.PreDestroy;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
-import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -74,8 +72,7 @@ public class ThreadPerDriverTaskExecutor
     private final int maxDriversPerTask;
     private final ScheduledThreadPoolExecutor backgroundTasks = new ScheduledThreadPoolExecutor(2, daemonThreadsNamed("task-executor-scheduler-%s"));
 
-    @GuardedBy("this")
-    private final Map<TaskId, TaskEntry> tasks = new HashMap<>();
+    private final Map<TaskId, TaskEntry> tasks = new ConcurrentHashMap<>();
 
     private volatile boolean closed;
 
@@ -173,12 +170,8 @@ public class ThreadPerDriverTaskExecutor
     public void removeTask(TaskHandle handle)
     {
         TaskEntry entry = (TaskEntry) handle;
-        synchronized (this) {
-            tasks.remove(entry.taskId());
-        }
-        if (!entry.isDestroyed()) {
-            entry.destroy();
-        }
+        tasks.remove(entry.taskId(), entry);
+        entry.destroy();
     }
 
     @Override
@@ -263,15 +256,19 @@ public class ThreadPerDriverTaskExecutor
             }
         }
 
-        // claim additional drivers up to the target global leaf drivers
-        Queue<TaskEntry> queue = new ArrayDeque<>(tasks.values());
+        // Claim additional drivers up to the target global leaf drivers. Iterate in rounds to
+        // retain the previous round-robin behavior without copying the task map into a queue.
         int target = targetGlobalLeafDrivers - runningLeafDrivers;
-        for (int i = 0; i < target && !queue.isEmpty(); i++) {
-            TaskEntry task = queue.poll();
-            if (task.runningLeafSplits() < min(task.targetConcurrency(), maxDriversPerTask)) {
-                claimLeafSplit(task, claimed);
-                if (task.hasPendingLeafSplits()) {
-                    queue.add(task);
+        boolean progress = true;
+        while (target > 0 && progress) {
+            progress = false;
+            for (TaskEntry task : tasks.values()) {
+                if (target == 0) {
+                    break;
+                }
+                if (task.runningLeafSplits() < min(task.targetConcurrency(), maxDriversPerTask) && claimLeafSplit(task, claimed)) {
+                    target--;
+                    progress = true;
                 }
             }
         }
@@ -340,13 +337,13 @@ public class ThreadPerDriverTaskExecutor
     }
 
     @Managed
-    public synchronized int getTasks()
+    public int getTasks()
     {
         return tasks.size();
     }
 
     @Managed
-    public synchronized int getTotalRunningSplits()
+    public int getTotalRunningSplits()
     {
         return tasks.values().stream()
                 .mapToInt(TaskEntry::totalRunningSplits)
@@ -354,7 +351,7 @@ public class ThreadPerDriverTaskExecutor
     }
 
     @Managed
-    public synchronized int getTotalRunningLeafSplits()
+    public int getTotalRunningLeafSplits()
     {
         return tasks.values().stream()
                 .mapToInt(TaskEntry::runningLeafSplits)
@@ -362,7 +359,7 @@ public class ThreadPerDriverTaskExecutor
     }
 
     @Managed
-    public synchronized int getTotalPendingLeafSplits()
+    public int getTotalPendingLeafSplits()
     {
         return tasks.values().stream()
                 .mapToInt(TaskEntry::pendingLeafSplitCount)

--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
@@ -15,6 +15,7 @@ package io.trino.execution.executor.dedicated;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ticker;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.ThreadSafe;
@@ -30,6 +31,7 @@ import io.trino.execution.TaskManagerConfig;
 import io.trino.execution.executor.RunningSplitInfo;
 import io.trino.execution.executor.TaskExecutor;
 import io.trino.execution.executor.TaskHandle;
+import io.trino.execution.executor.dedicated.TaskEntry.QueuedSplit;
 import io.trino.execution.executor.scheduler.FairScheduler;
 import io.trino.spi.VersionEmbedder;
 import jakarta.annotation.PostConstruct;
@@ -47,10 +49,12 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.DoubleSupplier;
 import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -73,14 +77,13 @@ public class ThreadPerDriverTaskExecutor
     @GuardedBy("this")
     private final Map<TaskId, TaskEntry> tasks = new HashMap<>();
 
-    @GuardedBy("this")
-    private boolean closed;
+    private volatile boolean closed;
 
     @GuardedBy("this")
     private int runningLeafDrivers;
 
     // Do not inline this field to avoid creating lambdas that cannot be cached by JVM.
-    private final Runnable leafSplitDoneCallback = this::leafSplitDone;
+    private final Consumer<TaskEntry> leafSplitDoneCallback = _ -> leafSplitDone();
 
     @Inject
     public ThreadPerDriverTaskExecutor(TaskManagerConfig config, Tracer tracer, VersionEmbedder versionEmbedder)
@@ -118,10 +121,32 @@ public class ThreadPerDriverTaskExecutor
     @Override
     public synchronized void stop()
     {
+        if (closed) {
+            return;
+        }
         closed = true;
-        tasks.values().forEach(TaskEntry::destroy);
+
+        Throwable failure = null;
+        for (TaskEntry task : tasks.values()) {
+            try {
+                task.destroy();
+            }
+            catch (Throwable t) {
+                failure = addFailure(failure, t);
+            }
+        }
         backgroundTasks.shutdownNow();
-        scheduler.close();
+        try {
+            scheduler.close();
+        }
+        catch (Throwable t) {
+            failure = addFailure(failure, t);
+        }
+
+        if (failure != null) {
+            throwIfUnchecked(failure);
+            throw new RuntimeException(failure);
+        }
     }
 
     @Override
@@ -157,13 +182,13 @@ public class ThreadPerDriverTaskExecutor
     }
 
     @Override
-    public synchronized List<ListenableFuture<Void>> enqueueSplits(TaskHandle handle, boolean intermediate, List<? extends SplitRunner> splits)
+    public List<ListenableFuture<Void>> enqueueSplits(TaskHandle handle, boolean intermediate, List<? extends SplitRunner> splits)
     {
         checkArgument(!closed, "Executor is already closed");
 
         TaskEntry entry = (TaskEntry) handle;
 
-        List<ListenableFuture<Void>> futures = new ArrayList<>();
+        List<ListenableFuture<Void>> futures = new ArrayList<>(splits.size());
         for (SplitRunner split : splits) {
             if (intermediate) {
                 futures.add(entry.runSplit(split));
@@ -177,46 +202,106 @@ public class ThreadPerDriverTaskExecutor
         return futures;
     }
 
-    private boolean scheduleLeafSplit(TaskEntry task)
+    private void leafSplitDone()
     {
-        boolean scheduled = task.dequeueAndRunLeafSplit(leafSplitDoneCallback);
-        if (scheduled) {
-            runningLeafDrivers++;
+        synchronized (this) {
+            runningLeafDrivers--;
         }
-
-        return scheduled;
-    }
-
-    private synchronized void leafSplitDone()
-    {
-        runningLeafDrivers--;
         scheduleMoreLeafSplits();
     }
 
-    private synchronized void scheduleMoreLeafSplits()
+    @VisibleForTesting
+    void scheduleMoreLeafSplits()
     {
-        // schedule minimum guaranteed leaf drivers for each task
+        // Start the splits outside the lock. The scheduler creates a thread per split, which on a
+        // loaded worker takes long enough that holding the lock across it stalls task registration,
+        // task removal and split completion for every task on the worker.
+        List<ClaimedLeafSplit> claimed = claimMoreLeafSplits();
+        for (int i = 0; i < claimed.size(); i++) {
+            ClaimedLeafSplit split = claimed.get(i);
+            try {
+                split.task().startLeafSplit(split.split(), leafSplitDoneCallback);
+            }
+            catch (Throwable e) {
+                // Claims before this one have listeners and remain running. Requeue this claim and
+                // every unstarted claim behind it; the periodic pass retries them later.
+                releaseClaims(claimed.subList(i, claimed.size()));
+                LOG.warn(e, "Error scheduling leaf splits");
+                return;
+            }
+        }
+    }
+
+    private void releaseClaims(List<ClaimedLeafSplit> claimed)
+    {
+        synchronized (this) {
+            runningLeafDrivers -= claimed.size();
+        }
+
+        // Each task requeues at the head, so release in reverse to preserve claim order.
+        for (int i = claimed.size() - 1; i >= 0; i--) {
+            ClaimedLeafSplit split = claimed.get(i);
+            split.task().releaseLeafSplit(split.split());
+        }
+    }
+
+    private synchronized List<ClaimedLeafSplit> claimMoreLeafSplits()
+    {
+        if (closed) {
+            return ImmutableList.of();
+        }
+
+        List<ClaimedLeafSplit> claimed = new ArrayList<>();
+
+        // claim minimum guaranteed leaf drivers for each task
         for (TaskEntry task : tasks.values()) {
             int target = max(0, minDriversPerTask - task.runningLeafSplits());
             for (int i = 0; i < target; i++) {
-                if (!scheduleLeafSplit(task)) {
+                if (!claimLeafSplit(task, claimed)) {
                     break;
                 }
             }
         }
 
-        // schedule additional drivers up to the target global leaf drivers
+        // claim additional drivers up to the target global leaf drivers
         Queue<TaskEntry> queue = new ArrayDeque<>(tasks.values());
         int target = targetGlobalLeafDrivers - runningLeafDrivers;
         for (int i = 0; i < target && !queue.isEmpty(); i++) {
             TaskEntry task = queue.poll();
             if (task.runningLeafSplits() < min(task.targetConcurrency(), maxDriversPerTask)) {
-                scheduleLeafSplit(task);
+                claimLeafSplit(task, claimed);
                 if (task.hasPendingLeafSplits()) {
                     queue.add(task);
                 }
             }
         }
+
+        return claimed;
+    }
+
+    @GuardedBy("this")
+    private boolean claimLeafSplit(TaskEntry task, List<ClaimedLeafSplit> claimed)
+    {
+        QueuedSplit split = task.claimLeafSplit();
+        if (split == null) {
+            return false;
+        }
+
+        runningLeafDrivers++;
+        claimed.add(new ClaimedLeafSplit(task, split));
+
+        return true;
+    }
+
+    private record ClaimedLeafSplit(TaskEntry task, QueuedSplit split) {}
+
+    private static Throwable addFailure(Throwable failure, Throwable newFailure)
+    {
+        if (failure == null) {
+            return newFailure;
+        }
+        failure.addSuppressed(newFailure);
+        return failure;
     }
 
     private void adjustConcurrency()

--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
@@ -34,6 +34,7 @@ import io.trino.execution.executor.TaskHandle;
 import io.trino.execution.executor.dedicated.TaskEntry.QueuedSplit;
 import io.trino.execution.executor.scheduler.FairScheduler;
 import io.trino.spi.VersionEmbedder;
+import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import org.weakref.jmx.Managed;
@@ -47,6 +48,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.DoubleSupplier;
 import java.util.function.Predicate;
@@ -63,6 +66,7 @@ public class ThreadPerDriverTaskExecutor
         implements TaskExecutor
 {
     private static final Logger LOG = Logger.get(ThreadPerDriverTaskExecutor.class);
+    private static final long FAILURE_LOG_INTERVAL_NANOS = TimeUnit.MINUTES.toNanos(1);
 
     private final FairScheduler scheduler;
     private final Tracer tracer;
@@ -79,8 +83,13 @@ public class ThreadPerDriverTaskExecutor
     @GuardedBy("this")
     private int runningLeafDrivers;
 
+    private final AtomicBoolean schedulingLeafSplits = new AtomicBoolean();
+    private final AtomicBoolean rescheduleLeafSplits = new AtomicBoolean();
+
     // Do not inline this field to avoid creating lambdas that cannot be cached by JVM.
-    private final Consumer<TaskEntry> leafSplitDoneCallback = _ -> leafSplitDone();
+    private final Consumer<TaskEntry> leafSplitDoneCallback = this::leafSplitDone;
+    private final FailureLogger schedulingFailureLogger = new FailureLogger("Error scheduling leaf splits");
+    private final Runnable scheduleMoreLeafSplitsQuietly = maintenance(this::scheduleMoreLeafSplits, schedulingFailureLogger);
 
     @Inject
     public ThreadPerDriverTaskExecutor(TaskManagerConfig config, Tracer tracer, VersionEmbedder versionEmbedder)
@@ -109,9 +118,9 @@ public class ThreadPerDriverTaskExecutor
     public synchronized void start()
     {
         scheduler.start();
-        backgroundTasks.scheduleWithFixedDelay(this::scheduleMoreLeafSplits, 0, 100, TimeUnit.MILLISECONDS);
-        backgroundTasks.scheduleWithFixedDelay(this::adjustConcurrency, 0, 10, TimeUnit.MILLISECONDS);
-        backgroundTasks.scheduleWithFixedDelay(this::logDiagnostics, 0, 30, TimeUnit.SECONDS);
+        backgroundTasks.scheduleWithFixedDelay(scheduleMoreLeafSplitsQuietly, 0, 100, TimeUnit.MILLISECONDS);
+        backgroundTasks.scheduleWithFixedDelay(maintenance(this::adjustConcurrency, "Error adjusting task concurrency"), 0, 10, TimeUnit.MILLISECONDS);
+        backgroundTasks.scheduleWithFixedDelay(maintenance(this::logDiagnostics, "Error logging diagnostics"), 0, 30, TimeUnit.SECONDS);
     }
 
     @PreDestroy
@@ -191,25 +200,83 @@ public class ThreadPerDriverTaskExecutor
             }
         }
 
-        scheduleMoreLeafSplits();
+        scheduleMoreLeafSplitsQuietly.run();
         return futures;
     }
 
-    private void leafSplitDone()
+    private void leafSplitDone(TaskEntry task)
     {
+        ClaimedLeafSplit replacement;
         synchronized (this) {
             runningLeafDrivers--;
+            replacement = claimLeafSplitForTask(task);
         }
-        scheduleMoreLeafSplits();
+
+        if (replacement != null) {
+            startClaimedSplits(ImmutableList.of(replacement));
+            return;
+        }
+
+        // When the task drains, let another task use the freed slot immediately. This runs the
+        // global pass once per task drain instead of once per split completion.
+        if (!task.hasPendingLeafSplits()) {
+            scheduleMoreLeafSplitsQuietly.run();
+        }
+    }
+
+    @GuardedBy("this")
+    @Nullable
+    private ClaimedLeafSplit claimLeafSplitForTask(TaskEntry task)
+    {
+        if (closed) {
+            return null;
+        }
+
+        int taskRunning = task.runningLeafSplits();
+        if (taskRunning >= minDriversPerTask &&
+                (runningLeafDrivers >= targetGlobalLeafDrivers || taskRunning >= min(task.targetConcurrency(), maxDriversPerTask))) {
+            return null;
+        }
+
+        List<ClaimedLeafSplit> claimed = new ArrayList<>(1);
+        if (!claimLeafSplit(task, claimed)) {
+            return null;
+        }
+        return claimed.getFirst();
     }
 
     @VisibleForTesting
     void scheduleMoreLeafSplits()
     {
-        // Start the splits outside the lock. The scheduler creates a thread per split, which on a
-        // loaded worker takes long enough that holding the lock across it stalls task registration,
-        // task removal and split completion for every task on the worker.
-        List<ClaimedLeafSplit> claimed = claimMoreLeafSplits();
+        rescheduleLeafSplits.set(true);
+        boolean retry = true;
+        while (true) {
+            if (!schedulingLeafSplits.compareAndSet(false, true)) {
+                return;
+            }
+
+            try {
+                do {
+                    rescheduleLeafSplits.set(false);
+                    retry = startClaimedSplits(claimMoreLeafSplits());
+                }
+                while (retry && rescheduleLeafSplits.get());
+            }
+            finally {
+                schedulingLeafSplits.set(false);
+            }
+
+            // Close the race where another caller requested a pass after the last flag check but
+            // before the gate was released.
+            if (!retry || !rescheduleLeafSplits.get()) {
+                return;
+            }
+        }
+    }
+
+    private boolean startClaimedSplits(List<ClaimedLeafSplit> claimed)
+    {
+        // Start the splits outside all locks. Thread creation is slow on an overloaded worker.
         for (int i = 0; i < claimed.size(); i++) {
             ClaimedLeafSplit split = claimed.get(i);
             try {
@@ -219,10 +286,11 @@ public class ThreadPerDriverTaskExecutor
                 // Claims before this one have listeners and remain running. Requeue this claim and
                 // every unstarted claim behind it; the periodic pass retries them later.
                 releaseClaims(claimed.subList(i, claimed.size()));
-                LOG.warn(e, "Error scheduling leaf splits");
-                return;
+                schedulingFailureLogger.log(e);
+                return false;
             }
         }
+        return true;
     }
 
     private void releaseClaims(List<ClaimedLeafSplit> claimed)
@@ -292,6 +360,29 @@ public class ThreadPerDriverTaskExecutor
 
     private record ClaimedLeafSplit(TaskEntry task, QueuedSplit split) {}
 
+    /// Wrap a task so that a failure does not take its caller down with it.
+    /// [ScheduledThreadPoolExecutor#scheduleWithFixedDelay] silently stops rescheduling a task
+    /// that throws, which would leave the worker permanently without leaf split scheduling or
+    /// concurrency adjustment. Failures here are typically symptoms of an overloaded worker,
+    /// such as being unable to create a thread, and it is expected to recover once load subsides.
+    @VisibleForTesting
+    static Runnable maintenance(Runnable task, String errorMessage)
+    {
+        return maintenance(task, new FailureLogger(errorMessage));
+    }
+
+    private static Runnable maintenance(Runnable task, FailureLogger failureLogger)
+    {
+        return () -> {
+            try {
+                task.run();
+            }
+            catch (Throwable e) {
+                failureLogger.log(e);
+            }
+        };
+    }
+
     private static Throwable addFailure(Throwable failure, Throwable newFailure)
     {
         if (failure == null) {
@@ -299,6 +390,41 @@ public class ThreadPerDriverTaskExecutor
         }
         failure.addSuppressed(newFailure);
         return failure;
+    }
+
+    private static final class FailureLogger
+    {
+        private final String message;
+        private final AtomicLong lastLogNanos = new AtomicLong(Long.MIN_VALUE);
+        private final AtomicLong suppressedFailures = new AtomicLong();
+
+        private FailureLogger(String message)
+        {
+            this.message = requireNonNull(message, "message is null");
+        }
+
+        public void log(Throwable failure)
+        {
+            long now = System.nanoTime();
+            while (true) {
+                long last = lastLogNanos.get();
+                if (last != Long.MIN_VALUE && now - last < FAILURE_LOG_INTERVAL_NANOS) {
+                    suppressedFailures.incrementAndGet();
+                    return;
+                }
+                if (lastLogNanos.compareAndSet(last, now)) {
+                    break;
+                }
+            }
+
+            long suppressed = suppressedFailures.getAndSet(0);
+            if (suppressed == 0) {
+                LOG.warn(failure, "%s", message);
+            }
+            else {
+                LOG.warn(failure, "%s (%s similar failures suppressed)", message, suppressed);
+            }
+        }
     }
 
     private void adjustConcurrency()

--- a/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/FairScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/FairScheduler.java
@@ -13,12 +13,12 @@
  */
 package io.trino.execution.executor.scheduler;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ticker;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.errorprone.annotations.ThreadSafe;
-import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.airlift.concurrent.ThreadPoolExecutorMBean;
 import io.airlift.log.Logger;
 
@@ -27,8 +27,11 @@ import java.util.StringJoiner;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -65,10 +68,22 @@ public final class FairScheduler
 
     private final Gate paused = new Gate(true);
 
-    @GuardedBy("this")
-    private boolean closed;
+    /// Guards the transition to the closed state. [#close()] takes the write lock, while the
+    /// operations that must not run against a closed scheduler take the read lock. A read lock
+    /// rather than a monitor because [#submit(Group,int,Schedulable)] creates the thread that
+    /// runs the task, which is slow enough on a loaded worker that serializing all submissions
+    /// behind a single lock stalls unrelated work such as registering or removing tasks.
+    private final ReadWriteLock lifecycleLock = new ReentrantReadWriteLock();
+
+    private volatile boolean closed;
 
     public FairScheduler(int maxConcurrentTasks, String threadNameFormat, Ticker ticker)
+    {
+        this(maxConcurrentTasks, daemonThreadsNamed(threadNameFormat), ticker);
+    }
+
+    @VisibleForTesting
+    public FairScheduler(int maxConcurrentTasks, ThreadFactory threadFactory, Ticker ticker)
     {
         this.ticker = requireNonNull(ticker, "ticker is null");
 
@@ -77,7 +92,7 @@ public final class FairScheduler
         schedulerExecutor = Executors.newCachedThreadPool(daemonThreadsNamed("fair-scheduler-%d"));
         schedulerExecutorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) schedulerExecutor);
 
-        executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(), daemonThreadsNamed(threadNameFormat));
+        executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(), threadFactory);
         executorMBean = new ThreadPoolExecutorMBean(executor);
         taskExecutor = MoreExecutors.listeningDecorator(executor);
     }
@@ -110,41 +125,59 @@ public final class FairScheduler
     }
 
     @Override
-    public synchronized void close()
+    public void close()
     {
-        if (closed) {
-            return;
+        lifecycleLock.writeLock().lock();
+        try {
+            if (closed) {
+                return;
+            }
+            closed = true;
+
+            Set<TaskControl> tasks = queue.finishAll();
+
+            for (TaskControl task : tasks) {
+                task.cancel();
+            }
+
+            taskExecutor.shutdownNow();
+            schedulerExecutor.shutdownNow();
         }
-        closed = true;
-
-        Set<TaskControl> tasks = queue.finishAll();
-
-        for (TaskControl task : tasks) {
-            task.cancel();
+        finally {
+            lifecycleLock.writeLock().unlock();
         }
-
-        taskExecutor.shutdownNow();
-        schedulerExecutor.shutdownNow();
     }
 
-    public synchronized Group createGroup(String name)
+    public Group createGroup(String name)
     {
-        checkArgument(!closed, "Already closed");
+        lifecycleLock.readLock().lock();
+        try {
+            checkArgument(!closed, "Already closed");
 
-        Group group = new Group(name);
-        queue.startGroup(group);
+            Group group = new Group(name);
+            queue.startGroup(group);
 
-        return group;
+            return group;
+        }
+        finally {
+            lifecycleLock.readLock().unlock();
+        }
     }
 
-    public synchronized void removeGroup(Group group)
+    public void removeGroup(Group group)
     {
-        checkArgument(!closed, "Already closed");
+        lifecycleLock.readLock().lock();
+        try {
+            checkArgument(!closed, "Already closed");
 
-        Set<TaskControl> tasks = queue.finishGroup(group);
+            Set<TaskControl> tasks = queue.finishGroup(group);
 
-        for (TaskControl task : tasks) {
-            task.cancel();
+            for (TaskControl task : tasks) {
+                task.cancel();
+            }
+        }
+        finally {
+            lifecycleLock.readLock().unlock();
         }
     }
 
@@ -155,13 +188,19 @@ public final class FairScheduler
                 .collect(toImmutableSet());
     }
 
-    public synchronized ListenableFuture<Void> submit(Group group, int id, Schedulable runner)
+    public ListenableFuture<Void> submit(Group group, int id, Schedulable runner)
     {
-        checkArgument(!closed, "Already closed");
+        lifecycleLock.readLock().lock();
+        try {
+            checkArgument(!closed, "Already closed");
 
-        TaskControl task = new TaskControl(group, id, ticker);
+            TaskControl task = new TaskControl(group, id, ticker);
 
-        return taskExecutor.submit(() -> runTask(runner, task), null);
+            return taskExecutor.submit(() -> runTask(runner, task), null);
+        }
+        finally {
+            lifecycleLock.readLock().unlock();
+        }
     }
 
     private void runTask(Schedulable runner, TaskControl task)

--- a/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/FairScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/FairScheduler.java
@@ -13,12 +13,12 @@
  */
 package io.trino.execution.executor.scheduler;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ticker;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.errorprone.annotations.ThreadSafe;
-import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.airlift.concurrent.ThreadPoolExecutorMBean;
 import io.airlift.log.Logger;
 
@@ -27,8 +27,11 @@ import java.util.StringJoiner;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -65,10 +68,20 @@ public final class FairScheduler
 
     private final Gate paused = new Gate(true);
 
-    @GuardedBy("this")
-    private boolean closed;
+    /// Prevents group creation and removal from racing with [#close()]. Submission only needs the
+    /// volatile `closed` check: a task accepted while close is in progress either observes that its
+    /// group was removed, or is rejected by the executor after shutdown.
+    private final ReadWriteLock lifecycleLock = new ReentrantReadWriteLock();
+
+    private volatile boolean closed;
 
     public FairScheduler(int maxConcurrentTasks, String threadNameFormat, Ticker ticker)
+    {
+        this(maxConcurrentTasks, daemonThreadsNamed(threadNameFormat), ticker);
+    }
+
+    @VisibleForTesting
+    public FairScheduler(int maxConcurrentTasks, ThreadFactory threadFactory, Ticker ticker)
     {
         this.ticker = requireNonNull(ticker, "ticker is null");
 
@@ -77,7 +90,7 @@ public final class FairScheduler
         schedulerExecutor = Executors.newCachedThreadPool(daemonThreadsNamed("fair-scheduler-%d"));
         schedulerExecutorMBean = new ThreadPoolExecutorMBean((ThreadPoolExecutor) schedulerExecutor);
 
-        executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(), daemonThreadsNamed(threadNameFormat));
+        executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(), threadFactory);
         executorMBean = new ThreadPoolExecutorMBean(executor);
         taskExecutor = MoreExecutors.listeningDecorator(executor);
     }
@@ -110,41 +123,59 @@ public final class FairScheduler
     }
 
     @Override
-    public synchronized void close()
+    public void close()
     {
-        if (closed) {
-            return;
+        lifecycleLock.writeLock().lock();
+        try {
+            if (closed) {
+                return;
+            }
+            closed = true;
+
+            Set<TaskControl> tasks = queue.finishAll();
+
+            for (TaskControl task : tasks) {
+                task.cancel();
+            }
+
+            taskExecutor.shutdownNow();
+            schedulerExecutor.shutdownNow();
         }
-        closed = true;
-
-        Set<TaskControl> tasks = queue.finishAll();
-
-        for (TaskControl task : tasks) {
-            task.cancel();
+        finally {
+            lifecycleLock.writeLock().unlock();
         }
-
-        taskExecutor.shutdownNow();
-        schedulerExecutor.shutdownNow();
     }
 
-    public synchronized Group createGroup(String name)
+    public Group createGroup(String name)
     {
-        checkArgument(!closed, "Already closed");
+        lifecycleLock.readLock().lock();
+        try {
+            checkArgument(!closed, "Already closed");
 
-        Group group = new Group(name);
-        queue.startGroup(group);
+            Group group = new Group(name);
+            queue.startGroup(group);
 
-        return group;
+            return group;
+        }
+        finally {
+            lifecycleLock.readLock().unlock();
+        }
     }
 
-    public synchronized void removeGroup(Group group)
+    public void removeGroup(Group group)
     {
-        checkArgument(!closed, "Already closed");
+        lifecycleLock.readLock().lock();
+        try {
+            checkArgument(!closed, "Already closed");
 
-        Set<TaskControl> tasks = queue.finishGroup(group);
+            Set<TaskControl> tasks = queue.finishGroup(group);
 
-        for (TaskControl task : tasks) {
-            task.cancel();
+            for (TaskControl task : tasks) {
+                task.cancel();
+            }
+        }
+        finally {
+            lifecycleLock.readLock().unlock();
         }
     }
 
@@ -155,7 +186,7 @@ public final class FairScheduler
                 .collect(toImmutableSet());
     }
 
-    public synchronized ListenableFuture<Void> submit(Group group, int id, Schedulable runner)
+    public ListenableFuture<Void> submit(Group group, int id, Schedulable runner)
     {
         checkArgument(!closed, "Already closed");
 

--- a/core/trino-main/src/test/java/io/trino/execution/executor/dedicated/TestThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/dedicated/TestThreadPerDriverTaskExecutor.java
@@ -13,6 +13,7 @@
  */
 package io.trino.execution.executor.dedicated;
 
+import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.Futures;
@@ -34,17 +35,132 @@ import java.util.OptionalInt;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.Phaser;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
+import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.tracing.Tracing.noopTracer;
 import static io.trino.util.EmbedVersion.testingVersionEmbedder;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestThreadPerDriverTaskExecutor
 {
+    @Test
+    @Timeout(30)
+    public void testSlowSplitStartDoesNotBlockTaskManagement()
+            throws Exception
+    {
+        // A worker under load takes a long time to create a thread. While a split is being started,
+        // tasks must still be able to come and go, otherwise the worker cannot shed the load that
+        // made thread creation slow in the first place.
+        AtomicBoolean stallNextThread = new AtomicBoolean();
+        CountDownLatch threadCreationStarted = new CountDownLatch(1);
+        CountDownLatch releaseThreadCreation = new CountDownLatch(1);
+
+        ThreadFactory threadFactory = runnable -> {
+            if (stallNextThread.compareAndSet(true, false)) {
+                threadCreationStarted.countDown();
+                awaitUninterruptibly(releaseThreadCreation);
+            }
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            return thread;
+        };
+
+        FairScheduler scheduler = new FairScheduler(2, threadFactory, Ticker.systemTicker());
+        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(noopTracer(), testingVersionEmbedder(), scheduler, 1, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        executor.start();
+        ExecutorService submitter = newSingleThreadExecutor(daemonThreadsNamed("submitter"));
+        try {
+            TaskHandle task = executor.addTask(new TaskId(new StageId("query", 1), 1, 1), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            SplitRunner split = new TestingSplitRunner(ImmutableList.of(_ -> Futures.immediateVoidFuture()));
+
+            stallNextThread.set(true);
+            Future<?> stalled = submitter.submit(() -> executor.enqueueSplits(task, true, ImmutableList.of(split)));
+            threadCreationStarted.await();
+
+            // registering and removing a task must not wait for the stalled thread creation
+            TaskId otherTaskId = new TaskId(new StageId("query", 1), 2, 1);
+            TaskHandle other = executor.addTask(otherTaskId, () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            executor.removeTask(other);
+
+            releaseThreadCreation.countDown();
+            stalled.get();
+        }
+        finally {
+            releaseThreadCreation.countDown();
+            submitter.shutdownNow();
+            executor.stop();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void testFailureToStartSplitReleasesItsClaim()
+            throws Exception
+    {
+        // Starting a split creates its thread, which an overloaded worker fails to do with
+        // OutOfMemoryError. The leaf driver accounting has to survive that, otherwise the worker
+        // permanently loses the capacity of every split it failed to start.
+        AtomicBoolean failNextThread = new AtomicBoolean();
+        ThreadFactory threadFactory = runnable -> {
+            if (failNextThread.compareAndSet(true, false)) {
+                throw new OutOfMemoryError("unable to create native thread");
+            }
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            return thread;
+        };
+
+        FairScheduler scheduler = new FairScheduler(2, threadFactory, Ticker.systemTicker());
+        // no minimum guarantee and a global budget of one leaf driver, so that a leaked claim is
+        // observable: it would leave targetGlobalLeafDrivers - runningLeafDrivers at zero and no
+        // later split could be scheduled
+        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(noopTracer(), testingVersionEmbedder(), scheduler, 0, Integer.MAX_VALUE, 1);
+        // start the scheduler but not the executor's background tasks, so that splits are only
+        // scheduled by the explicit enqueueSplits calls below
+        scheduler.start();
+        try {
+            TaskId taskId = new TaskId(new StageId("query", 1), 1, 1);
+            TaskEntry task = (TaskEntry) executor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+
+            // queue the split without scheduling it, so that the failing start happens in a later
+            // call and the caller is holding the split's future when it does
+            ListenableFuture<Void> done = task.enqueueLeafSplit(new TestingSplitRunner(ImmutableList.of(_ -> Futures.immediateVoidFuture())));
+
+            failNextThread.set(true);
+            assertThatThrownBy(() -> executor.enqueueSplits(task, false, ImmutableList.of()))
+                    .isInstanceOf(OutOfMemoryError.class);
+
+            // the task must be failed rather than left waiting on a split that never ran
+            assertThatThrownBy(done::get)
+                    .isInstanceOf(ExecutionException.class)
+                    .cause()
+                    .isInstanceOf(OutOfMemoryError.class);
+
+            assertThat(executor.getTotalRunningLeafSplits()).isEqualTo(0);
+            assertThat(executor.getTotalRunningSplits()).isEqualTo(0);
+
+            // a leaked claim would permanently consume the global leaf driver budget, leaving no
+            // capacity to schedule this one
+            SplitRunner next = new TestingSplitRunner(ImmutableList.of(_ -> Futures.immediateVoidFuture()));
+            executor.enqueueSplits(task, false, ImmutableList.of(next)).get(0).get();
+            assertThat(next.isFinished()).isTrue();
+        }
+        finally {
+            executor.stop();
+        }
+    }
+
     @Test
     @Timeout(10)
     public void testCancellationWhileProcessing()

--- a/core/trino-main/src/test/java/io/trino/execution/executor/dedicated/TestThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/dedicated/TestThreadPerDriverTaskExecutor.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Phaser;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
@@ -50,6 +51,7 @@ import static io.trino.util.EmbedVersion.testingVersionEmbedder;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestThreadPerDriverTaskExecutor
@@ -159,6 +161,71 @@ public class TestThreadPerDriverTaskExecutor
         finally {
             executor.stop();
         }
+    }
+
+    @Test
+    @Timeout(30)
+    public void testSplitCompletionDoesNotPropagateSchedulingFailure()
+            throws Exception
+    {
+        // leafSplitDone runs on the thread of a split that just finished. Failing to start some
+        // other split there is already reported to the task that owns it, so it must not escape
+        // into the completing split's stack, where it would unwind into the thread pool.
+        AtomicBoolean failNextThread = new AtomicBoolean();
+        ThreadFactory threadFactory = runnable -> {
+            if (failNextThread.compareAndSet(true, false)) {
+                throw new OutOfMemoryError("unable to create native thread");
+            }
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            return thread;
+        };
+
+        FairScheduler scheduler = new FairScheduler(2, threadFactory, Ticker.systemTicker());
+        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(noopTracer(), testingVersionEmbedder(), scheduler, 0, Integer.MAX_VALUE, 1);
+        scheduler.start();
+        try {
+            TaskId taskId = new TaskId(new StageId("query", 1), 1, 1);
+            TaskEntry task = (TaskEntry) executor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            ListenableFuture<Void> done = task.enqueueLeafSplit(new TestingSplitRunner(ImmutableList.of(_ -> Futures.immediateVoidFuture())));
+
+            failNextThread.set(true);
+            // Called directly rather than by letting a split finish, so that the assertion is on
+            // the one thing that matters: that it returns. The running leaf driver count it
+            // decrements is arranged rather than reached, which only widens the budget it then
+            // schedules against.
+            assertThatCode(executor::leafSplitDone).doesNotThrowAnyException();
+
+            // the split it could not start is still failed, so the failure is not simply discarded
+            assertThatThrownBy(done::get)
+                    .isInstanceOf(ExecutionException.class)
+                    .cause()
+                    .isInstanceOf(OutOfMemoryError.class);
+        }
+        finally {
+            executor.stop();
+        }
+    }
+
+    @Test
+    public void testMaintenanceSurvivesFailure()
+    {
+        // scheduleWithFixedDelay stops rescheduling a task that throws, so the wrapper must swallow
+        // the failure. It has to catch Error too: the failure an overloaded worker produces is
+        // OutOfMemoryError from creating a split's thread.
+        AtomicInteger runs = new AtomicInteger();
+        Runnable task = ThreadPerDriverTaskExecutor.maintenance(
+                () -> {
+                    if (runs.incrementAndGet() == 1) {
+                        throw new OutOfMemoryError("unable to create native thread");
+                    }
+                },
+                "Error in test task");
+
+        task.run();
+        task.run();
+
+        assertThat(runs.get()).isEqualTo(2);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/executor/dedicated/TestThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/dedicated/TestThreadPerDriverTaskExecutor.java
@@ -13,10 +13,12 @@
  */
 package io.trino.execution.executor.dedicated;
 
+import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.testing.TestingTicker;
 import io.airlift.units.Duration;
 import io.opentelemetry.api.trace.Span;
@@ -34,17 +36,266 @@ import java.util.OptionalInt;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.Phaser;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.tracing.Tracing.noopTracer;
 import static io.trino.util.EmbedVersion.testingVersionEmbedder;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestThreadPerDriverTaskExecutor
 {
+    @Test
+    @Timeout(30)
+    public void testSlowSplitStartDoesNotBlockTaskManagement()
+            throws Exception
+    {
+        // A worker under load takes a long time to create a thread. While a split is being started,
+        // tasks must still be able to come and go, otherwise the worker cannot shed the load that
+        // made thread creation slow in the first place.
+        AtomicBoolean stallNextThread = new AtomicBoolean();
+        CountDownLatch threadCreationStarted = new CountDownLatch(1);
+        CountDownLatch releaseThreadCreation = new CountDownLatch(1);
+
+        ThreadFactory threadFactory = runnable -> {
+            if (stallNextThread.compareAndSet(true, false)) {
+                threadCreationStarted.countDown();
+                awaitUninterruptibly(releaseThreadCreation);
+            }
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            return thread;
+        };
+
+        FairScheduler scheduler = new FairScheduler(3, threadFactory, Ticker.systemTicker());
+        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(noopTracer(), testingVersionEmbedder(), scheduler, 1, 1, Integer.MAX_VALUE);
+        // Do not start the executor's periodic scheduler: the replacement below must be started by
+        // the completion callback whose progress this test verifies.
+        scheduler.start();
+        ExecutorService submitter = newSingleThreadExecutor(daemonThreadsNamed("submitter"));
+        try {
+            TaskHandle task = executor.addTask(new TaskId(new StageId("query", 1), 1, 1), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            TestFuture firstBlocked = new TestFuture();
+            ListenableFuture<Void> firstDone = executor.enqueueSplits(
+                            task,
+                            false,
+                            ImmutableList.of(new TestingSplitRunner(ImmutableList.of(
+                                    _ -> firstBlocked,
+                                    _ -> Futures.immediateVoidFuture()))))
+                    .getFirst();
+            firstBlocked.awaitListenerAdded();
+
+            CountDownLatch replacementStarted = new CountDownLatch(1);
+            ListenableFuture<Void> replacementDone = executor.enqueueSplits(
+                            task,
+                            false,
+                            ImmutableList.of(new TestingSplitRunner(ImmutableList.of(_ -> {
+                                replacementStarted.countDown();
+                                return Futures.immediateVoidFuture();
+                            }))))
+                    .getFirst();
+
+            TaskHandle stalledTask = executor.addTask(new TaskId(new StageId("query", 1), 2, 1), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            SplitRunner stalledSplit = new TestingSplitRunner(ImmutableList.of(_ -> Futures.immediateVoidFuture()));
+
+            stallNextThread.set(true);
+            Future<?> stalled = submitter.submit(() -> executor.enqueueSplits(stalledTask, false, ImmutableList.of(stalledSplit)));
+            threadCreationStarted.await();
+
+            // Registering, removing and completing a leaf split must not wait for the stalled
+            // thread creation.
+            TaskId otherTaskId = new TaskId(new StageId("query", 1), 3, 1);
+            TaskHandle other = executor.addTask(otherTaskId, () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            executor.removeTask(other);
+            firstBlocked.set(null);
+            firstDone.get(10, TimeUnit.SECONDS);
+            assertThat(replacementStarted.await(10, TimeUnit.SECONDS)).isTrue();
+            replacementDone.get(10, TimeUnit.SECONDS);
+
+            releaseThreadCreation.countDown();
+            stalled.get();
+        }
+        finally {
+            releaseThreadCreation.countDown();
+            submitter.shutdownNow();
+            executor.stop();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void testFailureToStartSplitRequeuesItsClaim()
+            throws Exception
+    {
+        // Starting a split creates its thread, which an overloaded worker fails to do with
+        // OutOfMemoryError. The leaf driver accounting has to survive that, otherwise the worker
+        // permanently loses the capacity of every split it failed to start.
+        AtomicBoolean failNextThread = new AtomicBoolean();
+        ThreadFactory threadFactory = runnable -> {
+            if (failNextThread.compareAndSet(true, false)) {
+                throw new OutOfMemoryError("unable to create native thread");
+            }
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            return thread;
+        };
+
+        FairScheduler scheduler = new FairScheduler(2, threadFactory, Ticker.systemTicker());
+        // no minimum guarantee and a global budget of one leaf driver, so that a leaked claim is
+        // observable: it would leave targetGlobalLeafDrivers - runningLeafDrivers at zero and no
+        // later split could be scheduled
+        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(noopTracer(), testingVersionEmbedder(), scheduler, 0, Integer.MAX_VALUE, 1);
+        // start the scheduler but not the executor's background tasks, so that splits are only
+        // scheduled by the explicit enqueueSplits calls below
+        scheduler.start();
+        try {
+            TaskId taskId = new TaskId(new StageId("query", 1), 1, 1);
+            TaskEntry task = (TaskEntry) executor.addTask(taskId, () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+
+            // Queue the split without scheduling it, then fail its first start attempt.
+            ListenableFuture<Void> done = task.enqueueLeafSplit(new TestingSplitRunner(ImmutableList.of(_ -> Futures.immediateVoidFuture())));
+
+            failNextThread.set(true);
+            executor.scheduleMoreLeafSplits();
+
+            assertThat(done).isNotDone();
+            assertThat(executor.getTotalRunningLeafSplits()).isEqualTo(0);
+            assertThat(executor.getTotalRunningSplits()).isEqualTo(0);
+            assertThat(executor.getTotalPendingLeafSplits()).isEqualTo(1);
+
+            // A later pass retries the same split after thread capacity becomes available.
+            executor.scheduleMoreLeafSplits();
+            done.get();
+        }
+        finally {
+            executor.stop();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void testFailureToStartSecondSplitPreservesStartedClaim()
+            throws Exception
+    {
+        AtomicInteger threads = new AtomicInteger();
+        ThreadFactory threadFactory = runnable -> {
+            if (threads.incrementAndGet() == 2) {
+                throw new OutOfMemoryError("unable to create native thread");
+            }
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            return thread;
+        };
+
+        FairScheduler scheduler = new FairScheduler(2, threadFactory, Ticker.systemTicker());
+        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(noopTracer(), testingVersionEmbedder(), scheduler, 1, Integer.MAX_VALUE, 2);
+        scheduler.start();
+        try {
+            TaskEntry firstTask = (TaskEntry) executor.addTask(new TaskId(new StageId("query", 1), 1, 1), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            TaskEntry secondTask = (TaskEntry) executor.addTask(new TaskId(new StageId("query", 1), 2, 1), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            SettableFuture<Void> blocked = SettableFuture.create();
+            CountDownLatch started = new CountDownLatch(1);
+            ListenableFuture<Void> firstDone = firstTask.enqueueLeafSplit(new TestingSplitRunner(ImmutableList.of(_ -> {
+                started.countDown();
+                return blocked;
+            }, _ -> Futures.immediateVoidFuture())));
+            ListenableFuture<Void> secondDone = secondTask.enqueueLeafSplit(new TestingSplitRunner(ImmutableList.of(_ -> {
+                started.countDown();
+                return blocked;
+            }, _ -> Futures.immediateVoidFuture())));
+
+            executor.scheduleMoreLeafSplits();
+            started.await();
+
+            assertThat(executor.getTotalRunningLeafSplits()).isEqualTo(1);
+            assertThat(executor.getTotalRunningSplits()).isEqualTo(1);
+            assertThat(executor.getTotalPendingLeafSplits()).isEqualTo(1);
+
+            blocked.set(null);
+            executor.scheduleMoreLeafSplits();
+            firstDone.get();
+            secondDone.get();
+        }
+        finally {
+            executor.stop();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void testLeafCompletionSchedulesReplacementWhenCloseFails()
+            throws Exception
+    {
+        FairScheduler scheduler = FairScheduler.newInstance(1);
+        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(noopTracer(), testingVersionEmbedder(), scheduler, 1, 1, 1);
+        try {
+            TaskEntry task = (TaskEntry) executor.addTask(new TaskId(new StageId("query", 1), 1, 1), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            ListenableFuture<Void> failingDone = task.enqueueLeafSplit(new CloseFailingSplitRunner());
+            CountDownLatch replacementStarted = new CountDownLatch(1);
+            ListenableFuture<Void> replacementDone = task.enqueueLeafSplit(new TestingSplitRunner(ImmutableList.of(_ -> {
+                replacementStarted.countDown();
+                return Futures.immediateVoidFuture();
+            })));
+
+            executor.scheduleMoreLeafSplits();
+
+            failingDone.get(10, TimeUnit.SECONDS);
+            assertThat(replacementStarted.await(10, TimeUnit.SECONDS)).isTrue();
+            replacementDone.get(10, TimeUnit.SECONDS);
+        }
+        finally {
+            executor.stop();
+        }
+    }
+
+    @Test
+    public void testDestroyCompletesEveryLeafFutureWhenCloseFails()
+            throws Exception
+    {
+        FairScheduler scheduler = FairScheduler.newInstance(1);
+        TaskEntry task = new TaskEntry(
+                new TaskId(new StageId("query", 1), 1, 1),
+                scheduler,
+                testingVersionEmbedder(),
+                noopTracer(),
+                1,
+                () -> 0);
+        TestingSplitRunner failing = new CloseFailingSplitRunner();
+        TestingSplitRunner pending = new TestingSplitRunner(ImmutableList.of(_ -> Futures.immediateVoidFuture()));
+        ListenableFuture<Void> claimedDone = task.enqueueLeafSplit(failing);
+        ListenableFuture<Void> pendingDone = task.enqueueLeafSplit(pending);
+        task.claimLeafSplit();
+
+        try {
+            assertThatThrownBy(task::destroy)
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("close failed");
+
+            claimedDone.get();
+            pendingDone.get();
+            assertThat(failing.isFinished()).isTrue();
+            assertThat(pending.isFinished()).isTrue();
+
+            TestingSplitRunner afterDestroy = new TestingSplitRunner(ImmutableList.of(_ -> Futures.immediateVoidFuture()));
+            task.enqueueLeafSplit(afterDestroy).get();
+            assertThat(afterDestroy.isFinished()).isTrue();
+        }
+        finally {
+            scheduler.close();
+        }
+    }
+
     @Test
     @Timeout(10)
     public void testCancellationWhileProcessing()
@@ -244,7 +495,7 @@ public class TestThreadPerDriverTaskExecutor
         }
 
         @Override
-        public final void close()
+        public void close()
         {
             finished = true;
 
@@ -253,6 +504,22 @@ public class TestThreadPerDriverTaskExecutor
             if (runnerThread != null) {
                 runnerThread.interrupt();
             }
+        }
+    }
+
+    private static class CloseFailingSplitRunner
+            extends TestingSplitRunner
+    {
+        public CloseFailingSplitRunner()
+        {
+            super(ImmutableList.of(_ -> Futures.immediateVoidFuture()));
+        }
+
+        @Override
+        public void close()
+        {
+            super.close();
+            throw new RuntimeException("close failed");
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/executor/dedicated/TestThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/dedicated/TestThreadPerDriverTaskExecutor.java
@@ -234,6 +234,37 @@ public class TestThreadPerDriverTaskExecutor
 
     @Test
     @Timeout(30)
+    public void testStartRegistersResilientSchedulingTask()
+            throws Exception
+    {
+        AtomicBoolean failNextThread = new AtomicBoolean(true);
+        ThreadFactory threadFactory = runnable -> {
+            if (failNextThread.compareAndSet(true, false)) {
+                throw new OutOfMemoryError("unable to create native thread");
+            }
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            return thread;
+        };
+
+        FairScheduler scheduler = new FairScheduler(1, threadFactory, Ticker.systemTicker());
+        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(noopTracer(), testingVersionEmbedder(), scheduler, 0, Integer.MAX_VALUE, 1);
+        TaskEntry task = (TaskEntry) executor.addTask(new TaskId(new StageId("query", 1), 1, 1), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+        ListenableFuture<Void> done = task.enqueueLeafSplit(new TestingSplitRunner(ImmutableList.of(_ -> Futures.immediateVoidFuture())));
+
+        executor.start();
+        try {
+            // The immediate pass fails. The wrapped fixed-delay task must remain registered so the
+            // 100ms retry can start the split.
+            done.get(10, TimeUnit.SECONDS);
+        }
+        finally {
+            executor.stop();
+        }
+    }
+
+    @Test
+    @Timeout(30)
     public void testLeafCompletionSchedulesReplacementWhenCloseFails()
             throws Exception
     {
@@ -253,6 +284,40 @@ public class TestThreadPerDriverTaskExecutor
             failingDone.get(10, TimeUnit.SECONDS);
             assertThat(replacementStarted.await(10, TimeUnit.SECONDS)).isTrue();
             replacementDone.get(10, TimeUnit.SECONDS);
+        }
+        finally {
+            executor.stop();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void testLeafCompletionSchedulesAnotherTaskWhenTaskDrains()
+            throws Exception
+    {
+        FairScheduler scheduler = FairScheduler.newInstance(1);
+        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(noopTracer(), testingVersionEmbedder(), scheduler, 0, 1, 1);
+        try {
+            TaskEntry firstTask = (TaskEntry) executor.addTask(new TaskId(new StageId("query", 1), 1, 1), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            TestFuture firstBlocked = new TestFuture();
+            ListenableFuture<Void> firstDone = firstTask.enqueueLeafSplit(new TestingSplitRunner(ImmutableList.of(
+                    _ -> firstBlocked,
+                    _ -> Futures.immediateVoidFuture())));
+
+            executor.scheduleMoreLeafSplits();
+            firstBlocked.awaitListenerAdded();
+
+            TaskEntry secondTask = (TaskEntry) executor.addTask(new TaskId(new StageId("query", 1), 2, 1), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            CountDownLatch secondStarted = new CountDownLatch(1);
+            ListenableFuture<Void> secondDone = secondTask.enqueueLeafSplit(new TestingSplitRunner(ImmutableList.of(_ -> {
+                secondStarted.countDown();
+                return Futures.immediateVoidFuture();
+            })));
+
+            firstBlocked.set(null);
+            firstDone.get(10, TimeUnit.SECONDS);
+            assertThat(secondStarted.await(10, TimeUnit.SECONDS)).isTrue();
+            secondDone.get(10, TimeUnit.SECONDS);
         }
         finally {
             executor.stop();
@@ -294,6 +359,27 @@ public class TestThreadPerDriverTaskExecutor
         finally {
             scheduler.close();
         }
+    }
+
+    @Test
+    public void testMaintenanceSurvivesFailure()
+    {
+        // scheduleWithFixedDelay stops rescheduling a task that throws, so the wrapper must swallow
+        // the failure. It has to catch Error too: the failure an overloaded worker produces is
+        // OutOfMemoryError from creating a split's thread.
+        AtomicInteger runs = new AtomicInteger();
+        Runnable task = ThreadPerDriverTaskExecutor.maintenance(
+                () -> {
+                    if (runs.incrementAndGet() == 1) {
+                        throw new OutOfMemoryError("unable to create native thread");
+                    }
+                },
+                "Error in test task");
+
+        task.run();
+        task.run();
+
+        assertThat(runs.get()).isEqualTo(2);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/executor/scheduler/TestFairScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/scheduler/TestFairScheduler.java
@@ -13,6 +13,7 @@
  */
 package io.trino.execution.executor.scheduler;
 
+import com.google.common.base.Ticker;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -23,14 +24,66 @@ import org.junit.jupiter.api.Timeout;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestFairScheduler
 {
+    @Test
+    @Timeout(30)
+    public void testSubmitDoesNotBlockOtherOperations()
+            throws Exception
+    {
+        // Creating the thread that runs a task is slow on a loaded worker. Simulate that and verify
+        // that it does not hold up group management or the submission of unrelated tasks.
+        AtomicBoolean stallNextThread = new AtomicBoolean();
+        CountDownLatch threadCreationStarted = new CountDownLatch(1);
+        CountDownLatch releaseThreadCreation = new CountDownLatch(1);
+
+        ThreadFactory threadFactory = runnable -> {
+            if (stallNextThread.compareAndSet(true, false)) {
+                threadCreationStarted.countDown();
+                awaitUninterruptibly(releaseThreadCreation);
+            }
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            return thread;
+        };
+
+        FairScheduler scheduler = new FairScheduler(2, threadFactory, Ticker.systemTicker());
+        scheduler.start();
+        ExecutorService submitter = newSingleThreadExecutor(daemonThreadsNamed("submitter"));
+        try {
+            Group group = scheduler.createGroup("G1");
+
+            stallNextThread.set(true);
+            Future<?> stalled = submitter.submit(() -> scheduler.submit(group, 1, _ -> {}));
+            threadCreationStarted.await();
+
+            // these must not wait for the stalled thread creation to complete
+            Group other = scheduler.createGroup("G2");
+            scheduler.submit(other, 1, _ -> {}).get();
+            scheduler.removeGroup(other);
+
+            releaseThreadCreation.countDown();
+            stalled.get();
+        }
+        finally {
+            releaseThreadCreation.countDown();
+            submitter.shutdownNow();
+            scheduler.close();
+        }
+    }
+
     @Test
     public void testBasic()
             throws ExecutionException, InterruptedException

--- a/core/trino-main/src/test/java/io/trino/execution/executor/scheduler/TestFairScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/scheduler/TestFairScheduler.java
@@ -13,6 +13,7 @@
  */
 package io.trino.execution.executor.scheduler;
 
+import com.google.common.base.Ticker;
 import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -23,14 +24,119 @@ import org.junit.jupiter.api.Timeout;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestFairScheduler
 {
+    @Test
+    @Timeout(30)
+    public void testSubmitDoesNotBlockOtherOperations()
+            throws Exception
+    {
+        // Creating the thread that runs a task is slow on a loaded worker. Simulate that and verify
+        // that it does not hold up group management or the submission of unrelated tasks.
+        AtomicBoolean stallNextThread = new AtomicBoolean();
+        CountDownLatch threadCreationStarted = new CountDownLatch(1);
+        CountDownLatch releaseThreadCreation = new CountDownLatch(1);
+
+        ThreadFactory threadFactory = runnable -> {
+            if (stallNextThread.compareAndSet(true, false)) {
+                threadCreationStarted.countDown();
+                awaitUninterruptibly(releaseThreadCreation);
+            }
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            return thread;
+        };
+
+        FairScheduler scheduler = new FairScheduler(2, threadFactory, Ticker.systemTicker());
+        scheduler.start();
+        ExecutorService submitter = newSingleThreadExecutor(daemonThreadsNamed("submitter"));
+        try {
+            Group group = scheduler.createGroup("G1");
+
+            stallNextThread.set(true);
+            Future<?> stalled = submitter.submit(() -> scheduler.submit(group, 1, _ -> {}));
+            threadCreationStarted.await();
+
+            // these must not wait for the stalled thread creation to complete
+            Group other = scheduler.createGroup("G2");
+            scheduler.submit(other, 1, _ -> {}).get();
+            scheduler.removeGroup(other);
+
+            releaseThreadCreation.countDown();
+            stalled.get();
+        }
+        finally {
+            releaseThreadCreation.countDown();
+            submitter.shutdownNow();
+            scheduler.close();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void testCloseDoesNotWaitForThreadCreation()
+            throws Exception
+    {
+        CountDownLatch threadCreationStarted = new CountDownLatch(1);
+        CountDownLatch releaseThreadCreation = new CountDownLatch(1);
+        ThreadFactory threadFactory = runnable -> {
+            threadCreationStarted.countDown();
+            awaitUninterruptibly(releaseThreadCreation);
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            return thread;
+        };
+
+        FairScheduler scheduler = new FairScheduler(1, threadFactory, Ticker.systemTicker());
+        scheduler.start();
+        Group group = scheduler.createGroup("G");
+        ExecutorService executor = newSingleThreadExecutor(daemonThreadsNamed("submitter"));
+        try {
+            Future<?> submit = executor.submit(() -> scheduler.submit(group, 1, _ -> {}));
+            threadCreationStarted.await();
+
+            // Shutdown is safe without waiting for the submit call to finish creating its thread.
+            scheduler.close();
+
+            releaseThreadCreation.countDown();
+            assertThatThrownBy(submit::get)
+                    .isInstanceOf(ExecutionException.class)
+                    .cause()
+                    .isInstanceOf(RejectedExecutionException.class);
+        }
+        finally {
+            releaseThreadCreation.countDown();
+            executor.shutdownNow();
+            scheduler.close();
+        }
+    }
+
+    @Test
+    public void testSubmitAfterClose()
+    {
+        FairScheduler scheduler = FairScheduler.newInstance(1);
+        Group group = scheduler.createGroup("G");
+        scheduler.close();
+
+        assertThatThrownBy(() -> scheduler.submit(group, 1, _ -> {}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Already closed");
+    }
+
     @Test
     public void testBasic()
             throws ExecutionException, InterruptedException


### PR DESCRIPTION
## Description

Workers running the thread-per-driver task executor stop responding under load: they refuse HTTP
requests, drop out of discovery, and never recover until the JVM is restarted.

The two thread dumps attached to #21512 show the mechanism when read in aggregate. In both, 345 of
358 blocked threads are waiting on a single monitor — the singleton `ThreadPerDriverTaskExecutor` —
and the sole holder is inside `Thread.start0`, under `FairScheduler.submit`. The waiters are
`leafSplitDone` × 257, `addTask` × 40, `enqueueSplits` × 38, `removeTask` × 9, alongside 100
`Task-*` and 82 `http-*` threads.

That last pair is what makes it unrecoverable rather than merely slow. Submitting a split creates an
OS thread while holding a worker-global monitor, and task *removal* needs the same monitor. Once
thread creation is slow, the worker can no longer retire the drivers that made it slow, so the
condition sustains itself. `POST /v1/task` and `/v1/info/state` queue behind the same monitor, which
is the unresponsive-node symptom operators report.

## Additional context and related issues

- Fixes #21512.

Two observations from the dumps rule out the explanations offered on the issue. All 7,926 parked
`SplitRunner` threads are in `awaitUnblock` and none in `awaitReady`, with `fair-scheduler-0` idle in
`queue.dequeue()` — the scheduler is starved, not oversubscribed, so no scheduling-policy change
addresses this. And the 458 diagnostics posted on the issue (`pool=5774, active=4517` against
`slots=32`) show those threads are almost entirely *intermediate* splits, which
`enqueueSplits(intermediate=true)` starts without consulting any throttle. That matches the reporter
data showing failures skewed towards many-stage, many-task queries.

Reducing the cost of a parked driver is separate work and is not attempted here.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix workers becoming unresponsive and dropping out of the cluster when running
  queries with a large number of stages and tasks. ({issue}`21512`)
```

