### PR TITLE
Reduce product test bundle from 5 GB to 250 MB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -868,7 +868,7 @@ jobs:
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          $MAVEN clean install ${MAVEN_FAST_INSTALL} -pl '!:trino-docs'
+          $MAVEN clean install ${MAVEN_FAST_INSTALL} -P product-test-distribution -pl '!:trino-docs'
       - name: Determine impacted Maven modules
         if: >-
           github.event_name == 'pull_request' &&
@@ -895,11 +895,13 @@ jobs:
             client/trino-cli/target/*-executable.jar
             product-tests-trino-image.tar.gz
           retention-days: 1
-      - name: Product tests Maven artifacts
+      - name: Product test distribution
         uses: actions/upload-artifact@v7
         with:
-          name: product tests m2 io.trino
-          path: ~/.m2/repository/io/trino
+          name: product test distribution
+          path: |
+            testing/trino-product-tests/target/product-test-distribution
+            testing/trino-product-tests/target/iceberg-spark-runtime.jar
           retention-days: 1
       - name: Build product-test matrix from impacted modules
         if: >-
@@ -950,19 +952,16 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: product tests and server tarball
-      - name: Product tests Maven artifacts
+      - name: Product test distribution
         uses: actions/download-artifact@v8
         with:
-          name: product tests m2 io.trino
-          path: ~/.m2/repository/io/trino
+          name: product test distribution
+          path: testing/trino-product-tests/target
       - name: Load Trino Docker image for product tests
         run: |
           gzip -dc product-tests-trino-image.tar.gz | docker load
           version=$($MAVEN -f pom.xml --quiet help:evaluate -Dexpression=project.version -DforceStdout --raw-streams)
           docker tag "product-tests-trino:${version}-amd64" trino:for-product-tests
-      - name: Compile JUnit product test suites
-        run: |
-          $MAVEN -pl testing/trino-product-tests -Dair.check.skip-all=true -DskipTests test-compile
       - name: Product Tests (JUnit suites)
         id: tests
         shell: bash
@@ -993,6 +992,12 @@ jobs:
           SNOWFLAKE_WAREHOUSE: ${{ vars.SNOWFLAKE_WAREHOUSE }}
         run: |
           mkdir -p logs
+
+          # Suites load checked-in configuration from paths relative to the repository root.
+          product_test_distribution=testing/trino-product-tests/target/product-test-distribution
+          test_jar=("${product_test_distribution}"/lib/trino-product-tests-*-tests.jar)
+          product_test_classpath=$(< "${product_test_distribution}/classpath.txt")
+          product_test_classpath="${product_test_distribution}/${product_test_classpath//:/:${product_test_distribution}/}"
 
           declare -a suite_results=()
           declare -a suite_totals=()
@@ -1073,10 +1078,12 @@ jobs:
               fi
             fi
             set +e
-            $MAVEN -pl testing/trino-product-tests -Dair.check.skip-all=true -DskipTests exec:java \
-              -Dexec.classpathScope=test \
+            java \
+              -Xmx512M \
+              -XX:+ExitOnOutOfMemoryError \
               -Dtrino.product-tests.image="${TRINO_PRODUCT_TESTS_IMAGE}" \
-              -Dexec.mainClass=io.trino.tests.product.suite.${suite} \
+              -cp "${test_jar[0]}:${product_test_classpath}" \
+              io.trino.tests.product.suite.${suite} \
               | tee "${log_file}"
             rc=${PIPESTATUS[0]}
             set -e

--- a/testing/trino-product-tests/pom.xml
+++ b/testing/trino-product-tests/pom.xml
@@ -519,4 +519,63 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>product-test-distribution</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>build-product-test-classpath</id>
+                                <goals>
+                                    <goal>build-classpath</goal>
+                                </goals>
+                                <phase>prepare-package</phase>
+                                <configuration>
+                                    <fileSeparator>/</fileSeparator>
+                                    <includeScope>test</includeScope>
+                                    <outputFile>${project.build.directory}/product-test-distribution/classpath.txt</outputFile>
+                                    <pathSeparator>:</pathSeparator>
+                                    <prefix>lib</prefix>
+                                    <prependGroupId>true</prependGroupId>
+                                    <regenerateFile>true</regenerateFile>
+                                    <skip>false</skip>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>copy-product-test-dependencies</id>
+                                <goals>
+                                    <goal>copy-dependencies</goal>
+                                </goals>
+                                <phase>prepare-package</phase>
+                                <configuration>
+                                    <includeScope>test</includeScope>
+                                    <outputDirectory>${project.build.directory}/product-test-distribution/lib</outputDirectory>
+                                    <prependGroupId>true</prependGroupId>
+                                    <skip>false</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-tests</id>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/product-test-distribution/lib</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## Description

`build-pt` currently uploads the complete `io/trino` Maven repository, about 5 GB. Every product-test matrix job downloads that repository and runs Maven `test-compile` before launching its suites.

Build a compact product-test distribution once in `build-pt`. It contains the compiled product-test JAR, the Maven-ordered test runtime classpath, and only the required dependencies. Each `pt` job downloads the approximately 250 MB bundle and runs the suite main class directly with `java`, without downloading the Trino Maven repository or invoking Maven `test-compile`.

This preserves the existing GIB selection and full-matrix fallback, suite classes, secret handling, logs, summaries, failure reporting, and Docker, server, and CLI artifacts.

## Additional context and related issues

Local measurements:

- Existing checkout-specific `io/trino` repository: 4.85 GiB
- Distribution: 269.6 MiB uncompressed
- Representative ZIP: 241.7 MiB

Validation:

- Full clean reactor install with the distribution profile: 109 modules passed
- Product-test matrix script: 13 tests passed
- Classpath audit: 231 entries with no missing or unreferenced JARs
- `SuiteBlackHole` from the distribution: 1 test passed
- Strict POM, workflow YAML, and whitespace checks passed

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
