### PR TITLE
Expose metrics for DROP TABLE statement

### DIFF
--- a/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
+++ b/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
@@ -100,6 +100,8 @@ import static com.google.common.base.Suppliers.memoize;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.execution.QueryState.QUEUED;
 import static io.trino.execution.StagesInfo.getAllStages;
 import static io.trino.sql.planner.planprinter.PlanPrinter.jsonDistributedPlan;
@@ -114,6 +116,8 @@ public class QueryMonitor
 {
     private static final Logger log = Logger.get(QueryMonitor.class);
     private static final ZoneId ZONE_ID = ZoneId.systemDefault();
+    private static final int CONNECTOR_INFO_JSON_LIMIT = toIntExact(DataSize.of(10, MEGABYTE).toBytes());
+    private static final JsonCodec<Object> OBJECT_CODEC = jsonCodec(Object.class);
 
     private final JsonCodec<StagesInfo> stagesInfoCodec;
     private final JsonCodec<OperatorStats> operatorStatsCodec;
@@ -509,6 +513,25 @@ public class QueryMonitor
                                             .collect(toImmutableSet())))
                             .collect(toImmutableList()));
 
+            Optional<String> connectorOutputMetadata;
+            Optional<Boolean> jsonLengthLimitExceeded;
+            if (tableFinishInfo.isPresent()) {
+                connectorOutputMetadata = tableFinishInfo.map(TableFinishInfo::getConnectorOutputMetadata);
+                jsonLengthLimitExceeded = tableFinishInfo.map(TableFinishInfo::isJsonLengthLimitExceeded);
+            }
+            else {
+                Optional<Object> connectorInfo = queryInfo.getOutput().get().getConnectorInfo();
+                if (connectorInfo.isPresent()) {
+                    Optional<String> serialized = OBJECT_CODEC.toJsonWithLengthLimit(connectorInfo.get(), CONNECTOR_INFO_JSON_LIMIT);
+                    connectorOutputMetadata = serialized;
+                    jsonLengthLimitExceeded = Optional.of(serialized.isEmpty());
+                }
+                else {
+                    connectorOutputMetadata = Optional.empty();
+                    jsonLengthLimitExceeded = Optional.empty();
+                }
+            }
+
             output = Optional.of(
                     new QueryOutputMetadata(
                             queryInfo.getOutput().get().getCatalogName(),
@@ -516,8 +539,8 @@ public class QueryMonitor
                             queryInfo.getOutput().get().getSchema(),
                             queryInfo.getOutput().get().getTable(),
                             outputColumnsMetadata,
-                            tableFinishInfo.map(TableFinishInfo::getConnectorOutputMetadata),
-                            tableFinishInfo.map(TableFinishInfo::isJsonLengthLimitExceeded)));
+                            connectorOutputMetadata,
+                            jsonLengthLimitExceeded));
         }
         return new QueryIOMetadata(inputs.build(), output);
     }

--- a/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
@@ -320,7 +320,8 @@ public class CreateTableTask
                 tableName.objectName(),
                 Optional.of(tableMetadata.getColumns().stream()
                         .map(column -> new OutputColumn(new Column(column.getName(), column.getType().toString()), ImmutableSet.of()))
-                        .collect(toImmutableList()))));
+                        .collect(toImmutableList())),
+                Optional.empty()));
         return immediateVoidFuture();
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
@@ -20,11 +20,14 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.RedirectionAwareTableHandle;
+import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
+import io.trino.sql.analyzer.Output;
 import io.trino.sql.tree.DropTable;
 import io.trino.sql.tree.Expression;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
@@ -89,7 +92,18 @@ public class DropTableTask
         QualifiedObjectName tableName = redirectionAwareTableHandle.redirectedTableName().orElse(originalTableName);
         accessControl.checkCanDropTable(session.toSecurityContext(), tableName);
 
-        metadata.dropTable(session, redirectionAwareTableHandle.tableHandle().get(), tableName.asCatalogSchemaTableName());
+        TableHandle tableHandle = redirectionAwareTableHandle.tableHandle().get();
+        Optional<Object> connectorInfo = metadata.getInfo(session, tableHandle);
+
+        metadata.dropTable(session, tableHandle, tableName.asCatalogSchemaTableName());
+
+        stateMachine.setOutput(Optional.of(new Output(
+                tableName.catalogName(),
+                tableHandle.catalogHandle().getVersion(),
+                tableName.schemaName(),
+                tableName.objectName(),
+                Optional.empty(),
+                connectorInfo)));
 
         return immediateVoidFuture();
     }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -329,7 +329,7 @@ public class Analysis
     {
         return target.map(target -> {
             QualifiedObjectName name = target.getName();
-            return new Output(name.catalogName(), target.getCatalogVersion(), name.schemaName(), name.objectName(), target.getColumns());
+            return new Output(name.catalogName(), target.getCatalogVersion(), name.schemaName(), name.objectName(), target.getColumns(), Optional.empty());
         });
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Output.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Output.java
@@ -34,6 +34,7 @@ public final class Output
     private final String schema;
     private final String table;
     private final Optional<List<OutputColumn>> columns;
+    private final Optional<Object> connectorInfo;
 
     @JsonCreator
     public Output(
@@ -41,13 +42,15 @@ public final class Output
             @JsonProperty("catalogVersion") CatalogVersion catalogVersion,
             @JsonProperty("schema") String schema,
             @JsonProperty("table") String table,
-            @JsonProperty("columns") Optional<List<OutputColumn>> columns)
+            @JsonProperty("columns") Optional<List<OutputColumn>> columns,
+            @JsonProperty("connectorInfo") Optional<Object> connectorInfo)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.catalogVersion = requireNonNull(catalogVersion, "catalogVersion is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
         this.columns = columns.map(ImmutableList::copyOf);
+        this.connectorInfo = requireNonNull(connectorInfo, "connectorInfo is null");
     }
 
     @JsonProperty
@@ -78,6 +81,12 @@ public final class Output
     public Optional<List<OutputColumn>> getColumns()
     {
         return columns;
+    }
+
+    @JsonProperty
+    public Optional<Object> getConnectorInfo()
+    {
+        return connectorInfo;
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -361,6 +361,12 @@ public abstract class BaseDataDefinitionTaskTest
         }
 
         @Override
+        public Optional<Object> getInfo(Session session, TableHandle handle)
+        {
+            return Optional.empty();
+        }
+
+        @Override
         public void createTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata, SaveMode saveMode)
         {
             checkArgument(saveMode == REPLACE || saveMode == IGNORE || !tables.containsKey(tableMetadata.getTable()));

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestOutput.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestOutput.java
@@ -44,7 +44,8 @@ public class TestOutput
                                 new OutputColumn(
                                         new Column("column", "type"),
                                         ImmutableSet.of(
-                                                new SourceColumn(QualifiedObjectName.valueOf("catalog.schema.table"), "column"))))));
+                                                new SourceColumn(QualifiedObjectName.valueOf("catalog.schema.table"), "column"))))),
+                Optional.empty());
 
         String json = codec.toJson(expected);
         Output actual = codec.fromJson(json);
@@ -65,7 +66,8 @@ public class TestOutput
                                 new OutputColumn(
                                         new Column("ko.LU-mieńka", "type"),
                                         ImmutableSet.of(
-                                                new SourceColumn(new QualifiedObjectName("catalog.twój", "schema.ściema", "tabel.tabelkówna"), "co-lumn.słodziak\""))))));
+                                                new SourceColumn(new QualifiedObjectName("catalog.twój", "schema.ściema", "tabel.tabelkówna"), "co-lumn.słodziak\""))))),
+                Optional.empty());
 
         String json = codec.toJson(expected);
         Output actual = codec.fromJson(json);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -3506,6 +3506,10 @@ public class DeltaLakeMetadata
     @Override
     public Optional<Object> getInfo(ConnectorSession session, ConnectorTableHandle table)
     {
+        if (table instanceof CorruptedDeltaLakeTableHandle) {
+            return Optional.empty();
+        }
+
         DeltaLakeTableHandle handle = (DeltaLakeTableHandle) table;
         boolean isPartitioned = !handle.getMetadataEntry().getLowercasePartitionColumns().isEmpty();
         return Optional.of(new DeltaLakeInputInfo(isPartitioned, handle.getReadVersion()));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2462,6 +2462,10 @@ public class IcebergMetadata
     @Override
     public Optional<Object> getInfo(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
+        if (tableHandle instanceof CorruptedIcebergTableHandle) {
+            return Optional.empty();
+        }
+
         IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
         List<String> partitionFields = icebergTableHandle.getSpecId().isPresent() ?
                 PartitionSpecParser.fromJson(SchemaParser.fromJson(icebergTableHandle.getTableSchemaJson()), icebergTableHandle.getPartitionSpecJsons().get(icebergTableHandle.getSpecId().orElseThrow()))


### PR DESCRIPTION
## Description

This will improve the observability when DROP TABLE took a long time.
It may happen in lakehouse tables when there are too many files.

The query json example:
```sql
DROP TABLE iceberg.tpch.region;
```

```json
...
  "output": {
    "catalogName": "iceberg",
    "catalogVersion": "fc2ba268c0670061048636b33474c542099f6b801033f791a713f08956178c10",
    "schema": "tpch",
    "table": "region",
    "connectorInfo": {
      "formatVersion": 2,
      "snapshotId": 75716330123233260,
      "partitionFields": [],
      "tableDefaultFileFormat": "PARQUET",
      "totalRecords": "5",
      "totalDataFiles": "1",
      "totalDeleteFiles": "0",
      "totalPositionDeletes": "0",
      "totalEqualityDeletes": "0"
    }
  }
...
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.