### PR TITLE
Skip conflicting delete file validation for Iceberg DELETE

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -3348,7 +3348,6 @@ public class IcebergMetadata
 
         // Ensure a row that is updated by this commit was not deleted by a separate commit
         rowDelta.validateDeletedFiles();
-        rowDelta.validateNoConflictingDeleteFiles();
         rowDelta.scanManifestsWith(icebergScanExecutor);
 
         int formatVersion = table.getFormatVersion();
@@ -3358,6 +3357,7 @@ public class IcebergMetadata
         ImmutableList.Builder<String> referencedDataFiles = ImmutableList.builder();
         List<DeletionVectorInfo> deletionVectorInfos = new ArrayList<>();
         boolean hasDeleteTasks = false;
+        boolean hasDataTasks = false;
 
         // Commit tasks are deserialized and converted one at a time to bound coordinator memory for writes producing many files
         for (Slice fragment : fragments) {
@@ -3366,6 +3366,7 @@ public class IcebergMetadata
             domainCollector.add(task, partitionSpec);
             switch (task.content()) {
                 case DATA -> {
+                    hasDataTasks = true;
                     DataFiles.Builder builder = DataFiles.builder(partitionSpec)
                             .withPath(task.path())
                             .withFormat(task.fileFormat().toIceberg())
@@ -3434,6 +3435,11 @@ public class IcebergMetadata
 
         if (hasDeleteTasks) {
             rowDelta.validateDataFilesExist(referencedDataFiles.build());
+        }
+        if (hasDataTasks) {
+            // Iceberg requires this for UPDATE and MERGE only. Deleting a row that a concurrent commit also deleted is idempotent.
+            // A commit writing data files is an UPDATE or a MERGE, a commit writing only position deletes is a DELETE.
+            rowDelta.validateNoConflictingDeleteFiles();
         }
         if (!deletionVectorInfos.isEmpty()) {
             deletionVectorWriter.writeDeletionVectors(session, icebergTable, table, deletionVectorInfos, rowDelta);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -160,7 +160,12 @@ public abstract class BaseIcebergConnectorSmokeTest
             });
             List<String> expectedValues = expectedRows.filter(Optional::isPresent).map(Optional::get).collect(toImmutableList());
             assertThat(expectedValues).as("Expected at least one delete operation to pass").hasSizeLessThan(rows.size());
-            assertThat(query("SELECT * FROM " + tableName)).matches("VALUES " + String.join(", ", expectedValues));
+            if (expectedValues.isEmpty()) {
+                assertThat(query("SELECT * FROM " + tableName)).returnsEmptyResult();
+            }
+            else {
+                assertThat(query("SELECT * FROM " + tableName)).matches("VALUES " + String.join(", ", expectedValues));
+            }
         }
         finally {
             executor.shutdownNow();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergLocalConcurrentWrites.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergLocalConcurrentWrites.java
@@ -289,6 +289,45 @@ final class TestIcebergLocalConcurrentWrites
 
     // Repeat test with invocationCount for better test coverage, since the tested aspect is inherently non-deterministic.
     @RepeatedTest(3)
+    void testConcurrentDeleteOverlappingDataFiles()
+            throws Exception
+    {
+        int threads = 3;
+        CyclicBarrier barrier = new CyclicBarrier(threads);
+        ExecutorService executor = newFixedThreadPool(threads);
+        String tableName = "test_concurrent_delete_overlapping_data_files_" + randomNameSuffix();
+
+        // Force creating more parquet files via the target_max_file_size table property
+        assertUpdate("CREATE TABLE " + tableName + " (a BIGINT) WITH (target_max_file_size = '1kB')");
+        assertUpdate("INSERT INTO " + tableName + " SELECT * FROM UNNEST(SEQUENCE(1, 10000)) AS t(a)", 10000);
+
+        try {
+            // Every writer deletes rows spread over every data file, so each one references the data files the others do
+            List<Future<Boolean>> futures = IntStream.range(0, threads)
+                    .mapToObj(threadNumber -> executor.submit(() -> {
+                        barrier.await(10, SECONDS);
+                        getQueryRunner().execute("DELETE FROM " + tableName + " WHERE a % " + threads + " = " + threadNumber);
+                        return true;
+                    }))
+                    .collect(toImmutableList());
+
+            long successfulDeletesCount = futures.stream()
+                    .map(MoreFutures::getFutureValue)
+                    .filter(success -> success)
+                    .count();
+
+            assertThat(successfulDeletesCount).isEqualTo(threads);
+            assertThat(query("SELECT count(*) FROM " + tableName)).matches("VALUES BIGINT '0'");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, SECONDS)).isTrue();
+        }
+    }
+
+    // Repeat test with invocationCount for better test coverage, since the tested aspect is inherently non-deterministic.
+    @RepeatedTest(3)
     void testConcurrentTruncate()
             throws Exception
     {
@@ -1259,8 +1298,17 @@ final class TestIcebergLocalConcurrentWrites
             }
 
             optimizeFuture.get();
-            assertThat(expectedValues.size()).isGreaterThan(0).isLessThan(rows);
-            assertQuery("SELECT * FROM " + tableName, "VALUES " + String.join(", ", expectedValues));
+            assertThat(expectedValues.size()).isLessThan(rows);
+            if (useSmallFiles) {
+                // Optimize replaces the single row files, so a delete referencing one of them cannot commit
+                assertThat(expectedValues.size()).isGreaterThan(0);
+            }
+            if (expectedValues.isEmpty()) {
+                assertQueryReturnsEmptyResult("SELECT * FROM " + tableName);
+            }
+            else {
+                assertQuery("SELECT * FROM " + tableName, "VALUES " + String.join(", ", expectedValues));
+            }
         }
         finally {
             executor.shutdownNow();


### PR DESCRIPTION
## Description

Call `RowDelta.validateNoConflictingDeleteFiles` only when the commit writes data files, which means it is an UPDATE or a MERGE. A commit writing only position deletes is a DELETE and does not need it.

## Additional context and related issues

`RowDelta.validateNoConflictingDeleteFiles` javadoc states that the method must be called for UPDATE and MERGE independently of the isolation level, and that calling it for DELETE is not required because deleting a record that is also deleted concurrently is fine. Trino calls it for every row delta, so concurrent DELETEs that touch the same data files fail with "Found new conflicting delete files that can apply to records matching true". `SnapshotProducer` retries only on `CommitFailedException`, so this `ValidationException` fails the query immediately regardless of `iceberg.max-commit-retry`.

Trino has no SQL command type at this point, since DELETE, UPDATE and MERGE all route through `IcebergMergeTableHandle`. The emitted fragment mix is used instead.

Measured on 100 concurrent DELETEs against an unpartitioned table, 200 statements total:

| | succeeded | failed on validation | failed on retries |
| --- | --- | --- | --- |
| before | 2 | 198 | 0 |
| after | 132 | 0 | 68 |

Wall clock and p50 latency are unchanged. A partitioned control, where the validation was never tripped, does not move.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Improve success rate of concurrent `DELETE` statements. ({issue}`30850`)
```
