### PR TITLE
Suppress invalid metadata when listing columns in OpenSearch & Elasticsearch

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
+import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.trino.plugin.base.expression.ConnectorExpressions;
 import io.trino.plugin.base.projection.ApplyProjectionUtil;
@@ -110,6 +111,7 @@ import static io.airlift.slice.SliceUtf8.getCodePointAt;
 import static io.airlift.slice.SliceUtf8.lengthOfCodePoint;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.replaceWithNewVariables;
+import static io.trino.plugin.elasticsearch.ElasticsearchErrorCode.ELASTICSEARCH_INVALID_METADATA;
 import static io.trino.plugin.elasticsearch.ElasticsearchTableHandle.Type.QUERY;
 import static io.trino.plugin.elasticsearch.ElasticsearchTableHandle.Type.SCAN;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -134,6 +136,8 @@ import static java.util.function.Function.identity;
 public class ElasticsearchMetadata
         implements ConnectorMetadata
 {
+    private static final Logger log = Logger.get(ElasticsearchMetadata.class);
+
     private static final String PASSTHROUGH_QUERY_RESULT_COLUMN_NAME = "result";
     private static final ColumnMetadata PASSTHROUGH_QUERY_RESULT_COLUMN_METADATA = ColumnMetadata.builder()
             .setName(PASSTHROUGH_QUERY_RESULT_COLUMN_NAME)
@@ -454,6 +458,11 @@ public class ElasticsearchMetadata
                     catch (TrinoException e) {
                         // this may happen when table is being deleted concurrently
                         if (e.getCause() instanceof ResponseException cause && cause.getResponse().getStatusLine().getStatusCode() == 404) {
+                            return Stream.empty();
+                        }
+                        // this may happen when table contains unsupported types
+                        if (e.getErrorCode().equals(ELASTICSEARCH_INVALID_METADATA.toErrorCode())) {
+                            log.warn(e, "Failed to parse metadata of table %s during streaming table columns", name);
                             return Stream.empty();
                         }
                         throw e;

--- a/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
+++ b/plugin/trino-opensearch/src/main/java/io/trino/plugin/opensearch/OpenSearchMetadata.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
+import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.trino.plugin.base.expression.ConnectorExpressions;
 import io.trino.plugin.base.projection.ApplyProjectionUtil;
@@ -107,6 +108,7 @@ import static io.airlift.slice.SliceUtf8.getCodePointAt;
 import static io.airlift.slice.SliceUtf8.lengthOfCodePoint;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.replaceWithNewVariables;
+import static io.trino.plugin.opensearch.OpenSearchErrorCode.OPENSEARCH_INVALID_METADATA;
 import static io.trino.plugin.opensearch.OpenSearchSessionProperties.isProjectionPushdownEnabled;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -130,6 +132,8 @@ import static java.util.function.Function.identity;
 public class OpenSearchMetadata
         implements ConnectorMetadata
 {
+    private static final Logger log = Logger.get(OpenSearchMetadata.class);
+
     private static final String PASSTHROUGH_QUERY_RESULT_COLUMN_NAME = "result";
     private static final ColumnMetadata PASSTHROUGH_QUERY_RESULT_COLUMN_METADATA = ColumnMetadata.builder()
             .setName(PASSTHROUGH_QUERY_RESULT_COLUMN_NAME)
@@ -439,6 +443,11 @@ public class OpenSearchMetadata
                     catch (TrinoException e) {
                         // this may happen when table is being deleted concurrently
                         if (e.getCause() instanceof ResponseException cause && cause.getResponse().getStatusLine().getStatusCode() == 404) {
+                            return Stream.empty();
+                        }
+                        // this may happen when table contains unsupported types
+                        if (e.getErrorCode().equals(OPENSEARCH_INVALID_METADATA.toErrorCode())) {
+                            log.warn(e, "Failed to parse metadata of table %s during streaming table columns for %s", name, prefix);
                             return Stream.empty();
                         }
                         throw e;


### PR DESCRIPTION
## Description

https://github.com/trinodb/trino/actions/runs/32460630782/job/96707029518
```
[ERROR] io.trino.plugin.opensearch.TestOpenSearchConnectorTest.testSelectInformationSchemaColumns -- Time elapsed: 2.676 s <<< ERROR!
io.trino.testing.QueryFailedException: Error listing table columns for catalog opensearch: A column, (array_raw_field) cannot be declared as a Trino array and also be rendered as json.
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:597)
	at io.trino.testing.DistributedQueryRunner.execute(DistributedQueryRunner.java:580)
	at io.trino.sql.query.QueryAssertions$QueryAssert.lambda$new$1(QueryAssertions.java:296)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:194)
	at io.trino.sql.query.QueryAssertions$QueryAssert.result(QueryAssertions.java:421)
	at io.trino.sql.query.QueryAssertions$QueryAssert.containsAll(QueryAssertions.java:367)
	at io.trino.testing.BaseConnectorTest.testSelectInformationSchemaColumns(BaseConnectorTest.java:2509)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
	Suppressed: java.lang.Exception: SQL: SELECT table_name, column_name FROM information_schema.columns WHERE table_catalog = 'opensearch' AND table_schema = 'tpch' AND table_name LIKE '%orders%'
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:604)
		... 11 more
Caused by: io.trino.spi.TrinoException: Error listing table columns for catalog opensearch: A column, (array_raw_field) cannot be declared as a Trino array and also be rendered as json.
	at io.trino.metadata.MetadataListing.handleListingException(MetadataListing.java:389)
	at io.trino.metadata.MetadataListing.listTableColumns(MetadataListing.java:286)
	at io.trino.connector.informationschema.InformationSchemaPageSource.addColumnsRecords(InformationSchemaPageSource.java:227)
	at io.trino.connector.informationschema.InformationSchemaPageSource.buildPages(InformationSchemaPageSource.java:210)
	at io.trino.connector.informationschema.InformationSchemaPageSource.getNextSourcePage(InformationSchemaPageSource.java:178)
	at io.trino.spi.connector.MemoryUsageReportingPageSource.getNextSourcePage(MemoryUsageReportingPageSource.java:71)
	at io.trino.operator.ScanFilterAndProjectOperator$ConnectorPageSourceToPages.process(ScanFilterAndProjectOperator.java:332)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:426)
	at io.trino.operator.WorkProcessorUtils.getNextState(WorkProcessorUtils.java:261)
	at io.trino.operator.WorkProcessorUtils$YieldingProcess.process(WorkProcessorUtils.java:181)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:426)
	at io.trino.operator.WorkProcessorUtils$3.process(WorkProcessorUtils.java:346)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:426)
	at io.trino.operator.WorkProcessorUtils$3.process(WorkProcessorUtils.java:346)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:426)
	at io.trino.operator.WorkProcessorUtils$3.process(WorkProcessorUtils.java:346)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:426)
	at io.trino.operator.WorkProcessorUtils.getNextState(WorkProcessorUtils.java:261)
	at io.trino.operator.WorkProcessorUtils$BlockingProcess.process(WorkProcessorUtils.java:207)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:426)
	at io.trino.operator.WorkProcessorUtils.lambda$flatten$0(WorkProcessorUtils.java:317)
	at io.trino.operator.WorkProcessorUtils$3.process(WorkProcessorUtils.java:359)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:426)
	at io.trino.operator.WorkProcessorUtils.getNextState(WorkProcessorUtils.java:261)
	at io.trino.operator.WorkProcessorUtils.lambda$processStateMonitor$0(WorkProcessorUtils.java:240)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:426)
	at io.trino.operator.WorkProcessorUtils.getNextState(WorkProcessorUtils.java:261)
	at io.trino.operator.WorkProcessorUtils.lambda$finishWhen$0(WorkProcessorUtils.java:255)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:426)
	at io.trino.operator.WorkProcessorSourceOperatorAdapter.getOutput(WorkProcessorSourceOperatorAdapter.java:121)
	at io.trino.operator.OutputValidatingSourceOperator.getOutput(OutputValidatingSourceOperator.java:70)
	at io.trino.operator.Driver.processInternal(Driver.java:403)
	at io.trino.operator.Driver.lambda$process$0(Driver.java:306)
	at io.trino.operator.Driver.tryWithLock(Driver.java:709)
	at io.trino.operator.Driver.process(Driver.java:298)
	at io.trino.operator.Driver.processForDuration(Driver.java:269)
	at io.trino.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:852)
	at io.trino.execution.executor.dedicated.SplitProcessor.run(SplitProcessor.java:77)
	at io.trino.execution.executor.dedicated.TaskEntry$VersionEmbedderBridge.lambda$run$0(TaskEntry.java:205)
	at io.trino.$gen.Trino_testversion___.run(Unknown Source)
	at io.trino.execution.executor.dedicated.TaskEntry$VersionEmbedderBridge.run(TaskEntry.java:206)
	at io.trino.execution.executor.scheduler.FairScheduler.runTask(FairScheduler.java:177)
	at io.trino.execution.executor.scheduler.FairScheduler.lambda$submit$0(FairScheduler.java:164)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: io.trino.spi.TrinoException: A column, (array_raw_field) cannot be declared as a Trino array and also be rendered as json.
	at io.trino.plugin.opensearch.client.OpenSearchClient.parseType(OpenSearchClient.java:527)
	at io.trino.plugin.opensearch.client.OpenSearchClient.lambda$getIndexMetadata$0(OpenSearchClient.java:497)
	at io.trino.plugin.opensearch.client.OpenSearchClient.doRequest(OpenSearchClient.java:759)
	at io.trino.plugin.opensearch.client.OpenSearchClient.getIndexMetadata(OpenSearchClient.java:468)
	at io.trino.plugin.opensearch.OpenSearchMetadata.makeInternalTableMetadata(OpenSearchMetadata.java:217)
	at io.trino.plugin.opensearch.OpenSearchMetadata.getTableMetadata(OpenSearchMetadata.java:205)
	at io.trino.plugin.opensearch.OpenSearchMetadata.lambda$streamTableColumns$0(OpenSearchMetadata.java:436)
	at java.base/java.util.stream.ReferencePipeline$7$1FlatMap.accept(ReferencePipeline.java:288)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:1024)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:315)
	at java.base/java.util.Spliterators$1Adapter.forEachRemaining(Spliterators.java:694)
	at io.trino.spi.connector.ConnectorMetadata.streamRelationColumns(ConnectorMetadata.java:372)
	at io.trino.tracing.TracingConnectorMetadata.streamRelationColumns(TracingConnectorMetadata.java:334)
	at io.trino.metadata.MetadataManager.listTableColumns(MetadataManager.java:731)
	at io.trino.tracing.TracingMetadata.listTableColumns(TracingMetadata.java:388)
	at io.trino.metadata.MetadataListing.doListTableColumns(MetadataListing.java:293)
	at io.trino.metadata.MetadataListing.listTableColumns(MetadataListing.java:283)
	... 48 more
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.