### PR TITLE
Prevent stack overflow when planning large disjunctions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractCommonPredicatesExpressionRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractCommonPredicatesExpressionRewriter.java
@@ -23,6 +23,7 @@ import io.trino.sql.ir.Logical;
 import io.trino.sql.planner.DeterminismEvaluator;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -33,7 +34,6 @@ import static io.trino.sql.ir.IrUtils.extractPredicates;
 import static io.trino.sql.ir.Logical.Operator.AND;
 import static io.trino.sql.ir.Logical.Operator.OR;
 import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
-import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toList;
 
 public final class ExtractCommonPredicatesExpressionRewriter
@@ -91,10 +91,14 @@ public final class ExtractCommonPredicatesExpressionRewriter
         {
             List<List<Expression>> subPredicates = getSubPredicates(node);
 
-            Set<Expression> commonPredicates = ImmutableSet.copyOf(subPredicates.stream()
-                    .map(this::filterDeterministicPredicates)
-                    .reduce(Sets::intersection)
-                    .orElse(emptySet()));
+            Set<Expression> mutableCommonPredicates = new LinkedHashSet<>();
+            if (!subPredicates.isEmpty()) {
+                mutableCommonPredicates.addAll(filterDeterministicPredicates(subPredicates.getFirst()));
+                for (int index = 1; index < subPredicates.size() && !mutableCommonPredicates.isEmpty(); index++) {
+                    mutableCommonPredicates.retainAll(filterDeterministicPredicates(subPredicates.get(index)));
+                }
+            }
+            Set<Expression> commonPredicates = ImmutableSet.copyOf(mutableCommonPredicates);
 
             List<List<Expression>> uncorrelatedSubPredicates = subPredicates.stream()
                     .map(predicateList -> removeAll(predicateList, commonPredicates))

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -275,6 +275,27 @@ public class TestSimplifyExpressions
     }
 
     @Test
+    public void testLargeDisjunction()
+    {
+        Reference symbol = new Reference(BIGINT, "x");
+        ImmutableList.Builder<Expression> disjuncts = ImmutableList.builderWithExpectedSize(25_000);
+        for (long value = 0; value < 25_000; value++) {
+            disjuncts.add(comparison(EQUAL, symbol, new Constant(BIGINT, value)));
+        }
+
+        Expression expression = new Logical(OR, disjuncts.build());
+        assertThat(rewrite(
+                expression,
+                TEST_SESSION,
+                PLANNER_CONTEXT.getMetadata(),
+                emptySymbolAllocator(),
+                PLANNER_CONTEXT.getExpressionOptimizer()))
+                .isEqualTo(new Logical(AND, ImmutableList.of(
+                        comparison(LESS_THAN_OR_EQUAL, new Constant(BIGINT, 0L), symbol),
+                        comparison(LESS_THAN_OR_EQUAL, symbol, new Constant(BIGINT, 24_999L)))));
+    }
+
+    @Test
     public void testExtractCommonPredicatesIsIdempotent()
     {
         Reference first = new Reference(BOOLEAN, "a");


### PR DESCRIPTION
## Description

Queries with about 25,000 equality predicates joined by `OR` fail during planning with `STACK_OVERFLOW` before any task starts. The same predicates now plan successfully and retain their equivalent result.

Common-predicate extraction previously reduced the predicate sets with `Sets.intersection`, producing a deeply nested chain of lazy `SetView` objects. The planner now materializes the first set, intersects later sets in place, and stops once the intersection is empty.

## Additional context and related issues

- Fixes #30709

## Testing

Command used before and after the fix:

```text
./mvnw -pl core/trino-main -Dtest=TestSimplifyExpressions#testLargeDisjunction test
```

<details>
<summary>Raw red/green output</summary>

Before:

```text
at com.google.common.collect.Sets$2.iterator(Sets.java:940)
at com.google.common.collect.Sets$2$1.<init>(Sets.java:941)
[ERROR] TestSimplifyExpressions.testLargeDisjunction » StackOverflow
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
[INFO] BUILD FAILURE
```

After:

```text
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

</details>

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Prevent planning failures for queries with a large number of `OR` predicates. ({issue}`30709`)
```

