### PR TITLE
Accept locally built trino in product tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -959,7 +959,7 @@ jobs:
         run: |
           gzip -dc product-tests-trino-image.tar.gz | docker load
           version=$($MAVEN -f pom.xml --quiet help:evaluate -Dexpression=project.version -DforceStdout --raw-streams)
-          docker tag "product-tests-trino:${version}-amd64" trinodb/trino:latest
+          docker tag "product-tests-trino:${version}-amd64" trino:for-product-tests
       - name: Compile JUnit product test suites
         run: |
           $MAVEN -pl testing/trino-product-tests -Dair.check.skip-all=true -DskipTests test-compile
@@ -967,7 +967,7 @@ jobs:
         id: tests
         shell: bash
         env:
-          TRINO_PRODUCT_TESTS_IMAGE: trinodb/trino:latest
+          TRINO_PRODUCT_TESTS_IMAGE: "trino:for-product-tests"
           ABFS_CONTAINER: ${{ vars.AZURE_ABFS_HIERARCHICAL_CONTAINER }}
           ABFS_ACCOUNT: ${{ vars.AZURE_ABFS_HIERARCHICAL_ACCOUNT }}
           ABFS_ACCESS_KEY: ${{ secrets.AZURE_ABFS_HIERARCHICAL_ACCESS_KEY }}

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/MultiNodeTrinoCluster.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/MultiNodeTrinoCluster.java
@@ -392,7 +392,7 @@ public class MultiNodeTrinoCluster
             }
 
             // Build coordinator
-            TrinoContainer coordinator = new TrinoContainer(DockerImageName.parse(imageName));
+            TrinoContainer coordinator = new TrinoContainer(DockerImageName.parse(imageName).asCompatibleSubstituteFor("trinodb/trino"));
             coordinator.withNetwork(network);
             coordinator.withNetworkAliases(COORDINATOR_ALIAS);
 

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TrinoWorkerContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TrinoWorkerContainer.java
@@ -64,7 +64,7 @@ public class TrinoWorkerContainer
 
     public TrinoWorkerContainer(String imageName)
     {
-        super(DockerImageName.parse(imageName));
+        super(DockerImageName.parse(imageName).asCompatibleSubstituteFor(DEFAULT_IMAGE));
         withExposedPorts(HTTP_PORT);
         waitingFor(Wait.forHttp("/v1/info")
                 .forPort(HTTP_PORT)


### PR DESCRIPTION
`core/docker/build.sh` builds image named like
`trino:484-SNAPSHOT-arm64`, without `trinodb/` prefix. This is correct, but requires `asCompatibleSubstituteFor` to be accepted by `TrinoContainer`.  This follows similar change
(bf2e818cb819ba6854e901c7654bc2285590325f) in
`TrinoProductTestContainer`.

This commit also changes the ci.yml not to shadow public `trinodb/trino:latest` with a locally built image.
