### PR TITLE
Change kryo-shaded to runtime in Hudi

### DIFF
--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -197,7 +197,7 @@
             <groupId>com.esotericsoftware</groupId>
             <artifactId>kryo-shaded</artifactId>
             <version>4.0.3</version>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hudi/HudiEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hudi/HudiEnvironment.java
@@ -22,6 +22,7 @@ import io.trino.testing.containers.environment.QueryResult;
 import org.testcontainers.containers.Network;
 import org.testcontainers.trino.TrinoContainer;
 
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -30,6 +31,7 @@ import java.sql.Statement;
 import java.util.Map;
 
 import static io.trino.testing.containers.environment.QueryRetry.executeWithRetry;
+import static org.testcontainers.utility.MountableFile.forHostPath;
 
 /**
  * Hudi product test environment for interoperability testing.
@@ -55,6 +57,9 @@ import static io.trino.testing.containers.environment.QueryRetry.executeWithRetr
 public class HudiEnvironment
         extends ProductTestEnvironment
 {
+    private static final Path CONFIG_DIR = Path.of("testing/trino-product-tests/src/test/resources/docker/trino-product-tests/conf/environment/multinode-hudi");
+    private static final String JVM_CONFIG_TARGET = "/etc/trino/jvm.config";
+
     static {
         // Ensure the Hive JDBC driver is loaded for Spark Thrift Server connections
         try {
@@ -109,6 +114,7 @@ public class HudiEnvironment
                         "hive.config.resources", "/etc/trino/hdfs-site.xml",
                         "hive.hudi-catalog-name", "hudi"))
                 .build();
+        trino.withCopyFileToContainer(forHostPath(CONFIG_DIR.resolve("jvm.config").toString()), JVM_CONFIG_TARGET);
         TrinoProductTestContainer.startAndWait(trino);
     }
 

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hudi/TestHudiSparkCompatibility.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hudi/TestHudiSparkCompatibility.java
@@ -301,6 +301,33 @@ class TestHudiSparkCompatibility
         }
     }
 
+    @Test
+    void testReadCopyOnWriteTableWithPendingClustering(HudiEnvironment env)
+    {
+        String tableName = "test_hudi_cow_pending_clustering_" + randomNameSuffix();
+        String warehouseDir = env.getWarehouseDirectory();
+
+        env.executeSparkUpdate("CREATE TABLE default." + tableName +
+                "(id bigint, name string, ts bigint)" +
+                "USING hudi " +
+                "TBLPROPERTIES (" +
+                " type = 'cow'," +
+                " primaryKey = 'id'," +
+                " preCombineField = 'ts'," +
+                " hoodie.clustering.schedule.inline = 'true'," +
+                " hoodie.clustering.inline = 'false')" +
+                "LOCATION 'hdfs://hadoop-master:9000" + warehouseDir + "/" + tableName + "'");
+
+        try {
+            env.executeSparkUpdate("INSERT INTO default." + tableName + " VALUES (1, 'a1', 1000), (2, 'a2', 2000)");
+            assertThat(env.executeTrino("SELECT id, name FROM hudi.default." + tableName))
+                    .containsOnly(row(1L, "a1"), row(2L, "a2"));
+        }
+        finally {
+            env.executeSparkUpdate("DROP TABLE default." + tableName);
+        }
+    }
+
     private void createNonPartitionedTable(HudiEnvironment env, String tableName, String tableType)
     {
         String warehouseDir = env.getWarehouseDirectory();

--- a/testing/trino-product-tests/src/test/resources/docker/trino-product-tests/conf/environment/multinode-hudi/jvm.config
+++ b/testing/trino-product-tests/src/test/resources/docker/trino-product-tests/conf/environment/multinode-hudi/jvm.config
@@ -1,0 +1,18 @@
+-server
+--add-opens=java.base/java.nio=ALL-UNNAMED
+-Xmx2G
+-XX:G1HeapRegionSize=32M
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+ExitOnOutOfMemoryError
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:-OmitStackTraceInFastThrow
+-XX:ReservedCodeCacheSize=150M
+-XX:PerMethodRecompilationCutoff=10000
+-XX:PerBytecodeRecompilationCutoff=10000
+-Djdk.attach.allowAttachSelf=true
+-DHADOOP_USER_NAME=hive
+-Duser.timezone=Asia/Kathmandu
+-XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+-XX:+ExitOnOutOfMemoryError
+# Avro 1.12.1 removed the default serializable packages
+-Dorg.apache.avro.SERIALIZABLE_PACKAGES=org.apache.hudi.avro.model


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Trino version > 484 may cause NoClassDefFoundError in Hudi connector:

```
java.lang.RuntimeException: Query failed (#20260821_123624_00051_wgb4q): com/esotericsoftware/kryo/KryoSerializable

	at io.trino.testing.containers.environment.ProductTestEnvironment.executeTrino(ProductTestEnvironment.java:149)
	at io.trino.tests.product.hudi.TestHudiSparkCompatibility.testReadCopyOnWriteTableWithPendingClustering(TestHudiSparkCompatibility.java:323)
Caused by: java.sql.SQLException: Query failed (#20260821_123624_00051_wgb4q): com/esotericsoftware/kryo/KryoSerializable
	at io.trino.jdbc.ResultUtils.resultsException(ResultUtils.java:33)
	at io.trino.jdbc.AsyncResultIterator.lambda$new$1(AsyncResultIterator.java:95)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:328)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at --- Async.Stack.Trace --- (captured by IntelliJ IDEA debugger)
	at java.base/java.util.concurrent.FutureTask.<init>(FutureTask.java:153)
	at java.base/java.util.concurrent.AbstractExecutorService.newTaskFor(AbstractExecutorService.java:99)
	at java.base/java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:124)
	at io.trino.jdbc.AsyncResultIterator.<init>(AsyncResultIterator.java:69)
	at io.trino.jdbc.TrinoResultSet.<init>(TrinoResultSet.java:58)
	at io.trino.jdbc.TrinoResultSet.create(TrinoResultSet.java:50)
	at io.trino.jdbc.TrinoStatement.internalExecute(TrinoStatement.java:276)
	at io.trino.jdbc.TrinoStatement.execute(TrinoStatement.java:254)
	at io.trino.testing.containers.environment.ProductTestEnvironment.executeTrinoStatement(ProductTestEnvironment.java:241)
	at io.trino.testing.containers.environment.ProductTestEnvironment.lambda$executeTrino$0(ProductTestEnvironment.java:144)
	at dev.failsafe.Functions.lambda$toCtxSupplier$11(Functions.java:243)
	at dev.failsafe.Functions.lambda$get$0(Functions.java:46)
	at dev.failsafe.internal.RetryPolicyExecutor.lambda$apply$0(RetryPolicyExecutor.java:74)
	at dev.failsafe.SyncExecutionImpl.executeSync(SyncExecutionImpl.java:187)
	at dev.failsafe.FailsafeExecutor.call(FailsafeExecutor.java:376)
	at dev.failsafe.FailsafeExecutor.get(FailsafeExecutor.java:112)
	at io.trino.testing.containers.environment.QueryRetry.executeWithRetry(QueryRetry.java:44)
	at io.trino.testing.containers.environment.ProductTestEnvironment.executeTrino(ProductTestEnvironment.java:142)
	at io.trino.tests.product.hudi.TestHudiSparkCompatibility.testReadCopyOnWriteTableWithPendingClustering(TestHudiSparkCompatibility.java:323)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:700)
	at org.junit.platform.commons.support.ReflectionSupport.invokeMethod(ReflectionSupport.java:528)
	at org.junit.jupiter.engine.support.MethodReflectionUtils.invoke(MethodReflectionUtils.java:53)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:61)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:124)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:163)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:148)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:124)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:99)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:66)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:47)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:39)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:98)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invokeVoid(InterceptingExecutableInvoker.java:71)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$0(TestMethodTestDescriptor.java:219)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:215)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:157)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:70)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$2(NodeTestTask.java:176)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$1(NodeTestTask.java:166)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:139)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$0(NodeTestTask.java:164)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:163)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:116)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:42)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$2(NodeTestTask.java:180)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$1(NodeTestTask.java:166)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:139)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$0(NodeTestTask.java:164)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:163)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:116)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:42)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$2(NodeTestTask.java:180)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$1(NodeTestTask.java:166)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:139)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$0(NodeTestTask.java:164)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:74)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:163)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:116)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:36)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:52)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:58)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:256)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:228)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:189)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:109)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:66)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:168)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:65)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:137)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:126)
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:71)
	at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$2(InterceptingLauncher.java:66)
	at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
	at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:65)
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:71)
	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:94)
	at com.intellij.junit6.JUnit6TestRunnerHelper.execute(JUnit6TestRunnerHelper.java:69)
	at com.intellij.junit5.JUnit5IdeaTestRunner.startRunnerWithArgs(JUnit5IdeaTestRunner.java:70)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:226)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:62)
Caused by: java.lang.NoClassDefFoundError: com/esotericsoftware/kryo/KryoSerializable
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:962)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:144)
	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:454)
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:367)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:557)
	at io.trino.server.PluginClassLoader.loadClass(PluginClassLoader.java:114)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
	at org.apache.hudi.avro.HoodieAvroUtils.initRecordKeySchema(HoodieAvroUtils.java:425)
	at org.apache.hudi.avro.HoodieAvroUtils.<clinit>(HoodieAvroUtils.java:131)
	at org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeAvroMetadata(TimelineMetadataUtils.java:140)
	at org.apache.hudi.common.table.timeline.versioning.v1.CommitMetadataSerDeV1.deserialize(CommitMetadataSerDeV1.java:55)
	at org.apache.hudi.common.table.timeline.HoodieTimeline.readNonEmptyInstantContent(HoodieTimeline.java:153)
	at org.apache.hudi.common.table.timeline.HoodieTimeline.readRequestedReplaceMetadata(HoodieTimeline.java:299)
	at org.apache.hudi.common.util.ClusteringUtils.getRequestedReplaceMetadataOption(ClusteringUtils.java:212)
	at org.apache.hudi.common.util.ClusteringUtils.getRequestedReplaceMetadata(ClusteringUtils.java:198)
	at org.apache.hudi.common.util.ClusteringUtils.getClusteringPlan(ClusteringUtils.java:275)
	at org.apache.hudi.common.util.ClusteringUtils.getClusteringPlan(ClusteringUtils.java:251)
	at org.apache.hudi.common.util.ClusteringUtils.lambda$getAllPendingClusteringPlans$0(ClusteringUtils.java:89)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:214)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1716)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:723)
	at org.apache.hudi.common.util.ClusteringUtils.getAllFileGroupsInPendingClusteringPlans(ClusteringUtils.java:298)
	at org.apache.hudi.common.table.view.AbstractTableFileSystemView.init(AbstractTableFileSystemView.java:141)
	at org.apache.hudi.common.table.view.HoodieTableFileSystemView.init(HoodieTableFileSystemView.java:128)
	at org.apache.hudi.common.table.view.HoodieTableFileSystemView.<init>(HoodieTableFileSystemView.java:122)
	at org.apache.hudi.common.table.view.HoodieTableFileSystemView.fileListingBasedFileSystemView(HoodieTableFileSystemView.java:113)
	at org.apache.hudi.common.table.view.HoodieTableFileSystemView.fileListingBasedFileSystemView(HoodieTableFileSystemView.java:106)
	at io.trino.plugin.hudi.query.HudiReadOptimizedDirectoryLister.<init>(HudiReadOptimizedDirectoryLister.java:64)
	at io.trino.plugin.hudi.HudiSplitSource.<init>(HudiSplitSource.java:87)
	at io.trino.plugin.hudi.HudiSplitManager.getSplits(HudiSplitManager.java:101)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitManager.getSplits(ClassLoaderSafeConnectorSplitManager.java:51)
	at io.trino.split.SplitManager.getSplits(SplitManager.java:89)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.createSplitSource(SplitSourceFactory.java:191)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.visitTableScan(SplitSourceFactory.java:158)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.visitTableScan(SplitSourceFactory.java:132)
	at io.trino.sql.planner.plan.TableScanNode.accept(TableScanNode.java:219)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.visitOutput(SplitSourceFactory.java:368)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.visitOutput(SplitSourceFactory.java:132)
	at io.trino.sql.planner.plan.OutputNode.accept(OutputNode.java:82)
	at io.trino.sql.planner.SplitSourceFactory.createSplitSources(SplitSourceFactory.java:112)
	at io.trino.execution.scheduler.PipelinedQueryScheduler$DistributedStagesScheduler.createStageScheduler(PipelinedQueryScheduler.java:1075)
	at io.trino.execution.scheduler.PipelinedQueryScheduler$DistributedStagesScheduler.create(PipelinedQueryScheduler.java:949)
	at io.trino.execution.scheduler.PipelinedQueryScheduler.createDistributedStagesScheduler(PipelinedQueryScheduler.java:328)
	at io.trino.execution.scheduler.PipelinedQueryScheduler.start(PipelinedQueryScheduler.java:311)
	at io.trino.execution.SqlQueryExecution.start(SqlQueryExecution.java:446)
	at io.trino.execution.QueryManager.createQuery(QueryManager.java:317)
	at io.trino.dispatcher.LocalDispatchQuery.startExecution(LocalDispatchQuery.java:151)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$waitForMinimumWorkers$1(LocalDispatchQuery.java:135)
	at io.airlift.concurrent.MoreFutures.lambda$addSuccessCallback$0(MoreFutures.java:570)
	at io.airlift.concurrent.MoreFutures$3.onSuccess(MoreFutures.java:545)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1132)
	at io.trino.$gen.Trino_480____20260821_123558_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: java.lang.ClassNotFoundException: com.esotericsoftware.kryo.KryoSerializable
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:377)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:557)
	at io.trino.server.PluginClassLoader.loadClass(PluginClassLoader.java:114)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
	... 60 more
```

Just changing Kryo to runtime doesn't work: https://github.com/trinodb/trino/actions/runs/32482783922

```
Caused by: java.lang.SecurityException: Forbidden org.apache.hudi.avro.model.HoodieClusteringPlan! This class is not trusted to be included in Avro schemas. You may either use the system properties org.apache.avro.SERIALIZABLE_CLASSES and org.apache.avro.SERIALIZABLE_PACKAGES to set the comma separated list of the classes or packages you trust, or you can set them via the API (see org.apache.avro.util.ClassSecurityValidator).
	at org.apache.avro.util.ClassSecurityValidator$ClassSecurityPredicate.forbiddenClass(ClassSecurityValidator.java:106)
	at org.apache.avro.util.ClassSecurityValidator.validate(ClassSecurityValidator.java:60)
	at org.apache.avro.util.ClassUtils.forName(ClassUtils.java:99)
	at org.apache.avro.util.ClassUtils.forName(ClassUtils.java:72)
	at org.apache.avro.specific.SpecificData.lambda$getClass$2(SpecificData.java:393)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1724)
	at org.apache.avro.specific.SpecificData.getClass(SpecificData.java:391)
	at org.apache.hudi.avro.HoodieAvroUtils.convertFieldToSpecificRecordValue(HoodieAvroUtils.java:1512)
	at org.apache.hudi.avro.HoodieAvroUtils.convertToSpecificRecord(HoodieAvroUtils.java:1499)
	at org.apache.hudi.avro.HoodieAvroUtils.convertToSpecificRecord(HoodieAvroUtils.java:1483)
	at org.apache.hudi.common.table.timeline.TimelineMetadataUtils.deserializeAvroMetadata(TimelineMetadataUtils.java:140)
	at org.apache.hudi.common.table.timeline.versioning.v1.CommitMetadataSerDeV1.deserialize(CommitMetadataSerDeV1.java:55)
	... 48 more
```


## Release notes

```markdown
## Hudi
* Fix some things. ({issue}`issuenumber`)
```
