### PR TITLE
Bound REST case-insensitive mapping caches

### DIFF
--- a/docs/src/main/sphinx/object-storage/metastores.md
+++ b/docs/src/main/sphinx/object-storage/metastores.md
@@ -544,6 +544,10 @@ following properties:
 * - `iceberg.rest-catalog.case-insensitive-name-matching.cache-ttl`
   - [Duration](prop-type-duration) for which case-insensitive namespace, table, 
     and view names are cached. Defaults to `1m`.
+* - `iceberg.rest-catalog.case-insensitive-name-matching.cache-max-size`
+  - Maximum number of entries per case-insensitive name mapping cache. Applies
+    independently to the namespace cache and the table/view cache. Defaults to
+    `10000`.
 * - `iceberg.rest-catalog.http-headers`
   - Additional *non-sensitive* HTTP headers to include with requests to the REST catalog.
     Example: `Header-1: value 1, Header-2: value 2`.

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/IcebergRestCatalogConfig.java
@@ -19,6 +19,7 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import org.apache.iceberg.CatalogProperties;
 
@@ -67,6 +68,8 @@ public class IcebergRestCatalogConfig
     private boolean caseInsensitiveNameMatching;
     private Map<String, String> httpHeaders = ImmutableMap.of();
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
+    // Lightweight identifier mappings; short TTL keeps retained cardinality modest.
+    private long caseInsensitiveNameMatchingCacheMaximumSize = 10_000;
 
     @NotNull
     public URI getBaseUri()
@@ -277,6 +280,20 @@ public class IcebergRestCatalogConfig
     public IcebergRestCatalogConfig setCaseInsensitiveNameMatchingCacheTtl(Duration caseInsensitiveNameMatchingCacheTtl)
     {
         this.caseInsensitiveNameMatchingCacheTtl = caseInsensitiveNameMatchingCacheTtl;
+        return this;
+    }
+
+    @Min(1)
+    public long getCaseInsensitiveNameMatchingCacheMaximumSize()
+    {
+        return caseInsensitiveNameMatchingCacheMaximumSize;
+    }
+
+    @Config("iceberg.rest-catalog.case-insensitive-name-matching.cache-max-size")
+    @ConfigDescription("Maximum number of entries in the case insensitive object mapping cache")
+    public IcebergRestCatalogConfig setCaseInsensitiveNameMatchingCacheMaximumSize(long caseInsensitiveNameMatchingCacheMaximumSize)
+    {
+        this.caseInsensitiveNameMatchingCacheMaximumSize = caseInsensitiveNameMatchingCacheMaximumSize;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoIcebergRestCatalogFactory.java
@@ -96,10 +96,12 @@ public class TrinoIcebergRestCatalogFactory
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.caseInsensitiveNameMatching = restConfig.isCaseInsensitiveNameMatching();
         this.remoteNamespaceMappingCache = EvictableCacheBuilder.newBuilder()
+                .maximumSize(restConfig.getCaseInsensitiveNameMatchingCacheMaximumSize())
                 .expireAfterWrite(restConfig.getCaseInsensitiveNameMatchingCacheTtl().toMillis(), MILLISECONDS)
                 .shareNothingWhenDisabled()
                 .build();
         this.remoteTableMappingCache = EvictableCacheBuilder.newBuilder()
+                .maximumSize(restConfig.getCaseInsensitiveNameMatchingCacheMaximumSize())
                 .expireAfterWrite(restConfig.getCaseInsensitiveNameMatchingCacheTtl().toMillis(), MILLISECONDS)
                 .shareNothingWhenDisabled()
                 .build();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergRestCatalogConfig.java
@@ -48,6 +48,7 @@ public class TestIcebergRestCatalogConfig
                 .setServerAssignedTableLocationEnabled(false)
                 .setCaseInsensitiveNameMatching(false)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
+                .setCaseInsensitiveNameMatchingCacheMaximumSize(10_000)
                 .setHttpHeaders(List.of()));
     }
 
@@ -69,6 +70,7 @@ public class TestIcebergRestCatalogConfig
                 .put("iceberg.rest-catalog.server-assigned-table-location-enabled", "true")
                 .put("iceberg.rest-catalog.case-insensitive-name-matching", "true")
                 .put("iceberg.rest-catalog.case-insensitive-name-matching.cache-ttl", "3m")
+                .put("iceberg.rest-catalog.case-insensitive-name-matching.cache-max-size", "5000")
                 .put("iceberg.rest-catalog.http-headers", "Polaris-Realm: default-realm")
                 .buildOrThrow();
 
@@ -87,6 +89,7 @@ public class TestIcebergRestCatalogConfig
                 .setServerAssignedTableLocationEnabled(true)
                 .setCaseInsensitiveNameMatching(true)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(3, MINUTES))
+                .setCaseInsensitiveNameMatchingCacheMaximumSize(5000)
                 .setHttpHeaders(List.of("Polaris-Realm: default-realm"));
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The mapping caches had no maximum size — only TTL-based eviction. A configurable size bound is now exposed via `iceberg.rest-catalog.case-insensitive-name-matching.cache-max-size`.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

* https://github.com/trinodb/trino/pull/30747

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Add the `iceberg.rest-catalog.case-insensitive-name-matching.cache-max-size` configuration property to bound the size of case-insensitive mapping caches in REST catalogs. ({issue}`30856`)
```
