### PR TITLE
Skip coarse delete file validation for Iceberg v3 writes

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -3436,15 +3436,35 @@ public class IcebergMetadata
         if (hasDeleteTasks) {
             rowDelta.validateDataFilesExist(referencedDataFiles.build());
         }
-        if (hasDataTasks) {
-            // Iceberg requires this for UPDATE and MERGE only. Deleting a row that a concurrent commit also deleted is idempotent.
-            // A commit writing data files is an UPDATE or a MERGE, a commit writing only position deletes is a DELETE.
+        // Iceberg requires this for UPDATE and MERGE only. Deleting a row that a concurrent commit also deleted is idempotent.
+        // A commit writing data files is an UPDATE or a MERGE, a commit writing only position deletes is a DELETE.
+        // Iceberg rejects concurrently added deletion vectors per referenced data file, so at format version 3 this
+        // check is needed only for equality deletes.
+        if (hasDataTasks && (formatVersion < 3 || mayHaveEqualityDeletes(session, table))) {
             rowDelta.validateNoConflictingDeleteFiles();
         }
         if (!deletionVectorInfos.isEmpty()) {
             deletionVectorWriter.writeDeletionVectors(session, icebergTable, table, deletionVectorInfos, rowDelta);
         }
         commitUpdateAndTransaction(rowDelta, session, transaction, "write");
+    }
+
+    /**
+     * Checks the latest snapshot summary; a missing summary or equality delete count is treated as having
+     * equality deletes. Equality deletes committed after this check and before the write commits are not detected.
+     */
+    private boolean mayHaveEqualityDeletes(ConnectorSession session, IcebergTableHandle table)
+    {
+        Snapshot currentSnapshot = catalog.loadTable(session, table.getSchemaTableName()).currentSnapshot();
+        if (currentSnapshot == null) {
+            return false;
+        }
+        Map<String, String> summary = currentSnapshot.summary();
+        if (summary == null) {
+            return true;
+        }
+        String totalEqualityDeletes = summary.get(TOTAL_EQ_DELETES_PROP);
+        return totalEqualityDeletes == null || !totalEqualityDeletes.equals("0");
     }
 
     /**

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergLocalConcurrentWrites.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergLocalConcurrentWrites.java
@@ -14,13 +14,16 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.concurrent.MoreFutures;
+import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.blackhole.BlackHolePlugin;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.TestTable;
+import org.apache.iceberg.Table;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -39,6 +42,10 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getFileSystemFactory;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getHiveMetastore;
+import static io.trino.plugin.iceberg.IcebergTestUtils.loadTable;
+import static io.trino.plugin.iceberg.util.EqualityDeleteUtils.writeEqualityDeleteForTable;
 import static io.trino.testing.QueryAssertions.getTrinoExceptionCause;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
@@ -497,14 +504,119 @@ final class TestIcebergLocalConcurrentWrites
 
     // Repeat test with invocationCount for better test coverage, since the tested aspect is inherently non-deterministic.
     @RepeatedTest(3)
+    void testConcurrentUpdateOfSeparateDataFilesWithDeletionVectors()
+            throws Exception
+    {
+        int threads = 3;
+        CyclicBarrier barrier = new CyclicBarrier(threads);
+        ExecutorService executor = newFixedThreadPool(threads);
+        String tableName = "test_concurrent_update_separate_data_files_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " (a BIGINT, part BIGINT) WITH (format_version = 3)");
+        // Separate INSERTs keep each part group in its own data file in this unpartitioned table
+        assertUpdate("INSERT INTO " + tableName + " SELECT a, 1 FROM UNNEST(SEQUENCE(1, 100)) AS t(a)", 100);
+        assertUpdate("INSERT INTO " + tableName + " SELECT a, 2 FROM UNNEST(SEQUENCE(1, 100)) AS t(a)", 100);
+        assertUpdate("INSERT INTO " + tableName + " SELECT a, 3 FROM UNNEST(SEQUENCE(1, 100)) AS t(a)", 100);
+
+        // UPDATE will increase every value by 1
+        long expectedDataSum = (long) computeScalar("SELECT sum(a + 1) FROM " + tableName);
+
+        try {
+            // update data concurrently, with each query matching rows of a single data file
+            executor.invokeAll(IntStream.rangeClosed(1, threads)
+                            .mapToObj(part -> (Callable<Void>) () -> {
+                                barrier.await(10, SECONDS);
+                                getQueryRunner().execute("UPDATE " + tableName + " SET a = a + 1 WHERE part = " + part);
+                                return null;
+                            })
+                            .collect(toImmutableList()))
+                    .forEach(MoreFutures::getDone);
+
+            assertThat((long) computeScalar("SELECT sum(a) FROM " + tableName)).isEqualTo(expectedDataSum);
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, SECONDS)).isTrue();
+        }
+    }
+
+    // Repeat test with invocationCount for better test coverage, since the tested aspect is inherently non-deterministic.
+    @RepeatedTest(3)
+    void testConcurrentUpdateWithEqualityDeletes()
+            throws Exception
+    {
+        int threads = 2;
+        CyclicBarrier barrier = new CyclicBarrier(threads);
+        ExecutorService executor = newFixedThreadPool(threads);
+        String tableName = "test_concurrent_update_equality_deletes_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " (a BIGINT, part BIGINT) WITH (format_version = 3)");
+        // Separate INSERTs keep each part group in its own data file in this unpartitioned table
+        assertUpdate("INSERT INTO " + tableName + " SELECT a, 1 FROM UNNEST(SEQUENCE(1, 100)) AS t(a)", 100);
+        assertUpdate("INSERT INTO " + tableName + " SELECT a, 2 FROM UNNEST(SEQUENCE(1, 100)) AS t(a)", 100);
+
+        // An equality delete matching no rows still marks the table as containing equality deletes
+        TrinoFileSystemFactory fileSystemFactory = getFileSystemFactory(getQueryRunner());
+        Table icebergTable = loadTable(tableName, getHiveMetastore(getQueryRunner()), fileSystemFactory, "iceberg", "tpch");
+        writeEqualityDeleteForTable(icebergTable, fileSystemFactory, Optional.empty(), Optional.empty(), ImmutableMap.of("part", 999L), Optional.empty());
+
+        long baseDataSum = (long) computeScalar("SELECT sum(a) FROM " + tableName);
+
+        try {
+            // update data concurrently, with each query matching rows of a single data file
+            List<Future<Boolean>> futures = IntStream.rangeClosed(1, threads)
+                    .mapToObj(part -> executor.submit(() -> {
+                        barrier.await(10, SECONDS);
+                        try {
+                            getQueryRunner().execute("UPDATE " + tableName + " SET a = a + 1 WHERE part = " + part);
+                            return true;
+                        }
+                        catch (Exception e) {
+                            RuntimeException trinoException = getTrinoExceptionCause(e);
+                            try {
+                                assertThat(trinoException).hasMessageMatching("Failed to commit the transaction during write.*|" +
+                                        "Failed to commit during write.*");
+                            }
+                            catch (Throwable verifyFailure) {
+                                if (verifyFailure != e) {
+                                    verifyFailure.addSuppressed(e);
+                                }
+                                throw verifyFailure;
+                            }
+                            return false;
+                        }
+                    }))
+                    .collect(toImmutableList());
+
+            long successes = futures.stream()
+                    .map(future -> tryGetFutureValue(future, 10, SECONDS).orElseThrow(() -> new RuntimeException("Wait timed out")))
+                    .filter(success -> success)
+                    .count();
+
+            // Equality deletes keep the conservative conflict validation, so only one update commits
+            assertThat(successes).isEqualTo(1);
+            assertThat((long) computeScalar("SELECT sum(a) FROM " + tableName)).isEqualTo(baseDataSum + 100);
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, SECONDS)).isTrue();
+        }
+    }
+
+    // Repeat test with invocationCount for better test coverage, since the tested aspect is inherently non-deterministic.
+    @RepeatedTest(3)
     void testConcurrentOverlappingUpdate()
             throws Exception
     {
-        testConcurrentOverlappingUpdate(false);
-        testConcurrentOverlappingUpdate(true);
+        testConcurrentOverlappingUpdate(false, 2);
+        testConcurrentOverlappingUpdate(true, 2);
+        testConcurrentOverlappingUpdate(false, 3);
+        testConcurrentOverlappingUpdate(true, 3);
     }
 
-    private void testConcurrentOverlappingUpdate(boolean partitioned)
+    private void testConcurrentOverlappingUpdate(boolean partitioned, int formatVersion)
             throws Exception
     {
         int threads = 3;
@@ -513,7 +625,7 @@ final class TestIcebergLocalConcurrentWrites
         String tableName = "test_concurrent_overlapping_updates_table_" + randomNameSuffix();
 
         assertUpdate("CREATE TABLE " + tableName + " (a, part) " +
-                (partitioned ? " WITH (partitioning = ARRAY['part'])" : "") +
+                " WITH (format_version = " + formatVersion + (partitioned ? ", partitioning = ARRAY['part']" : "") + ")" +
                 " AS VALUES (1, 10), (11, 20), (21, NULL), (31, 40)", 4);
 
         try {


### PR DESCRIPTION
## Description

For UPDATE and MERGE on Iceberg format version 3 tables, skip `validateNoConflictingDeleteFiles` when the table has no equality deletes. Iceberg already rejects concurrently added deletion vectors per referenced data file, so the coarse validation only adds false conflicts between writes that touch disjoint data files. The validation is kept when the table may contain equality deletes, since those are not covered by the per-file check.

## Additional context and related issues

The equality delete check reads the latest table snapshot summary, so equality deletes committed after that read and before the write commits are not detected. Concurrent DV commits for the same data file still conflict; apache/iceberg#17754 proposes merging them for pure delete commits.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Reduce commit conflicts for concurrent `UPDATE` and `MERGE` on tables with format version 3. ({issue}`issuenumber`)
```