### PR TITLE
Fix common test flakes and improve diagnostics

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectionCreationTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectionCreationTest.java
@@ -22,10 +22,10 @@ import org.junit.jupiter.api.BeforeAll;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.SystemSessionProperties.TASK_MAX_WRITER_COUNT;
@@ -61,7 +61,7 @@ public abstract class BaseJdbcConnectionCreationTest
 
     protected void assertJdbcConnections(Session session, @Language("SQL") String query, int expectedJdbcConnectionsCount, Optional<String> errorMessage)
     {
-        int before = connectionFactory.openConnections.get();
+        int before = connectionFactory.connectionCreationCount();
         if (errorMessage.isPresent()) {
             assertQueryFails(query, errorMessage.get());
         }
@@ -72,8 +72,19 @@ public abstract class BaseJdbcConnectionCreationTest
                     .build();
             getQueryRunner().execute(querySession, query);
         }
-        int after = connectionFactory.openConnections.get();
-        assertThat(after - before).isEqualTo(expectedJdbcConnectionsCount);
+        int after = connectionFactory.connectionCreationCount();
+        try {
+            assertThat(after - before)
+                    .as("JDBC connections created for query: %s", query)
+                    .isEqualTo(expectedJdbcConnectionsCount);
+        }
+        catch (AssertionError failure) {
+            connectionFactory.addConnectionCreationStackTraces(failure, before, after);
+            throw failure;
+        }
+        finally {
+            connectionFactory.clearConnectionCreationStackTraces(after);
+        }
         connectionFactory.assertThatNoConnectionHasLeaked();
     }
 
@@ -82,8 +93,9 @@ public abstract class BaseJdbcConnectionCreationTest
     {
         // Map from connection to a fake exception (holds stacktrace) pointing to the place where the connection was created
         private final Map<Connection, Exception> connectionCreations = synchronizedMap(new IdentityHashMap<>());
-        private final AtomicInteger openConnections = new AtomicInteger();
+        private final Map<Integer, Exception> connectionCreationStackTraces = new HashMap<>();
         private final ConnectionFactory delegate;
+        private int createdConnections;
 
         public ConnectionCountingConnectionFactory(DriverConnectionFactory delegate)
         {
@@ -94,9 +106,9 @@ public abstract class BaseJdbcConnectionCreationTest
         public Connection openConnection(ConnectorSession session)
                 throws SQLException
         {
-            openConnections.incrementAndGet();
+            Exception connectionCreation = recordConnectionCreation();
             Connection connection = delegate.openConnection(session);
-            Exception previous = connectionCreations.put(connection, new Exception("STACKTRACE"));
+            Exception previous = connectionCreations.put(connection, connectionCreation);
             if (previous != null) {
                 // connectionCreations do not support two connections at a time yet
                 IllegalStateException exception = new IllegalStateException("Two connections are opened for same session");
@@ -125,6 +137,34 @@ public abstract class BaseJdbcConnectionCreationTest
                     super.close();
                 }
             };
+        }
+
+        private synchronized int connectionCreationCount()
+        {
+            return createdConnections;
+        }
+
+        private synchronized Exception recordConnectionCreation()
+        {
+            createdConnections++;
+            Exception connectionCreation = new Exception("JDBC connection creation %s".formatted(createdConnections));
+            connectionCreationStackTraces.put(createdConnections, connectionCreation);
+            return connectionCreation;
+        }
+
+        private synchronized void addConnectionCreationStackTraces(AssertionError failure, int before, int after)
+        {
+            for (int connectionNumber = before + 1; connectionNumber <= after; connectionNumber++) {
+                Exception connectionCreation = connectionCreationStackTraces.get(connectionNumber);
+                if (connectionCreation != null) {
+                    failure.addSuppressed(connectionCreation);
+                }
+            }
+        }
+
+        private synchronized void clearConnectionCreationStackTraces(int throughConnectionNumber)
+        {
+            connectionCreationStackTraces.keySet().removeIf(connectionNumber -> connectionNumber <= throughConnectionNumber);
         }
 
         private void assertThatNoConnectionHasLeaked()

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlJdbcConnectionCreation.java
@@ -74,15 +74,6 @@ public class TestPostgreSqlJdbcConnectionCreation
         return queryRunner;
     }
 
-    @Override
-    protected Session getSession()
-    {
-        Session session = super.getSession();
-        return Session.builder(session)
-                .setCatalogSessionProperty(session.getCatalog().orElseThrow(), NON_TRANSACTIONAL_MERGE, "true")
-                .build();
-    }
-
     private static ConnectionCountingConnectionFactory getConnectionCountingConnectionFactory(TestingPostgreSqlServer postgreSqlServer)
     {
         Properties connectionProperties = new Properties();
@@ -125,17 +116,23 @@ public class TestPostgreSqlJdbcConnectionCreation
 
     private void testJdbcMergeConnectionCreations()
     {
+        Session session = getSession();
+        String catalog = session.getCatalog().orElseThrow();
+        Session transactionalMergeSession = Session.builder(session)
+                .setCatalogSessionProperty(catalog, NON_TRANSACTIONAL_MERGE, "false")
+                .build();
+
         // Transactional merge
-        assertJdbcConnections("CREATE TABLE copy_of_customer_transactional AS SELECT * FROM customer", 6, Optional.empty());
+        assertJdbcConnections(transactionalMergeSession, "CREATE TABLE copy_of_customer_transactional AS SELECT * FROM customer", 6, Optional.empty());
         postgreSqlServer.execute("ALTER TABLE copy_of_customer_transactional ADD CONSTRAINT t_copy_of_customer_transactional PRIMARY KEY (custkey)");
 
-        assertJdbcConnections("DELETE FROM copy_of_customer_transactional WHERE abs(custkey) = 1", 18, Optional.empty());
-        assertJdbcConnections("UPDATE copy_of_customer_transactional SET name = 'POLAND' WHERE abs(custkey) = 1", 26, Optional.empty());
-        assertJdbcConnections("MERGE INTO copy_of_customer_transactional n USING customer r ON r.custkey = n.custkey WHEN MATCHED THEN DELETE", 19, Optional.empty());
+        assertJdbcConnections(transactionalMergeSession, "DELETE FROM copy_of_customer_transactional WHERE abs(custkey) = 1", 14, Optional.empty());
+        assertJdbcConnections(transactionalMergeSession, "UPDATE copy_of_customer_transactional SET name = 'POLAND' WHERE abs(custkey) = 1", 18, Optional.empty());
+        assertJdbcConnections(transactionalMergeSession, "MERGE INTO copy_of_customer_transactional n USING customer r ON r.custkey = n.custkey WHEN MATCHED THEN DELETE", 15, Optional.empty());
 
         // Non-transactional merge
-        Session nonTransactionalMergeSession = Session.builder(getSession())
-                .setCatalogSessionProperty(getSession().getCatalog().orElseThrow(), NON_TRANSACTIONAL_MERGE, "true")
+        Session nonTransactionalMergeSession = Session.builder(session)
+                .setCatalogSessionProperty(catalog, NON_TRANSACTIONAL_MERGE, "true")
                 .build();
         assertJdbcConnections(nonTransactionalMergeSession, "CREATE TABLE copy_of_customer_non_transactional AS SELECT * FROM customer", 6, Optional.empty());
         postgreSqlServer.execute("ALTER TABLE copy_of_customer_non_transactional ADD CONSTRAINT t_copy_of_customer_non_transactional PRIMARY KEY (custkey)");

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlLogParser.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlLogParser.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.postgresql;
+
+import io.trino.plugin.jdbc.RemoteDatabaseEvent;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.plugin.jdbc.RemoteDatabaseEvent.Status.CANCELLED;
+import static io.trino.plugin.jdbc.RemoteDatabaseEvent.Status.RUNNING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestPostgreSqlLogParser
+{
+    @Test
+    public void testCancellationWithInterleavedLogEntries()
+    {
+        TestingPostgreSqlServer.PostgreSqlLogParser logParser = new TestingPostgreSqlServer.PostgreSqlLogParser();
+
+        assertThat(logParser.parse(logEntry(123, "ERROR:  canceling statement due to user request"))).isEmpty();
+        assertThat(logParser.parse(logEntry(456, "LOG:  execute <unnamed>: SELECT 1")))
+                .contains(new RemoteDatabaseEvent("SELECT 1", RUNNING));
+        assertThat(logParser.parse(logEntry(123, "LOG:  duration: 1000.000 ms"))).isEmpty();
+        assertThat(logParser.parse(logEntry(123, "STATEMENT:  SELECT pg_sleep(60)")))
+                .contains(new RemoteDatabaseEvent("SELECT pg_sleep(60)", CANCELLED));
+    }
+
+    private static String logEntry(int backendProcessId, String message)
+    {
+        return "2026-08-21 12:34:56.789 UTC [%s] %s".formatted(backendProcessId, message);
+    }
+}

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
@@ -28,7 +28,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Iterator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -64,7 +64,7 @@ public class TestingPostgreSqlServer
     private static final String PASSWORD = "test";
     private static final String DATABASE = "tpch";
 
-    private static final String LOG_PREFIX_REGEXP = "^([-:0-9. ]+UTC \\[[0-9]+\\] )";
+    private static final Pattern LOG_LINE_PATTERN = Pattern.compile("^[-:0-9. ]+UTC \\[([0-9]+)\\] (.*)$");
     private static final String LOG_RUNNING_STATEMENT_PREFIX = "LOG:  execute <unnamed>";
     private static final String LOG_CANCELLATION_EVENT = "ERROR:  canceling statement due to user request";
 
@@ -106,32 +106,37 @@ public class TestingPostgreSqlServer
     private class RemoteDatabaseEventLogConsumer
             implements Consumer<OutputFrame>
     {
-        private boolean cancellationHit;
+        private final PostgreSqlLogParser logParser = new PostgreSqlLogParser();
 
         @Override
         public void accept(OutputFrame outputFrame)
         {
-            if (tracingEvents.isEmpty()) {
-                return;
-            }
-
-            buildEvent(outputFrame)
+            logParser.parse(outputFrame.getUtf8StringWithoutLineEnding())
                     .ifPresent(remoteDatabaseEvent -> tracingEvents.forEach(tracingEvent -> tracingEvent.accept(remoteDatabaseEvent)));
         }
+    }
 
-        private Optional<RemoteDatabaseEvent> buildEvent(OutputFrame outputFrame)
+    static class PostgreSqlLogParser
+    {
+        private final Set<String> cancelledBackendProcessIds = new HashSet<>();
+
+        public Optional<RemoteDatabaseEvent> parse(String logEntry)
         {
-            String logLine = outputFrame.getUtf8StringWithoutLineEnding().replaceAll(LOG_PREFIX_REGEXP, "");
-
-            if (cancellationHit) {
-                cancellationHit = false;
-                if (logLine.startsWith(LOG_CANCELLED_STATEMENT_PREFIX)) {
-                    return Optional.of(new RemoteDatabaseEvent(logLine.substring(LOG_CANCELLED_STATEMENT_PREFIX.length()), CANCELLED));
-                }
+            Matcher logLineMatcher = LOG_LINE_PATTERN.matcher(logEntry);
+            if (!logLineMatcher.matches()) {
+                return Optional.empty();
             }
 
+            String backendProcessId = logLineMatcher.group(1);
+            String logLine = logLineMatcher.group(2);
+
             if (logLine.equals(LOG_CANCELLATION_EVENT)) {
-                cancellationHit = true;
+                cancelledBackendProcessIds.add(backendProcessId);
+                return Optional.empty();
+            }
+
+            if (logLine.startsWith(LOG_CANCELLED_STATEMENT_PREFIX) && cancelledBackendProcessIds.remove(backendProcessId)) {
+                return Optional.of(new RemoteDatabaseEvent(logLine.substring(LOG_CANCELLED_STATEMENT_PREFIX.length()), CANCELLED));
             }
 
             if (logLine.startsWith(LOG_RUNNING_STATEMENT_PREFIX)) {
@@ -181,28 +186,11 @@ public class TestingPostgreSqlServer
 
     protected List<RemoteDatabaseEvent> getRemoteDatabaseEvents()
     {
-        List<String> logs = getLogs();
-        Iterator<String> logsIterator = logs.iterator();
-        ImmutableList.Builder<RemoteDatabaseEvent> events = ImmutableList.builder();
-        while (logsIterator.hasNext()) {
-            String logLine = logsIterator.next().replaceAll(LOG_PREFIX_REGEXP, "");
-            if (logLine.startsWith(LOG_RUNNING_STATEMENT_PREFIX)) {
-                Matcher matcher = SQL_QUERY_FIND_PATTERN.matcher(logLine.substring(LOG_RUNNING_STATEMENT_PREFIX.length()));
-                if (matcher.find()) {
-                    String sqlStatement = matcher.group(2);
-                    events.add(new RemoteDatabaseEvent(sqlStatement, RUNNING));
-                }
-            }
-            if (logLine.equals(LOG_CANCELLATION_EVENT)) {
-                // next line must be present
-                String cancelledStatementLogLine = logsIterator.next().replaceAll(LOG_PREFIX_REGEXP, "");
-                if (cancelledStatementLogLine.startsWith(LOG_CANCELLED_STATEMENT_PREFIX)) {
-                    events.add(new RemoteDatabaseEvent(cancelledStatementLogLine.substring(LOG_CANCELLED_STATEMENT_PREFIX.length()), CANCELLED));
-                }
-            }
-            // ignore unsupported log lines
-        }
-        return events.build();
+        PostgreSqlLogParser logParser = new PostgreSqlLogParser();
+        return getLogs().stream()
+                .map(logParser::parse)
+                .flatMap(Optional::stream)
+                .collect(toImmutableList());
     }
 
     private List<String> getLogs()

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -180,6 +180,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -5822,52 +5823,102 @@ public abstract class BaseConnectorTest
 
         int threads = 4;
         CyclicBarrier barrier = new CyclicBarrier(threads);
-        ExecutorService executor = newFixedThreadPool(threads);
         try (TestTable table = createTableWithOneIntegerColumn("test_add_column")) {
             String tableName = table.getName();
-
-            List<Future<Optional<String>>> futures = IntStream.range(0, threads)
-                    .mapToObj(threadNumber -> executor.submit(() -> {
-                        barrier.await(30, SECONDS);
-                        try {
-                            String columnName = "col" + threadNumber;
-                            getQueryRunner().execute("ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " integer");
-                            return Optional.of(columnName);
-                        }
-                        catch (Exception e) {
-                            RuntimeException trinoException = getTrinoExceptionCause(e);
+            ExecutorService executor = newFixedThreadPool(threads);
+            try {
+                // Capture worker stacks to provide diagnostics for resolving flakes in this concurrent test.
+                ConcurrentMap<Integer, Thread> workerThreads = new ConcurrentHashMap<>();
+                List<Future<Optional<String>>> futures = IntStream.range(0, threads)
+                        .mapToObj(threadNumber -> executor.submit(() -> {
+                            workerThreads.put(threadNumber, Thread.currentThread());
                             try {
-                                verifyConcurrentAddColumnFailurePermissible(trinoException);
-                            }
-                            catch (Throwable verifyFailure) {
-                                if (verifyFailure != e) {
-                                    verifyFailure.addSuppressed(e);
+                                barrier.await(30, SECONDS);
+                                try {
+                                    String columnName = "col" + threadNumber;
+                                    getQueryRunner().execute(addColumnQuery(tableName, threadNumber));
+                                    return Optional.of(columnName);
                                 }
-                                throw verifyFailure;
+                                catch (Exception e) {
+                                    RuntimeException trinoException = getTrinoExceptionCause(e);
+                                    try {
+                                        verifyConcurrentAddColumnFailurePermissible(trinoException);
+                                    }
+                                    catch (Throwable verifyFailure) {
+                                        if (verifyFailure != e) {
+                                            verifyFailure.addSuppressed(e);
+                                        }
+                                        throw verifyFailure;
+                                    }
+                                    return Optional.<String>empty();
+                                }
                             }
-                            return Optional.<String>empty();
-                        }
-                    }))
-                    .collect(toImmutableList());
+                            finally {
+                                workerThreads.remove(threadNumber);
+                            }
+                        }))
+                        .collect(toImmutableList());
 
-            List<String> addedColumns = futures.stream()
-                    .map(future -> tryGetFutureValue(future, 30, SECONDS).orElseThrow(() -> new RuntimeException("Wait timed out")))
-                    .filter(Optional::isPresent)
-                    .map(Optional::get)
-                    .collect(toImmutableList());
+                long deadline = System.nanoTime() + SECONDS.toNanos(30);
+                List<String> addedColumns = new ArrayList<>();
+                for (int threadNumber = 0; threadNumber < futures.size(); threadNumber++) {
+                    long remainingNanos = deadline - System.nanoTime();
+                    int remainingMillis = (int) Math.max(0, NANOSECONDS.toMillis(remainingNanos));
+                    Optional<Optional<String>> result = tryGetFutureValue(futures.get(threadNumber), remainingMillis, MILLISECONDS);
+                    if (result.isEmpty()) {
+                        throw concurrentAddColumnTimeout(tableName, futures, workerThreads, threadNumber);
+                    }
+                    result.orElseThrow().ifPresent(addedColumns::add);
+                }
 
-            assertThat(query("DESCRIBE " + tableName))
-                    .result()
-                    .projected("Column")
-                    .skippingTypesCheck()
-                    .matches(Stream.concat(Stream.of("col"), addedColumns.stream())
-                            .map(value -> format("'%s'", value))
-                            .collect(joining(",", "VALUES ", "")));
+                assertThat(query("DESCRIBE " + tableName))
+                        .result()
+                        .projected("Column")
+                        .skippingTypesCheck()
+                        .matches(Stream.concat(Stream.of("col"), addedColumns.stream())
+                                .map(value -> format("'%s'", value))
+                                .collect(joining(",", "VALUES ", "")));
+            }
+            finally {
+                executor.shutdownNow();
+                executor.awaitTermination(10, SECONDS);
+            }
         }
-        finally {
-            executor.shutdownNow();
-            executor.awaitTermination(30, SECONDS);
+    }
+
+    private static String addColumnQuery(String tableName, int threadNumber)
+    {
+        return "ALTER TABLE %s ADD COLUMN col%s integer".formatted(tableName, threadNumber);
+    }
+
+    private static AssertionError concurrentAddColumnTimeout(
+            String tableName,
+            List<? extends Future<?>> futures,
+            ConcurrentMap<Integer, Thread> workerThreads,
+            int timedOutThreadNumber)
+    {
+        List<Integer> unfinishedOperations = IntStream.range(0, futures.size())
+                .filter(threadNumber -> !futures.get(threadNumber).isDone())
+                .boxed()
+                .collect(toList());
+        if (unfinishedOperations.isEmpty()) {
+            unfinishedOperations.add(timedOutThreadNumber);
         }
+
+        String unfinishedQueries = unfinishedOperations.stream()
+                .map(threadNumber -> addColumnQuery(tableName, threadNumber))
+                .collect(joining("\n  - ", "\n  - ", ""));
+        AssertionError failure = new AssertionError("Timed out after 30 seconds waiting for concurrent ADD COLUMN operations. Unfinished operations:%s".formatted(unfinishedQueries));
+        unfinishedOperations.forEach(threadNumber -> {
+            Thread workerThread = workerThreads.get(threadNumber);
+            if (workerThread != null) {
+                Exception workerStack = new Exception("Worker thread '%s' executing: %s".formatted(workerThread.getName(), addColumnQuery(tableName, threadNumber)));
+                workerStack.setStackTrace(workerThread.getStackTrace());
+                failure.addSuppressed(workerStack);
+            }
+        });
+        log.error(failure, "Concurrent ADD COLUMN operations did not finish");
+        return failure;
     }
 
     protected void verifyConcurrentAddColumnFailurePermissible(Exception e)

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestServerAbandonedQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestServerAbandonedQueries.java
@@ -21,6 +21,7 @@ import io.trino.client.StatementClientFactory;
 import io.trino.client.uri.TrinoUri;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.server.testing.TestingTrinoServer;
+import io.trino.spi.QueryId;
 import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -29,9 +30,12 @@ import org.junit.jupiter.api.parallel.Execution;
 
 import java.time.ZoneId;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import static io.trino.client.uri.HttpClientFactory.toHttpClientBuilder;
+import static io.trino.spi.StandardErrorCode.ABANDONED_QUERY;
+import static io.trino.testing.assertions.Assert.assertEventually;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -55,7 +59,6 @@ public class TestServerAbandonedQueries
 
     @Test
     public void testAbandonedQueries()
-            throws InterruptedException
     {
         TrinoUri trinoUri = TrinoUri.builder()
                 .setUri(server.getBaseUrl())
@@ -67,13 +70,15 @@ public class TestServerAbandonedQueries
                 .source("test")
                 .timeZone(ZoneId.of("UTC"))
                 .user(Optional.of("user"))
-                .heartbeatInterval(new Duration(1, TimeUnit.SECONDS))
+                .heartbeatInterval(new Duration(100, MILLISECONDS))
                 .build();
 
         try (StatementClient client = StatementClientFactory.newStatementClient(httpClient, session, "SELECT * FROM tpch.sf1.nation")) {
             client.advance();
-            // heartbeat is expected every 1 second, the check runs every second, plus one second padding
-            Thread.sleep(3000);
+            assertEventually(new Duration(10, SECONDS), () -> assertThat(server.getQueryManager()
+                    .getQueryInfo(new QueryId(client.currentStatusInfo().getId()))
+                    .getErrorCode())
+                    .isEqualTo(ABANDONED_QUERY.toErrorCode()));
             client.advance();
             assertThat(client.currentStatusInfo().getError().getMessage())
                     .contains("was abandoned by the client, as it may have exited or stopped checking for query results");


### PR DESCRIPTION
## Description

Reduce several recurring merge-queue test failures:

- Remove the heartbeat timing race from `TestServerAbandonedQueries`.
- Correlate PostgreSQL cancellation statements by backend process ID when logs from multiple processes are interleaved.
- Run transactional and non-transactional MERGE connection-count checks with explicit session settings, and attach connection-creation stacks to count failures.
- Give concurrent ADD COLUMN operations one shared deadline and report unfinished SQL with worker stacks before cancelling workers and dropping the table.

## Additional context and related issues

- Related to #27507. The concurrent ADD COLUMN change improves failure diagnostics and cleanup ordering; it does not claim to resolve the underlying database stall.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```