### PR TITLE
Run product test suites in parallel

### DIFF
--- a/.github/bin/build-pt-matrix.py
+++ b/.github/bin/build-pt-matrix.py
@@ -49,6 +49,7 @@ SUITES = [
     "SuiteStorageFormatsDetailed",
     "SuiteParquet",
     "SuiteIceberg",
+    "SuiteIcebergVariants",
     "SuiteDeltaLakeOss",
     "SuiteCompatibility",
     "SuiteGcs",
@@ -91,6 +92,7 @@ HIVE_SUITES = DATABRICKS_SUITES | {
     "SuiteHmsOnly",
     "SuiteHudi",
     "SuiteIceberg",
+    "SuiteIcebergVariants",
     "SuiteParquet",
     "SuiteSqlCancel",
     "SuiteStorageFormatsDetailed",
@@ -106,6 +108,7 @@ ICEBERG_SUITES = {
     "SuiteHiveStorageFormats",
     "SuiteHmsOnly",
     "SuiteIceberg",
+    "SuiteIcebergVariants",
     "SuiteStorageFormatsDetailed",
 }
 JDBC_CONNECTOR_SUITES = ALL_CONNECTORS_SMOKE | {
@@ -130,7 +133,7 @@ MODULE_TO_SUITES = {
     "plugin/trino-blob-cache-alluxio": {
         "SuiteDeltaLakeOss",
         "SuiteHiveAlluxioCaching",
-        "SuiteIceberg",
+        "SuiteIcebergVariants",
     },
     "plugin/trino-exchange-filesystem": {"SuiteFaultTolerant"},
     "plugin/trino-example-jdbc": set(),
@@ -155,7 +158,7 @@ MODULE_TO_SUITES = {
     "plugin/trino-jmx": ALL_CONNECTORS_SMOKE | {
         "SuiteDeltaLakeOss",
         "SuiteHiveAlluxioCaching",
-        "SuiteIceberg",
+        "SuiteIcebergVariants",
     },
     "plugin/trino-kafka": ALL_CONNECTORS_SMOKE | {"SuiteKafka"},
     "plugin/trino-loki": ALL_CONNECTORS_SMOKE | {"SuiteLoki"},

--- a/.github/bin/build-pt-matrix.py
+++ b/.github/bin/build-pt-matrix.py
@@ -50,7 +50,10 @@ SUITES = [
     "SuiteParquet",
     "SuiteIceberg",
     "SuiteIcebergVariants",
+    "SuiteDeltaLakeFloci",
+    "SuiteDeltaLakeHdfs",
     "SuiteDeltaLakeOss",
+    "SuiteDeltaLakeAlluxioCaching",
     "SuiteCompatibility",
     "SuiteGcs",
     "SuiteAzure",
@@ -72,6 +75,9 @@ DATABRICKS_SUITES = frozenset({
 })
 DELTA_LAKE_SUITES = DATABRICKS_SUITES | {
     "SuiteAzure",
+    "SuiteDeltaLakeAlluxioCaching",
+    "SuiteDeltaLakeFloci",
+    "SuiteDeltaLakeHdfs",
     "SuiteDeltaLakeOss",
     "SuiteGcs",
 }
@@ -80,6 +86,8 @@ HIVE_SUITES = DATABRICKS_SUITES | {
     "SuiteAzure",
     "SuiteClients",
     "SuiteCompatibility",
+    "SuiteDeltaLakeFloci",
+    "SuiteDeltaLakeHdfs",
     "SuiteDeltaLakeOss",
     "SuiteGcs",
     "SuiteHdfsImpersonation",
@@ -103,7 +111,7 @@ HIVE_SUITES = DATABRICKS_SUITES | {
 ICEBERG_SUITES = {
     "SuiteAzure",
     "SuiteCompatibility",
-    "SuiteDeltaLakeOss",
+    "SuiteDeltaLakeFloci",
     "SuiteGcs",
     "SuiteHiveStorageFormats",
     "SuiteHmsOnly",
@@ -131,7 +139,7 @@ MODULE_TO_SUITES = {
     # same level: shared libraries, clients, core, and other infrastructure cause a full run.
     "plugin/trino-base-jdbc": JDBC_CONNECTOR_SUITES,
     "plugin/trino-blob-cache-alluxio": {
-        "SuiteDeltaLakeOss",
+        "SuiteDeltaLakeAlluxioCaching",
         "SuiteHiveAlluxioCaching",
         "SuiteIcebergVariants",
     },
@@ -156,7 +164,7 @@ MODULE_TO_SUITES = {
     "plugin/trino-iceberg": ALL_CONNECTORS_SMOKE | ICEBERG_SUITES,
     "plugin/trino-ignite": ALL_CONNECTORS_SMOKE | {"SuiteIgnite"},
     "plugin/trino-jmx": ALL_CONNECTORS_SMOKE | {
-        "SuiteDeltaLakeOss",
+        "SuiteDeltaLakeAlluxioCaching",
         "SuiteHiveAlluxioCaching",
         "SuiteIcebergVariants",
     },

--- a/.github/bin/build-pt-matrix.py
+++ b/.github/bin/build-pt-matrix.py
@@ -11,88 +11,56 @@ from pathlib import Path
 SUITE_DIR = Path("testing/trino-product-tests/src/test/java/io/trino/tests/product/suite")
 SUITE_HELPERS = {"SuiteRunner", "SuiteTag"}
 
-BUCKETS = [
-    ("jdbc-core", [
-        "SuiteMysql",
-        "SuitePostgresql",
-        "SuiteSqlServer",
-        "SuiteFunctions",
-        "SuiteTpch",
-        "SuiteTpcds",
-    ]),
-    ("jdbc-external", [
-        "SuiteExasol",
-        "SuiteSnowflake",
-    ]),
-    ("connector-smoke", [
-        "SuiteCassandra",
-        "SuiteClickhouse",
-        "SuiteBlackHole",
-        "SuiteAllConnectorsSmoke",
-        "SuiteIgnite",
-    ]),
-    ("auth-and-clients", [
-        "SuiteKafka",
-        "SuiteLdap",
-        "SuiteOauth2",
-        "SuiteClients",
-        "SuiteJdbcKerberos",
-        "SuiteLoki",
-        "SuiteRanger",
-        "SuiteTls",
-    ]),
-    ("hive-basic", [
-        "SuiteHiveBasic",
-        "SuiteHmsOnly",
-        "SuiteHiveStorageFormats",
-        "SuiteSqlCancel",
-    ]),
-    ("hive-kerberos", [
-        "SuiteHdfsImpersonation",
-        "SuiteTwoHives",
-        "SuiteHive4",
-        "SuiteHudi",
-    ]),
-    ("hive-transactional", [
-        "SuiteHiveTransactional",
-        "SuiteAuthorization",
-        "SuiteFaultTolerant",
-    ]),
-    ("hive-storage", [
-        "SuiteHiveSpark",
-        "SuiteHiveAlluxioCaching",
-        "SuiteStorageFormatsDetailed",
-        "SuiteParquet",
-    ]),
-    ("iceberg", [
-        "SuiteIceberg",
-    ]),
-    ("delta-lake", [
-        "SuiteDeltaLakeOss",
-        "SuiteCompatibility",
-    ]),
-    ("cloud-object-store", [
-        "SuiteGcs",
-        "SuiteAzure",
-    ]),
-    ("databricks-133", [
-        "SuiteDeltaLakeDatabricks133",
-    ]),
-    ("databricks-143", [
-        "SuiteDeltaLakeDatabricks143",
-    ]),
-    ("databricks-154", [
-        "SuiteDeltaLakeDatabricks154",
-    ]),
-    ("databricks-164", [
-        "SuiteDeltaLakeDatabricks164",
-    ]),
-    ("databricks-173", [
-        "SuiteDeltaLakeDatabricks173",
-    ]),
+SUITES = [
+    "SuiteMysql",
+    "SuitePostgresql",
+    "SuiteSqlServer",
+    "SuiteFunctions",
+    "SuiteTpch",
+    "SuiteTpcds",
+    "SuiteExasol",
+    "SuiteSnowflake",
+    "SuiteCassandra",
+    "SuiteClickhouse",
+    "SuiteBlackHole",
+    "SuiteAllConnectorsSmoke",
+    "SuiteIgnite",
+    "SuiteKafka",
+    "SuiteLdap",
+    "SuiteOauth2",
+    "SuiteClients",
+    "SuiteJdbcKerberos",
+    "SuiteLoki",
+    "SuiteRanger",
+    "SuiteTls",
+    "SuiteHiveBasic",
+    "SuiteHmsOnly",
+    "SuiteHiveStorageFormats",
+    "SuiteSqlCancel",
+    "SuiteHdfsImpersonation",
+    "SuiteTwoHives",
+    "SuiteHive4",
+    "SuiteHudi",
+    "SuiteHiveTransactional",
+    "SuiteAuthorization",
+    "SuiteFaultTolerant",
+    "SuiteHiveSpark",
+    "SuiteHiveAlluxioCaching",
+    "SuiteStorageFormatsDetailed",
+    "SuiteParquet",
+    "SuiteIceberg",
+    "SuiteDeltaLakeOss",
+    "SuiteCompatibility",
+    "SuiteGcs",
+    "SuiteAzure",
+    "SuiteDeltaLakeDatabricks133",
+    "SuiteDeltaLakeDatabricks143",
+    "SuiteDeltaLakeDatabricks154",
+    "SuiteDeltaLakeDatabricks164",
+    "SuiteDeltaLakeDatabricks173",
 ]
 
-ALL_SUITES = frozenset(suite for _, suites in BUCKETS for suite in suites)
+ALL_SUITES = frozenset(SUITES)
 ALL_CONNECTORS_SMOKE = frozenset({"SuiteAllConnectorsSmoke"})
 DATABRICKS_SUITES = frozenset({
     "SuiteDeltaLakeDatabricks133",
@@ -263,13 +231,9 @@ def build_matrix(impacted_modules):
         selected_suites = ALL_SUITES
 
     include = []
-    for bucket, suites in BUCKETS:
-        filtered_suites = [suite for suite in suites if suite in selected_suites]
-        if filtered_suites:
-            include.append({
-                "bucket": bucket,
-                "suites": " ".join(filtered_suites),
-            })
+    for suite in SUITES:
+        if suite in selected_suites:
+            include.append({"suite": suite})
     return {"include": include} if include else {}
 
 
@@ -298,7 +262,7 @@ def suites_for_impacted_modules(impacted_modules):
 
 
 def validate_configuration(suite_dir=SUITE_DIR):
-    declared_suites = [suite for _, suites in BUCKETS for suite in suites]
+    declared_suites = SUITES
     duplicate_suites = sorted({suite for suite in declared_suites if declared_suites.count(suite) > 1})
     if duplicate_suites:
         raise ValueError(f"Suites declared more than once: {', '.join(duplicate_suites)}")
@@ -327,8 +291,8 @@ class TestBuildMatrix(unittest.TestCase):
             build_matrix({"plugin/trino-mysql"}),
             {
                 "include": [
-                    {"bucket": "jdbc-core", "suites": "SuiteMysql"},
-                    {"bucket": "connector-smoke", "suites": "SuiteAllConnectorsSmoke"},
+                    {"suite": "SuiteMysql"},
+                    {"suite": "SuiteAllConnectorsSmoke"},
                 ],
             },
         )
@@ -338,9 +302,9 @@ class TestBuildMatrix(unittest.TestCase):
             build_matrix({"plugin/trino-mariadb"}),
             {
                 "include": [
-                    {"bucket": "jdbc-core", "suites": "SuiteMysql"},
-                    {"bucket": "connector-smoke", "suites": "SuiteAllConnectorsSmoke"},
-                    {"bucket": "auth-and-clients", "suites": "SuiteRanger"},
+                    {"suite": "SuiteMysql"},
+                    {"suite": "SuiteAllConnectorsSmoke"},
+                    {"suite": "SuiteRanger"},
                 ],
             },
         )
@@ -397,7 +361,9 @@ class TestBuildMatrix(unittest.TestCase):
         self.assertEqual(build_matrix(set()), build_matrix(None))
 
     def test_forced_full_run(self):
-        self.assertEqual(suites_from_matrix(build_matrix(None)), ALL_SUITES)
+        matrix = build_matrix(None)
+        self.assertEqual(suites_from_matrix(matrix), ALL_SUITES)
+        self.assertEqual(len(matrix["include"]), len(ALL_SUITES))
 
     def test_understood_module_without_product_tests_produces_empty_matrix(self):
         self.assertEqual(build_matrix({"plugin/trino-example-jdbc"}), {})
@@ -407,11 +373,7 @@ class TestBuildMatrix(unittest.TestCase):
 
 
 def suites_from_matrix(matrix):
-    return {
-        suite
-        for item in matrix.get("include", [])
-        for suite in item["suites"].split()
-    }
+    return {item["suite"] for item in matrix.get("include", [])}
 
 
 validate_configuration()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -929,7 +929,7 @@ jobs:
 
   pt:
     runs-on: 'ubuntu-latest'
-    name: pt (${{ matrix.bucket }})
+    name: pt (${{ matrix.suite }})
     if: needs.build-pt.outputs.matrix != '{}'
     strategy:
       fail-fast: false
@@ -1002,13 +1002,13 @@ jobs:
           declare -a suite_results=()
           declare -a suite_totals=()
           declare -a skipped_suites=()
-          echo "## pt ${{ matrix.bucket }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "## pt ${{ matrix.suite }}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           failed=0
           failed_suites=()
 
-          for suite in ${{ matrix.suites }}; do
+          for suite in ${{ matrix.suite }}; do
             log_file="logs/${suite}.log"
             echo "### ${suite}" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -1114,9 +1114,9 @@ jobs:
 
           echo ""
           echo "========================================"
-          echo "        PT-JUNIT BUCKET SUMMARY         "
+          echo "         PT-JUNIT SUITE SUMMARY         "
           echo "========================================"
-          echo "Bucket: ${{ matrix.bucket }}"
+          echo "Suite: ${{ matrix.suite }}"
           echo ""
           for entry in "${suite_results[@]}"; do
             suite_name=${entry%%:*}
@@ -1164,7 +1164,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: pt (${{ matrix.bucket }})
+          name: pt (${{ matrix.suite }})
           path: logs/
           retention-days: 7
       - name: Update PR check
@@ -1183,7 +1183,7 @@ jobs:
         if: ${{ failure() && github.event_name == 'merge_group' }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: .github/bin/cancel-merge-queue-workflow.sh "pt (${{ matrix.bucket }})"
+        run: .github/bin/cancel-merge-queue-workflow.sh "pt (${{ matrix.suite }})"
 
 
   build-success:

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteDeltaLakeAlluxioCaching.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteDeltaLakeAlluxioCaching.java
@@ -14,15 +14,15 @@
 package io.trino.tests.product.suite;
 
 import io.trino.tests.product.TestGroup;
-import io.trino.tests.product.deltalake.DeltaLakeOssEnvironment;
+import io.trino.tests.product.deltalake.DeltaLakeFlociCachingEnvironment;
 import io.trino.tests.product.suite.SuiteRunner.TestRunResult;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public final class SuiteDeltaLakeOss
+public final class SuiteDeltaLakeAlluxioCaching
 {
-    private SuiteDeltaLakeOss() {}
+    private SuiteDeltaLakeAlluxioCaching() {}
 
     public static void main(String[] args)
             throws Exception
@@ -31,8 +31,8 @@ public final class SuiteDeltaLakeOss
 
         List<TestRunResult> results = new ArrayList<>();
 
-        results.add(SuiteRunner.forEnvironment(DeltaLakeOssEnvironment.class)
-                .includeTag(TestGroup.DeltaLakeOss.class)
+        results.add(SuiteRunner.forEnvironment(DeltaLakeFlociCachingEnvironment.class)
+                .includeTag(TestGroup.DeltaLakeAlluxioCaching.class)
                 .run());
 
         SuiteRunner.printSummary(results);

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteDeltaLakeFloci.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteDeltaLakeFloci.java
@@ -14,15 +14,15 @@
 package io.trino.tests.product.suite;
 
 import io.trino.tests.product.TestGroup;
-import io.trino.tests.product.deltalake.DeltaLakeOssEnvironment;
+import io.trino.tests.product.deltalake.DeltaLakeFlociEnvironment;
 import io.trino.tests.product.suite.SuiteRunner.TestRunResult;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public final class SuiteDeltaLakeOss
+public final class SuiteDeltaLakeFloci
 {
-    private SuiteDeltaLakeOss() {}
+    private SuiteDeltaLakeFloci() {}
 
     public static void main(String[] args)
             throws Exception
@@ -31,8 +31,8 @@ public final class SuiteDeltaLakeOss
 
         List<TestRunResult> results = new ArrayList<>();
 
-        results.add(SuiteRunner.forEnvironment(DeltaLakeOssEnvironment.class)
-                .includeTag(TestGroup.DeltaLakeOss.class)
+        results.add(SuiteRunner.forEnvironment(DeltaLakeFlociEnvironment.class)
+                .includeTag(TestGroup.DeltaLakeFloci.class)
                 .run());
 
         SuiteRunner.printSummary(results);

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteDeltaLakeHdfs.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteDeltaLakeHdfs.java
@@ -14,15 +14,15 @@
 package io.trino.tests.product.suite;
 
 import io.trino.tests.product.TestGroup;
-import io.trino.tests.product.deltalake.DeltaLakeOssEnvironment;
+import io.trino.tests.product.deltalake.DeltaLakeKerberosHdfsEnvironment;
 import io.trino.tests.product.suite.SuiteRunner.TestRunResult;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public final class SuiteDeltaLakeOss
+public final class SuiteDeltaLakeHdfs
 {
-    private SuiteDeltaLakeOss() {}
+    private SuiteDeltaLakeHdfs() {}
 
     public static void main(String[] args)
             throws Exception
@@ -31,8 +31,8 @@ public final class SuiteDeltaLakeOss
 
         List<TestRunResult> results = new ArrayList<>();
 
-        results.add(SuiteRunner.forEnvironment(DeltaLakeOssEnvironment.class)
-                .includeTag(TestGroup.DeltaLakeOss.class)
+        results.add(SuiteRunner.forEnvironment(DeltaLakeKerberosHdfsEnvironment.class)
+                .includeTag(TestGroup.DeltaLakeHdfs.class)
                 .run());
 
         SuiteRunner.printSummary(results);

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteIceberg.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteIceberg.java
@@ -14,12 +14,7 @@
 package io.trino.tests.product.suite;
 
 import io.trino.tests.product.TestGroup;
-import io.trino.tests.product.hive.HiveIcebergRedirectionsEnvironment;
-import io.trino.tests.product.iceberg.MultiNodeIcebergFlociCachingEnvironment;
 import io.trino.tests.product.iceberg.SparkIcebergEnvironment;
-import io.trino.tests.product.iceberg.SparkIcebergJdbcCatalogEnvironment;
-import io.trino.tests.product.iceberg.SparkIcebergNessieEnvironment;
-import io.trino.tests.product.iceberg.SparkIcebergRestEnvironment;
 import io.trino.tests.product.suite.SuiteRunner.TestRunResult;
 
 import java.util.ArrayList;
@@ -39,27 +34,6 @@ public final class SuiteIceberg
         results.add(SuiteRunner.forEnvironment(SparkIcebergEnvironment.class)
                 .includeTag(TestGroup.Iceberg.class)
                 .excludeTag(TestGroup.IcebergFormatVersionCompatibility.class)
-                .excludeTag(TestGroup.StorageFormats.class)
-                .run());
-
-        results.add(SuiteRunner.forEnvironment(HiveIcebergRedirectionsEnvironment.class)
-                .includeTag(TestGroup.HiveIcebergRedirections.class)
-                .run());
-
-        results.add(SuiteRunner.forEnvironment(SparkIcebergRestEnvironment.class)
-                .includeTag(TestGroup.IcebergRest.class)
-                .run());
-
-        results.add(SuiteRunner.forEnvironment(SparkIcebergJdbcCatalogEnvironment.class)
-                .includeTag(TestGroup.IcebergJdbc.class)
-                .run());
-
-        results.add(SuiteRunner.forEnvironment(SparkIcebergNessieEnvironment.class)
-                .includeTag(TestGroup.IcebergNessie.class)
-                .run());
-
-        results.add(SuiteRunner.forEnvironment(MultiNodeIcebergFlociCachingEnvironment.class)
-                .includeTag(TestGroup.IcebergAlluxioCaching.class)
                 .excludeTag(TestGroup.StorageFormats.class)
                 .run());
 

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteIcebergVariants.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteIcebergVariants.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.suite;
+
+import io.trino.tests.product.TestGroup;
+import io.trino.tests.product.hive.HiveIcebergRedirectionsEnvironment;
+import io.trino.tests.product.iceberg.MultiNodeIcebergFlociCachingEnvironment;
+import io.trino.tests.product.iceberg.SparkIcebergJdbcCatalogEnvironment;
+import io.trino.tests.product.iceberg.SparkIcebergNessieEnvironment;
+import io.trino.tests.product.iceberg.SparkIcebergRestEnvironment;
+import io.trino.tests.product.suite.SuiteRunner.TestRunResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class SuiteIcebergVariants
+{
+    private SuiteIcebergVariants() {}
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        System.setProperty("trino.product-test.environment-mode", "STRICT");
+
+        List<TestRunResult> results = new ArrayList<>();
+
+        results.add(SuiteRunner.forEnvironment(HiveIcebergRedirectionsEnvironment.class)
+                .includeTag(TestGroup.HiveIcebergRedirections.class)
+                .run());
+
+        results.add(SuiteRunner.forEnvironment(SparkIcebergRestEnvironment.class)
+                .includeTag(TestGroup.IcebergRest.class)
+                .run());
+
+        results.add(SuiteRunner.forEnvironment(SparkIcebergJdbcCatalogEnvironment.class)
+                .includeTag(TestGroup.IcebergJdbc.class)
+                .run());
+
+        results.add(SuiteRunner.forEnvironment(SparkIcebergNessieEnvironment.class)
+                .includeTag(TestGroup.IcebergNessie.class)
+                .run());
+
+        results.add(SuiteRunner.forEnvironment(MultiNodeIcebergFlociCachingEnvironment.class)
+                .includeTag(TestGroup.IcebergAlluxioCaching.class)
+                .excludeTag(TestGroup.StorageFormats.class)
+                .run());
+
+        SuiteRunner.printSummary(results);
+        System.exit(SuiteRunner.hasFailures(results) ? 1 : 0);
+    }
+}


### PR DESCRIPTION
## Description

Run each JUnit product test suite in an independent CI matrix job instead of combining multiple suites in larger jobs.

Split the long Iceberg coverage into the existing Spark and Hive metastore suite plus a second suite for the five shorter environment variants. Split the existing non-Databricks Delta Lake environments into four independent suites. The five Databricks jobs remain unchanged, avoiding additional concurrency against those systems.

The full matrix contains 50 unique suite jobs.

## CI impact

The following indicative comparison uses total job wall time, including setup and teardown, from the [existing bundled layout](https://github.com/trinodb/trino/actions/runs/32546990187) and the [50-job layout in this PR](https://github.com/trinodb/trino/actions/runs/32556482632):

| Area | Existing bundled job | New longest job | Improvement |
|---|---:|---:|---:|
| Overall critical path (Iceberg) | 38:05 | 24:35 | 13:30 (35%) |
| Authentication and clients | 32:18 | 12:57 | 19:21 (60%) |
| Delta Lake | 30:58 | 16:23 | 14:35 (47%) |

All 50 product-test jobs completed successfully. The actual `SuiteIceberg` test step took 21:58 of its 24:35 total job time.

These runs do not provide a meaningful Databricks runtime measurement because the secret-dependent tests did not perform test work. This change preserves the existing five Databricks jobs and does not increase concurrency against those systems.

## Additional context and related issues

Builds on #30846, which reduced the product test distribution size and startup cost.

## Testing

- `python3 .github/bin/build-pt-matrix.py --test`
- `./mvnw -pl testing/trino-product-tests -am -DskipTests -Dair.check.skip-all install`
- `./mvnw -pl testing/trino-product-tests test`

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```