### PR TITLE
Replace page source provider memory polling with shared memory context

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorServices.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorServices.java
@@ -139,7 +139,7 @@ public class ConnectorServices
             requireNonNull(connectorRecordSetProvider, format("Connector '%s' returned a null record set provider", catalogHandle));
             verify(connectorPageSourceProviderFactory == null, "Connector '%s' returned both page source and record set providers", catalogHandle);
             var pageSourceProvider = new RecordPageSourceProvider(connectorRecordSetProvider);
-            connectorPageSourceProviderFactory = () -> pageSourceProvider;
+            connectorPageSourceProviderFactory = _ -> pageSourceProvider;
         }
         catch (UnsupportedOperationException _) {
         }

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemPageSourceProvider.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemPageSourceProvider.java
@@ -73,7 +73,8 @@ public class SystemPageSourceProvider
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.connectorPageSourceProvider = requireNonNull(pageSourceProviderFactory, "pageSourceProviderFactory is null")
-                .map(ConnectorPageSourceProviderFactory::createPageSourceProvider);
+                // system tables hold no state shared across page sources, so there is nothing to account for
+                .map(factory -> factory.createPageSourceProvider(MemoryContext.NO_LIMIT));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
@@ -80,6 +80,7 @@ public class ScanFilterAndProjectOperator
     private long readTimeNanos;
     private long dynamicFilterSplitsProcessed;
     private Metrics metrics = Metrics.EMPTY;
+    private boolean released;
 
     private ScanFilterAndProjectOperator(
             OperatorContext operatorContext,
@@ -169,13 +170,19 @@ public class ScanFilterAndProjectOperator
     @Override
     public void close()
     {
-        if (pageSource != null) {
-            try {
+        try {
+            if (pageSource != null) {
                 pageSource.close();
                 metrics = pageSource.getMetrics();
             }
-            catch (IOException e) {
-                throw new UncheckedIOException(e);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        finally {
+            if (!released) {
+                released = true;
+                pageSourceProvider.release();
             }
         }
     }
@@ -192,7 +199,6 @@ public class ScanFilterAndProjectOperator
         final List<ColumnHandle> columns;
         final DynamicFilter dynamicFilter;
         final List<Type> types;
-        final LocalMemoryContext pageSourceProviderMemoryContext;
         final LocalMemoryContext pageSourceMemoryContext;
         final LocalMemoryContext memoryContext;
         final AggregatedMemoryContext localAggregatedMemoryContext;
@@ -223,7 +229,6 @@ public class ScanFilterAndProjectOperator
             this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
             this.dynamicFilter = requireNonNull(dynamicFilter, "dynamicFilter is null");
             this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
-            this.pageSourceProviderMemoryContext = aggregatedMemoryContext.newLocalMemoryContext(ScanFilterAndProjectOperator.class.getSimpleName() + "-PageSourceProvider");
             this.pageSourceMemoryContext = aggregatedMemoryContext.newLocalMemoryContext(ScanFilterAndProjectOperator.class.getSimpleName() + "-ConnectorPageSource");
             this.memoryContext = aggregatedMemoryContext.newLocalMemoryContext(ScanFilterAndProjectOperator.class.getSimpleName());
             this.localAggregatedMemoryContext = newSimpleAggregatedMemoryContext();
@@ -262,7 +267,7 @@ public class ScanFilterAndProjectOperator
         {
             ConnectorSession connectorSession = session.toConnectorSession();
             return WorkProcessor
-                    .create(new ConnectorPageSourceToPages(pageSourceProviderMemoryContext))
+                    .create(new ConnectorPageSourceToPages())
                     .yielding(yieldSignal::isSet)
                     .flatMap(page -> {
                         WorkProcessor<Page> workProcessor = pageProcessor.createWorkProcessor(
@@ -310,13 +315,6 @@ public class ScanFilterAndProjectOperator
     private class ConnectorPageSourceToPages
             implements WorkProcessor.Process<SourcePage>
     {
-        final LocalMemoryContext pageSourceProviderMemoryContext;
-
-        ConnectorPageSourceToPages(LocalMemoryContext pageSourceProviderMemoryContext)
-        {
-            this.pageSourceProviderMemoryContext = pageSourceProviderMemoryContext;
-        }
-
         @Override
         public ProcessState<SourcePage> process()
         {
@@ -330,7 +328,6 @@ public class ScanFilterAndProjectOperator
             }
 
             SourcePage page = pageSource.getNextSourcePage();
-            pageSourceProviderMemoryContext.setBytes(pageSourceProvider.getMemoryUsage());
 
             // update operator stats
             processedPositions += page == null ? 0 : page.getPositionCount();
@@ -384,7 +381,8 @@ public class ScanFilterAndProjectOperator
                 DynamicFilter dynamicFilter,
                 List<Type> types,
                 DataSize minOutputPageSize,
-                int minOutputPageRowCount)
+                int minOutputPageRowCount,
+                AggregatedMemoryContext pageSourceProviderMemoryContext)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
@@ -397,7 +395,7 @@ public class ScanFilterAndProjectOperator
             this.types = requireNonNull(types, "types is null");
             this.minOutputPageSize = requireNonNull(minOutputPageSize, "minOutputPageSize is null");
             this.minOutputPageRowCount = minOutputPageRowCount;
-            this.pageSourceProvider = pageSourceProvider.createPageSourceProvider(table.catalogHandle());
+            this.pageSourceProvider = pageSourceProvider.createPageSourceProvider(table.catalogHandle(), pageSourceProviderMemoryContext);
         }
 
         @Override
@@ -447,7 +445,7 @@ public class ScanFilterAndProjectOperator
                 DriverYieldSignal yieldSignal,
                 WorkProcessor<Split> split)
         {
-            return new ScanFilterAndProjectOperator(
+            ScanFilterAndProjectOperator operator = new ScanFilterAndProjectOperator(
                     operatorContext,
                     yieldSignal,
                     split,
@@ -460,12 +458,18 @@ public class ScanFilterAndProjectOperator
                     types,
                     minOutputPageSize,
                     minOutputPageRowCount);
+            pageSourceProvider.retain();
+            return operator;
         }
 
         @Override
         public void noMoreOperators()
         {
+            if (closed) {
+                return;
+            }
             closed = true;
+            pageSourceProvider.release();
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.metadata.Split;
 import io.trino.metadata.TableHandle;
@@ -70,7 +71,8 @@ public class TableScanOperator
                 TableHandle table,
                 Optional<ConnectorTableCredentials> tableCredentials,
                 List<ColumnHandle> columns,
-                List<Type> columnTypes)
+                List<Type> columnTypes,
+                AggregatedMemoryContext pageSourceProviderMemoryContext)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
@@ -79,7 +81,7 @@ public class TableScanOperator
             this.tableCredentials = requireNonNull(tableCredentials, "tableCredentials is null");
             this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
             this.columnTypes = ImmutableList.copyOf(requireNonNull(columnTypes, "columnTypes is null"));
-            this.pageSourceProvider = pageSourceProvider.createPageSourceProvider(table.catalogHandle());
+            this.pageSourceProvider = pageSourceProvider.createPageSourceProvider(table.catalogHandle(), pageSourceProviderMemoryContext);
         }
 
         @Override
@@ -101,6 +103,7 @@ public class TableScanOperator
                     table,
                     tableCredentials,
                     columns);
+            pageSourceProvider.retain();
 
             if (isSourcePagesValidationEnabled(operatorContext.getSession())) {
                 return new OutputValidatingSourceOperator(
@@ -114,7 +117,11 @@ public class TableScanOperator
         @Override
         public void noMoreOperators()
         {
+            if (closed) {
+                return;
+            }
             closed = true;
+            pageSourceProvider.release();
         }
     }
 
@@ -124,7 +131,6 @@ public class TableScanOperator
     private final TableHandle table;
     private final Optional<ConnectorTableCredentials> tableCredentials;
     private final List<ColumnHandle> columns;
-    private final LocalMemoryContext pageSourceProviderMemoryContext;
     private final LocalMemoryContext pageSourceMemoryContext;
     private final SettableFuture<Void> blocked = SettableFuture.create();
 
@@ -134,6 +140,7 @@ public class TableScanOperator
     private ConnectorPageSource source;
 
     private boolean finished;
+    private boolean released;
 
     private long completedBytes;
     private long completedPositions;
@@ -153,7 +160,6 @@ public class TableScanOperator
         this.table = requireNonNull(table, "table is null");
         this.tableCredentials = requireNonNull(tableCredentials, "tableCredentials is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
-        this.pageSourceProviderMemoryContext = operatorContext.newLocalUserMemoryContext(TableScanOperator.class.getSimpleName() + "-PageSourceProvider");
         this.pageSourceMemoryContext = operatorContext.newLocalUserMemoryContext(TableScanOperator.class.getSimpleName() + "-ConnectorPageSource");
     }
 
@@ -199,7 +205,15 @@ public class TableScanOperator
     @Override
     public void close()
     {
-        finish();
+        try {
+            finish();
+        }
+        finally {
+            if (!released) {
+                released = true;
+                pageSourceProvider.release();
+            }
+        }
     }
 
     @Override
@@ -215,7 +229,6 @@ public class TableScanOperator
             catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
-            pageSourceProviderMemoryContext.setBytes(pageSourceProvider.getMemoryUsage());
             operatorContext.setLatestConnectorMetrics(source.getMetrics());
         }
     }
@@ -225,9 +238,6 @@ public class TableScanOperator
     {
         if (!finished) {
             finished = (source != null) && source.isFinished();
-            if (source != null) {
-                pageSourceProviderMemoryContext.setBytes(pageSourceProvider.getMemoryUsage());
-            }
         }
 
         return finished;
@@ -297,8 +307,6 @@ public class TableScanOperator
         completedPositions = endCompletedPositions;
         readTimeNanos = endReadTimeNanos;
 
-        // updating memory usage should happen after page is loaded.
-        pageSourceProviderMemoryContext.setBytes(pageSourceProvider.getMemoryUsage());
         operatorContext.setLatestConnectorMetrics(source.getMetrics());
         return page;
     }

--- a/core/trino-main/src/main/java/io/trino/split/PageSourceManager.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSourceManager.java
@@ -17,8 +17,11 @@ import com.google.inject.Inject;
 import io.trino.Session;
 import io.trino.connector.CatalogHandle;
 import io.trino.connector.CatalogServiceProvider;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.memory.context.LocalMemoryContext;
 import io.trino.metadata.Split;
 import io.trino.metadata.TableHandle;
+import io.trino.operator.ReferenceCount;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
@@ -33,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.trino.SystemSessionProperties.isAllowPushdownIntoConnectors;
 import static java.util.Objects.requireNonNull;
 
@@ -48,18 +52,27 @@ public class PageSourceManager
     }
 
     @Override
-    public PageSourceProvider createPageSourceProvider(CatalogHandle catalogHandle)
+    public PageSourceProvider createPageSourceProvider(CatalogHandle catalogHandle, AggregatedMemoryContext memoryContext)
     {
         ConnectorPageSourceProviderFactory provider = pageSourceProviderFactory.getService(catalogHandle);
-        return new PageSourceProviderInstance(provider.createPageSourceProvider());
+        return new PageSourceProviderInstance(provider, memoryContext.newLocalMemoryContext(PageSourceProvider.class.getSimpleName()));
     }
 
-    private record PageSourceProviderInstance(ConnectorPageSourceProvider pageSourceProvider)
+    /**
+     * Holds the reservation for the connector state shared by all page sources of a single scan. The reservation
+     * is given up once the operators of the scan have dropped their references.
+     */
+    private static final class PageSourceProviderInstance
             implements PageSourceProvider
     {
-        private PageSourceProviderInstance
+        private final ConnectorPageSourceProvider pageSourceProvider;
+        private final ReferenceCount referenceCount = new ReferenceCount(1);
+
+        private PageSourceProviderInstance(ConnectorPageSourceProviderFactory pageSourceProviderFactory, LocalMemoryContext sharedMemoryContext)
         {
-            requireNonNull(pageSourceProvider, "pageSourceProvider is null");
+            requireNonNull(sharedMemoryContext, "sharedMemoryContext is null");
+            this.pageSourceProvider = pageSourceProviderFactory.createPageSourceProvider(sharedMemoryContext::setBytes);
+            referenceCount.getFreeFuture().addListener(sharedMemoryContext::close, directExecutor());
         }
 
         @Override
@@ -94,9 +107,15 @@ public class PageSourceManager
         }
 
         @Override
-        public long getMemoryUsage()
+        public void retain()
         {
-            return pageSourceProvider.getMemoryUsage();
+            referenceCount.retain();
+        }
+
+        @Override
+        public void release()
+        {
+            referenceCount.release();
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/split/PageSourceProvider.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSourceProvider.java
@@ -36,9 +36,14 @@ public interface PageSourceProvider
             DynamicFilter dynamicFilter,
             MemoryContext memoryContext);
 
-    // TODO (https://github.com/trinodb/trino/issues/29955) replace with MemoryContext
-    default long getMemoryUsage()
-    {
-        return 0;
-    }
+    /**
+     * Adds a reference to the reservation for state which the connector shares across the page sources
+     * created by this provider. A newly created provider holds one reference.
+     */
+    default void retain() {}
+
+    /**
+     * Drops a reference added by {@link #retain()}. Dropping the last reference gives up the reservation.
+     */
+    default void release() {}
 }

--- a/core/trino-main/src/main/java/io/trino/split/PageSourceProviderFactory.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSourceProviderFactory.java
@@ -14,8 +14,14 @@
 package io.trino.split;
 
 import io.trino.connector.CatalogHandle;
+import io.trino.memory.context.AggregatedMemoryContext;
 
 public interface PageSourceProviderFactory
 {
-    PageSourceProvider createPageSourceProvider(CatalogHandle catalogHandle);
+    /**
+     * Creates a page source provider for a single table scan.
+     *
+     * @param memoryContext accounts for state which the connector shares across the page sources of the scan
+     */
+    PageSourceProvider createPageSourceProvider(CatalogHandle catalogHandle, AggregatedMemoryContext memoryContext);
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2130,7 +2130,8 @@ public class LocalExecutionPlanner
                             dynamicFilter,
                             getTypes(projections),
                             getFilterAndProjectMinOutputPageSize(session),
-                            getFilterAndProjectMinOutputPageRowCount(session));
+                            getFilterAndProjectMinOutputPageRowCount(session),
+                            context.getTaskContext().aggregateUserMemoryContext());
 
                     return new PhysicalOperation(operatorFactory, outputMappings);
                 }
@@ -2172,7 +2173,16 @@ public class LocalExecutionPlanner
             }
 
             Optional<ConnectorTableCredentials> tableCredentials = context.getTaskContext().getTableCredentials(node.getId());
-            OperatorFactory operatorFactory = new TableScanOperatorFactory(context.getNextOperatorId(), planNodeId, node.getId(), pageSourceManager, node.getTable(), tableCredentials, columns.build(), columnTypes.build());
+            OperatorFactory operatorFactory = new TableScanOperatorFactory(
+                    context.getNextOperatorId(),
+                    planNodeId,
+                    node.getId(),
+                    pageSourceManager,
+                    node.getTable(),
+                    tableCredentials,
+                    columns.build(),
+                    columnTypes.build(),
+                    context.getTaskContext().aggregateUserMemoryContext());
             return new PhysicalOperation(operatorFactory, makeLayout(node));
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractSpatialJoins.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractSpatialJoins.java
@@ -83,6 +83,7 @@ import static io.trino.SystemSessionProperties.getCharVarcharCoercion;
 import static io.trino.SystemSessionProperties.getSpatialPartitioningTableName;
 import static io.trino.SystemSessionProperties.isSpatialJoinEnabled;
 import static io.trino.matching.Capture.newCapture;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.spi.StandardErrorCode.INVALID_SPATIAL_PARTITIONING;
 import static io.trino.spi.connector.Constraint.alwaysTrue;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -448,38 +449,43 @@ public class ExtractSpatialJoins
 
         Optional<KdbTree> kdbTree = Optional.empty();
         try (SplitSource splitSource = splitManager.getSplits(session, session.getQuerySpan(), tableHandle, DynamicFilter.EMPTY, alwaysTrue())) {
-            PageSourceProvider statefulPageSourceProvider = pageSourceManager.createPageSourceProvider(tableHandle.catalogHandle());
-            while (!Thread.currentThread().isInterrupted()) {
-                SplitBatch splitBatch = getFutureValue(splitSource.getNextBatch(1000));
-                List<Split> splits = splitBatch.getSplits();
+            PageSourceProvider statefulPageSourceProvider = pageSourceManager.createPageSourceProvider(tableHandle.catalogHandle(), newSimpleAggregatedMemoryContext());
+            try {
+                while (!Thread.currentThread().isInterrupted()) {
+                    SplitBatch splitBatch = getFutureValue(splitSource.getNextBatch(1000));
+                    List<Split> splits = splitBatch.getSplits();
 
-                for (Split split : splits) {
-                    try (ConnectorPageSource pageSource = statefulPageSourceProvider.createPageSource(session, split, tableHandle, tableCredentials, ImmutableList.of(kdbTreeColumn), DynamicFilter.EMPTY, MemoryContext.NO_LIMIT)) {
-                        do {
-                            getFutureValue(pageSource.isBlocked());
-                            SourcePage page = pageSource.getNextSourcePage();
-                            if (page != null && page.getPositionCount() > 0) {
-                                checkSpatialPartitioningTable(kdbTree.isEmpty(), "Expected exactly one row for table %s, but found more", name);
-                                checkSpatialPartitioningTable(page.getPositionCount() == 1, "Expected exactly one row for table %s, but found %s rows", name, page.getPositionCount());
-                                Slice slice = VARCHAR.getSlice(page.getBlock(0), 0);
-                                try {
-                                    kdbTree = Optional.of(KdbTreeUtils.fromJson(slice));
-                                }
-                                catch (IllegalArgumentException e) {
-                                    checkSpatialPartitioningTable(false, "Invalid JSON string for KDB tree: %s", e.getMessage());
+                    for (Split split : splits) {
+                        try (ConnectorPageSource pageSource = statefulPageSourceProvider.createPageSource(session, split, tableHandle, tableCredentials, ImmutableList.of(kdbTreeColumn), DynamicFilter.EMPTY, MemoryContext.NO_LIMIT)) {
+                            do {
+                                getFutureValue(pageSource.isBlocked());
+                                SourcePage page = pageSource.getNextSourcePage();
+                                if (page != null && page.getPositionCount() > 0) {
+                                    checkSpatialPartitioningTable(kdbTree.isEmpty(), "Expected exactly one row for table %s, but found more", name);
+                                    checkSpatialPartitioningTable(page.getPositionCount() == 1, "Expected exactly one row for table %s, but found %s rows", name, page.getPositionCount());
+                                    Slice slice = VARCHAR.getSlice(page.getBlock(0), 0);
+                                    try {
+                                        kdbTree = Optional.of(KdbTreeUtils.fromJson(slice));
+                                    }
+                                    catch (IllegalArgumentException e) {
+                                        checkSpatialPartitioningTable(false, "Invalid JSON string for KDB tree: %s", e.getMessage());
+                                    }
                                 }
                             }
+                            while (!pageSource.isFinished());
                         }
-                        while (!pageSource.isFinished());
+                        catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
                     }
-                    catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                }
 
-                if (splitBatch.isLastBatch()) {
-                    break;
+                    if (splitBatch.isLastBatch()) {
+                        break;
+                    }
                 }
+            }
+            finally {
+                statefulPageSourceProvider.release();
             }
         }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestingPageSourceProvider.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestingPageSourceProvider.java
@@ -28,6 +28,7 @@ import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.FixedPageSource;
+import io.trino.spi.connector.MemoryContext;
 
 import java.util.List;
 import java.util.Optional;
@@ -44,7 +45,7 @@ public class TestingPageSourceProvider
     }
 
     @Override
-    public ConnectorPageSourceProvider createPageSourceProvider()
+    public ConnectorPageSourceProvider createPageSourceProvider(MemoryContext memoryContext)
     {
         return this;
     }

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkScanFilterAndProjectOperator.java
@@ -75,6 +75,7 @@ import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.trino.SystemSessionProperties.getCharVarcharCoercion;
 import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -180,7 +181,7 @@ public class BenchmarkScanFilterAndProjectOperator
                     0,
                     new PlanNodeId("test"),
                     new PlanNodeId("test_source"),
-                    _ -> (_, _, _, _, _, _, _) -> new FixedPageSource(inputPages),
+                    (_, _) -> (_, _, _, _, _, _, _) -> new FixedPageSource(inputPages),
                     _ -> pageProcessor,
                     TEST_TABLE_HANDLE,
                     Optional.empty(),
@@ -188,7 +189,8 @@ public class BenchmarkScanFilterAndProjectOperator
                     DynamicFilter.EMPTY,
                     types,
                     FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_SIZE,
-                    FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_ROW_COUNT);
+                    FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_ROW_COUNT,
+                    newSimpleAggregatedMemoryContext());
         }
 
         public TaskContext createTaskContext()

--- a/core/trino-main/src/test/java/io/trino/operator/TestScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestScanFilterAndProjectOperator.java
@@ -19,6 +19,10 @@ import io.airlift.units.DataSize;
 import io.trino.SequencePageBuilder;
 import io.trino.Session;
 import io.trino.block.BlockAssertions;
+import io.trino.connector.CatalogServiceProvider;
+import io.trino.connector.TestingColumnHandle;
+import io.trino.execution.TestingPageSourceProvider;
+import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.metadata.FunctionManager;
 import io.trino.metadata.Split;
 import io.trino.metadata.TestingFunctionResolution;
@@ -33,6 +37,8 @@ import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.FixedPageSource;
 import io.trino.spi.connector.RecordPageSource;
 import io.trino.spi.connector.SourcePage;
+import io.trino.split.PageSourceManager;
+import io.trino.split.PageSourceProvider;
 import io.trino.sql.gen.ExpressionCompiler;
 import io.trino.sql.gen.PageFunctionCompiler;
 import io.trino.sql.gen.columnar.ColumnarFilterCompiler;
@@ -66,6 +72,7 @@ import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.trino.RowPagesBuilder.rowPagesBuilder;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.block.BlockAssertions.createIntsBlock;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.operator.OperatorAssertion.toMaterializedResult;
 import static io.trino.operator.PageAssertions.assertPageEquals;
 import static io.trino.spi.function.OperatorType.EQUAL;
@@ -130,7 +137,7 @@ public class TestScanFilterAndProjectOperator
                 0,
                 new PlanNodeId("test"),
                 new PlanNodeId("0"),
-                _ -> (_, _, _, _, _, _, _) -> new FixedPageSource(ImmutableList.of(input)),
+                (_, _) -> (_, _, _, _, _, _, _) -> new FixedPageSource(ImmutableList.of(input)),
                 _ -> pageProcessor.get(),
                 TEST_TABLE_HANDLE,
                 Optional.empty(),
@@ -138,7 +145,8 @@ public class TestScanFilterAndProjectOperator
                 DynamicFilter.EMPTY,
                 ImmutableList.of(VARCHAR),
                 DataSize.ofBytes(0),
-                0);
+                0,
+                newSimpleAggregatedMemoryContext());
 
         try (SourceOperator operator = factory.createOperator(driverContext)) {
             operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
@@ -149,6 +157,54 @@ public class TestScanFilterAndProjectOperator
 
             assertThat(actual).containsExactlyElementsOf(expected);
         }
+    }
+
+    @Test
+    public void testSharedMemoryReleasedWithLastReference()
+            throws Exception
+    {
+        AggregatedMemoryContext scanMemoryContext = newSimpleAggregatedMemoryContext();
+        PageSourceProvider pageSourceProvider = createPageSourceProvider(scanMemoryContext);
+
+        Reference col0 = new Reference(BIGINT, "$col_0");
+        Map<Symbol, Integer> layout = ImmutableMap.of(new Symbol(BIGINT, "$col_0"), 0);
+        Supplier<PageProcessor> pageProcessor = expressionCompiler.compilePageProcessor(TEST_SESSION, Optional.empty(), ImmutableList.of(col0), layout);
+
+        ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory factory = new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                new PlanNodeId("0"),
+                (_, _) -> pageSourceProvider,
+                _ -> pageProcessor.get(),
+                TEST_TABLE_HANDLE,
+                Optional.empty(),
+                ImmutableList.of(new TestingColumnHandle("col0")),
+                DynamicFilter.EMPTY,
+                ImmutableList.of(BIGINT),
+                DataSize.ofBytes(0),
+                0,
+                newSimpleAggregatedMemoryContext());
+
+        SourceOperator operator = factory.createOperator(newDriverContext());
+        operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
+        operator.noMoreSplits();
+        toPages(operator);
+        assertThat(scanMemoryContext.getBytes()).isEqualTo(1024);
+
+        operator.close();
+        assertThat(scanMemoryContext.getBytes()).isEqualTo(1024);
+
+        factory.noMoreOperators();
+        assertThat(scanMemoryContext.getBytes()).isEqualTo(0);
+    }
+
+    private static PageSourceProvider createPageSourceProvider(AggregatedMemoryContext scanMemoryContext)
+    {
+        return new PageSourceManager(CatalogServiceProvider.singleton(TEST_CATALOG_HANDLE, memoryContext -> {
+            memoryContext.setBytes(1024);
+            return new TestingPageSourceProvider();
+        }))
+                .createPageSourceProvider(TEST_CATALOG_HANDLE, scanMemoryContext);
     }
 
     @Test
@@ -175,7 +231,7 @@ public class TestScanFilterAndProjectOperator
                 0,
                 new PlanNodeId("test"),
                 new PlanNodeId("0"),
-                _ -> (_, _, _, _, _, _, _) -> new FixedPageSource(input),
+                (_, _) -> (_, _, _, _, _, _, _) -> new FixedPageSource(input),
                 _ -> pageProcessor.get(),
                 TEST_TABLE_HANDLE,
                 Optional.empty(),
@@ -183,7 +239,8 @@ public class TestScanFilterAndProjectOperator
                 DynamicFilter.EMPTY,
                 ImmutableList.of(BIGINT),
                 DataSize.of(64, KILOBYTE),
-                2);
+                2,
+                newSimpleAggregatedMemoryContext());
 
         try (SourceOperator operator = factory.createOperator(newDriverContext())) {
             operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
@@ -218,7 +275,7 @@ public class TestScanFilterAndProjectOperator
                 0,
                 new PlanNodeId("test"),
                 new PlanNodeId("0"),
-                _ -> (_, _, _, _, _, _, _) -> new SinglePagePageSource(input),
+                (_, _) -> (_, _, _, _, _, _, _) -> new SinglePagePageSource(input),
                 _ -> pageProcessor,
                 TEST_TABLE_HANDLE,
                 Optional.empty(),
@@ -226,7 +283,8 @@ public class TestScanFilterAndProjectOperator
                 DynamicFilter.EMPTY,
                 ImmutableList.of(BIGINT),
                 DataSize.ofBytes(0),
-                0);
+                0,
+                newSimpleAggregatedMemoryContext());
 
         try (SourceOperator operator = factory.createOperator(driverContext)) {
             operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
@@ -255,7 +313,7 @@ public class TestScanFilterAndProjectOperator
                 0,
                 new PlanNodeId("test"),
                 new PlanNodeId("0"),
-                _ -> (_, _, _, _, _, _, _) -> new RecordPageSource(new PageRecordSet(ImmutableList.of(VARCHAR), input)),
+                (_, _) -> (_, _, _, _, _, _, _) -> new RecordPageSource(new PageRecordSet(ImmutableList.of(VARCHAR), input)),
                 _ -> pageProcessor.get(),
                 TEST_TABLE_HANDLE,
                 Optional.empty(),
@@ -263,7 +321,8 @@ public class TestScanFilterAndProjectOperator
                 DynamicFilter.EMPTY,
                 ImmutableList.of(VARCHAR),
                 DataSize.ofBytes(0),
-                0);
+                0,
+                newSimpleAggregatedMemoryContext());
 
         try (SourceOperator operator = factory.createOperator(driverContext)) {
             operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));

--- a/core/trino-main/src/test/java/io/trino/operator/TestTableScanOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTableScanOperator.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.connector.CatalogServiceProvider;
+import io.trino.connector.TestingColumnHandle;
+import io.trino.execution.TestingPageSourceProvider;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.metadata.Split;
+import io.trino.operator.TableScanOperator.TableScanOperatorFactory;
+import io.trino.split.PageSourceManager;
+import io.trino.split.PageSourceProvider;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.testing.TestingSplit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
+import static io.trino.testing.TestingHandles.TEST_TABLE_HANDLE;
+import static io.trino.testing.TestingTaskContext.createTaskContext;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestTableScanOperator
+{
+    private ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
+    private ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed(getClass().getSimpleName() + "-scheduledExecutor-%s"));
+
+    @AfterAll
+    public void tearDown()
+    {
+        executor.shutdownNow();
+        executor = null;
+        scheduledExecutor.shutdownNow();
+        scheduledExecutor = null;
+    }
+
+    @Test
+    public void testSharedMemoryReleasedWithLastReference()
+            throws Exception
+    {
+        AggregatedMemoryContext scanMemoryContext = newSimpleAggregatedMemoryContext();
+        PageSourceProvider pageSourceProvider = createPageSourceProvider(scanMemoryContext);
+        TableScanOperatorFactory factory = new TableScanOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                new PlanNodeId("0"),
+                (_, _) -> pageSourceProvider,
+                TEST_TABLE_HANDLE,
+                Optional.empty(),
+                ImmutableList.of(new TestingColumnHandle("col0")),
+                ImmutableList.of(BIGINT),
+                newSimpleAggregatedMemoryContext());
+
+        SourceOperator operator = factory.createOperator(newDriverContext());
+        operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
+        operator.noMoreSplits();
+        while (!operator.isFinished()) {
+            operator.getOutput();
+        }
+        assertThat(scanMemoryContext.getBytes()).isEqualTo(1024);
+
+        operator.close();
+        assertThat(scanMemoryContext.getBytes()).isEqualTo(1024);
+
+        factory.noMoreOperators();
+        assertThat(scanMemoryContext.getBytes()).isEqualTo(0);
+    }
+
+    private static PageSourceProvider createPageSourceProvider(AggregatedMemoryContext scanMemoryContext)
+    {
+        return new PageSourceManager(CatalogServiceProvider.singleton(TEST_CATALOG_HANDLE, memoryContext -> {
+            memoryContext.setBytes(1024);
+            return new TestingPageSourceProvider();
+        }))
+                .createPageSourceProvider(TEST_CATALOG_HANDLE, scanMemoryContext);
+    }
+
+    private DriverContext newDriverContext()
+    {
+        return createTaskContext(executor, scheduledExecutor, TEST_SESSION)
+                .addPipelineContext(0, true, true, false)
+                .addDriverContext();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/split/TestPageSourceManager.java
+++ b/core/trino-main/src/test/java/io/trino/split/TestPageSourceManager.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.split;
+
+import io.trino.connector.CatalogServiceProvider;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.spi.connector.ConnectorPageSourceProvider;
+import io.trino.spi.connector.ConnectorPageSourceProviderFactory;
+import io.trino.spi.connector.MemoryContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestPageSourceManager
+{
+    @Test
+    public void testSharedMemoryReleasedWithLastReference()
+    {
+        AtomicReference<MemoryContext> sharedMemoryContext = new AtomicReference<>();
+        AggregatedMemoryContext scanMemoryContext = newSimpleAggregatedMemoryContext();
+        PageSourceProvider provider = createPageSourceProvider(sharedMemoryContext, scanMemoryContext);
+
+        provider.retain();
+        provider.retain();
+        sharedMemoryContext.get().setBytes(1024);
+        assertThat(scanMemoryContext.getBytes()).isEqualTo(1024);
+
+        provider.release();
+        provider.release();
+        assertThat(scanMemoryContext.getBytes()).isEqualTo(1024);
+
+        // the reference held by the operator factory
+        provider.release();
+        assertThat(scanMemoryContext.getBytes()).isEqualTo(0);
+    }
+
+    @Test
+    public void testReleaseWithoutReference()
+    {
+        PageSourceProvider provider = createPageSourceProvider(new AtomicReference<>(), newSimpleAggregatedMemoryContext());
+
+        provider.release();
+        assertThatThrownBy(provider::release)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Reference has already been freed");
+    }
+
+    private static PageSourceProvider createPageSourceProvider(AtomicReference<MemoryContext> sharedMemoryContext, AggregatedMemoryContext scanMemoryContext)
+    {
+        ConnectorPageSourceProviderFactory factory = memoryContext -> {
+            sharedMemoryContext.set(memoryContext);
+            return new ConnectorPageSourceProvider() {};
+        };
+        return new PageSourceManager(CatalogServiceProvider.singleton(TEST_CATALOG_HANDLE, factory))
+                .createPageSourceProvider(TEST_CATALOG_HANDLE, scanMemoryContext);
+    }
+}

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -243,6 +243,15 @@
                                     <justification>Related dictionary compaction can produce simpler block representations.</justification>
                                 </item>
                                 <item>
+                                    <code>java.method.removed</code>
+                                    <old>method long io.trino.spi.connector.ConnectorPageSourceProvider::getMemoryUsage()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method io.trino.spi.connector.ConnectorPageSourceProvider io.trino.spi.connector.ConnectorPageSourceProviderFactory::createPageSourceProvider()</old>
+                                    <new>method io.trino.spi.connector.ConnectorPageSourceProvider io.trino.spi.connector.ConnectorPageSourceProviderFactory::createPageSourceProvider(io.trino.spi.connector.MemoryContext)</new>
+                                </item>
+                                <item>
                                     <code>java.method.visibilityIncreased</code>
                                     <old>method int io.trino.spi.block.ArrayBlock::getOffsetBase()</old>
                                 </item>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
@@ -80,7 +80,7 @@ public interface Connector
     default ConnectorPageSourceProviderFactory getPageSourceProviderFactory()
     {
         ConnectorPageSourceProvider pageSourceProvider = getPageSourceProvider();
-        return () -> pageSourceProvider;
+        return _ -> pageSourceProvider;
     }
 
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSourceProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSourceProvider.java
@@ -68,16 +68,4 @@ public interface ConnectorPageSourceProvider
         ConnectorPageSource delegate = createPageSource(transaction, session, split, table, tableCredentials, columns, dynamicFilter);
         return new MemoryUsageReportingPageSource(delegate, memoryContext);
     }
-
-    /**
-     * Get the total memory that needs to be reserved in the memory pool.
-     * This should include any memory used in the page source provider that is shared across all page sources created by this provider.
-     *
-     * @return the memory used so far in table read
-     */
-    // TODO (https://github.com/trinodb/trino/issues/29955) replace with MemoryContext
-    default long getMemoryUsage()
-    {
-        return 0;
-    }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSourceProviderFactory.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSourceProviderFactory.java
@@ -15,5 +15,14 @@ package io.trino.spi.connector;
 
 public interface ConnectorPageSourceProviderFactory
 {
-    ConnectorPageSourceProvider createPageSourceProvider();
+    /**
+     * Creates a page source provider for a single table scan.
+     *
+     * @param memoryContext reports memory retained by state which the provider shares across the page
+     *         sources it creates, such as Iceberg equality delete filters. The provider reports the total size of
+     *         that state. The engine tolerates concurrent calls from split threads, but the provider is responsible
+     *         for reporting a value consistent with the state it holds. The reservation is given up once every page
+     *         source created by the provider has been closed.
+     */
+    ConnectorPageSourceProvider createPageSourceProvider(MemoryContext memoryContext);
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSourceProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSourceProvider.java
@@ -74,12 +74,4 @@ public class ClassLoaderSafeConnectorPageSourceProvider
             return delegate.createPageSource(transaction, session, split, table, tableCredentials, columns, dynamicFilter, memoryContext);
         }
     }
-
-    @Override
-    public long getMemoryUsage()
-    {
-        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getMemoryUsage();
-        }
-    }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSourceProviderFactory.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSourceProviderFactory.java
@@ -17,6 +17,7 @@ import com.google.inject.Inject;
 import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorPageSourceProviderFactory;
+import io.trino.spi.connector.MemoryContext;
 
 import static java.util.Objects.requireNonNull;
 
@@ -34,10 +35,10 @@ public class ClassLoaderSafeConnectorPageSourceProviderFactory
     }
 
     @Override
-    public ConnectorPageSourceProvider createPageSourceProvider()
+    public ConnectorPageSourceProvider createPageSourceProvider(MemoryContext memoryContext)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return new ClassLoaderSafeConnectorPageSourceProvider(delegate.createPageSourceProvider(), classLoader);
+            return new ClassLoaderSafeConnectorPageSourceProvider(delegate.createPageSourceProvider(memoryContext), classLoader);
         }
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -101,6 +101,7 @@ import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.hdfs.HdfsTestUtils.HDFS_FILE_SYSTEM_FACTORY;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.orc.OrcReader.MAX_BATCH_SIZE;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
@@ -611,11 +612,12 @@ public class TestOrcPageSourceMemoryTracking
                     0,
                     new PlanNodeId("0"),
                     new PlanNodeId("0"),
-                    _ -> (_, _, _, _, _, _, memoryContext) -> newPageSource(memoryContext),
+                    (_, _) -> (_, _, _, _, _, _, memoryContext) -> newPageSource(memoryContext),
                     TEST_TABLE_HANDLE,
                     Optional.empty(),
                     columns.stream().map(ColumnHandle.class::cast).collect(toImmutableList()),
-                    types);
+                    types,
+                    newSimpleAggregatedMemoryContext());
             SourceOperator operator = sourceOperatorFactory.createOperator(driverContext);
             operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
             return operator;
@@ -633,7 +635,7 @@ public class TestOrcPageSourceMemoryTracking
                     0,
                     new PlanNodeId("test"),
                     new PlanNodeId("0"),
-                    _ -> (_, _, _, _, _, _, memoryContext) -> newPageSource(memoryContext),
+                    (_, _) -> (_, _, _, _, _, _, memoryContext) -> newPageSource(memoryContext),
                     _ -> pageProcessor.get(),
                     TEST_TABLE_HANDLE,
                     Optional.empty(),
@@ -641,7 +643,8 @@ public class TestOrcPageSourceMemoryTracking
                     DynamicFilter.EMPTY,
                     types,
                     DataSize.ofBytes(0),
-                    0);
+                    0,
+                    newSimpleAggregatedMemoryContext());
             SourceOperator operator = sourceOperatorFactory.createOperator(driverContext);
             operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
             operator.noMoreSplits();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -257,6 +257,7 @@ public class IcebergPageSourceProvider
     private final ParquetFooterCache parquetFooterCache;
     private final Optional<BlocksHashFactory> blocksHashFactory;
     private final EncryptionManagerFactory encryptionManagerFactory;
+    private final MemoryContext sharedMemoryContext;
     private final DeleteManager unpartitionedTableDeleteManager;
     private final Map<Integer, Function<PartitionData, PartitionKey>> partitionKeyFactories = new ConcurrentHashMap<>();
     private final Map<PartitionKey, DeleteManager> partitionedDeleteManagers = new ConcurrentHashMap<>();
@@ -270,7 +271,8 @@ public class IcebergPageSourceProvider
             TypeManager typeManager,
             ParquetFooterCache parquetFooterCache,
             Optional<BlocksHashFactory> blocksHashFactory,
-            EncryptionManagerFactory encryptionManagerFactory)
+            EncryptionManagerFactory encryptionManagerFactory,
+            MemoryContext sharedMemoryContext)
     {
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.fileIoFactory = requireNonNull(fileIoFactory, "fileIoFactory is null");
@@ -281,7 +283,8 @@ public class IcebergPageSourceProvider
         this.parquetFooterCache = requireNonNull(parquetFooterCache, "parquetFooterCache is null");
         this.blocksHashFactory = requireNonNull(blocksHashFactory, "blocksHashFactory is null");
         this.encryptionManagerFactory = requireNonNull(encryptionManagerFactory, "encryptionManagerFactory is null");
-        this.unpartitionedTableDeleteManager = new DeleteManager(typeManager, blocksHashFactory);
+        this.sharedMemoryContext = requireNonNull(sharedMemoryContext, "sharedMemoryContext is null");
+        this.unpartitionedTableDeleteManager = new DeleteManager(typeManager, blocksHashFactory, this::reportDeleteFilterMemoryUsage);
     }
 
     @Override
@@ -435,17 +438,20 @@ public class IcebergPageSourceProvider
 
         // filter out deleted rows
         if (!deletes.isEmpty()) {
-            Supplier<Optional<PageFilter>> deletePredicate = memoize(() -> getDeleteManager(partitionSpec, partitionData)
-                    .getDeletePageFilter(
-                            path,
-                            dataSequenceNumber,
-                            deletes,
-                            requiredColumns,
-                            tableSchema,
-                            readerPageSourceWithRowPositions.startRowPosition(),
-                            readerPageSourceWithRowPositions.endRowPosition(),
-                            deleteFile -> readDeletionVector(fileSystem, deleteFile),
-                            (deleteFile, deleteColumns, tupleDomain) -> openDeleteFile(session, fileSystem, deleteFile, deleteColumns, tupleDomain, memoryContext.newAggregatedMemoryContext())));
+            Supplier<Optional<PageFilter>> deletePredicate = memoize(() -> {
+                Optional<PageFilter> pageFilter = getDeleteManager(partitionSpec, partitionData)
+                        .getDeletePageFilter(
+                                path,
+                                dataSequenceNumber,
+                                deletes,
+                                requiredColumns,
+                                tableSchema,
+                                readerPageSourceWithRowPositions.startRowPosition(),
+                                readerPageSourceWithRowPositions.endRowPosition(),
+                                deleteFile -> readDeletionVector(fileSystem, deleteFile),
+                                (deleteFile, deleteColumns, tupleDomain) -> openDeleteFile(session, fileSystem, deleteFile, deleteColumns, tupleDomain, memoryContext.newAggregatedMemoryContext()));
+                return pageFilter;
+            });
             pageSource = TransformConnectorPageSource.create(pageSource, page -> {
                 try {
                     Optional<PageFilter> pageFilter = deletePredicate.get();
@@ -464,13 +470,16 @@ public class IcebergPageSourceProvider
         return pageSource;
     }
 
-    @Override
-    public long getMemoryUsage()
+    /**
+     * Delete filters are shared by all splits of the scan, so their size is reported at provider scope,
+     * after each delete file loads. The lock makes the reported value consistent with the filters held at that point.
+     */
+    private synchronized void reportDeleteFilterMemoryUsage()
     {
-        return unpartitionedTableDeleteManager.getEstimatedSizeInBytes() +
+        sharedMemoryContext.setBytes(unpartitionedTableDeleteManager.getEstimatedSizeInBytes() +
                 partitionedDeleteManagers.values().stream()
                         .mapToLong(DeleteManager::getEstimatedSizeInBytes)
-                        .sum();
+                        .sum());
     }
 
     private DeleteManager getDeleteManager(PartitionSpec partitionSpec, PartitionData partitionData)
@@ -490,7 +499,7 @@ public class IcebergPageSourceProvider
                         })
                 .apply(partitionData);
 
-        return partitionedDeleteManagers.computeIfAbsent(partitionKey, _ -> new DeleteManager(typeManager, blocksHashFactory));
+        return partitionedDeleteManagers.computeIfAbsent(partitionKey, _ -> new DeleteManager(typeManager, blocksHashFactory, this::reportDeleteFilterMemoryUsage));
     }
 
     private record PartitionKey(int specId, StructLikeWrapper partitionData) {}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProviderFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProviderFactory.java
@@ -24,6 +24,7 @@ import io.trino.plugin.iceberg.encryption.EncryptionManagerFactory;
 import io.trino.plugin.iceberg.fileio.ForwardingFileIoFactory;
 import io.trino.spi.BlocksHashFactory;
 import io.trino.spi.connector.ConnectorPageSourceProviderFactory;
+import io.trino.spi.connector.MemoryContext;
 import io.trino.spi.type.TypeManager;
 
 import java.util.Optional;
@@ -70,8 +71,8 @@ public class IcebergPageSourceProviderFactory
     }
 
     @Override
-    public IcebergPageSourceProvider createPageSourceProvider()
+    public IcebergPageSourceProvider createPageSourceProvider(MemoryContext memoryContext)
     {
-        return new IcebergPageSourceProvider(fileSystemFactory, fileIoFactory, fileFormatDataSourceStats, orcReaderOptions, parquetReaderOptions, typeManager, parquetFooterCache, blocksHashFactory, encryptionManagerFactory);
+        return new IcebergPageSourceProvider(fileSystemFactory, fileIoFactory, fileFormatDataSourceStats, orcReaderOptions, parquetReaderOptions, typeManager, parquetFooterCache, blocksHashFactory, encryptionManagerFactory, memoryContext);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DefaultDeletionVectorWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DefaultDeletionVectorWriter.java
@@ -31,6 +31,7 @@ import io.trino.spi.NodeVersion;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.MemoryContext;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.DeleteFile;
@@ -313,7 +314,7 @@ public class DefaultDeletionVectorWriter
     // TODO (https://github.com/trinodb/trino/issues/29957) memory usage reporting
     private ConnectorPageSource openDeleteFilePageSource(ConnectorSession session, DeleteFile deleteFile, TrinoFileSystem fileSystem)
     {
-        return pageSourceProviderFactory.createPageSourceProvider().openDeleteFile(
+        return pageSourceProviderFactory.createPageSourceProvider(MemoryContext.NO_LIMIT).openDeleteFile(
                 session,
                 fileSystem,
                 io.trino.plugin.iceberg.delete.DeleteFile.fromIceberg(deleteFile),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DeleteManager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DeleteManager.java
@@ -49,12 +49,14 @@ public class DeleteManager
 {
     private final TypeManager typeManager;
     private final Optional<BlocksHashFactory> blocksHashFactory;
+    private final Runnable memoryUsageReporter;
     private final Map<List<Integer>, EqualityDeleteFilterBuilder> equalityDeleteFiltersBySchema = new ConcurrentHashMap<>();
 
-    public DeleteManager(TypeManager typeManager, Optional<BlocksHashFactory> blocksHashFactory)
+    public DeleteManager(TypeManager typeManager, Optional<BlocksHashFactory> blocksHashFactory, Runnable memoryUsageReporter)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.blocksHashFactory = requireNonNull(blocksHashFactory, "blocksHashFactory is null");
+        this.memoryUsageReporter = requireNonNull(memoryUsageReporter, "memoryUsageReporter is null");
     }
 
     public Optional<PageFilter> getDeletePageFilter(
@@ -175,6 +177,8 @@ public class DeleteManager
             if (loadFuture.state() != SUCCESS) {
                 pendingLoads.add(loadFuture);
             }
+            // loads that win the race run synchronously in this thread, so this reports each loaded file as it completes
+            memoryUsageReporter.run();
         }
 
         // Wait loads happening in other threads

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessorProviderFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessorProviderFactory.java
@@ -20,6 +20,7 @@ import io.trino.plugin.iceberg.IcebergPageSourceProviderFactory;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorTableCredentials;
+import io.trino.spi.connector.MemoryContext;
 import io.trino.spi.function.table.ConnectorTableFunctionHandle;
 import io.trino.spi.function.table.TableFunctionProcessorProvider;
 import io.trino.spi.function.table.TableFunctionProcessorProviderFactory;
@@ -43,7 +44,7 @@ public class TableChangesFunctionProcessorProviderFactory
     @Override
     public TableFunctionProcessorProvider createTableFunctionProcessorProvider()
     {
-        IcebergPageSourceProvider pageSourceProvider = (IcebergPageSourceProvider) icebergPageSourceProviderFactory.createPageSourceProvider();
+        IcebergPageSourceProvider pageSourceProvider = (IcebergPageSourceProvider) icebergPageSourceProviderFactory.createPageSourceProvider(MemoryContext.NO_LIMIT);
         return new TableChangesFunctionProcessorProvider(pageSourceProvider);
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -591,7 +591,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 blocksHashFactory,
                 icebergConfig,
                 ENCRYPTION_MANAGER_FACTORY);
-        return factory.createPageSourceProvider().createPageSource(
+        return factory.createPageSourceProvider(MemoryContext.NO_LIMIT).createPageSource(
                 transaction,
                 getSession(icebergConfig),
                 split,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPageSourceProvider.java
@@ -47,6 +47,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.MemoryContext;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
@@ -68,6 +69,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.trino.hdfs.HdfsTestUtils.HDFS_ENVIRONMENT;
@@ -139,9 +141,10 @@ class TestIcebergPageSourceProvider
                 Optional.empty(),
                 Optional.empty());
 
-        IcebergPageSourceProvider provider = createPageSourceProvider();
+        AtomicLong sharedMemoryUsage = new AtomicLong();
+        IcebergPageSourceProvider provider = createPageSourceProvider(sharedMemoryUsage::set);
 
-        assertThat(provider.getMemoryUsage()).isEqualTo(0);
+        assertThat(sharedMemoryUsage.get()).isEqualTo(0);
 
         TestingConnectorSession session = TestingConnectorSession.builder()
                 .setPropertyMetadata(new IcebergSessionProperties(
@@ -177,7 +180,7 @@ class TestIcebergPageSourceProvider
                 newSimpleAggregatedMemoryContext(),
                 Optional.empty())) {
             // Memory should still be 0 before reading any pages (lazy loading)
-            assertThat(provider.getMemoryUsage()).isEqualTo(0);
+            assertThat(sharedMemoryUsage.get()).isEqualTo(0);
 
             // Read pages to trigger lazy loading of equality deletes
             while (!pageSource.isFinished()) {
@@ -185,7 +188,7 @@ class TestIcebergPageSourceProvider
             }
 
             // After reading, the equality delete filter should be loaded and tracked in memory
-            assertThat(provider.getMemoryUsage()).isGreaterThan(100);
+            assertThat(sharedMemoryUsage.get()).isGreaterThan(100);
         }
     }
 
@@ -277,7 +280,7 @@ class TestIcebergPageSourceProvider
         return builder.build();
     }
 
-    private static IcebergPageSourceProvider createPageSourceProvider()
+    private static IcebergPageSourceProvider createPageSourceProvider(MemoryContext memoryContext)
     {
         BlocksHashFactory blocksHashFactory = new FlatHashStrategyCompiler(new TypeOperators(), new NullSafeHashCompiler(new TypeOperators())).createBlocksHashFactory();
         return new IcebergPageSourceProvider(
@@ -289,7 +292,8 @@ class TestIcebergPageSourceProvider
                 TESTING_TYPE_MANAGER,
                 ParquetFooterCache.noop(),
                 Optional.of(blocksHashFactory),
-                ENCRYPTION_MANAGER_FACTORY);
+                ENCRYPTION_MANAGER_FACTORY,
+                memoryContext);
     }
 
     private static class TestingParquetFooterCache

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehousePageSourceProviderFactory.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehousePageSourceProviderFactory.java
@@ -62,7 +62,7 @@ public class LakehousePageSourceProviderFactory
     }
 
     @Override
-    public ConnectorPageSourceProvider createPageSourceProvider()
+    public ConnectorPageSourceProvider createPageSourceProvider(MemoryContext sharedMemoryContext)
     {
         // createPageSourceProvider is called for each scan within a query
         // we hold on to ConnectorPageSourceProvider instance to allow IcebergPageSourceProvider to reuse equality deletes between splits of the same scan
@@ -84,35 +84,22 @@ public class LakehousePageSourceProviderFactory
                 if (delegate == null) {
                     synchronized (this) {
                         if (delegate == null) {
-                            delegate = forHandle(split, table);
+                            delegate = forHandle(split, table, sharedMemoryContext);
                         }
                     }
                 }
                 return delegate.createPageSource(transaction, session, split, table, tableCredentials, columns, dynamicFilter, memoryContext);
             }
-
-            @Override
-            public long getMemoryUsage()
-            {
-                ConnectorPageSourceProvider provider = delegate;
-                if (provider == null) {
-                    // No page source was created, so no memory is used
-                    return 0;
-                }
-                return provider.getMemoryUsage();
-            }
         };
     }
 
-    private ConnectorPageSourceProvider forHandle(ConnectorSplit split, ConnectorTableHandle handle)
+    private ConnectorPageSourceProvider forHandle(ConnectorSplit split, ConnectorTableHandle handle, MemoryContext sharedMemoryContext)
     {
-        if (split instanceof FilesTableSplit) {
-            return icebergPageSourceProviderFactory.createPageSourceProvider();
+        if (split instanceof FilesTableSplit || handle instanceof IcebergTableHandle) {
+            return icebergPageSourceProviderFactory.createPageSourceProvider(sharedMemoryContext);
         }
-
         return switch (handle) {
             case HiveTableHandle _ -> hivePageSourceProvider;
-            case IcebergTableHandle _ -> icebergPageSourceProviderFactory.createPageSourceProvider();
             case DeltaLakeTableHandle _ -> deltaLakePageSourceProvider;
             case HudiTableHandle _ -> hudiPageSourceProvider;
             default -> throw new UnsupportedOperationException("Unsupported table handle " + handle.getClass() + " with split " + split.getClass());


### PR DESCRIPTION
## Description

Each scan operator polled `ConnectorPageSourceProvider.getMemoryUsage()` and reserved the provider-wide total in its own memory context, multiplying the reservation for Iceberg equality delete filters by the number of drivers.

The engine now passes a memory context to `ConnectorPageSourceProviderFactory.createPageSourceProvider`, and the connector reports the size of state shared across the page sources of a scan (e.g. equality delete filters) there once. The reservation is released when the operators of the scan close.

## Additional context and related issues

- Supersedes #30208, thanks @okayhooni for reporting the problem and proposing the initial fix.
- Resolves #29955 by removing `io.trino.split.PageSourceProvider#getMemoryUsage`.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## SPI
* Remove `ConnectorPageSourceProvider.getMemoryUsage()` and pass a shared memory context to `ConnectorPageSourceProviderFactory.createPageSourceProvider()`. ({issue}`29955`)

## Iceberg
* Fix over-accounting of memory usage in scans on tables with equality delete filters. ({issue}`30865`)
```

