### PR TITLE
Add ALTER MATERIALIZED VIEW ... EXECUTE engine support

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -122,6 +122,12 @@ public interface Metadata
             String procedureName,
             Map<String, Object> executeProperties);
 
+    Optional<TableExecuteHandle> getTableHandleForMaterializedViewExecute(
+            Session session,
+            TableHandle tableHandle,
+            String procedureName,
+            Map<String, Object> executeProperties);
+
     Set<ColumnHandle> getColumnHandlesForTableExecute(Session session, TableExecuteHandle tableExecuteHandle);
 
     Optional<TableLayout> getLayoutForTableExecute(Session session, TableExecuteHandle tableExecuteHandle);

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -361,6 +361,33 @@ public final class MetadataManager
     }
 
     @Override
+    public Optional<TableExecuteHandle> getTableHandleForMaterializedViewExecute(Session session, TableHandle tableHandle, String procedure, Map<String, Object> executeProperties)
+    {
+        requireNonNull(session, "session is null");
+        requireNonNull(tableHandle, "tableHandle is null");
+        requireNonNull(procedure, "procedure is null");
+        requireNonNull(executeProperties, "executeProperties is null");
+
+        CatalogHandle catalogHandle = tableHandle.catalogHandle();
+        CatalogMetadata catalogMetadata = getCatalogMetadata(session, catalogHandle);
+        ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
+
+        Optional<ConnectorTableExecuteHandle> executeHandle = metadata.getTableHandleForMaterializedViewExecute(
+                session.toConnectorSession(catalogHandle),
+                new InjectedConnectorAccessControl(accessControl, session.toSecurityContext(), catalogHandle.getCatalogName().toString()),
+                tableHandle.connectorHandle(),
+                procedure,
+                executeProperties,
+                getRetryPolicy(session).getRetryMode());
+
+        return executeHandle.map(handle -> new TableExecuteHandle(
+                catalogHandle,
+                tableHandle.transaction(),
+                tableHandle.connectorHandle(),
+                handle));
+    }
+
+    @Override
     public Set<ColumnHandle> getColumnHandlesForTableExecute(Session session, TableExecuteHandle tableExecuteHandle)
     {
         CatalogHandle catalogHandle = tableExecuteHandle.catalogHandle();

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -275,6 +275,9 @@ public class Analysis
     private final Multimap<NodeRef<Expression>, Field> fieldLineage = ArrayListMultimap.create();
 
     private Optional<TableExecuteHandle> tableExecuteHandle = Optional.empty();
+    // AST node the execute handle is registered against; for a materialized view this names the view,
+    // while the registered TableHandle is the view's storage table
+    private Optional<Table> tableExecuteTable = Optional.empty();
 
     // names of tables and aliased relations. All names are resolved case-insensitive.
     private final Map<NodeRef<Relation>, QualifiedName> relationNames = new LinkedHashMap<>();
@@ -1498,6 +1501,18 @@ public class Analysis
     public Optional<TableExecuteHandle> getTableExecuteHandle()
     {
         return tableExecuteHandle;
+    }
+
+    public void setTableExecuteTable(Table table)
+    {
+        requireNonNull(table, "table is null");
+        checkState(this.tableExecuteTable.isEmpty(), "tableExecuteTable already set");
+        this.tableExecuteTable = Optional.of(table);
+    }
+
+    public Table getTableExecuteTable()
+    {
+        return tableExecuteTable.orElseThrow(() -> new IllegalStateException("tableExecuteTable not set"));
     }
 
     public void setTableFunctionAnalysis(TableFunctionInvocation node, TableFunctionInvocationAnalysis analysis)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -195,6 +195,7 @@ import io.trino.sql.tree.Lateral;
 import io.trino.sql.tree.Limit;
 import io.trino.sql.tree.Literal;
 import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.MeasureDefinition;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.MergeCase;
@@ -1282,60 +1283,116 @@ class StatementAnalyzer
                     tableName,
                     procedureName);
 
-            if (!accessControl.getRowFilters(session.toSecurityContext(), tableName).isEmpty()) {
-                throw semanticException(NOT_SUPPORTED, node, "ALTER TABLE EXECUTE is not supported for table with row filter");
+            return analyzeTableExecute(
+                    node,
+                    new ExecuteTarget.TableExecuteTarget(table, tableName.catalogName(), tableName, tableHandle),
+                    procedureName,
+                    node.getArguments(),
+                    node.getWhere(),
+                    scope);
+        }
+
+        @Override
+        protected Scope visitMaterializedViewExecute(MaterializedViewExecute node, Optional<Scope> scope)
+        {
+            Table table = node.getTable();
+            QualifiedObjectName materializedViewName = createQualifiedObjectName(session, table, node.getName());
+            MaterializedViewDefinition materializedViewDefinition = metadata.getMaterializedView(session, materializedViewName)
+                    .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, table, "Materialized view '%s' does not exist", materializedViewName));
+            String procedureName = node.getProcedureName().getCanonicalValue();
+
+            accessControl.checkCanExecuteTableProcedure(session.toSecurityContext(), materializedViewName, procedureName);
+
+            QualifiedName storageName = getMaterializedViewStorageTableName(materializedViewDefinition)
+                    .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, table, "Storage table for materialized view '%s' does not exist", materializedViewName));
+            QualifiedObjectName storageTableName = createQualifiedObjectName(session, table, storageName);
+            checkStorageTableNotRedirected(storageTableName);
+            TableHandle storageTableHandle = metadata.getTableHandle(session, storageTableName)
+                    .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, table, "Table '%s' does not exist", storageTableName));
+
+            return analyzeTableExecute(
+                    node,
+                    new ExecuteTarget.MaterializedViewExecuteTarget(table, storageTableName.catalogName(), materializedViewName, storageTableHandle),
+                    procedureName,
+                    node.getArguments(),
+                    node.getWhere(),
+                    scope);
+        }
+
+        private Scope analyzeTableExecute(
+                Node node,
+                ExecuteTarget target,
+                String procedureName,
+                List<CallArgument> arguments,
+                Optional<Expression> where,
+                Optional<Scope> scope)
+        {
+            if (!accessControl.getRowFilters(session.toSecurityContext(), target.authorizationTarget()).isEmpty()) {
+                throw semanticException(NOT_SUPPORTED, node, "%s is not supported for %s with row filter", target.updateType(), target.targetNoun());
             }
 
-            TableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle);
-            if (!accessControl.getColumnMasks(session.toSecurityContext(), tableName, tableMetadata.columns().stream().map(ColumnMetadata::getColumnSchema).collect(toImmutableList())).isEmpty()) {
-                throw semanticException(NOT_SUPPORTED, node, "ALTER TABLE EXECUTE is not supported for table with column masks");
+            TableMetadata tableMetadata = metadata.getTableMetadata(session, target.tableHandle());
+            if (!accessControl.getColumnMasks(session.toSecurityContext(), target.authorizationTarget(), tableMetadata.columns().stream().map(ColumnMetadata::getColumnSchema).collect(toImmutableList())).isEmpty()) {
+                throw semanticException(NOT_SUPPORTED, node, "%s is not supported for %s with column masks", target.updateType(), target.targetNoun());
             }
 
-            Scope tableScope = analyze(table);
+            Scope tableScope = switch (target) {
+                case ExecuteTarget.MaterializedViewExecuteTarget materializedViewExecuteTarget -> {
+                    analysis.addEmptyColumnReferencesForTable(accessControl, session.getIdentity(), materializedViewExecuteTarget.authorizationTarget(), getBranchName(materializedViewExecuteTarget.tableNode()));
+                    yield createScopeForMaterializedViewStorageTableExecute(materializedViewExecuteTarget.tableNode(), materializedViewExecuteTarget.authorizationTarget(), scope, materializedViewExecuteTarget.storageTableHandle());
+                }
+                case ExecuteTarget.TableExecuteTarget tableExecuteTarget -> analyze(tableExecuteTarget.tableNode());
+            };
 
-            String catalogName = tableName.catalogName();
-            CatalogHandle catalogHandle = getRequiredCatalogHandle(metadata, session, node, catalogName);
+            CatalogHandle catalogHandle = getRequiredCatalogHandle(metadata, session, node, target.catalogName());
             TableProcedureMetadata procedureMetadata = tableProceduresRegistry.resolve(catalogHandle, procedureName);
 
             // analyze WHERE
-            if (!procedureMetadata.getExecutionMode().supportsFilter() && node.getWhere().isPresent()) {
+            if (!procedureMetadata.getExecutionMode().supportsFilter() && where.isPresent()) {
                 throw semanticException(NOT_SUPPORTED, node, "WHERE not supported for procedure %s", procedureName);
             }
-            node.getWhere().ifPresent(where -> analyzeWhere(node, tableScope, where));
+            where.ifPresent(whereExpression -> analyzeWhere(node, tableScope, whereExpression));
 
             // analyze arguments
 
-            List<Property> arguments = processTableExecuteArguments(node, procedureMetadata, scope);
+            List<Property> properties = processTableExecuteArguments(node, arguments, procedureMetadata, scope);
             Map<String, Object> tableProperties = tableProceduresPropertyManager.getProperties(
-                    catalogName,
+                    target.catalogName(),
                     catalogHandle,
                     procedureName,
-                    arguments,
+                    properties,
                     session,
                     plannerContext,
                     accessControl,
                     analysis.getParameters());
 
-            TableExecuteHandle executeHandle =
-                    metadata.getTableHandleForExecute(
-                                    session,
-                                    tableHandle,
-                                    procedureName,
-                                    tableProperties)
-                            .orElseThrow(() -> semanticException(NOT_SUPPORTED, node, "Procedure '%s' cannot be executed on table '%s'", procedureName, tableName));
+            TableExecuteHandle executeHandle = switch (target) {
+                case ExecuteTarget.MaterializedViewExecuteTarget materializedViewExecuteTarget -> metadata.getTableHandleForMaterializedViewExecute(
+                                session,
+                                target.tableHandle(),
+                                procedureName,
+                                tableProperties)
+                        .orElseThrow(() -> semanticException(NOT_SUPPORTED, node, "Procedure '%s' cannot be executed on materialized view '%s'", procedureName, materializedViewExecuteTarget.materializedViewName()));
+                case ExecuteTarget.TableExecuteTarget tableExecuteTarget -> metadata.getTableHandleForExecute(
+                                session,
+                                target.tableHandle(),
+                                procedureName,
+                                tableProperties)
+                        .orElseThrow(() -> semanticException(NOT_SUPPORTED, node, "Procedure '%s' cannot be executed on table '%s'", procedureName, tableExecuteTarget.tableName()));
+            };
 
             analysis.setTableExecuteReadsData(procedureMetadata.getExecutionMode().isReadsData());
             analysis.setTableExecuteHandle(executeHandle);
+            analysis.setTableExecuteTable(target.tableNode());
 
-            analysis.setUpdateType("ALTER TABLE EXECUTE");
-            analysis.setUpdateTarget(executeHandle.catalogHandle().getVersion(), tableName, Optional.of(table), Optional.empty());
+            analysis.setUpdateType(target.updateType());
+            analysis.setUpdateTarget(executeHandle.catalogHandle().getVersion(), target.authorizationTarget(), Optional.of(target.tableNode()), Optional.empty());
 
             return createAndAssignScope(node, scope, Field.newUnqualified("metric_name", VARCHAR), Field.newUnqualified("metric_value", BIGINT));
         }
 
-        private List<Property> processTableExecuteArguments(TableExecute node, TableProcedureMetadata procedureMetadata, Optional<Scope> scope)
+        private List<Property> processTableExecuteArguments(Node node, List<CallArgument> arguments, TableProcedureMetadata procedureMetadata, Optional<Scope> scope)
         {
-            List<CallArgument> arguments = node.getArguments();
             Predicate<CallArgument> hasName = argument -> argument.getName().isPresent();
             boolean anyNamed = arguments.stream().anyMatch(hasName);
             boolean allNamed = arguments.stream().allMatch(hasName);
@@ -2642,6 +2699,21 @@ class StatementAnalyzer
                     view.getColumns(),
                     freshStorageTable,
                     true);
+        }
+
+        private Scope createScopeForMaterializedViewStorageTableExecute(Table table, QualifiedObjectName viewName, Optional<Scope> scope, TableHandle storageTable)
+        {
+            TableSchema tableSchema = metadata.getTableSchema(session, storageTable);
+            Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, storageTable);
+            List<Field> outputFields = analyzeTableOutputFields(table, viewName, tableSchema, columnHandles);
+
+            Scope accessControlScope = Scope.builder()
+                    .withRelationType(RelationId.anonymous(), new RelationType(outputFields))
+                    .build();
+            analyzeFiltersAndMasks(table, viewName, new RelationType(outputFields), accessControlScope);
+            analysis.registerTable(table, Optional.of(storageTable), viewName, getBranchName(table), session.getIdentity().getUser(), accessControlScope, Optional.empty());
+
+            return createAndAssignScope(table, scope, outputFields);
         }
 
         private Scope createScopeForView(Table table, QualifiedObjectName name, Optional<Scope> scope, ViewDefinition view)
@@ -6718,6 +6790,71 @@ class StatementAnalyzer
         public List<TableArgumentAnalysis> getTableArgumentAnalyses()
         {
             return tableArgumentAnalyses;
+        }
+    }
+
+    private sealed interface ExecuteTarget
+    {
+        String updateType();
+
+        String targetNoun();
+
+        Table tableNode();
+
+        QualifiedObjectName authorizationTarget();
+
+        String catalogName();
+
+        TableHandle tableHandle();
+
+        record TableExecuteTarget(Table tableNode, String catalogName, QualifiedObjectName tableName, TableHandle tableHandle)
+                implements ExecuteTarget
+        {
+            @Override
+            public QualifiedObjectName authorizationTarget()
+            {
+                return tableName;
+            }
+
+            @Override
+            public String updateType()
+            {
+                return "ALTER TABLE EXECUTE";
+            }
+
+            @Override
+            public String targetNoun()
+            {
+                return "table";
+            }
+        }
+
+        record MaterializedViewExecuteTarget(Table tableNode, String catalogName, QualifiedObjectName materializedViewName, TableHandle storageTableHandle)
+                implements ExecuteTarget
+        {
+            @Override
+            public QualifiedObjectName authorizationTarget()
+            {
+                return materializedViewName;
+            }
+
+            @Override
+            public TableHandle tableHandle()
+            {
+                return storageTableHandle;
+            }
+
+            @Override
+            public String updateType()
+            {
+                return "ALTER MATERIALIZED VIEW EXECUTE";
+            }
+
+            @Override
+            public String targetNoun()
+            {
+                return "materialized view";
+            }
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -109,6 +109,7 @@ import io.trino.sql.tree.Delete;
 import io.trino.sql.tree.ExplainAnalyze;
 import io.trino.sql.tree.Insert;
 import io.trino.sql.tree.LambdaArgumentDeclaration;
+import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.Query;
@@ -392,8 +393,8 @@ public class LogicalPlanner
         if (statement instanceof ExplainAnalyze explainAnalyze) {
             return createExplainAnalyzePlan(analysis, explainAnalyze);
         }
-        if (statement instanceof TableExecute tableExecute) {
-            return createTableExecutePlan(analysis, tableExecute);
+        if (statement instanceof TableExecute || statement instanceof MaterializedViewExecute) {
+            return createTableExecutePlan(analysis, statement);
         }
         throw new TrinoException(NOT_SUPPORTED, "Unsupported statement type " + statement.getClass().getSimpleName());
     }
@@ -1066,9 +1067,15 @@ public class LogicalPlanner
         return result;
     }
 
-    private RelationPlan createTableExecutePlan(Analysis analysis, TableExecute statement)
+    private RelationPlan createTableExecutePlan(Analysis analysis, Statement statement)
     {
-        Table table = statement.getTable();
+        Optional<io.trino.sql.tree.Expression> where = switch (statement) {
+            case TableExecute tableExecute -> tableExecute.getWhere();
+            case MaterializedViewExecute materializedViewExecute -> materializedViewExecute.getWhere();
+            default -> throw new IllegalArgumentException("Unexpected statement: " + statement);
+        };
+
+        Table table = analysis.getTableExecuteTable();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, table.getName());
         TableExecuteHandle executeHandle = analysis.getTableExecuteHandle().orElseThrow();
 
@@ -1085,9 +1092,9 @@ public class LogicalPlanner
         TableHandle tableHandle = analysis.getTableHandle(table);
         RelationPlan tableScanPlan = createRelationPlan(analysis, table);
         PlanBuilder sourcePlanBuilder = newPlanBuilder(tableScanPlan, analysis, ImmutableMap.of(), ImmutableMap.of(), session, plannerContext, symbolAllocator);
-        if (statement.getWhere().isPresent()) {
+        if (where.isPresent()) {
             SubqueryPlanner subqueryPlanner = new SubqueryPlanner(analysis, symbolAllocator, idAllocator, buildLambdaDeclarationToSymbolMap(analysis, symbolAllocator), plannerContext, Optional.empty(), session, ImmutableMap.of());
-            io.trino.sql.tree.Expression whereExpression = statement.getWhere().get();
+            io.trino.sql.tree.Expression whereExpression = where.get();
             sourcePlanBuilder = subqueryPlanner.handleSubqueries(sourcePlanBuilder, whereExpression, analysis.getSubqueries(statement));
             sourcePlanBuilder = sourcePlanBuilder.withNewRoot(new FilterNode(idAllocator.getNextId(), sourcePlanBuilder.getRoot(), sourcePlanBuilder.rewrite(whereExpression)));
         }

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -156,6 +156,15 @@ public class TracingConnectorMetadata
     }
 
     @Override
+    public Optional<ConnectorTableExecuteHandle> getTableHandleForMaterializedViewExecute(ConnectorSession session, ConnectorAccessControl accessControl, ConnectorTableHandle tableHandle, String procedureName, Map<String, Object> executeProperties, RetryMode retryMode)
+    {
+        Span span = startSpan("getTableHandleForMaterializedViewExecute", tableHandle);
+        try (var _ = scopedSpan(span)) {
+            return delegate.getTableHandleForMaterializedViewExecute(session, accessControl, tableHandle, procedureName, executeProperties, retryMode);
+        }
+    }
+
+    @Override
     public Set<ColumnHandle> getColumnHandlesForTableExecute(ConnectorSession connectorSession, ConnectorTableHandle tableHandle, ConnectorTableExecuteHandle connectorTableExecuteHandle)
     {
         Span span = startSpan("getColumnHandlesForTableExecute", tableHandle);

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -217,6 +217,16 @@ public class TracingMetadata
     }
 
     @Override
+    public Optional<TableExecuteHandle> getTableHandleForMaterializedViewExecute(Session session, TableHandle tableHandle, String procedureName, Map<String, Object> executeProperties)
+    {
+        Span span = startSpan("getTableHandleForMaterializedViewExecute", tableHandle)
+                .setAttribute(TrinoAttributes.PROCEDURE, procedureName);
+        try (var _ = scopedSpan(span)) {
+            return delegate.getTableHandleForMaterializedViewExecute(session, tableHandle, procedureName, executeProperties);
+        }
+    }
+
+    @Override
     public Set<ColumnHandle> getColumnHandlesForTableExecute(Session session, TableExecuteHandle tableExecuteHandle)
     {
         Span span = startSpan("getColumnHandlesForTableExecute", tableExecuteHandle);

--- a/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
@@ -105,6 +105,7 @@ import io.trino.sql.tree.FastForwardBranch;
 import io.trino.sql.tree.Grant;
 import io.trino.sql.tree.GrantRoles;
 import io.trino.sql.tree.Insert;
+import io.trino.sql.tree.MaterializedViewExecute;
 import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.Prepare;
 import io.trino.sql.tree.Query;
@@ -198,6 +199,7 @@ public final class StatementUtils
             .add(basicStatement(ShowBranches.class, DESCRIBE))
             // Table Procedure
             .add(basicStatement(TableExecute.class, ALTER_TABLE_EXECUTE))
+            .add(basicStatement(MaterializedViewExecute.class, ALTER_TABLE_EXECUTE))
             // DML
             .add(basicStatement(CreateTableAsSelect.class, INSERT))
             .add(basicStatement(RefreshMaterializedView.class, INSERT))

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -159,6 +159,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public Optional<TableExecuteHandle> getTableHandleForMaterializedViewExecute(Session session, TableHandle tableHandle, String procedureName, Map<String, Object> executeProperties)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Set<ColumnHandle> getColumnHandlesForTableExecute(Session session, TableExecuteHandle tableExecuteHandle)
     {
         throw new UnsupportedOperationException();

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -4199,6 +4199,38 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testInvalidTableExecute()
+    {
+        assertFails("ALTER TABLE foo EXECUTE optimize")
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("line 1:7: Table 'tpch.s1.foo' does not exist");
+        assertFails("ALTER TABLE v1 EXECUTE optimize")
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessage("line 1:1: ALTER TABLE EXECUTE is not supported for views");
+        assertFails("ALTER TABLE mv1 EXECUTE optimize")
+                .hasErrorCode(NOT_SUPPORTED)
+                .hasMessage("line 1:1: ALTER TABLE EXECUTE is not supported for materialized views");
+    }
+
+    @Test
+    public void testInvalidMaterializedViewExecute()
+    {
+        assertFails("ALTER MATERIALIZED VIEW foo EXECUTE optimize")
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("line 1:7: Materialized view 'tpch.s1.foo' does not exist");
+        assertFails("ALTER MATERIALIZED VIEW t1 EXECUTE optimize")
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("line 1:7: Materialized view 'tpch.s1.t1' does not exist");
+        assertFails("ALTER MATERIALIZED VIEW v1 EXECUTE optimize")
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("line 1:7: Materialized view 'tpch.s1.v1' does not exist");
+        // mv1 has no storage table configured in the mock metadata
+        assertFails("ALTER MATERIALIZED VIEW mv1 EXECUTE optimize")
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("line 1:7: Storage table for materialized view 'tpch.s1.mv1' does not exist");
+    }
+
+    @Test
     public void testInvalidShowTables()
     {
         assertFails("SHOW TABLES FROM a.b.c")

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -140,6 +140,24 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Variant of {@link #getTableHandleForExecute} used when the procedure is invoked through
+     * {@code ALTER MATERIALIZED VIEW ... EXECUTE}. The statement names a materialized view, while {@code tableHandle}
+     * is the handle of that view's storage table. Connectors that expose a different set of procedures on
+     * materialized view storage than on plain tables can override this to apply those rules, regardless of whether
+     * the storage table is also reachable by name. The default rejects the statement.
+     */
+    default Optional<ConnectorTableExecuteHandle> getTableHandleForMaterializedViewExecute(
+            ConnectorSession session,
+            ConnectorAccessControl accessControl,
+            ConnectorTableHandle tableHandle,
+            String procedureName,
+            Map<String, Object> executeProperties,
+            RetryMode retryMode)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "This connector does not support materialized view procedures");
+    }
+
+    /**
      * Returns source table columns required to execute a table procedure.
      * <p>
      * Connectors may override this to return the exact source-column set needed for the procedure.

--- a/docs/src/main/sphinx/sql/alter-materialized-view.md
+++ b/docs/src/main/sphinx/sql/alter-materialized-view.md
@@ -6,6 +6,8 @@
 ALTER MATERIALIZED VIEW [ IF EXISTS ] name RENAME TO new_name
 ALTER MATERIALIZED VIEW name SET PROPERTIES property_name = expression [, ...]
 ALTER MATERIALIZED VIEW name SET AUTHORIZATION ( user | USER user | ROLE role )
+ALTER MATERIALIZED VIEW name EXECUTE command [ ( parameter => expression [, ... ] ) ]
+    [ WHERE expression ]
 ```
 
 ## Description
@@ -30,6 +32,23 @@ reverts its value back to the default in that materialized view.
 
 Support for `ALTER MATERIALIZED VIEW SET PROPERTIES` varies between
 connectors. Refer to the connector documentation for more details.
+
+(alter-materialized-view-execute)=
+### EXECUTE
+
+The `ALTER MATERIALIZED VIEW EXECUTE` statement followed by a `command` and
+`parameters` modifies the materialized view or its underlying storage
+according to the specified command and parameters.
+
+You can use the `=>` operator for passing named parameter values. The left side
+is the name of the parameter, the right side is the value being passed.
+
+Running a command against a materialized view requires the privilege to
+execute that command against the view itself, not against its underlying
+storage table.
+
+Support for `ALTER MATERIALIZED VIEW EXECUTE` varies between connectors.
+Refer to the connector documentation for more details.
 
 ## Examples
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -213,6 +213,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public Optional<ConnectorTableExecuteHandle> getTableHandleForMaterializedViewExecute(ConnectorSession session, ConnectorAccessControl accessControl, ConnectorTableHandle tableHandle, String procedureName, Map<String, Object> executeProperties, RetryMode retryMode)
+    {
+        try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getTableHandleForMaterializedViewExecute(session, accessControl, tableHandle, procedureName, executeProperties, retryMode);
+        }
+    }
+
+    @Override
     public Map<String, Long> executeTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle)
     {
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(classLoader)) {

--- a/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseMetadata.java
+++ b/plugin/trino-lakehouse/src/main/java/io/trino/plugin/lakehouse/LakehouseMetadata.java
@@ -188,6 +188,12 @@ public class LakehouseMetadata
     }
 
     @Override
+    public Optional<ConnectorTableExecuteHandle> getTableHandleForMaterializedViewExecute(ConnectorSession session, ConnectorAccessControl accessControl, ConnectorTableHandle tableHandle, String procedureName, Map<String, Object> executeProperties, RetryMode retryMode)
+    {
+        return forHandle(tableHandle).getTableHandleForMaterializedViewExecute(session, accessControl, tableHandle, procedureName, executeProperties, retryMode);
+    }
+
+    @Override
     public Set<ColumnHandle> getColumnHandlesForTableExecute(ConnectorSession connectorSession, ConnectorTableHandle tableHandle, ConnectorTableExecuteHandle connectorTableExecuteHandle)
     {
         return forHandle(tableHandle).getColumnHandlesForTableExecute(connectorSession, tableHandle, connectorTableExecuteHandle);

--- a/testing/trino-testing/src/main/java/io/trino/testing/QueryAssertions.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/QueryAssertions.java
@@ -341,7 +341,11 @@ public final class QueryAssertions
         List<MaterializedRow> actualRows = actualResults.getMaterializedRows();
         List<MaterializedRow> expectedRows = expectedResults.getMaterializedRows();
 
-        if (compareUpdate && !actualResults.getUpdateType().equals(Optional.of("ALTER TABLE EXECUTE"))) {
+        // ALTER TABLE EXECUTE and ALTER MATERIALIZED VIEW EXECUTE both return procedure metrics as rows
+        // (metric_name, metric_value), not a single scalar update count, so they are compared as ordinary rows below.
+        boolean isTableExecute = actualResults.getUpdateType().equals(Optional.of("ALTER TABLE EXECUTE")) ||
+                actualResults.getUpdateType().equals(Optional.of("ALTER MATERIALIZED VIEW EXECUTE"));
+        if (compareUpdate && !isTableExecute) {
             if (actualResults.getUpdateType().isEmpty()) {
                 fail("update type not present for query " + queryId + ": \n" + actual);
             }


### PR DESCRIPTION
## Description

Follow-up of the addition of the `ALTER MATERIALIZED VIEW ... EXECUTE` syntax: https://github.com/trinodb/trino/pull/30546

For the end usage in iceberg connector see this PR: https://github.com/trinodb/trino/pull/30432
The iceberg connector support will come as separate PR as requested originally.

---

Analyze and plan MaterializedViewExecute by reusing the ALTER TABLE EXECUTE path, with the analysis shared by both statements extracted into analyzeTableExecute().

Authorize the procedure, row filters and column masks against the materialized view, and build the execute relation from its storage table's schema and column handles so the procedure sees every storage column.

Add ConnectorMetadata#getMaterializedViewTableHandleForExecute so a connector can accept or reject a procedure based on the target being materialized view storage. The default rejects the statement.


## Additional context and related issues
https://github.com/trinodb/trino/pull/30546
https://github.com/trinodb/trino/pull/30432


## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

