### PR TITLE
Add Databricks 18 LTS product test environment

### DIFF
--- a/.github/bin/build-pt-matrix.py
+++ b/.github/bin/build-pt-matrix.py
@@ -62,6 +62,7 @@ SUITES = [
     "SuiteDeltaLakeDatabricks154",
     "SuiteDeltaLakeDatabricks164",
     "SuiteDeltaLakeDatabricks173",
+    "SuiteDeltaLakeDatabricks18",
 ]
 
 ALL_SUITES = frozenset(SUITES)
@@ -72,6 +73,7 @@ DATABRICKS_SUITES = frozenset({
     "SuiteDeltaLakeDatabricks154",
     "SuiteDeltaLakeDatabricks164",
     "SuiteDeltaLakeDatabricks173",
+    "SuiteDeltaLakeDatabricks18",
 })
 DELTA_LAKE_SUITES = DATABRICKS_SUITES | {
     "SuiteAzure",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1062,6 +1062,7 @@ jobs:
           DATABRICKS_154_JDBC_URL: ${{ vars.DATABRICKS_154_JDBC_URL }}
           DATABRICKS_164_JDBC_URL: ${{ vars.DATABRICKS_164_JDBC_URL }}
           DATABRICKS_173_JDBC_URL: ${{ vars.DATABRICKS_173_JDBC_URL }}
+          DATABRICKS_18_JDBC_URL: ${{ vars.DATABRICKS_18_JDBC_URL }}
           DATABRICKS_LOGIN: token
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           GCP_CREDENTIALS_KEY: ${{ secrets.GCP_CREDENTIALS_KEY }}
@@ -1129,6 +1130,10 @@ jobs:
               SuiteDeltaLakeDatabricks173)
                 availability_env=DATABRICKS_TOKEN
                 required_env+=(S3_BUCKET AWS_REGION TRINO_AWS_ACCESS_KEY_ID TRINO_AWS_SECRET_ACCESS_KEY DATABRICKS_TOKEN DATABRICKS_173_JDBC_URL)
+                ;;
+              SuiteDeltaLakeDatabricks18)
+                availability_env=DATABRICKS_TOKEN
+                required_env+=(S3_BUCKET AWS_REGION TRINO_AWS_ACCESS_KEY_ID TRINO_AWS_SECRET_ACCESS_KEY DATABRICKS_TOKEN DATABRICKS_18_JDBC_URL)
                 ;;
             esac
 

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/TestGroup.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/TestGroup.java
@@ -439,8 +439,13 @@ public @interface TestGroup
 
     @Target({TYPE, METHOD})
     @Retention(RUNTIME)
-    @Tag("delta-lake-exclude-173")
-    @interface DeltaLakeExclude173 {}
+    @Tag("delta-lake-databricks-173")
+    @interface DeltaLakeDatabricks173 {}
+
+    @Target({TYPE, METHOD})
+    @Retention(RUNTIME)
+    @Tag("delta-lake-exclude-18")
+    @interface DeltaLakeExclude18 {}
 
     @Target({TYPE, METHOD})
     @Retention(RUNTIME)

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/DeltaLakeDatabricks18Environment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/DeltaLakeDatabricks18Environment.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.deltalake;
+
+import static io.trino.testing.SystemEnvironmentUtils.requireEnv;
+
+public class DeltaLakeDatabricks18Environment
+        extends DeltaLakeDatabricksEnvironment
+{
+    @Override
+    protected String databricksJdbcUrl()
+    {
+        return requireEnv("DATABRICKS_18_JDBC_URL");
+    }
+}

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/TestDeltaLakeAlterTableCompatibilityDatabricks.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/TestDeltaLakeAlterTableCompatibilityDatabricks.java
@@ -42,6 +42,7 @@ class TestDeltaLakeAlterTableCompatibilityDatabricks
     @TestGroup.DeltaLakeDatabricks143
     @TestGroup.DeltaLakeDatabricks154
     @TestGroup.DeltaLakeDatabricks164
+    @TestGroup.DeltaLakeDatabricks173
     void testConfiguredConnectors(DeltaLakeDatabricksEnvironment env)
     {
         assertDefaultConnectors(env, "hive", "delta_lake");

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/TestDeltaLakeCheckpointsDatabricksCompatibility.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/TestDeltaLakeCheckpointsDatabricksCompatibility.java
@@ -62,6 +62,7 @@ class TestDeltaLakeCheckpointsDatabricksCompatibility
     @TestGroup.DeltaLakeDatabricks143
     @TestGroup.DeltaLakeDatabricks154
     @TestGroup.DeltaLakeDatabricks164
+    @TestGroup.DeltaLakeDatabricks173
     @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
     void testDatabricksUsesCheckpointInterval(DeltaLakeDatabricksEnvironment env)
     {

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/TestDeltaLakeCreateTableAsSelectCompatibilityDatabricks.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/TestDeltaLakeCreateTableAsSelectCompatibilityDatabricks.java
@@ -39,6 +39,7 @@ class TestDeltaLakeCreateTableAsSelectCompatibilityDatabricks
     @TestGroup.DeltaLakeDatabricks143
     @TestGroup.DeltaLakeDatabricks154
     @TestGroup.DeltaLakeDatabricks164
+    @TestGroup.DeltaLakeDatabricks173
     @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
     void testTrinoTypesWithDatabricks(DeltaLakeDatabricksEnvironment env)
     {

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCreateTableCompatibility.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCreateTableCompatibility.java
@@ -31,8 +31,10 @@ import static io.trino.tests.product.deltalake.DeltaLakeDatabricksUtilsJunit.DAT
 import static io.trino.tests.product.deltalake.DeltaLakeDatabricksUtilsJunit.dropDeltaTableWithRetry;
 import static io.trino.tests.product.deltalake.DeltaLakeDatabricksUtilsJunit.getColumnCommentOnDatabricks;
 import static io.trino.tests.product.deltalake.DeltaLakeDatabricksUtilsJunit.getColumnCommentOnTrino;
+import static io.trino.tests.product.deltalake.DeltaLakeDatabricksUtilsJunit.getDatabricksRuntimeVersion;
 import static io.trino.tests.product.deltalake.DeltaLakeDatabricksUtilsJunit.getTableCommentOnDatabricks;
 import static io.trino.tests.product.deltalake.DeltaLakeDatabricksUtilsJunit.getTableCommentOnTrino;
+import static io.trino.tests.product.deltalake.util.DatabricksVersion.DATABRICKS_183_RUNTIME_VERSION;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -64,13 +66,14 @@ class TestDeltaLakeDatabricksCreateTableCompatibility
                     """
                     CREATE TABLE spark_catalog.default.%s (
                       integer INT,
-                      string STRING,
+                      string %s,
                       timetz TIMESTAMP)
                     USING delta
                     LOCATION 's3://%s/%s'
                     %s\
                     """,
                     tableName,
+                    getDatabricksStringColumnType(env),
                     env.getBucketName(),
                     tableDirectory,
                     getDatabricksDefaultTableProperties());
@@ -107,7 +110,7 @@ class TestDeltaLakeDatabricksCreateTableCompatibility
                     """
                     CREATE TABLE spark_catalog.default.%s (
                       integer INT,
-                      string STRING,
+                      string %s,
                       timetz TIMESTAMP)
                     USING delta
                     PARTITIONED BY (string)
@@ -115,6 +118,7 @@ class TestDeltaLakeDatabricksCreateTableCompatibility
                     %s\
                     """,
                     tableName,
+                    getDatabricksStringColumnType(env),
                     env.getBucketName(),
                     tableDirectory,
                     getDatabricksDefaultTableProperties());
@@ -149,13 +153,14 @@ class TestDeltaLakeDatabricksCreateTableCompatibility
                     """
                     CREATE TABLE spark_catalog.default.%s (
                       integer INT,
-                      string STRING,
+                      string %s,
                       timetz TIMESTAMP)
                     USING delta
                     LOCATION 's3://%s/%s'
                     %s\
                     """,
                     tableName,
+                    getDatabricksStringColumnType(env),
                     env.getBucketName(),
                     tableDirectory,
                     getDatabricksDefaultTableProperties());
@@ -196,7 +201,7 @@ class TestDeltaLakeDatabricksCreateTableCompatibility
                     """
                     CREATE TABLE spark_catalog.default.%s (
                       integer INT,
-                      string STRING,
+                      string %s,
                       timetz TIMESTAMP)
                     USING delta
                     PARTITIONED BY (string)
@@ -204,6 +209,7 @@ class TestDeltaLakeDatabricksCreateTableCompatibility
                     %s\
                     """,
                     tableName,
+                    getDatabricksStringColumnType(env),
                     env.getBucketName(),
                     tableDirectory,
                     getDatabricksDefaultTableProperties());
@@ -397,6 +403,14 @@ class TestDeltaLakeDatabricksCreateTableCompatibility
         finally {
             dropDeltaTableWithRetry(env, "default." + tableName);
         }
+    }
+
+    private static String getDatabricksStringColumnType(DeltaLakeDatabricksEnvironment env)
+    {
+        if (getDatabricksRuntimeVersion(env).orElseThrow().isAtLeast(DATABRICKS_183_RUNTIME_VERSION)) {
+            return "STRING COLLATE UTF8_BINARY";
+        }
+        return "STRING";
     }
 
     private static String getDatabricksDefaultTableProperties()

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/TestDeltaLakeIdentityColumnCompatibility.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/TestDeltaLakeIdentityColumnCompatibility.java
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @RequiresEnvironment(DeltaLakeDatabricksEnvironment.class)
 @TestGroup.ConfiguredFeatures
 @TestGroup.DeltaLakeDatabricks
-@TestGroup.DeltaLakeExclude173
+@TestGroup.DeltaLakeExclude18
 @TestGroup.ProfileSpecificTests
 class TestDeltaLakeIdentityColumnCompatibility
 {

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/TestDeltaLakeWriteDatabricksCompatibilityDatabricks.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/TestDeltaLakeWriteDatabricksCompatibilityDatabricks.java
@@ -294,7 +294,7 @@ class TestDeltaLakeWriteDatabricksCompatibilityDatabricks
     }
 
     @Test
-    @TestGroup.DeltaLakeExclude173
+    @TestGroup.DeltaLakeExclude18
     @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
     void testTrinoVacuumRemoveChangeDataFeedFiles(DeltaLakeDatabricksEnvironment env)
     {

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/util/DatabricksVersion.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/deltalake/util/DatabricksVersion.java
@@ -23,6 +23,7 @@ public record DatabricksVersion(int majorVersion, int minorVersion)
 {
     public static final DatabricksVersion DATABRICKS_143_RUNTIME_VERSION = new DatabricksVersion(14, 3);
     public static final DatabricksVersion DATABRICKS_122_RUNTIME_VERSION = new DatabricksVersion(12, 2);
+    public static final DatabricksVersion DATABRICKS_183_RUNTIME_VERSION = new DatabricksVersion(18, 3);
 
     private static final Pattern DATABRICKS_VERSION_PATTERN = Pattern.compile("(\\d+)\\.(\\d+)");
 

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteDeltaLakeDatabricks18.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/suite/SuiteDeltaLakeDatabricks18.java
@@ -14,25 +14,26 @@
 package io.trino.tests.product.suite;
 
 import io.trino.tests.product.TestGroup;
-import io.trino.tests.product.deltalake.DeltaLakeDatabricks173Environment;
+import io.trino.tests.product.deltalake.DeltaLakeDatabricks18Environment;
 import io.trino.tests.product.suite.SuiteRunner.TestRunResult;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public final class SuiteDeltaLakeDatabricks173
+public final class SuiteDeltaLakeDatabricks18
 {
-    private SuiteDeltaLakeDatabricks173() {}
+    private SuiteDeltaLakeDatabricks18() {}
 
-    public static void main(String[] args)
+    static void main()
             throws Exception
     {
         System.setProperty("trino.product-test.environment-mode", "STRICT");
 
         List<TestRunResult> results = new ArrayList<>();
-        results.add(SuiteRunner.forEnvironment(DeltaLakeDatabricks173Environment.class)
+        results.add(SuiteRunner.forEnvironment(DeltaLakeDatabricks18Environment.class)
                 .includeTag(TestGroup.ConfiguredFeatures.class)
-                .includeTag(TestGroup.DeltaLakeDatabricks173.class)
+                .includeTag(TestGroup.DeltaLakeDatabricks.class)
+                .excludeTag(TestGroup.DeltaLakeExclude18.class)
                 .run());
 
         SuiteRunner.printSummary(results);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

https://docs.databricks.com/aws/en/release-notes/runtime/

Databricks 18 LTS has been released in June 2026.

Add testing coverage for trino-delta-lake connector against this Databricks runtime.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


New CI variable needed:

```
DATABRICKS_18_JDBC_URL="jdbc:databricks://dbc-88a53597-967a.cloud.databricks.com:443/default;transportMode=http;ssl=1;httpPath=sql/protocolv1/o/336535122231371/0824-101618-eob1zdht;AuthMech=3"
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
