### PR TITLE
Allow NULL environment as resource group wildcard

### DIFF
--- a/plugin/trino-resource-group-managers/pom.xml
+++ b/plugin/trino-resource-group-managers/pom.xml
@@ -93,6 +93,11 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManager.java
@@ -379,8 +379,13 @@ public class DbResourceGroupConfigurationManager
         // Specs are built from db records, validate and return manager spec
         List<ResourceGroupSpec> rootGroups = rootGroupIds.stream().map(resourceGroupSpecMap::get).collect(Collectors.toList());
 
+        // The SQL query returns selectors for all groups matching this environment or having
+        // a NULL environment (wildcard). Filter out selectors whose resource group was not
+        // reachable from a root — e.g. a NULL-env child under an env-specific parent that
+        // belongs to a different environment.
         List<SelectorSpec> selectors = dao.getSelectors(environment)
                 .stream()
+                .filter(selectorRecord -> resourceGroupSpecMap.containsKey(selectorRecord.getResourceGroupId()))
                 .map(selectorRecord ->
                         new SelectorSpec(
                                 selectorRecord.getUserRegex(),

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManagerFactory.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManagerFactory.java
@@ -15,7 +15,6 @@ package io.trino.plugin.resourcegroups.db;
 
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
-import io.airlift.configuration.ConfigurationFactory;
 import io.airlift.json.JsonModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.plugin.base.jmx.PrefixObjectNameGeneratorModule;
@@ -26,8 +25,6 @@ import io.trino.spi.resourcegroups.ResourceGroupConfigurationManagerFactory;
 import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
-
-import static io.airlift.configuration.ConfigurationUtils.replaceEnvironmentVariables;
 
 public class DbResourceGroupConfigurationManagerFactory
         implements ResourceGroupConfigurationManagerFactory
@@ -41,7 +38,6 @@ public class DbResourceGroupConfigurationManagerFactory
     @Override
     public ResourceGroupConfigurationManager<?> create(Map<String, String> config, ResourceGroupConfigurationManagerContext context)
     {
-        FlywayMigration.migrate(new ConfigurationFactory(replaceEnvironmentVariables(config)).build(DbResourceGroupConfig.class));
         Bootstrap app = new Bootstrap(
                 "io.trino.bootstrap.resource-group." + getName(),
                 new MBeanModule(),
@@ -57,6 +53,8 @@ public class DbResourceGroupConfigurationManagerFactory
                 .disableSystemProperties()
                 .setRequiredConfigurationProperties(config)
                 .initialize();
+
+        injector.getInstance(FlywayMigration.class).migrate();
 
         return injector.getInstance(DbResourceGroupConfigurationManager.class);
     }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupsModule.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupsModule.java
@@ -31,6 +31,7 @@ public class DbResourceGroupsModule
     public void configure(Binder binder)
     {
         configBinder(binder).bindConfig(DbResourceGroupConfig.class);
+        binder.bind(FlywayMigration.class).in(Scopes.SINGLETON);
         binder.bind(ResourceGroupsDao.class).toProvider(DaoProvider.class).in(Scopes.SINGLETON);
         binder.bind(DbResourceGroupConfigurationManager.class).in(Scopes.SINGLETON);
         binder.bind(ResourceGroupConfigurationManager.class).to(DbResourceGroupConfigurationManager.class).in(Scopes.SINGLETON);

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/FlywayMigration.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/FlywayMigration.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.resourcegroups.db;
 
 import io.airlift.log.Logger;
+import jakarta.inject.Inject;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.output.MigrateResult;
 
@@ -23,7 +24,31 @@ public class FlywayMigration
 {
     private static final Logger log = Logger.get(FlywayMigration.class);
 
-    private FlywayMigration() {}
+    private final Flyway flyway;
+    private final boolean runMigrations;
+
+    @Inject
+    public FlywayMigration(DbResourceGroupConfig config)
+    {
+        flyway = Flyway.configure()
+                .dataSource(config.getConfigDbUrl(), config.getConfigDbUser(), config.getConfigDbPassword())
+                .locations(getLocation(config.getConfigDbUrl()))
+                .baselineOnMigrate(true)
+                .baselineVersion("0")
+                .load();
+        runMigrations = config.isRunMigrationsEnabled();
+    }
+
+    public void migrate()
+    {
+        if (!runMigrations) {
+            log.info("Skipping migrations");
+            return;
+        }
+        log.info("Performing migrations...");
+        MigrateResult migrations = flyway.migrate();
+        log.info("Performed %s migrations", migrations.migrationsExecuted);
+    }
 
     private static String getLocation(String configDbUrl)
     {
@@ -39,23 +64,5 @@ public class FlywayMigration
         // validation is not performed in DbResourceGroupConfig because DB backed
         // resource group tests use the h2 database.
         throw new IllegalArgumentException(format("Invalid JDBC URL: %s. Only PostgreSQL, MySQL, and Oracle are supported.", configDbUrl));
-    }
-
-    public static void migrate(DbResourceGroupConfig config)
-    {
-        if (!config.isRunMigrationsEnabled()) {
-            log.info("Skipping migrations");
-            return;
-        }
-        log.info("Performing migrations...");
-        Flyway flyway = Flyway.configure()
-                .dataSource(config.getConfigDbUrl(), config.getConfigDbUser(), config.getConfigDbPassword())
-                .locations(getLocation(config.getConfigDbUrl()))
-                .baselineOnMigrate(true)
-                .baselineVersion("0")
-                .load();
-
-        MigrateResult migrations = flyway.migrate();
-        log.info("Performed %s migrations", migrations.migrationsExecuted);
     }
 }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupsDao.java
@@ -58,14 +58,14 @@ public interface ResourceGroupsDao
             "  hard_concurrency_limit, scheduling_policy, scheduling_weight, jmx_export, soft_cpu_limit, " +
             "  hard_cpu_limit, hard_physical_data_scan_limit, parent\n" +
             "FROM resource_groups\n" +
-            "WHERE environment = :environment\n")
+            "WHERE environment = :environment OR environment IS NULL\n")
     @UseRowMapper(ResourceGroupSpecBuilder.Mapper.class)
     List<ResourceGroupSpecBuilder> getResourceGroups(@Bind("environment") String environment);
 
     @SqlQuery("SELECT S.resource_group_id, S.priority, S.user_regex, S.source_regex, S.original_user_regex, S.authenticated_user_regex, S.query_text_regex, S.query_type, S.client_tags, S.selector_resource_estimate, S.user_group_regex\n" +
             "FROM selectors S\n" +
             "JOIN resource_groups R ON (S.resource_group_id = R.resource_group_id)\n" +
-            "WHERE R.environment = :environment\n" +
+            "WHERE (R.environment = :environment OR R.environment IS NULL)\n" +
             "ORDER by priority DESC")
     @UseRowMapper(SelectorRecord.Mapper.class)
     List<SelectorRecord> getSelectors(@Bind("environment") String environment);
@@ -87,13 +87,13 @@ public interface ResourceGroupsDao
     void createSelectorsTable();
 
     @SqlUpdate("CREATE TABLE IF NOT EXISTS exact_match_source_selectors(\n" +
+            "  id BIGINT NOT NULL AUTO_INCREMENT,\n" +
             "  environment VARCHAR(128),\n" +
             "  source VARCHAR(512) NOT NULL,\n" +
             "  query_type VARCHAR(512),\n" +
             "  update_time TIMESTAMP NOT NULL,\n" +
             "  resource_group_id VARCHAR(256) NOT NULL,\n" +
-            "  PRIMARY KEY (environment, source, query_type),\n" +
-            "  UNIQUE (source, environment, query_type, resource_group_id)\n" +
+            "  PRIMARY KEY (id)\n" +
             ")")
     void createExactMatchSelectorsTable();
 

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/BaseTestDbResourceGroupsFlywayMigration.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/BaseTestDbResourceGroupsFlywayMigration.java
@@ -53,7 +53,7 @@ public abstract class BaseTestDbResourceGroupsFlywayMigration
                 .setConfigDbUrl(container.getJdbcUrl())
                 .setConfigDbUser(container.getUsername())
                 .setConfigDbPassword(container.getPassword());
-        FlywayMigration.migrate(config);
+        new FlywayMigration(config).migrate();
         verifyResourceGroupsSchema(0);
 
         dropAllTables();
@@ -71,7 +71,7 @@ public abstract class BaseTestDbResourceGroupsFlywayMigration
                 .setConfigDbUrl(container.getJdbcUrl())
                 .setConfigDbUser(container.getUsername())
                 .setConfigDbPassword(container.getPassword());
-        FlywayMigration.migrate(config);
+        new FlywayMigration(config).migrate();
         verifyResourceGroupsSchema(0);
         String t1Drop = "DROP TABLE t1";
         String t2Drop = "DROP TABLE t2";
@@ -90,7 +90,7 @@ public abstract class BaseTestDbResourceGroupsFlywayMigration
                 .setConfigDbUser(container.getUsername())
                 .setConfigDbPassword(container.getPassword())
                 .setRunMigrationsEnabled(false);
-        FlywayMigration.migrate(config);
+        new FlywayMigration(config).migrate();
         assertThat(tableExists("resource_groups")).isFalse();
         assertThat(tableExists("resource_groups_global_properties")).isFalse();
     }
@@ -102,7 +102,7 @@ public abstract class BaseTestDbResourceGroupsFlywayMigration
                 .setConfigDbUrl(container.getJdbcUrl())
                 .setConfigDbUser(container.getUsername())
                 .setConfigDbPassword(container.getPassword());
-        FlywayMigration.migrate(config);
+        new FlywayMigration(config).migrate();
         String cpuInsert = "INSERT INTO resource_groups_global_properties VALUES ('cpu_quota_period', '1h')";
         String dataInsert = "INSERT INTO resource_groups_global_properties VALUES ('physical_data_scan_quota_period', '1h')";
         Handle handle = jdbi.open();


### PR DESCRIPTION
## Description

Allow a resource group (and its selectors) to apply to all environments by setting the environment column to NULL. Previously, a resource group was only matched when its environment value exactly equalled the value supplied at runtime; NULL was simply ignored.

## Additional context and related issues

No upstream issue yet.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(*) Release notes are required, with the following suggested text:

```markdown
## Resource Group Managers
* Allow `NULL` environment on resource groups and selectors to act as a wildcard that matches every deployment.
```
