### PR TITLE
Add file-based access control for table procedures

### DIFF
--- a/docs/src/main/sphinx/security/file-system-access-control.md
+++ b/docs/src/main/sphinx/security/file-system-access-control.md
@@ -494,11 +494,51 @@ connector](/connector/delta-lake). It allows all users to execute the
 (system-file-table-procedure-rules)=
 #### Table procedure rules
 
-Table procedures are executed using the
-[ALTER TABLE ... EXECUTE](alter-table-execute) syntax.
+These rules control the ability of a user to execute table procedures, such as
+`OPTIMIZE`, using the [ALTER TABLE ... EXECUTE](alter-table-execute) syntax.
 
-File-based access control does not support privileges for table procedures and
-therefore all are effectively allowed.
+Table procedures modify the underlying data of a table. Read-only and none
+catalog access deny all table procedures on that catalog, regardless of the
+rules in this section.
+
+When table procedure rules are present, the authorization is based on the
+first matching rule, processed from top to bottom. If no rules match, the
+authorization is denied. If table procedure rules are not present, only table
+procedures on the `system` catalog can be executed.
+
+Each table procedure rule is composed of the following fields:
+
+- `user` (optional): regular expression to match against username.
+  Defaults to `.*`.
+- `role` (optional): regular expression to match against role names.
+  Defaults to `.*`.
+- `group` (optional): regular expression to match against group names.
+  Defaults to `.*`.
+- `catalog` (optional): regular expression to match against catalog name.
+  Defaults to `.*`.
+- `procedure` (optional): regular expression to match against table procedure
+  names.
+  Defaults to `.*`.
+- `privileges` (required): zero or more of `EXECUTE`.
+
+The following example allows the `admin` user to execute the `optimize` table
+procedure on a catalog called `delta`, that uses the [Delta Lake
+connector](/connector/delta-lake):
+
+```json
+{
+  "table_procedures": [
+    {
+      "user": "admin",
+      "catalog": "delta",
+      "procedure": "optimize",
+      "privileges": [
+        "EXECUTE"
+      ]
+    }
+  ]
+}
+```
 
 (verify-rules)=
 #### Verify configuration
@@ -924,6 +964,42 @@ in the `function` schema of this catalog:
       "schema": "function",
       "privileges": [
         "EXECUTE", "GRANT_EXECUTE", "OWNERSHIP"
+      ]
+    }
+  ]
+}
+```
+
+#### Table procedure rules
+
+These rules control the ability of a user to execute table procedures, such as
+`OPTIMIZE`, using the [ALTER TABLE ... EXECUTE](alter-table-execute) syntax.
+
+When these rules are present, the authorization is based on the first
+matching rule, processed from top to bottom. If no rules match, the
+authorization is denied. If table procedure rules are not present, access is
+not allowed.
+
+- `user` (optional): regular expression to match against username.
+  Defaults to `.*`.
+- `group` (optional): regular expression to match against group names.
+  Defaults to `.*`.
+- `procedure` (optional): regular expression to match against table procedure
+  names.
+  Defaults to `.*`.
+- `privileges` (required): zero or more of `EXECUTE`.
+
+The following example allows the `admin` user to execute the `optimize` table
+procedure:
+
+```json
+{
+  "table_procedures": [
+    {
+      "user": "admin",
+      "procedure": "optimize",
+      "privileges": [
+        "EXECUTE"
       ]
     }
   ]

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AccessControlRules.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AccessControlRules.java
@@ -28,6 +28,7 @@ public class AccessControlRules
     private final List<SessionPropertyAccessControlRule> sessionPropertyRules;
     private final List<FunctionAccessControlRule> functionRules;
     private final List<ProcedureAccessControlRule> procedureRules;
+    private final List<TableProcedureAccessControlRule> tableProcedureRules;
     private final List<AuthorizationRule> authorizationRules;
 
     @JsonCreator
@@ -37,6 +38,7 @@ public class AccessControlRules
             @JsonProperty("session_properties") @JsonAlias("sessionProperties") Optional<List<SessionPropertyAccessControlRule>> sessionPropertyRules,
             @JsonProperty("functions") Optional<List<FunctionAccessControlRule>> functionRules,
             @JsonProperty("procedures") Optional<List<ProcedureAccessControlRule>> procedureRules,
+            @JsonProperty("table_procedures") Optional<List<TableProcedureAccessControlRule>> tableProcedureRules,
             @JsonProperty("authorization") Optional<List<AuthorizationRule>> authorizationRules)
     {
         this.schemaRules = schemaRules.orElse(ImmutableList.of(SchemaAccessControlRule.ALLOW_ALL));
@@ -46,6 +48,8 @@ public class AccessControlRules
         this.functionRules = functionRules.orElse(ImmutableList.of());
         // procedures are not allowed by default
         this.procedureRules = procedureRules.orElse(ImmutableList.of());
+        // table procedures are not allowed by default
+        this.tableProcedureRules = tableProcedureRules.orElse(ImmutableList.of());
         this.authorizationRules = authorizationRules.orElse(ImmutableList.of());
     }
 
@@ -74,6 +78,11 @@ public class AccessControlRules
         return procedureRules;
     }
 
+    public List<TableProcedureAccessControlRule> getTableProcedureRules()
+    {
+        return tableProcedureRules;
+    }
+
     public List<AuthorizationRule> getAuthorizationRules()
     {
         return authorizationRules;
@@ -86,6 +95,7 @@ public class AccessControlRules
                 sessionPropertyRules.stream().anyMatch(rule -> rule.getRoleRegex().isPresent()) ||
                 functionRules.stream().anyMatch(rule -> rule.getRoleRegex().isPresent()) ||
                 procedureRules.stream().anyMatch(rule -> rule.getRoleRegex().isPresent()) ||
+                tableProcedureRules.stream().anyMatch(rule -> rule.getRoleRegex().isPresent()) ||
                 authorizationRules.stream().anyMatch(rule -> rule.getOriginalRolePattern().isPresent()) ||
                 authorizationRules.stream().anyMatch(rule -> rule.getNewRolePattern().isPresent());
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/CatalogTableProcedureAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/CatalogTableProcedureAccessControlRule.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
+import io.trino.plugin.base.security.TableProcedureAccessControlRule.TableProcedurePrivilege;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static io.trino.plugin.base.security.TableProcedureAccessControlRule.TableProcedurePrivilege.EXECUTE;
+import static java.util.Objects.requireNonNull;
+
+public class CatalogTableProcedureAccessControlRule
+{
+    public static final CatalogTableProcedureAccessControlRule ALLOW_BUILTIN = new CatalogTableProcedureAccessControlRule(
+            ImmutableSet.of(EXECUTE),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(Pattern.compile("system")),
+            Optional.empty());
+
+    private final Optional<Pattern> catalogRegex;
+    private final TableProcedureAccessControlRule tableProcedureAccessControlRule;
+
+    @JsonCreator
+    public CatalogTableProcedureAccessControlRule(
+            @JsonProperty("privileges") Set<TableProcedurePrivilege> privileges,
+            @JsonProperty("user") Optional<Pattern> userRegex,
+            @JsonProperty("role") Optional<Pattern> roleRegex,
+            @JsonProperty("group") Optional<Pattern> groupRegex,
+            @JsonProperty("catalog") Optional<Pattern> catalogRegex,
+            @JsonProperty("procedure") Optional<Pattern> procedureRegex)
+    {
+        this(catalogRegex, new TableProcedureAccessControlRule(privileges, userRegex, roleRegex, groupRegex, procedureRegex));
+    }
+
+    private CatalogTableProcedureAccessControlRule(Optional<Pattern> catalogRegex, TableProcedureAccessControlRule tableProcedureAccessControlRule)
+    {
+        this.catalogRegex = requireNonNull(catalogRegex, "catalogRegex is null");
+        this.tableProcedureAccessControlRule = requireNonNull(tableProcedureAccessControlRule, "tableProcedureAccessControlRule is null");
+    }
+
+    public boolean matches(String user, Set<String> roles, Set<String> groups, String catalogName, String procedureName)
+    {
+        if (!catalogRegex.map(regex -> regex.matcher(catalogName).matches()).orElse(true)) {
+            return false;
+        }
+        return tableProcedureAccessControlRule.matches(user, roles, groups, procedureName);
+    }
+
+    Optional<AnyCatalogPermissionsRule> toAnyCatalogPermissionsRule()
+    {
+        if (tableProcedureAccessControlRule.getPrivileges().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new AnyCatalogPermissionsRule(
+                tableProcedureAccessControlRule.getUserRegex(),
+                tableProcedureAccessControlRule.getRoleRegex(),
+                tableProcedureAccessControlRule.getGroupRegex(),
+                catalogRegex));
+    }
+
+    public boolean canExecuteTableProcedure()
+    {
+        return tableProcedureAccessControlRule.canExecuteTableProcedure();
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -75,6 +75,7 @@ import static io.trino.spi.security.AccessDeniedException.denyDropSchema;
 import static io.trino.spi.security.AccessDeniedException.denyDropTable;
 import static io.trino.spi.security.AccessDeniedException.denyDropView;
 import static io.trino.spi.security.AccessDeniedException.denyExecuteProcedure;
+import static io.trino.spi.security.AccessDeniedException.denyExecuteTableProcedure;
 import static io.trino.spi.security.AccessDeniedException.denyFastForwardBranch;
 import static io.trino.spi.security.AccessDeniedException.denyGrantRoles;
 import static io.trino.spi.security.AccessDeniedException.denyGrantSchemaPrivilege;
@@ -123,6 +124,7 @@ public class FileBasedAccessControl
     private final List<SessionPropertyAccessControlRule> sessionPropertyRules;
     private final List<FunctionAccessControlRule> functionRules;
     private final List<ProcedureAccessControlRule> procedureRules;
+    private final List<TableProcedureAccessControlRule> tableProcedureRules;
     private final List<AuthorizationRule> authorizationRules;
     private final Set<AnySchemaPermissionsRule> anySchemaPermissionsRules;
 
@@ -137,6 +139,7 @@ public class FileBasedAccessControl
         this.sessionPropertyRules = rules.getSessionPropertyRules();
         this.functionRules = rules.getFunctionRules();
         this.procedureRules = rules.getProcedureRules();
+        this.tableProcedureRules = rules.getTableProcedureRules();
         this.authorizationRules = rules.getAuthorizationRules();
         ImmutableSet.Builder<AnySchemaPermissionsRule> anySchemaPermissionsRules = ImmutableSet.builder();
         schemaRules.stream()
@@ -718,7 +721,18 @@ public class FileBasedAccessControl
     }
 
     @Override
-    public void checkCanExecuteTableProcedure(ConnectorSecurityContext context, SchemaTableName tableName, String procedure) {}
+    public void checkCanExecuteTableProcedure(ConnectorSecurityContext context, SchemaTableName tableName, String procedure)
+    {
+        ConnectorIdentity identity = context.getIdentity();
+        boolean allowed = tableProcedureRules.stream()
+                .filter(rule -> rule.matches(identity.getUser(), identity.getEnabledSystemRoles(), identity.getGroups(), procedure))
+                .findFirst()
+                .filter(TableProcedureAccessControlRule::canExecuteTableProcedure)
+                .isPresent();
+        if (!allowed) {
+            denyExecuteTableProcedure(tableName.toString(), procedure);
+        }
+    }
 
     @Override
     public boolean canExecuteFunction(ConnectorSecurityContext context, SchemaRoutineName function)

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -89,6 +89,7 @@ import static io.trino.spi.security.AccessDeniedException.denyDropTable;
 import static io.trino.spi.security.AccessDeniedException.denyDropView;
 import static io.trino.spi.security.AccessDeniedException.denyExecuteProcedure;
 import static io.trino.spi.security.AccessDeniedException.denyExecuteQuery;
+import static io.trino.spi.security.AccessDeniedException.denyExecuteTableProcedure;
 import static io.trino.spi.security.AccessDeniedException.denyGrantRoles;
 import static io.trino.spi.security.AccessDeniedException.denyGrantSchemaPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyGrantTablePrivilege;
@@ -147,6 +148,7 @@ public class FileBasedSystemAccessControl
     private final List<CatalogSessionPropertyAccessControlRule> catalogSessionPropertyRules;
     private final List<CatalogFunctionAccessControlRule> functionRules;
     private final List<CatalogProcedureAccessControlRule> procedureRules;
+    private final List<CatalogTableProcedureAccessControlRule> tableProcedureRules;
     private final Set<AnyCatalogPermissionsRule> anyCatalogPermissionsRules;
     private final Set<AnyCatalogSchemaPermissionsRule> anyCatalogSchemaPermissionsRules;
 
@@ -163,7 +165,8 @@ public class FileBasedSystemAccessControl
             List<SessionPropertyAccessControlRule> sessionPropertyRules,
             List<CatalogSessionPropertyAccessControlRule> catalogSessionPropertyRules,
             List<CatalogFunctionAccessControlRule> functionRules,
-            List<CatalogProcedureAccessControlRule> procedureRules)
+            List<CatalogProcedureAccessControlRule> procedureRules,
+            List<CatalogTableProcedureAccessControlRule> tableProcedureRules)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.catalogRules = catalogRules;
@@ -178,6 +181,7 @@ public class FileBasedSystemAccessControl
         this.catalogSessionPropertyRules = catalogSessionPropertyRules;
         this.functionRules = functionRules;
         this.procedureRules = procedureRules;
+        this.tableProcedureRules = tableProcedureRules;
 
         ImmutableSet.Builder<AnyCatalogPermissionsRule> anyCatalogPermissionsRules = ImmutableSet.builder();
         schemaRules.stream()
@@ -198,6 +202,10 @@ public class FileBasedSystemAccessControl
                 .forEach(anyCatalogPermissionsRules::add);
         procedureRules.stream()
                 .map(CatalogProcedureAccessControlRule::toAnyCatalogPermissionsRule)
+                .flatMap(Optional::stream)
+                .forEach(anyCatalogPermissionsRules::add);
+        tableProcedureRules.stream()
+                .map(CatalogTableProcedureAccessControlRule::toAnyCatalogPermissionsRule)
                 .flatMap(Optional::stream)
                 .forEach(anyCatalogPermissionsRules::add);
         this.anyCatalogPermissionsRules = anyCatalogPermissionsRules.build();
@@ -1007,6 +1015,7 @@ public class FileBasedSystemAccessControl
     public void checkCanExecuteProcedure(SystemSecurityContext systemSecurityContext, CatalogSchemaRoutineName procedure)
     {
         Identity identity = systemSecurityContext.getIdentity();
+        // TODO: Shouldn't this permission check be ALL instead of READ_ONLY as procedures can mutate too (e.g. register_table, flush_metadata_cache)
         boolean allowed = canAccessCatalog(systemSecurityContext, procedure.getCatalogName(), READ_ONLY) &&
                 procedureRules.stream()
                         .filter(rule -> rule.matches(identity.getUser(), identity.getEnabledRoles(), identity.getGroups(), procedure))
@@ -1031,7 +1040,19 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
-    public void checkCanExecuteTableProcedure(SystemSecurityContext systemSecurityContext, CatalogSchemaTableName table, String procedure) {}
+    public void checkCanExecuteTableProcedure(SystemSecurityContext systemSecurityContext, CatalogSchemaTableName table, String procedure)
+    {
+        Identity identity = systemSecurityContext.getIdentity();
+        boolean allowed = canAccessCatalog(systemSecurityContext, table.getCatalogName(), ALL) &&
+                tableProcedureRules.stream()
+                        .filter(rule -> rule.matches(identity.getUser(), identity.getEnabledRoles(), identity.getGroups(), table.getCatalogName(), procedure))
+                        .findFirst()
+                        .filter(CatalogTableProcedureAccessControlRule::canExecuteTableProcedure)
+                        .isPresent();
+        if (!allowed) {
+            denyExecuteTableProcedure(table.toString(), procedure);
+        }
+    }
 
     @Override
     public void checkCanShowFunctions(SystemSecurityContext context, CatalogSchemaName schema)
@@ -1352,6 +1373,7 @@ public class FileBasedSystemAccessControl
         private List<CatalogSessionPropertyAccessControlRule> catalogSessionPropertyRules = ImmutableList.of(CatalogSessionPropertyAccessControlRule.ALLOW_ALL);
         private List<CatalogFunctionAccessControlRule> functionRules = ImmutableList.of(CatalogFunctionAccessControlRule.ALLOW_BUILTIN);
         private List<CatalogProcedureAccessControlRule> procedureRules = ImmutableList.of(CatalogProcedureAccessControlRule.ALLOW_BUILTIN);
+        private List<CatalogTableProcedureAccessControlRule> tableProcedureRules = ImmutableList.of(CatalogTableProcedureAccessControlRule.ALLOW_BUILTIN);
 
         public Builder setLifeCycleManager(LifeCycleManager lifeCycleManager)
         {
@@ -1374,6 +1396,7 @@ public class FileBasedSystemAccessControl
             catalogSessionPropertyRules = ImmutableList.of();
             functionRules = ImmutableList.of();
             procedureRules = ImmutableList.of();
+            tableProcedureRules = ImmutableList.of();
             return this;
         }
 
@@ -1449,6 +1472,12 @@ public class FileBasedSystemAccessControl
             return this;
         }
 
+        public Builder setTableProcedureRules(List<CatalogTableProcedureAccessControlRule> tableProcedureRules)
+        {
+            this.tableProcedureRules = tableProcedureRules;
+            return this;
+        }
+
         public FileBasedSystemAccessControl build()
         {
             return new FileBasedSystemAccessControl(
@@ -1464,7 +1493,8 @@ public class FileBasedSystemAccessControl
                     sessionPropertyRules,
                     catalogSessionPropertyRules,
                     functionRules,
-                    procedureRules);
+                    procedureRules,
+                    tableProcedureRules);
         }
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControlModule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControlModule.java
@@ -114,6 +114,7 @@ public class FileBasedSystemAccessControlModule
                 .setCatalogSessionPropertyRules(rules.getCatalogSessionPropertyRules().orElse(ImmutableList.of(CatalogSessionPropertyAccessControlRule.ALLOW_ALL)))
                 .setFunctionRules(rules.getFunctionRules().orElse(ImmutableList.of(CatalogFunctionAccessControlRule.ALLOW_BUILTIN)))
                 .setProcedureRules(rules.getProcedureRules().orElse(ImmutableList.of(CatalogProcedureAccessControlRule.ALLOW_BUILTIN)))
+                .setTableProcedureRules(rules.getTableProcedureRules().orElse(ImmutableList.of(CatalogTableProcedureAccessControlRule.ALLOW_BUILTIN)))
                 .build();
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControlRules.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControlRules.java
@@ -34,6 +34,7 @@ public class FileBasedSystemAccessControlRules
     private final Optional<List<CatalogSessionPropertyAccessControlRule>> catalogSessionPropertyRules;
     private final Optional<List<CatalogFunctionAccessControlRule>> functionRules;
     private final Optional<List<CatalogProcedureAccessControlRule>> procedureRules;
+    private final Optional<List<CatalogTableProcedureAccessControlRule>> tableProcedureRules;
 
     @JsonCreator
     public FileBasedSystemAccessControlRules(
@@ -48,7 +49,8 @@ public class FileBasedSystemAccessControlRules
             @JsonProperty("system_session_properties") Optional<List<SessionPropertyAccessControlRule>> sessionPropertyRules,
             @JsonProperty("catalog_session_properties") Optional<List<CatalogSessionPropertyAccessControlRule>> catalogSessionPropertyRules,
             @JsonProperty("functions") Optional<List<CatalogFunctionAccessControlRule>> functionRules,
-            @JsonProperty("procedures") Optional<List<CatalogProcedureAccessControlRule>> procedureRules)
+            @JsonProperty("procedures") Optional<List<CatalogProcedureAccessControlRule>> procedureRules,
+            @JsonProperty("table_procedures") Optional<List<CatalogTableProcedureAccessControlRule>> tableProcedureRules)
     {
         this.catalogRules = catalogRules.map(ImmutableList::copyOf);
         this.queryAccessRules = queryAccessRules.map(ImmutableList::copyOf);
@@ -62,6 +64,7 @@ public class FileBasedSystemAccessControlRules
         this.catalogSessionPropertyRules = catalogSessionPropertyRules.map(ImmutableList::copyOf);
         this.functionRules = functionRules.map(ImmutableList::copyOf);
         this.procedureRules = procedureRules.map(ImmutableList::copyOf);
+        this.tableProcedureRules = tableProcedureRules.map(ImmutableList::copyOf);
     }
 
     public Optional<List<CatalogAccessControlRule>> getCatalogRules()
@@ -122,5 +125,10 @@ public class FileBasedSystemAccessControlRules
     public Optional<List<CatalogProcedureAccessControlRule>> getProcedureRules()
     {
         return procedureRules;
+    }
+
+    public Optional<List<CatalogTableProcedureAccessControlRule>> getTableProcedureRules()
+    {
+        return tableProcedureRules;
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/TableProcedureAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/TableProcedureAccessControlRule.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static io.trino.plugin.base.security.TableProcedureAccessControlRule.TableProcedurePrivilege.EXECUTE;
+import static java.util.Objects.requireNonNull;
+
+public class TableProcedureAccessControlRule
+{
+    private final Set<TableProcedurePrivilege> privileges;
+    private final Optional<Pattern> userRegex;
+    private final Optional<Pattern> roleRegex;
+    private final Optional<Pattern> groupRegex;
+    private final Optional<Pattern> procedureRegex;
+
+    @JsonCreator
+    public TableProcedureAccessControlRule(
+            @JsonProperty("privileges") Set<TableProcedurePrivilege> privileges,
+            @JsonProperty("user") Optional<Pattern> userRegex,
+            @JsonProperty("role") Optional<Pattern> roleRegex,
+            @JsonProperty("group") Optional<Pattern> groupRegex,
+            @JsonProperty("procedure") Optional<Pattern> procedureRegex)
+    {
+        this.privileges = ImmutableSet.copyOf(requireNonNull(privileges, "privileges is null"));
+        this.userRegex = requireNonNull(userRegex, "userRegex is null");
+        this.roleRegex = requireNonNull(roleRegex, "roleRegex is null");
+        this.groupRegex = requireNonNull(groupRegex, "groupRegex is null");
+        this.procedureRegex = requireNonNull(procedureRegex, "procedureRegex is null");
+    }
+
+    public boolean matches(String user, Set<String> roles, Set<String> groups, String procedureName)
+    {
+        return userRegex.map(regex -> regex.matcher(user).matches()).orElse(true) &&
+                roleRegex.map(regex -> roles.stream().anyMatch(role -> regex.matcher(role).matches())).orElse(true) &&
+                groupRegex.map(regex -> groups.stream().anyMatch(group -> regex.matcher(group).matches())).orElse(true) &&
+                procedureRegex.map(regex -> regex.matcher(procedureName).matches()).orElse(true);
+    }
+
+    public boolean canExecuteTableProcedure()
+    {
+        return privileges.contains(EXECUTE);
+    }
+
+    Set<TableProcedurePrivilege> getPrivileges()
+    {
+        return privileges;
+    }
+
+    Optional<Pattern> getUserRegex()
+    {
+        return userRegex;
+    }
+
+    Optional<Pattern> getRoleRegex()
+    {
+        return roleRegex;
+    }
+
+    Optional<Pattern> getGroupRegex()
+    {
+        return groupRegex;
+    }
+
+    public enum TableProcedurePrivilege
+    {
+        EXECUTE
+    }
+}

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedConnectorAccessControlTest.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedConnectorAccessControlTest.java
@@ -675,6 +675,20 @@ public abstract class BaseFileBasedConnectorAccessControlTest
     }
 
     @Test
+    public void testTableProcedureRulesForCheckCanExecute()
+            throws Exception
+    {
+        ConnectorAccessControl accessControl = createAccessControl("visibility.json");
+
+        accessControl.checkCanExecuteTableProcedure(BOB, new SchemaTableName("bob-schema", "bob-table"), "some_table_procedure");
+        assertDenied(() -> accessControl.checkCanExecuteTableProcedure(BOB, new SchemaTableName("bob-schema", "bob-table"), "another_table_procedure"));
+
+        assertDenied(() -> accessControl.checkCanExecuteTableProcedure(CHARLIE, new SchemaTableName("procedure-schema", "some-table"), "some_table_procedure"));
+
+        assertDenied(() -> accessControl.checkCanExecuteTableProcedure(ALICE, new SchemaTableName("alice-schema", "alice-table"), "some_table_procedure"));
+    }
+
+    @Test
     public void testInvalidRules()
     {
         assertThatThrownBy(() -> createAccessControl("invalid.json"))

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
@@ -132,6 +132,7 @@ public abstract class BaseFileBasedSystemAccessControlTest
     private static final String SET_SYSTEM_SESSION_PROPERTY_ACCESS_DENIED_MESSAGE = "Cannot set system session property .*";
     private static final String SET_CATALOG_SESSION_PROPERTY_ACCESS_DENIED_MESSAGE = "Cannot set catalog session property .*";
     private static final String EXECUTE_PROCEDURE_ACCESS_DENIED_MESSAGE = "Cannot execute procedure .*";
+    private static final String EXECUTE_TABLE_PROCEDURE_ACCESS_DENIED_MESSAGE = "Cannot execute table procedure .*";
 
     protected abstract SystemAccessControl newFileBasedSystemAccessControl(Path configFile, Map<String, String> properties);
 
@@ -1536,6 +1537,26 @@ public abstract class BaseFileBasedSystemAccessControlTest
         assertAccessDenied(
                 () -> accessControl.checkCanExecuteProcedure(ALICE, new CatalogSchemaRoutineName("alice-catalog", new SchemaRoutineName("procedure-schema", "some_procedure"))),
                 EXECUTE_PROCEDURE_ACCESS_DENIED_MESSAGE);
+    }
+
+    @Test
+    public void testTableProcedureRulesForCheckCanExecute()
+            throws Exception
+    {
+        SystemAccessControl accessControl = newFileBasedSystemAccessControl("file-based-system-access-visibility.json");
+
+        accessControl.checkCanExecuteTableProcedure(BOB, new CatalogSchemaTableName("alice-catalog", "bob-schema", "bob-table"), "some_table_procedure");
+        assertAccessDenied(
+                () -> accessControl.checkCanExecuteTableProcedure(BOB, new CatalogSchemaTableName("alice-catalog", "bob-schema", "bob-table"), "another_table_procedure"),
+                EXECUTE_TABLE_PROCEDURE_ACCESS_DENIED_MESSAGE);
+        assertAccessDenied(
+                () -> accessControl.checkCanExecuteTableProcedure(ALICE, new CatalogSchemaTableName("alice-catalog", "alice-schema", "alice-table"), "some_table_procedure"),
+                EXECUTE_TABLE_PROCEDURE_ACCESS_DENIED_MESSAGE);
+
+        // table procedures may modify data so they are denied unless catalog permissions allow (even though a matching rule grants EXECUTE)
+        assertAccessDenied(
+                () -> accessControl.checkCanExecuteTableProcedure(BOB, new CatalogSchemaTableName("specific-catalog", "specific-schema", "specific-table"), "some_table_procedure"),
+                EXECUTE_TABLE_PROCEDURE_ACCESS_DENIED_MESSAGE);
     }
 
     @Test

--- a/lib/trino-plugin-toolkit/src/test/resources/file-based-system-access-visibility.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/file-based-system-access-visibility.json
@@ -163,5 +163,22 @@
             "privileges": [
             ]
         }
+    ],
+    "table_procedures": [
+        {
+            "user": "bob",
+            "catalog": "alice-catalog",
+            "procedure": "some_table_procedure",
+            "privileges": [
+                "EXECUTE"
+            ]
+        },
+        {
+            "catalog": "specific-catalog",
+            "procedure": "some_table_procedure",
+            "privileges": [
+                "EXECUTE"
+            ]
+        }
     ]
 }

--- a/lib/trino-plugin-toolkit/src/test/resources/visibility.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/visibility.json
@@ -82,5 +82,20 @@
         "privileges": [
         ]
       }
+    ],
+    "table_procedures": [
+        {
+            "user": "bob",
+            "procedure": "some_table_procedure",
+            "privileges": [
+                "EXECUTE"
+            ]
+        },
+        {
+            "user": "charlie",
+            "procedure": "some_table_procedure",
+            "privileges": [
+            ]
+        }
     ]
 }


### PR DESCRIPTION
## Description

- Fixes https://github.com/trinodb/trino/issues/22874

## Additional context and related issues

Implements access control for `ALTER TABLE EXECUTE ...`.

- Supersedes #22926.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```