### PR TITLE
Improve page processing of dictionary encoded data

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageProjection.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/DictionaryAwarePageProjection.java
@@ -110,6 +110,11 @@ public class DictionaryAwarePageProjection
         }
 
         // there is no dictionary handling or dictionary handling failed; fall back to general projection
+        if (block instanceof DictionaryBlock dictionaryBlock) {
+            // project the dictionary at translated ids so the projection reads the flat block
+            int[] outputIds = filterDictionaryIds(dictionaryBlock, selectedPositions);
+            return projection.project(session, SourcePage.create(dictionaryBlock.getDictionary()), SelectedPositions.positionsList(outputIds, 0, outputIds.length));
+        }
         return projection.project(session, SourcePage.create(block), selectedPositions);
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/project/InputPageProjection.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/InputPageProjection.java
@@ -14,6 +14,9 @@
 package io.trino.operator.project;
 
 import io.trino.spi.block.Block;
+import io.trino.spi.block.DictionaryBlock;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.block.ValueBlock;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SourcePage;
 
@@ -48,7 +51,12 @@ public class InputPageProjection
         requireNonNull(selectedPositions, "selectedPositions is null");
 
         if (selectedPositions.isList()) {
-            block = block.copyPositions(selectedPositions.getPositions(), selectedPositions.getOffset(), selectedPositions.size());
+            switch (block) {
+                // Avoids unnecessary copying
+                case DictionaryBlock _, RunLengthEncodedBlock _ -> block = block.getPositions(selectedPositions.getPositions(), selectedPositions.getOffset(), selectedPositions.size());
+                // Avoids creating a masking dictionary block out of a non-dictionary block
+                case ValueBlock _ -> block = block.copyPositions(selectedPositions.getPositions(), selectedPositions.getOffset(), selectedPositions.size());
+            }
         }
         else if (selectedPositions.size() == block.getPositionCount()) {
             return block;

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -72,7 +72,8 @@ public class PageProcessor
         this.identityProjections = !projections.isEmpty() && projections.stream().allMatch(InputPageProjection.class::isInstance);
         this.projections = projections.stream()
                 .map(projection -> {
-                    if (projection.getInputChannels().size() == 1 && projection.isDeterministic()) {
+                    // input projections preserve the encoding of their input on their own
+                    if (projection.getInputChannels().size() == 1 && projection.isDeterministic() && !(projection instanceof InputPageProjection)) {
                         return new DictionaryAwarePageProjection(projection, dictionarySourceIdFunction);
                     }
                     return projection;

--- a/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
@@ -57,11 +57,12 @@ import static io.airlift.bytecode.OpCode.NOP;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantClassDataAt;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantFalse;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantTrue;
-import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.FUNCTION;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NULL_FLAG;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.VALUE_BLOCK_POSITION;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.VALUE_BLOCK_POSITION_NOT_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static java.lang.Math.toIntExact;
@@ -335,14 +336,18 @@ public final class BytecodeUtils
                         block.append(boxPrimitiveIfNecessary(scope, type));
                         block.append(scope.getVariable("wasNull").set(constantFalse()));
                     }
-                    case BLOCK_POSITION -> {
+                    case VALUE_BLOCK_POSITION -> {
                         InputReferenceNode inputReferenceNode = (InputReferenceNode) arguments.get(realParameterIndex);
-                        block.append(inputReferenceNode.produceBlockAndPosition());
+                        block.append(inputReferenceNode.produceValueBlockAndPosition());
                         stackTypes.add(int.class);
-                        if (!functionNullability.isArgumentNullable(realParameterIndex)) {
-                            block.append(scope.getVariable("wasNull").set(inputReferenceNode.blockAndPositionIsNull()));
-                            block.append(ifWasNullPopAndGoto(scope, end, unboxedReturnType, stackTypes.reversed()));
-                        }
+                        currentParameterIndex++;
+                    }
+                    case VALUE_BLOCK_POSITION_NOT_NULL -> {
+                        InputReferenceNode inputReferenceNode = (InputReferenceNode) arguments.get(realParameterIndex);
+                        block.append(inputReferenceNode.produceValueBlockAndPosition());
+                        stackTypes.add(int.class);
+                        block.append(scope.getVariable("wasNull").set(inputReferenceNode.valueBlockPositionIsNull()));
+                        block.append(ifWasNullPopAndGoto(scope, end, unboxedReturnType, stackTypes.reversed()));
                         currentParameterIndex++;
                     }
                     case IN_OUT -> {
@@ -383,10 +388,13 @@ public final class BytecodeUtils
 
     private static InvocationArgumentConvention getPreferredArgumentConvention(BytecodeNode argument, int argumentCount, boolean nullable)
     {
-        // a Java function can only have 255 arguments, so if the count is low use block position or boxed nullable as they are more efficient
+        // a Java function can only have 255 arguments, so if the count is low use value block position or boxed nullable as they are more efficient
         if (argumentCount <= 64) {
             if (argument instanceof InputReferenceNode) {
-                return BLOCK_POSITION;
+                if (nullable) {
+                    return VALUE_BLOCK_POSITION;
+                }
+                return VALUE_BLOCK_POSITION_NOT_NULL;
             }
             if (nullable) {
                 return NULL_FLAG;

--- a/core/trino-main/src/main/java/io/trino/sql/gen/InputReferenceCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/InputReferenceCompiler.java
@@ -14,7 +14,6 @@
 package io.trino.sql.gen;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.primitives.Primitives;
 import io.airlift.bytecode.BytecodeBlock;
 import io.airlift.bytecode.BytecodeNode;
 import io.airlift.bytecode.BytecodeVisitor;
@@ -24,11 +23,19 @@ import io.airlift.bytecode.Variable;
 import io.airlift.bytecode.control.IfStatement;
 import io.airlift.bytecode.expression.BytecodeExpression;
 import io.airlift.slice.Slice;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.ValueBlock;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
 import org.objectweb.asm.MethodVisitor;
 
+import java.lang.invoke.MethodHandle;
 import java.util.List;
 
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.VALUE_BLOCK_POSITION_NOT_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
+import static io.trino.sql.gen.BytecodeUtils.invoke;
 import static io.trino.sql.gen.SqlTypeBytecodeExpression.constantType;
 
 /**
@@ -38,19 +45,21 @@ final class InputReferenceCompiler
 {
     private InputReferenceCompiler() {}
 
-    public static BytecodeNode generateInputReference(CallSiteBinder callSiteBinder, Scope scope, Type type, BytecodeExpression block, BytecodeExpression position)
+    public static BytecodeNode generateInputReference(TypeOperators typeOperators, CallSiteBinder callSiteBinder, Scope scope, Type type, BytecodeExpression block, BytecodeExpression position)
     {
-        return new InputReferenceNode(callSiteBinder, scope, type, block, position);
+        return new InputReferenceNode(typeOperators, callSiteBinder, scope, type, block, position);
     }
 
     static class InputReferenceNode
             implements BytecodeNode
     {
-        private final BytecodeNode body;
+        private final BytecodeBlock body;
         private final BytecodeExpression block;
         private final BytecodeExpression position;
+        private final Variable valueBlock;
+        private final Variable valuePosition;
 
-        private InputReferenceNode(CallSiteBinder callSiteBinder, Scope scope, Type type, BytecodeExpression block, BytecodeExpression position)
+        private InputReferenceNode(TypeOperators typeOperators, CallSiteBinder callSiteBinder, Scope scope, Type type, BytecodeExpression block, BytecodeExpression position)
         {
             // Generate body based on block and position
             Variable wasNullVariable = scope.getVariable("wasNull");
@@ -59,24 +68,37 @@ final class InputReferenceCompiler
                 callType = Object.class;
             }
 
+            Variable valueBlock = scope.createTempVariable(ValueBlock.class);
+            Variable valuePosition = scope.createTempVariable(int.class);
+
             IfStatement ifStatement = new IfStatement();
-            ifStatement.condition(block.invoke("isNull", boolean.class, position));
+            ifStatement.condition(valueBlock.invoke("isNull", boolean.class, valuePosition));
 
             ifStatement.ifTrue()
                     .putVariable(wasNullVariable, true)
                     .pushJavaDefault(callType);
 
-            String methodName = "get" + Primitives.wrap(callType).getSimpleName();
-            BytecodeExpression value = constantType(callSiteBinder, type).invoke(methodName, callType, block, position);
+            BytecodeExpression value;
+            if (callType == Object.class) {
+                value = constantType(callSiteBinder, type).invoke("getObject", Object.class, valueBlock.cast(Block.class), valuePosition);
+            }
+            else {
+                MethodHandle readValue = typeOperators.getReadValueOperator(type, simpleConvention(FAIL_ON_NULL, VALUE_BLOCK_POSITION_NOT_NULL));
+                readValue = readValue.asType(readValue.type().changeReturnType(callType));
+                value = invoke(callSiteBinder.bind(readValue), "readValue", valueBlock, valuePosition);
+            }
             Class<?> expectedType = callSiteBinder.getAccessibleType(type.getJavaType());
             if (callType != expectedType) {
                 value = value.cast(expectedType);
             }
             ifStatement.ifFalse(value);
 
-            this.body = ifStatement;
             this.block = block;
             this.position = position;
+            this.valueBlock = valueBlock;
+            this.valuePosition = valuePosition;
+            this.body = loadValueBlockAndPosition()
+                    .append(ifStatement);
         }
 
         @Override
@@ -94,20 +116,26 @@ final class InputReferenceCompiler
         @Override
         public <T> T accept(BytecodeNode parent, BytecodeVisitor<T> visitor)
         {
-            return visitor.visitIf(parent, (IfStatement) body);
+            return visitor.visitBlock(parent, body);
         }
 
-        public BytecodeNode produceBlockAndPosition()
+        public BytecodeNode produceValueBlockAndPosition()
         {
-            BytecodeBlock blockAndPosition = new BytecodeBlock();
-            blockAndPosition.append(block);
-            blockAndPosition.append(position);
-            return blockAndPosition;
+            return loadValueBlockAndPosition()
+                    .append(valueBlock)
+                    .append(valuePosition);
         }
 
-        public BytecodeExpression blockAndPositionIsNull()
+        private BytecodeBlock loadValueBlockAndPosition()
         {
-            return block.invoke("isNull", boolean.class, position);
+            return new BytecodeBlock()
+                    .append(valueBlock.set(block.invoke("getUnderlyingValueBlock", ValueBlock.class)))
+                    .append(valuePosition.set(block.invoke("getUnderlyingValuePosition", int.class, position)));
+        }
+
+        public BytecodeExpression valueBlockPositionIsNull()
+        {
+            return valueBlock.invoke("isNull", boolean.class, valuePosition);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinFilterFunctionCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinFilterFunctionCompiler.java
@@ -38,6 +38,7 @@ import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeOperators;
 import io.trino.sql.gen.LambdaBytecodeGenerator.CompiledLambda;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.ExpressionRewriter;
@@ -211,7 +212,7 @@ public class JoinFilterFunctionCompiler
         Variable wasNullVariable = scope.declareVariable("wasNull", body, constantFalse());
         scope.declareVariable("session", body, method.getThis().getField(sessionField));
 
-        BiFunction<Reference, Scope, BytecodeNode> referenceCompiler = fieldReferenceCompiler(callSiteBinder, layout, leftPosition, leftPage, rightPosition, rightPage, leftBlocksSize);
+        BiFunction<Reference, Scope, BytecodeNode> referenceCompiler = fieldReferenceCompiler(typeManager.getTypeOperators(), callSiteBinder, layout, leftPosition, leftPage, rightPosition, rightPage, leftBlocksSize);
 
         ExpressionBytecodeCompiler compiler = new ExpressionBytecodeCompiler(
                 classDefinition,
@@ -251,6 +252,7 @@ public class JoinFilterFunctionCompiler
     }
 
     private static BiFunction<Reference, Scope, BytecodeNode> fieldReferenceCompiler(
+            TypeOperators typeOperators,
             CallSiteBinder callSiteBinder,
             Map<Symbol, Integer> layout,
             Variable leftPosition,
@@ -266,6 +268,7 @@ public class JoinFilterFunctionCompiler
             }
             if (field < leftBlocksSize) {
                 return generateInputReference(
+                        typeOperators,
                         callSiteBinder,
                         scope,
                         reference.type(),
@@ -273,6 +276,7 @@ public class JoinFilterFunctionCompiler
                         leftPosition);
             }
             return generateInputReference(
+                    typeOperators,
                     callSiteBinder,
                     scope,
                     reference.type(),

--- a/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
@@ -48,6 +48,7 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SourcePage;
 import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeOperators;
 import io.trino.sql.gen.LambdaBytecodeGenerator.CompiledLambda;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
@@ -372,7 +373,7 @@ public class PageFunctionCompiler
                 classDefinition,
                 callSiteBinder,
                 cachedInstanceBinder,
-                fieldReferenceCompilerProjection(compactLayout, callSiteBinder),
+                fieldReferenceCompilerProjection(typeManager.getTypeOperators(), compactLayout, callSiteBinder),
                 functionManager,
                 metadata,
                 typeManager,
@@ -589,7 +590,7 @@ public class PageFunctionCompiler
                 classDefinition,
                 callSiteBinder,
                 cachedInstanceBinder,
-                fieldReferenceCompiler(compactLayout, callSiteBinder, scope),
+                fieldReferenceCompiler(typeManager.getTypeOperators(), compactLayout, callSiteBinder, scope),
                 functionManager,
                 metadata,
                 typeManager,
@@ -633,11 +634,12 @@ public class PageFunctionCompiler
         }
     }
 
-    private static BiFunction<Reference, Scope, BytecodeNode> fieldReferenceCompilerProjection(Map<Symbol, Integer> compactLayout, CallSiteBinder callSiteBinder)
+    private static BiFunction<Reference, Scope, BytecodeNode> fieldReferenceCompilerProjection(TypeOperators typeOperators, Map<Symbol, Integer> compactLayout, CallSiteBinder callSiteBinder)
     {
         return (reference, scope) -> {
             int field = compactLayout.get(Symbol.from(reference));
             return generateInputReference(
+                    typeOperators,
                     callSiteBinder,
                     scope,
                     reference.type(),
@@ -646,7 +648,7 @@ public class PageFunctionCompiler
         };
     }
 
-    private static BiFunction<Reference, Scope, BytecodeNode> fieldReferenceCompiler(Map<Symbol, Integer> compactLayout, CallSiteBinder callSiteBinder, Scope filterScope)
+    private static BiFunction<Reference, Scope, BytecodeNode> fieldReferenceCompiler(TypeOperators typeOperators, Map<Symbol, Integer> compactLayout, CallSiteBinder callSiteBinder, Scope filterScope)
     {
         return (reference, scope) -> {
             int field = compactLayout.get(Symbol.from(reference));
@@ -655,6 +657,7 @@ public class PageFunctionCompiler
                     ? scope.getVariable("block_" + field)
                     : scope.getVariable("page").invoke("getBlock", Block.class, constantInt(field));
             return generateInputReference(
+                    typeOperators,
                     callSiteBinder,
                     scope,
                     reference.type(),

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageProjection.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestDictionaryAwarePageProjection.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.Arrays;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.block.BlockAssertions.assertBlockEquals;
@@ -150,6 +151,41 @@ public class TestDictionaryAwarePageProjection
     }
 
     @Test
+    public void testFallbackProjectsFlatDictionary()
+    {
+        AtomicReference<Class<?>> innerInputClass = new AtomicReference<>();
+        DictionaryAwarePageProjection projection = new DictionaryAwarePageProjection(
+                new TestPageProjection()
+                {
+                    @Override
+                    public Block project(ConnectorSession session, SourcePage page, SelectedPositions selectedPositions)
+                    {
+                        innerInputClass.set(page.getBlock(0).getClass());
+                        return super.project(session, page, selectedPositions);
+                    }
+                },
+                _ -> randomDictionaryId());
+        testProjectRange(createDictionaryBlock(100, 20), DictionaryBlock.class, projection);
+        // unprofitable new dictionary falls back; the inner projection receives the flat dictionary
+        testProjectRange(createDictionaryBlock(100, 25), LongArrayBlock.class, projection);
+        assertThat(innerInputClass.get()).isEqualTo(LongArrayBlock.class);
+    }
+
+    @Test
+    public void testFallbackWithUnorderedDictionaryIds()
+    {
+        Block block = createDictionaryBlockWithUnorderedIds(100, 25);
+
+        DictionaryAwarePageProjection rangeProjection = createProjection();
+        testProjectRange(createDictionaryBlock(100, 20), DictionaryBlock.class, rangeProjection);
+        testProjectRange(block, LongArrayBlock.class, rangeProjection);
+
+        DictionaryAwarePageProjection listProjection = createProjection();
+        testProjectList(createDictionaryBlock(100, 20), DictionaryBlock.class, listProjection);
+        testProjectList(block, LongArrayBlock.class, listProjection);
+    }
+
+    @Test
     public void testPreservesDictionaryInstance()
     {
         DictionaryAwarePageProjection projection = new DictionaryAwarePageProjection(
@@ -177,6 +213,14 @@ public class TestDictionaryAwarePageProjection
         Block dictionary = createLongSequenceBlock(0, dictionarySize);
         int[] ids = new int[blockSize];
         Arrays.setAll(ids, index -> index % dictionarySize);
+        return DictionaryBlock.create(ids.length, dictionary, ids);
+    }
+
+    private static Block createDictionaryBlockWithUnorderedIds(int dictionarySize, int blockSize)
+    {
+        Block dictionary = createLongSequenceBlock(0, dictionarySize);
+        int[] ids = new int[blockSize];
+        Arrays.setAll(ids, index -> (blockSize - index) % 5);
         return DictionaryBlock.create(ids.length, dictionary, ids);
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestPageProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestPageProcessor.java
@@ -21,6 +21,7 @@ import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.TestingSourcePage;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SourcePage;
 import io.trino.sql.gen.columnar.PageFilterEvaluator;
@@ -40,7 +41,9 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.block.BlockAssertions.createLongDictionaryBlock;
 import static io.trino.block.BlockAssertions.createLongSequenceBlock;
+import static io.trino.block.BlockAssertions.createLongsBlock;
 import static io.trino.block.BlockAssertions.createSlicesBlock;
 import static io.trino.block.BlockAssertions.createStringsBlock;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
@@ -48,6 +51,7 @@ import static io.trino.operator.PageAssertions.assertPageEquals;
 import static io.trino.operator.project.PageProcessor.MAX_BATCH_SIZE;
 import static io.trino.operator.project.PageProcessor.MAX_PAGE_SIZE_IN_BYTES;
 import static io.trino.operator.project.PageProcessor.MIN_PAGE_SIZE_IN_BYTES;
+import static io.trino.operator.project.SelectedPositions.positionsList;
 import static io.trino.operator.project.SelectedPositions.positionsRange;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -423,6 +427,22 @@ public class TestPageProcessor
         Optional<Page> page = output.next();
         assertThat(page).isPresent();
         assertThat(page.get().getPositionCount()).isEqualTo(rows);
+        assertThat(output.hasNext()).isFalse();
+    }
+
+    @Test
+    public void testIdentityProjectionPreservesDictionaryEncoding()
+    {
+        PageProcessor pageProcessor = new PageProcessor(
+                Optional.of(new PageFilterEvaluator(new TestingPageFilter(positionsList(new int[] {0, 3, 5, 7}, 0, 4)))),
+                ImmutableList.of(new InputPageProjection(1)));
+
+        SourcePage inputPage = SourcePage.create(new Page(createLongSequenceBlock(0, 100), createLongDictionaryBlock(0, 100, 10)));
+        Iterator<Optional<Page>> output = processAndAssertRetainedPageSize(pageProcessor, inputPage);
+
+        Page page = output.next().orElseThrow();
+        assertThat(page.getBlock(0)).isInstanceOf(DictionaryBlock.class);
+        assertPageEquals(ImmutableList.of(BIGINT), page, new Page(createLongsBlock(0L, 3L, 5L, 7L)));
         assertThat(output.hasNext()).isFalse();
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestPageFunctionCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestPageFunctionCompiler.java
@@ -34,7 +34,9 @@ import io.trino.spi.Page;
 import io.trino.spi.block.ArrayBlockBuilder;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.MapBlockBuilder;
+import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.block.VariableWidthBlock;
 import io.trino.spi.block.VariableWidthBlockBuilder;
 import io.trino.spi.connector.SourcePage;
@@ -53,6 +55,7 @@ import io.trino.spi.type.TypeDescriptor;
 import io.trino.spi.type.TypeOperators;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.FieldReference;
@@ -78,6 +81,7 @@ import static io.airlift.bytecode.Access.a;
 import static io.airlift.bytecode.Parameter.arg;
 import static io.airlift.bytecode.ParameterizedType.type;
 import static io.airlift.slice.Slices.allocate;
+import static io.trino.block.BlockAssertions.createLongsBlock;
 import static io.trino.block.BlockAssertions.createRepeatedValuesBlock;
 import static io.trino.block.BlockAssertions.createStringsBlock;
 import static io.trino.operator.scalar.ArrayTransformFunction.ARRAY_TRANSFORM_NAME;
@@ -140,6 +144,33 @@ public class TestPageFunctionCompiler
         // if block builder in generated code was not reset properly, we could get junk results after the failure
         goodResult = project(projection, goodPage, SelectedPositions.positionsRange(0, goodPage.getPositionCount()));
         assertThat(goodPage.getPositionCount()).isEqualTo(goodResult.getPositionCount());
+    }
+
+    @Test
+    public void testProjectionOverWrappedBlocks()
+    {
+        PageFunctionCompiler functionCompiler = FUNCTION_RESOLUTION.getPageFunctionCompiler();
+        PageProjection add10 = functionCompiler.compileProjection(ADD_10_EXPRESSION, LAYOUT, SQL_STANDARD, Optional.empty()).get();
+        PageProjection coalesce = functionCompiler.compileProjection(
+                        new Coalesce(new Reference(BIGINT, "$col_0"), new Constant(BIGINT, 42L)),
+                        LAYOUT,
+                        SQL_STANDARD,
+                        Optional.empty())
+                .get();
+
+        // dictionary block with nulls, read out of order and with repeats
+        Block values = createLongsBlock(0L, 1L, null, 3L);
+        Page dictionaryPage = createPageWithBlockAtChannel2(DictionaryBlock.create(5, values, new int[] {3, 2, 1, 3, 0}));
+        assertBlockValues(project(add10, dictionaryPage, SelectedPositions.positionsRange(0, 5)), 13L, null, 11L, 13L, 10L);
+        assertBlockValues(project(coalesce, dictionaryPage, SelectedPositions.positionsRange(0, 5)), 3L, 42L, 1L, 3L, 0L);
+
+        Page rlePage = createPageWithBlockAtChannel2(RunLengthEncodedBlock.create(values.getRegion(0, 1), 3));
+        assertBlockValues(project(add10, rlePage, SelectedPositions.positionsRange(0, 3)), 10L, 10L, 10L);
+        assertBlockValues(project(coalesce, rlePage, SelectedPositions.positionsRange(0, 3)), 0L, 0L, 0L);
+
+        Page nullRlePage = createPageWithBlockAtChannel2(RunLengthEncodedBlock.create(values.getRegion(2, 1), 3));
+        assertBlockValues(project(add10, nullRlePage, SelectedPositions.positionsRange(0, 3)), null, null, null);
+        assertBlockValues(project(coalesce, nullRlePage, SelectedPositions.positionsRange(0, 3)), 42L, 42L, 42L);
     }
 
     @Test
@@ -494,6 +525,25 @@ public class TestPageFunctionCompiler
         SourcePage sourcePage = SourcePage.create(page);
         SourcePage inputPage = projection.getInputChannels().getInputChannels(sourcePage);
         return projection.project(SESSION, inputPage, selectedPositions);
+    }
+
+    private static Page createPageWithBlockAtChannel2(Block block)
+    {
+        int positionCount = block.getPositionCount();
+        return new Page(createRepeatedValuesBlock(0L, positionCount), createRepeatedValuesBlock(0L, positionCount), block);
+    }
+
+    private static void assertBlockValues(Block block, Long... expected)
+    {
+        assertThat(block.getPositionCount()).isEqualTo(expected.length);
+        for (int position = 0; position < expected.length; position++) {
+            if (expected[position] == null) {
+                assertThat(block.isNull(position)).isTrue();
+            }
+            else {
+                assertThat(BIGINT.getLong(block, position)).isEqualTo(expected[position]);
+            }
+        }
     }
 
     private static Page createLongBlockPage(long... values)


### PR DESCRIPTION
## Description

Three improvements to page processing, one per commit.

**Preserve encoded blocks in InputPageProjection.** An input projection
given a positions list copies the selected positions out of the block. For dictionary and run length
encoded blocks a copy is not needed, translating the ids preserves the encoding and avoids
materializing the dictionary values.

**Project the dictionary in page projection fallback.** When `DictionaryAwarePageProjection` gives up
on dictionary processing, its fallback projects the dictionary block, so every position is read
through the id indirection. The fallback now projects the dictionary at translated ids, which reads
the flat block behind it. The number of projection evaluations is unchanged, so the heuristic which
chose the fallback is unaffected. Input projections preserve the encoding of their input on their
own, given the first commit, so they are no longer wrapped in `DictionaryAwarePageProjection` and
the fallback applies to every wrapped projection.

**Read compiled expression inputs via READ_VALUE operators.** Compiled projections and filters read
their inputs through `Type` getters on the `Block` interface. Those call sites see every block
implementation and become megamorphic, and each read unwraps to the underlying value block again.
`InputReferenceCompiler` now unwraps once and reads through the `READ_VALUE` operator bound to the
concrete value block class, and input reference arguments to scalar functions are passed with the
`VALUE_BLOCK_POSITION` conventions.

## Additional context and related issues

Measured with JMH benchmarks written for this work, on an idle 16 core Graviton4 machine with JDK 25.
The benchmarks are not part of this PR, since they exist only to attribute the change. Each cell is
the median of 4 interleaved rounds, in ops/s. Round-to-round noise is under 1%.

| | master | + projection fallback | + value block reads |
| --- | --- | --- | --- |
| 8192 entry dictionary, columnar evaluation | 2240 | 2653 | 2654 |
| 8192 entry dictionary, row oriented evaluation | 1987 | 2301 | 4631 |
| mix of flat, dictionary and run length encoded blocks | 259 | 260 | 370 |
| flat blocks | 550 | 551 | 549 |

The value block reads mostly subsume the fallback change, except on the columnar dictionary
configuration, where the fallback commit contributes an extra 10%.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve performance of filters and projections over dictionary encoded data. ({issue}`30877`)
```
