### PR TITLE
Iceberg: cache StsClient in REST SigV4 credential provider

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/StsAwsCredentialProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/StsAwsCredentialProvider.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.trino.spi.TrinoException;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
@@ -29,6 +30,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_CATALOG_ERROR;
@@ -47,35 +49,53 @@ public class StsAwsCredentialProvider
     public static final String AWS_ROLE_EXTERNAL_ID = "aws_external_id";
     public static final String AWS_IAM_ROLE_SESSION_NAME = "aws_iam_role_session_name";
 
+    // Iceberg REST SigV4 creates a new AuthSession (and calls create()) per catalog
+    // touch. roleArn is static catalog config, so one client per key is enough.
+    // Do not implement AutoCloseable: Iceberg may close per-session providers, which
+    // would shut down a shared client still in use.
+    private static final ConcurrentHashMap<ClientKey, StsAwsCredentialProvider> PROVIDERS = new ConcurrentHashMap<>();
+
     private final AwsCredentialsProvider delegate;
+    private final StsClient stsClient;
 
     public StsAwsCredentialProvider(AwsCredentialsProvider delegate)
     {
+        this(delegate, null);
+    }
+
+    private StsAwsCredentialProvider(AwsCredentialsProvider delegate, StsClient stsClient)
+    {
         this.delegate = requireNonNull(delegate, "delegate is null");
+        this.stsClient = stsClient;
     }
 
     public static StsAwsCredentialProvider create(Map<String, String> properties)
     {
-        if (properties.containsKey(AWS_IAM_ROLE)) {
-            String accessKey = properties.get(AWS_STS_ACCESS_KEY_ID);
-            String secretAccessKey = properties.get(AWS_STS_SECRET_ACCESS_KEY);
-
-            Optional<AwsCredentialsProvider> staticCredentialsProvider = createStaticCredentialsProvider(accessKey, secretAccessKey);
-            return new StsAwsCredentialProvider(StsAssumeRoleCredentialsProvider.builder()
-                    .refreshRequest(request -> request
-                            .roleArn(properties.get(AWS_IAM_ROLE))
-                            .roleSessionName(properties.get(AWS_IAM_ROLE_SESSION_NAME))
-                            .externalId(properties.get(AWS_ROLE_EXTERNAL_ID)))
-                    .stsClient(createStsClient(
-                            properties.get(AWS_STS_ENDPOINT),
-                            properties.get(AWS_STS_REGION),
-                            properties.get(AWS_STS_SIGNER_REGION),
-                            staticCredentialsProvider))
-                    .asyncCredentialUpdateEnabled(true)
-                    .build());
+        if (!properties.containsKey(AWS_IAM_ROLE)) {
+            throw new TrinoException(ICEBERG_CATALOG_ERROR, "IAM role configs are not configured");
         }
+        return PROVIDERS.computeIfAbsent(ClientKey.from(properties), ignored -> createUncached(properties));
+    }
 
-        throw new TrinoException(ICEBERG_CATALOG_ERROR, "IAM role configs are not configured");
+    private static StsAwsCredentialProvider createUncached(Map<String, String> properties)
+    {
+        String accessKey = properties.get(AWS_STS_ACCESS_KEY_ID);
+        String secretAccessKey = properties.get(AWS_STS_SECRET_ACCESS_KEY);
+        Optional<AwsCredentialsProvider> staticCredentialsProvider = createStaticCredentialsProvider(accessKey, secretAccessKey);
+        StsClient stsClient = createStsClient(
+                properties.get(AWS_STS_ENDPOINT),
+                properties.get(AWS_STS_REGION),
+                properties.get(AWS_STS_SIGNER_REGION),
+                staticCredentialsProvider);
+        return new StsAwsCredentialProvider(StsAssumeRoleCredentialsProvider.builder()
+                .refreshRequest(request -> request
+                        .roleArn(properties.get(AWS_IAM_ROLE))
+                        .roleSessionName(properties.get(AWS_IAM_ROLE_SESSION_NAME))
+                        .externalId(properties.get(AWS_ROLE_EXTERNAL_ID)))
+                .stsClient(stsClient)
+                .asyncCredentialUpdateEnabled(true)
+                .build(),
+                stsClient);
     }
 
     @Override
@@ -126,5 +146,41 @@ public class StsAwsCredentialProvider
                 .map(Region::of).ifPresent(sts::region);
         credentialsProvider.ifPresent(sts::credentialsProvider);
         return sts.build();
+    }
+
+    @VisibleForTesting
+    StsClient stsClient()
+    {
+        return stsClient;
+    }
+
+    @VisibleForTesting
+    static void resetCache()
+    {
+        PROVIDERS.clear();
+    }
+
+    private record ClientKey(
+            String roleArn,
+            String externalId,
+            String sessionName,
+            String stsEndpoint,
+            String stsRegion,
+            String signerRegion,
+            String accessKeyId,
+            String secretAccessKey)
+    {
+        static ClientKey from(Map<String, String> properties)
+        {
+            return new ClientKey(
+                    properties.get(AWS_IAM_ROLE),
+                    properties.get(AWS_ROLE_EXTERNAL_ID),
+                    properties.get(AWS_IAM_ROLE_SESSION_NAME),
+                    properties.get(AWS_STS_ENDPOINT),
+                    properties.get(AWS_STS_REGION),
+                    properties.get(AWS_STS_SIGNER_REGION),
+                    properties.get(AWS_STS_ACCESS_KEY_ID),
+                    properties.get(AWS_STS_SECRET_ACCESS_KEY));
+        }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestStsAwsCredentialProvider.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestStsAwsCredentialProvider.java
@@ -13,14 +13,32 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
+import java.util.Map;
+
+import static io.trino.plugin.iceberg.StsAwsCredentialProvider.AWS_IAM_ROLE;
+import static io.trino.plugin.iceberg.StsAwsCredentialProvider.AWS_IAM_ROLE_SESSION_NAME;
+import static io.trino.plugin.iceberg.StsAwsCredentialProvider.AWS_STS_ACCESS_KEY_ID;
+import static io.trino.plugin.iceberg.StsAwsCredentialProvider.AWS_STS_ENDPOINT;
+import static io.trino.plugin.iceberg.StsAwsCredentialProvider.AWS_STS_REGION;
+import static io.trino.plugin.iceberg.StsAwsCredentialProvider.AWS_STS_SECRET_ACCESS_KEY;
+import static io.trino.plugin.iceberg.StsAwsCredentialProvider.AWS_STS_SIGNER_REGION;
 import static io.trino.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 import static io.trino.testing.InterfaceTestUtils.assertProperForwardingMethodsAreCalled;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class TestStsAwsCredentialProvider
 {
+    @AfterEach
+    void tearDown()
+    {
+        StsAwsCredentialProvider.resetCache();
+    }
+
     @Test
     void testEverythingImplemented()
     {
@@ -31,5 +49,43 @@ class TestStsAwsCredentialProvider
     void testProperForwardingMethodsAreCalled()
     {
         assertProperForwardingMethodsAreCalled(AwsCredentialsProvider.class, StsAwsCredentialProvider::new);
+    }
+
+    @Test
+    void testCreateReusesStsClientForSameCatalogProperties()
+    {
+        Map<String, String> properties = catalogProperties("arn:aws:iam::000000000000:role/trino-s3tables");
+
+        StsAwsCredentialProvider first = StsAwsCredentialProvider.create(properties);
+        StsAwsCredentialProvider second = StsAwsCredentialProvider.create(properties);
+
+        assertThat(first).isSameAs(second);
+        assertThat(first.stsClient()).isSameAs(second.stsClient());
+        assertThat(first.stsClient()).isNotNull();
+    }
+
+    @Test
+    void testCreateUsesDistinctStsClientForDifferentRoles()
+    {
+        StsAwsCredentialProvider first = StsAwsCredentialProvider.create(
+                catalogProperties("arn:aws:iam::000000000000:role/a"));
+        StsAwsCredentialProvider second = StsAwsCredentialProvider.create(
+                catalogProperties("arn:aws:iam::000000000000:role/b"));
+
+        assertThat(first).isNotSameAs(second);
+        assertThat(first.stsClient()).isNotSameAs(second.stsClient());
+    }
+
+    private static Map<String, String> catalogProperties(String roleArn)
+    {
+        return ImmutableMap.<String, String>builder()
+                .put(AWS_IAM_ROLE, roleArn)
+                .put(AWS_IAM_ROLE_SESSION_NAME, "trino-iceberg-rest-catalog")
+                .put(AWS_STS_ENDPOINT, "http://127.0.0.1:4566")
+                .put(AWS_STS_REGION, "us-east-1")
+                .put(AWS_STS_SIGNER_REGION, "us-east-1")
+                .put(AWS_STS_ACCESS_KEY_ID, "test")
+                .put(AWS_STS_SECRET_ACCESS_KEY, "test")
+                .buildOrThrow();
     }
 }


### PR DESCRIPTION
## Description

Iceberg REST SigV4 (`RESTSigV4AuthManager.contextualSession`) constructs a new `AuthSession` on every catalog operation and calls `StsAwsCredentialProvider.create()`. `create()` built a new AWS SDK v2 `StsClient` every time and never closed it. The class is not `SdkAutoCloseable`, so Iceberg apache/iceberg#15818 cannot close it either.

On catalogs with `iceberg.rest-catalog.security=SIGV4` and `s3.iam-role` (IRSA / assume-role) this retains one TLS context + trust store per query (~67 KiB). Observed on Trino 480 against S3 Tables: ~89k `DefaultStsClient` / ~1.3 GiB/day coordinator heap.

`roleArn` is static catalog config, so one client per `(role, STS endpoint/region, keys)` is enough. This PR caches `create()` on that key. It does **not** implement `AutoCloseable`: Iceberg would close a per-session provider and would shut down a shared client still in use.

## Additional context and related issues

- Fixes #30887
- Related: #25002 (introduced this `create()` path), apache/iceberg#15818 (close AutoCloseable providers — does not apply here)
- Catalog properties (`session`, `session-timeout`, `oauth2.token-exchange-enabled`, `vended-credentials-enabled`) do not reach `create()`

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Fix `StsClient` leak in Iceberg REST SigV4 catalogs that use `s3.iam-role`. ({issue}`30887`)
```
