### PR TITLE
Suggest similar function names on FUNCTION_NOT_FOUND

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionBinder.java
@@ -400,8 +400,13 @@ class FunctionBinder
 
     static TrinoException functionNotFound(String name, List<TypeDescriptorProvider> parameterTypes, Collection<CatalogFunctionMetadata> candidates)
     {
+        return functionNotFound(name, parameterTypes, candidates, Optional.empty());
+    }
+
+    static TrinoException functionNotFound(String name, List<TypeDescriptorProvider> parameterTypes, Collection<CatalogFunctionMetadata> candidates, Optional<String> suggestion)
+    {
         if (candidates.isEmpty()) {
-            return new TrinoException(FUNCTION_NOT_FOUND, format("Function '%s' not registered", name));
+            return new TrinoException(FUNCTION_NOT_FOUND, format("Function '%s' not registered%s", name, suggestion.map(". Did you mean %s?"::formatted).orElse("")));
         }
 
         Set<String> expectedParameters = new TreeSet<>();

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
@@ -43,6 +43,7 @@ import io.trino.sql.tree.QualifiedName;
 import io.trino.type.CharVarcharCoercion;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -65,6 +66,10 @@ import static io.trino.spi.function.FunctionKind.AGGREGATE;
 import static io.trino.spi.function.FunctionKind.WINDOW;
 import static io.trino.spi.security.AccessDeniedException.denyExecuteFunction;
 import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypeDescriptors;
+import static io.trino.util.JaroWinkler.similarity;
+import static java.util.Comparator.comparingDouble;
+import static java.util.Locale.ENGLISH;
+import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 
 public class FunctionResolver
@@ -276,7 +281,7 @@ public class FunctionResolver
         }
 
         List<CatalogFunctionMetadata> candidates = allCandidates.build();
-        throw functionNotFound(name.toString(), parameterTypes, candidates);
+        throw functionNotFound(name.toString(), parameterTypes, candidates, trySuggestFunctionNames(session, name, authorizedPath, accessControl));
     }
 
     static ResolvedFunction resolveFunctionBinding(
@@ -374,6 +379,82 @@ public class FunctionResolver
             names.add(new CatalogSchemaFunctionName(element.getCatalogName(), element.getSchemaName(), parts.get(0)));
         }
         return names.build();
+    }
+
+    private Optional<String> trySuggestFunctionNames(
+            Session session,
+            QualifiedName name,
+            List<CatalogSchemaFunctionName> authorizedPath,
+            AccessControl accessControl)
+    {
+        try {
+            return suggestFunctionNames(session, name, authorizedPath, accessControl);
+        }
+        catch (RuntimeException _) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<String> suggestFunctionNames(
+            Session session,
+            QualifiedName name,
+            List<CatalogSchemaFunctionName> authorizedPath,
+            AccessControl accessControl)
+    {
+        Set<String> visibleNames = new LinkedHashSet<>();
+        for (FunctionMetadata function : metadata.listGlobalFunctions(session)) {
+            if (function.isHidden() || function.getKind() == FunctionKind.TABLE) {
+                continue;
+            }
+            visibleNames.addAll(function.getNames());
+        }
+        for (CatalogSchemaFunctionName pathName : authorizedPath) {
+            if (isBuiltinFunctionName(pathName)) {
+                continue;
+            }
+            CatalogSchemaName schema = new CatalogSchemaName(pathName.catalogName(), pathName.schemaName());
+            for (FunctionMetadata function : metadata.listFunctions(session, schema)) {
+                if (function.isHidden()) {
+                    continue;
+                }
+                for (String functionName : function.getNames()) {
+                    CatalogSchemaFunctionName candidate = new CatalogSchemaFunctionName(pathName.catalogName(), pathName.schemaName(), functionName);
+                    if (canExecuteFunction(session, accessControl, candidate)) {
+                        visibleNames.add(functionName);
+                    }
+                }
+            }
+        }
+
+        String lowercaseName = name.getSuffix().toLowerCase(ROOT);
+        List<String> suggestions = visibleNames.stream()
+                .filter(candidate -> !candidate.equalsIgnoreCase(lowercaseName))
+                .map(candidate -> new Match(candidate, similarity(candidate.toLowerCase(ENGLISH), lowercaseName)))
+                .filter(match -> match.similarity() > 0.85)
+                .sorted(comparingDouble(Match::similarity).reversed())
+                .limit(3)
+                .map(Match::candidate)
+                .collect(toImmutableList());
+
+        return switch (suggestions.size()) {
+            case 0 -> Optional.empty();
+            case 1 -> Optional.of(quote(suggestions.getFirst()));
+            case 2 -> Optional.of(quote(suggestions.getFirst()) + " or " + quote(suggestions.get(1)));
+            default -> Optional.of(quote(suggestions.getFirst()) + ", " + quote(suggestions.get(1)) + " or " + quote(suggestions.get(2)));
+        };
+    }
+
+    private record Match(String candidate, double similarity)
+    {
+        public Match
+        {
+            requireNonNull(candidate, "candidate is null");
+        }
+    }
+
+    private static String quote(String name)
+    {
+        return "'" + name.replace("'", "''") + "'";
     }
 
     private static boolean canExecuteFunction(Session session, AccessControl accessControl, CatalogSchemaFunctionName functionName)

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -444,6 +444,18 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testFunctionNotFoundSuggestion()
+    {
+        assertFails("SELECT from_iso8601_tiamestamp('2020-01-01')")
+                .hasErrorCode(FUNCTION_NOT_FOUND)
+                .hasMessage("line 1:8: Function 'from_iso8601_tiamestamp' not registered. Did you mean 'from_iso8601_timestamp'?");
+
+        assertFails("SELECT xyzzy_no_such_function(1)")
+                .hasErrorCode(FUNCTION_NOT_FOUND)
+                .hasMessage("line 1:8: Function 'xyzzy_no_such_function' not registered");
+    }
+
+    @Test
     public void testHavingReferencesOutputAlias()
     {
         assertFails("SELECT sum(a) x FROM t1 HAVING x > 5")


### PR DESCRIPTION
## Description

When a function name cannot be resolved, the error message now includes a "Did you mean...?" suggestion if a visible function name has Jaro-Winkler similarity above 0.85.

Example:

```
Function 'from_iso8601_tiamestamp' not registered. Did you mean 'from_iso8601_timestamp'?
```

* Fixes #30499

## Additional context and related issues

This follows the same approach as column suggestions in #30494. Suggestions are generated from builtin functions plus functions listed on the authorized SQL path. Hidden functions and table functions are excluded. Catalog functions are suggested only when the current user can execute them.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Suggest similar function names in `FUNCTION_NOT_FOUND` errors. ({issue}`30499`)
```

Made with [Cursor](https://cursor.com)