### PR TITLE
Support REST catalog server-side scan planning in loadTable

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/ServerPlannedTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/ServerPlannedTable.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.BatchScan;
+import org.apache.iceberg.TableScan;
+
+/**
+ * A table that keeps Trino's quoted table name convention while delegating scan creation to a
+ * table loaded from the REST catalog. Used when the catalog requested server-side scan planning
+ * for the table: recreating a plain {@link BaseTable} would discard the scan implementation and
+ * silently fall back to local planning.
+ */
+final class ServerPlannedTable
+        extends BaseTable
+{
+    private final BaseTable delegate;
+
+    ServerPlannedTable(BaseTable delegate, String name)
+    {
+        super(delegate.operations(), name, delegate.reporter());
+        this.delegate = delegate;
+    }
+
+    @Override
+    public TableScan newScan()
+    {
+        return delegate.newScan();
+    }
+
+    @Override
+    public BatchScan newBatchScan()
+    {
+        return delegate.newBatchScan();
+    }
+
+    @Override
+    public boolean allowDistributedPlanning()
+    {
+        return delegate.allowDistributedPlanning();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -600,6 +600,11 @@ public class TrinoRestCatalog
                             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to load table '%s'".formatted(schemaTableName.getTableName()), e);
                         }
                         // Creating a new base table is necessary to adhere to Trino's expectations for quoted table names
+                        if (!baseTable.allowDistributedPlanning()) {
+                            // The catalog requested server-side scan planning for this table, so
+                            // keep the RESTTable scan implementation alongside the quoted name
+                            return new ServerPlannedTable(baseTable, quotedTableName(schemaTableName));
+                        }
                         return new BaseTable(baseTable.operations(), quotedTableName(schemaTableName), baseTable.reporter());
                     });
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/ScanPlanningRestCatalogAdapter.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/ScanPlanningRestCatalogAdapter.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.rest;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.ParserContext;
+import org.apache.iceberg.rest.RESTCatalogAdapter;
+import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+/**
+ * Opts every table into REST server-side scan planning by adding
+ * {@code scan-planning-mode=server} to load table responses, and counts plan requests.
+ */
+public class ScanPlanningRestCatalogAdapter
+        extends RESTCatalogAdapter
+{
+    private final AtomicInteger planRequests = new AtomicInteger();
+
+    public ScanPlanningRestCatalogAdapter(Catalog delegate)
+    {
+        super(delegate);
+    }
+
+    public int planRequests()
+    {
+        return planRequests.get();
+    }
+
+    @Override
+    protected <T extends RESTResponse> T execute(
+            HTTPRequest request,
+            Class<T> responseType,
+            Consumer<ErrorResponse> errorHandler,
+            Consumer<Map<String, String>> responseHeaders,
+            ParserContext parserContext)
+    {
+        if ("POST".equals(request.method().name()) && request.path().endsWith("/plan")) {
+            planRequests.incrementAndGet();
+        }
+        T response = super.execute(request, responseType, errorHandler, responseHeaders, parserContext);
+        if (response instanceof LoadTableResponse loadTableResponse) {
+            LoadTableResponse modified = LoadTableResponse.builder()
+                    .withTableMetadata(loadTableResponse.tableMetadata())
+                    .addAllConfig(loadTableResponse.config())
+                    .addAllConfig(ImmutableMap.of("scan-planning-mode", "server"))
+                    .build();
+            return responseType.cast(modified);
+        }
+        return response;
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestTrinoRestCatalog.java
@@ -34,11 +34,25 @@ import io.trino.spi.connector.ConnectorViewDefinition.ViewColumn;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.RESTException;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.rest.DelegatingRestSessionCatalog;
 import org.apache.iceberg.rest.RESTSessionCatalog;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.view.View;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
@@ -362,5 +376,94 @@ public class TestTrinoRestCatalog
                 Optional.of(SESSION.getUser()),
                 false,
                 ImmutableList.of());
+    }
+
+    @Test
+    public void testServerRequestedScanPlanning()
+            throws Exception
+    {
+        Path warehouseLocation = Files.createTempDirectory(null);
+        Catalog backend = backendCatalog(warehouseLocation);
+        ScanPlanningRestCatalogAdapter adapter = new ScanPlanningRestCatalogAdapter(backend);
+        RESTSessionCatalog restSessionCatalog = DelegatingRestSessionCatalog.builder()
+                .delegate(backend)
+                .adapter(adapter)
+                .build();
+        restSessionCatalog.initialize("iceberg_rest", ImmutableMap.of());
+        TrinoRestCatalog catalog = createTrinoRestCatalog(false, restSessionCatalog, false, false);
+
+        String namespace = "test_server_planning_" + randomNameSuffix();
+        SchemaTableName schemaTableName = new SchemaTableName(namespace, "planned_table");
+        createTableWithIdRangeFiles(backend, warehouseLocation, schemaTableName, 3);
+
+        BaseTable icebergTable = catalog.loadTable(SESSION, schemaTableName);
+        assertThat(icebergTable.allowDistributedPlanning())
+                .as("table opted into server-side scan planning keeps the planning implementation")
+                .isFalse();
+        assertThat(icebergTable.name()).isEqualTo("\"" + namespace + "\".\"planned_table\"");
+
+        int planRequestsBefore = adapter.planRequests();
+        try (CloseableIterable<FileScanTask> fileScanTasks = icebergTable.newScan().planFiles()) {
+            assertThat(fileScanTasks).hasSize(3);
+        }
+        try (CloseableIterable<FileScanTask> fileScanTasks = icebergTable.newScan()
+                .filter(Expressions.greaterThanOrEqual("id", 200L))
+                .planFiles()) {
+            assertThat(fileScanTasks)
+                    .as("server-side planning should prune files by column bounds")
+                    .hasSize(1);
+        }
+        assertThat(adapter.planRequests())
+                .as("scan planning should go through the REST plan endpoint")
+                .isGreaterThan(planRequestsBefore);
+    }
+
+    @Test
+    public void testLoadTableWithoutServerScanPlanning()
+            throws Exception
+    {
+        Path warehouseLocation = Files.createTempDirectory(null);
+        Catalog backend = backendCatalog(warehouseLocation);
+        RESTSessionCatalog restSessionCatalog = DelegatingRestSessionCatalog.builder()
+                .delegate(backend)
+                .build();
+        restSessionCatalog.initialize("iceberg_rest", ImmutableMap.of());
+        TrinoRestCatalog catalog = createTrinoRestCatalog(false, restSessionCatalog, false, false);
+
+        String namespace = "test_local_planning_" + randomNameSuffix();
+        SchemaTableName schemaTableName = new SchemaTableName(namespace, "planned_table");
+        createTableWithIdRangeFiles(backend, warehouseLocation, schemaTableName, 1);
+
+        BaseTable loadedTable = catalog.loadTable(SESSION, schemaTableName);
+        assertThat(loadedTable.allowDistributedPlanning())
+                .as("tables without server-side scan planning are unaffected")
+                .isTrue();
+        assertThat(loadedTable).isNotInstanceOf(ServerPlannedTable.class);
+    }
+
+    private static void createTableWithIdRangeFiles(Catalog backend, Path warehouseLocation, SchemaTableName schemaTableName, int files)
+    {
+        ((SupportsNamespaces) backend).createNamespace(Namespace.of(schemaTableName.getSchemaName()));
+        Table table = backend.createTable(
+                TableIdentifier.of(schemaTableName.getSchemaName(), schemaTableName.getTableName()),
+                new Schema(Types.NestedField.required(1, "id", Types.LongType.get())));
+        for (int file = 0; file < files; file++) {
+            long lowerBound = file * 100L;
+            long upperBound = lowerBound + 99;
+            table.newFastAppend()
+                    .appendFile(DataFiles.builder(PartitionSpec.unpartitioned())
+                            .withPath(warehouseLocation.resolve("data-" + file + ".parquet").toString())
+                            .withFileSizeInBytes(10)
+                            .withMetrics(new Metrics(
+                                    100L,
+                                    null,
+                                    ImmutableMap.of(1, 100L),
+                                    ImmutableMap.of(1, 0L),
+                                    null,
+                                    ImmutableMap.of(1, Conversions.toByteBuffer(Types.LongType.get(), lowerBound)),
+                                    ImmutableMap.of(1, Conversions.toByteBuffer(Types.LongType.get(), upperBound))))
+                            .build())
+                    .commit();
+        }
     }
 }

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/DelegatingRestSessionCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/rest/DelegatingRestSessionCatalog.java
@@ -97,6 +97,7 @@ public class DelegatingRestSessionCatalog
     public static class Builder
     {
         private Catalog delegate;
+        private RESTCatalogAdapter adapter;
 
         public Builder delegate(Catalog delegate)
         {
@@ -104,11 +105,17 @@ public class DelegatingRestSessionCatalog
             return this;
         }
 
+        public Builder adapter(RESTCatalogAdapter adapter)
+        {
+            this.adapter = adapter;
+            return this;
+        }
+
         public DelegatingRestSessionCatalog build()
         {
             requireNonNull(delegate, "Delegate must be set");
 
-            return new DelegatingRestSessionCatalog(new RESTCatalogAdapter(delegate), delegate);
+            return new DelegatingRestSessionCatalog(adapter != null ? adapter : new RESTCatalogAdapter(delegate), delegate);
         }
     }
 }


### PR DESCRIPTION
## Description

Iceberg 1.11 added a client for REST server-side scan planning: when a REST
catalog advertises the plan endpoints and sets `scan-planning-mode=server` in
`LoadTableResponse` config, `RESTSessionCatalog.loadTable` returns a
`RESTTable` whose scans plan through the catalog's `planTableScan` endpoint.

`TrinoRestCatalog.loadTable` currently rewraps the loaded table into a plain
`BaseTable` (for quoted table name handling), which discards the `RESTTable`
scan implementation. The result is that Trino always plans locally, even when
the catalog explicitly opted the table into server-side planning.

This change wraps opted-in tables in a small delegating `BaseTable` subclass
that keeps the quoted table name convention while delegating `newScan` and
`newBatchScan` to the `RESTTable`, so the existing naming behavior is unchanged
for every table. Catalogs that do not request server-side planning are
unaffected: `RESTSessionCatalog` only returns `RESTTable` for opted-in tables,
so the new branch is dead code against Polaris, Nessie, Glue, and other current
catalogs unless they start requesting it.

Tested manually against a REST catalog implementing the scan planning
endpoints (spec: apache/iceberg#9695 added them to the REST OpenAPI spec).
With this change applied to an otherwise stock 483 build, a range-predicate query had
50 data files considered server-side and 1 file-scan-task returned to Trino;
results matched local planning. Without the change the same setup planned
locally. Happy to add an integration test if maintainers can point me at the
preferred harness for REST catalog behavior (RESTCatalogAdapter in
iceberg-core tests now implements the plan endpoints, which looks usable).

If maintainers would prefer an explicit client-side control as well, exposing
Iceberg's `scan-planning-mode` catalog property in the connector configuration
would make a small follow-up and lets operators force local planning regardless
of what the catalog requests.

## Additional context and related issues

Server-side scan planning lets a catalog apply pruning that Trino cannot do
from file statistics alone (for example bloom-filter based file skipping for
selective predicates) and return a smaller file list to every connected
engine. The Iceberg client support shipped in 1.11, which Trino already
bundles; this is the only change needed for Trino to honor a catalog that
requests it.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Support server-side scan planning when a REST catalog requests it via
  table load configuration. ({issue}`30891`)
```
