### PR TITLE
Add theta_sketch_jaccard_similarity to DataSketches plugin

### DIFF
--- a/docs/src/main/sphinx/functions/datasketches.md
+++ b/docs/src/main/sphinx/functions/datasketches.md
@@ -8,8 +8,9 @@ approximate answers with mathematical guarantees much faster than traditional
 exact methods. DataSketches functions allow querying these serialized sketches
 from Trino. Support for the
 [Theta Sketch framework](https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html)
-is available through {func}`theta_sketch_union` and
-{func}`theta_sketch_cardinality`, typically used to replace expensive
+is available through {func}`theta_sketch_union`,
+{func}`theta_sketch_cardinality`, and
+{func}`theta_sketch_jaccard_similarity`, typically used to replace expensive
 `COUNT(DISTINCT ...)` aggregations when sketches are precomputed and stored.
 
 ## Configuration
@@ -68,6 +69,13 @@ Returns the estimated value of the sketch.
 
 Returns the estimated value of the sketch using the supplied `seed`. Use this
 when the sketch was created with a non-default seed.
+:::
+
+:::{function} theta_sketch_jaccard_similarity(sketch_a, sketch_b) -> double
+Returns the Jaccard similarity index of two sketches, defined as the size of
+their intersection divided by the size of their union. The result is between
+`0.0` for disjoint inputs and `1.0` for identical inputs. Both input sketches
+must have been built with the default seed.
 :::
 
 ## Examples

--- a/docs/src/main/sphinx/release.md
+++ b/docs/src/main/sphinx/release.md
@@ -6,6 +6,7 @@
 ```{toctree}
 :maxdepth: 1
 
+release/release-484
 release/release-483
 release/release-482
 release/release-481

--- a/docs/src/main/sphinx/release/release-484.md
+++ b/docs/src/main/sphinx/release/release-484.md
@@ -1,0 +1,6 @@
+# Release 484 (unreleased)
+
+## General
+
+* Add the `theta_sketch_jaccard_similarity` function to the
+  {doc}`/functions/datasketches` plugin.

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/Jaccard.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/Jaccard.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.theta;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+import org.apache.datasketches.theta.JaccardSimilarity;
+import org.apache.datasketches.theta.ThetaSketch;
+
+import java.lang.foreign.MemorySegment;
+
+import static org.apache.datasketches.common.Util.DEFAULT_UPDATE_SEED;
+
+public final class Jaccard
+{
+    private Jaccard() {}
+
+    @ScalarFunction("theta_sketch_jaccard_similarity")
+    @Description("Returns the Jaccard similarity index of two theta sketches built with the default seed")
+    @SqlType(StandardTypes.DOUBLE)
+    public static double jaccardSimilarity(@SqlType(StandardTypes.VARBINARY) Slice sketchA, @SqlType(StandardTypes.VARBINARY) Slice sketchB)
+    {
+        boolean emptyA = sketchA.length() == 0;
+        boolean emptyB = sketchB.length() == 0;
+        if (emptyA && emptyB) {
+            return 1;
+        }
+        if (emptyA || emptyB) {
+            return 0;
+        }
+        ThetaSketch a = ThetaSketch.wrap(MemorySegment.ofArray(sketchA.getBytes()), DEFAULT_UPDATE_SEED);
+        ThetaSketch b = ThetaSketch.wrap(MemorySegment.ofArray(sketchB.getBytes()), DEFAULT_UPDATE_SEED);
+        // JaccardSimilarity.jaccard returns {lowerBound, estimate, upperBound}; index 1 is the point estimate.
+        return JaccardSimilarity.jaccard(a, b)[1];
+    }
+}

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchFunctionsConnectorFactory.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchFunctionsConnectorFactory.java
@@ -36,6 +36,7 @@ public class SketchFunctionsConnectorFactory
                 .functions(Estimate.class)
                 .functions(Union.class)
                 .functions(UnionWithParams.class)
+                .functions(Jaccard.class)
                 .build();
 
         return new SketchFunctionsConnector(new SketchMetadata(bundle), bundle);

--- a/plugin/trino-datasketches/src/test/java/io/trino/plugin/datasketches/TestDataSketches.java
+++ b/plugin/trino-datasketches/src/test/java/io/trino/plugin/datasketches/TestDataSketches.java
@@ -19,6 +19,7 @@ import io.trino.Session;
 import io.trino.plugin.datasketches.state.SketchState;
 import io.trino.plugin.datasketches.state.SketchStateFactory;
 import io.trino.plugin.datasketches.theta.Estimate;
+import io.trino.plugin.datasketches.theta.Jaccard;
 import io.trino.plugin.datasketches.theta.SketchFunctionsPlugin;
 import io.trino.plugin.datasketches.theta.Union;
 import io.trino.plugin.datasketches.theta.UnionWithParams;
@@ -45,6 +46,7 @@ import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.apache.datasketches.common.Util.DEFAULT_UPDATE_SEED;
 import static org.apache.datasketches.thetacommon.ThetaUtil.DEFAULT_NOMINAL_ENTRIES;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 public class TestDataSketches
         extends AbstractTestQueryFramework
@@ -228,6 +230,61 @@ public class TestDataSketches
                 """.formatted(unionNominalEntries, DEFAULT_UPDATE_SEED, sketchA, sketchB));
 
         assertThat(estimate).isEqualTo(unionNominalEntries);
+    }
+
+    // -------------------------------------------------------------------------
+    // Jaccard similarity
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testJaccardIdentical()
+    {
+        String sketch = toHexSketch(new int[] {1, 2, 3, 4, 5});
+        double similarity = (double) computeScalar(
+                "SELECT theta_sketch_jaccard_similarity(X'%s', X'%s')".formatted(sketch, sketch));
+        assertThat(similarity).isEqualTo(1d);
+    }
+
+    @Test
+    public void testJaccardDisjoint()
+    {
+        String sketchA = toHexSketch(new int[] {1, 2, 3});
+        String sketchB = toHexSketch(new int[] {4, 5, 6});
+        double similarity = (double) computeScalar(
+                "SELECT theta_sketch_jaccard_similarity(X'%s', X'%s')".formatted(sketchA, sketchB));
+        assertThat(similarity).isEqualTo(0d);
+    }
+
+    @Test
+    public void testJaccardPartialOverlap()
+    {
+        // |A n B| = 5, |A u B| = 15 -> J = 1/3
+        String sketchA = toHexSketch(new int[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+        String sketchB = toHexSketch(new int[] {6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+        double similarity = (double) computeScalar(
+                "SELECT theta_sketch_jaccard_similarity(X'%s', X'%s')".formatted(sketchA, sketchB));
+        assertThat(similarity).isCloseTo(1.0 / 3.0, within(1e-6));
+    }
+
+    @Test
+    public void testJaccardSymmetric()
+    {
+        String sketchA = toHexSketch(new int[] {1, 2, 3, 4, 5});
+        String sketchB = toHexSketch(new int[] {3, 4, 5, 6, 7});
+        double ab = (double) computeScalar(
+                "SELECT theta_sketch_jaccard_similarity(X'%s', X'%s')".formatted(sketchA, sketchB));
+        double ba = (double) computeScalar(
+                "SELECT theta_sketch_jaccard_similarity(X'%s', X'%s')".formatted(sketchB, sketchA));
+        assertThat(ab).isEqualTo(ba);
+    }
+
+    @Test
+    public void testJaccardEmptyInputs()
+    {
+        Slice sketch = toSketchSlice(new int[] {1, 2, 3}, DEFAULT_UPDATE_SEED, DEFAULT_ENTRIES);
+        assertThat(Jaccard.jaccardSimilarity(Slices.EMPTY_SLICE, Slices.EMPTY_SLICE)).isEqualTo(1d);
+        assertThat(Jaccard.jaccardSimilarity(Slices.EMPTY_SLICE, sketch)).isEqualTo(0d);
+        assertThat(Jaccard.jaccardSimilarity(sketch, Slices.EMPTY_SLICE)).isEqualTo(0d);
     }
 
     private String toHexSketch(int[] data)


### PR DESCRIPTION
## Description

Adds the `theta_sketch_jaccard_similarity(sketch_a, sketch_b) -> double` scalar to the DataSketches plugin. It returns the Jaccard index J(A,B) = |A∩B| / |A∪B| in the range [0, 1] (1.0 = identical, 0.0 = disjoint), taken as the point estimate of the library's 95.4% confidence interval.

Jaccard is binary and symmetric, so it is implemented as a scalar with two sketch arguments. Empty-input corner cases match the library: both empty → 1.0, exactly one empty → 0.0.

## Additional context and related issues

This function is default-seed only and deliberately offers no seed overload: `JaccardSimilarity.jaccard` builds its internal union/intersection without a seed (i.e. `DEFAULT_UPDATE_SEED`), so non-default-seed inputs would throw a seed mismatch. Both input sketches must have been built with the default seed; this is stated in the function reference. Exposing the full `{lower, estimate, upper}` interval is left as a possible follow-up.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add the `theta_sketch_jaccard_similarity` function to the DataSketches plugin.
```
