### PR TITLE
Add theta_sketch_cardinality bounds to DataSketches plugin

### DIFF
--- a/docs/src/main/sphinx/functions/datasketches.md
+++ b/docs/src/main/sphinx/functions/datasketches.md
@@ -8,8 +8,10 @@ approximate answers with mathematical guarantees much faster than traditional
 exact methods. DataSketches functions allow querying these serialized sketches
 from Trino. Support for the
 [Theta Sketch framework](https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html)
-is available through {func}`theta_sketch_union` and
-{func}`theta_sketch_cardinality`, typically used to replace expensive
+is available through {func}`theta_sketch_union`,
+{func}`theta_sketch_cardinality`,
+{func}`theta_sketch_cardinality_lower_bound`, and
+{func}`theta_sketch_cardinality_upper_bound`, typically used to replace expensive
 `COUNT(DISTINCT ...)` aggregations when sketches are precomputed and stored.
 
 ## Configuration
@@ -68,6 +70,21 @@ Returns the estimated value of the sketch.
 
 Returns the estimated value of the sketch using the supplied `seed`. Use this
 when the sketch was created with a non-default seed.
+:::
+
+:::{function} theta_sketch_cardinality_lower_bound(sketch, num_std_dev [, seed]) -> double
+Returns the lower bound of the sketch cardinality estimate for the given number
+of standard deviations. `num_std_dev` must be 1, 2, or 3, corresponding to
+approximately 68%, 95%, and 99.7% confidence. For a sketch in exact mode the
+lower bound equals the exact count. The optional `seed` parameter must match the
+seed used to build the sketch.
+:::
+
+:::{function} theta_sketch_cardinality_upper_bound(sketch, num_std_dev [, seed]) -> double
+Returns the upper bound of the sketch cardinality estimate for the given number
+of standard deviations. `num_std_dev` must be 1, 2, or 3. For a sketch in exact
+mode the upper bound equals the exact count. The optional `seed` parameter must
+match the seed used to build the sketch.
 :::
 
 ## Examples

--- a/docs/src/main/sphinx/release.md
+++ b/docs/src/main/sphinx/release.md
@@ -6,6 +6,7 @@
 ```{toctree}
 :maxdepth: 1
 
+release/release-484
 release/release-483
 release/release-482
 release/release-481

--- a/docs/src/main/sphinx/release/release-484.md
+++ b/docs/src/main/sphinx/release/release-484.md
@@ -1,0 +1,7 @@
+# Release 484 (unreleased)
+
+## General
+
+* Add the `theta_sketch_cardinality_lower_bound` and
+  `theta_sketch_cardinality_upper_bound` functions to the
+  {doc}`/functions/datasketches` plugin.

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/CardinalityBounds.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/CardinalityBounds.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.theta;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.TrinoException;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+import org.apache.datasketches.theta.ThetaSketch;
+
+import java.lang.foreign.MemorySegment;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static java.lang.Math.toIntExact;
+import static org.apache.datasketches.common.Util.DEFAULT_UPDATE_SEED;
+
+public final class CardinalityBounds
+{
+    private CardinalityBounds() {}
+
+    @ScalarFunction("theta_sketch_cardinality_lower_bound")
+    @Description("Returns the lower bound of the sketch cardinality estimate for the given number of standard deviations (1, 2, or 3)")
+    @SqlType(StandardTypes.DOUBLE)
+    public static double lowerBound(@SqlType(StandardTypes.VARBINARY) Slice inputValue, @SqlType(StandardTypes.INTEGER) long numStdDev)
+    {
+        return lowerBound(inputValue, numStdDev, DEFAULT_UPDATE_SEED);
+    }
+
+    @ScalarFunction("theta_sketch_cardinality_lower_bound")
+    @Description("Returns the lower bound of the sketch cardinality estimate using the supplied seed")
+    @SqlType(StandardTypes.DOUBLE)
+    public static double lowerBound(@SqlType(StandardTypes.VARBINARY) Slice inputValue, @SqlType(StandardTypes.INTEGER) long numStdDev, @SqlType(StandardTypes.BIGINT) long seed)
+    {
+        int stdDev = checkNumStdDev(numStdDev);
+        if (inputValue.length() == 0) {
+            return 0;
+        }
+        return ThetaSketch.wrap(MemorySegment.ofArray(inputValue.getBytes()), seed).getLowerBound(stdDev);
+    }
+
+    @ScalarFunction("theta_sketch_cardinality_upper_bound")
+    @Description("Returns the upper bound of the sketch cardinality estimate for the given number of standard deviations (1, 2, or 3)")
+    @SqlType(StandardTypes.DOUBLE)
+    public static double upperBound(@SqlType(StandardTypes.VARBINARY) Slice inputValue, @SqlType(StandardTypes.INTEGER) long numStdDev)
+    {
+        return upperBound(inputValue, numStdDev, DEFAULT_UPDATE_SEED);
+    }
+
+    @ScalarFunction("theta_sketch_cardinality_upper_bound")
+    @Description("Returns the upper bound of the sketch cardinality estimate using the supplied seed")
+    @SqlType(StandardTypes.DOUBLE)
+    public static double upperBound(@SqlType(StandardTypes.VARBINARY) Slice inputValue, @SqlType(StandardTypes.INTEGER) long numStdDev, @SqlType(StandardTypes.BIGINT) long seed)
+    {
+        int stdDev = checkNumStdDev(numStdDev);
+        if (inputValue.length() == 0) {
+            return 0;
+        }
+        return ThetaSketch.wrap(MemorySegment.ofArray(inputValue.getBytes()), seed).getUpperBound(stdDev);
+    }
+
+    private static int checkNumStdDev(long numStdDev)
+    {
+        if (numStdDev < 1 || numStdDev > 3) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "numStdDev must be 1, 2, or 3: " + numStdDev);
+        }
+        return toIntExact(numStdDev);
+    }
+}

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchFunctionsConnectorFactory.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchFunctionsConnectorFactory.java
@@ -36,6 +36,7 @@ public class SketchFunctionsConnectorFactory
                 .functions(Estimate.class)
                 .functions(Union.class)
                 .functions(UnionWithParams.class)
+                .functions(CardinalityBounds.class)
                 .build();
 
         return new SketchFunctionsConnector(new SketchMetadata(bundle), bundle);

--- a/plugin/trino-datasketches/src/test/java/io/trino/plugin/datasketches/TestDataSketches.java
+++ b/plugin/trino-datasketches/src/test/java/io/trino/plugin/datasketches/TestDataSketches.java
@@ -18,10 +18,12 @@ import io.airlift.slice.Slices;
 import io.trino.Session;
 import io.trino.plugin.datasketches.state.SketchState;
 import io.trino.plugin.datasketches.state.SketchStateFactory;
+import io.trino.plugin.datasketches.theta.CardinalityBounds;
 import io.trino.plugin.datasketches.theta.Estimate;
 import io.trino.plugin.datasketches.theta.SketchFunctionsPlugin;
 import io.trino.plugin.datasketches.theta.Union;
 import io.trino.plugin.datasketches.theta.UnionWithParams;
+import io.trino.spi.TrinoException;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.MaterializedResult;
@@ -45,6 +47,7 @@ import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.apache.datasketches.common.Util.DEFAULT_UPDATE_SEED;
 import static org.apache.datasketches.thetacommon.ThetaUtil.DEFAULT_NOMINAL_ENTRIES;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestDataSketches
         extends AbstractTestQueryFramework
@@ -230,6 +233,66 @@ public class TestDataSketches
         assertThat(estimate).isEqualTo(unionNominalEntries);
     }
 
+    // -------------------------------------------------------------------------
+    // Cardinality error bounds
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCardinalityBoundsExactMode()
+    {
+        // A small sketch is in exact mode: lower = estimate = upper = exact count for any numStdDev
+        String sketch = toHexSketch(new int[] {1, 2, 3});
+        for (int numStdDev = 1; numStdDev <= 3; numStdDev++) {
+            double lower = (double) computeScalar(
+                    "SELECT theta_sketch_cardinality_lower_bound(X'%s', %d)".formatted(sketch, numStdDev));
+            double upper = (double) computeScalar(
+                    "SELECT theta_sketch_cardinality_upper_bound(X'%s', %d)".formatted(sketch, numStdDev));
+            assertThat(lower).isEqualTo(3d);
+            assertThat(upper).isEqualTo(3d);
+        }
+    }
+
+    @Test
+    public void testCardinalityBoundsEstimationMode()
+    {
+        // Force estimation mode: 20000 distinct values into a K=DEFAULT_NOMINAL_ENTRIES sketch
+        String sketch = toHexSketch(0, 20000, DEFAULT_NOMINAL_ENTRIES);
+        double estimate = (double) computeScalar("SELECT theta_sketch_cardinality(X'%s')".formatted(sketch));
+        double lower = (double) computeScalar("SELECT theta_sketch_cardinality_lower_bound(X'%s', 2)".formatted(sketch));
+        double upper = (double) computeScalar("SELECT theta_sketch_cardinality_upper_bound(X'%s', 2)".formatted(sketch));
+        assertThat(lower).isLessThan(estimate);
+        assertThat(estimate).isLessThan(upper);
+
+        // Wider confidence -> wider interval
+        double lower1 = (double) computeScalar("SELECT theta_sketch_cardinality_lower_bound(X'%s', 1)".formatted(sketch));
+        double lower3 = (double) computeScalar("SELECT theta_sketch_cardinality_lower_bound(X'%s', 3)".formatted(sketch));
+        double upper1 = (double) computeScalar("SELECT theta_sketch_cardinality_upper_bound(X'%s', 1)".formatted(sketch));
+        double upper3 = (double) computeScalar("SELECT theta_sketch_cardinality_upper_bound(X'%s', 3)".formatted(sketch));
+        assertThat(lower3).isLessThanOrEqualTo(lower1);
+        assertThat(upper3).isGreaterThanOrEqualTo(upper1);
+    }
+
+    @Test
+    public void testCardinalityBoundsMatchLibrary()
+    {
+        String sketch = toHexSketch(0, 20000, DEFAULT_NOMINAL_ENTRIES);
+        ThetaSketch reference = buildCompactSketch(0, 20000, DEFAULT_NOMINAL_ENTRIES, DEFAULT_UPDATE_SEED);
+        double lower = (double) computeScalar("SELECT theta_sketch_cardinality_lower_bound(X'%s', 2)".formatted(sketch));
+        double upper = (double) computeScalar("SELECT theta_sketch_cardinality_upper_bound(X'%s', 2)".formatted(sketch));
+        assertThat(lower).isEqualTo(reference.getLowerBound(2));
+        assertThat(upper).isEqualTo(reference.getUpperBound(2));
+    }
+
+    @Test
+    public void testCardinalityBoundsInvalidNumStdDev()
+    {
+        Slice sketch = toSketchSlice(new int[] {1, 2, 3}, DEFAULT_UPDATE_SEED, DEFAULT_ENTRIES);
+        assertThatThrownBy(() -> CardinalityBounds.lowerBound(sketch, 4))
+                .isInstanceOf(TrinoException.class);
+        assertThatThrownBy(() -> CardinalityBounds.upperBound(sketch, 0))
+                .isInstanceOf(TrinoException.class);
+    }
+
     private String toHexSketch(int[] data)
     {
         UpdatableThetaSketch sketch = UpdatableThetaSketch.builder()
@@ -251,6 +314,18 @@ public class TestDataSketches
             sketch.update(i);
         }
         return base16().lowerCase().encode(sketch.compact().toByteArray());
+    }
+
+    private static ThetaSketch buildCompactSketch(int from, int to, int nominalEntries, long seed)
+    {
+        UpdatableThetaSketch sketch = UpdatableThetaSketch.builder()
+                .setNominalEntries(nominalEntries)
+                .setSeed(seed)
+                .build();
+        for (int i = from; i < to; i++) {
+            sketch.update(i);
+        }
+        return ThetaSketch.wrap(MemorySegment.ofArray(sketch.compact().toByteArray()), seed);
     }
 
     private static Slice toSketchSlice(int[] data, long seed, int nominalEntries)


### PR DESCRIPTION
## Description

Adds two scalars to the DataSketches plugin:

- `theta_sketch_cardinality_lower_bound(sketch, num_std_dev [, seed]) -> double`
- `theta_sketch_cardinality_upper_bound(sketch, num_std_dev [, seed]) -> double`

They return the lower/upper confidence bound of a sketch's cardinality estimate. `num_std_dev` must be 1, 2, or 3 (≈68.3% / 95.4% / 99.7% confidence). For a sketch in exact mode the bounds collapse to the exact retained count; in estimation mode `lower < estimate < upper`. Empty sketch returns 0, matching `theta_sketch_cardinality`. A custom-seed overload is provided.

Two separate named functions (mirroring the library's two methods) are clearer and more SQL-discoverable than a single bound-selector argument. An out-of-range `num_std_dev` raises `TrinoException(INVALID_FUNCTION_ARGUMENT)` with a clear message rather than returning a silently-wrong value.

## Additional context and related issues

Bounds are computed from a single sketch's retained entries and theta, so a `seed` overload is safe (the seed only validates the `wrap`). The tests cross-check results against datasketches-java's own `getLowerBound`/`getUpperBound` computed on the same sketch.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add the `theta_sketch_cardinality_lower_bound` and `theta_sketch_cardinality_upper_bound` functions to the DataSketches plugin.
```
