### PR TITLE
Add theta_sketch_a_not_b to DataSketches plugin

### DIFF
--- a/docs/src/main/sphinx/functions/datasketches.md
+++ b/docs/src/main/sphinx/functions/datasketches.md
@@ -8,8 +8,9 @@ approximate answers with mathematical guarantees much faster than traditional
 exact methods. DataSketches functions allow querying these serialized sketches
 from Trino. Support for the
 [Theta Sketch framework](https://datasketches.apache.org/docs/Theta/ThetaSketchFramework.html)
-is available through {func}`theta_sketch_union` and
-{func}`theta_sketch_cardinality`, typically used to replace expensive
+is available through {func}`theta_sketch_union`,
+{func}`theta_sketch_a_not_b`, and {func}`theta_sketch_cardinality`,
+typically used to replace expensive
 `COUNT(DISTINCT ...)` aggregations when sketches are precomputed and stored.
 
 ## Configuration
@@ -57,6 +58,14 @@ Returns a serialized sketch as `varbinary`, which is a merged collection of
 sketches. The optional `nominal_entries` and `seed` parameters let you specify
 non-default sketch size and seed when merging sketches created with custom
 settings.
+:::
+
+:::{function} theta_sketch_a_not_b(sketch_a, sketch_b [, seed]) -> varbinary
+Returns a serialized sketch as `varbinary` representing the set difference of
+`sketch_a` minus `sketch_b`, that is the elements in the first sketch that are
+not in the second. This scalar function takes two sketches and is not
+commutative, so argument order matters. The optional `seed` parameter must match
+the seed used to build both input sketches.
 :::
 
 :::{function} theta_sketch_cardinality(sketch) -> double

--- a/docs/src/main/sphinx/release.md
+++ b/docs/src/main/sphinx/release.md
@@ -6,6 +6,7 @@
 ```{toctree}
 :maxdepth: 1
 
+release/release-484
 release/release-483
 release/release-482
 release/release-481

--- a/docs/src/main/sphinx/release/release-484.md
+++ b/docs/src/main/sphinx/release/release-484.md
@@ -1,0 +1,6 @@
+# Release 484 (unreleased)
+
+## General
+
+* Add the `theta_sketch_a_not_b` function for set difference to the
+  {doc}`/functions/datasketches` plugin.

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/ANotB.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/ANotB.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.datasketches.theta;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+import org.apache.datasketches.theta.ThetaAnotB;
+import org.apache.datasketches.theta.ThetaSetOperation;
+import org.apache.datasketches.theta.ThetaSketch;
+
+import java.lang.foreign.MemorySegment;
+
+import static org.apache.datasketches.common.Util.DEFAULT_UPDATE_SEED;
+
+public final class ANotB
+{
+    private ANotB() {}
+
+    @ScalarFunction("theta_sketch_a_not_b")
+    @Description("Returns a sketch representing the set difference A-and-not-B of two theta sketches")
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice aNotB(@SqlType(StandardTypes.VARBINARY) Slice sketchA, @SqlType(StandardTypes.VARBINARY) Slice sketchB)
+    {
+        return aNotB(sketchA, sketchB, DEFAULT_UPDATE_SEED);
+    }
+
+    @ScalarFunction("theta_sketch_a_not_b")
+    @Description("Returns a sketch representing the set difference A-and-not-B using the supplied seed")
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice aNotB(@SqlType(StandardTypes.VARBINARY) Slice sketchA, @SqlType(StandardTypes.VARBINARY) Slice sketchB, @SqlType(StandardTypes.BIGINT) long seed)
+    {
+        // An empty A yields an empty difference; an empty B subtracts nothing. Both cases return A
+        // unchanged, matching the plugin convention that a zero-length varbinary is an absent sketch.
+        if (sketchA.length() == 0 || sketchB.length() == 0) {
+            return sketchA;
+        }
+        ThetaSketch a = ThetaSketch.wrap(MemorySegment.ofArray(sketchA.getBytes()), seed);
+        ThetaSketch b = ThetaSketch.wrap(MemorySegment.ofArray(sketchB.getBytes()), seed);
+        ThetaAnotB operation = ThetaSetOperation.builder().setSeed(seed).buildANotB();
+        return Slices.wrappedBuffer(operation.aNotB(a, b).toByteArray());
+    }
+}

--- a/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchFunctionsConnectorFactory.java
+++ b/plugin/trino-datasketches/src/main/java/io/trino/plugin/datasketches/theta/SketchFunctionsConnectorFactory.java
@@ -36,6 +36,7 @@ public class SketchFunctionsConnectorFactory
                 .functions(Estimate.class)
                 .functions(Union.class)
                 .functions(UnionWithParams.class)
+                .functions(ANotB.class)
                 .build();
 
         return new SketchFunctionsConnector(new SketchMetadata(bundle), bundle);

--- a/plugin/trino-datasketches/src/test/java/io/trino/plugin/datasketches/TestDataSketches.java
+++ b/plugin/trino-datasketches/src/test/java/io/trino/plugin/datasketches/TestDataSketches.java
@@ -18,6 +18,7 @@ import io.airlift.slice.Slices;
 import io.trino.Session;
 import io.trino.plugin.datasketches.state.SketchState;
 import io.trino.plugin.datasketches.state.SketchStateFactory;
+import io.trino.plugin.datasketches.theta.ANotB;
 import io.trino.plugin.datasketches.theta.Estimate;
 import io.trino.plugin.datasketches.theta.SketchFunctionsPlugin;
 import io.trino.plugin.datasketches.theta.Union;
@@ -228,6 +229,88 @@ public class TestDataSketches
                 """.formatted(unionNominalEntries, DEFAULT_UPDATE_SEED, sketchA, sketchB));
 
         assertThat(estimate).isEqualTo(unionNominalEntries);
+    }
+
+    // -------------------------------------------------------------------------
+    // A-not-B (set difference)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testANotBOverlapping()
+    {
+        // {1..10} \ {6..15} = {1,2,3,4,5}
+        String sketchA = toHexSketch(new int[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+        String sketchB = toHexSketch(new int[] {6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+
+        double estimate = (double) computeScalar(
+                "SELECT theta_sketch_cardinality(theta_sketch_a_not_b(X'%s', X'%s'))".formatted(sketchA, sketchB));
+
+        assertThat(estimate).isEqualTo(5d);
+    }
+
+    @Test
+    public void testANotBDisjoint()
+    {
+        // Disjoint sets: A \ B = A
+        String sketchA = toHexSketch(new int[] {1, 2, 3});
+        String sketchB = toHexSketch(new int[] {4, 5, 6});
+
+        double estimate = (double) computeScalar(
+                "SELECT theta_sketch_cardinality(theta_sketch_a_not_b(X'%s', X'%s'))".formatted(sketchA, sketchB));
+
+        assertThat(estimate).isEqualTo(3d);
+    }
+
+    @Test
+    public void testANotBSelf()
+    {
+        // A \ A = empty
+        String sketch = toHexSketch(new int[] {1, 2, 3, 4, 5});
+
+        double estimate = (double) computeScalar(
+                "SELECT theta_sketch_cardinality(theta_sketch_a_not_b(X'%s', X'%s'))".formatted(sketch, sketch));
+
+        assertThat(estimate).isEqualTo(0d);
+    }
+
+    @Test
+    public void testANotBNonCommutative()
+    {
+        // A={1..10}, B={8..15}: A\B={1..7}=7, B\A={11..15}=5
+        String sketchA = toHexSketch(new int[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+        String sketchB = toHexSketch(new int[] {8, 9, 10, 11, 12, 13, 14, 15});
+
+        double aNotB = (double) computeScalar(
+                "SELECT theta_sketch_cardinality(theta_sketch_a_not_b(X'%s', X'%s'))".formatted(sketchA, sketchB));
+        double bNotA = (double) computeScalar(
+                "SELECT theta_sketch_cardinality(theta_sketch_a_not_b(X'%s', X'%s'))".formatted(sketchB, sketchA));
+
+        assertThat(aNotB).isEqualTo(7d);
+        assertThat(bNotA).isEqualTo(5d);
+    }
+
+    @Test
+    public void testANotBCustomSeed()
+    {
+        String sketchA = base16().lowerCase().encode(toSketchSlice(new int[] {1, 2, 3, 4, 5}, TEST_SEED, TEST_ENTRIES).getBytes());
+        String sketchB = base16().lowerCase().encode(toSketchSlice(new int[] {4, 5, 6, 7}, TEST_SEED, TEST_ENTRIES).getBytes());
+
+        double estimate = (double) computeScalar(
+                """
+                SELECT theta_sketch_cardinality(theta_sketch_a_not_b(X'%s', X'%s', CAST(%d AS BIGINT)), CAST(%d AS BIGINT))
+                """.formatted(sketchA, sketchB, TEST_SEED, TEST_SEED));
+
+        assertThat(estimate).isEqualTo(3d);
+    }
+
+    @Test
+    public void testANotBEmptyInputs()
+    {
+        Slice sketch = toSketchSlice(new int[] {1, 2, 3, 4, 5}, DEFAULT_UPDATE_SEED, DEFAULT_ENTRIES);
+        // Empty A -> empty difference
+        assertThat(ANotB.aNotB(Slices.EMPTY_SLICE, sketch).length()).isEqualTo(0);
+        // Empty B -> A unchanged
+        assertThat(ANotB.aNotB(sketch, Slices.EMPTY_SLICE)).isEqualTo(sketch);
     }
 
     private String toHexSketch(int[] data)


### PR DESCRIPTION
## Description

Adds the `theta_sketch_a_not_b(sketch_a, sketch_b [, seed])` scalar to the DataSketches plugin. It returns the set difference A∖B (elements in the first sketch that are not in the second) as a serialized Theta sketch.

A∖B is a binary, non-commutative operation with no meaningful "reduce over N rows" semantics, so it is implemented as a scalar with two sketch arguments (modeled on the existing `theta_sketch_cardinality` scalar) rather than an aggregation — no state or serializer. A custom-seed overload is provided; both inputs must share the seed.

Empty-input handling matches the plugin convention that a zero-length `varbinary` is an absent sketch: an empty A yields an empty difference, and an empty B subtracts nothing (returns A unchanged). These are guarded before wrapping to avoid the library throwing on zero bytes.

## Additional context and related issues

NULL inputs short-circuit to a NULL result automatically because the arguments are not `@SqlNullable`, matching the library's treatment of null as a programming error rather than the empty set.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Add the `theta_sketch_a_not_b` function for set difference to the DataSketches plugin.
```
