### PR TITLE
Optimize row construction for input references

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkRowConstructor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkRowConstructor.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.SequencePageBuilder;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.project.PageProjection;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.sql.ir.Coalesce;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.Row;
+import io.trino.sql.planner.Symbol;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static io.trino.type.CharVarcharCoercion.SQL_STANDARD;
+import static java.util.Collections.nCopies;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@State(Scope.Thread)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(2)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkRowConstructor
+{
+    private static final int POSITION_COUNT = 1024;
+
+    @Param({"16", "32", "48", "64", "60"})
+    private int fieldCount = 16;
+
+    @Param({"bigint", "varchar"})
+    private String type = "bigint";
+
+    @Param({"direct", "all-computed", "mixed"})
+    private String expressionShape = "direct";
+
+    private PageProjection projection;
+    private SourcePage inputPage;
+    private SelectedPositions selectedPositions;
+
+    @Setup
+    public void setup()
+    {
+        Type fieldType = switch (type) {
+            case "bigint" -> BIGINT;
+            case "varchar" -> VARCHAR;
+            default -> throw new IllegalArgumentException("Unsupported type: " + type);
+        };
+
+        String inputName = "$col_0";
+        Symbol inputSymbol = new Symbol(fieldType, inputName);
+        Expression input = new Reference(fieldType, inputName);
+        Row row = new Row(createFields(input), RowType.anonymous(nCopies(fieldCount, fieldType)));
+
+        TestingFunctionResolution functionResolution = new TestingFunctionResolution();
+        projection = functionResolution.getPageFunctionCompiler()
+                .compileProjection(row, ImmutableMap.of(inputSymbol, 0), SQL_STANDARD, Optional.empty())
+                .get();
+
+        Page page = SequencePageBuilder.createSequencePage(ImmutableList.of(fieldType), POSITION_COUNT);
+        inputPage = projection.getInputChannels().getInputChannels(SourcePage.create(page));
+        selectedPositions = SelectedPositions.positionsRange(0, POSITION_COUNT);
+    }
+
+    private List<Expression> createFields(Expression input)
+    {
+        Expression computedInput = new Coalesce(input, input);
+        return switch (expressionShape) {
+            case "direct" -> nCopies(fieldCount, input);
+            case "all-computed" -> nCopies(fieldCount, computedInput);
+            case "mixed" -> {
+                ImmutableList.Builder<Expression> fields = ImmutableList.builderWithExpectedSize(fieldCount);
+                for (int field = 0; field < fieldCount; field++) {
+                    fields.add(field % 2 == 0 ? input : computedInput);
+                }
+                yield fields.build();
+            }
+            default -> throw new IllegalArgumentException("Unsupported expression shape: " + expressionShape);
+        };
+    }
+
+    @Benchmark
+    public Block project()
+    {
+        return projection.project(SESSION, inputPage, selectedPositions);
+    }
+
+    @Test
+    void testBenchmark()
+    {
+        for (String expressionShape : ImmutableList.of("direct", "all-computed", "mixed")) {
+            this.expressionShape = expressionShape;
+            for (String type : ImmutableList.of("bigint", "varchar")) {
+                this.type = type;
+                for (int fieldCount : ImmutableList.of(16, 32, 48, 64, 60)) {
+                    this.fieldCount = fieldCount;
+                    setup();
+                    assertThat(project().getPositionCount()).isEqualTo(POSITION_COUNT);
+                }
+            }
+        }
+    }
+
+    static void main()
+            throws RunnerException
+    {
+        benchmark(BenchmarkRowConstructor.class)
+                .withOptions(options -> options.addProfiler(GCProfiler.class))
+                .run();
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information at https://trino.io/development/process.html, at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #core-dev in Slack. -->

<!-- Provide an overview for maintainers and reviewers. -->
## Description

Improve the evaluation of `ROW` expressions containing direct input references.

Previously, every field of a row constructor was read from its input block and written into a new single-position block. This change detects fields compiled as direct `InputReferenceNode` expressions and uses `Block.getRegion(position, 1)` as the corresponding raw field block instead. This avoids decoding and rebuilding values while preserving nulls and encoded block representations.

The optimization applies to both row-constructor code generation paths:

* Row constructors with up to 64 fields store direct input regions in the resulting `Block[]`.
* Larger row constructors retain their generated partial methods and use a `RowConstructorState` containing field builders and reusable field blocks. Computed expressions continue to use `BlockBuilder`, while direct input references store their regions directly in the field-block array.

`RowConstructorState` is passed as a single additional argument to partial methods. This keeps high-arity generated lambda methods within the JVM limit of 255 parameter slots.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Large row constructors are split into generated partial methods to keep each method below HotSpot's huge-method threshold and the JVM 64 KB method-size limit. The optimization therefore can't pass both `BlockBuilder[]` and `Block[]` to every partial method.

For example, a generated instance method containing a session parameter and 252 lambda arguments already consumes 254 parameter slots including the receiver. Passing one `RowConstructorState` uses the final available slot, while passing two separate arrays would require 256 slots.

`Block.getRegion(position, 1)` preserves the input block representation, including dictionary and run-length encoded blocks. The resulting field block always contains one position, so it can be used by `SqlRow` with raw index zero.

### Validation

The following cases are covered:

* Direct input references with null and non-contiguous selected positions.
* Dictionary and RLE inputs, including encoded nulls.
* Non-zero selected-position ranges.
* A 65-field row using a private Java representation, verifying that direct fields are not extracted through `Type.getObject`.
* A mixed large row with computed expressions in both the first and last generated partial methods.
* A 65-field row inside a 252-argument lambda, covering the JVM parameter-slot boundary.
* Benchmark smoke coverage for direct, computed, and mixed expressions.

### Benchmark

The benchmark covers direct input references, `COALESCE(input, input)` as the all-computed control, and alternating direct/computed fields. 

Lower values are better.

| Shape | Type | Baseline time (us/op) | Current time (us/op) | Delta | Baseline allocation (B/op) | Current allocation (B/op) | Delta |
|---|---|---:|---:|---:|---:|---:|---:|
| direct | BIGINT | 1,233.3 ± 132.3 | 906.9 ± 126.2 | -26.5% | 10,054,241 | 8,481,372 | -15.6% |
| direct | VARCHAR | 4,063.2 ± 89.2 | 1,592.7 ± 304.2 | -60.8% | 40,371,593 | 11,085,158 | -72.5% |
| all-computed | BIGINT | 1,155.7 ± 77.2 | 1,331.3 ± 290.7 | +15.2% | 10,054,240 | 10,103,394 | +0.5% |
| all-computed | VARCHAR | 4,024.1 ± 57.2 | 4,399.8 ± 524.8 | +9.3% | 40,371,592 | 40,371,598 | ~0% |
| mixed | BIGINT | 1,197.3 ± 131.6 | 1,388.9 ± 896.7 | +16.0% | 10,054,240 | 9,292,387 | -7.6% |
| mixed | VARCHAR | 4,128.7 ± 331.8 | 2,810.2 ± 115.4 | -31.9% | 40,371,594 | 25,503,095 | -36.8% |

Direct input references reduce allocation by avoiding value extraction and rebuilding single-position field blocks. The improvement is larger for `VARCHAR`, where rebuilding variable-width values is more expensive.

The all-computed cases are negative controls and do not use the new direct input-reference path. Their allocation remains within 0.5% of the baseline. The timing confidence intervals for the all-computed cases and mixed `BIGINT` overlap, so this run does not establish a statistically significant runtime change for those cases.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve evaluation performance and reduce memory allocations for `ROW` expressions containing direct column references.
```