### PR TITLE
Fix connector scalar functions failing on column arguments

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionAdapter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionAdapter.java
@@ -250,10 +250,11 @@ public final class ScalarFunctionAdapter
             InvocationReturnConvention actualReturnConvention,
             InvocationReturnConvention expectedReturnConvention)
     {
+        if (actualReturnConvention == NULLABLE_RETURN) {
+            methodHandle = explicitCastArguments(methodHandle, methodHandle.type().changeReturnType(wrap(returnType.getJavaType())));
+        }
+
         if (actualReturnConvention == expectedReturnConvention) {
-            if (actualReturnConvention == NULLABLE_RETURN) {
-                return explicitCastArguments(methodHandle, methodHandle.type().changeReturnType(wrap(returnType.getJavaType())));
-            }
             return methodHandle;
         }
 
@@ -310,6 +311,9 @@ public final class ScalarFunctionAdapter
         }
 
         if (actualArgumentConvention == expectedArgumentConvention) {
+            if (actualArgumentConvention == BOXED_NULLABLE) {
+                methodHandle = explicitCastArguments(methodHandle, methodHandle.type().changeParameterType(parameterIndex, wrap(argumentType.getJavaType())));
+            }
             return methodHandle;
         }
         if (actualArgumentConvention == IN_OUT) {

--- a/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionAdapter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionAdapter.java
@@ -251,6 +251,9 @@ public final class ScalarFunctionAdapter
             InvocationReturnConvention expectedReturnConvention)
     {
         if (actualReturnConvention == expectedReturnConvention) {
+            if (actualReturnConvention == NULLABLE_RETURN) {
+                return explicitCastArguments(methodHandle, methodHandle.type().changeReturnType(wrap(returnType.getJavaType())));
+            }
             return methodHandle;
         }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionAdapter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionAdapter.java
@@ -326,8 +326,9 @@ public final class ScalarFunctionAdapter
         if (expectedArgumentConvention == NEVER_NULL) {
             if (actualArgumentConvention == BOXED_NULLABLE) {
                 // if actual argument is boxed primitive, change method handle to accept a primitive and then box to actual method
-                if (isWrapperType(methodHandle.type().parameterType(parameterIndex))) {
-                    MethodType targetType = methodHandle.type().changeParameterType(parameterIndex, unwrap(methodHandle.type().parameterType(parameterIndex)));
+                Class<?> argumentJavaType = argumentType.getJavaType();
+                if (argumentJavaType.isPrimitive()) {
+                    MethodType targetType = methodHandle.type().changeParameterType(parameterIndex, argumentJavaType);
                     methodHandle = explicitCastArguments(methodHandle, targetType);
                 }
                 return methodHandle;
@@ -400,7 +401,10 @@ public final class ScalarFunctionAdapter
             }
 
             if (actualArgumentConvention == BOXED_NULLABLE) {
-                return collectArguments(methodHandle, parameterIndex, boxedToNullFlagFilter(methodHandle.type().parameterType(parameterIndex)));
+                return collectArguments(
+                        methodHandle,
+                        parameterIndex,
+                        boxedToNullFlagFilter(methodHandle.type().parameterType(parameterIndex), argumentType.getJavaType()));
             }
         }
 
@@ -747,13 +751,12 @@ public final class ScalarFunctionAdapter
         }
     }
 
-    private static MethodHandle boxedToNullFlagFilter(Class<?> argumentType)
+    private static MethodHandle boxedToNullFlagFilter(Class<?> actualArgumentType, Class<?> expectedArgumentType)
     {
         // Start with identity
-        MethodHandle handle = identity(argumentType);
-        // if argument is a primitive, box it
-        if (isWrapperType(argumentType)) {
-            handle = explicitCastArguments(handle, handle.type().changeParameterType(0, unwrap(argumentType)));
+        MethodHandle handle = identity(actualArgumentType);
+        if (actualArgumentType != expectedArgumentType) {
+            handle = explicitCastArguments(handle, handle.type().changeParameterType(0, expectedArgumentType));
         }
         // Add boolean null flag
         handle = dropArguments(handle, 1, boolean.class);

--- a/core/trino-spi/src/test/java/io/trino/spi/function/TestScalarFunctionAdapter.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/function/TestScalarFunctionAdapter.java
@@ -103,13 +103,14 @@ class TestScalarFunctionAdapter
     public void testAdaptNullableReturnToBlockBuilder()
             throws Throwable
     {
-        // adapt identity(Double):Double to identity(Double, BlockBuilder):void
+        // adapt identity(Object):Object to identity(Double, BlockBuilder):void
         MethodHandle adaptedMethodHandle = ScalarFunctionAdapter.adapt(
-                identity(Double.class),
+                identity(Object.class),
                 DOUBLE,
                 ImmutableList.of(DOUBLE),
                 simpleConvention(NULLABLE_RETURN, BOXED_NULLABLE),
                 simpleConvention(BLOCK_BUILDER, BOXED_NULLABLE));
+        assertThat(adaptedMethodHandle.type()).isEqualTo(methodType(void.class, Double.class, BlockBuilder.class));
 
         // verify non-null and null value are written to the block
         BlockBuilder blockBuilder = DOUBLE.createFixedSizeBlockBuilder(1);

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestConnectorSessionFunctions.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestConnectorSessionFunctions.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorPlugin;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencies;
+import io.trino.spi.function.FunctionId;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.InvocationConvention;
+import io.trino.spi.function.ScalarFunctionAdapter;
+import io.trino.spi.function.ScalarFunctionImplementation;
+import io.trino.spi.function.Signature;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.util.Reflection.methodHandle;
+
+public class TestConnectorSessionFunctions
+        extends AbstractTestQueryFramework
+{
+    private static final MethodHandle MULTIPLY = methodHandle(TestConnectorSessionFunctions.class, "multiply", ConnectorSession.class, Object.class);
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return DistributedQueryRunner.builder(testSessionBuilder().build())
+                .setAdditionalSetup(queryRunner -> {
+                    queryRunner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
+                            .withFunctions(List.of(FunctionMetadata.scalarBuilder("multiply")
+                                    .signature(Signature.builder()
+                                            .argumentType(BIGINT)
+                                            .returnType(BIGINT)
+                                            .build())
+                                    .nullable()
+                                    .argumentNullability(true)
+                                    .hidden()
+                                    .build()))
+                            .withFunctionProvider(Optional.of(new FunctionProvider()
+                            {
+                                @Override
+                                public ScalarFunctionImplementation getScalarFunctionImplementation(
+                                        FunctionId functionId,
+                                        BoundSignature boundSignature,
+                                        FunctionDependencies functionDependencies,
+                                        InvocationConvention invocationConvention)
+                                {
+                                    InvocationConvention actualConvention = new InvocationConvention(
+                                            List.of(BOXED_NULLABLE),
+                                            NULLABLE_RETURN,
+                                            true,
+                                            false);
+                                    MethodHandle adapted = ScalarFunctionAdapter.adapt(
+                                            MULTIPLY,
+                                            boundSignature.getReturnType(),
+                                            boundSignature.getArgumentTypes(),
+                                            actualConvention,
+                                            invocationConvention);
+                                    return ScalarFunctionImplementation.builder()
+                                            .methodHandle(adapted)
+                                            .build();
+                                }
+                            }))
+                            .build()));
+                    queryRunner.createCatalog("mock", "mock");
+                    queryRunner.installPlugin(new TpchPlugin());
+                    queryRunner.createCatalog("tpch", "tpch");
+                })
+                .build();
+    }
+
+    @Test
+    public void testNullableObjectReturnWithColumnArgument()
+    {
+        assertQuery("SELECT mock.default.multiply(nationkey) FROM tpch.tiny.nation WHERE nationkey = 1", "VALUES 2");
+    }
+
+    public static Object multiply(ConnectorSession session, Object value)
+    {
+        return value == null ? null : (Long) value * 2;
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestConnectorSessionFunctions.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestConnectorSessionFunctions.java
@@ -53,15 +53,24 @@ public class TestConnectorSessionFunctions
         return DistributedQueryRunner.builder(testSessionBuilder().build())
                 .setAdditionalSetup(queryRunner -> {
                     queryRunner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
-                            .withFunctions(List.of(FunctionMetadata.scalarBuilder("multiply")
-                                    .signature(Signature.builder()
-                                            .argumentType(BIGINT)
-                                            .returnType(BIGINT)
-                                            .build())
-                                    .nullable()
-                                    .argumentNullability(true)
-                                    .hidden()
-                                    .build()))
+                            .withFunctions(List.of(
+                                    FunctionMetadata.scalarBuilder("multiply")
+                                            .signature(Signature.builder()
+                                                    .argumentType(BIGINT)
+                                                    .returnType(BIGINT)
+                                                    .build())
+                                            .nullable()
+                                            .argumentNullability(true)
+                                            .hidden()
+                                            .build(),
+                                    FunctionMetadata.scalarBuilder("multiply_nonnull")
+                                            .signature(Signature.builder()
+                                                    .argumentType(BIGINT)
+                                                    .returnType(BIGINT)
+                                                    .build())
+                                            .nullable()
+                                            .hidden()
+                                            .build()))
                             .withFunctionProvider(Optional.of(new FunctionProvider()
                             {
                                 @Override
@@ -99,6 +108,18 @@ public class TestConnectorSessionFunctions
     public void testNullableObjectReturnWithColumnArgument()
     {
         assertQuery("SELECT mock.default.multiply(nationkey) FROM tpch.tiny.nation WHERE nationkey = 1", "VALUES 2");
+    }
+
+    @Test
+    public void testNullableObjectArgumentWithExpression()
+    {
+        assertQuery("SELECT mock.default.multiply(nationkey + length(name)) FROM tpch.tiny.nation WHERE nationkey = 1", "VALUES 20");
+    }
+
+    @Test
+    public void testNullableObjectArgumentWithNonNullableExpression()
+    {
+        assertQuery("SELECT mock.default.multiply_nonnull(nationkey + length(name)) FROM tpch.tiny.nation WHERE nationkey = 1", "VALUES 20");
     }
 
     public static Object multiply(ConnectorSession session, Object value)


### PR DESCRIPTION
## Description

Connector authors can define a valid nullable scalar with an `Object` method handle, but calling it on a table column fails before returning any rows. A direct column produces `Error processing class definition`. A computed column produces `Expected argument type to be long, but is class java.lang.Object`.

After this change, the same functions return the expected values for direct columns and computed expressions. Trino narrows generic returns and arguments to the bound SQL Java type before adapting the call convention.

### Verification

```shell
./mvnw -pl core/trino-spi -Dtest=io.trino.spi.function.TestScalarFunctionAdapter install -Dair.check.skip-all
./mvnw -pl testing/trino-tests -Dtest=io.trino.tests.TestConnectorSessionFunctions test -Dair.check.skip-all
./mvnw -pl core/trino-spi,testing/trino-tests -DskipTests package
```

The regression uses a mock connector that registers `multiply(BIGINT)` as `(ConnectorSession, Object) -> Object`. The same tests ran with the production source from `upstream/master` and from this branch.

<details>
<summary>Raw logs</summary>

```text
Before (upstream/master production source):
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 2
[ERROR] TestConnectorSessionFunctions.testNullableObjectReturnWithColumnArgument
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0

Caused by: io.trino.spi.TrinoException: Expected argument type to be long, but is class java.lang.Object
[ERROR] TestConnectorSessionFunctions.testNullableObjectArgumentWithExpression
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

After (branch head):
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
[INFO] trino-spi .......................................... SUCCESS
[INFO] trino-tests ........................................ SUCCESS
[INFO] BUILD SUCCESS
```

</details>

## Additional context and related issues

Related: https://github.com/trinodb/trino/issues/30889

- Literal-only evaluation fix: https://github.com/trinodb/trino/pull/30904

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix failures when connector scalar functions use generic nullable Java method handles. ({issue}`30889`)
```
