### PR TITLE
Fix connector scalar functions failing on literal arguments

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionEvaluator.java
@@ -305,7 +305,7 @@ public class IrExpressionEvaluator
 
     private Object evaluateInternal(Call call, Session session, Map<String, Object> bindings)
     {
-        return functionInvoker.invoke(call.function(), session.toConnectorSession(), call.arguments().stream()
+        return functionInvoker.invoke(call.function(), session.toConnectorSession(call.function().catalogHandle()), call.arguments().stream()
                 .map(argument -> evaluate(argument, session, bindings))
                 .collect(toList()));
     }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestLocalEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestLocalEngineOnlyQueries.java
@@ -13,20 +13,39 @@
  */
 package io.trino.tests;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.connector.MockConnectorPlugin;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencies;
+import io.trino.spi.function.FunctionId;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.InvocationConvention;
+import io.trino.spi.function.ScalarFunctionImplementation;
+import io.trino.spi.function.Signature;
 import io.trino.testing.AbstractTestEngineOnlyQueries;
 import io.trino.testing.CustomFunctionBundle;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
 
+import java.lang.invoke.MethodHandle;
+import java.util.Optional;
+
 import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.AbstractTestEngineOnlyQueries.TESTING_CATALOG;
+import static io.trino.util.Reflection.methodHandle;
 import static org.junit.jupiter.api.Assumptions.abort;
 
 public class TestLocalEngineOnlyQueries
         extends AbstractTestEngineOnlyQueries
 {
+    private static final MethodHandle MULTIPLY = methodHandle(TestLocalEngineOnlyQueries.class, "multiply", ConnectorSession.class, long.class);
+
     @Override
     protected QueryRunner createQueryRunner()
     {
@@ -37,6 +56,27 @@ public class TestLocalEngineOnlyQueries
             queryRunner.getSessionPropertyManager().addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);
             queryRunner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
                     .withSessionProperties(TEST_CATALOG_PROPERTIES)
+                    .withFunctions(ImmutableList.of(FunctionMetadata.scalarBuilder("multiply")
+                            .signature(Signature.builder()
+                                    .argumentType(BIGINT)
+                                    .returnType(BIGINT)
+                                    .build())
+                            .description("")
+                            .build()))
+                    .withFunctionProvider(Optional.of(new FunctionProvider()
+                    {
+                        @Override
+                        public ScalarFunctionImplementation getScalarFunctionImplementation(
+                                FunctionId functionId,
+                                BoundSignature boundSignature,
+                                FunctionDependencies functionDependencies,
+                                InvocationConvention invocationConvention)
+                        {
+                            return ScalarFunctionImplementation.builder()
+                                    .methodHandle(MULTIPLY)
+                                    .build();
+                        }
+                    }))
                     .build()));
             queryRunner.createCatalog(TESTING_CATALOG, "mock", ImmutableMap.of());
         }
@@ -44,6 +84,21 @@ public class TestLocalEngineOnlyQueries
             throw closeAllSuppress(e, queryRunner);
         }
         return queryRunner;
+    }
+
+    @Test
+    public void testConnectorFunctionLiteralArgumentUsesCatalogSession()
+    {
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty(TESTING_CATALOG, "connector_long", "3")
+                .build();
+
+        assertQuery(session, "SELECT testing_catalog.default.multiply(5)", "SELECT CAST(15 AS BIGINT)");
+    }
+
+    public static long multiply(ConnectorSession session, long value)
+    {
+        return session.getProperty("connector_long", Long.class) * value;
     }
 
     @Test


### PR DESCRIPTION
## Description

Connector authors can call a scalar that reads a catalog property on table rows, but the same function fails when passed a literal. `SELECT testing_catalog.default.multiply(5)` raises `Session property 'null.connector_long' does not exist`.

After this change, the literal call returns `15`, matching split-backed execution. The expression evaluator binds its `ConnectorSession` to the resolved function's catalog before invocation.

### Verification

```shell
./mvnw -pl core/trino-main install -DskipTests -Dair.check.skip-all
./mvnw -pl testing/trino-tests -Dtest=io.trino.tests.TestLocalEngineOnlyQueries test -Dair.check.skip-all
./mvnw -pl core/trino-main,testing/trino-tests -DskipTests package
```

The regression uses a mock connector with a declared `connector_long` property and a `multiply(BIGINT)` function. The test session sets that property to `3`. The same focused query ran with the production source from `upstream/master` and from this branch.

<details>
<summary>Raw logs</summary>

```text
Before (upstream/master production source):
Caused by: io.trino.testing.QueryFailedException: Session property 'null.connector_long' does not exist
Caused by: io.trino.spi.TrinoException: Session property 'null.connector_long' does not exist
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

After (branch head):
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[WARNING] Tests run: 348, Failures: 0, Errors: 0, Skipped: 2
[INFO] trino-main ......................................... SUCCESS
[INFO] trino-tests ........................................ SUCCESS
[INFO] BUILD SUCCESS
```

</details>

## Additional context and related issues

Related: https://github.com/trinodb/trino/issues/30889

- Generic method-handle adaptation fix: https://github.com/trinodb/trino/pull/30903

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix connector scalar functions reading catalog session properties when called with literal arguments. ({issue}`30889`)
```
