### PR TITLE
Update dependencies

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetMetadataConverter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetMetadataConverter.java
@@ -51,6 +51,7 @@ import org.apache.parquet.internal.column.columnindex.BinaryTruncator;
 import org.apache.parquet.internal.column.columnindex.ColumnIndexBuilder;
 import org.apache.parquet.internal.column.columnindex.OffsetIndexBuilder;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.ColumnOrder;
 import org.apache.parquet.schema.ColumnOrder.ColumnOrderName;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.BsonLogicalTypeAnnotation;
@@ -70,6 +71,7 @@ import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnot
 import org.apache.parquet.schema.LogicalTypeAnnotation.UUIDLogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
 
 import java.util.Arrays;
 import java.util.List;
@@ -239,13 +241,18 @@ public final class ParquetMetadataConverter
         if (!isMinMaxStatsSupported(type)) {
             return null;
         }
+        // Without nan counts, parquet 1.18+ conservatively keeps all pages when filtering
+        // floating point columns, so forward them for files that carry them
         return ColumnIndexBuilder.build(
                 type,
                 fromParquetBoundaryOrder(parquetColumnIndex.getBoundary_order()),
                 parquetColumnIndex.getNull_pages(),
                 parquetColumnIndex.getNull_counts(),
+                parquetColumnIndex.getNan_counts(),
                 parquetColumnIndex.getMin_values(),
-                parquetColumnIndex.getMax_values());
+                parquetColumnIndex.getMax_values(),
+                null,
+                null);
     }
 
     public static org.apache.parquet.internal.column.columnindex.OffsetIndex fromParquetOffsetIndex(OffsetIndex parquetOffsetIndex)
@@ -262,7 +269,9 @@ public final class ParquetMetadataConverter
         if (isGeospatialLogicalType(type.getLogicalTypeAnnotation())) {
             return false;
         }
-        return type.columnOrder().getColumnOrderName() == ColumnOrderName.TYPE_DEFINED_ORDER;
+        // IEEE 754 total order is the parquet 1.18+ default for floating point columns, see toTypeDefinedOrder
+        return type.columnOrder().getColumnOrderName() == ColumnOrderName.TYPE_DEFINED_ORDER
+                || type.columnOrder().getColumnOrderName() == ColumnOrderName.IEEE_754_TOTAL_ORDER;
     }
 
     public static Statistics toParquetStatistics(org.apache.parquet.column.statistics.Statistics<?> stats, int truncateLength)
@@ -270,7 +279,10 @@ public final class ParquetMetadataConverter
         Statistics formatStats = new Statistics();
         if (!stats.isEmpty() && withinLimit(stats, truncateLength)) {
             formatStats.setNull_count(stats.getNumNulls());
-            if (stats.hasNonNullValue()) {
+            if (stats.isNanCountSet()) {
+                formatStats.setNan_count(stats.getNanCount());
+            }
+            if (stats.hasNonNullValue() && !mayContainNaN(stats)) {
                 byte[] min;
                 byte[] max;
                 boolean isMinValueExact = true;
@@ -323,15 +335,60 @@ public final class ParquetMetadataConverter
         return formatStats;
     }
 
+    /// Floating point min/max is omitted from footers when the column may contain NaN, see [#toTypeDefinedOrder(PrimitiveType)]
+    private static boolean mayContainNaN(org.apache.parquet.column.statistics.Statistics<?> stats)
+    {
+        return isFloatingPointType(stats.type()) && (!stats.isNanCountSet() || stats.getNanCount() > 0);
+    }
+
+    private static boolean isFloatingPointType(PrimitiveType type)
+    {
+        PrimitiveTypeName typeName = type.getPrimitiveTypeName();
+        return typeName == PrimitiveTypeName.DOUBLE || typeName == PrimitiveTypeName.FLOAT;
+    }
+
+    /// Returns the given type with the type-defined column order for floating point types.
+    ///
+    /// Parquet 1.18+ defaults floating point columns to the IEEE 754 total order, which changes how
+    /// statistics are computed and interpreted: NaN values are included in min/max (with NaN presence
+    /// conveyed through the new nan_count field) instead of invalidating the statistics, and
+    /// -0.0/+0.0 are not normalized. Parquet 1.17 writers instead let NaN poison the max value,
+    /// which made readers discard the statistics, so NaN presence implied no usable bounds.
+    ///
+    /// Trino and the table formats it writes to (Delta Lake, Iceberg) treat NaN as larger than any
+    /// other value, so NaN-excluding bounds would cause incorrect pruning in readers unaware of
+    /// nan_count. Trino also does not declare column orders in file footers, and its consumers
+    /// (e.g. the Delta Lake writer) rely on the legacy behavior where NaN min/max values mark the
+    /// statistics as invalid. Both writing and interpreting statistics must therefore keep using
+    /// the type-defined order, and footers must omit floating point min/max whenever the column
+    /// may contain NaN.
+    public static PrimitiveType toTypeDefinedOrder(PrimitiveType type)
+    {
+        if (!isFloatingPointType(type) || type.columnOrder().getColumnOrderName() == ColumnOrderName.TYPE_DEFINED_ORDER) {
+            return type;
+        }
+        Types.PrimitiveBuilder<PrimitiveType> builder = Types.primitive(type.getPrimitiveTypeName(), type.getRepetition())
+                .columnOrder(ColumnOrder.typeDefined());
+        if (type.getLogicalTypeAnnotation() != null) {
+            builder = builder.as(type.getLogicalTypeAnnotation());
+        }
+        if (type.getId() != null) {
+            builder = builder.id(type.getId().intValue());
+        }
+        return builder.named(type.getName());
+    }
+
     public static org.apache.parquet.column.statistics.Statistics<?> fromParquetStatistics(String createdBy, Statistics statistics, PrimitiveType type)
     {
         org.apache.parquet.column.statistics.Statistics.Builder statsBuilder =
-                org.apache.parquet.column.statistics.Statistics.getBuilderForReading(type);
+                org.apache.parquet.column.statistics.Statistics.getBuilderForReading(toTypeDefinedOrder(type));
         if (statistics != null) {
             if (statistics.isSetMin_value() && statistics.isSetMax_value()) {
                 byte[] min = statistics.min_value.array();
                 byte[] max = statistics.max_value.array();
-                if (isMinMaxStatsSupported(type) || minMaxStatsAreExactSingleValue(type, min, max)) {
+                // NaN-excluding bounds cannot be used for pruning, see toTypeDefinedOrder
+                boolean containsNaN = isFloatingPointType(type) && statistics.isSetNan_count() && statistics.getNan_count() > 0;
+                if (!containsNaN && (isMinMaxStatsSupported(type) || minMaxStatsAreExactSingleValue(type, min, max))) {
                     statsBuilder.withMin(min);
                     statsBuilder.withMax(max);
                 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/FilteredOffsetIndex.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/FilteredOffsetIndex.java
@@ -15,8 +15,8 @@ package io.trino.parquet.reader;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
+import org.apache.parquet.filter2.columnindex.RowRanges;
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
-import org.apache.parquet.internal.filter2.columnindex.RowRanges;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/FilteredRowRanges.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/FilteredRowRanges.java
@@ -13,7 +13,7 @@
  */
 package io.trino.parquet.reader;
 
-import org.apache.parquet.internal.filter2.columnindex.RowRanges;
+import org.apache.parquet.filter2.columnindex.RowRanges;
 
 import java.util.List;
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ApacheParquetValueDecoders.java
@@ -24,8 +24,8 @@ import java.nio.ByteBuffer;
 
 import static io.trino.spi.block.Bitmap.clear;
 import static io.trino.spi.block.Bitmap.set;
-import static java.lang.Double.doubleToLongBits;
-import static java.lang.Float.floatToIntBits;
+import static java.lang.Double.doubleToRawLongBits;
+import static java.lang.Float.floatToRawIntBits;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -100,7 +100,8 @@ public class ApacheParquetValueDecoders
         public void read(long[] values, int offset, int length)
         {
             for (int i = offset; i < offset + length; i++) {
-                values[i] = doubleToLongBits(delegate.readDouble());
+                // Raw conversion preserves NaN payloads, matching the PLAIN decoder behavior
+                values[i] = doubleToRawLongBits(delegate.readDouble());
             }
         }
 
@@ -131,7 +132,8 @@ public class ApacheParquetValueDecoders
         public void read(int[] values, int offset, int length)
         {
             for (int i = offset; i < offset + length; i++) {
-                values[i] = floatToIntBits(delegate.readFloat());
+                // Raw conversion preserves NaN payloads, matching the PLAIN decoder behavior
+                values[i] = floatToRawIntBits(delegate.readFloat());
             }
         }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
@@ -62,6 +62,7 @@ import static io.trino.parquet.writer.ParquetCompressor.getCompressor;
 import static io.trino.parquet.writer.ParquetDataOutput.createDataOutput;
 import static io.trino.parquet.writer.repdef.DefLevelWriterProvider.getRootDefinitionLevelWriter;
 import static io.trino.parquet.writer.repdef.RepLevelWriterProvider.getRootRepetitionLevelWriter;
+import static io.trino.parquet.writer.valuewriter.PrimitiveValueWriter.createStatistics;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static org.apache.parquet.format.Util.writePageHeader;
@@ -134,7 +135,7 @@ public class PrimitiveColumnWriter
         this.compressor = getCompressor(compressionCodec);
         this.pageSizeThreshold = pageSizeThreshold;
         this.pageValueCountLimit = pageValueCountLimit;
-        this.columnStatistics = Statistics.createStats(columnDescriptor.getPrimitiveType());
+        this.columnStatistics = createStatistics(columnDescriptor.getPrimitiveType());
         this.compressedOutputStream = new ChunkedSliceOutput(MINIMUM_OUTPUT_BUFFER_CHUNK_SIZE, MAXIMUM_OUTPUT_BUFFER_CHUNK_SIZE);
         this.bloomFilter = requireNonNull(bloomFilter, "bloomFilter is null");
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/PrimitiveValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/PrimitiveValueWriter.java
@@ -13,6 +13,7 @@
  */
 package io.trino.parquet.writer.valuewriter;
 
+import io.trino.parquet.ParquetMetadataConverter;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
@@ -30,13 +31,22 @@ public abstract class PrimitiveValueWriter
 {
     private Statistics<?> statistics;
     private final PrimitiveType parquetType;
+    // Type with the column order under which statistics are computed, see ParquetMetadataConverter#toTypeDefinedOrder
+    private final PrimitiveType statisticsType;
     private final ValuesWriter valuesWriter;
 
     public PrimitiveValueWriter(PrimitiveType parquetType, ValuesWriter valuesWriter)
     {
         this.parquetType = requireNonNull(parquetType, "parquetType is null");
+        this.statisticsType = ParquetMetadataConverter.toTypeDefinedOrder(parquetType);
         this.valuesWriter = requireNonNull(valuesWriter, "valuesWriter is null");
-        this.statistics = Statistics.createStats(parquetType);
+        this.statistics = Statistics.createStats(statisticsType);
+    }
+
+    /// Creates statistics computed with the type-defined column order semantics, see ParquetMetadataConverter#toTypeDefinedOrder
+    public static Statistics<?> createStatistics(PrimitiveType type)
+    {
+        return Statistics.createStats(ParquetMetadataConverter.toTypeDefinedOrder(type));
     }
 
     ValuesWriter getValuesWriter()
@@ -81,7 +91,7 @@ public abstract class PrimitiveValueWriter
     public void reset()
     {
         valuesWriter.reset();
-        this.statistics = Statistics.createStats(parquetType);
+        this.statistics = Statistics.createStats(statisticsType);
     }
 
     @Override

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/AbstractColumnReaderRowRangesTest.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/AbstractColumnReaderRowRangesTest.java
@@ -38,7 +38,7 @@ import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainI
 import org.apache.parquet.column.values.fallback.FallbackValuesWriter;
 import org.apache.parquet.column.values.plain.PlainValuesWriter;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridEncoder;
-import org.apache.parquet.internal.filter2.columnindex.RowRanges;
+import org.apache.parquet.filter2.columnindex.RowRanges;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnIndexBuilder.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnIndexBuilder.java
@@ -24,6 +24,7 @@ import org.apache.parquet.internal.column.columnindex.BoundaryOrder;
 import org.apache.parquet.internal.column.columnindex.ColumnIndex;
 import org.apache.parquet.internal.column.columnindex.ColumnIndexBuilder;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.ColumnOrder;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
@@ -733,11 +734,12 @@ public class TestColumnIndexBuilder
                 Types.required(BOOLEAN).named("test_boolean"),
                 BoundaryOrder.DESCENDING,
                 asList(false, true, false, true, false, true),
-                asList(9L, 8L, 7L, 6L, 5L, 0L),
+                // Since parquet 1.18, ColumnIndexBuilder rejects a null page with a zero null count
+                asList(9L, 8L, 7L, 6L, 5L, 4L),
                 toBBList(false, null, false, null, true, null),
                 toBBList(true, null, false, null, true, null));
         assertThat(BoundaryOrder.DESCENDING).isEqualTo(columnIndex.getBoundaryOrder());
-        assertCorrectNullCounts(columnIndex, 9, 8, 7, 6, 5, 0);
+        assertCorrectNullCounts(columnIndex, 9, 8, 7, 6, 5, 4);
         assertCorrectNullPages(columnIndex, false, true, false, true, false, true);
         assertCorrectValues(columnIndex.getMaxValues(), true, null, false, null, true, null);
         assertCorrectValues(columnIndex.getMinValues(), false, null, false, null, true, null);
@@ -842,7 +844,8 @@ public class TestColumnIndexBuilder
     @Test
     public void testBuildDoubleZeroNaN()
     {
-        PrimitiveType type = Types.required(DOUBLE).named("test_double");
+        // Zero/NaN normalization only applies under the legacy type-defined order
+        PrimitiveType type = Types.required(DOUBLE).columnOrder(ColumnOrder.typeDefined()).named("test_double");
         ColumnIndexBuilder builder = ColumnIndexBuilder.getBuilder(type, Integer.MAX_VALUE);
         StatsBuilder sb = new StatsBuilder();
         builder.add(sb.stats(type, -1.0, -0.0));
@@ -975,7 +978,8 @@ public class TestColumnIndexBuilder
     @Test
     public void testBuildFloatZeroNaN()
     {
-        PrimitiveType type = Types.required(FLOAT).named("test_float");
+        // Zero/NaN normalization only applies under the legacy type-defined order
+        PrimitiveType type = Types.required(FLOAT).columnOrder(ColumnOrder.typeDefined()).named("test_float");
         ColumnIndexBuilder builder = ColumnIndexBuilder.getBuilder(type, Integer.MAX_VALUE);
         StatsBuilder sb = new StatsBuilder();
         builder.add(sb.stats(type, -1.0f, -0.0f));

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnIndexFilter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestColumnIndexFilter.java
@@ -16,6 +16,7 @@ package io.trino.parquet.reader;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongList;
 import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.filter2.columnindex.RowRanges;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.Statistics;
 import org.apache.parquet.filter2.predicate.UserDefinedPredicate;
@@ -27,7 +28,6 @@ import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.internal.column.columnindex.OffsetIndexBuilder;
 import org.apache.parquet.internal.filter2.columnindex.ColumnIndexFilter;
 import org.apache.parquet.internal.filter2.columnindex.ColumnIndexStore;
-import org.apache.parquet.internal.filter2.columnindex.RowRanges;
 import org.apache.parquet.schema.PrimitiveType;
 import org.junit.jupiter.api.Test;
 
@@ -79,6 +79,9 @@ public class TestColumnIndexFilter
         private final BoundaryOrder order;
         private List<Boolean> nullPages = new ArrayList<>();
         private List<Long> nullCounts = new ArrayList<>();
+        // Without nan counts, parquet 1.18+ conservatively disables page pruning
+        // for floating point columns as their min/max may be NaN-polluted
+        private List<Long> nanCounts = new ArrayList<>();
         private List<ByteBuffer> minValues = new ArrayList<>();
         private List<ByteBuffer> maxValues = new ArrayList<>();
 
@@ -92,6 +95,7 @@ public class TestColumnIndexFilter
         {
             nullPages.add(true);
             nullCounts.add(nullCount);
+            nanCounts.add(0L);
             minValues.add(EMPTY);
             maxValues.add(EMPTY);
             return this;
@@ -101,6 +105,7 @@ public class TestColumnIndexFilter
         {
             nullPages.add(false);
             nullCounts.add(nullCount);
+            nanCounts.add(0L);
             minValues.add(ByteBuffer.wrap(BytesUtils.intToBytes(min)));
             maxValues.add(ByteBuffer.wrap(BytesUtils.intToBytes(max)));
             return this;
@@ -110,6 +115,7 @@ public class TestColumnIndexFilter
         {
             nullPages.add(false);
             nullCounts.add(nullCount);
+            nanCounts.add(0L);
             minValues.add(ByteBuffer.wrap(min.getBytes(UTF_8)));
             maxValues.add(ByteBuffer.wrap(max.getBytes(UTF_8)));
             return this;
@@ -119,6 +125,7 @@ public class TestColumnIndexFilter
         {
             nullPages.add(false);
             nullCounts.add(nullCount);
+            nanCounts.add(0L);
             minValues.add(ByteBuffer.wrap(BytesUtils.longToBytes(Double.doubleToLongBits(min))));
             maxValues.add(ByteBuffer.wrap(BytesUtils.longToBytes(Double.doubleToLongBits(max))));
             return this;
@@ -126,7 +133,7 @@ public class TestColumnIndexFilter
 
         ColumnIndex build()
         {
-            return ColumnIndexBuilder.build(type, order, nullPages, nullCounts, minValues, maxValues);
+            return ColumnIndexBuilder.build(type, order, nullPages, nullCounts, nanCounts, minValues, maxValues, null, null);
         }
     }
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingRowRanges.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestingRowRanges.java
@@ -14,12 +14,7 @@
 package io.trino.parquet.reader;
 
 import io.trino.parquet.reader.FilteredRowRanges.RowRange;
-import org.apache.parquet.internal.column.columnindex.OffsetIndex;
-import org.apache.parquet.internal.filter2.columnindex.RowRanges;
-
-import java.util.stream.IntStream;
-
-import static java.util.Objects.requireNonNull;
+import org.apache.parquet.filter2.columnindex.RowRanges;
 
 public class TestingRowRanges
 {
@@ -32,47 +27,10 @@ public class TestingRowRanges
 
     public static RowRanges toRowRanges(RowRange... ranges)
     {
-        return RowRanges.create(-1, IntStream.range(0, ranges.length).iterator(), new MockOffsetIndex(ranges));
-    }
-
-    private static class MockOffsetIndex
-            implements OffsetIndex
-    {
-        private final RowRange[] rowRanges;
-
-        private MockOffsetIndex(RowRange[] rowRanges)
-        {
-            this.rowRanges = requireNonNull(rowRanges, "rowRanges is null");
+        RowRanges.Builder builder = RowRanges.builder();
+        for (RowRange range : ranges) {
+            builder.addSelectedRange(range.start(), range.end());
         }
-
-        @Override
-        public int getPageCount()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long getOffset(int pageIndex)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public int getCompressedPageSize(int pageIndex)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long getFirstRowIndex(int pageIndex)
-        {
-            return rowRanges[pageIndex].start();
-        }
-
-        @Override
-        public long getLastRowIndex(int pageIndex, long rowGroupRowCount)
-        {
-            return rowRanges[pageIndex].end();
-        }
+        return builder.build();
     }
 }

--- a/lib/trino-record-decoder/pom.xml
+++ b/lib/trino-record-decoder/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
-        <dep.wire.version>6.4.5</dep.wire.version>
+        <dep.wire.version>6.4.7</dep.wire.version>
     </properties>
 
     <dependencies>

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeWriter.java
@@ -25,8 +25,10 @@ import org.apache.parquet.column.EncodingStats;
 import org.apache.parquet.column.statistics.Statistics;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.ColumnOrder;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
@@ -102,7 +104,8 @@ public class TestDeltaLakeWriter
     public void testMergeFloatNaNStatistics()
     {
         String columnName = "t_float";
-        PrimitiveType type = new PrimitiveType(Type.Repetition.REQUIRED, PrimitiveType.PrimitiveTypeName.FLOAT, columnName);
+        // Type-defined order matches how MetadataReader interprets floating point statistics, see ParquetMetadataConverter#toTypeDefinedOrder
+        PrimitiveType type = Types.required(PrimitiveType.PrimitiveTypeName.FLOAT).columnOrder(ColumnOrder.typeDefined()).named(columnName);
         List<ColumnChunkMetadata> metadata = ImmutableList.of(
                 createMetaData(
                         columnName,
@@ -132,7 +135,8 @@ public class TestDeltaLakeWriter
     public void testMergeDoubleNaNStatistics()
     {
         String columnName = "t_double";
-        PrimitiveType type = new PrimitiveType(Type.Repetition.REQUIRED, PrimitiveType.PrimitiveTypeName.DOUBLE, columnName);
+        // Type-defined order matches how MetadataReader interprets floating point statistics, see ParquetMetadataConverter#toTypeDefinedOrder
+        PrimitiveType type = Types.required(PrimitiveType.PrimitiveTypeName.DOUBLE).columnOrder(ColumnOrder.typeDefined()).named(columnName);
         List<ColumnChunkMetadata> metadata = ImmutableList.of(
                 createMetaData(
                         columnName,

--- a/plugin/trino-ranger/pom.xml
+++ b/plugin/trino-ranger/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <dep.aws-sdk.version>1.12.797</dep.aws-sdk.version>
-        <dep.graalvm.version>25.2.4</dep.graalvm.version>
+        <dep.graalvm.version>25.3.4.1</dep.graalvm.version>
         <!-- TODO: remove once Ranger upgrades to Jetty 12 -->
         <dep.jetty11.version>11.0.26</dep.jetty11.version>
         <dep.ranger.version>2.9.0</dep.ranger.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2170,7 +2170,7 @@
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-xml</artifactId>
-                <version>4.1.1</version>
+                <version>4.2.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2164,7 +2164,7 @@
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
-                <version>4.0.3</version>
+                <version>4.1.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>26.86.0</version>
+                <version>26.87.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -2182,7 +2182,7 @@
             <dependency>
                 <groupId>org.conscrypt</groupId>
                 <artifactId>conscrypt-openjdk-uber</artifactId>
-                <version>2.6.1</version>
+                <version>2.6.2</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
             <dependency>
                 <groupId>com.adobe.testing</groupId>
                 <artifactId>s3mock-testcontainers</artifactId>
-                <version>5.1.0</version>
+                <version>5.2.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-bom</artifactId>
-                <version>2025.0.6</version>
+                <version>2025.0.7</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2195,7 +2195,7 @@
             <dependency>
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
-                <version>3.32.0-GA</version>
+                <version>3.33.0-GA</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
         <dep.netty.version>4.2.17.Final</dep.netty.version>
         <dep.okhttp.version>5.5.0</dep.okhttp.version>
         <dep.okio.version>3.18.1</dep.okio.version>
-        <dep.parquet.version>1.17.1</dep.parquet.version>
+        <dep.parquet.version>1.18.0</dep.parquet.version>
         <dep.protobuf.version>4.35.1</dep.protobuf.version>
         <dep.sis.version>1.6</dep.sis.version>
         <dep.snowflake.version>4.3.3</dep.snowflake.version>

--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.53.2</version>
+                <version>2.54.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/testing/trino-server-dev/pom.xml
+++ b/testing/trino-server-dev/pom.xml
@@ -18,7 +18,7 @@
              restricted to the development server and are not shipped in the tarball.
              Keep dep.maven.version in sync with maven-model in the root pom. -->
         <dep.maven.version>3.9.16</dep.maven.version>
-        <dep.maven-resolver.version>2.0.21</dep.maven-resolver.version>
+        <dep.maven-resolver.version>2.0.22</dep.maven-resolver.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The update to Apache Parquet 1.18.0 changes NaN handling in floating point statistics
and column indexes. Trino keeps writing and interpreting statistics with the legacy
type-defined semantics (NaN invalidates min/max bounds), since Trino, Delta Lake, and
Iceberg treat NaN as larger than any other value and NaN-excluding bounds could cause
incorrect pruning. See `ParquetMetadataConverter#toTypeDefinedOrder` for details.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive, Iceberg, Delta Lake, Hudi connectors
* Skip writing min/max statistics for floating point Parquet columns that contain
  NaN values. ({issue}`30906`)
* Disable Parquet column index based page pruning on `DOUBLE` and `REAL` columns for
  files that do not declare NaN counts, which includes all files written by Apache
  Parquet before 1.18.0. ({issue}`30906`)
```
