### PR TITLE
Fix the Web UI authentication status endpoint incorrectly reporting JWT-authenticated requests as unauthenticated.

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ui/LoginResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/LoginResource.java
@@ -16,6 +16,7 @@ package io.trino.server.ui;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.inject.Inject;
 import io.trino.server.security.ResourceSecurity;
+import io.trino.spi.security.Identity;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
@@ -32,6 +33,7 @@ import jakarta.ws.rs.core.SecurityContext;
 import java.util.Optional;
 
 import static com.google.common.base.Strings.emptyToNull;
+import static io.trino.server.ServletSecurityUtils.authenticatedIdentity;
 import static io.trino.server.security.ResourceSecurity.AccessType.WEB_UI;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_AUTH_INFO;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_LOGIN_FORM;
@@ -59,7 +61,9 @@ public class LoginResource
     public AuthInfo getAuthInfo(@Context ContainerRequestContext request, @Context SecurityContext securityContext)
     {
         boolean isPasswordAllowed = formWebUiAuthenticationManager.isPasswordAllowed(securityContext.isSecure());
-        Optional<String> username = formWebUiAuthenticationManager.getAuthenticatedUsername(request);
+        Optional<String> username = authenticatedIdentity(request)
+                .map(Identity::getUser)
+                .or(() -> formWebUiAuthenticationManager.getAuthenticatedUsername(request));
         return new AuthInfo("form", isPasswordAllowed, username.isPresent(), username);
     }
 

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
@@ -650,6 +650,10 @@ public class TestWebUi
                     false);
             OkHttpClient clientWithCert = clientBuilder.build();
             testAlwaysAuthorized(httpServerInfo.getHttpsUri(), clientWithCert, nodeId);
+            assertThat(assertOk(clientWithCert, getLocation(httpServerInfo.getHttpsUri(), "/ui/auth/info")))
+                    .hasValueSatisfying(body -> assertThat(body).contains(
+                            "\"authenticated\":true",
+                            "\"username\":\"CN=PrestoTest, O=PrestoTest, L=Palo Alto, ST=California, C=US\""));
         }
     }
 
@@ -679,11 +683,16 @@ public class TestWebUi
                     .compact();
 
             OkHttpClient clientWithJwt = client.newBuilder()
+                    .addInterceptor(chain -> chain.proceed(chain.request().newBuilder()
+                            .header(AUTHORIZATION, "Bearer " + token)
+                            .build()))
                     .authenticator((_, response) -> response.request().newBuilder()
                             .header(AUTHORIZATION, "Bearer " + token)
                             .build())
                     .build();
             testAlwaysAuthorized(httpServerInfo.getHttpsUri(), clientWithJwt, nodeId);
+            assertThat(assertOk(clientWithJwt, getLocation(httpServerInfo.getHttpsUri(), "/ui/auth/info")))
+                    .hasValueSatisfying(body -> assertThat(body).contains("\"authenticated\":true", "\"username\":\"test-user\""));
         }
     }
 


### PR DESCRIPTION
## Description

  Fix the Web UI authentication status endpoint incorrectly reporting
  JWT-authenticated requests as unauthenticated.

  `LoginResource#getAuthInfo` previously determined the authenticated user solely
  from the form login cookie. Protocol authenticators such as JWT instead attach
  the authenticated `Identity` directly to the request.

  The endpoint now reads the request identity first and falls back to the form
  login cookie when no protocol-authenticated identity is available.

  This allows the new Web UI to recognize JWT-authenticated requests, including
  deployments where an authenticating reverse proxy sends the bearer token
  preemptively. Existing form authentication behavior remains unchanged.

  ## Additional context and related issues

  - Fixes #30910.

  The JWT Web UI test now:

  - Sends the bearer token preemptively, matching the behavior of an
    authenticating reverse proxy.
  - Verifies that `/ui/auth/info` reports the request as authenticated.
  - Verifies that the response contains the username from the JWT identity.

  This is separate from #30591, which concerns the form login endpoint changing
  in Trino 483.

  ## Release notes

  (x) Release notes are required, with the following suggested text:

  ```markdown
  ## Web UI
  * Fix the Web UI failing to recognize requests authenticated using JWT. ({issue}`30910`)
