### PR TITLE
Load compiled filter input blocks on first use

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/InputReferenceCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/InputReferenceCompiler.java
@@ -54,6 +54,7 @@ final class InputReferenceCompiler
             implements BytecodeNode
     {
         private final BytecodeBlock body;
+        private final Variable inputBlock;
         private final BytecodeExpression block;
         private final BytecodeExpression position;
         private final Variable valueBlock;
@@ -68,6 +69,7 @@ final class InputReferenceCompiler
                 callType = Object.class;
             }
 
+            Variable inputBlock = scope.createTempVariable(Block.class);
             Variable valueBlock = scope.createTempVariable(ValueBlock.class);
             Variable valuePosition = scope.createTempVariable(int.class);
 
@@ -93,6 +95,7 @@ final class InputReferenceCompiler
             }
             ifStatement.ifFalse(value);
 
+            this.inputBlock = inputBlock;
             this.block = block;
             this.position = position;
             this.valueBlock = valueBlock;
@@ -129,8 +132,9 @@ final class InputReferenceCompiler
         private BytecodeBlock loadValueBlockAndPosition()
         {
             return new BytecodeBlock()
-                    .append(valueBlock.set(block.invoke("getUnderlyingValueBlock", ValueBlock.class)))
-                    .append(valuePosition.set(block.invoke("getUnderlyingValuePosition", int.class, position)));
+                    .append(inputBlock.set(block))
+                    .append(valueBlock.set(inputBlock.invoke("getUnderlyingValueBlock", ValueBlock.class)))
+                    .append(valuePosition.set(inputBlock.invoke("getUnderlyingValuePosition", int.class, position)));
         }
 
         public BytecodeExpression valueBlockPositionIsNull()

--- a/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/PageFunctionCompiler.java
@@ -29,7 +29,6 @@ import io.airlift.bytecode.Scope;
 import io.airlift.bytecode.Variable;
 import io.airlift.bytecode.control.ForLoop;
 import io.airlift.bytecode.control.IfStatement;
-import io.airlift.bytecode.expression.BytecodeExpression;
 import io.trino.cache.CacheStatsMBean;
 import io.trino.cache.NonEvictableCache;
 import io.trino.metadata.FunctionManager;
@@ -583,14 +582,12 @@ public class PageFunctionCompiler
         Scope scope = method.getScope();
         BytecodeBlock body = method.getBody();
 
-        declareBlockVariables(filter, compactLayout, page, scope, body);
-
         Variable wasNullVariable = scope.declareVariable("wasNull", body, constantFalse());
         ExpressionBytecodeCompiler compiler = new ExpressionBytecodeCompiler(
                 classDefinition,
                 callSiteBinder,
                 cachedInstanceBinder,
-                fieldReferenceCompiler(typeManager.getTypeOperators(), compactLayout, callSiteBinder, scope),
+                fieldReferenceCompiler(typeManager.getTypeOperators(), compactLayout, callSiteBinder),
                 functionManager,
                 metadata,
                 typeManager,
@@ -604,13 +601,6 @@ public class PageFunctionCompiler
                 .putVariable(result)
                 .append(and(not(wasNullVariable), result).ret());
         return method;
-    }
-
-    private static void declareBlockVariables(Expression expression, Map<Symbol, Integer> compactLayout, Parameter page, Scope scope, BytecodeBlock body)
-    {
-        for (int channel : getInputChannels(expression, compactLayout)) {
-            scope.declareVariable("block_" + channel, body, page.invoke("getBlock", Block.class, constantInt(channel)));
-        }
     }
 
     private static Set<Integer> getInputChannels(Expression expression, Map<Symbol, Integer> compactLayout)
@@ -648,20 +638,17 @@ public class PageFunctionCompiler
         };
     }
 
-    private static BiFunction<Reference, Scope, BytecodeNode> fieldReferenceCompiler(TypeOperators typeOperators, Map<Symbol, Integer> compactLayout, CallSiteBinder callSiteBinder, Scope filterScope)
+    private static BiFunction<Reference, Scope, BytecodeNode> fieldReferenceCompiler(TypeOperators typeOperators, Map<Symbol, Integer> compactLayout, CallSiteBinder callSiteBinder)
     {
         return (reference, scope) -> {
             int field = compactLayout.get(Symbol.from(reference));
-            // Scope identity distinguishes the filter method from generated helpers, which cannot access block variables.
-            BytecodeExpression block = scope == filterScope
-                    ? scope.getVariable("block_" + field)
-                    : scope.getVariable("page").invoke("getBlock", Block.class, constantInt(field));
+            // Reads through SourcePage.getBlock at each use site so channels skipped by short-circuit evaluation are never loaded
             return generateInputReference(
                     typeOperators,
                     callSiteBinder,
                     scope,
                     reference.type(),
-                    block,
+                    scope.getVariable("page").invoke("getBlock", Block.class, constantInt(field)),
                     scope.getVariable("position"));
         };
     }

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestPageFunctionCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestPageFunctionCompiler.java
@@ -25,6 +25,7 @@ import io.trino.metadata.InternalFunctionBundle;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.SqlScalarFunction;
 import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.TestingSourcePage;
 import io.trino.operator.project.PageFilter;
 import io.trino.operator.project.PageProjection;
 import io.trino.operator.project.SelectedPositions;
@@ -60,6 +61,7 @@ import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.FieldReference;
 import io.trino.sql.ir.Lambda;
+import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.ir.Row;
 import io.trino.sql.planner.Symbol;
@@ -544,6 +546,56 @@ public class TestPageFunctionCompiler
                 assertThat(BIGINT.getLong(block, position)).isEqualTo(expected[position]);
             }
         }
+    }
+
+    @Test
+    public void testShortCircuitAndFilterSkipsChannelLoad()
+    {
+        Expression filter = new Logical(
+                Logical.Operator.AND,
+                ImmutableList.of(
+                        comparison(GREATER_THAN, new Reference(BIGINT, "$col_0"), new Constant(BIGINT, 100L)),
+                        comparison(GREATER_THAN, new Reference(BIGINT, "$col_1"), new Constant(BIGINT, 100L))));
+        Map<Symbol, Integer> layout = ImmutableMap.of(
+                new Symbol(BIGINT, "$col_0"), 0,
+                new Symbol(BIGINT, "$col_1"), 1);
+        PageFilter compiled = FUNCTION_RESOLUTION.getPageFunctionCompiler()
+                .compileFilter(filter, layout, SQL_STANDARD, Optional.empty())
+                .get();
+
+        TestingSourcePage allRejected = new TestingSourcePage(3, createLongsBlock(1L, 2L, 3L), createLongsBlock(200L, 201L, 202L));
+        assertThat(compiled.filter(SESSION, compiled.getInputChannels().getInputChannels(allRejected)).size()).isEqualTo(0);
+        assertThat(allRejected.wasLoaded(0)).isTrue();
+        assertThat(allRejected.wasLoaded(1)).isFalse();
+
+        TestingSourcePage someAccepted = new TestingSourcePage(3, createLongsBlock(1L, 200L, 3L), createLongsBlock(200L, 201L, 202L));
+        assertThat(compiled.filter(SESSION, compiled.getInputChannels().getInputChannels(someAccepted)).size()).isEqualTo(1);
+        assertThat(someAccepted.wasLoaded(1)).isTrue();
+    }
+
+    @Test
+    public void testShortCircuitOrFilterSkipsChannelLoad()
+    {
+        Expression filter = new Logical(
+                Logical.Operator.OR,
+                ImmutableList.of(
+                        comparison(GREATER_THAN, new Reference(BIGINT, "$col_0"), new Constant(BIGINT, 100L)),
+                        comparison(GREATER_THAN, new Reference(BIGINT, "$col_1"), new Constant(BIGINT, 100L))));
+        Map<Symbol, Integer> layout = ImmutableMap.of(
+                new Symbol(BIGINT, "$col_0"), 0,
+                new Symbol(BIGINT, "$col_1"), 1);
+        PageFilter compiled = FUNCTION_RESOLUTION.getPageFunctionCompiler()
+                .compileFilter(filter, layout, SQL_STANDARD, Optional.empty())
+                .get();
+
+        TestingSourcePage allAccepted = new TestingSourcePage(3, createLongsBlock(101L, 102L, 103L), createLongsBlock(1L, 2L, 3L));
+        assertThat(compiled.filter(SESSION, compiled.getInputChannels().getInputChannels(allAccepted)).size()).isEqualTo(3);
+        assertThat(allAccepted.wasLoaded(0)).isTrue();
+        assertThat(allAccepted.wasLoaded(1)).isFalse();
+
+        TestingSourcePage someRejected = new TestingSourcePage(3, createLongsBlock(101L, 2L, 103L), createLongsBlock(1L, 2L, 3L));
+        assertThat(compiled.filter(SESSION, compiled.getInputChannels().getInputChannels(someRejected)).size()).isEqualTo(2);
+        assertThat(someRejected.wasLoaded(1)).isTrue();
     }
 
     private static Page createLongBlockPage(long... values)


### PR DESCRIPTION
## Description

Compiled row-wise filters loaded every referenced channel up front, so `SourcePage.getBlock` read columns referenced only by later `AND` conjuncts even when earlier conjuncts rejected every row. Field references now read through `SourcePage.getBlock` at each use site, so a channel is loaded only when a conjunct actually evaluates it. Physical input for the repro in the linked issue drops from 46MB to 80KB, matching pre-475 behavior.

## Additional context and related issues

* Fixes #30909

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Avoid reading columns that are not needed to evaluate a filter due to short-circuiting of `AND` conditions. ({issue}`30909`)
```
