### PR TITLE
Update protobuf to 4.36.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <dep.okhttp.version>5.5.0</dep.okhttp.version>
         <dep.okio.version>3.18.1</dep.okio.version>
         <dep.parquet.version>1.18.0</dep.parquet.version>
-        <dep.protobuf.version>4.35.1</dep.protobuf.version>
+        <dep.protobuf.version>4.36.0</dep.protobuf.version>
         <dep.sis.version>1.6</dep.sis.version>
         <dep.snowflake.version>4.3.3</dep.snowflake.version>
         <dep.swagger.version>2.2.54</dep.swagger.version>


### PR DESCRIPTION
> With this release JavaProto no longer uses sun.misc.Unsafe as long as you are utilizing the standard generated code. You should no longer see warnings printed about sun.misc.Unsafe. If you see any issues, please let us know on https://github.com/protocolbuffers/protobuf/issues/20760

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
