### PR TITLE
Clarify Iceberg add_files docs

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -712,11 +712,13 @@ nested directories, or `false` to ignore them.
 #### Add files
 
 The connector can add files from tables or locations to an existing Iceberg
-table if `iceberg.add-files-procedure.enabled` is set to `true` for the catalog.
+table.
 
 Use the procedure `add_files_from_table` to add existing files from a Hive table
 in the current catalog, or `add_files` to add existing files from a specified
-location, to an existing Iceberg table.
+location, to an existing Iceberg table. The `add_files_from_table` procedure is
+always available; `add_files` procedure additionally requires
+`iceberg.add-files-procedure.enabled` to be set to `true`.
  
 The data files must be the Parquet, ORC, or Avro file format.
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Clarify Iceberg add_files docs that add_files_from_table is always available regardless of catalog option `iceberg.add-files-procedure.enabled` value. 


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

`addFilesProcedureEnabled` only blocks add_files
- https://github.com/trinodb/trino/blob/master/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java#L1881

and not add_files_from_table
- https://github.com/trinodb/trino/blob/master/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java#L1921


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
