### PR TITLE
Preserve conjunct order under unsafe pushdown

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -951,7 +951,8 @@ public class PredicatePushDown
                     if (!isDeterministic(conjunct)) {
                         nonDeterministic.add(conjunct);
                     }
-                    else if (mayFail(plannerContext, getCharVarcharCoercion(session), conjunct)) {
+                    // Unsafe pushdown keeps may-fail conjuncts in their original position
+                    else if (!allowUnsafePushdown && mayFail(plannerContext, getCharVarcharCoercion(session), conjunct)) {
                         mayFail.add(conjunct);
                     }
                     else if (isInferenceCandidate(plannerContext, getCharVarcharCoercion(session), conjunct)) {
@@ -1045,7 +1046,7 @@ public class PredicatePushDown
             boolean doNotPush = !combineConjuncts(joinConjuncts.build()).equals(TRUE);
             // attempt to push down the predicates that may fail
             for (Expression conjunct : mayFail) {
-                if (doNotPush && !allowUnsafePushdown) {
+                if (doNotPush) {
                     joinConjuncts.add(allInference.rewrite(conjunct, Sets.union(leftScope, rightScope)));
                 }
                 else {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHivePlans.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHivePlans.java
@@ -25,6 +25,7 @@ import io.trino.plugin.hive.TestingHiveConnectorFactory;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.security.PrincipalType;
 import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Cast;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.In;
 import io.trino.sql.ir.IrExpressions;
@@ -48,6 +49,7 @@ import java.util.Optional;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.trino.SystemSessionProperties.ALLOW_UNSAFE_PUSHDOWN;
 import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.trino.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static io.trino.SystemSessionProperties.getCharVarcharCoercion;
@@ -58,6 +60,7 @@ import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.ComparisonOperator.EQUAL;
+import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN_OR_EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.NOT_EQUAL;
 import static io.trino.sql.ir.Logical.Operator.AND;
 import static io.trino.sql.ir.TestingIr.comparison;
@@ -332,6 +335,63 @@ public class TestHivePlans
                                                 exchange(REMOTE,
                                                         REPLICATE,
                                                         tableScan("table_unpartitioned", Map.of("R_STR_COL", "str_col", "R_INT_COL", "int_col"))))))));
+    }
+
+    @Test
+    public void testUnsafePushdownPreservesConjunctOrder()
+    {
+        // Unsafe pushdown places may-fail conjuncts below the join in their written position.
+        Session unsafePushdown = Session.builder(noJoinReordering())
+                .setSystemProperty(ALLOW_UNSAFE_PUSHDOWN, "true")
+                .build();
+        assertDistributedPlan(
+                "SELECT l.str_col FROM table_unpartitioned l JOIN table_unpartitioned r ON l.int_col = r.int_col " +
+                        "WHERE l.int_col % l.int_col >= 0 AND l.str_col LIKE '%t%'",
+                unsafePushdown,
+                output(
+                        join(INNER, builder -> builder
+                                .equiCriteria("L_INT_COL", "R_INT_COL")
+                                .left(
+                                        exchange(REMOTE, REPARTITION,
+                                                filter(
+                                                        new Logical(AND, ImmutableList.of(
+                                                                comparison(GREATER_THAN_OR_EQUAL, new Call(MODULO_INTEGER, ImmutableList.of(new Reference(INTEGER, "L_INT_COL"), new Reference(INTEGER, "L_INT_COL"))), new Constant(INTEGER, 0L)),
+                                                                new Call(LIKE, ImmutableList.of(new Reference(createVarcharType(5), "L_STR_COL"), new Constant(LIKE_PATTERN, LikePattern.compile("%t%", Optional.empty())))))),
+                                                        tableScan("table_unpartitioned", Map.of("L_STR_COL", "str_col", "L_INT_COL", "int_col")))))
+                                .right(
+                                        exchange(LOCAL,
+                                                exchange(REMOTE, REPARTITION,
+                                                        filter(
+                                                                comparison(GREATER_THAN_OR_EQUAL, new Call(MODULO_INTEGER, ImmutableList.of(new Reference(INTEGER, "R_INT_COL"), new Reference(INTEGER, "R_INT_COL"))), new Constant(INTEGER, 0L)),
+                                                                tableScan("table_unpartitioned", Map.of("R_INT_COL", "int_col")))))))));
+    }
+
+    @Test
+    public void testUnsafePushdownMayFailEqualityJoinsInference()
+    {
+        // A may-fail equality feeds equality inference, so the left filter holds a derived equality.
+        Session unsafePushdown = Session.builder(noJoinReordering())
+                .setSystemProperty(ALLOW_UNSAFE_PUSHDOWN, "true")
+                .build();
+        assertDistributedPlan(
+                "SELECT l.str_col FROM table_unpartitioned l JOIN table_unpartitioned r ON l.int_col = r.int_col " +
+                        "WHERE CAST(l.str_col AS integer) = r.int_col AND l.str_col LIKE '%t%'",
+                unsafePushdown,
+                output(
+                        join(INNER, builder -> builder
+                                .equiCriteria("L_INT_COL", "R_INT_COL")
+                                .left(
+                                        exchange(REMOTE, REPARTITION,
+                                                filter(
+                                                        new Logical(AND, ImmutableList.of(
+                                                                comparison(EQUAL, new Cast(new Reference(createVarcharType(5), "L_STR_COL"), INTEGER), new Reference(INTEGER, "L_INT_COL")),
+                                                                new Call(LIKE, ImmutableList.of(new Reference(createVarcharType(5), "L_STR_COL"), new Constant(LIKE_PATTERN, LikePattern.compile("%t%", Optional.empty())))))),
+                                                        tableScan("table_unpartitioned", Map.of("L_STR_COL", "str_col", "L_INT_COL", "int_col")))))
+                                .right(
+                                        exchange(LOCAL,
+                                                exchange(REMOTE,
+                                                        REPARTITION,
+                                                        tableScan("table_unpartitioned", Map.of("R_INT_COL", "int_col"))))))));
     }
 
     // Disable join ordering so that expected plans are well defined.


### PR DESCRIPTION
## Description

`optimizer.allow-unsafe-pushdown` (e09938378ba) is a temporary escape hatch to restore the pre-445 pushdown behavior for predicates that may fail. It only restores half of it: may-fail conjuncts are pushed below the join again, but they are appended after all never-failing conjuncts rather than keeping their original position.

Since compiled row-wise filters read their input columns at first use (#30912), conjunct order determines physical input. For the common shape

```sql
SELECT ...
FROM t JOIN d ON t.user_id = d.user_id
WHERE may_fail_parse(t.event_time) BETWEEN ...  -- selective, may fail
  AND t.wide_col LIKE '%needle%'               -- expensive, never fails
```

the `LIKE` runs first and loads the wide column for every batch, even though the window would have rejected nearly all rows. On a 15000-row table with a ~5 KB wide column and `allow_unsafe_pushdown=true`, physical input is 46,117,976 B before this change and 84,820 B after (~540x). The same query without a join reads 50,572 B.

With the flag enabled, may-fail conjuncts now skip the quarantine in `PredicatePushDown#processInnerJoin` and are classified alongside the rest, which is the pre-445 behavior the flag is documented to restore. Comparison-shaped conjuncts keep their written position, and equality-shaped ones become inference candidates again, so they can be re-emitted as derived scope and straddling equalities.

- Fixes #30917

## Additional context and related issues

Follow-up to #30909 / #30912: filter input columns load at use sites, which makes conjunct order determine physical reads. Related to the `// TODO: remove once #22268 is fixed` note on `optimizer.allow-unsafe-pushdown`.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix excessive data reads for joins with a filter that can fail when `optimizer.allow-unsafe-pushdown` is enabled. ({issue}`30917`)
```
