### PR TITLE
Allow NUMERIC as an alias for DECIMAL

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
@@ -161,6 +161,7 @@ public final class TypeRegistry
         addParametricType(VarcharParametricType.VARCHAR);
         addParametricType(CharParametricType.CHAR);
         addParametricType(DecimalParametricType.DECIMAL);
+        addParametricType(DecimalParametricType.NUMERIC);
         addParametricType(ROW);
         addParametricType(ARRAY);
         addParametricType(MAP);

--- a/core/trino-main/src/main/java/io/trino/type/DecimalParametricType.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalParametricType.java
@@ -22,15 +22,25 @@ import io.trino.spi.type.TypeParameter;
 
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
+
 public class DecimalParametricType
         implements ParametricType
 {
-    public static final DecimalParametricType DECIMAL = new DecimalParametricType();
+    public static final DecimalParametricType DECIMAL = new DecimalParametricType(StandardTypes.DECIMAL);
+    public static final DecimalParametricType NUMERIC = new DecimalParametricType("numeric");
+
+    private final String name;
+
+    private DecimalParametricType(String name)
+    {
+        this.name = requireNonNull(name, "name is null");
+    }
 
     @Override
     public String getName()
     {
-        return StandardTypes.DECIMAL;
+        return name;
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestTypeOfFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestTypeOfFunction.java
@@ -71,9 +71,13 @@ public class TestTypeOfFunction
                 .isEqualTo("varchar(10)");
         assertThat(assertions.function("typeof", "CAST(NULL AS DECIMAL(5,1))"))
                 .isEqualTo("decimal(5,1)");
+        assertThat(assertions.function("typeof", "CAST(NULL AS NUMERIC(5,1))"))
+                .isEqualTo("decimal(5,1)");
         assertThat(assertions.function("typeof", "CAST(NULL AS DECIMAL(1))"))
                 .isEqualTo("decimal(1,0)");
         assertThat(assertions.function("typeof", "CAST(NULL AS DECIMAL)"))
+                .isEqualTo("decimal(38,0)");
+        assertThat(assertions.function("typeof", "CAST(NULL AS NUMERIC)"))
                 .isEqualTo("decimal(38,0)");
         assertThat(assertions.function("typeof", "CAST(NULL AS ARRAY(INTEGER))"))
                 .isEqualTo("array(integer)");

--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalParametricType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalParametricType.java
@@ -169,4 +169,37 @@ public class TestDecimalParametricType
                 .binding("a", "0").evaluate())
                 .hasMessage("DECIMAL precision must be in range [1, 38]: 0");
     }
+
+    @Test
+    public void numericIsAnAliasForDecimal()
+    {
+        assertThat(assertions.expression("cast(a as NUMERIC(2, 0))")
+                .binding("a", "1"))
+                .isEqualTo(decimal("01", createDecimalType(2, 0)));
+
+        assertThat(assertions.expression("cast(a as NUMERIC(2))")
+                .binding("a", "1"))
+                .isEqualTo(decimal("01", createDecimalType(2)));
+
+        assertThat(assertions.expression("cast(a as NUMERIC)")
+                .binding("a", "1"))
+                .isEqualTo(decimal("1", createDecimalType(38)));
+
+        assertThat(assertions.function("typeof", "CAST(NULL AS NUMERIC(5,1))"))
+                .isEqualTo("decimal(5,1)");
+        assertThat(assertions.function("typeof", "CAST(NULL AS NUMERIC)"))
+                .isEqualTo("decimal(38,0)");
+    }
+
+    @Test
+    public void numericRejectsInvalidPrecisionAndScale()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as NUMERIC(1,2))")
+                .binding("a", "1").evaluate())
+                .hasMessage("DECIMAL scale must be in range [0, precision (1)]: 2");
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(a as NUMERIC(0))")
+                .binding("a", "1").evaluate())
+                .hasMessage("DECIMAL precision must be in range [1, 38]: 0");
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestTypeRegistry.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTypeRegistry.java
@@ -20,6 +20,7 @@ import io.trino.spi.type.TypeNotFoundException;
 import io.trino.spi.type.TypeOperators;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestTypeRegistry
@@ -38,5 +39,15 @@ public class TestTypeRegistry
     public void testOperatorsImplemented()
     {
         typeRegistry.verifyTypes();
+    }
+
+    @Test
+    public void testNumericIsAliasForDecimal()
+    {
+        assertThat(typeRegistry.isTypeRegistered("numeric")).isTrue();
+        assertThat(typeRegistry.fromSqlType("numeric(10, 2)"))
+                .isEqualTo(typeRegistry.fromSqlType("decimal(10, 2)"));
+        assertThat(typeRegistry.fromSqlType("NUMERIC"))
+                .isEqualTo(typeRegistry.fromSqlType("DECIMAL"));
     }
 }

--- a/docs/src/main/sphinx/language/types.md
+++ b/docs/src/main/sphinx/language/types.md
@@ -152,7 +152,7 @@ Example literals: `NUMBER '10.3'`, `NUMBER '1234567890'`,
 ## Exact numeric
 
 Exact numeric values can be expressed as numeric literals such as `1.1`, and
-are supported by the `DECIMAL` data type.
+are supported by the `DECIMAL` and `NUMERIC` data types.
 
 Underscore characters are ignored within literal values, and can be used to
 increase readability. For example, decimal `123_456.789_123` is equivalent to
@@ -162,17 +162,18 @@ underscores, and underscores beside the comma (`.`) are not permitted.
 Leading zeros in literal values are permitted and ignored. For example,
 `000123.456` is equivalent to `123.456`.
 
-### `DECIMAL`
+### `DECIMAL` or `NUMERIC`
 
 A exact decimal number. Precision up to 38 digits is supported but performance
-is best up to 18 digits.
+is best up to 18 digits. The names `DECIMAL` and `NUMERIC` can both be used for
+this type. Declared columns and `CAST` results still report `decimal(p, s)`.
 
 The decimal type takes two literal parameters:
 
 - **precision** - total number of digits
 - **scale** - number of digits in fractional part. Scale is optional and defaults to 0.
 
-Example type definitions: `DECIMAL(10,3)`, `DECIMAL(20)`
+Example type definitions: `DECIMAL(10,3)`, `NUMERIC(10,3)`, `DECIMAL(20)`
 
 Example literals: `DECIMAL '10.3'`, `DECIMAL '1234567890'`, `1.1`
 


### PR DESCRIPTION
## Description

Accept `NUMERIC` and `NUMERIC(p, s)` as aliases for `DECIMAL` / `DECIMAL(p, s)` in type names, including `CREATE TABLE` and `CAST`. The resolved type remains `decimal(p, s)`.

* Fixes #28031

## Additional context and related issues

`NUMERIC` is registered as a second name on the existing decimal parametric type, the same way `INT` aliases `INTEGER`. Invalid precision and scale still use the decimal constructor checks.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Allow `NUMERIC` as an alias for `DECIMAL`. ({issue}`28031`)
```