### PR TITLE
Add retry policy for listing tables in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -103,6 +103,12 @@ public class BigQueryClient
             .onRetry(event -> log.debug("Getting destination table failed, retrying: %s", event.getLastException()))
             .handleIf(BigQueryUtil::isRetryable)
             .build();
+    private static final RetryPolicy<Object> LISTING_TABLES_RETRY_POLICY = RetryPolicy.builder()
+            .withMaxRetries(3)
+            .withBackoff(100, 2000, ChronoUnit.MILLIS)
+            .onRetry(event -> log.debug("Listing tables failed, retrying: %s", event.getLastException()))
+            .handleIf(e -> e instanceof BigQueryException exception && exception.getCode() == 503)
+            .build();
 
     // BigQuery has different table_type in `INFORMATION_SCHEMA` than API responses that returns TableDefinition.Type
     // see https://cloud.google.com/bigquery/docs/information-schema-tables#schema
@@ -400,7 +406,8 @@ public class BigQueryClient
         // BigQuery.listTables returns partial information on each table. See javadoc for more details.
         Iterable<Table> allTables;
         try {
-            allTables = bigQuery.listTables(remoteDatasetId, BigQuery.TableListOption.pageSize(metadataPageSize)).iterateAll();
+            allTables = Failsafe.with(LISTING_TABLES_RETRY_POLICY)
+                    .get(() -> bigQuery.listTables(remoteDatasetId, BigQuery.TableListOption.pageSize(metadataPageSize)).iterateAll());
         }
         catch (BigQueryException e) {
             throw new TrinoException(BIGQUERY_LISTING_TABLE_ERROR, "Failed to retrieve tables from BigQuery", e);


### PR DESCRIPTION
## Description

```
[ERROR] io.trino.plugin.bigquery.TestBigQueryAvroConnectorTest.testSelectInformationSchemaTables -- Time elapsed: 47.66 s <<< FAILURE!
2026-08-27T01:21:42.495-0600	INFO	main	io.trino.testing.containers.junit.ReportLeakedContainers	DockerClientFactory not initialized, so there should be no leaked containers, skipping the check
java.lang.AssertionError: Execution of 'actual' query 20260827_071547_01190_s3aw9 failed: SELECT DISTINCT table_name FROM information_schema.tables WHERE table_schema = 'information_schema' OR rand() = 42 ORDER BY 1
	at io.trino.testing.QueryAssertions.assertDistributedQuery(QueryAssertions.java:303)
	at io.trino.testing.QueryAssertions.assertQuery(QueryAssertions.java:191)
	at io.trino.testing.QueryAssertions.assertQuery(QueryAssertions.java:164)
	at io.trino.testing.AbstractTestQueryFramework.assertQuery(AbstractTestQueryFramework.java:359)
	at io.trino.testing.BaseConnectorTest.testSelectInformationSchemaTables(BaseConnectorTest.java:2497)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.tryRemoveAndExec(ForkJoinPool.java:1490)
	at java.base/java.util.concurrent.ForkJoinPool.helpJoin(ForkJoinPool.java:2248)
	at java.base/java.util.concurrent.ForkJoinTask.awaitDone(ForkJoinTask.java:499)
	at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:669)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:511)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1450)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2019)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: io.trino.testing.QueryFailedException: Error listing tables for catalog bigquery: io.trino.spi.TrinoException: Failed to retrieve tables from BigQuery
	at io.trino.testing.AbstractTestingTrinoClient.execute(AbstractTestingTrinoClient.java:138)
	at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:669)
	at io.trino.testing.DistributedQueryRunner.executeWithQueryId(DistributedQueryRunner.java:658)
	at io.trino.testing.QueryAssertions.assertDistributedQuery(QueryAssertions.java:294)
	... 14 more
	Suppressed: java.lang.Exception: SQL: SELECT DISTINCT table_name FROM information_schema.tables WHERE table_schema = 'information_schema' OR rand() = 42 ORDER BY 1
		at io.trino.testing.DistributedQueryRunner.executeInternal(DistributedQueryRunner.java:676)
		... 16 more
Caused by: io.trino.spi.TrinoException: Error listing tables for catalog bigquery: io.trino.spi.TrinoException: Failed to retrieve tables from BigQuery
	at io.trino.metadata.MetadataListing.handleListingException(MetadataListing.java:375)
	at io.trino.metadata.MetadataListing.listTables(MetadataListing.java:139)
	at io.trino.connector.informationschema.InformationSchemaPageSource.addTablesRecords(InformationSchemaPageSource.java:284)
	at io.trino.connector.informationschema.InformationSchemaPageSource.buildPages(InformationSchemaPageSource.java:213)
	at io.trino.connector.informationschema.InformationSchemaPageSource.getNextSourcePage(InformationSchemaPageSource.java:177)
	at io.trino.operator.ScanFilterAndProjectOperator$ConnectorPageSourceToPages.process(ScanFilterAndProjectOperator.java:330)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:423)
	at io.trino.operator.WorkProcessorUtils.getNextState(WorkProcessorUtils.java:261)
	at io.trino.operator.WorkProcessorUtils$YieldingProcess.process(WorkProcessorUtils.java:181)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:423)
	at io.trino.operator.WorkProcessorUtils$3.process(WorkProcessorUtils.java:346)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:423)
	at io.trino.operator.WorkProcessorUtils$3.process(WorkProcessorUtils.java:346)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:423)
	at io.trino.operator.WorkProcessorUtils$3.process(WorkProcessorUtils.java:346)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:423)
	at io.trino.operator.WorkProcessorUtils.getNextState(WorkProcessorUtils.java:261)
	at io.trino.operator.WorkProcessorUtils$BlockingProcess.process(WorkProcessorUtils.java:207)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:423)
	at io.trino.operator.WorkProcessorUtils.lambda$flatten$0(WorkProcessorUtils.java:317)
	at io.trino.operator.WorkProcessorUtils$3.process(WorkProcessorUtils.java:359)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:423)
	at io.trino.operator.WorkProcessorUtils.getNextState(WorkProcessorUtils.java:261)
	at io.trino.operator.WorkProcessorUtils.lambda$processStateMonitor$0(WorkProcessorUtils.java:240)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:423)
	at io.trino.operator.WorkProcessorUtils.getNextState(WorkProcessorUtils.java:261)
	at io.trino.operator.WorkProcessorUtils.lambda$finishWhen$0(WorkProcessorUtils.java:255)
	at io.trino.operator.WorkProcessorUtils$ProcessWorkProcessor.process(WorkProcessorUtils.java:423)
	at io.trino.operator.WorkProcessorSourceOperatorAdapter.getOutput(WorkProcessorSourceOperatorAdapter.java:125)
	at io.trino.operator.OutputValidatingSourceOperator.getOutput(OutputValidatingSourceOperator.java:70)
	at io.trino.operator.Driver.processInternal(Driver.java:400)
	at io.trino.operator.Driver.lambda$process$0(Driver.java:303)
	at io.trino.operator.Driver.tryWithLock(Driver.java:706)
	at io.trino.operator.Driver.process(Driver.java:295)
	at io.trino.operator.Driver.processForDuration(Driver.java:266)
	at io.trino.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:854)
	at io.trino.execution.executor.timesharing.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:189)
	at io.trino.execution.executor.timesharing.TimeSharingTaskExecutor$TaskRunner.run(TimeSharingTaskExecutor.java:651)
	at io.trino.$gen.Trino_testversion____20260827_065747_1.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: java.lang.RuntimeException: io.trino.spi.TrinoException: Failed to retrieve tables from BigQuery
	at io.trino.plugin.bigquery.BigQueryMetadata.processInParallel(BigQueryMetadata.java:503)
	at io.trino.plugin.bigquery.BigQueryMetadata.listTables(BigQueryMetadata.java:254)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.listTables(ClassLoaderSafeConnectorMetadata.java:315)
	at io.trino.tracing.TracingConnectorMetadata.listTables(TracingConnectorMetadata.java:282)
	at io.trino.metadata.MetadataManager.listTables(MetadataManager.java:604)
	at io.trino.tracing.TracingMetadata.listTables(TracingMetadata.java:352)
	at io.trino.metadata.MetadataListing.doListTables(MetadataListing.java:145)
	at io.trino.metadata.MetadataListing.listTables(MetadataListing.java:136)
	... 40 more
Caused by: io.trino.spi.TrinoException: Failed to retrieve tables from BigQuery
	at io.trino.plugin.bigquery.BigQueryClient.listTableIds(BigQueryClient.java:406)
	at io.trino.plugin.bigquery.BigQueryMetadata.listTablesInRemoteSchema(BigQueryMetadata.java:262)
	at io.trino.plugin.bigquery.BigQueryMetadata.lambda$listTables$1(BigQueryMetadata.java:254)
	at io.trino.plugin.bigquery.BigQueryMetadata.lambda$processInParallel$1(BigQueryMetadata.java:493)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
	... 3 more
Caused by: com.google.cloud.bigquery.BigQueryException: Error encountered during execution. Retrying may solve the problem.
	at com.google.cloud.bigquery.BigQueryRetryHelper.runWithRetries(BigQueryRetryHelper.java:71)
	at com.google.cloud.bigquery.BigQueryImpl.listTables(BigQueryImpl.java:1451)
	at com.google.cloud.bigquery.BigQueryImpl.listTables(BigQueryImpl.java:1305)
	at io.trino.plugin.bigquery.BigQueryClient.listTableIds(BigQueryClient.java:403)
	... 9 more
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 503 Service Unavailable
GET https://bigquery.googleapis.com/bigquery/v2/projects/sep-bq-cicd/datasets/test/tables?maxResults=1000&prettyPrint=false
{
  "code": 503,
  "errors": [
    {
      "domain": "global",
      "message": "Error encountered during execution. Retrying may solve the problem.",
      "reason": "backendError"
    }
  ],
  "message": "Error encountered during execution. Retrying may solve the problem.",
  "status": "UNAVAILABLE"
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:145)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:118)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:37)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$3.interceptResponse(AbstractGoogleClientRequest.java:479)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1111)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:565)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:506)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:616)
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.listTablesSkipExceptionTranslation(HttpBigQueryRpc.java:739)
	at com.google.cloud.bigquery.BigQueryImpl$21.call(BigQueryImpl.java:1459)
	at com.google.cloud.bigquery.BigQueryImpl$21.call(BigQueryImpl.java:1453)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:102)
	at com.google.cloud.bigquery.BigQueryRetryHelper.run(BigQueryRetryHelper.java:108)
	at com.google.cloud.bigquery.BigQueryRetryHelper.runWithRetries(BigQueryRetryHelper.java:62)
	... 12 more
```
