### PR TITLE
Fix typo in partition_projection_interval_unit description

### DIFF
--- a/docs/src/main/sphinx/connector/hive.md
+++ b/docs/src/main/sphinx/connector/hive.md
@@ -1209,7 +1209,7 @@ SELECT * FROM example.web."page_views$partitions";
     [projection.${columnName}.format](https://docs.aws.amazon.com/athena/latest/ug/partition-projection-supported-types.html).
   -
 * - `partition_projection_interval_unit`
-  - Used with `partition_projection_type=DATA`. The date column projection range
+  - Used with `partition_projection_type` set to `DATE`. The date column projection range
     interval unit given in `partition_projection_interval`. Mapped from the AWS
     Athena table property
     [projection.${columnName}.interval.unit](https://docs.aws.amazon.com/athena/latest/ug/partition-projection-supported-types.html).


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

This PR fixes a small typo in the documentation.

`partition_projection_type=DATA` is clearly a typo. `DATA` should be `DATE` or more realistic syntax is:

https://github.com/trinodb/trino/blob/662c8b45d56b15cbe5b733ea2095bb84f4ecd07d/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveS3AndGlueTest.java#L338-L345

I followed the previous items rather than `partition_projection_type='date'` syntax.

https://github.com/trinodb/trino/blob/662c8b45d56b15cbe5b733ea2095bb84f4ecd07d/docs/src/main/sphinx/connector/hive.md?plain=1#L1203-L1209


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

