### PR TITLE
Core, Iceberg: Classify Iceberg commit conflicts as TRANSACTION_CONFLICT

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -400,6 +400,7 @@ import static io.trino.spi.StandardErrorCode.PERMISSION_DENIED;
 import static io.trino.spi.StandardErrorCode.QUERY_REJECTED;
 import static io.trino.spi.StandardErrorCode.TABLE_ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
+import static io.trino.spi.StandardErrorCode.TRANSACTION_CONFLICT;
 import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
 import static io.trino.spi.connector.MaterializedViewFreshness.Freshness.FRESH;
 import static io.trino.spi.connector.MaterializedViewFreshness.Freshness.FRESH_WITHIN_GRACE_PERIOD;
@@ -2238,7 +2239,10 @@ public class IcebergMetadata
         try {
             transaction.commitTransaction();
         }
-        catch (UncheckedIOException | ValidationException | CommitFailedException | CommitStateUnknownException | RESTException e) {
+        catch (CommitFailedException e) {
+            throw new TrinoException(TRANSACTION_CONFLICT, format("Failed to commit the transaction during %s: %s", operation, requireNonNullElse(e.getMessage(), e)), e);
+        }
+        catch (UncheckedIOException | ValidationException | CommitStateUnknownException | RESTException e) {
             throw new TrinoException(ICEBERG_COMMIT_ERROR, format("Failed to commit the transaction during %s: %s", operation, requireNonNullElse(e.getMessage(), e)), e);
         }
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -57,6 +57,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.types.Types;
 
@@ -101,6 +102,7 @@ import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
 import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
+import static io.trino.spi.StandardErrorCode.TRANSACTION_CONFLICT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.NumberType.NUMBER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
@@ -111,6 +113,7 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 import static java.util.UUID.randomUUID;
 import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
 import static org.apache.iceberg.TableMetadata.newTableMetadata;
@@ -362,7 +365,12 @@ public abstract class AbstractTrinoCatalog
         Transaction transaction = IcebergUtil.newCreateTableTransaction(this, tableMetadata, session, false, tableLocation, _ -> false, ImmutableList.of());
         AppendFiles appendFiles = transaction.newAppend();
         commit(appendFiles, session);
-        transaction.commitTransaction();
+        try {
+            transaction.commitTransaction();
+        }
+        catch (CommitFailedException e) {
+            throw new TrinoException(TRANSACTION_CONFLICT, format("Failed to commit the transaction while creating materialized view storage table: %s", requireNonNullElse(e.getMessage(), e)), e);
+        }
         return storageTable;
     }
 
@@ -552,6 +560,9 @@ public abstract class AbstractTrinoCatalog
                 .commit();
         try {
             transaction.commitTransaction();
+        }
+        catch (CommitFailedException e) {
+            throw new TrinoException(TRANSACTION_CONFLICT, format("Failed to commit the transaction while replacing materialized view storage table: %s", requireNonNullElse(e.getMessage(), e)), e);
         }
         finally {
             if (isMaterializedViewStorage(storageTableName.getTableName())) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
@@ -58,6 +58,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.types.TypeUtil;
@@ -92,6 +93,7 @@ import static io.trino.plugin.iceberg.procedure.MigrationUtils.buildDataFiles;
 import static io.trino.spi.StandardErrorCode.DUPLICATE_COLUMN_NAME;
 import static io.trino.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.StandardErrorCode.TRANSACTION_CONFLICT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.invoke.MethodHandles.lookup;
@@ -249,7 +251,12 @@ public class MigrateProcedure
                     .build();
             metastore.replaceTable(schemaName, tableName, newTable, principalPrivileges, ImmutableMap.of());
 
-            transaction.commitTransaction();
+            try {
+                transaction.commitTransaction();
+            }
+            catch (CommitFailedException e) {
+                throw new TrinoException(TRANSACTION_CONFLICT, "Failed to migrate table", e);
+            }
             log.debug("Successfully migrated %s table to Iceberg format", sourceTableName);
 
             return ImmutableMap.<String, Long>builder()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrationUtils.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrationUtils.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
@@ -77,6 +78,7 @@ import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.CONSTRAINT_VIOLATION;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.StandardErrorCode.TRANSACTION_CONFLICT;
 import static java.util.Objects.requireNonNullElse;
 import static org.apache.iceberg.TableProperties.DEFAULT_NAME_MAPPING;
 import static org.apache.iceberg.mapping.NameMappingParser.toJson;
@@ -181,6 +183,9 @@ public final class MigrationUtils
             List<DataFile> dataFiles = buildDataFilesFromLocation(fileSystem, recursiveDirectory, format, location, partitionSpec, Optional.empty(), table.schema());
             return addFiles(session, table, dataFiles, icebergScanExecutor);
         }
+        catch (TrinoException e) {
+            throw e;
+        }
         catch (Exception e) {
             throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to add files: " + requireNonNullElse(e.getMessage(), e), e);
         }
@@ -256,6 +261,9 @@ public final class MigrationUtils
             }
             return addFiles(session, targetTable, dataFilesBuilder.build(), icebergScanExecutor);
         }
+        catch (TrinoException e) {
+            throw e;
+        }
         catch (Exception e) {
             throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to add files: " + requireNonNullElse(e.getMessage(), e), e);
         }
@@ -323,7 +331,12 @@ public final class MigrationUtils
             }
             appendFiles.scanManifestsWith(icebergScanExecutor);
             appendFiles.commit();
-            transaction.commitTransaction();
+            try {
+                transaction.commitTransaction();
+            }
+            catch (CommitFailedException e) {
+                throw new TrinoException(TRANSACTION_CONFLICT, "Failed to add files: " + requireNonNullElse(e.getMessage(), e), e);
+            }
             log.debug("Successfully added files to %s table", table.name());
             return dataFiles.size();
         }


### PR DESCRIPTION
- Fixes #16770

Iceberg's `Transaction.commitTransaction()` is called from several
places in the connector, and none of them classified a
`CommitFailedException` (an optimistic concurrency conflict) any
differently from other commit failures. Some wrapped it into the
generic `ICEBERG_COMMIT_ERROR`, and two call sites in
`AbstractTrinoCatalog` had no exception handling around the commit at
all.

This follows the same pattern already used by the Hive connector's
`SemiTransactionalHiveMetastore`, which classifies this kind of
conflict as `TRANSACTION_CONFLICT`.

Changes:
- `IcebergMetadata`: split `CommitFailedException` out of the existing
  catch block in the shared `commitTransaction` helper.
- `AbstractTrinoCatalog`: added exception handling around the two
  previously-unwrapped commits in the materialized view storage table
  create/replace paths.
- `MigrateProcedure`, `MigrationUtils`: wrapped the commit call with a
  narrow catch, and added a `catch (TrinoException e) { throw e; }`
  guard in the outer wrapper methods so the new classification isn't
  re-wrapped by their existing broad `catch (Exception e)`.

Tested with `TestIcebergMigrateProcedure`, `TestIcebergMaterializedView`,
and `TestIcebergAddFilesProcedure` (111 tests total, all passing).