### PR TITLE
Retry BigQuery Storage Write API appends on RESOURCE_EXHAUSTED

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.md
+++ b/docs/src/main/sphinx/connector/bigquery.md
@@ -290,6 +290,18 @@ a few caveats:
     `bigquery.rpc-retry-delay-multiplier` to calculate the retry delay
     for the next RPC call.
   - `1.0`
+* - `bigquery.write-retry-max-attempts`
+  - The maximum number of attempts for a Storage Write API append request,
+    including the initial attempt.
+  - `5`
+* - `bigquery.write-retry-initial-delay`
+  - The initial backoff [duration](prop-type-duration) before retrying a
+    failed Storage Write API append request.
+  - `500ms`
+* - `bigquery.write-retry-max-delay`
+  - The maximum backoff [duration](prop-type-duration) between retries of a
+    failed Storage Write API append request.
+  - `30s`
 * - `bigquery.rpc-proxy.enabled`
   - Use a proxy for communication with BigQuery.
   - `false`

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
@@ -32,6 +32,7 @@ import static io.trino.plugin.base.logging.FormatInterpolator.hasValidPlaceholde
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 @DefunctConfig("bigquery.parallelism")
 public class BigQueryConfig
@@ -66,6 +67,9 @@ public class BigQueryConfig
     private boolean projectionPushDownEnabled = true;
     private int metadataParallelism = Math.min(Runtime.getRuntime().availableProcessors(), MAX_METADATA_PARALLELISM);
     private Optional<Integer> maxParallelism = Optional.empty();
+    private int writeRetryMaxAttempts = 5;
+    private Duration writeRetryInitialDelay = new Duration(500, MILLISECONDS);
+    private Duration writeRetryMaxDelay = new Duration(30, SECONDS);
 
     public Optional<String> getProjectId()
     {
@@ -422,5 +426,49 @@ public class BigQueryConfig
     public boolean isValidCaseInsensitiveNameMatchingCacheTtl()
     {
         return caseInsensitiveNameMatchingCacheTtl.isZero() || caseInsensitiveNameMatching;
+    }
+
+    @Min(0)
+    public int getWriteRetryMaxAttempts()
+    {
+        return writeRetryMaxAttempts;
+    }
+
+    @Config("bigquery.write-retry-max-attempts")
+    @ConfigDescription("The maximum number of attempts for a Storage Write API append request, including the initial attempt")
+    public BigQueryConfig setWriteRetryMaxAttempts(int writeRetryMaxAttempts)
+    {
+        this.writeRetryMaxAttempts = writeRetryMaxAttempts;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("0ms")
+    public Duration getWriteRetryInitialDelay()
+    {
+        return writeRetryInitialDelay;
+    }
+
+    @Config("bigquery.write-retry-initial-delay")
+    @ConfigDescription("The initial backoff delay before retrying a failed Storage Write API append request")
+    public BigQueryConfig setWriteRetryInitialDelay(Duration writeRetryInitialDelay)
+    {
+        this.writeRetryInitialDelay = writeRetryInitialDelay;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("0ms")
+    public Duration getWriteRetryMaxDelay()
+    {
+        return writeRetryMaxDelay;
+    }
+
+    @Config("bigquery.write-retry-max-delay")
+    @ConfigDescription("The maximum backoff delay between retries of a failed Storage Write API append request")
+    public BigQueryConfig setWriteRetryMaxDelay(Duration writeRetryMaxDelay)
+    {
+        this.writeRetryMaxDelay = writeRetryMaxDelay;
+        return this;
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.api.gax.rpc.HeaderProvider;
 import com.google.common.collect.ImmutableMultimap;
@@ -37,6 +38,7 @@ import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.function.table.ConnectorTableFunction;
 import io.trino.spi.procedure.Procedure;
 
+import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
@@ -125,6 +127,19 @@ public class BigQueryConnectorModule
         public static BigQueryLabelFactory labelFactory(BigQueryConfig config)
         {
             return new BigQueryLabelFactory(config.getQueryLabelName(), new FormatInterpolator<>(config.getQueryLabelFormat(), SessionInterpolatedValues.values()));
+        }
+
+        @Provides
+        @Singleton
+        @ForBigQueryWriter
+        public static RetrySettings provideRetrySettings(BigQueryConfig config)
+        {
+            return RetrySettings.newBuilder()
+                    .setMaxAttempts(config.getWriteRetryMaxAttempts())
+                    .setInitialRetryDelayDuration(Duration.ofMillis(config.getWriteRetryInitialDelay().toMillis()))
+                    .setRetryDelayMultiplier(1.3)
+                    .setMaxRetryDelayDuration(Duration.ofMillis(config.getWriteRetryMaxDelay().toMillis()))
+                    .build();
         }
 
         @Provides

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.bigquery;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
@@ -171,6 +172,7 @@ public class BigQueryMetadata
 
     private final BigQueryClientFactory bigQueryClientFactory;
     private final BigQueryWriteClientFactory writeClientFactory;
+    private final RetrySettings writerRetrySettings;
     private final BigQueryTypeManager typeManager;
     private final AtomicReference<Runnable> rollbackAction = new AtomicReference<>();
     private final ListeningExecutorService executorService;
@@ -179,12 +181,14 @@ public class BigQueryMetadata
     public BigQueryMetadata(
             BigQueryClientFactory bigQueryClientFactory,
             BigQueryWriteClientFactory writeClientFactory,
+            RetrySettings writerRetrySettings,
             BigQueryTypeManager typeManager,
             ListeningExecutorService executorService,
             boolean isLegacyMetadataListing)
     {
         this.bigQueryClientFactory = requireNonNull(bigQueryClientFactory, "bigQueryClientFactory is null");
         this.writeClientFactory = requireNonNull(writeClientFactory, "writeClientFactory is null");
+        this.writerRetrySettings = requireNonNull(writerRetrySettings, "writerRetrySettings is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.executorService = requireNonNull(executorService, "executorService is null");
         this.isLegacyMetadataListing = isLegacyMetadataListing;
@@ -793,7 +797,7 @@ public class BigQueryMetadata
             WriteStream stream = writeClient.createWriteStream(createWriteStreamRequest);
             JSONArray batch = new JSONArray();
             fragments.forEach(slice -> batch.put(ImmutableMap.of(pageSinkIdColumnName, slice.getLong(0))));
-            try (JsonStreamWriter writer = JsonStreamWriter.newBuilder(stream.getName(), stream.getTableSchema(), writeClient).build()) {
+            try (JsonStreamWriter writer = JsonStreamWriter.newBuilder(stream.getName(), stream.getTableSchema(), writeClient).setRetrySettings(writerRetrySettings).build()) {
                 ApiFuture<AppendRowsResponse> future = writer.append(batch);
                 AppendRowsResponse response = future.get();
                 if (response.hasError()) {

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSink.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSink.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.bigquery;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
 import com.google.cloud.bigquery.storage.v1.BigQueryWriteClient;
 import com.google.cloud.bigquery.storage.v1.CreateWriteStreamRequest;
@@ -55,9 +56,11 @@ public class BigQueryPageSink
     private final List<Type> columnTypes;
     private final ConnectorPageSinkId pageSinkId;
     private final Optional<String> pageSinkIdColumnName;
+    private final RetrySettings retrySettings;
 
     public BigQueryPageSink(
             BigQueryWriteClient client,
+            RetrySettings retrySettings,
             RemoteTableName remoteTableName,
             List<String> columnNames,
             List<Type> columnTypes,
@@ -66,6 +69,7 @@ public class BigQueryPageSink
             Optional<String> pageSinkIdColumnName)
     {
         this.client = requireNonNull(client, "client is null");
+        this.retrySettings = requireNonNull(retrySettings, "retrySettings is null");
         requireNonNull(remoteTableName, "remoteTableName is null");
         this.columnNames = ImmutableList.copyOf(requireNonNull(columnNames, "columnNames is null"));
         this.columnTypes = ImmutableList.copyOf(requireNonNull(columnTypes, "columnTypes is null"));
@@ -106,7 +110,7 @@ public class BigQueryPageSink
     private void insertWithCommitted(JSONArray batch)
     {
         WriteStream stream = writeStream.updateAndGet(this::getOrCreateWriteStream);
-        try (JsonStreamWriter writer = JsonStreamWriter.newBuilder(stream.getName(), stream.getTableSchema(), client).build()) {
+        try (JsonStreamWriter writer = JsonStreamWriter.newBuilder(stream.getName(), stream.getTableSchema(), client).setRetrySettings(retrySettings).build()) {
             ApiFuture<AppendRowsResponse> future = writer.append(batch);
             AppendRowsResponse response = future.get(); // Throw error
             if (response.hasError()) {

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSinkProvider.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSinkProvider.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.inject.Inject;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
@@ -31,11 +32,13 @@ public class BigQueryPageSinkProvider
         implements ConnectorPageSinkProvider
 {
     private final BigQueryWriteClientFactory clientFactory;
+    private final RetrySettings retrySettings;
 
     @Inject
-    public BigQueryPageSinkProvider(BigQueryWriteClientFactory clientFactory)
+    public BigQueryPageSinkProvider(BigQueryWriteClientFactory clientFactory, @ForBigQueryWriter RetrySettings retrySettings)
     {
         this.clientFactory = requireNonNull(clientFactory, "clientFactory is null");
+        this.retrySettings = requireNonNull(retrySettings, "retrySettings is null");
     }
 
     @Override
@@ -49,6 +52,7 @@ public class BigQueryPageSinkProvider
         BigQueryOutputTableHandle handle = (BigQueryOutputTableHandle) outputTableHandle;
         return new BigQueryPageSink(
                 clientFactory.create(session),
+                retrySettings,
                 handle.remoteTableName(),
                 handle.columnNames(),
                 handle.columnTypes(),
@@ -68,6 +72,7 @@ public class BigQueryPageSinkProvider
         BigQueryInsertTableHandle handle = (BigQueryInsertTableHandle) insertTableHandle;
         return new BigQueryPageSink(
                 clientFactory.create(session),
+                retrySettings,
                 handle.remoteTableName(),
                 handle.columnNames(),
                 handle.columnTypes(),

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/DefaultBigQueryMetadataFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/DefaultBigQueryMetadataFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.inject.Inject;
 
@@ -23,6 +24,7 @@ public class DefaultBigQueryMetadataFactory
 {
     private final BigQueryClientFactory bigQueryClient;
     private final BigQueryWriteClientFactory writeClientFactory;
+    private final RetrySettings writerRetrySettings;
     private final ListeningExecutorService executorService;
     private final BigQueryTypeManager typeManager;
     private final boolean isLegacyMetadataListing;
@@ -31,12 +33,14 @@ public class DefaultBigQueryMetadataFactory
     public DefaultBigQueryMetadataFactory(
             BigQueryClientFactory bigQueryClient,
             BigQueryWriteClientFactory writeClientFactory,
+            @ForBigQueryWriter RetrySettings writerRetrySettings,
             BigQueryTypeManager typeManager,
             ListeningExecutorService executorService,
             BigQueryConfig config)
     {
         this.bigQueryClient = requireNonNull(bigQueryClient, "bigQueryClient is null");
         this.writeClientFactory = requireNonNull(writeClientFactory, "writeClientFactory is null");
+        this.writerRetrySettings = requireNonNull(writerRetrySettings, "writerRetrySettings is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.executorService = requireNonNull(executorService, "executorService is null");
         this.isLegacyMetadataListing = config.isLegacyMetadataListing();
@@ -45,6 +49,6 @@ public class DefaultBigQueryMetadataFactory
     @Override
     public BigQueryMetadata create(BigQueryTransactionHandle transaction)
     {
-        return new BigQueryMetadata(bigQueryClient, writeClientFactory, typeManager, executorService, isLegacyMetadataListing);
+        return new BigQueryMetadata(bigQueryClient, writeClientFactory, writerRetrySettings, typeManager, executorService, isLegacyMetadataListing);
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ForBigQueryWriter.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ForBigQueryWriter.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface ForBigQueryWriter {}

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
@@ -28,6 +28,7 @@ import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestBigQueryConfig
 {
@@ -58,7 +59,10 @@ public class TestBigQueryConfig
                 .setProxyEnabled(false)
                 .setProjectionPushdownEnabled(true)
                 .setMetadataParallelism(Runtime.getRuntime().availableProcessors())
-                .setMaxParallelism(null));
+                .setMaxParallelism(null)
+                .setWriteRetryMaxAttempts(5)
+                .setWriteRetryInitialDelay(new Duration(500, MILLISECONDS))
+                .setWriteRetryMaxDelay(new Duration(30, SECONDS)));
     }
 
     @Test
@@ -89,6 +93,9 @@ public class TestBigQueryConfig
                 .put("bigquery.metadata.parallelism", "31")
                 .put("bigquery.max-parallelism", "100")
                 .put("bigquery.projection-pushdown-enabled", "false")
+                .put("bigquery.write-retry-max-attempts", "8")
+                .put("bigquery.write-retry-initial-delay", "1s")
+                .put("bigquery.write-retry-max-delay", "1m")
                 .buildOrThrow();
 
         BigQueryConfig expected = new BigQueryConfig()
@@ -115,7 +122,10 @@ public class TestBigQueryConfig
                 .setProxyEnabled(true)
                 .setProjectionPushdownEnabled(false)
                 .setMetadataParallelism(31)
-                .setMaxParallelism(100);
+                .setMaxParallelism(100)
+                .setWriteRetryMaxAttempts(8)
+                .setWriteRetryInitialDelay(new Duration(1, SECONDS))
+                .setWriteRetryMaxDelay(new Duration(1, MINUTES));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description

Configures the BigQuery Storage Write API's built-in retry-with-backoff for
`RESOURCE_EXHAUSTED` (quota) errors, which the connector left disabled.

Today, a quota error on an `AppendRows` call fails the task immediately and
triggers a full fault-tolerant-execution retry which re-appends every row
of the split from scratch, inflating bytes written to BigQuery. This adds
three config properties and passes them into both write-stream writers so
retries happen at the RPC layer instead of escalating to task failure:

- `bigquery.write-retry-max-attempts` (default `5`)
- `bigquery.write-retry-initial-delay` (default `500ms`)
- `bigquery.write-retry-max-delay` (default `30s`)

## Release notes

```markdown
## BigQuery
* TBD. ({issue}`issuenumber`)
```
