### PR TITLE
Add alter table mv execute iceberg support

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -2236,6 +2236,19 @@ The Iceberg connector supports the {ref}`WHEN STALE <mv-when-stale>` clause in
 {doc}`/sql/create-materialized-view` to control the behavior when a materialized
 view is stale. 
 
+You can perform physical maintenance of the storage table with {ref}`ALTER
+MATERIALIZED VIEW EXECUTE <alter-materialized-view-execute>`. Only the
+`optimize`, `optimize_manifests`, `expire_snapshots`, and `remove_orphan_files`
+procedures are supported; other procedures are rejected because they would
+desynchronize the storage table from the materialized view. Running a
+procedure requires the privilege to execute that procedure against the
+materialized view, and preserves the metadata used to determine freshness, so
+a subsequent `REFRESH MATERIALIZED VIEW` can still be incremental:
+
+```
+ALTER MATERIALIZED VIEW mv_name EXECUTE optimize
+```
+
 Dropping a materialized view with {doc}`/sql/drop-materialized-view` removes
 the definition and the storage table.
 

--- a/docs/src/main/sphinx/sql/alter-materialized-view.md
+++ b/docs/src/main/sphinx/sql/alter-materialized-view.md
@@ -43,6 +43,18 @@ according to the specified command and parameters.
 You can use the `=>` operator for passing named parameter values. The left side
 is the name of the parameter, the right side is the value being passed.
 
+Executable commands are contributed by connectors, such as the `optimize`
+command provided by the [Iceberg](iceberg-alter-table-execute) connector. For example, a user observing
+many small files in the storage of a often incrementally refreshed materialized view
+called `test_mv` in the `test` schema of the `example` catalog,
+can use the `optimize` command to merge all files below the `file_size_threshold` value.
+The result is fewer, but larger files, which typically results in higher query performance
+on the data in the files:
+
+```
+ALTER MATERIALIZED VIEW example.test.test_mv EXECUTE optimize(file_size_threshold => '16MB')
+```
+
 Running a command against a materialized view requires the privilege to
 execute that command against the view itself, not against its underlying
 storage table.

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewSummary.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewSummary.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotUpdate;
+
+import java.util.List;
+import java.util.Map;
+
+public final class IcebergMaterializedViewSummary
+{
+    // Snapshot summary properties tracking the tables/functions a materialized view depends on, and its snapshot ids.
+    public static final String DEPENDS_ON_TABLES = "dependsOnTables";
+    public static final String DEPENDS_ON_TABLE_FUNCTIONS = "dependsOnTableFunctions";
+    public static final String DEPENDS_ON_NON_DETERMINISTIC_FUNCTIONS = "dependsOnNonDeterministicFunctions";
+    // Value should be ISO-8601 formatted time instant
+    public static final String TRINO_QUERY_START_TIME = "trino-query-start-time";
+
+    private static final List<String> DEPENDENCY_SUMMARY_PROPERTIES = ImmutableList.of(
+            DEPENDS_ON_TABLES,
+            DEPENDS_ON_TABLE_FUNCTIONS,
+            DEPENDS_ON_NON_DETERMINISTIC_FUNCTIONS,
+            TRINO_QUERY_START_TIME);
+
+    private IcebergMaterializedViewSummary() {}
+
+    /**
+     * Carries forward the materialized view dependency summary properties from the given snapshot onto the
+     * given snapshot update. Maintenance operations that commit a new snapshot on a materialized view storage table
+     * (OPTIMIZE, optimize_manifests) would otherwise drop these properties, which would
+     * break freshness computation and demote the next incremental refresh to a full refresh. This is a no-op for
+     * ordinary tables, which do not carry these properties.
+     * <p>
+     * Callers should pass the same snapshot the maintenance operation validated/scanned against, rather than
+     * re-reading the table's current snapshot, so the copied summary stays consistent with what was actually
+     * rewritten.
+     */
+    public static void carryForwardMaterializedViewDependencies(Snapshot snapshot, SnapshotUpdate<?> snapshotUpdate)
+    {
+        Map<String, String> summary = snapshot.summary();
+        for (String key : DEPENDENCY_SUMMARY_PROPERTIES) {
+            String value = summary.get(key);
+            if (value != null) {
+                snapshotUpdate.set(key, value);
+            }
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -299,6 +299,11 @@ import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_MISSING_METADATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_UNSUPPORTED_VIEW_DIALECT;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.DEPENDS_ON_NON_DETERMINISTIC_FUNCTIONS;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.DEPENDS_ON_TABLES;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.DEPENDS_ON_TABLE_FUNCTIONS;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.TRINO_QUERY_START_TIME;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.carryForwardMaterializedViewDependencies;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.FILE_MODIFIED_TIME;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.FILE_PATH;
 import static io.trino.plugin.iceberg.IcebergMetadataColumn.LAST_UPDATED_SEQUENCE_NUMBER;
@@ -496,12 +501,14 @@ public class IcebergMetadata
 
     public static final int GET_METADATA_BATCH_SIZE = 1000;
     private static final MapSplitter MAP_SPLITTER = Splitter.on(",").trimResults().omitEmptyStrings().withKeyValueSeparator("=");
-
-    private static final String DEPENDS_ON_TABLES = "dependsOnTables";
-    private static final String DEPENDS_ON_TABLE_FUNCTIONS = "dependsOnTableFunctions";
-    private static final String DEPENDS_ON_NON_DETERMINISTIC_FUNCTIONS = "dependsOnNonDeterministicFunctions";
-    // Value should be ISO-8601 formatted time instant
-    private static final String TRINO_QUERY_START_TIME = "trino-query-start-time";
+    // Any procedure added here that commits a NEW snapshot must call
+    // IcebergMaterializedViewSummary.carryForwardMaterializedViewDependencies before committing, otherwise the
+    // materialized view's dependency summary is dropped and the next refresh is demoted from incremental to full.
+    private static final Set<IcebergTableProcedureId> MATERIALIZED_VIEW_STORAGE_ALLOWED_PROCEDURES = Sets.immutableEnumSet(
+            OPTIMIZE,
+            OPTIMIZE_MANIFESTS,
+            EXPIRE_SNAPSHOTS,
+            REMOVE_ORPHAN_FILES);
 
     private final CatalogName catalogName;
     private final TypeManager typeManager;
@@ -894,7 +901,7 @@ public class IcebergMetadata
         SchemaTableName baseName = new SchemaTableName(tableName.getSchemaName(), name);
         try {
             return getMaterializedView(session, baseName)
-                    .flatMap(_ -> catalog.getMaterializedViewStorageTable(session, baseName))
+                    .map(definition -> loadMaterializedViewStorageTable(session, baseName, definition))
                     .or(() -> Optional.of(catalog.loadTable(session, baseName)));
         }
         catch (TableNotFoundException e) {
@@ -904,6 +911,24 @@ public class IcebergMetadata
             // avoid dealing with non Iceberg tables
             return Optional.empty();
         }
+    }
+
+    private BaseTable loadMaterializedViewStorageTable(ConnectorSession session, SchemaTableName materializedViewName, ConnectorMaterializedViewDefinition definition)
+    {
+        SchemaTableName storageTableName = getMaterializedViewStorageTableName(materializedViewName, definition);
+        // With iceberg.materialized-views.hide-storage-table disabled the storage table is a regular, separately-named Iceberg table.
+        if (!isMaterializedViewStorage(storageTableName.getTableName())) {
+            return catalog.loadTable(session, storageTableName);
+        }
+        return catalog.getMaterializedViewStorageTable(session, materializedViewName)
+                .orElseThrow(() -> new TrinoException(TABLE_NOT_FOUND, "Storage table metadata not found for materialized view " + materializedViewName));
+    }
+
+    private static SchemaTableName getMaterializedViewStorageTableName(SchemaTableName materializedViewName, ConnectorMaterializedViewDefinition materializedViewDefinition)
+    {
+        return materializedViewDefinition.getStorageTable()
+                .map(CatalogSchemaTableName::getSchemaTableName)
+                .orElseThrow(() -> new IllegalStateException("Storage table missing in definition of materialized view " + materializedViewName));
     }
 
     private Optional<SystemTable> getRawSystemTable(ConnectorSession session, SchemaTableName tableName)
@@ -1763,7 +1788,41 @@ public class IcebergMetadata
             Map<String, Object> executeProperties,
             RetryMode retryMode)
     {
-        IcebergTableHandle tableHandle = (IcebergTableHandle) connectorTableHandle;
+        return internalGetTableHandleForExecute(
+                session,
+                accessControl,
+                (IcebergTableHandle) connectorTableHandle,
+                procedureName,
+                executeProperties,
+                false);
+    }
+
+    @Override
+    public Optional<ConnectorTableExecuteHandle> getTableHandleForMaterializedViewExecute(
+            ConnectorSession session,
+            ConnectorAccessControl accessControl,
+            ConnectorTableHandle connectorTableHandle,
+            String procedureName,
+            Map<String, Object> executeProperties,
+            RetryMode retryMode)
+    {
+        return internalGetTableHandleForExecute(
+                session,
+                accessControl,
+                (IcebergTableHandle) connectorTableHandle,
+                procedureName,
+                executeProperties,
+                true);
+    }
+
+    private Optional<ConnectorTableExecuteHandle> internalGetTableHandleForExecute(
+            ConnectorSession session,
+            ConnectorAccessControl accessControl,
+            IcebergTableHandle tableHandle,
+            String procedureName,
+            Map<String, Object> executeProperties,
+            boolean isMaterializedViewExecute)
+    {
         checkArgument(tableHandle.getTableType() == DATA, "Cannot execute table procedure %s on non-DATA table: %s", procedureName, tableHandle.getTableType());
         Table icebergTable = catalog.loadTable(session, tableHandle.getSchemaTableName());
         if (tableHandle.getSnapshotId().isPresent() && (tableHandle.getSnapshotId().orElseThrow() != icebergTable.currentSnapshot().snapshotId())) {
@@ -1776,6 +1835,11 @@ public class IcebergMetadata
         }
         catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Unknown procedure '" + procedureName + "'");
+        }
+
+        boolean isExecutedOnMaterializedViewStorageTable = isMaterializedViewStorage(tableHandle.getSchemaTableName().getTableName()) || isMaterializedViewExecute;
+        if (isExecutedOnMaterializedViewStorageTable && !MATERIALIZED_VIEW_STORAGE_ALLOWED_PROCEDURES.contains(procedureId)) {
+            throw new TrinoException(NOT_SUPPORTED, "Table procedure %s is not supported on a materialized view storage table".formatted(procedureName));
         }
 
         return switch (procedureId) {
@@ -2191,6 +2255,7 @@ public class IcebergMetadata
         rewriteFiles.dataSequenceNumber(snapshot.sequenceNumber());
         rewriteFiles.validateFromSnapshot(snapshot.snapshotId());
         rewriteFiles.scanManifestsWith(icebergScanExecutor);
+        carryForwardMaterializedViewDependencies(snapshot, rewriteFiles);
         commitUpdate(rewriteFiles, session, "optimize");
 
         long newSnapshotId = icebergTable.currentSnapshot().snapshotId();
@@ -4170,9 +4235,7 @@ public class IcebergMetadata
             return new MaterializedViewFreshness(STALE, Optional.empty());
         }
 
-        SchemaTableName storageTableName = materializedViewDefinition.get().getStorageTable()
-                .map(CatalogSchemaTableName::getSchemaTableName)
-                .orElseThrow(() -> new IllegalStateException("Storage table missing in definition of materialized view " + materializedViewName));
+        SchemaTableName storageTableName = getMaterializedViewStorageTableName(materializedViewName, materializedViewDefinition.get());
 
         Table icebergTable = catalog.loadTable(session, storageTableName);
         Optional<Snapshot> currentSnapshot = Optional.ofNullable(icebergTable.currentSnapshot());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/OptimizeManifests.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/OptimizeManifests.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RewriteManifests;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.metrics.CommitMetricsResult;
@@ -50,6 +51,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewSummary.carryForwardMaterializedViewDependencies;
 import static io.trino.plugin.iceberg.IcebergUtil.loadDataManifestsFromSnapshot;
 import static java.lang.Math.toIntExact;
 import static org.apache.iceberg.IcebergManifestUtils.liveEntries;
@@ -65,7 +67,8 @@ public final class OptimizeManifests
     public static Map<String, Long> optimizeManifests(BaseTable table, ExecutorService icebergScanExecutor)
     {
         // org.apache.iceberg.BaseRewriteManifests currently rewrites only data manifests
-        List<ManifestFile> manifests = loadDataManifestsFromSnapshot(table, table.currentSnapshot());
+        Snapshot snapshot = table.currentSnapshot();
+        List<ManifestFile> manifests = loadDataManifestsFromSnapshot(table, snapshot);
         if (manifests.isEmpty()) {
             return ImmutableMap.of();
         }
@@ -106,8 +109,9 @@ public final class OptimizeManifests
                     }
                     return clusteredPartitionValues.get(value);
                 })
-                .scanManifestsWith(icebergScanExecutor)
-                .commit();
+                .scanManifestsWith(icebergScanExecutor);
+        carryForwardMaterializedViewDependencies(snapshot, rewriteManifests);
+        rewriteManifests.commit();
 
         CommitReport report = reporter.commitReport();
         if (report == null) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -5824,6 +5824,75 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testOptimizeMaterializedView()
+            throws Exception
+    {
+        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion <= IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
+            String tableName = "test_optimize_" + randomNameSuffix();
+            assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar) WITH (format_version = " + formatVersion + ")");
+            String mvName = "test_optimize_mv_" + randomNameSuffix();
+            assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " WITH (format_version = " + formatVersion + ")" + " AS SELECT * FROM " + tableName);
+
+            // DistributedQueryRunner sets node-scheduler.include-coordinator by default, so include coordinator
+            int workerCount = getQueryRunner().getNodeCount();
+
+            // optimize an empty storage table
+            assertQuerySucceeds(withSingleWriterPerTask(getSession()), "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE");
+            assertThat(getSnapshotIds(mvName)).isEmpty();
+
+            assertUpdate("INSERT INTO " + tableName + " VALUES (11, 'eleven')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (12, 'zwölf')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (13, 'trzynaście')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (14, 'quatorze')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + tableName + " VALUES (15, 'пʼятнадцять')", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+            List<String> initialFiles = getActiveFiles(mvName);
+            assertThat(initialFiles)
+                    .hasSize(5)
+                    // Verify we have sufficiently many test rows with respect to worker count.
+                    .hasSizeGreaterThan(workerCount);
+
+            // For optimize we need to set task_min_writer_count to 1, otherwise it will create more than one file.
+            assertUpdate(
+                    withSingleWriterPerTask(getSession()),
+                    "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE",
+                    "VALUES ('rewritten_data_files_count', 5), ('removed_delete_files_count', 0), ('added_data_files_count', 1)");
+            assertThat(query("SELECT sum(key), listagg(value, ' ') WITHIN GROUP (ORDER BY key) FROM " + mvName))
+                    .matches("VALUES (BIGINT '65', VARCHAR 'eleven zwölf trzynaście quatorze пʼятнадцять')");
+            List<String> updatedFiles = getActiveFiles(mvName);
+            assertThat(updatedFiles)
+                    .hasSizeBetween(1, workerCount)
+                    .doesNotContainAnyElementsOf(initialFiles);
+            // No files should be removed (this is expire_snapshots's job, when it exists)
+            assertThat(getAllDataFilesFromMvStorageTableDirectory(mvName))
+                    .containsExactlyInAnyOrderElementsOf(concat(initialFiles, updatedFiles));
+
+            // optimize with low retention threshold, nothing should change
+            // For optimize we need to set task_min_writer_count to 1, otherwise it will create more than one file.
+            computeActual(withSingleWriterPerTask(getSession()), "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE (file_size_threshold => '33B')");
+            assertThat(query("SELECT sum(key), listagg(value, ' ') WITHIN GROUP (ORDER BY key) FROM " + mvName))
+                    .matches("VALUES (BIGINT '65', VARCHAR 'eleven zwölf trzynaście quatorze пʼятнадцять')");
+            assertThat(getActiveFiles(mvName)).isEqualTo(updatedFiles);
+            assertThat(getAllDataFilesFromMvStorageTableDirectory(mvName))
+                    .containsExactlyInAnyOrderElementsOf(concat(initialFiles, updatedFiles));
+
+            // optimize with delimited procedure name
+            assertQueryFails("ALTER MATERIALIZED VIEW " + mvName + " EXECUTE \"optimize\"", "Table procedure not registered: optimize");
+            assertUpdate("ALTER MATERIALIZED VIEW " + mvName + " EXECUTE \"OPTIMIZE\"");
+            // optimize with delimited parameter name (and procedure name)
+            assertUpdate("ALTER MATERIALIZED VIEW " + mvName + " EXECUTE \"OPTIMIZE\" (\"file_size_threshold\" => '33B')"); // TODO (https://github.com/trinodb/trino/issues/11326) this should fail
+            assertUpdate("ALTER MATERIALIZED VIEW " + mvName + " EXECUTE \"OPTIMIZE\" (\"FILE_SIZE_THRESHOLD\" => '33B')");
+            assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
     public void testOptimizeForPartitionedTable()
             throws IOException
     {
@@ -6230,20 +6299,36 @@ public abstract class BaseIcebergConnectorTest
 
     protected String getTableLocation(String tableName)
     {
+        return getLocationFromShowCreate("SHOW CREATE TABLE " + tableName);
+    }
+
+    protected String getMvStorageTableLocation(String mvName)
+    {
+        return getLocationFromShowCreate("SHOW CREATE MATERIALIZED VIEW " + mvName);
+    }
+
+    private String getLocationFromShowCreate(String showCreateStatement)
+    {
         Pattern locationPattern = Pattern.compile(".*location = '(.*?)'.*", Pattern.DOTALL);
-        Matcher m = locationPattern.matcher((String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue());
+        Matcher m = locationPattern.matcher((String) computeActual(showCreateStatement).getOnlyValue());
         if (m.find()) {
             String location = m.group(1);
             verify(!m.find(), "Unexpected second match");
             return location;
         }
-        throw new IllegalStateException("Location not found in SHOW CREATE TABLE result");
+        throw new IllegalStateException("Location not found in " + showCreateStatement + " result");
     }
 
     protected List<String> getAllDataFilesFromTableDirectory(String tableName)
             throws IOException
     {
         return listFiles(getIcebergTableDataPath(getTableLocation(tableName)));
+    }
+
+    protected List<String> getAllDataFilesFromMvStorageTableDirectory(String mvName)
+            throws IOException
+    {
+        return listFiles(getIcebergTableDataPath(getMvStorageTableLocation(mvName)));
     }
 
     @Test
@@ -6948,6 +7033,42 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testExpireSnapshotsMaterializedView()
+            throws Exception
+    {
+        String tableName = "test_expiring_snapshots_" + randomNameSuffix();
+        String mvName = "test_expiring_snapshots_mv_" + randomNameSuffix();
+        Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
+        assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer)");
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + tableName);
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2)", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        assertThat(query("SELECT sum(value), listagg(key, ' ') WITHIN GROUP (ORDER BY key) FROM " + mvName))
+                .matches("VALUES (BIGINT '3', VARCHAR 'one two')");
+
+        List<Long> initialSnapshots = getSnapshotIds(mvName);
+        String tableLocation = getMvStorageTableLocation(mvName);
+        List<String> initialFiles = getAllMetadataFilesFromTableDirectory(tableLocation);
+        assertQuerySucceeds(sessionWithShortRetentionUnlocked, "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')");
+
+        assertThat(query("SELECT sum(value), listagg(key, ' ') WITHIN GROUP (ORDER BY key) FROM " + mvName))
+                .matches("VALUES (BIGINT '3', VARCHAR 'one two')");
+        List<String> updatedFiles = getAllMetadataFilesFromTableDirectory(tableLocation);
+        List<Long> updatedSnapshots = getSnapshotIds(mvName);
+        // MV refresh writes no per-snapshot Puffin .stats file (unlike a plain INSERT), so EXPIRE_SNAPSHOTS
+        // reclaims only manifest lists here — one fewer file than the plain-table case in testExpireSnapshots.
+        assertThat(updatedFiles).hasSize(initialFiles.size() - 1);
+        assertThat(updatedSnapshots.size()).isLessThan(initialSnapshots.size());
+        assertThat(updatedSnapshots).hasSize(1);
+        assertThat(initialSnapshots).containsAll(updatedSnapshots);
+    }
+
+    @Test
     public void testExpireSnapshotsPartitionedTable()
             throws Exception
     {
@@ -7200,6 +7321,44 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Test
+    public void testRemoveOrphanFilesMaterializedView()
+            throws Exception
+    {
+        String tableName = "test_deleting_orphan_files_unnecessary_files" + randomNameSuffix();
+        String mvName = "test_deleting_orphan_files_unnecessary_files_mv_" + randomNameSuffix();
+        Session sessionWithShortRetentionUnlocked = prepareCleanUpSession();
+        assertUpdate("CREATE TABLE " + tableName + " (key varchar, value integer)");
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + tableName);
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('one', 1)", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('two', 2), ('three', 3)", 2);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 2);
+        assertUpdate("DELETE FROM " + tableName + " WHERE key = 'two'", 1);
+        // performs full refresh as there has been a DELETE, so refresh goes through whole table (2 rows)
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 2);
+        String location = getMvStorageTableLocation(mvName);
+        String orphanFile1 = getIcebergTableDataPath(location) + "/invalidData1." + format;
+        String orphanFile2 = getIcebergTableDataPath(location) + "/invalidData2." + format;
+        int orphanFile1Bytes = 123;
+        int orphanFile2Bytes = 456;
+        int totalOrphanBytes = orphanFile1Bytes + orphanFile2Bytes;
+        createFile(orphanFile1, new byte[orphanFile1Bytes]);
+        createFile(orphanFile2, new byte[orphanFile2Bytes]);
+        List<String> initialDataFiles = getAllDataFilesFromMvStorageTableDirectory(mvName);
+        assertThat(initialDataFiles).contains(orphanFile1, orphanFile2);
+
+        assertUpdate(
+                sessionWithShortRetentionUnlocked,
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')",
+                "VALUES ('processed_manifests_count', 5), ('active_files_count', 17), ('scanned_files_count', 19), ('deleted_files_count', 2), ('deleted_bytes', " + totalOrphanBytes + ")");
+        assertQuery("SELECT * FROM " + tableName, "VALUES ('one', 1), ('three', 3)");
+
+        List<String> updatedDataFiles = getAllDataFilesFromMvStorageTableDirectory(mvName);
+        assertThat(updatedDataFiles.size()).isLessThan(initialDataFiles.size());
+        assertThat(updatedDataFiles).doesNotContain(orphanFile1, orphanFile2);
+    }
+
+    @Test
     public void testIfRemoveOrphanFilesCleansUnnecessaryDataFilesInPartitionedTable()
             throws Exception
     {
@@ -7275,7 +7434,7 @@ public abstract class BaseIcebergConnectorTest
         List<String> prunedMetadataFiles = getAllMetadataFilesFromTableDirectory(tableDirectory);
         List<Long> prunedSnapshots = getSnapshotIds(tableName);
         assertThat(prunedMetadataFiles).as("prunedMetadataFiles")
-                .hasSize(initialMetadataFiles.size() - 2);
+                .hasSizeLessThan(initialMetadataFiles.size());
         assertThat(prunedSnapshots).as("prunedSnapshots")
                 .hasSizeLessThan(initialSnapshots.size())
                 .hasSize(1);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -5766,7 +5766,7 @@ public abstract class BaseIcebergConnectorTest
     public void testOptimize()
             throws Exception
     {
-        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion < IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
+        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion <= IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
             String tableName = "test_optimize_" + randomNameSuffix();
             assertUpdate("CREATE TABLE " + tableName + " (key integer, value varchar) WITH (format_version = " + formatVersion + ")");
 
@@ -5896,7 +5896,7 @@ public abstract class BaseIcebergConnectorTest
     public void testOptimizeForPartitionedTable()
             throws IOException
     {
-        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion < IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
+        for (int formatVersion = IcebergConfig.FORMAT_VERSION_SUPPORT_MIN; formatVersion <= IcebergConfig.FORMAT_VERSION_SUPPORT_MAX; formatVersion++) {
             // This test will have its own session to make sure partitioning is indeed forced and is not a result
             // of session configuration
             Session session = testSessionBuilder()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -79,6 +79,7 @@ import static io.trino.spi.function.table.TableFunctionProcessorState.Processed.
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.testing.MaterializedResult.DEFAULT_PRECISION;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.DROP_MATERIALIZED_VIEW;
+import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.EXECUTE_TABLE_PROCEDURE;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.REFRESH_MATERIALIZED_VIEW;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.RENAME_MATERIALIZED_VIEW;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
@@ -1087,6 +1088,315 @@ public abstract class BaseIcebergMaterializedViewTest
                     .describedAs(tableType.name())
                     .failure().hasMessageMatching(".* Table '.*.\"" + mvName + "\\$" + tableType.name().toLowerCase(ENGLISH) + "\"' does not exist");
         }
+    }
+
+    @Test
+    public void testMaterializedViewMaintenanceAuthorizedByExecuteTableProcedurePrivilege()
+    {
+        String catalog = getSession().getCatalog().orElseThrow();
+        String schema = getSession().getSchema().orElseThrow();
+        String mvName = "test_optimize_ac_mv_" + randomNameSuffix();
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM base_table1");
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 6);
+
+        // Maintenance is authorized as execute-table-procedure on the materialized view itself.
+        assertAccessDenied(
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE",
+                "Cannot execute table procedure OPTIMIZE on " + catalog + "\\." + schema + "\\." + mvName,
+                privilege(format("%s.%s.%s.OPTIMIZE", catalog, schema, mvName), EXECUTE_TABLE_PROCEDURE));
+
+        // It is NOT gated by the refresh privilege: a maintenance runner should not need the ability
+        // to fully recompute and overwrite the view's contents.
+        assertAccessAllowed(
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE",
+                privilege(mvName, REFRESH_MATERIALIZED_VIEW));
+
+        // SELECT is checked against the materialized view's own name, matching the privilege required to read
+        // it, not against its (possibly hidden) storage table.
+        assertAccessDenied(
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE",
+                "Cannot select from columns .*",
+                privilege(mvName, SELECT_COLUMN));
+
+        // A grant or deny on the storage table's own synthetic name is irrelevant to this statement.
+        assertAccessAllowed(
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE",
+                privilege(mvName + "$materialized_view_storage", SELECT_COLUMN));
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+    }
+
+    @Test
+    public void testUnsafeProcedureRejectedOnMaterializedView()
+    {
+        testUnsafeProcedureRejectedOnMaterializedView(getSession());
+    }
+
+    @Test
+    public void testUnsafeProcedureRejectedOnMaterializedViewWithVisibleStorageTable()
+    {
+        // With iceberg.materialized-views.hide-storage-table disabled, the storage table is a plain
+        // "st_<uuid>"-named table rather than "<mv>$materialized_view_storage", so the connector cannot
+        // recognize it as materialized view storage by name alone; the engine must still signal that the
+        // procedure was reached through ALTER MATERIALIZED VIEW EXECUTE. iceberg_legacy_mv is set up (sharing
+        // the same underlying storage as the default catalog) exactly for this case.
+        testUnsafeProcedureRejectedOnMaterializedView(Session.builder(getSession())
+                .setCatalog("iceberg_legacy_mv")
+                .build());
+    }
+
+    private void testUnsafeProcedureRejectedOnMaterializedView(Session session)
+    {
+        String mvName = "test_unsafe_procedure_mv_" + randomNameSuffix();
+        assertUpdate(session, "CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM base_table1");
+        assertUpdate(session, "REFRESH MATERIALIZED VIEW " + mvName, 6);
+
+        // Procedures that would change the storage table's logical contents or desync it from the materialized view
+        // are rejected; only physical maintenance is allowed.
+        assertQueryFails(
+                session,
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE DROP_EXTENDED_STATS",
+                "Table procedure DROP_EXTENDED_STATS is not supported on a materialized view storage table");
+
+        long snapshotId = (long) computeScalar(session, "SELECT snapshot_id FROM \"" + mvName + "$snapshots\" ORDER BY committed_at LIMIT 1");
+        assertQueryFails(
+                session,
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE ROLLBACK_TO_SNAPSHOT(" + snapshotId + ")",
+                "Table procedure ROLLBACK_TO_SNAPSHOT is not supported on a materialized view storage table");
+
+        assertQueryFails(
+                session,
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE ADD_FILES_FROM_TABLE(schema_name => CURRENT_SCHEMA, table_name => 'base_table1')",
+                "Table procedure ADD_FILES_FROM_TABLE is not supported on a materialized view storage table");
+
+        assertUpdate(session, "DROP MATERIALIZED VIEW " + mvName);
+    }
+
+    @Test
+    public void testUnallowedProcedureRejectedOnHiddenStorageTableByName()
+    {
+        String mvName = "test_unsafe_procedure_storage_" + randomNameSuffix();
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM base_table1");
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 6);
+
+        assertQueryFails(
+                "ALTER TABLE \"" + mvName + "$materialized_view_storage\" EXECUTE DROP_EXTENDED_STATS",
+                "Table procedure DROP_EXTENDED_STATS is not supported on a materialized view storage table");
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+    }
+
+    @Test
+    public void testMaterializedViewOptimizePreservesDependencyMetadata()
+    {
+        String sourceTable = "test_optimize_preserve_src_" + randomNameSuffix();
+        String mvName = "test_optimize_preserve_mv_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + sourceTable + " (id BIGINT)");
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 1, 2, 3", 3);
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + sourceTable);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 3);
+
+        // Baseline: a refresh after a single-row insert is incremental (only the delta is written).
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 4", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        // OPTIMIZE the storage table between refreshes.
+        assertUpdate("ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE");
+
+        // The dependency metadata survives the optimize snapshot.
+        assertThat((String) computeScalar(
+                "SELECT element_at(summary, 'dependsOnTables') FROM \"" + mvName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1"))
+                .isNotNull()
+                .contains(sourceTable);
+
+        // OPTIMIZE with no source change must not make the MV stale.
+        assertFreshness(mvName, "FRESH");
+
+        // The next refresh stays incremental: only the new delta row is written, not a full re-scan.
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 5", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertThat(computeScalar("SELECT count(*) FROM " + mvName)).isEqualTo(5L);
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        assertUpdate("DROP TABLE " + sourceTable);
+    }
+
+    @Test
+    public void testOptimizeMaterializedViewWithVisibleStorageTable()
+    {
+        // With iceberg.materialized-views.hide-storage-table disabled the storage table is a plain "st_<uuid>" table
+        // rather than "<mv>$materialized_view_storage". OPTIMIZE must still compact it through ALTER MATERIALIZED VIEW
+        // EXECUTE; format version 3 additionally exercises the row-lineage columns the storage-table scan must expose.
+        Session session = Session.builder(getSession())
+                .setCatalog("iceberg_legacy_mv")
+                .setSystemProperty("task_min_writer_count", "1")
+                .build();
+        String sourceTable = "test_optimize_legacy_src_" + randomNameSuffix();
+        String mvName = "test_optimize_legacy_mv_" + randomNameSuffix();
+        assertUpdate(session, "CREATE TABLE " + sourceTable + " (key integer, value varchar) WITH (format_version = 3)");
+        assertUpdate(session, "CREATE MATERIALIZED VIEW " + mvName + " WITH (format_version = 3) AS SELECT * FROM " + sourceTable);
+
+        // Populate across several refreshes so the storage table ends up with multiple data files.
+        assertUpdate(session, "INSERT INTO " + sourceTable + " VALUES (1, 'a')", 1);
+        assertUpdate(session, "REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertUpdate(session, "INSERT INTO " + sourceTable + " VALUES (2, 'b')", 1);
+        assertUpdate(session, "REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertUpdate(session, "INSERT INTO " + sourceTable + " VALUES (3, 'c')", 1);
+        assertUpdate(session, "REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertThat((long) computeScalar(session, "SELECT count(*) FROM \"" + mvName + "$files\"")).isGreaterThan(1L);
+
+        assertQuerySucceeds(session, "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE");
+
+        // The storage table is compacted to a single file and its contents are preserved.
+        assertThat((long) computeScalar(session, "SELECT count(*) FROM \"" + mvName + "$files\"")).isEqualTo(1L);
+        assertThat(query(session, "SELECT * FROM " + mvName))
+                .matches("VALUES (1, CAST('a' AS varchar)), (2, CAST('b' AS varchar)), (3, CAST('c' AS varchar))");
+
+        assertUpdate(session, "DROP MATERIALIZED VIEW " + mvName);
+        assertUpdate(session, "DROP TABLE " + sourceTable);
+    }
+
+    @Test
+    public void testExecuteOnMissingMaterializedView()
+    {
+        String mvName = "non_existent_mv_" + randomNameSuffix();
+        assertQueryFails(
+                "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE OPTIMIZE",
+                "line 1:7: Materialized view '.*\\." + mvName + "' does not exist");
+    }
+
+    @Test
+    public void testExecuteOnTable()
+    {
+        String tableName = "test_execute_on_table_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (id BIGINT)");
+
+        // ALTER MATERIALIZED VIEW EXECUTE resolves its target purely as a materialized view; a plain table
+        // named the same way is reported as a missing materialized view, exactly like a nonexistent name.
+        assertQueryFails(
+                "ALTER MATERIALIZED VIEW " + tableName + " EXECUTE OPTIMIZE",
+                "line 1:7: Materialized view '.*\\." + tableName + "' does not exist");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testExecuteOnView()
+    {
+        String viewName = "test_execute_on_view_" + randomNameSuffix();
+        assertUpdate("CREATE VIEW " + viewName + " AS SELECT * FROM base_table1");
+
+        assertQueryFails(
+                "ALTER MATERIALIZED VIEW " + viewName + " EXECUTE OPTIMIZE",
+                "line 1:7: Materialized view '.*\\." + viewName + "' does not exist");
+
+        assertUpdate("DROP VIEW " + viewName);
+    }
+
+    @Test
+    public void testMaterializedViewExecuteOptimizeWithWhere()
+    {
+        String sourceTable = "test_optimize_where_src_" + randomNameSuffix();
+        String mvName = "test_optimize_where_mv_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + sourceTable + " (id BIGINT, part BIGINT)");
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES (1, 1)", 1);
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES (2, 2)", 1);
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " WITH (partitioning = ARRAY['part']) AS SELECT * FROM " + sourceTable);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 2);
+
+        // A second incremental refresh appends a second file to both partitions.
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES (3, 1)", 1);
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES (4, 2)", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 2);
+
+        String storageTable = "\"" + mvName + "$materialized_view_storage\"";
+        assertThat((long) computeScalar("SELECT count(DISTINCT \"$path\") FROM " + storageTable + " WHERE part = 1"))
+                .isGreaterThanOrEqualTo(2);
+        long filesInPart2Before = (long) computeScalar("SELECT count(DISTINCT \"$path\") FROM " + storageTable + " WHERE part = 2");
+        assertThat(filesInPart2Before).isEqualTo(2L);
+
+        assertUpdate("ALTER MATERIALIZED VIEW " + mvName + " EXECUTE optimize WHERE part = 1");
+
+        // Only the matching partition is coalesced into a single file; the other partition is untouched.
+        assertThat((long) computeScalar("SELECT count(DISTINCT \"$path\") FROM " + storageTable + " WHERE part = 1"))
+                .isEqualTo(1);
+        assertThat((long) computeScalar("SELECT count(DISTINCT \"$path\") FROM " + storageTable + " WHERE part = 2"))
+                .isEqualTo(filesInPart2Before);
+
+        assertThat((long) computeScalar("SELECT count(*) FROM " + mvName)).isEqualTo(4L);
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        assertUpdate("DROP TABLE " + sourceTable);
+    }
+
+    @Test
+    public void testMaterializedViewExpireSnapshotsPreservesDependencyMetadata()
+    {
+        String sourceTable = "test_expire_preserve_src_" + randomNameSuffix();
+        String mvName = "test_expire_preserve_mv_" + randomNameSuffix();
+        Session shortRetentionSession = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "expire_snapshots_min_retention", "0s")
+                .build();
+        assertUpdate("CREATE TABLE " + sourceTable + " (id BIGINT)");
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 1, 2, 3", 3);
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + sourceTable);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 3);
+
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 4", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        assertUpdate(shortRetentionSession, "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE EXPIRE_SNAPSHOTS (retention_threshold => '0s')");
+
+        // EXPIRE_SNAPSHOTS commits no new snapshot; the dependency metadata stays on the retained current snapshot.
+        String dependencyMetadataAfterExpire = (String) computeScalar(
+                "SELECT element_at(summary, 'dependsOnTables') FROM \"" + mvName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1");
+        assertThat(dependencyMetadataAfterExpire)
+                .isNotNull()
+                .contains(sourceTable);
+
+        assertFreshness(mvName, "FRESH");
+
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 5", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertThat(computeScalar("SELECT count(*) FROM " + mvName)).isEqualTo(5L);
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        assertUpdate("DROP TABLE " + sourceTable);
+    }
+
+    @Test
+    public void testMaterializedViewRemoveOrphanFilesPreservesDependencyMetadata()
+    {
+        String sourceTable = "test_remove_orphan_preserve_src_" + randomNameSuffix();
+        String mvName = "test_remove_orphan_preserve_mv_" + randomNameSuffix();
+        Session shortRetentionSession = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "remove_orphan_files_min_retention", "0s")
+                .build();
+        assertUpdate("CREATE TABLE " + sourceTable + " (id BIGINT)");
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 1, 2, 3", 3);
+        assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + sourceTable);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 3);
+
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 4", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+        assertUpdate(shortRetentionSession, "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE REMOVE_ORPHAN_FILES (retention_threshold => '0s')");
+
+        // REMOVE_ORPHAN_FILES only deletes unreferenced files; the dependency metadata stays on the untouched current snapshot.
+        String dependencyMetadataAfterRemoveOrphans = (String) computeScalar(
+                "SELECT element_at(summary, 'dependsOnTables') FROM \"" + mvName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1");
+        assertThat(dependencyMetadataAfterRemoveOrphans)
+                .isNotNull()
+                .contains(sourceTable);
+
+        assertFreshness(mvName, "FRESH");
+
+        assertUpdate("INSERT INTO " + sourceTable + " VALUES 5", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+        assertThat(computeScalar("SELECT count(*) FROM " + mvName)).isEqualTo(5L);
+
+        assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        assertUpdate("DROP TABLE " + sourceTable);
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergOptimizeManifestsProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergOptimizeManifestsProcedure.java
@@ -129,6 +129,54 @@ final class TestIcebergOptimizeManifestsProcedure
     }
 
     @Test
+    void testOptimizeManifestsOnMaterializedView()
+    {
+        try (TestTable table = newTrinoTable("test_optimize_manifests_on_mv_storage_table", "(x int)")) {
+            String mvName = "test_optimize_manifests_mv_" + randomNameSuffix();
+            assertUpdate("CREATE MATERIALIZED VIEW " + mvName + " AS SELECT * FROM " + table.getName());
+
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 1", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 2", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+
+            Set<String> manifestFiles = manifestFiles(mvName);
+            assertThat(manifestFiles).hasSize(2);
+
+            // The two data manifests are combined into one.
+            assertUpdate(
+                    "ALTER MATERIALIZED VIEW " + mvName + " EXECUTE optimize_manifests",
+                    "VALUES " +
+                            "('rewritten_manifests_count', 2), " +
+                            "('added_manifests_count', 1), " +
+                            "('kept_manifests_count', 0), " +
+                            "('processed_manifest_entries_count', 2)");
+            Set<String> optimizedManifestFiles = manifestFiles(mvName);
+            assertThat(optimizedManifestFiles).hasSize(1);
+            assertThat(Sets.intersection(optimizedManifestFiles, manifestFiles)).isEmpty();
+
+            assertThat(query("SELECT * FROM " + mvName))
+                    .matches("VALUES 1, 2");
+
+            String dependencyMetadataAfterOptimizeManifests = (String) computeScalar(
+                    "SELECT element_at(summary, 'dependsOnTables') FROM \"" + mvName + "$snapshots\" ORDER BY committed_at DESC LIMIT 1");
+            assertThat(dependencyMetadataAfterOptimizeManifests)
+                    .isNotNull()
+                    .contains(table.getName());
+
+            assertThat((String) computeScalar("SELECT freshness FROM system.metadata.materialized_views WHERE catalog_name = CURRENT_CATALOG AND schema_name = CURRENT_SCHEMA AND name = '" + mvName + "'"))
+                    .isEqualTo("FRESH");
+
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 3", 1);
+            assertUpdate("REFRESH MATERIALIZED VIEW " + mvName, 1);
+            assertThat(query("SELECT * FROM " + mvName))
+                    .matches("VALUES 1, 2, 3");
+
+            assertUpdate("DROP MATERIALIZED VIEW " + mvName);
+        }
+    }
+
+    @Test
     void testSplitManifests()
     {
         try (TestTable table = newTrinoTable("test_optimize_manifests", "(x int)")) {


### PR DESCRIPTION
## Description

Adds support for `ALTER MATERIALIZED VIEW ... EXECUTE` to iceberg connector.
It allows targeting materialized views with maintenance procedures (from explicit allow-list on connector side), that runs on underlying storage table.
This should help keep MVs that gets refreshed incrementally to maintain healthy storage iceberg table.

## Additional context and related issues

Follow-up of: https://github.com/trinodb/trino/pull/30868
Completes: https://github.com/trinodb/trino/issues/21797

Once it gets merged, the: https://github.com/trinodb/trino/pull/30432 can be closed (as it was original PR which was then split to many step-by-step PRs.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector                                                                                                                                                                                                 
* Add support for running `OPTIMIZE`, `OPTIMIZE_MANIFESTS`, `EXPIRE_SNAPSHOTS`, `REMOVE_ORPHAN_FILES` and `DROP_EXTENDED_STATS` on materialized view storage table through `ALTER MATERIALIZED VIEW ... EXECUTE`
```
