### PR TITLE
Fix MERGE row ID collisions between target and source

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -1125,7 +1125,16 @@ class QueryPlanner
         Symbol uniqueIdSymbol = symbolAllocator.newSymbol("unique_id", BIGINT);
         Expression uniqueIdExpression = new Coalesce(targetUniqueIdSymbol.toSymbolReference(), sourceUniqueIdSymbol.toSymbolReference());
 
+        // AssignUniqueId values are unique within one plan node, but target and source use separate nodes.
+        // Keep their id namespaces separate when both nodes are executed in the same stage.
+        Symbol uniqueIdFromTargetSymbol = symbolAllocator.newSymbol("unique_id_from_target", BOOLEAN);
+        Expression uniqueIdFromTargetExpression = not(
+                metadata,
+                getCharVarcharCoercion(session),
+                new IsNull(targetUniqueIdSymbol.toSymbolReference()));
+
         projectionAssignmentsBuilder.put(uniqueIdSymbol, uniqueIdExpression);
+        projectionAssignmentsBuilder.put(uniqueIdFromTargetSymbol, uniqueIdFromTargetExpression);
         projectionAssignmentsBuilder.putIdentity(rowIdSymbol);
         projectionAssignmentsBuilder.put(mergeRowSymbol, caseExpression);
 
@@ -1143,12 +1152,16 @@ class QueryPlanner
                         .put(caseNumberSymbol, new FieldReference(mergeRowSymbol.toSymbolReference(), mergeAnalysis.getMergeRowType().getFields().size() - 1))
                         .build());
 
-        // Mark distinct combinations of the unique_id value and the case_number
+        // Mark distinct combinations of the unique_id value, its origin, and the case_number
         Symbol isDistinctSymbol = symbolAllocator.newSymbol("is_distinct", BOOLEAN);
-        MarkDistinctNode markDistinctNode = new MarkDistinctNode(idAllocator.getNextId(), project, isDistinctSymbol, ImmutableList.of(uniqueIdSymbol, caseNumberSymbol));
+        MarkDistinctNode markDistinctNode = new MarkDistinctNode(
+                idAllocator.getNextId(),
+                project,
+                isDistinctSymbol,
+                ImmutableList.of(uniqueIdSymbol, uniqueIdFromTargetSymbol, caseNumberSymbol));
 
         // The unique_id which originates from either the source or target table will not be null
-        // Raise an error if the unique_id/case_number combination was not distinct
+        // Raise an error if the unique_id/origin/case_number combination was not distinct
         Expression filter = ifExpression(
                 not(metadata, getCharVarcharCoercion(session), isDistinctSymbol.toSymbolReference()),
                 new Cast(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestMerge.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestMerge.java
@@ -116,10 +116,11 @@ public class TestMerge
                                 new Case(
                                         ImmutableList.of(new WhenClause(new Call(NOT, ImmutableList.of(new Reference(BOOLEAN, "is_distinct"))), new Cast(new Call(FAIL, ImmutableList.of(new Constant(INTEGER, (long) MERGE_TARGET_ROW_MULTIPLE_MATCHES.toErrorCode().getCode()), new Constant(VARCHAR, utf8Slice("One MERGE target table row matched more than one source row")))), BOOLEAN))),
                                         TRUE),
-                                markDistinct("is_distinct", ImmutableList.of("unique_id", "case_number"),
+                                markDistinct("is_distinct", ImmutableList.of("unique_id", "unique_id_from_target", "case_number"),
                                         anyTree(
                                                 project(ImmutableMap.of(
                                                                 "unique_id", expression(new Coalesce(ImmutableList.of(new Reference(BIGINT, "target_unique_id"), new Reference(BIGINT, "source_unique_id")))),
+                                                                "unique_id_from_target", expression(new Call(NOT, ImmutableList.of(new IsNull(new Reference(BIGINT, "target_unique_id"))))),
                                                                 "field", expression(new Reference(BIGINT, "field")),
                                                                 "merge_row", expression(new Reference(ROW_TYPE, "merge_row")),
                                                                 "case_number", expression(new FieldReference(new Reference(ROW_TYPE, "merge_row"), 4))),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergIssue30639.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergIssue30639.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.Session;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+
+public class TestIcebergIssue30639
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder().build();
+    }
+
+    @Test
+    public void testMergeWithPartitionedJoinAndUnmodifiedRows()
+    {
+        try (TestTable target = new TestTable(
+                getQueryRunner()::execute,
+                "test_issue_30639_target",
+                "WITH (partitioning = ARRAY['bucket(k1, 16)', 'bucket(k2, 8)']) AS " +
+                        "SELECT 'a-' || CAST(i AS varchar) AS k1, 'b-' || CAST(i AS varchar) AS k2, " +
+                        "'UPDATED' AS value, TIMESTAMP '2026-01-01 00:00:00.000000' AS updated_at " +
+                        "FROM UNNEST(sequence(1, 3000)) t(i)")) {
+            try (TestTable source = new TestTable(
+                    getQueryRunner()::execute,
+                    "test_issue_30639_source",
+                    "AS " +
+                            "SELECT 'a-' || CAST(i AS varchar) AS k1, 'b-' || CAST(i AS varchar) AS k2, " +
+                            "'UPDATED' AS value, TIMESTAMP '2026-01-01 00:00:00.000000' AS updated_at " +
+                            "FROM UNNEST(sequence(1, 3000)) t(i) " +
+                            "UNION ALL " +
+                            "SELECT 'x-' || CAST(a.i AS varchar) || '-' || CAST(b.j AS varchar), " +
+                            "'y-' || CAST(a.i AS varchar) || '-' || CAST(b.j AS varchar), " +
+                            "'DELETED', TIMESTAMP '2026-01-02 00:00:00.000000' " +
+                            "FROM UNNEST(sequence(1, 6000)) a(i) CROSS JOIN UNNEST(sequence(1, 7)) b(j)")) {
+                Session session = Session.builder(getSession())
+                        .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "PARTITIONED")
+                        .build();
+
+                assertUpdate(
+                        session,
+                        "MERGE INTO %s t USING %s s ".formatted(target.getName(), source.getName()) +
+                                "ON t.k1 = s.k1 AND t.k2 = s.k2 " +
+                                "WHEN MATCHED AND s.updated_at > t.updated_at THEN UPDATE SET value = s.value, updated_at = s.updated_at " +
+                                "WHEN NOT MATCHED AND s.value <> 'DELETED' THEN INSERT (k1, k2, value, updated_at) VALUES (s.k1, s.k2, s.value, s.updated_at)",
+                        0);
+                assertQuery("SELECT count(*) FROM " + target.getName(), "VALUES 3000");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

`MERGE` assigns independent unique IDs to target and source rows. After the right join, Trino coalesces these IDs and uses the result to detect multiple source rows for one target row. A target ID and a source ID can have the same numeric value, so unrelated rows can be treated as duplicates and produce a false `MERGE_TARGET_ROW_MULTIPLE_MATCHES` error.

Keep a boolean that records whether each ID came from the target. Include it in the `MarkDistinct` key so the two ID namespaces cannot collide.

Add an Iceberg regression test based on the reproducer from the linked issue. The test fails on current `master` and passes with this change. The existing test for genuine multiple source matches still passes.

## Additional context and related issues

- Fixes #30639

Commit 0e880c8cad already makes duplicated factories for one `AssignUniqueId` node share an ID pool. This change handles the separate target and source `AssignUniqueId` nodes used by `MERGE`.

Validation:

- `TestMerge`
- `TestIcebergIssue30639`
- `TestIcebergV2ParquetConnectorTest#testMergeMultipleRowsMatchFails`
- `./mvnw --projects core/trino-main,plugin/trino-iceberg --also-make validate`

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix false `MERGE_TARGET_ROW_MULTIPLE_MATCHES` failures for partitioned `MERGE` queries. ({issue}`30639`)
```