### PR TITLE
Add last_column_takes_rest Hive table property

### DIFF
--- a/docs/src/main/sphinx/connector/hive.md
+++ b/docs/src/main/sphinx/connector/hive.md
@@ -1041,6 +1041,11 @@ WITH (format='CSV',
     `CSV`, and `REGEX`. The catalog property `hive.storage-format` sets the
     default value and can change it to a different default.
   -
+* - `last_column_takes_rest`
+  - Set this property to `true` so that the last column absorbs the remainder
+    of the line, including any further occurrences of the field separator.
+    Requires TextFile, RCText, or SequenceFile format.
+  -
 * - `null_format`
   - The serialization format for `NULL` value. Requires TextFile, RCText, or
     SequenceFile format.

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -236,6 +236,7 @@ import static io.trino.plugin.hive.HiveTableProperties.CSV_ESCAPE;
 import static io.trino.plugin.hive.HiveTableProperties.CSV_QUOTE;
 import static io.trino.plugin.hive.HiveTableProperties.CSV_SEPARATOR;
 import static io.trino.plugin.hive.HiveTableProperties.EXTERNAL_LOCATION_PROPERTY;
+import static io.trino.plugin.hive.HiveTableProperties.LAST_COLUMN_TAKES_REST;
 import static io.trino.plugin.hive.HiveTableProperties.NULL_FORMAT_PROPERTY;
 import static io.trino.plugin.hive.HiveTableProperties.ORC_BLOOM_FILTER_COLUMNS;
 import static io.trino.plugin.hive.HiveTableProperties.ORC_BLOOM_FILTER_FPP;
@@ -264,6 +265,7 @@ import static io.trino.plugin.hive.HiveTableProperties.getParquetBloomFilterColu
 import static io.trino.plugin.hive.HiveTableProperties.getPartitionedBy;
 import static io.trino.plugin.hive.HiveTableProperties.getRegexPattern;
 import static io.trino.plugin.hive.HiveTableProperties.getSingleCharacterProperty;
+import static io.trino.plugin.hive.HiveTableProperties.isLastColumnTakesRest;
 import static io.trino.plugin.hive.HiveTableProperties.isRegexCaseInsensitive;
 import static io.trino.plugin.hive.HiveTableProperties.isTransactional;
 import static io.trino.plugin.hive.HiveTimestampPrecision.NANOSECONDS;
@@ -378,6 +380,7 @@ public class HiveMetadata
     private static final String TEXT_FIELD_SEPARATOR_KEY = SerdeConstants.FIELD_DELIM;
     private static final String TEXT_FIELD_SEPARATOR_ESCAPE_KEY = SerdeConstants.ESCAPE_CHAR;
     private static final String NULL_FORMAT_KEY = SerdeConstants.SERIALIZATION_NULL_FORMAT;
+    private static final String LAST_COLUMN_TAKES_REST_KEY = SerdeConstants.SERIALIZATION_LAST_COLUMN_TAKES_REST;
 
     public static final String AVRO_SCHEMA_URL_KEY = "avro.schema.url";
     public static final String AVRO_SCHEMA_LITERAL_KEY = "avro.schema.literal";
@@ -759,6 +762,8 @@ public class HiveMetadata
         // Multi-format property
         getSerdeProperty(table, NULL_FORMAT_KEY)
                 .ifPresent(nullFormat -> properties.put(NULL_FORMAT_PROPERTY, nullFormat));
+        getSerdeProperty(table, LAST_COLUMN_TAKES_REST_KEY)
+                .ifPresent(lastColumnTakesRest -> properties.put(LAST_COLUMN_TAKES_REST, parseBoolean(lastColumnTakesRest)));
 
         // Textfile specific properties
         getSerdeProperty(table, TEXT_FIELD_SEPARATOR_KEY)
@@ -1213,13 +1218,18 @@ public class HiveMetadata
             }
         });
 
-        // null_format is allowed in textfile, rctext, and sequencefile
-        Set<HiveStorageFormat> allowsNullFormat = ImmutableSet.of(
+        // null_format and last_column_takes_rest are allowed in textfile, rctext, and sequencefile
+        Set<HiveStorageFormat> allowsLazySimpleSerdeProperties = ImmutableSet.of(
                 HiveStorageFormat.TEXTFILE, HiveStorageFormat.RCTEXT, HiveStorageFormat.SEQUENCEFILE);
         getNullFormat(tableMetadata.getProperties())
                 .ifPresent(format -> {
-                    checkFormatForProperty(hiveStorageFormat, allowsNullFormat, NULL_FORMAT_PROPERTY);
+                    checkFormatForProperty(hiveStorageFormat, allowsLazySimpleSerdeProperties, NULL_FORMAT_PROPERTY);
                     tableProperties.put(NULL_FORMAT_KEY, format);
+                });
+        isLastColumnTakesRest(tableMetadata.getProperties())
+                .ifPresent(lastColumnTakesRest -> {
+                    checkFormatForProperty(hiveStorageFormat, allowsLazySimpleSerdeProperties, LAST_COLUMN_TAKES_REST);
+                    tableProperties.put(LAST_COLUMN_TAKES_REST_KEY, String.valueOf(lastColumnTakesRest));
                 });
 
         // Textfile-specific properties

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
@@ -62,6 +62,7 @@ public class HiveTableProperties
     public static final String TEXTFILE_FIELD_SEPARATOR = "textfile_field_separator";
     public static final String TEXTFILE_FIELD_SEPARATOR_ESCAPE = "textfile_field_separator_escape";
     public static final String NULL_FORMAT_PROPERTY = "null_format";
+    public static final String LAST_COLUMN_TAKES_REST = "last_column_takes_rest";
     public static final String SKIP_HEADER_LINE_COUNT = "skip_header_line_count";
     public static final String SKIP_FOOTER_LINE_COUNT = "skip_footer_line_count";
     public static final String CSV_SEPARATOR = "csv_separator";
@@ -169,6 +170,7 @@ public class HiveTableProperties
                 stringProperty(TEXTFILE_FIELD_SEPARATOR, "TEXTFILE field separator character", null, false),
                 stringProperty(TEXTFILE_FIELD_SEPARATOR_ESCAPE, "TEXTFILE field separator escape character", null, false),
                 stringProperty(NULL_FORMAT_PROPERTY, "Serialization format for NULL value", null, false),
+                booleanProperty(LAST_COLUMN_TAKES_REST, "Whether the last column of a delimited text table absorbs the remainder of the line", null, false),
                 stringProperty(CSV_SEPARATOR, "CSV separator character", null, false),
                 stringProperty(CSV_QUOTE, "CSV quote character", null, false),
                 stringProperty(CSV_ESCAPE, "CSV escape character", null, false),
@@ -244,6 +246,11 @@ public class HiveTableProperties
     public static Optional<String> getNullFormat(Map<String, Object> tableProperties)
     {
         return Optional.ofNullable((String) tableProperties.get(NULL_FORMAT_PROPERTY));
+    }
+
+    public static Optional<Boolean> isLastColumnTakesRest(Map<String, Object> tableProperties)
+    {
+        return Optional.ofNullable((Boolean) tableProperties.get(LAST_COLUMN_TAKES_REST));
     }
 
     public static HiveStorageFormat getHiveStorageFormat(Map<String, Object> tableProperties)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SerdeConstants.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SerdeConstants.java
@@ -17,6 +17,7 @@ public final class SerdeConstants
 {
     public static final String SERIALIZATION_LIB = "serialization.lib";
     public static final String SERIALIZATION_NULL_FORMAT = "serialization.null.format";
+    public static final String SERIALIZATION_LAST_COLUMN_TAKES_REST = "serialization.last.column.takes.rest";
 
     public static final String FIELD_DELIM = "field.delim";
     public static final String ESCAPE_CHAR = "escape.delim";

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -4532,6 +4532,19 @@ public abstract class BaseHiveConnectorTest
     }
 
     @Test
+    public void testCreateExternalTableWithLastColumnTakesRest()
+            throws Exception
+    {
+        testCreateExternalTable(
+                "test_create_external_with_last_column_takes_rest",
+                "helloXworldXextra\nbyeXworldXstuff", // the last column absorbs the remainder of the line, separator characters included
+                "VALUES ('hello', 'worldXextra'), ('bye', 'worldXstuff')",
+                ImmutableList.of(
+                        "last_column_takes_rest = true",
+                        "textfile_field_separator = 'X'"));
+    }
+
+    @Test
     public void testCreateExternalTableWithFieldSeparatorEscape()
             throws Exception
     {


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Exposes LazySimpleSerDe's `serialization.last.column.takes.rest` as 
a `CREATE TABLE` property, so the last column can absorb the remainder
of a delimited line, separator characters included.

Allowed for TEXTFILE,RCTEXT, and SEQUENCEFILE file formats.



Example:

```
CREATE TABLE logs (ts STRING, level STRING, message STRING)
ROW FORMAT DELIMITED
FIELDS TERMINATED BY '\t'
WITH SERDEPROPERTIES ('serialization.last.column.takes.rest'='true')
STORED AS TEXTFILE;
```
A row like 

```
2026-08-28\tERROR\tsomething failed\tstack: at foo.bar
``` 

would normally split into 4+ tokens for a 3-column table.

With this property however, `message` becomes 
```
something failed\tstack: at foo.bar
```
Everything after the second delimiter, unsplit.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The class `io.trino.hive.formats.line.simple.SimpleDeserializer` already has necessary handling for this table property.
What this PR does is simply to expose the functionality for Hive tables created via Trino.

https://github.com/trinodb/trino/blob/cec02f062b7613c357c497355bea1c3bc01ccce3/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/simple/SimpleDeserializer.java#L112-L115

https://github.com/trinodb/trino/blob/cec02f062b7613c357c497355bea1c3bc01ccce3/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/simple/SimpleDeserializer.java#L130-L133


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive
* Add `last_column_takes_rest` Hive table property . ({issue}`issuenumber`)
```
