### PR TITLE
Fix connector scalar functions failing on literal arguments

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionEvaluator.java
@@ -305,7 +305,7 @@ public class IrExpressionEvaluator
 
     private Object evaluateInternal(Call call, Session session, Map<String, Object> bindings)
     {
-        return functionInvoker.invoke(call.function(), session.toConnectorSession(), call.arguments().stream()
+        return functionInvoker.invoke(call.function(), session.toConnectorSession(call.function().catalogHandle()), call.arguments().stream()
                 .map(argument -> evaluate(argument, session, bindings))
                 .collect(toList()));
     }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestConnectorSessionFunctions.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestConnectorSessionFunctions.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import io.trino.Session;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorPlugin;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencies;
+import io.trino.spi.function.FunctionId;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.InvocationConvention;
+import io.trino.spi.function.ScalarFunctionImplementation;
+import io.trino.spi.function.Signature;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.spi.session.PropertyMetadata.longProperty;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.util.Reflection.methodHandle;
+
+public class TestConnectorSessionFunctions
+        extends AbstractTestQueryFramework
+{
+    private static final MethodHandle MULTIPLY = methodHandle(TestConnectorSessionFunctions.class, "multiply", ConnectorSession.class, long.class);
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return DistributedQueryRunner.builder(testSessionBuilder().build())
+                .setAdditionalSetup(queryRunner -> {
+                    queryRunner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
+                            .withSessionProperty(longProperty("connector_long", "Multiplier", 2L, false))
+                            .withFunctions(List.of(FunctionMetadata.scalarBuilder("multiply")
+                                    .signature(Signature.builder()
+                                            .argumentType(BIGINT)
+                                            .returnType(BIGINT)
+                                            .build())
+                                    .noDescription()
+                                    .build()))
+                            .withFunctionProvider(Optional.of(new FunctionProvider()
+                            {
+                                @Override
+                                public ScalarFunctionImplementation getScalarFunctionImplementation(
+                                        FunctionId functionId,
+                                        BoundSignature boundSignature,
+                                        FunctionDependencies functionDependencies,
+                                        InvocationConvention invocationConvention)
+                                {
+                                    return ScalarFunctionImplementation.builder()
+                                            .methodHandle(MULTIPLY)
+                                            .build();
+                                }
+                            }))
+                            .build()));
+                    queryRunner.createCatalog("mock", "mock");
+                })
+                .build();
+    }
+
+    @Test
+    public void testConnectorFunctionLiteralArgumentUsesCatalogSession()
+    {
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty("mock", "connector_long", "3")
+                .build();
+
+        assertQuery(session, "SELECT mock.default.multiply(5)", "VALUES 15");
+    }
+
+    public static long multiply(ConnectorSession session, long value)
+    {
+        return session.getProperty("connector_long", Long.class) * value;
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestLocalEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestLocalEngineOnlyQueries.java
@@ -13,20 +13,39 @@
  */
 package io.trino.tests;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.connector.MockConnectorPlugin;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencies;
+import io.trino.spi.function.FunctionId;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.InvocationConvention;
+import io.trino.spi.function.ScalarFunctionImplementation;
+import io.trino.spi.function.Signature;
 import io.trino.testing.AbstractTestEngineOnlyQueries;
 import io.trino.testing.CustomFunctionBundle;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
 
+import java.lang.invoke.MethodHandle;
+import java.util.Optional;
+
 import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.AbstractTestEngineOnlyQueries.TESTING_CATALOG;
+import static io.trino.util.Reflection.methodHandle;
 import static org.junit.jupiter.api.Assumptions.abort;
 
 public class TestLocalEngineOnlyQueries
         extends AbstractTestEngineOnlyQueries
 {
+    private static final MethodHandle MULTIPLY = methodHandle(TestLocalEngineOnlyQueries.class, "multiply", ConnectorSession.class, long.class);
+
     @Override
     protected QueryRunner createQueryRunner()
     {
@@ -37,6 +56,27 @@ public class TestLocalEngineOnlyQueries
             queryRunner.getSessionPropertyManager().addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);
             queryRunner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
                     .withSessionProperties(TEST_CATALOG_PROPERTIES)
+                    .withFunctions(ImmutableList.of(FunctionMetadata.scalarBuilder("multiply")
+                            .signature(Signature.builder()
+                                    .argumentType(BIGINT)
+                                    .returnType(BIGINT)
+                                    .build())
+                            .description("")
+                            .build()))
+                    .withFunctionProvider(Optional.of(new FunctionProvider()
+                    {
+                        @Override
+                        public ScalarFunctionImplementation getScalarFunctionImplementation(
+                                FunctionId functionId,
+                                BoundSignature boundSignature,
+                                FunctionDependencies functionDependencies,
+                                InvocationConvention invocationConvention)
+                        {
+                            return ScalarFunctionImplementation.builder()
+                                    .methodHandle(MULTIPLY)
+                                    .build();
+                        }
+                    }))
                     .build()));
             queryRunner.createCatalog(TESTING_CATALOG, "mock", ImmutableMap.of());
         }
@@ -44,6 +84,21 @@ public class TestLocalEngineOnlyQueries
             throw closeAllSuppress(e, queryRunner);
         }
         return queryRunner;
+    }
+
+    @Test
+    public void testConnectorFunctionLiteralArgumentUsesCatalogSession()
+    {
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty(TESTING_CATALOG, "connector_long", "3")
+                .build();
+
+        assertQuery(session, "SELECT testing_catalog.default.multiply(5)", "SELECT CAST(15 AS BIGINT)");
+    }
+
+    public static long multiply(ConnectorSession session, long value)
+    {
+        return session.getProperty("connector_long", Long.class) * value;
     }
 
     @Test


### PR DESCRIPTION
## Description

Connector authors can call a scalar that reads a catalog property on table rows, but the same function fails when passed a literal. `SELECT mock.default.multiply(5)` raises `Session property 'null.connector_long' does not exist`.

After this change, the literal call returns `15`. The expression evaluator binds its `ConnectorSession` to the resolved function's catalog before invocation. This fixes the constant-folded path. Compiled projections over table columns are covered by https://github.com/trinodb/trino/pull/30930.

### Verification

The regression registers a `multiply(BIGINT)` function and sets its catalog's `connector_long` property to `3`. I compiled the same test against `upstream/master` production source and this branch.

```shell
./mvnw -pl core/trino-spi,core/trino-main -DskipTests install -Dair.check.skip-all
./mvnw -pl testing/trino-tests -Dtest=TestConnectorSessionFunctions test -Dair.check.skip-all
```

<details>
<summary>Raw logs</summary>

```text
Before (upstream/master production source):
Caused by: io.trino.testing.QueryFailedException: Session property 'null.connector_long' does not exist
Caused by: io.trino.spi.TrinoException: Session property 'null.connector_long' does not exist
[ERROR] TestConnectorSessionFunctions.testConnectorFunctionLiteralArgumentUsesCatalogSession
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
[INFO] BUILD FAILURE

After (rebased branch head):
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

</details>

## Additional context and related issues

Related: https://github.com/trinodb/trino/issues/30889

- Generic method-handle adaptation: https://github.com/trinodb/trino/pull/30930

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix failure when connector functions that read catalog session properties are called with constant arguments. ({issue}`30889`)
```
