### PR TITLE
 Decompose PipelinedQueryScheduler recovery logic into focused components

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
@@ -535,58 +535,8 @@ public class SqlQueryExecution
 
         RetryPolicy retryPolicy = getRetryPolicy(getSession());
         QueryScheduler scheduler = switch (retryPolicy) {
-            case QUERY, NONE -> new PipelinedQueryScheduler(
-                    stateMachine,
-                    plan.getRoot(),
-                    nodePartitioningManager,
-                    nodeScheduler,
-                    remoteTaskFactory,
-                    plan.isSummarizeTaskInfos(),
-                    scheduleSplitBatchSize,
-                    queryExecutor,
-                    schedulerExecutor,
-                    nodeManager,
-                    nodeTaskMap,
-                    executionPolicy,
-                    tracer,
-                    schedulerStats,
-                    dynamicFilterService,
-                    tableExecuteContextManager,
-                    plannerContext.getMetadata(),
-                    splitSourceFactory,
-                    coordinatorTaskManager);
-            case TASK -> new EventDrivenFaultTolerantQueryScheduler(
-                    stateMachine,
-                    plannerContext.getMetadata(),
-                    remoteTaskFactory,
-                    taskDescriptorStorage,
-                    eventDrivenTaskSourceFactory,
-                    plan.isSummarizeTaskInfos(),
-                    nodeTaskMap,
-                    queryExecutor,
-                    schedulerExecutor,
-                    tracer,
-                    schedulerStats,
-                    partitionMemoryEstimatorFactory,
-                    outputStatsEstimatorFactory,
-                    nodePartitioningManager,
-                    exchangeManagerRegistry.getExchangeManager(),
-                    exchangeMetricsCollector,
-                    nodeAllocatorService,
-                    nodeManager,
-                    dynamicFilterService,
-                    taskExecutionStats,
-                    new AdaptivePlanner(
-                            stateMachine.getSession(),
-                            plannerContext,
-                            adaptivePlanOptimizers,
-                            planFragmenter,
-                            DISTRIBUTED_PLAN_SANITY_CHECKER,
-                            stateMachine.getWarningCollector(),
-                            planOptimizersStatsCollector,
-                            tableStatsProvider),
-                    stageExecutionStats,
-                    plan.getRoot());
+            case QUERY, NONE -> createPipelinedScheduler(plan);
+            case TASK -> createFaultTolerantScheduler(plan, tableStatsProvider);
         };
 
         queryScheduler.set(scheduler);
@@ -595,6 +545,66 @@ public class SqlQueryExecution
                 queryScheduler.set(null);
             }
         });
+    }
+
+    private PipelinedQueryScheduler createPipelinedScheduler(PlanRoot plan)
+    {
+        return new PipelinedQueryScheduler(
+                stateMachine,
+                plan.getRoot(),
+                nodePartitioningManager,
+                nodeScheduler,
+                remoteTaskFactory,
+                plan.isSummarizeTaskInfos(),
+                scheduleSplitBatchSize,
+                queryExecutor,
+                schedulerExecutor,
+                nodeManager,
+                nodeTaskMap,
+                executionPolicy,
+                tracer,
+                schedulerStats,
+                dynamicFilterService,
+                tableExecuteContextManager,
+                plannerContext.getMetadata(),
+                splitSourceFactory,
+                coordinatorTaskManager);
+    }
+
+    private EventDrivenFaultTolerantQueryScheduler createFaultTolerantScheduler(PlanRoot plan, CachingTableStatsProvider tableStatsProvider)
+    {
+        return new EventDrivenFaultTolerantQueryScheduler(
+                stateMachine,
+                plannerContext.getMetadata(),
+                remoteTaskFactory,
+                taskDescriptorStorage,
+                eventDrivenTaskSourceFactory,
+                plan.isSummarizeTaskInfos(),
+                nodeTaskMap,
+                queryExecutor,
+                schedulerExecutor,
+                tracer,
+                schedulerStats,
+                partitionMemoryEstimatorFactory,
+                outputStatsEstimatorFactory,
+                nodePartitioningManager,
+                exchangeManagerRegistry.getExchangeManager(),
+                exchangeMetricsCollector,
+                nodeAllocatorService,
+                nodeManager,
+                dynamicFilterService,
+                taskExecutionStats,
+                new AdaptivePlanner(
+                        stateMachine.getSession(),
+                        plannerContext,
+                        adaptivePlanOptimizers,
+                        planFragmenter,
+                        DISTRIBUTED_PLAN_SANITY_CHECKER,
+                        stateMachine.getWarningCollector(),
+                        planOptimizersStatsCollector,
+                        tableStatsProvider),
+                stageExecutionStats,
+                plan.getRoot());
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
@@ -552,7 +552,7 @@ public class SqlQueryExecution
                                     getRetryDelayScaleFactor(getSession()))))
                     .create();
             case NONE -> pipelinedSchedulerFactory(plan).create();
-            case TASK -> createFaultTolerantScheduler(plan, tableStatsProvider);
+            case TASK -> faultTolerantSchedulerFactory(plan, tableStatsProvider).create();
         };
 
         queryScheduler.set(scheduler);
@@ -587,9 +587,9 @@ public class SqlQueryExecution
                 coordinatorTaskManager);
     }
 
-    private EventDrivenFaultTolerantQueryScheduler createFaultTolerantScheduler(PlanRoot plan, CachingTableStatsProvider tableStatsProvider)
+    private EventDrivenFaultTolerantQueryScheduler.Factory faultTolerantSchedulerFactory(PlanRoot plan, CachingTableStatsProvider tableStatsProvider)
     {
-        return new EventDrivenFaultTolerantQueryScheduler(
+        return new EventDrivenFaultTolerantQueryScheduler.Factory(
                 stateMachine,
                 plannerContext.getMetadata(),
                 remoteTaskFactory,

--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
@@ -33,6 +33,8 @@ import io.trino.exchange.ExchangeMetricsCollector;
 import io.trino.execution.QueryPreparer.PreparedQuery;
 import io.trino.execution.StateMachine.StateChangeListener;
 import io.trino.execution.querystats.PlanOptimizersStatsCollector;
+import io.trino.execution.recovery.BackoffPolicy;
+import io.trino.execution.recovery.RetryingRecoveryStrategy;
 import io.trino.execution.scheduler.NodeScheduler;
 import io.trino.execution.scheduler.PipelinedQueryScheduler;
 import io.trino.execution.scheduler.QueryScheduler;
@@ -96,6 +98,10 @@ import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.airlift.units.Duration.succinctDuration;
+import static io.trino.SystemSessionProperties.getQueryRetryAttempts;
+import static io.trino.SystemSessionProperties.getRetryDelayScaleFactor;
+import static io.trino.SystemSessionProperties.getRetryInitialDelay;
+import static io.trino.SystemSessionProperties.getRetryMaxDelay;
 import static io.trino.SystemSessionProperties.getRetryPolicy;
 import static io.trino.SystemSessionProperties.isEnableDynamicFiltering;
 import static io.trino.execution.ParameterExtractor.bindParameters;
@@ -535,7 +541,17 @@ public class SqlQueryExecution
 
         RetryPolicy retryPolicy = getRetryPolicy(getSession());
         QueryScheduler scheduler = switch (retryPolicy) {
-            case QUERY, NONE -> createPipelinedScheduler(plan);
+            case QUERY -> pipelinedSchedulerFactory(plan)
+                    .withFailureRecoveryStrategy(pipelinedScheduler -> new RetryingRecoveryStrategy(
+                            (_, delay) -> pipelinedScheduler.retry(delay),
+                            stateMachine::isDone,
+                            new BackoffPolicy(
+                                    getQueryRetryAttempts(getSession()),
+                                    getRetryInitialDelay(getSession()),
+                                    getRetryMaxDelay(getSession()),
+                                    getRetryDelayScaleFactor(getSession()))))
+                    .create();
+            case NONE -> pipelinedSchedulerFactory(plan).create();
             case TASK -> createFaultTolerantScheduler(plan, tableStatsProvider);
         };
 
@@ -547,9 +563,9 @@ public class SqlQueryExecution
         });
     }
 
-    private PipelinedQueryScheduler createPipelinedScheduler(PlanRoot plan)
+    private PipelinedQueryScheduler.Factory pipelinedSchedulerFactory(PlanRoot plan)
     {
-        return new PipelinedQueryScheduler(
+        return new PipelinedQueryScheduler.Factory(
                 stateMachine,
                 plan.getRoot(),
                 nodePartitioningManager,

--- a/core/trino-main/src/main/java/io/trino/execution/recovery/BackoffPolicy.java
+++ b/core/trino-main/src/main/java/io/trino/execution/recovery/BackoffPolicy.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.recovery;
+
+import io.airlift.units.Duration;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.min;
+import static java.lang.Math.pow;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public record BackoffPolicy(int maxRetries, Duration initialDelay, Duration maxDelay, double scaleFactor)
+{
+    private static final Duration ZERO = new Duration(0, MILLISECONDS);
+
+    public BackoffPolicy
+    {
+        // 0 is a valid configuration: query-retry-attempts=0 means the failure is passed on without any retry
+        checkArgument(maxRetries >= 0, "maxRetries must be >= 0, got %s", maxRetries);
+        checkArgument(scaleFactor >= 1.0, "scaleFactor must be >= 1.0, got %s", scaleFactor);
+        requireNonNull(initialDelay, "initialDelay is null");
+        requireNonNull(maxDelay, "maxDelay is null");
+        checkArgument(maxDelay.compareTo(initialDelay) >= 0, "maxDelay (%s) must be >= initialDelay (%s)", maxDelay, initialDelay);
+    }
+
+    public static final BackoffPolicy RETRY_ONCE_IMMEDIATE = new BackoffPolicy(1, ZERO, ZERO, 1.0);
+
+    public Duration delayFor(int retry)
+    {
+        long millis = min(initialDelay.toMillis() * (long) pow(scaleFactor, retry), maxDelay.toMillis());
+        return new Duration(millis, MILLISECONDS);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/recovery/FailQuery.java
+++ b/core/trino-main/src/main/java/io/trino/execution/recovery/FailQuery.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.recovery;
+
+import io.trino.spi.ErrorCode;
+
+import java.util.function.Consumer;
+
+public final class FailQuery
+        implements FailureRecoveryStrategy
+{
+    public static final FailQuery INSTANCE = new FailQuery();
+
+    private FailQuery() {}
+
+    @Override
+    public boolean handleFailure(Throwable failure, ErrorCode errorCode, Consumer<Throwable> failQuery)
+    {
+        failQuery.accept(failure);
+        return true;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/recovery/FailureRecoveryStrategy.java
+++ b/core/trino-main/src/main/java/io/trino/execution/recovery/FailureRecoveryStrategy.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.recovery;
+
+import io.trino.spi.ErrorCode;
+
+import java.util.function.Consumer;
+
+/**
+ * Owns a scheduler's reaction to a distributed-stages failure
+ */
+public interface FailureRecoveryStrategy
+{
+    /**
+     * @param failQuery fails the query; invoked by a strategy to reject a failure as not worth recovering from
+     * @return true if handled (recovery in flight, or {@code failQuery} invoked) and the caller must do nothing further;
+     *         false if declined, and the caller must try the next strategy or invoke {@code failQuery} itself
+     */
+    boolean handleFailure(Throwable failure, ErrorCode errorCode, Consumer<Throwable> failQuery);
+}

--- a/core/trino-main/src/main/java/io/trino/execution/recovery/RecoveryAction.java
+++ b/core/trino-main/src/main/java/io/trino/execution/recovery/RecoveryAction.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.recovery;
+
+import io.airlift.units.Duration;
+
+public interface RecoveryAction
+{
+    void run(Throwable failure, Duration delay);
+}

--- a/core/trino-main/src/main/java/io/trino/execution/recovery/RetryableErrorClassifier.java
+++ b/core/trino-main/src/main/java/io/trino/execution/recovery/RetryableErrorClassifier.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.recovery;
+
+import io.trino.spi.ErrorCode;
+
+import static io.trino.spi.ErrorType.EXTERNAL;
+import static io.trino.spi.ErrorType.INTERNAL_ERROR;
+import static io.trino.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
+
+public final class RetryableErrorClassifier
+{
+    private RetryableErrorClassifier() {}
+
+    public static boolean isRetryable(ErrorCode errorCode)
+    {
+        if (errorCode == null) {
+            return true;
+        }
+
+        if (errorCode.isFatal()) {
+            return false;
+        }
+        return errorCode.getType() == INTERNAL_ERROR
+                || errorCode.getType() == EXTERNAL
+                || errorCode.getCode() == CLUSTER_OUT_OF_MEMORY.toErrorCode().getCode();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/recovery/RetryingRecoveryStrategy.java
+++ b/core/trino-main/src/main/java/io/trino/execution/recovery/RetryingRecoveryStrategy.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.recovery;
+
+import io.trino.spi.ErrorCode;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+
+import static io.trino.execution.recovery.RetryableErrorClassifier.isRetryable;
+import static java.util.Objects.requireNonNull;
+
+public class RetryingRecoveryStrategy
+        implements FailureRecoveryStrategy
+{
+    private final RecoveryAction recoveryAction;
+    private final BooleanSupplier queryDone;
+    private final BackoffPolicy backoffPolicy;
+    private final AtomicInteger retries = new AtomicInteger();
+
+    public RetryingRecoveryStrategy(RecoveryAction recoveryAction, BooleanSupplier queryDone, BackoffPolicy backoffPolicy)
+    {
+        this.recoveryAction = requireNonNull(recoveryAction, "recoveryAction is null");
+        this.queryDone = requireNonNull(queryDone, "queryDone is null");
+        this.backoffPolicy = requireNonNull(backoffPolicy, "backoffPolicy is null");
+    }
+
+    @Override
+    public boolean handleFailure(Throwable failure, ErrorCode errorCode, Consumer<Throwable> failQuery)
+    {
+        if (queryDone.getAsBoolean() || !isRetryable(errorCode)) {
+            failQuery.accept(failure);
+            return true;
+        }
+        int retry = retries.getAndIncrement();
+        if (retry >= backoffPolicy.maxRetries()) {
+            return false; // caller handles
+        }
+        recoveryAction.run(failure, backoffPolicy.delayFor(retry));
+        return true;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
@@ -122,6 +122,7 @@ import static io.trino.SystemSessionProperties.getRetryMaxDelay;
 import static io.trino.SystemSessionProperties.getRetryPolicy;
 import static io.trino.SystemSessionProperties.getWriterScalingMinDataProcessed;
 import static io.trino.execution.QueryState.STARTING;
+import static io.trino.execution.recovery.RetryableErrorClassifier.isRetryable;
 import static io.trino.execution.scheduler.PipelinedQueryScheduler.ConstantKey.EMPTY;
 import static io.trino.execution.scheduler.PipelinedQueryScheduler.ConstantKey.ONE;
 import static io.trino.execution.scheduler.PipelinedStageExecution.createPipelinedStageExecution;
@@ -136,9 +137,6 @@ import static io.trino.execution.scheduler.StageExecution.State.SCHEDULED;
 import static io.trino.operator.RetryPolicy.NONE;
 import static io.trino.operator.RetryPolicy.QUERY;
 import static io.trino.operator.output.SkewedPartitionRebalancer.getSkewedBucketCount;
-import static io.trino.spi.ErrorType.EXTERNAL;
-import static io.trino.spi.ErrorType.INTERNAL_ERROR;
-import static io.trino.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static io.trino.spi.StandardErrorCode.REMOTE_TASK_FAILED;
@@ -393,21 +391,7 @@ public class PipelinedQueryScheduler
 
     private boolean shouldRetry(ErrorCode errorCode)
     {
-        return retryPolicy == RetryPolicy.QUERY && currentAttempt.get() < maxQueryRetryAttempts && isRetryableErrorCode(errorCode);
-    }
-
-    private static boolean isRetryableErrorCode(ErrorCode errorCode)
-    {
-        if (errorCode == null) {
-            return true;
-        }
-
-        if (errorCode.isFatal()) {
-            return false;
-        }
-        return errorCode.getType() == INTERNAL_ERROR
-                || errorCode.getType() == EXTERNAL
-                || errorCode.getCode() == CLUSTER_OUT_OF_MEMORY.toErrorCode().getCode();
+        return retryPolicy == RetryPolicy.QUERY && currentAttempt.get() < maxQueryRetryAttempts && isRetryable(errorCode);
     }
 
     private void scheduleRetryWithDelay(long delayInMillis)

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
@@ -50,6 +50,7 @@ import io.trino.execution.TableExecuteContextManager;
 import io.trino.execution.TaskFailureListener;
 import io.trino.execution.TaskId;
 import io.trino.execution.TaskStatus;
+import io.trino.execution.recovery.BackoffPolicy;
 import io.trino.execution.scheduler.policy.ExecutionPolicy;
 import io.trino.execution.scheduler.policy.ExecutionSchedule;
 import io.trino.execution.scheduler.policy.StagesScheduleResult;
@@ -149,8 +150,6 @@ import static io.trino.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static io.trino.sql.planner.plan.ExchangeNode.Type.REPLICATE;
 import static io.trino.util.Failures.checkCondition;
 import static io.trino.util.Failures.toFailure;
-import static java.lang.Math.min;
-import static java.lang.Math.pow;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -180,11 +179,8 @@ public class PipelinedQueryScheduler
     private final CoordinatorStagesScheduler coordinatorStagesScheduler;
 
     private final RetryPolicy retryPolicy;
-    private final int maxQueryRetryAttempts;
+    private final BackoffPolicy backoffPolicy;
     private final AtomicInteger currentAttempt = new AtomicInteger();
-    private final Duration retryInitialDelay;
-    private final Duration retryMaxDelay;
-    private final double retryDelayScaleFactor;
     private final Span schedulerSpan;
 
     @GuardedBy("this")
@@ -256,10 +252,11 @@ public class PipelinedQueryScheduler
 
         retryPolicy = getRetryPolicy(queryStateMachine.getSession());
         verify(retryPolicy == NONE || retryPolicy == QUERY, "unexpected retry policy: %s", retryPolicy);
-        maxQueryRetryAttempts = getQueryRetryAttempts(queryStateMachine.getSession());
-        retryInitialDelay = getRetryInitialDelay(queryStateMachine.getSession());
-        retryMaxDelay = getRetryMaxDelay(queryStateMachine.getSession());
-        retryDelayScaleFactor = getRetryDelayScaleFactor(queryStateMachine.getSession());
+        backoffPolicy = new BackoffPolicy(
+                getQueryRetryAttempts(queryStateMachine.getSession()),
+                getRetryInitialDelay(queryStateMachine.getSession()),
+                getRetryMaxDelay(queryStateMachine.getSession()),
+                getRetryDelayScaleFactor(queryStateMachine.getSession()));
     }
 
     @Override
@@ -369,7 +366,7 @@ public class PipelinedQueryScheduler
                         .orElseGet(() -> new StageFailureInfo(toFailure(new VerifyException("distributedStagesScheduler failed but failure cause is not present")), Optional.empty()));
                 ErrorCode errorCode = stageFailureInfo.getFailureInfo().errorCode();
                 if (shouldRetry(errorCode)) {
-                    long delayInMillis = min(retryInitialDelay.toMillis() * ((long) pow(retryDelayScaleFactor, currentAttempt.get())), retryMaxDelay.toMillis());
+                    long delayInMillis = backoffPolicy.delayFor(currentAttempt.get()).toMillis();
                     currentAttempt.incrementAndGet();
                     scheduleRetryWithDelay(delayInMillis);
                 }
@@ -391,7 +388,7 @@ public class PipelinedQueryScheduler
 
     private boolean shouldRetry(ErrorCode errorCode)
     {
-        return retryPolicy == RetryPolicy.QUERY && currentAttempt.get() < maxQueryRetryAttempts && isRetryable(errorCode);
+        return retryPolicy == RetryPolicy.QUERY && currentAttempt.get() < backoffPolicy.maxRetries() && isRetryable(errorCode);
     }
 
     private void scheduleRetryWithDelay(long delayInMillis)

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
@@ -50,7 +50,8 @@ import io.trino.execution.TableExecuteContextManager;
 import io.trino.execution.TaskFailureListener;
 import io.trino.execution.TaskId;
 import io.trino.execution.TaskStatus;
-import io.trino.execution.recovery.BackoffPolicy;
+import io.trino.execution.recovery.FailQuery;
+import io.trino.execution.recovery.FailureRecoveryStrategy;
 import io.trino.execution.scheduler.policy.ExecutionPolicy;
 import io.trino.execution.scheduler.policy.ExecutionSchedule;
 import io.trino.execution.scheduler.policy.StagesScheduleResult;
@@ -97,6 +98,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -116,14 +118,9 @@ import static io.airlift.concurrent.MoreFutures.whenAnyComplete;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.trino.SystemSessionProperties.getMaxHashPartitionCount;
 import static io.trino.SystemSessionProperties.getMaxWriterTaskCount;
-import static io.trino.SystemSessionProperties.getQueryRetryAttempts;
-import static io.trino.SystemSessionProperties.getRetryDelayScaleFactor;
-import static io.trino.SystemSessionProperties.getRetryInitialDelay;
-import static io.trino.SystemSessionProperties.getRetryMaxDelay;
 import static io.trino.SystemSessionProperties.getRetryPolicy;
 import static io.trino.SystemSessionProperties.getWriterScalingMinDataProcessed;
 import static io.trino.execution.QueryState.STARTING;
-import static io.trino.execution.recovery.RetryableErrorClassifier.isRetryable;
 import static io.trino.execution.scheduler.PipelinedQueryScheduler.ConstantKey.EMPTY;
 import static io.trino.execution.scheduler.PipelinedQueryScheduler.ConstantKey.ONE;
 import static io.trino.execution.scheduler.PipelinedStageExecution.createPipelinedStageExecution;
@@ -179,19 +176,21 @@ public class PipelinedQueryScheduler
     private final CoordinatorStagesScheduler coordinatorStagesScheduler;
 
     private final RetryPolicy retryPolicy;
-    private final BackoffPolicy backoffPolicy;
     private final AtomicInteger currentAttempt = new AtomicInteger();
     private final Span schedulerSpan;
 
     @GuardedBy("this")
     private boolean started;
 
+    private final FailureRecoveryStrategy failureRecoveryStrategy;
+
     @GuardedBy("this")
     private final AtomicReference<DistributedStagesScheduler> distributedStagesScheduler = new AtomicReference<>();
     @GuardedBy("this")
     private Future<Void> distributedStagesSchedulingTask;
 
-    public PipelinedQueryScheduler(
+    private PipelinedQueryScheduler(
+            Function<PipelinedQueryScheduler, FailureRecoveryStrategy> failureRecoveryStrategyFactory,
             QueryStateMachine queryStateMachine,
             SubPlan plan,
             NodePartitioningManager nodePartitioningManager,
@@ -252,11 +251,16 @@ public class PipelinedQueryScheduler
 
         retryPolicy = getRetryPolicy(queryStateMachine.getSession());
         verify(retryPolicy == NONE || retryPolicy == QUERY, "unexpected retry policy: %s", retryPolicy);
-        backoffPolicy = new BackoffPolicy(
-                getQueryRetryAttempts(queryStateMachine.getSession()),
-                getRetryInitialDelay(queryStateMachine.getSession()),
-                getRetryMaxDelay(queryStateMachine.getSession()),
-                getRetryDelayScaleFactor(queryStateMachine.getSession()));
+        this.failureRecoveryStrategy = requireNonNull(failureRecoveryStrategyFactory.apply(this), "failureRecoveryStrategy is null");
+    }
+
+    /**
+     * Re-run the distributed stages of this query in place after the given delay.
+     */
+    public void retry(Duration delay)
+    {
+        currentAttempt.incrementAndGet();
+        scheduleRetryWithDelay(delay.toMillis());
     }
 
     @Override
@@ -365,30 +369,24 @@ public class PipelinedQueryScheduler
                 StageFailureInfo stageFailureInfo = distributedStagesScheduler.getFailureCause()
                         .orElseGet(() -> new StageFailureInfo(toFailure(new VerifyException("distributedStagesScheduler failed but failure cause is not present")), Optional.empty()));
                 ErrorCode errorCode = stageFailureInfo.getFailureInfo().errorCode();
-                if (shouldRetry(errorCode)) {
-                    long delayInMillis = backoffPolicy.delayFor(currentAttempt.get()).toMillis();
-                    currentAttempt.incrementAndGet();
-                    scheduleRetryWithDelay(delayInMillis);
-                }
-                else {
+                Throwable cause = stageFailureInfo.getFailureInfo().toException();
+                Consumer<Throwable> failQuery = failure -> {
                     stageManager.getDistributedStagesInTopologicalOrder().forEach(stage -> {
                         if (stageFailureInfo.getFailedStageId().isPresent() && stageFailureInfo.getFailedStageId().get().equals(stage.getStageId())) {
-                            stage.fail(stageFailureInfo.getFailureInfo().toException());
+                            stage.fail(failure);
                         }
                         else {
                             stage.abort();
                         }
                     });
-                    queryStateMachine.transitionToFailed(stageFailureInfo.getFailureInfo().toException());
+                    queryStateMachine.transitionToFailed(failure);
+                };
+                if (!failureRecoveryStrategy.handleFailure(cause, errorCode, failQuery)) {
+                    failQuery.accept(cause);
                 }
             }
         });
         return Optional.of(distributedStagesScheduler);
-    }
-
-    private boolean shouldRetry(ErrorCode errorCode)
-    {
-        return retryPolicy == RetryPolicy.QUERY && currentAttempt.get() < backoffPolicy.maxRetries() && isRetryable(errorCode);
     }
 
     private void scheduleRetryWithDelay(long delayInMillis)
@@ -1585,6 +1583,109 @@ public class PipelinedQueryScheduler
         {
             this.handle = requireNonNull(handle, "handle cannot be null");
             this.partitionCount = partitionCount;
+        }
+    }
+
+    /**
+     * Builds a {@link PipelinedQueryScheduler} with a {@link FailureRecoveryStrategy} wired at construction time.
+     * The strategy is supplied as a function of the scheduler so it can close over the not-yet-constructed instance
+     * (e.g. to call {@link #retry(Duration)}). Defaults to {@link FailQuery#INSTANCE} when no strategy is provided.
+     */
+    public static final class Factory
+    {
+        private final QueryStateMachine queryStateMachine;
+        private final SubPlan plan;
+        private final NodePartitioningManager nodePartitioningManager;
+        private final NodeScheduler nodeScheduler;
+        private final RemoteTaskFactory remoteTaskFactory;
+        private final boolean summarizeTaskInfo;
+        private final int splitBatchSize;
+        private final ExecutorService queryExecutor;
+        private final ScheduledExecutorService schedulerExecutor;
+        private final InternalNodeManager nodeManager;
+        private final NodeTaskMap nodeTaskMap;
+        private final ExecutionPolicy executionPolicy;
+        private final Tracer tracer;
+        private final SplitSchedulerStats schedulerStats;
+        private final DynamicFilterService dynamicFilterService;
+        private final TableExecuteContextManager tableExecuteContextManager;
+        private final Metadata metadata;
+        private final SplitSourceFactory splitSourceFactory;
+        private final SqlTaskManager coordinatorTaskManager;
+
+        private Function<PipelinedQueryScheduler, FailureRecoveryStrategy> failureRecoveryStrategyFactory = _ -> FailQuery.INSTANCE;
+
+        public Factory(
+                QueryStateMachine queryStateMachine,
+                SubPlan plan,
+                NodePartitioningManager nodePartitioningManager,
+                NodeScheduler nodeScheduler,
+                RemoteTaskFactory remoteTaskFactory,
+                boolean summarizeTaskInfo,
+                int splitBatchSize,
+                ExecutorService queryExecutor,
+                ScheduledExecutorService schedulerExecutor,
+                InternalNodeManager nodeManager,
+                NodeTaskMap nodeTaskMap,
+                ExecutionPolicy executionPolicy,
+                Tracer tracer,
+                SplitSchedulerStats schedulerStats,
+                DynamicFilterService dynamicFilterService,
+                TableExecuteContextManager tableExecuteContextManager,
+                Metadata metadata,
+                SplitSourceFactory splitSourceFactory,
+                SqlTaskManager coordinatorTaskManager)
+        {
+            this.queryStateMachine = queryStateMachine;
+            this.plan = plan;
+            this.nodePartitioningManager = nodePartitioningManager;
+            this.nodeScheduler = nodeScheduler;
+            this.remoteTaskFactory = remoteTaskFactory;
+            this.summarizeTaskInfo = summarizeTaskInfo;
+            this.splitBatchSize = splitBatchSize;
+            this.queryExecutor = queryExecutor;
+            this.schedulerExecutor = schedulerExecutor;
+            this.nodeManager = nodeManager;
+            this.nodeTaskMap = nodeTaskMap;
+            this.executionPolicy = executionPolicy;
+            this.tracer = tracer;
+            this.schedulerStats = schedulerStats;
+            this.dynamicFilterService = dynamicFilterService;
+            this.tableExecuteContextManager = tableExecuteContextManager;
+            this.metadata = metadata;
+            this.splitSourceFactory = splitSourceFactory;
+            this.coordinatorTaskManager = coordinatorTaskManager;
+        }
+
+        public Factory withFailureRecoveryStrategy(Function<PipelinedQueryScheduler, FailureRecoveryStrategy> factory)
+        {
+            this.failureRecoveryStrategyFactory = requireNonNull(factory, "factory is null");
+            return this;
+        }
+
+        public PipelinedQueryScheduler create()
+        {
+            return new PipelinedQueryScheduler(
+                    failureRecoveryStrategyFactory,
+                    queryStateMachine,
+                    plan,
+                    nodePartitioningManager,
+                    nodeScheduler,
+                    remoteTaskFactory,
+                    summarizeTaskInfo,
+                    splitBatchSize,
+                    queryExecutor,
+                    schedulerExecutor,
+                    nodeManager,
+                    nodeTaskMap,
+                    executionPolicy,
+                    tracer,
+                    schedulerStats,
+                    dynamicFilterService,
+                    tableExecuteContextManager,
+                    metadata,
+                    splitSourceFactory,
+                    coordinatorTaskManager);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -69,6 +69,8 @@ import io.trino.execution.TaskStatus;
 import io.trino.execution.buffer.OutputBufferStatus;
 import io.trino.execution.buffer.SpoolingOutputBuffers;
 import io.trino.execution.buffer.SpoolingOutputStats;
+import io.trino.execution.recovery.FailQuery;
+import io.trino.execution.recovery.FailureRecoveryStrategy;
 import io.trino.execution.resourcegroups.IndexedPriorityQueue;
 import io.trino.execution.scheduler.OutputDataSizeEstimate;
 import io.trino.execution.scheduler.QueryScheduler;
@@ -214,6 +216,7 @@ public class EventDrivenFaultTolerantQueryScheduler
 
     private static final Logger log = Logger.get(EventDrivenFaultTolerantQueryScheduler.class);
 
+    private final FailureRecoveryStrategy failureRecoveryStrategy;
     private final QueryStateMachine queryStateMachine;
     private final Metadata metadata;
     private final RemoteTaskFactory remoteTaskFactory;
@@ -246,7 +249,8 @@ public class EventDrivenFaultTolerantQueryScheduler
     @GuardedBy("this")
     private Scheduler scheduler;
 
-    public EventDrivenFaultTolerantQueryScheduler(
+    private EventDrivenFaultTolerantQueryScheduler(
+            FailureRecoveryStrategy failureRecoveryStrategy,
             QueryStateMachine queryStateMachine,
             Metadata metadata,
             RemoteTaskFactory remoteTaskFactory,
@@ -302,6 +306,8 @@ public class EventDrivenFaultTolerantQueryScheduler
         this.stageEstimationForEagerParentEnabled = isFaultTolerantExecutionStageEstimationForEagerParentEnabled(queryStateMachine.getSession());
 
         stageRegistry = new StageRegistry(queryStateMachine, originalPlan);
+
+        this.failureRecoveryStrategy = requireNonNull(failureRecoveryStrategy, "failureRecoveryStrategy is null");
     }
 
     @Override
@@ -381,7 +387,8 @@ public class EventDrivenFaultTolerantQueryScheduler
                     maxPartitionCount,
                     stageEstimationForEagerParentEnabled,
                     adaptivePlanner,
-                    nodePartitioningManager::getBucketCount);
+                    nodePartitioningManager::getBucketCount,
+                    failureRecoveryStrategy);
             queryExecutor.submit(scheduler::run);
         }
         catch (Throwable t) {
@@ -789,6 +796,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         private final SchedulingDelayer schedulingDelayer;
 
         private boolean queryOutputSet;
+        private final FailureRecoveryStrategy failureRecoveryStrategy;
 
         public Scheduler(
                 QueryStateMachine queryStateMachine,
@@ -821,7 +829,8 @@ public class EventDrivenFaultTolerantQueryScheduler
                 int maxPartitionCount,
                 boolean stageEstimationForEagerParentEnabled,
                 Optional<AdaptivePlanner> adaptivePlanner,
-                LocalExchangeBucketCountProvider bucketCountProvider)
+                LocalExchangeBucketCountProvider bucketCountProvider,
+                FailureRecoveryStrategy failureRecoveryStrategy)
         {
             this.queryStateMachine = requireNonNull(queryStateMachine, "queryStateMachine is null");
             this.metadata = requireNonNull(metadata, "metadata is null");
@@ -836,6 +845,7 @@ public class EventDrivenFaultTolerantQueryScheduler
             this.schedulerStats = requireNonNull(schedulerStats, "schedulerStats is null");
             this.memoryEstimatorFactory = requireNonNull(memoryEstimatorFactory, "memoryEstimatorFactory is null");
             this.outputStatsEstimator = requireNonNull(outputStatsEstimator, "outputStatsEstimator is null");
+            this.failureRecoveryStrategy = requireNonNull(failureRecoveryStrategy, "failureRecoveryStrategy is null");
             this.partitioningSchemeFactory = requireNonNull(partitioningSchemeFactory, "partitioningSchemeFactory is null");
             this.exchangeManager = requireNonNull(exchangeManager, "exchangeManager is null");
             this.exchangeMetricsCollector = requireNonNull(exchangeMetricsCollector, "exchangeMetricsCollector is null");
@@ -911,7 +921,10 @@ public class EventDrivenFaultTolerantQueryScheduler
             failure = closeAndAddSuppressed(failure, nodeAllocator);
 
             failure.ifPresent(fail -> {
-                queryStateMachine.transitionToFailed(fail);
+                ErrorCode errorCode = fail instanceof TrinoException trinoException ? trinoException.getErrorCode() : null;
+                if (!failureRecoveryStrategy.handleFailure(fail, errorCode, queryStateMachine::transitionToFailed)) {
+                    queryStateMachine.transitionToFailed(fail);
+                }
                 schedulerSpan.addEvent("scheduler_failure", Attributes.of(FAILURE_MESSAGE, fail.getMessage()));
             });
             schedulerSpan.end();
@@ -1088,7 +1101,10 @@ public class EventDrivenFaultTolerantQueryScheduler
 
                     taskFailures.forEach(taskFailure -> failure.addSuppressed(new RuntimeException("Task " + taskFailure.getKey() + " failed", taskFailure.getValue())));
 
-                    queryStateMachine.transitionToFailed(failure);
+                    ErrorCode errorCode = failure instanceof TrinoException trinoException ? trinoException.getErrorCode() : null;
+                    if (!failureRecoveryStrategy.handleFailure(failure, errorCode, queryStateMachine::transitionToFailed)) {
+                        queryStateMachine.transitionToFailed(failure);
+                    }
                     return true;
                 }
             }
@@ -1121,7 +1137,10 @@ public class EventDrivenFaultTolerantQueryScheduler
                     @Override
                     public void onFailure(Throwable t)
                     {
-                        queryStateMachine.transitionToFailed(t);
+                        ErrorCode errorCode = t instanceof TrinoException trinoException ? trinoException.getErrorCode() : null;
+                        if (!failureRecoveryStrategy.handleFailure(t, errorCode, queryStateMachine::transitionToFailed)) {
+                            queryStateMachine.transitionToFailed(t);
+                        }
                     }
                 }, queryExecutor);
                 queryOutputSet = true;
@@ -1724,7 +1743,11 @@ public class EventDrivenFaultTolerantQueryScheduler
                         case FINISHED -> scheduledExecutorService.schedule(() -> {
                             if (!finalTaskInfoReceived.get()) {
                                 log.error("Did not receive final task info for task %s after it FINISHED; internal inconsistency; failing query", task.getTaskId());
-                                queryStateMachine.transitionToFailed(new TrinoException(GENERIC_INTERNAL_ERROR, "Did not receive final task info for task after it finished; failing query"));
+                                Throwable failure = new TrinoException(GENERIC_INTERNAL_ERROR, "Did not receive final task info for task after it finished; failing query");
+                                ErrorCode errorCode = failure instanceof TrinoException trinoException ? trinoException.getErrorCode() : null;
+                                if (!failureRecoveryStrategy.handleFailure(failure, errorCode, queryStateMachine::transitionToFailed)) {
+                                    queryStateMachine.transitionToFailed(failure);
+                                }
                             }
                         }, NO_FINAL_TASK_INFO_CHECK_INTERVAL.toMillis(), MILLISECONDS);
                         case CANCELED, ABORTED, FAILED -> scheduledExecutorService.schedule(() -> {
@@ -3746,6 +3769,116 @@ public class EventDrivenFaultTolerantQueryScheduler
                     .add("executionClass", executionClass)
                     .add("waitingForSinkInstanceHandle", waitingForSinkInstanceHandle)
                     .toString();
+        }
+    }
+
+    /**
+     * Builds an {@link EventDrivenFaultTolerantQueryScheduler}. Uses {@link FailQuery#INSTANCE} as the
+     * failure recovery strategy — FTE terminal failures are not retried by default.
+     */
+    public static final class Factory
+    {
+        private final QueryStateMachine queryStateMachine;
+        private final Metadata metadata;
+        private final RemoteTaskFactory remoteTaskFactory;
+        private final TaskDescriptorStorage taskDescriptorStorage;
+        private final EventDrivenTaskSourceFactory taskSourceFactory;
+        private final boolean summarizeTaskInfo;
+        private final NodeTaskMap nodeTaskMap;
+        private final ExecutorService queryExecutor;
+        private final ScheduledExecutorService scheduledExecutorService;
+        private final Tracer tracer;
+        private final SplitSchedulerStats schedulerStats;
+        private final PartitionMemoryEstimatorFactory memoryEstimatorFactory;
+        private final OutputStatsEstimatorFactory outputStatsEstimatorFactory;
+        private final NodePartitioningManager nodePartitioningManager;
+        private final ExchangeManager exchangeManager;
+        private final ExchangeMetricsCollector exchangeMetricsCollector;
+        private final NodeAllocatorService nodeAllocatorService;
+        private final InternalNodeManager nodeManager;
+        private final DynamicFilterService dynamicFilterService;
+        private final TaskExecutionStats taskExecutionStats;
+        private final AdaptivePlanner adaptivePlanner;
+        private final StageExecutionStats stageExecutionStats;
+        private final SubPlan originalPlan;
+
+        public Factory(
+                QueryStateMachine queryStateMachine,
+                Metadata metadata,
+                RemoteTaskFactory remoteTaskFactory,
+                TaskDescriptorStorage taskDescriptorStorage,
+                EventDrivenTaskSourceFactory taskSourceFactory,
+                boolean summarizeTaskInfo,
+                NodeTaskMap nodeTaskMap,
+                ExecutorService queryExecutor,
+                ScheduledExecutorService scheduledExecutorService,
+                Tracer tracer,
+                SplitSchedulerStats schedulerStats,
+                PartitionMemoryEstimatorFactory memoryEstimatorFactory,
+                OutputStatsEstimatorFactory outputStatsEstimatorFactory,
+                NodePartitioningManager nodePartitioningManager,
+                ExchangeManager exchangeManager,
+                ExchangeMetricsCollector exchangeMetricsCollector,
+                NodeAllocatorService nodeAllocatorService,
+                InternalNodeManager nodeManager,
+                DynamicFilterService dynamicFilterService,
+                TaskExecutionStats taskExecutionStats,
+                AdaptivePlanner adaptivePlanner,
+                StageExecutionStats stageExecutionStats,
+                SubPlan originalPlan)
+        {
+            this.queryStateMachine = queryStateMachine;
+            this.metadata = metadata;
+            this.remoteTaskFactory = remoteTaskFactory;
+            this.taskDescriptorStorage = taskDescriptorStorage;
+            this.taskSourceFactory = taskSourceFactory;
+            this.summarizeTaskInfo = summarizeTaskInfo;
+            this.nodeTaskMap = nodeTaskMap;
+            this.queryExecutor = queryExecutor;
+            this.scheduledExecutorService = scheduledExecutorService;
+            this.tracer = tracer;
+            this.schedulerStats = schedulerStats;
+            this.memoryEstimatorFactory = memoryEstimatorFactory;
+            this.outputStatsEstimatorFactory = outputStatsEstimatorFactory;
+            this.nodePartitioningManager = nodePartitioningManager;
+            this.exchangeManager = exchangeManager;
+            this.exchangeMetricsCollector = exchangeMetricsCollector;
+            this.nodeAllocatorService = nodeAllocatorService;
+            this.nodeManager = nodeManager;
+            this.dynamicFilterService = dynamicFilterService;
+            this.taskExecutionStats = taskExecutionStats;
+            this.adaptivePlanner = adaptivePlanner;
+            this.stageExecutionStats = stageExecutionStats;
+            this.originalPlan = originalPlan;
+        }
+
+        public EventDrivenFaultTolerantQueryScheduler create()
+        {
+            return new EventDrivenFaultTolerantQueryScheduler(
+                    FailQuery.INSTANCE,
+                    queryStateMachine,
+                    metadata,
+                    remoteTaskFactory,
+                    taskDescriptorStorage,
+                    taskSourceFactory,
+                    summarizeTaskInfo,
+                    nodeTaskMap,
+                    queryExecutor,
+                    scheduledExecutorService,
+                    tracer,
+                    schedulerStats,
+                    memoryEstimatorFactory,
+                    outputStatsEstimatorFactory,
+                    nodePartitioningManager,
+                    exchangeManager,
+                    exchangeMetricsCollector,
+                    nodeAllocatorService,
+                    nodeManager,
+                    dynamicFilterService,
+                    taskExecutionStats,
+                    adaptivePlanner,
+                    stageExecutionStats,
+                    originalPlan);
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/recovery/TestRetryableErrorClassifier.java
+++ b/core/trino-main/src/test/java/io/trino/execution/recovery/TestRetryableErrorClassifier.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.recovery;
+
+import io.trino.spi.ErrorCode;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.spi.ErrorType.EXTERNAL;
+import static io.trino.spi.ErrorType.INSUFFICIENT_RESOURCES;
+import static io.trino.spi.ErrorType.INTERNAL_ERROR;
+import static io.trino.spi.ErrorType.USER_ERROR;
+import static io.trino.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestRetryableErrorClassifier
+{
+    @Test
+    void testMissingErrorCodeIsRetryable()
+    {
+        assertThat(RetryableErrorClassifier.isRetryable(null)).isTrue();
+    }
+
+    @Test
+    void testRetryableErrorTypes()
+    {
+        assertThat(RetryableErrorClassifier.isRetryable(new ErrorCode(1, "TEST_INTERNAL", INTERNAL_ERROR))).isTrue();
+        assertThat(RetryableErrorClassifier.isRetryable(new ErrorCode(2, "TEST_EXTERNAL", EXTERNAL))).isTrue();
+    }
+
+    @Test
+    void testClusterOutOfMemoryIsRetryable()
+    {
+        assertThat(RetryableErrorClassifier.isRetryable(CLUSTER_OUT_OF_MEMORY.toErrorCode())).isTrue();
+    }
+
+    @Test
+    void testNonRetryableErrorTypes()
+    {
+        assertThat(RetryableErrorClassifier.isRetryable(new ErrorCode(3, "TEST_USER", USER_ERROR))).isFalse();
+        assertThat(RetryableErrorClassifier.isRetryable(new ErrorCode(4, "TEST_RESOURCES", INSUFFICIENT_RESOURCES))).isFalse();
+    }
+
+    @Test
+    void testFatalErrorIsNotRetryable()
+    {
+        assertThat(RetryableErrorClassifier.isRetryable(new ErrorCode(5, "TEST_FATAL_INTERNAL", INTERNAL_ERROR, true))).isFalse();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/recovery/TestRetryingRecoveryStrategy.java
+++ b/core/trino-main/src/test/java/io/trino/execution/recovery/TestRetryingRecoveryStrategy.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.recovery;
+
+import io.airlift.units.Duration;
+import io.trino.spi.ErrorCode;
+import io.trino.spi.TrinoException;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+
+import static io.trino.spi.ErrorType.INTERNAL_ERROR;
+import static io.trino.spi.ErrorType.USER_ERROR;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestRetryingRecoveryStrategy
+{
+    private static final ErrorCode RETRYABLE_ERROR = new ErrorCode(1, "TEST_INTERNAL", INTERNAL_ERROR);
+    private static final ErrorCode NON_RETRYABLE_ERROR = new ErrorCode(2, "TEST_USER", USER_ERROR);
+    private static final BooleanSupplier NOT_DONE = () -> false;
+
+    @Test
+    void testRerunsUntilRetriesExhausted()
+    {
+        TestingRecoveryAction recorder = new TestingRecoveryAction();
+        int maxRetries = 2;
+        RetryingRecoveryStrategy strategy = new RetryingRecoveryStrategy(recorder, NOT_DONE, backoff(maxRetries, "1s", "10s", 2.0));
+        List<Throwable> queryFailures = new ArrayList<>();
+
+        assertThat(strategy.handleFailure(failure(), RETRYABLE_ERROR, queryFailures::add)).isTrue();
+        assertThat(strategy.handleFailure(failure(), RETRYABLE_ERROR, queryFailures::add)).isTrue();
+        assertThat(recorder.reruns()).hasSize(maxRetries);
+        assertThat(queryFailures).isEmpty();
+
+        assertThat(strategy.handleFailure(failure(), RETRYABLE_ERROR, queryFailures::add)).isFalse();
+        assertThat(recorder.reruns()).hasSize(maxRetries);
+        assertThat(queryFailures).isEmpty();
+    }
+
+    @Test
+    void testZeroRetriesPassesFailureOn()
+    {
+        TestingRecoveryAction recorder = new TestingRecoveryAction();
+        RetryingRecoveryStrategy strategy = new RetryingRecoveryStrategy(recorder, NOT_DONE, backoff(0, "1s", "10s", 2.0));
+        List<Throwable> queryFailures = new ArrayList<>();
+
+        assertThat(strategy.handleFailure(failure(), RETRYABLE_ERROR, queryFailures::add)).isFalse();
+        assertThat(recorder.reruns()).isEmpty();
+        assertThat(queryFailures).isEmpty();
+    }
+
+    @Test
+    void testNonRetryableErrorFailsQuery()
+    {
+        TestingRecoveryAction rerunner = new TestingRecoveryAction();
+        RetryingRecoveryStrategy strategy = new RetryingRecoveryStrategy(rerunner, NOT_DONE, backoff(1, "1s", "10s", 2.0));
+        List<Throwable> queryFailures = new ArrayList<>();
+
+        TrinoException failure = failure();
+        strategy.handleFailure(failure, NON_RETRYABLE_ERROR, queryFailures::add);
+        assertThat(rerunner.reruns()).isEmpty();
+        assertThat(queryFailures).containsExactly(failure);
+    }
+
+    @Test
+    void testExponentialBackoffCappedAtMaxDelay()
+    {
+        TestingRecoveryAction recorder = new TestingRecoveryAction();
+        RetryingRecoveryStrategy strategy = new RetryingRecoveryStrategy(recorder, NOT_DONE, backoff(10, "1s", "4s", 2.0));
+        List<Throwable> queryFailures = new ArrayList<>();
+
+        strategy.handleFailure(failure(), RETRYABLE_ERROR, queryFailures::add);
+        strategy.handleFailure(failure(), RETRYABLE_ERROR, queryFailures::add);
+        strategy.handleFailure(failure(), RETRYABLE_ERROR, queryFailures::add);
+        strategy.handleFailure(failure(), RETRYABLE_ERROR, queryFailures::add);
+
+        assertThat(recorder.reruns().stream().map(Duration::toMillis))
+                .containsExactly(1000L, 2000L, 4000L, 4000L);
+        assertThat(queryFailures).isEmpty();
+    }
+
+    @Test
+    void testQueryDoneShortCircuitsToFail()
+    {
+        TestingRecoveryAction recorder = new TestingRecoveryAction();
+        RetryingRecoveryStrategy strategy = new RetryingRecoveryStrategy(recorder, () -> true, backoff(3, "1s", "10s", 2.0));
+        List<Throwable> queryFailures = new ArrayList<>();
+
+        TrinoException failure = failure();
+        strategy.handleFailure(failure, RETRYABLE_ERROR, queryFailures::add);
+
+        assertThat(recorder.reruns()).isEmpty();
+        assertThat(queryFailures).containsExactly(failure);
+    }
+
+    @Test
+    void testSingleImmediatePolicy()
+    {
+        TestingRecoveryAction recorder = new TestingRecoveryAction();
+        RetryingRecoveryStrategy strategy = new RetryingRecoveryStrategy(recorder, NOT_DONE, BackoffPolicy.RETRY_ONCE_IMMEDIATE);
+        List<Throwable> queryFailures = new ArrayList<>();
+
+        assertThat(strategy.handleFailure(failure(), RETRYABLE_ERROR, queryFailures::add)).isTrue();
+        assertThat(recorder.reruns()).hasSize(1);
+        assertThat(recorder.reruns().get(0).toMillis()).isZero();
+        assertThat(queryFailures).isEmpty();
+
+        assertThat(strategy.handleFailure(failure(), RETRYABLE_ERROR, queryFailures::add)).isFalse();
+        assertThat(recorder.reruns()).hasSize(1);
+        assertThat(queryFailures).isEmpty();
+    }
+
+    private static TrinoException failure()
+    {
+        return new TrinoException(GENERIC_INTERNAL_ERROR, "worker crashed");
+    }
+
+    private static BackoffPolicy backoff(int maxRetries, String initialDelay, String maxDelay, double scaleFactor)
+    {
+        return new BackoffPolicy(maxRetries, Duration.valueOf(initialDelay), Duration.valueOf(maxDelay), scaleFactor);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/recovery/TestingRecoveryAction.java
+++ b/core/trino-main/src/test/java/io/trino/execution/recovery/TestingRecoveryAction.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.recovery;
+
+import io.airlift.units.Duration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class TestingRecoveryAction
+        implements RecoveryAction
+{
+    private final List<Duration> reruns = new ArrayList<>();
+
+    @Override
+    public void run(Throwable failure, Duration delay)
+    {
+        reruns.add(delay);
+    }
+
+    public List<Duration> reruns()
+    {
+        return reruns;
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
Improves testability and maintainability by applying single-responsibility decomposition. Each extracted component can now be tested and reasoned about in isolation, without navigating the full scheduler.

- Split scheduler instantiation out of SqlQueryExecution into dedicated factory methods
- Extracted RetryableErrorClassifier from PipelinedQueryScheduler into its own class
- Introduced BackoffPolicy to encapsulate query retry delay calculation
- Extracted failure recovery flow into FailureRecoveryStrategy / RetryingRecoveryStrategy components
- Introduced EventDrivenFaultTolerantQueryScheduler.Factory for cleaner construction and DI

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:


