### PR TITLE
Pluggable credential providers POC

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorContextInstance.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorContextInstance.java
@@ -25,6 +25,7 @@ import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorExpressionEvaluator;
 import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.function.FunctionBundleFactory;
+import io.trino.spi.security.credential.CredentialResolver;
 import io.trino.spi.type.TypeManager;
 
 import static java.util.Objects.requireNonNull;
@@ -44,6 +45,7 @@ public class ConnectorContextInstance
     private final BlocksHashFactory blocksHashFactory;
     private final ConnectorExpressionEvaluator evaluator;
     private final ConnectorCacheFactory cacheFactory;
+    private final CredentialResolver credentialResolver;
 
     public ConnectorContextInstance(
             OpenTelemetry openTelemetry,
@@ -57,7 +59,8 @@ public class ConnectorContextInstance
             FunctionBundleFactory functionBundleFactory,
             BlocksHashFactory blocksHashFactory,
             ConnectorExpressionEvaluator evaluator,
-            ConnectorCacheFactory cacheFactory)
+            ConnectorCacheFactory cacheFactory,
+            CredentialResolver credentialResolver)
     {
         this.openTelemetry = requireNonNull(openTelemetry, "openTelemetry is null");
         this.tracer = requireNonNull(tracer, "tracer is null");
@@ -71,6 +74,7 @@ public class ConnectorContextInstance
         this.blocksHashFactory = requireNonNull(blocksHashFactory, "blocksHashFactory is null");
         this.evaluator = requireNonNull(evaluator, "evaluator is null");
         this.cacheFactory = requireNonNull(cacheFactory, "cacheFactory is null");
+        this.credentialResolver = requireNonNull(credentialResolver, "credentialResolver is null");
     }
 
     @Override
@@ -143,5 +147,11 @@ public class ConnectorContextInstance
     public ConnectorCacheFactory getCacheFactory()
     {
         return cacheFactory;
+    }
+
+    @Override
+    public CredentialResolver getCredentialResolver()
+    {
+        return credentialResolver;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
@@ -41,6 +41,7 @@ import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorExpressionEvaluator;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.spi.connector.ConnectorName;
+import io.trino.spi.security.credential.CredentialResolver;
 import io.trino.spi.type.TypeManager;
 import io.trino.sql.planner.OptimizerConfig;
 import io.trino.transaction.TransactionManager;
@@ -80,6 +81,7 @@ public class DefaultCatalogFactory
     private final SecretsResolver secretsResolver;
     private final ConnectorExpressionEvaluator evaluator;
     private final CacheManagerRegistry cacheManagerRegistry;
+    private final CredentialResolver credentialResolver;
 
     @Inject
     public DefaultCatalogFactory(
@@ -98,7 +100,8 @@ public class DefaultCatalogFactory
             OptimizerConfig optimizerConfig,
             SecretsResolver secretsResolver,
             ConnectorExpressionEvaluator evaluator,
-            CacheManagerRegistry cacheManagerRegistry)
+            CacheManagerRegistry cacheManagerRegistry,
+            CredentialResolver credentialResolver)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
@@ -116,6 +119,7 @@ public class DefaultCatalogFactory
         this.secretsResolver = requireNonNull(secretsResolver, "secretsResolver is null");
         this.evaluator = requireNonNull(evaluator, "evaluator is null");
         this.cacheManagerRegistry = requireNonNull(cacheManagerRegistry, "cacheManagerRegistry is null");
+        this.credentialResolver = requireNonNull(credentialResolver, "credentialResolver is null");
     }
 
     @Override
@@ -211,7 +215,8 @@ public class DefaultCatalogFactory
                 new InternalFunctionBundleFactory(),
                 blocksHashFactory,
                 evaluator,
-                cacheManagerRegistry.createConnectorCacheFactory(catalogName));
+                cacheManagerRegistry.createConnectorCacheFactory(catalogName),
+                credentialResolver);
 
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(connectorFactory.getClass().getClassLoader())) {
             // TODO: connector factory should take CatalogName

--- a/core/trino-main/src/main/java/io/trino/security/credential/CredentialProviderRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/security/credential/CredentialProviderRegistry.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+import io.trino.spi.security.credential.CredentialResolver;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class CredentialProviderRegistry
+        implements CredentialResolver
+{
+    public static final Pattern VALID_NAME = Pattern.compile("[a-z][a-z0-9-]*");
+    private static final Pattern VALID_FACTORY_NAME = Pattern.compile("[a-z][a-z0-9_]*");
+
+    private final CredentialProviderStore credentialProviderStore;
+    private final Map<String, CredentialProviderFactory> factories = new ConcurrentHashMap<>();
+    private final Map<String, CredentialProvider> credentialProviders = new ConcurrentHashMap<>();
+
+    @Inject
+    public CredentialProviderRegistry(CredentialProviderStore credentialProviderStore)
+    {
+        this.credentialProviderStore = requireNonNull(credentialProviderStore, "credentialProviderStore is null");
+    }
+
+    public void addCredentialProviderFactory(CredentialProviderFactory credentialProviderFactory)
+    {
+        if (!VALID_FACTORY_NAME.matcher(credentialProviderFactory.getFactoryName()).matches()) {
+            throw new IllegalArgumentException("Invalid credential provider factory name: %s, should match %s".formatted(credentialProviderFactory.getFactoryName(), VALID_FACTORY_NAME.pattern()));
+        }
+        if (factories.putIfAbsent(credentialProviderFactory.getFactoryName(), credentialProviderFactory) != null) {
+            throw new IllegalArgumentException(format("Credential provider factory '%s' is already registered", credentialProviderFactory.getFactoryName()));
+        }
+    }
+
+    public void loadCredentialProviders()
+    {
+        credentialProviderStore.loadCredentialProviders(factories, credentialProviders);
+        for (String provider : credentialProviders.keySet()) {
+            if (!VALID_NAME.matcher(provider).matches()) {
+                throw new IllegalArgumentException("Invalid credential provider name: %s, should match %s".formatted(provider, VALID_NAME.pattern()));
+            }
+        }
+    }
+
+    @Override
+    public Optional<CredentialProvider> get(String providerName)
+    {
+        return Optional.ofNullable(credentialProviders.get(providerName));
+    }
+
+    @Override
+    public Set<String> loadedProviders()
+    {
+        return ImmutableSet.copyOf(credentialProviders.keySet());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/security/credential/CredentialProviderStore.java
+++ b/core/trino-main/src/main/java/io/trino/security/credential/CredentialProviderStore.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+
+import java.util.Map;
+
+public interface CredentialProviderStore
+{
+    void loadCredentialProviders(Map<String, CredentialProviderFactory> factories, Map<String, CredentialProvider> credentialProviders);
+}

--- a/core/trino-main/src/main/java/io/trino/security/credential/CredentialProviderStoreModule.java
+++ b/core/trino-main/src/main/java/io/trino/security/credential/CredentialProviderStoreModule.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.trino.spi.security.credential.CredentialResolver;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class CredentialProviderStoreModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(FileCredentialProviderStoreConfig.class);
+        binder.bind(FileCredentialProviderStore.class).in(Scopes.SINGLETON);
+        binder.bind(CredentialProviderStore.class).to(FileCredentialProviderStore.class).in(Scopes.SINGLETON);
+
+        binder.bind(CredentialProviderRegistry.class).in(Scopes.SINGLETON);
+        binder.bind(CredentialResolver.class).to(CredentialProviderRegistry.class).in(Scopes.SINGLETON);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/security/credential/FileCredentialProviderStore.java
+++ b/core/trino-main/src/main/java/io/trino/security/credential/FileCredentialProviderStore.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.airlift.configuration.secrets.SecretsResolver;
+import io.airlift.log.Logger;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
+import static java.util.Objects.requireNonNull;
+
+public class FileCredentialProviderStore
+        implements CredentialProviderStore
+{
+    private static final Logger LOG = Logger.get(FileCredentialProviderStore.class);
+    private final File credentialProviderConfigDir;
+    private final SecretsResolver secretsResolver;
+
+    @Inject
+    public FileCredentialProviderStore(FileCredentialProviderStoreConfig config, SecretsResolver secretsResolver)
+    {
+        this.credentialProviderConfigDir = requireNonNull(config, "config is null").getCredentialProviderConfigDir();
+        this.secretsResolver = requireNonNull(secretsResolver, "secretsResolver is null");
+    }
+
+    @Override
+    public void loadCredentialProviders(Map<String, CredentialProviderFactory> factories, Map<String, CredentialProvider> credentialProviders)
+    {
+        if (!credentialProviderConfigDir.isDirectory()) {
+            LOG.warn("Credential providers directory does not exist or is not a directory: " + credentialProviderConfigDir.getAbsolutePath());
+        }
+
+        listCredentialProviderFiles(credentialProviderConfigDir)
+                .stream()
+                .map(file -> new CredentialProviderConfigFile(file.getName().replace(".properties", ""), file))
+                .filter(configFile -> !credentialProviders.containsKey(configFile.name()))
+                .map(CredentialProviderConfigFile::loadProperties)
+                .forEach(properties -> {
+                    CredentialProviderFactory credentialProviderFactory = factories.get(properties.factoryName());
+                    if (credentialProviderFactory == null) {
+                        throw new IllegalStateException("Credential provider factory %s not found in: [%s]".formatted(properties.factoryName(), String.join(", ", factories.keySet())));
+                    }
+                    Map<String, String> config = secretsResolver.getResolvedConfiguration(properties.properties());
+                    credentialProviders.put(properties.providerName(), credentialProviderFactory.create(properties.providerName(), config));
+                });
+    }
+
+    private static List<File> listCredentialProviderFiles(File credentialProvidersDirectory)
+    {
+        if (credentialProvidersDirectory == null || !credentialProvidersDirectory.isDirectory()) {
+            return ImmutableList.of();
+        }
+
+        File[] files = credentialProvidersDirectory.listFiles();
+        if (files == null) {
+            return ImmutableList.of();
+        }
+        return Arrays.stream(files)
+                .filter(File::isFile)
+                .filter(file -> file.getName().endsWith(".properties"))
+                .collect(toImmutableList());
+    }
+
+    public record CredentialProviderConfigFile(String name, File file)
+    {
+        public CredentialProviderProperties loadProperties()
+        {
+            Map<String, String> properties;
+            try {
+                properties = new HashMap<>(loadPropertiesFrom(file.getPath()));
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException("Error reading catalog property file " + file, e);
+            }
+
+            String factoryName = properties.remove("credential-provider.name");
+            checkState(factoryName != null, "Credential provider configuration %s does not contain 'credential-provider.name'", file.getAbsoluteFile());
+
+            return new CredentialProviderProperties(name, factoryName.strip(), properties);
+        }
+    }
+
+    public record CredentialProviderProperties(String providerName, String factoryName, Map<String, String> properties) {}
+}

--- a/core/trino-main/src/main/java/io/trino/security/credential/FileCredentialProviderStoreConfig.java
+++ b/core/trino-main/src/main/java/io/trino/security/credential/FileCredentialProviderStoreConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.NotNull;
+
+import java.io.File;
+
+public class FileCredentialProviderStoreConfig
+{
+    private File configDir = new File("etc/credential-provider");
+
+    @Config("credential-provider.config-dir")
+    @ConfigDescription("Directory where credential provider property files are located")
+    public FileCredentialProviderStoreConfig setCredentialProviderConfigDir(File configDir)
+    {
+        this.configDir = configDir;
+        return this;
+    }
+
+    @NotNull
+    public File getCredentialProviderConfigDir()
+    {
+        return configDir;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/PluginManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/PluginManager.java
@@ -32,6 +32,7 @@ import io.trino.metadata.LanguageFunctionEngineManager;
 import io.trino.metadata.TypeRegistry;
 import io.trino.security.AccessControlManager;
 import io.trino.security.GroupProviderManager;
+import io.trino.security.credential.CredentialProviderRegistry;
 import io.trino.server.protocol.spooling.SpoolingManagerRegistry;
 import io.trino.server.security.CertificateAuthenticatorManager;
 import io.trino.server.security.HeaderAuthenticatorManager;
@@ -51,6 +52,7 @@ import io.trino.spi.security.GroupProviderFactory;
 import io.trino.spi.security.HeaderAuthenticatorFactory;
 import io.trino.spi.security.PasswordAuthenticatorFactory;
 import io.trino.spi.security.SystemAccessControlFactory;
+import io.trino.spi.security.credential.CredentialProviderFactory;
 import io.trino.spi.session.SessionPropertyConfigurationManagerFactory;
 import io.trino.spi.spool.SpoolingManagerFactory;
 import io.trino.spi.type.ParametricType;
@@ -115,6 +117,7 @@ public class PluginManager
     private final ExchangeManagerRegistry exchangeManagerRegistry;
     private final SpoolingManagerRegistry spoolingManagerRegistry;
     private final CacheManagerRegistry cacheManagerRegistry;
+    private final CredentialProviderRegistry credentialProviderRegistry;
     private final SessionPropertyDefaults sessionPropertyDefaults;
     private final TypeRegistry typeRegistry;
     private final BlockEncodingManager blockEncodingManager;
@@ -141,7 +144,8 @@ public class PluginManager
             HandleResolver handleResolver,
             ExchangeManagerRegistry exchangeManagerRegistry,
             SpoolingManagerRegistry spoolingManagerRegistry,
-            CacheManagerRegistry cacheManagerRegistry)
+            CacheManagerRegistry cacheManagerRegistry,
+            CredentialProviderRegistry credentialProviderRegistry)
     {
         this.pluginsProvider = requireNonNull(pluginsProvider, "pluginsProvider is null");
         this.catalogStoreManager = requireNonNull(catalogStoreManager, "catalogStoreManager is null");
@@ -162,6 +166,7 @@ public class PluginManager
         this.exchangeManagerRegistry = requireNonNull(exchangeManagerRegistry, "exchangeManagerRegistry is null");
         this.spoolingManagerRegistry = requireNonNull(spoolingManagerRegistry, "spoolingManagerRegistry is null");
         this.cacheManagerRegistry = requireNonNull(cacheManagerRegistry, "cacheManagerRegistry is null");
+        this.credentialProviderRegistry = requireNonNull(credentialProviderRegistry, "credentialProviderRegistry is null");
     }
 
     @Override
@@ -313,6 +318,11 @@ public class PluginManager
         for (BlobCacheManagerFactory factory : plugin.getBlobCacheManagerFactories()) {
             log.info("Registering blob cache manager %s", factory.getName());
             cacheManagerRegistry.addBlobCacheManagerFactory(factory);
+        }
+
+        for (CredentialProviderFactory factory : plugin.getCredentialProviderFactories()) {
+            log.info("Registering credential provider %s", factory.getFactoryName());
+            credentialProviderRegistry.addCredentialProviderFactory(factory);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/Server.java
+++ b/core/trino-main/src/main/java/io/trino/server/Server.java
@@ -50,6 +50,8 @@ import io.trino.node.NodeManagerModule;
 import io.trino.security.AccessControlManager;
 import io.trino.security.AccessControlModule;
 import io.trino.security.GroupProviderManager;
+import io.trino.security.credential.CredentialProviderRegistry;
+import io.trino.security.credential.CredentialProviderStoreModule;
 import io.trino.server.protocol.spooling.SpoolingManagerRegistry;
 import io.trino.server.security.CertificateAuthenticatorManager;
 import io.trino.server.security.HeaderAuthenticatorManager;
@@ -111,6 +113,7 @@ public class Server
                 .add(new NodeModule())
                 .add(new NodeStateManagerModule())
                 .add(new PrefixObjectNameGeneratorModule("io.trino"))
+                .add(new CredentialProviderStoreModule())
                 .add(new ServerMainModule(trinoVersion))
                 .add(new ServerSecurityModule())
                 .add(new TracingModule("trino", trinoVersion))
@@ -135,6 +138,8 @@ public class Server
 
             var catalogStoreManager = injector.getInstance(Key.get(new TypeLiteral<Optional<CatalogStoreManager>>() {}));
             catalogStoreManager.ifPresent(CatalogStoreManager::loadConfiguredCatalogStore);
+
+            injector.getInstance(CredentialProviderRegistry.class).loadCredentialProviders();
 
             ConnectorServicesProvider connectorServicesProvider = injector.getInstance(ConnectorServicesProvider.class);
             connectorServicesProvider.loadInitialCatalogs();

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
@@ -80,6 +80,7 @@ public class OAuth2Authenticator
         }
         Identity.Builder builder = Identity.forUser(userMapping.mapUser(principal.get()));
         builder.withPrincipal(new BasicPrincipal(principal.get()));
+        builder.withAdditionalExtraCredentials(Map.of("oauth2_access_token", tokenPair.accessToken()));
         return Optional.of(builder.build());
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -75,6 +75,7 @@ import io.trino.security.AccessControl;
 import io.trino.security.AccessControlConfig;
 import io.trino.security.AccessControlManager;
 import io.trino.security.GroupProviderManager;
+import io.trino.security.credential.CredentialProviderRegistry;
 import io.trino.server.NodeStateManager;
 import io.trino.server.NodeStateManager.CurrentNodeState;
 import io.trino.server.PluginInstaller;
@@ -111,6 +112,8 @@ import io.trino.sql.planner.NodePartitioningManager;
 import io.trino.sql.planner.Plan;
 import io.trino.testing.ProcedureTester;
 import io.trino.testing.TestingAccessControlManager;
+import io.trino.testing.TestingCredentialProviderStore;
+import io.trino.testing.TestingCredentialProviderStoreModule;
 import io.trino.testing.TestingEventListenerManager;
 import io.trino.testing.TestingGroupProvider;
 import io.trino.testing.TestingGroupProviderManager;
@@ -224,6 +227,8 @@ public class TestingTrinoServer
     private final ExchangeManagerRegistry exchangeManagerRegistry;
     private final CacheManagerRegistry cacheManagerRegistry;
     private final SpoolingManagerRegistry spoolingManagerRegistry;
+    private final TestingCredentialProviderStore credentialProviderStore;
+    private final CredentialProviderRegistry credentialProviderRegistry;
 
     public static class TestShutdownAction
             implements ShutdownAction
@@ -319,6 +324,7 @@ public class TestingTrinoServer
                 .add(new CatalogManagerModule())
                 .add(new TransactionManagerModule())
                 .add(new NodeManagerModule(VERSION))
+                .add(new TestingCredentialProviderStoreModule())
                 .add(new ServerMainModule(VERSION))
                 .add(new TestingWarningCollectorModule())
                 .add(binder -> {
@@ -439,6 +445,8 @@ public class TestingTrinoServer
         exchangeManagerRegistry = injector.getInstance(ExchangeManagerRegistry.class);
         cacheManagerRegistry = injector.getInstance(CacheManagerRegistry.class);
         spoolingManagerRegistry = injector.getInstance(SpoolingManagerRegistry.class);
+        credentialProviderStore = injector.getInstance(TestingCredentialProviderStore.class);
+        credentialProviderRegistry = injector.getInstance(CredentialProviderRegistry.class);
 
         systemAccessControlConfiguration.ifPresentOrElse(
                 configuration -> {
@@ -730,6 +738,12 @@ public class TestingTrinoServer
                 attemptId,
                 injectionType,
                 errorType);
+    }
+
+    public void addCredentialProvider(String name, String factoryName, Map<String, String> properties)
+    {
+        credentialProviderStore.addCredentialProvider(name, factoryName, properties);
+        credentialProviderRegistry.loadCredentialProviders();
     }
 
     private static Path tempDirectory()

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -141,6 +141,8 @@ import io.trino.operator.table.ExcludeColumnsFunction;
 import io.trino.plugin.base.security.AllowAllSystemAccessControl;
 import io.trino.security.AllowAllAccessControl;
 import io.trino.security.GroupProviderManager;
+import io.trino.security.credential.CredentialProviderRegistry;
+import io.trino.security.credential.CredentialProviderStore;
 import io.trino.server.PluginManager;
 import io.trino.server.ServerConfig;
 import io.trino.server.SessionPropertyDefaults;
@@ -351,6 +353,7 @@ public class PlanTester
     private final StatementAnalyzerFactory statementAnalyzerFactory;
     private final JsonCodec<Expression> expressionCodec;
     private final InternalConnectorExpressionEvaluator evaluator;
+    private final CredentialProviderRegistry credentialProviderRegistry;
     private boolean printPlan;
 
     public static PlanTester create(Session defaultSession)
@@ -443,6 +446,10 @@ public class PlanTester
         FunctionManager functionManager = new FunctionManager(createFunctionProvider(catalogManager), globalFunctionCatalog, languageFunctionManager);
         this.plannerContext = new PlannerContext(metadata, typeOperators, blockEncodingSerde, typeManager, functionManager, languageFunctionManager, tracer, expressionCodec);
         this.evaluator = new InternalConnectorExpressionEvaluator(plannerContext);
+
+        CredentialProviderStore credentialProviderStore = new TestingCredentialProviderStore();
+        this.credentialProviderRegistry = new CredentialProviderRegistry(credentialProviderStore);
+
         NodeInfo nodeInfo = new NodeInfo("test");
         catalogFactory.setCatalogFactory(new DefaultCatalogFactory(
                 metadata,
@@ -460,7 +467,8 @@ public class PlanTester
                 optimizerConfig,
                 secretsResolver,
                 evaluator,
-                cacheManagerRegistry));
+                cacheManagerRegistry,
+                credentialProviderRegistry));
         this.splitManager = new SplitManager(createSplitManagerProvider(catalogManager), tracer, new QueryManagerConfig());
         this.pageSourceManager = new PageSourceManager(createPageSourceProviderFactory(catalogManager));
         this.pageSinkManager = new PageSinkManager(createPageSinkProvider(catalogManager));
@@ -531,6 +539,7 @@ public class PlanTester
                 new SpoolingEnabledConfig(),
                 noop(),
                 noopTracer());
+
         this.pluginManager = new PluginManager(
                 (_, _) -> {},
                 Optional.empty(),
@@ -550,7 +559,8 @@ public class PlanTester
                 new HandleResolver(),
                 exchangeManagerRegistry,
                 spoolingManagerRegistry,
-                cacheManagerRegistry);
+                cacheManagerRegistry,
+                credentialProviderRegistry);
 
         catalogManager.registerGlobalSystemConnector(globalSystemConnector);
         languageFunctionManager.setPlannerContext(plannerContext);

--- a/core/trino-main/src/main/java/io/trino/testing/QueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/QueryRunner.java
@@ -131,5 +131,7 @@ public interface QueryRunner
 
     void loadBlobCacheManager(String name, Map<String, String> properties);
 
+    void addCredentialProvider(String name, String factoryName, Map<String, String> properties);
+
     record MaterializedResultWithPlan(QueryId queryId, Optional<Plan> queryPlan, MaterializedResult result) {}
 }

--- a/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
@@ -345,4 +345,10 @@ public final class StandaloneQueryRunner
     {
         server.loadBlobCacheManager(name, properties);
     }
+
+    @Override
+    public void addCredentialProvider(String name, String factoryName, Map<String, String> properties)
+    {
+        server.addCredentialProvider(name, factoryName, properties);
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/testing/TestingConnectorContext.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingConnectorContext.java
@@ -32,6 +32,7 @@ import io.trino.spi.cache.ConnectorCacheFactory;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.function.FunctionBundleFactory;
+import io.trino.spi.security.credential.CredentialResolver;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeOperators;
 import io.trino.util.EmbedVersion;
@@ -123,5 +124,11 @@ public final class TestingConnectorContext
     public ConnectorCacheFactory getCacheFactory()
     {
         return new TestingConnectorCacheFactory();
+    }
+
+    @Override
+    public CredentialResolver getCredentialResolver()
+    {
+        return new TestingCredentialResolver();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/testing/TestingCredentialProviderStore.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingCredentialProviderStore.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import io.trino.security.credential.CredentialProviderStore;
+import io.trino.spi.TrinoException;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+
+public class TestingCredentialProviderStore
+        implements CredentialProviderStore
+{
+    private final Map<String, CredentialProviderProperties> providers = new ConcurrentHashMap<>();
+
+    public void addCredentialProvider(String name, String factoryName, Map<String, String> properties)
+    {
+        providers.put(name, new CredentialProviderProperties(factoryName, properties));
+    }
+
+    @Override
+    public void loadCredentialProviders(Map<String, CredentialProviderFactory> factories, Map<String, CredentialProvider> credentialProviders)
+    {
+        providers.forEach((name, properties) -> {
+            CredentialProviderFactory factory = factories.get(properties.factoryName());
+            if (factory == null) {
+                throw new TrinoException(CONFIGURATION_INVALID, "Factory not found: " + properties.factoryName());
+            }
+            if (!credentialProviders.containsKey(name)) {
+                credentialProviders.put(name, factory.create(name, properties.config()));
+            }
+        });
+    }
+
+    private record CredentialProviderProperties(String factoryName, Map<String, String> config) {}
+}

--- a/core/trino-main/src/main/java/io/trino/testing/TestingCredentialProviderStoreModule.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingCredentialProviderStoreModule.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.trino.security.credential.CredentialProviderRegistry;
+import io.trino.security.credential.CredentialProviderStore;
+import io.trino.security.credential.FileCredentialProviderStoreConfig;
+import io.trino.spi.security.credential.CredentialResolver;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class TestingCredentialProviderStoreModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(FileCredentialProviderStoreConfig.class);
+        binder.bind(TestingCredentialProviderStore.class).in(Scopes.SINGLETON);
+        binder.bind(CredentialProviderStore.class).to(TestingCredentialProviderStore.class).in(Scopes.SINGLETON);
+
+        binder.bind(CredentialProviderRegistry.class).in(Scopes.SINGLETON);
+        binder.bind(CredentialResolver.class).to(CredentialProviderRegistry.class).in(Scopes.SINGLETON);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/testing/TestingCredentialResolver.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingCredentialResolver.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialResolver;
+
+import java.util.Optional;
+import java.util.Set;
+
+public class TestingCredentialResolver
+        implements CredentialResolver
+{
+    @Override
+    public Optional<CredentialProvider> get(String providerName)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public Set<String> loadedProviders()
+    {
+        return Set.of();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/security/credential/TestCredentialProviderRegistry.java
+++ b/core/trino-main/src/test/java/io/trino/security/credential/TestCredentialProviderRegistry.java
@@ -1,0 +1,402 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.name.Named;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import io.airlift.slice.Slice;
+import io.trino.plugin.base.ConnectorContextModule;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencies;
+import io.trino.spi.function.FunctionDependencyDeclaration;
+import io.trino.spi.function.FunctionId;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.InvocationConvention;
+import io.trino.spi.function.ScalarFunctionAdapter;
+import io.trino.spi.function.ScalarFunctionImplementation;
+import io.trino.spi.function.SchemaFunctionName;
+import io.trino.spi.function.Signature;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.Identity;
+import io.trino.spi.security.credential.Credential;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+import io.trino.spi.transaction.IsolationLevel;
+import io.trino.sql.SqlPath;
+import io.trino.sql.query.QueryAssertions;
+import jakarta.validation.constraints.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
+import static io.trino.plugin.base.security.credential.CredentialProviderModule.credentialProvider;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.security.credential.CredentialProvider.assertSupportedTypes;
+import static io.trino.spi.type.TypeDescriptor.mapType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.lang.invoke.MethodType.methodType;
+import static java.util.Collections.nCopies;
+import static java.util.Objects.requireNonNull;
+
+public class TestCredentialProviderRegistry
+{
+    @Test
+    public void test()
+    {
+        try (QueryAssertions assertions = new QueryAssertions(testSessionBuilder()
+                .setPath(SqlPath.buildPath("test_catalog_name.test_schema_name", Optional.empty()))
+                .setIdentity(Identity.ofUser("test_user"))
+                .build())) {
+            assertions.addPlugin(new TestPlugin());
+            assertions.addCredentialProvider("my-configured-provider", "test_provider_factory_name", Map.of("username", "admin", "password", "welcome123"));
+            assertions.getQueryRunner().createCatalog("test_catalog_name", "test_connector_name", Map.of("credential-provider.my-code-named-provider.name", "my-configured-provider"));
+            assertions.function("greeting", "'hello'")
+                    .assertThat()
+                    .isEqualTo("hello world from test_user as admin: welcome123");
+        }
+    }
+
+    public static class TestPlugin
+            implements Plugin
+    {
+        @Override
+        public Iterable<ConnectorFactory> getConnectorFactories()
+        {
+            return ImmutableSet.of(new TestConnectorFactory());
+        }
+
+        @Override
+        public Iterable<CredentialProviderFactory> getCredentialProviderFactories()
+        {
+            return ImmutableList.of(new TestCredentialProviderFactory());
+        }
+    }
+
+    public static class TestConnectorFactory
+            implements ConnectorFactory
+    {
+        @Override
+        public String getName()
+        {
+            return "test_connector_name";
+        }
+
+        @Override
+        public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+        {
+            checkStrictSpiVersionMatch(context, this);
+
+            Bootstrap app = new Bootstrap(
+                    "io.trino.bootstrap.catalog." + catalogName,
+                    new TestModule(),
+                    new ConnectorContextModule(catalogName, context));
+
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .disableSystemProperties()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+
+            return injector.getInstance(Connector.class);
+        }
+    }
+
+    public enum TestTransactionHandle
+            implements ConnectorTransactionHandle
+    {
+        INSTANCE
+    }
+
+    public static class TestMetadata
+            implements ConnectorMetadata
+    {
+        private static final String SCHEMA_NAME = "test_schema_name";
+
+        private final List<FunctionMetadata> functions;
+
+        @Inject
+        public TestMetadata(List<FunctionMetadata> functions)
+        {
+            this.functions = ImmutableList.copyOf(requireNonNull(functions, "functions is null"));
+        }
+
+        @Override
+        public Collection<FunctionMetadata> listFunctions(ConnectorSession session, String schemaName)
+        {
+            return schemaName.equals(SCHEMA_NAME) ? functions : List.of();
+        }
+
+        @Override
+        public Collection<FunctionMetadata> getFunctions(ConnectorSession session, SchemaFunctionName name)
+        {
+            if (!name.schemaName().equals(SCHEMA_NAME)) {
+                return List.of();
+            }
+            return functions.stream()
+                    .filter(function -> function.getCanonicalName().equals(name.functionName()))
+                    .toList();
+        }
+
+        @Override
+        public FunctionMetadata getFunctionMetadata(ConnectorSession session, FunctionId functionId)
+        {
+            return functions.stream()
+                    .filter(function -> function.getFunctionId().equals(functionId))
+                    .findFirst()
+                    .orElseThrow();
+        }
+
+        @Override
+        public FunctionDependencyDeclaration getFunctionDependencies(ConnectorSession session, FunctionId functionId, BoundSignature boundSignature)
+        {
+            return FunctionDependencyDeclaration.builder()
+                    .addType(mapType(VARCHAR.getTypeDescriptor(), VARCHAR.getTypeDescriptor()))
+                    .build();
+        }
+    }
+
+    public static class TestConnector
+            implements Connector
+    {
+        private final FunctionProvider functionProvider;
+        private final ConnectorMetadata metadata;
+
+        @Override
+        public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
+        {
+            return TestTransactionHandle.INSTANCE;
+        }
+
+        @Inject
+        public TestConnector(FunctionProvider functionProvider, ConnectorMetadata metadata)
+        {
+            this.functionProvider = requireNonNull(functionProvider, "functionProvider is null");
+            this.metadata = requireNonNull(metadata, "metadata is null");
+        }
+
+        @Override
+        public Optional<FunctionProvider> getFunctionProvider()
+        {
+            return Optional.of(functionProvider);
+        }
+
+        @Override
+        public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transactionHandle)
+        {
+            return metadata;
+        }
+
+        @Override
+        public void shutdown() {}
+    }
+
+    public static class TestModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            credentialProvider(binder, "my-code-named-provider");
+            binder.bind(TestConnector.class).in(SINGLETON);
+            binder.bind(Connector.class).to(TestConnector.class).in(SINGLETON);
+
+            binder.bind(TestMetadata.class).in(SINGLETON);
+            binder.bind(ConnectorMetadata.class).to(TestMetadata.class).in(SINGLETON);
+
+            binder.bind(TestFunctionProvider.class).in(SINGLETON);
+            binder.bind(FunctionProvider.class).to(TestFunctionProvider.class).in(SINGLETON);
+        }
+
+        @Provides
+        public static List<FunctionMetadata> getFunctionMetadata(TestFunctionProvider functions)
+        {
+            return functions.getFunctions();
+        }
+    }
+
+    public static class TestFunctionProvider
+            implements FunctionProvider
+    {
+        private final MethodHandle methodHandle;
+        private static final List<FunctionMetadata> FUNCTIONS = ImmutableList.of(FunctionMetadata.scalarBuilder("greeting")
+                .description("Greet the planet")
+                .signature(Signature.builder()
+                        .returnType(VARCHAR.getTypeDescriptor())
+                        .argumentTypes(List.of(VARCHAR.getTypeDescriptor()))
+                        .build())
+                .build());
+
+        private final CredentialProvider credentialProvider;
+
+        @Inject
+        public TestFunctionProvider(@Named("my-code-named-provider") CredentialProvider credentialProvider)
+                throws Exception
+        {
+            this.credentialProvider = requireNonNull(credentialProvider, "credentialProvider is null");
+            methodHandle = lookup().findVirtual(TestFunctionProvider.class, "greeting", methodType(Slice.class, ConnectorSession.class, Slice.class));
+        }
+
+        public List<FunctionMetadata> getFunctions()
+        {
+            return FUNCTIONS;
+        }
+
+        @Override
+        public ScalarFunctionImplementation getScalarFunctionImplementation(
+                FunctionId functionId,
+                BoundSignature boundSignature,
+                FunctionDependencies functionDependencies,
+                InvocationConvention invocationConvention)
+        {
+            return ScalarFunctionImplementation.builder()
+                    .methodHandle(ScalarFunctionAdapter.adapt(
+                            this.methodHandle.bindTo(this),
+                            boundSignature.getReturnType(),
+                            boundSignature.getArgumentTypes(),
+                            new InvocationConvention(
+                                    nCopies(boundSignature.getArity(), NEVER_NULL),
+                                    FAIL_ON_NULL,
+                                    true,
+                                    false),
+                            invocationConvention))
+                    .build();
+        }
+
+        public Slice greeting(ConnectorSession session, Slice greeting)
+        {
+            TestCredential credential = credentialProvider.getCredential(session.getIdentity(), TestCredential.class).orElseThrow();
+            return utf8Slice("%s world from %s: %s".formatted(greeting.toStringUtf8(), credential.username(), credential.password()));
+        }
+    }
+
+    public record TestCredential(String username, String password)
+            implements Credential {}
+
+    public static class TestCredentialProvider
+            implements CredentialProvider
+    {
+        private final TestCredentialProviderConfig config;
+
+        @Inject
+        public TestCredentialProvider(TestCredentialProviderConfig config)
+        {
+            this.config = requireNonNull(config, "config is null");
+        }
+
+        @Override
+        public <T extends Credential> Optional<T> getCredential(ConnectorIdentity identity, Class<T> type)
+        {
+            assertSupportedTypes(this, type, TestCredential.class);
+            return Optional.of((T) new TestCredential("%s as %s".formatted(identity.getUser(), config.getUsername()), config.getPassword()));
+        }
+    }
+
+    public static class TestCredentialProviderConfig
+    {
+        private String username;
+        private String password;
+
+        @NotNull
+        public String getUsername()
+        {
+            return username;
+        }
+
+        @Config("username")
+        public TestCredentialProviderConfig setUsername(String username)
+        {
+            this.username = username;
+            return this;
+        }
+
+        @NotNull
+        public String getPassword()
+        {
+            return password;
+        }
+
+        @Config("password")
+        @ConfigSecuritySensitive
+        public TestCredentialProviderConfig setPassword(String password)
+        {
+            this.password = password;
+            return this;
+        }
+    }
+
+    public static class TestCredentialProviderFactory
+            implements CredentialProviderFactory
+    {
+        @Override
+        public String getFactoryName()
+        {
+            return "test_provider_factory_name";
+        }
+
+        @Override
+        public CredentialProvider create(String providerName, Map<String, String> config)
+        {
+            Bootstrap app = new Bootstrap(
+                    "io.trino.bootstrap.credential-provider.%s".formatted(providerName),
+                    new TestCredentialProviderModule());
+
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .disableSystemProperties()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+
+            return injector.getInstance(TestCredentialProvider.class);
+        }
+    }
+
+    public static class TestCredentialProviderModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            configBinder(binder).bindConfig(TestCredentialProviderConfig.class);
+            binder.bind(TestCredentialProvider.class).in(SINGLETON);
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -143,6 +143,11 @@ public class QueryAssertions
         runner.installPlugin(plugin);
     }
 
+    public void addCredentialProvider(String name, String factoryName, Map<String, String> properties)
+    {
+        runner.addCredentialProvider(name, factoryName, properties);
+    }
+
     @CheckReturnValue
     public AssertProvider<QueryAssert> query(@Language("SQL") String query)
     {

--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -40,6 +40,12 @@
         </artifact>
     </artifactSet>
 
+    <artifactSet to="plugin/credential-provider-basic">
+        <artifact id="${project.groupId}:trino-credential-provider-basic:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
     <artifactSet to="plugin/datasketches">
         <artifact id="${project.groupId}:trino-datasketches:zip:${project.version}">
             <unpack />

--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -40,8 +40,20 @@
         </artifact>
     </artifactSet>
 
+    <artifactSet to="plugin/credential-provider-api-key">
+        <artifact id="${project.groupId}:trino-credential-provider-api-key:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
     <artifactSet to="plugin/credential-provider-basic">
         <artifact id="${project.groupId}:trino-credential-provider-basic:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
+    <artifactSet to="plugin/credential-provider-oidc">
+        <artifact id="${project.groupId}:trino-credential-provider-oidc:zip:${project.version}">
             <unpack />
         </artifact>
     </artifactSet>

--- a/core/trino-spi/src/main/java/io/trino/spi/Plugin.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Plugin.java
@@ -26,6 +26,7 @@ import io.trino.spi.security.GroupProviderFactory;
 import io.trino.spi.security.HeaderAuthenticatorFactory;
 import io.trino.spi.security.PasswordAuthenticatorFactory;
 import io.trino.spi.security.SystemAccessControlFactory;
+import io.trino.spi.security.credential.CredentialProviderFactory;
 import io.trino.spi.session.SessionPropertyConfigurationManagerFactory;
 import io.trino.spi.spool.SpoolingManagerFactory;
 import io.trino.spi.type.ParametricType;
@@ -124,6 +125,11 @@ public interface Plugin
     }
 
     default Iterable<BlobCacheManagerFactory> getBlobCacheManagerFactories()
+    {
+        return emptyList();
+    }
+
+    default Iterable<CredentialProviderFactory> getCredentialProviderFactories()
     {
         return emptyList();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
@@ -24,6 +24,7 @@ import io.trino.spi.Unstable;
 import io.trino.spi.VersionEmbedder;
 import io.trino.spi.cache.ConnectorCacheFactory;
 import io.trino.spi.function.FunctionBundleFactory;
+import io.trino.spi.security.credential.CredentialResolver;
 import io.trino.spi.type.TypeManager;
 
 import java.util.Optional;
@@ -108,5 +109,11 @@ public interface ConnectorContext
     default ConnectorCacheFactory getCacheFactory()
     {
         return _ -> Optional.empty();
+    }
+
+    @Unstable
+    default CredentialResolver getCredentialResolver()
+    {
+        throw new UnsupportedOperationException();
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/BasicCredential.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/BasicCredential.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+import java.util.Base64;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public record BasicCredential(String username, String password)
+        implements HttpHeadersCredential
+{
+    @Override
+    public Map<String, String> getHeaders()
+    {
+        return Map.of("Authorization", "Basic %s".formatted(Base64.getEncoder().encodeToString("%s:%s".formatted(username, password).getBytes(UTF_8))));
+    }
+
+    @Override
+    public String toString()
+    {
+        return "BasicCredential{username=%s, password=[REDACTED]}".formatted(username);
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/BearerTokenCredential.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/BearerTokenCredential.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record BearerTokenCredential(String bearerToken, Instant expiration)
+        implements HttpHeadersCredential
+{
+    public boolean isValid()
+    {
+        return expiration().isAfter(Instant.now());
+    }
+
+    @Override
+    public Map<String, String> getHeaders()
+    {
+        return Map.of("Authorization", "Bearer %s".formatted(bearerToken));
+    }
+
+    @Override
+    public String toString()
+    {
+        return "BearerTokenCredential{bearerToken=[REDACTED], expiration=%s}".formatted(expiration);
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/Credential.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/Credential.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+public interface Credential {}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/CredentialProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/CredentialProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.security.ConnectorIdentity;
+
+import java.util.Optional;
+
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
+
+public interface CredentialProvider
+{
+    <T extends Credential> Optional<T> getCredential(ConnectorIdentity identity, Class<T> type);
+
+    @SafeVarargs
+    static void assertSupportedTypes(CredentialProvider provider, Class<? extends Credential> type, Class<? extends Credential>... supportedTypes)
+    {
+        for (Class<? extends Credential> supportedType : supportedTypes) {
+            if (type.isAssignableFrom(supportedType)) {
+                return;
+            }
+        }
+
+        throw new TrinoException(CONFIGURATION_INVALID, "Configured %s does not return %s but only one of: [%s]".formatted(
+                provider.getClass().getSimpleName(),
+                type.getSimpleName(),
+                stream(supportedTypes).map(Class::getSimpleName).collect(joining(", "))));
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/CredentialProviderFactory.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/CredentialProviderFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+import java.util.Map;
+
+public interface CredentialProviderFactory
+{
+    String getFactoryName();
+
+    CredentialProvider create(String providerName, Map<String, String> config);
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/CredentialResolver.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/CredentialResolver.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface CredentialResolver
+{
+    Optional<CredentialProvider> get(String providerName);
+
+    Set<String> loadedProviders();
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/HttpHeadersCredential.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/HttpHeadersCredential.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+import java.util.Map;
+
+public interface HttpHeadersCredential
+        extends Credential
+{
+    Map<String, String> getHeaders();
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/StringCredential.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/StringCredential.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+public record StringCredential(String value)
+        implements Credential
+{
+    @Override
+    public String toString()
+    {
+        return "StringCredential[value=[REDACTED]]";
+    }
+}

--- a/docs/src/main/sphinx/security.md
+++ b/docs/src/main/sphinx/security.md
@@ -63,3 +63,12 @@ security/ranger-access-control
 security/internal-communication
 security/secrets
 ```
+
+
+## Credential providers
+
+```{toctree}
+:maxdepth: 1
+
+security/credential-providers
+```

--- a/docs/src/main/sphinx/security/credential-providers.md
+++ b/docs/src/main/sphinx/security/credential-providers.md
@@ -1,0 +1,36 @@
+# Credential providers
+A credential provider is a separate module to be configured and to be linked to
+a connector. This way, a connector can obtain a per-user credential to be used
+to authenticate when connecting to a data source.
+
+:::{list-table} Server configuration
+:widths: 50 50
+:header-rows: 1
+
+* - Property name
+  - Description
+* - `credential-provider.config-dir`
+  -  The directory for the named properties files. Defaults to 
+     `etc/credential-provider`
+:::
+
+## Configuration
+To configure credential providers, create a named properties file
+in `etc/credential-provider`, for example `test.properties`. This 
+name can be used in the connector properties to connect to a data source, for
+example `credential-provider.database.name=test`. The name `database` is
+chosen by the developer of the connector and describes where the credential 
+is used for. A connector may need multiple credential providers for 
+different purposes (`database`, `storage`, etc.).
+
+(security-supported-credential-providers)=
+## Supported credential providers
+
+(security-credential-provider-basic)=
+### Basic auth
+
+```none
+credential-provider.name=basic
+username=admin
+password=welcome123!
+```

--- a/docs/src/main/sphinx/security/credential-providers.md
+++ b/docs/src/main/sphinx/security/credential-providers.md
@@ -10,8 +10,8 @@ to authenticate when connecting to a data source.
 * - Property name
   - Description
 * - `credential-provider.config-dir`
-  -  The directory for the named properties files. Defaults to 
-     `etc/credential-provider`
+  - The directory for the named properties files. Defaults to 
+    `etc/credential-provider`
 :::
 
 ## Configuration
@@ -26,11 +26,43 @@ different purposes (`database`, `storage`, etc.).
 (security-supported-credential-providers)=
 ## Supported credential providers
 
+(security-credential-api-key)=
+### API key
+```none
+credential-provider.name=api_key
+api-key=YOUR-KEY
+```
+
 (security-credential-provider-basic)=
 ### Basic auth
-
 ```none
 credential-provider.name=basic
 username=admin
 password=welcome123!
 ```
+
+(security-credential-provider-oidc)=
+### OpenID connect token-exchange RFC-8693
+```none
+credential-provider.name=oidc
+audience=
+client-id=
+client-secret=
+scopes=
+token-url=
+```
+
+* - Property name
+  - Description
+* - `audience`
+  - The audience for the access token to obtain
+* - `client-id`
+  - The oauth2 client id
+* - `client-secret`
+  - The oauth2 client secret
+* - `scopes`
+  - The scopes for the access token to obtain, e.g. `openid email profile`
+* - `token-url`
+  - The token url, e.g.
+    `https://keycloak.company.com/realms/master/protocol/openid-connect/token`
+:::

--- a/docs/src/main/sphinx/security/overview.md
+++ b/docs/src/main/sphinx/security/overview.md
@@ -157,3 +157,9 @@ More information is available with the documentation for individual
 
 {doc}`Secrets management <secrets>` can be used for the catalog properties files
 content.
+
+(security-credential-providers)=
+## Credential providers
+
+Connectors may support the usage of one or more {doc}`credential providers 
+<credential-providers>` to provide authentication to connector data sources.

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ConnectorContextModule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ConnectorContextModule.java
@@ -28,6 +28,7 @@ import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorExpressionEvaluator;
 import io.trino.spi.connector.MetadataProvider;
+import io.trino.spi.security.credential.CredentialResolver;
 import io.trino.spi.type.TypeManager;
 
 import static java.util.Objects.requireNonNull;
@@ -61,5 +62,6 @@ public class ConnectorContextModule
         binder.bind(PageIndexerFactory.class).toInstance(context.getPageIndexerFactory());
         binder.bind(BlocksHashFactory.class).toInstance(context.getBlocksHashFactory());
         binder.bind(ConnectorExpressionEvaluator.class).toInstance(context.getExpressionEvaluator());
+        binder.bind(CredentialResolver.class).toInstance(context.getCredentialResolver());
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/CredentialProviderConfig.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/CredentialProviderConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security.credential;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.NotNull;
+
+public class CredentialProviderConfig
+{
+    private String name;
+
+    @Config("name")
+    @ConfigDescription("The name of the properties file in the etc/credential-provider directory")
+    public CredentialProviderConfig setName(String name)
+    {
+        this.name = name;
+        return this;
+    }
+
+    @NotNull
+    public String getName()
+    {
+        return name;
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/CredentialProviderModule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/CredentialProviderModule.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security.credential;
+
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialResolver;
+
+import java.util.regex.Pattern;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
+
+public class CredentialProviderModule
+        implements Module
+{
+    private static final Pattern VALID_NAME = Pattern.compile("[a-z][a-z0-9-]*");
+
+    protected final Named named;
+    private final String prefix;
+
+    protected CredentialProviderModule(String name, String prefix)
+    {
+        this.named = Names.named(requireNonNull(name, "name is null"));
+        this.prefix = prefix;
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        String prefix = this.prefix == null ? "" : "%s.".formatted(this.prefix);
+        configBinder(binder).bindConfig(CredentialProviderConfig.class, named, "%scredential-provider.%s".formatted(prefix, named.value()));
+        binder.bind(CredentialProvider.class).annotatedWith(named).toProvider(new CredentialProviderProvider(named)).in(SINGLETON);
+    }
+
+    public static void credentialProvider(Binder binder, String name)
+    {
+        credentialProvider(binder, name, null);
+    }
+
+    public static void credentialProvider(Binder binder, String name, String prefix)
+    {
+        if (!VALID_NAME.matcher(name).matches()) {
+            throw new IllegalArgumentException("Invalid credential provider name: %s, should match %s".formatted(name, VALID_NAME.pattern()));
+        }
+        binder.install(new CredentialProviderModule(name, prefix));
+    }
+
+    private static class CredentialProviderProvider
+            implements Provider<CredentialProvider>
+    {
+        private final Named named;
+        private Injector injector;
+
+        public CredentialProviderProvider(Named named)
+        {
+            this.named = requireNonNull(named, "named is null");
+        }
+
+        @Inject
+        public void setInjector(Injector injector)
+        {
+            this.injector = injector;
+        }
+
+        @Override
+        public CredentialProvider get()
+        {
+            requireNonNull(injector, "injector is null");
+            CredentialResolver credentialResolver = injector.getInstance(CredentialResolver.class);
+            String name = injector.getInstance(Key.get(CredentialProviderConfig.class, named)).getName();
+
+            // When the credential provider plugin is not loaded yet,
+            // use the lazy provider as it should be resolvable when all plugins are loaded
+            return credentialResolver.get(name).orElseGet(() -> new LazyCredentialProvider(credentialResolver, name));
+        }
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/HttpHeadersCredentialUtil.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/HttpHeadersCredentialUtil.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security.credential;
+
+import io.airlift.http.client.HeaderName;
+import io.airlift.http.client.Request;
+import io.trino.spi.security.credential.HttpHeadersCredential;
+
+public class HttpHeadersCredentialUtil
+{
+    private HttpHeadersCredentialUtil() {}
+
+    public static Request.Builder applyHeaders(Request.Builder request, HttpHeadersCredential header)
+    {
+        header.getHeaders().forEach((key, value) -> request.setHeader(HeaderName.of(key), value));
+        return request;
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/LazyCredentialProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/LazyCredentialProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security.credential;
+
+import com.google.inject.Inject;
+import io.trino.spi.TrinoException;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.credential.Credential;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialResolver;
+
+import java.util.Optional;
+
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+import static java.util.Objects.requireNonNull;
+
+public class LazyCredentialProvider
+        implements CredentialProvider
+{
+    private final CredentialResolver credentialResolver;
+    private final String name;
+    private CredentialProvider credentialProvider;
+
+    @Inject
+    public LazyCredentialProvider(CredentialResolver credentialResolver, String name)
+    {
+        this.credentialResolver = requireNonNull(credentialResolver, "credentialResolver is null");
+        this.name = requireNonNull(name, "name is null");
+    }
+
+    @Override
+    public <T extends Credential> Optional<T> getCredential(ConnectorIdentity identity, Class<T> type)
+    {
+        if (credentialProvider == null) {
+            credentialProvider = credentialResolver.get(name).orElseThrow(() -> new TrinoException(CONFIGURATION_INVALID, "Credential provider %s not configured. Loaded: [%s]".formatted(name, String.join(", ", credentialResolver.loadedProviders()))));
+        }
+        return credentialProvider.getCredential(identity, type);
+    }
+}

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AbstractAiClient.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AbstractAiClient.java
@@ -18,6 +18,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.json.JsonCodec;
 import io.trino.spi.TrinoException;
+import io.trino.spi.security.ConnectorIdentity;
 
 import java.util.List;
 import java.util.Locale;
@@ -62,7 +63,7 @@ public abstract class AbstractAiClient
     }
 
     @Override
-    public String analyzeSentiment(String text)
+    public String analyzeSentiment(ConnectorIdentity identity, String text)
     {
         String prompt =
                 """
@@ -72,12 +73,12 @@ public abstract class AbstractAiClient
                 %s
                 """.formatted(text);
 
-        String response = completion(analyzeSentimentModel, prompt);
+        String response = completion(identity, analyzeSentimentModel, prompt);
         return response.toLowerCase(Locale.ROOT);
     }
 
     @Override
-    public String classify(String text, List<String> labels)
+    public String classify(ConnectorIdentity identity, String text, List<String> labels)
     {
         String prompt =
                 """
@@ -88,7 +89,7 @@ public abstract class AbstractAiClient
                 %s
                 """.formatted(LIST_CODEC.toJson(labels), text);
 
-        String response = completion(classifyModel, prompt);
+        String response = completion(identity, classifyModel, prompt);
         try {
             return STRING_CODEC.fromJson(response);
         }
@@ -98,7 +99,7 @@ public abstract class AbstractAiClient
     }
 
     @Override
-    public Map<String, String> extract(String text, List<String> labels)
+    public Map<String, String> extract(ConnectorIdentity identity, String text, List<String> labels)
     {
         String prompt =
                 """
@@ -112,7 +113,7 @@ public abstract class AbstractAiClient
                 %s
                 """.formatted(LIST_CODEC.toJson(labels), text);
 
-        String response = completion(extractModel, prompt);
+        String response = completion(identity, extractModel, prompt);
         try {
             return filterValues(MAP_CODEC.fromJson(response), Objects::nonNull);
         }
@@ -122,7 +123,7 @@ public abstract class AbstractAiClient
     }
 
     @Override
-    public String fixGrammar(String text)
+    public String fixGrammar(ConnectorIdentity identity, String text)
     {
         String prompt =
                 """
@@ -132,17 +133,17 @@ public abstract class AbstractAiClient
                 %s
                 """.formatted(text);
 
-        return completion(fixGrammarModel, prompt);
+        return completion(identity, fixGrammarModel, prompt);
     }
 
     @Override
-    public String generate(String prompt)
+    public String generate(ConnectorIdentity identity, String prompt)
     {
-        return completion(generateModel, prompt);
+        return completion(identity, generateModel, prompt);
     }
 
     @Override
-    public String mask(String text, List<String> labels)
+    public String mask(ConnectorIdentity identity, String text, List<String> labels)
     {
         String prompt =
                 """
@@ -155,11 +156,11 @@ public abstract class AbstractAiClient
                 %s
                 """.formatted(LIST_CODEC.toJson(labels), text);
 
-        return completion(maskModel, prompt);
+        return completion(identity, maskModel, prompt);
     }
 
     @Override
-    public String translate(String text, String language)
+    public String translate(ConnectorIdentity identity, String text, String language)
     {
         String prompt =
                 """
@@ -171,14 +172,14 @@ public abstract class AbstractAiClient
                 %s
                 """.formatted(STRING_CODEC.toJson(language), text);
 
-        return completion(translateModel, prompt);
+        return completion(identity, translateModel, prompt);
     }
 
-    private String completion(String model, String prompt)
+    private String completion(ConnectorIdentity identity, String model, String prompt)
     {
         try {
-            String key = model + "\0" + prompt;
-            return completionCache.get(key, () -> generateCompletion(model, prompt));
+            String key = "%s\0%s\0%s".formatted(identity.getUser(), model, prompt);
+            return completionCache.get(key, () -> generateCompletion(identity, model, prompt));
         }
         catch (ExecutionException e) {
             throw new UncheckedExecutionException(e);
@@ -191,5 +192,5 @@ public abstract class AbstractAiClient
         }
     }
 
-    protected abstract String generateCompletion(String model, String prompt);
+    protected abstract String generateCompletion(ConnectorIdentity identity, String model, String prompt);
 }

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiClient.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiClient.java
@@ -13,22 +13,24 @@
  */
 package io.trino.plugin.ai.functions;
 
+import io.trino.spi.security.ConnectorIdentity;
+
 import java.util.List;
 import java.util.Map;
 
 public interface AiClient
 {
-    String analyzeSentiment(String text);
+    String analyzeSentiment(ConnectorIdentity connectorIdentity, String text);
 
-    String classify(String text, List<String> labels);
+    String classify(ConnectorIdentity connectorIdentity, String text, List<String> labels);
 
-    Map<String, String> extract(String text, List<String> labels);
+    Map<String, String> extract(ConnectorIdentity connectorIdentity, String text, List<String> labels);
 
-    String fixGrammar(String text);
+    String fixGrammar(ConnectorIdentity connectorIdentity, String text);
 
-    String generate(String prompt);
+    String generate(ConnectorIdentity connectorIdentity, String prompt);
 
-    String mask(String text, List<String> labels);
+    String mask(ConnectorIdentity connectorIdentity, String text, List<String> labels);
 
-    String translate(String text, String language);
+    String translate(ConnectorIdentity connectorIdentity, String text, String language);
 }

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiFunctions.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AiFunctions.java
@@ -18,6 +18,7 @@ import com.google.inject.Inject;
 import io.airlift.slice.Slice;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.SqlMap;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionDependencies;
 import io.trino.spi.function.FunctionId;
@@ -92,13 +93,13 @@ public class AiFunctions
 
     static {
         try {
-            AI_ANALYZE_SENTIMENT = lookup().findVirtual(AiFunctions.class, "aiAnalyzeSentiment", methodType(Slice.class, Slice.class));
-            AI_CLASSIFY = lookup().findVirtual(AiFunctions.class, "aiClassify", methodType(Slice.class, Slice.class, Block.class));
-            AI_EXTRACT = lookup().findVirtual(AiFunctions.class, "aiExtract", methodType(SqlMap.class, MapType.class, Slice.class, Block.class));
-            AI_FIX_GRAMMAR = lookup().findVirtual(AiFunctions.class, "aiFixGrammar", methodType(Slice.class, Slice.class));
-            AI_GEN = lookup().findVirtual(AiFunctions.class, "aiGen", methodType(Slice.class, Slice.class));
-            AI_MASK = lookup().findVirtual(AiFunctions.class, "aiMask", methodType(Slice.class, Slice.class, Block.class));
-            AI_TRANSLATE = lookup().findVirtual(AiFunctions.class, "aiTranslate", methodType(Slice.class, Slice.class, Slice.class));
+            AI_ANALYZE_SENTIMENT = lookup().findVirtual(AiFunctions.class, "aiAnalyzeSentiment", methodType(Slice.class, ConnectorSession.class, Slice.class));
+            AI_CLASSIFY = lookup().findVirtual(AiFunctions.class, "aiClassify", methodType(Slice.class, ConnectorSession.class, Slice.class, Block.class));
+            AI_EXTRACT = lookup().findVirtual(AiFunctions.class, "aiExtract", methodType(SqlMap.class, MapType.class, ConnectorSession.class, Slice.class, Block.class));
+            AI_FIX_GRAMMAR = lookup().findVirtual(AiFunctions.class, "aiFixGrammar", methodType(Slice.class, ConnectorSession.class, Slice.class));
+            AI_GEN = lookup().findVirtual(AiFunctions.class, "aiGen", methodType(Slice.class, ConnectorSession.class, Slice.class));
+            AI_MASK = lookup().findVirtual(AiFunctions.class, "aiMask", methodType(Slice.class, ConnectorSession.class, Slice.class, Block.class));
+            AI_TRANSLATE = lookup().findVirtual(AiFunctions.class, "aiTranslate", methodType(Slice.class, ConnectorSession.class, Slice.class, Slice.class));
         }
         catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
@@ -146,7 +147,7 @@ public class AiFunctions
         InvocationConvention actualConvention = new InvocationConvention(
                 nCopies(boundSignature.getArity(), NEVER_NULL),
                 FAIL_ON_NULL,
-                false,
+                true,
                 false);
 
         handle = ScalarFunctionAdapter.adapt(
@@ -161,39 +162,39 @@ public class AiFunctions
                 .build();
     }
 
-    public Slice aiAnalyzeSentiment(Slice text)
+    public Slice aiAnalyzeSentiment(ConnectorSession session, Slice text)
     {
-        return utf8Slice(client.analyzeSentiment(text.toStringUtf8()));
+        return utf8Slice(client.analyzeSentiment(session.getIdentity(), text.toStringUtf8()));
     }
 
-    public Slice aiClassify(Slice text, Block labels)
+    public Slice aiClassify(ConnectorSession session, Slice text, Block labels)
     {
-        return utf8Slice(client.classify(text.toStringUtf8(), fromSqlArray(labels)));
+        return utf8Slice(client.classify(session.getIdentity(), text.toStringUtf8(), fromSqlArray(labels)));
     }
 
-    public SqlMap aiExtract(MapType mapType, Slice text, Block labels)
+    public SqlMap aiExtract(MapType mapType, ConnectorSession session, Slice text, Block labels)
     {
-        return toSqlMap(mapType, client.extract(text.toStringUtf8(), fromSqlArray(labels)));
+        return toSqlMap(mapType, client.extract(session.getIdentity(), text.toStringUtf8(), fromSqlArray(labels)));
     }
 
-    public Slice aiFixGrammar(Slice text)
+    public Slice aiFixGrammar(ConnectorSession session, Slice text)
     {
-        return utf8Slice(client.fixGrammar(text.toStringUtf8()));
+        return utf8Slice(client.fixGrammar(session.getIdentity(), text.toStringUtf8()));
     }
 
-    public Slice aiGen(Slice prompt)
+    public Slice aiGen(ConnectorSession session, Slice prompt)
     {
-        return utf8Slice(client.generate(prompt.toStringUtf8()));
+        return utf8Slice(client.generate(session.getIdentity(), prompt.toStringUtf8()));
     }
 
-    public Slice aiMask(Slice text, Block labels)
+    public Slice aiMask(ConnectorSession session, Slice text, Block labels)
     {
-        return utf8Slice(client.mask(text.toStringUtf8(), fromSqlArray(labels)));
+        return utf8Slice(client.mask(session.getIdentity(), text.toStringUtf8(), fromSqlArray(labels)));
     }
 
-    public Slice aiTranslate(Slice text, Slice language)
+    public Slice aiTranslate(ConnectorSession session, Slice text, Slice language)
     {
-        return utf8Slice(client.translate(text.toStringUtf8(), language.toStringUtf8()));
+        return utf8Slice(client.translate(session.getIdentity(), text.toStringUtf8(), language.toStringUtf8()));
     }
 
     private static List<String> fromSqlArray(Block block)

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AnthropicClient.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AnthropicClient.java
@@ -16,6 +16,7 @@ package io.trino.plugin.ai.functions;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import io.airlift.http.client.HeaderName;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.Request;
@@ -24,6 +25,9 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.spi.TrinoException;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.StringCredential;
 
 import java.net.URI;
 import java.util.List;
@@ -60,20 +64,20 @@ public class AnthropicClient
     private final HttpClient httpClient;
     private final Tracer tracer;
     private final URI endpoint;
-    private final String apiKey;
+    private final CredentialProvider credentialProvider;
 
     @Inject
-    public AnthropicClient(@ForAiClient HttpClient httpClient, Tracer tracer, AnthropicConfig anthropicConfig, AiConfig aiConfig)
+    public AnthropicClient(@ForAiClient HttpClient httpClient, Tracer tracer, AnthropicConfig anthropicConfig, AiConfig aiConfig, @Named("api-key") CredentialProvider credentialProvider)
     {
         super(aiConfig);
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.tracer = requireNonNull(tracer, "tracer is null");
         this.endpoint = anthropicConfig.getEndpoint();
-        this.apiKey = anthropicConfig.getApiKey();
+        this.credentialProvider = requireNonNull(credentialProvider, "credentialProvider is null");
     }
 
     @Override
-    protected String generateCompletion(String model, String prompt)
+    protected String generateCompletion(ConnectorIdentity connectorIdentity, String model, String prompt)
     {
         URI uri = uriBuilderFrom(endpoint)
                 .appendPath("/v1/messages")
@@ -81,10 +85,11 @@ public class AnthropicClient
 
         MessageRequest.Message messages = new MessageRequest.Message("user", prompt);
         MessageRequest body = new MessageRequest(model, 4096, List.of(messages));
+        StringCredential credential = credentialProvider.getCredential(connectorIdentity, StringCredential.class).orElseThrow();
 
         Request request = preparePost()
                 .setUri(uri)
-                .setHeader(X_API_KEY_HEADER, apiKey)
+                .setHeader(X_API_KEY_HEADER, credential.value())
                 .setHeader(ANTHROPIC_VERSION_HEADER, "2023-06-01")
                 .setHeader(CONTENT_TYPE, JSON_UTF_8.toString())
                 .setBodyGenerator(jsonBodyGenerator(MESSAGE_REQUEST_CODEC, body))

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AnthropicConfig.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/AnthropicConfig.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.ai.functions;
 
 import io.airlift.configuration.Config;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.net.URI;
@@ -22,7 +21,6 @@ import java.net.URI;
 public class AnthropicConfig
 {
     private URI endpoint = URI.create("https://api.anthropic.com");
-    private String apiKey;
 
     @NotNull
     public URI getEndpoint()
@@ -34,19 +32,6 @@ public class AnthropicConfig
     public AnthropicConfig setEndpoint(URI endpoint)
     {
         this.endpoint = endpoint;
-        return this;
-    }
-
-    @NotEmpty
-    public String getApiKey()
-    {
-        return apiKey;
-    }
-
-    @Config("ai.anthropic.api-key")
-    public AnthropicConfig setApiKey(String apiKey)
-    {
-        this.apiKey = apiKey;
         return this;
     }
 }

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/OpenAiClient.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/OpenAiClient.java
@@ -16,6 +16,7 @@ package io.trino.plugin.ai.functions;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.Request;
 import io.airlift.json.JsonCodec;
@@ -23,12 +24,14 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.spi.TrinoException;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.HttpHeadersCredential;
 
 import java.net.URI;
 import java.util.List;
 
 import static com.google.common.net.MediaType.JSON_UTF_8;
-import static io.airlift.http.client.HeaderNames.AUTHORIZATION;
 import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
@@ -49,6 +52,7 @@ import static io.trino.plugin.ai.functions.GenAiAttributes.OPENAI_RESPONSE_SERVI
 import static io.trino.plugin.ai.functions.GenAiAttributes.OPENAI_RESPONSE_SYSTEM_FINGERPRINT;
 import static io.trino.plugin.ai.functions.GenAiAttributes.OPERATION_NAME_CHAT;
 import static io.trino.plugin.ai.functions.GenAiAttributes.PROVIDER_NAME_OPENAI;
+import static io.trino.plugin.base.security.credential.HttpHeadersCredentialUtil.applyHeaders;
 import static java.util.Objects.requireNonNull;
 
 public class OpenAiClient
@@ -59,32 +63,33 @@ public class OpenAiClient
 
     private final HttpClient httpClient;
     private final Tracer tracer;
-    private final URI endpoint;
-    private final String apiKey;
+    private final OpenAiConfig openAiConfig;
+    private final CredentialProvider credentialProvider;
 
     @Inject
-    public OpenAiClient(@ForAiClient HttpClient httpClient, Tracer tracer, OpenAiConfig openAiConfig, AiConfig aiConfig)
+    public OpenAiClient(@ForAiClient HttpClient httpClient, Tracer tracer, OpenAiConfig openAiConfig, AiConfig aiConfig, @Named("inference") CredentialProvider credentialProvider)
     {
         super(aiConfig);
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
         this.tracer = requireNonNull(tracer, "tracer is null");
-        this.endpoint = openAiConfig.getEndpoint();
-        this.apiKey = openAiConfig.getApiKey();
+        this.openAiConfig = requireNonNull(openAiConfig, "openAiConfig is null");
+        this.credentialProvider = requireNonNull(credentialProvider, "credentialProvider is null");
     }
 
     @Override
-    protected String generateCompletion(String model, String prompt)
+    protected String generateCompletion(ConnectorIdentity identity, String model, String prompt)
     {
-        URI uri = uriBuilderFrom(endpoint)
+        HttpHeadersCredential credential = credentialProvider.getCredential(identity, HttpHeadersCredential.class).orElseThrow();
+
+        URI uri = uriBuilderFrom(openAiConfig.getEndpoint())
                 .appendPath("/v1/chat/completions")
                 .build();
 
         ChatRequest.Message messages = new ChatRequest.Message("user", prompt);
         ChatRequest body = new ChatRequest(model, List.of(messages), 0);
 
-        Request request = preparePost()
+        Request request = applyHeaders(preparePost(), credential)
                 .setUri(uri)
-                .setHeader(AUTHORIZATION, "Bearer " + apiKey)
                 .setHeader(CONTENT_TYPE, JSON_UTF_8.toString())
                 .setBodyGenerator(jsonBodyGenerator(CHAT_REQUEST_CODEC, body))
                 .build();

--- a/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/OpenAiModule.java
+++ b/plugin/trino-ai-functions/src/main/java/io/trino/plugin/ai/functions/OpenAiModule.java
@@ -19,6 +19,7 @@ import com.google.inject.Scopes;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static io.trino.plugin.base.security.credential.CredentialProviderModule.credentialProvider;
 
 public class OpenAiModule
         implements Module
@@ -29,6 +30,7 @@ public class OpenAiModule
         configBinder(binder).bindConfig(OpenAiConfig.class);
 
         httpClientBinder(binder).bindHttpClient("ai", ForAiClient.class);
+        credentialProvider(binder, "inference", "ai.openai");
 
         binder.bind(OpenAiClient.class).in(Scopes.SINGLETON);
         binder.bind(AiClient.class).to(OpenAiClient.class).in(Scopes.SINGLETON);

--- a/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/AbstractTestAiFunctions.java
+++ b/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/AbstractTestAiFunctions.java
@@ -58,10 +58,13 @@ public abstract class AbstractTestAiFunctions
         assertions = new QueryAssertions(testSessionBuilder()
                 .setPath(SqlPath.buildPath("ai.ai", Optional.empty()))
                 .build());
+        initCredentials();
         assertions.addPlugin(new AiPlugin());
         assertions.getQueryRunner().createCatalog("ai", "ai", getProperties(
                 HostAndPort.fromParts("localhost", hoverfly.getHoverflyConfig().getProxyPort())));
     }
+
+    protected abstract void initCredentials();
 
     @AfterAll
     public void teardown()

--- a/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/TestAnthropicConfig.java
+++ b/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/TestAnthropicConfig.java
@@ -29,8 +29,7 @@ class TestAnthropicConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(AnthropicConfig.class)
-                .setEndpoint(URI.create("https://api.anthropic.com"))
-                .setApiKey(null));
+                .setEndpoint(URI.create("https://api.anthropic.com")));
     }
 
     @Test
@@ -38,12 +37,10 @@ class TestAnthropicConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("ai.anthropic.endpoint", "https://api.example.com")
-                .put("ai.anthropic.api-key", "test-key")
                 .buildOrThrow();
 
         AnthropicConfig expected = new AnthropicConfig()
-                .setEndpoint(URI.create("https://api.example.com"))
-                .setApiKey("test-key");
+                .setEndpoint(URI.create("https://api.example.com"));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/TestAnthropicFunctions.java
+++ b/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/TestAnthropicFunctions.java
@@ -18,6 +18,7 @@ import com.google.common.net.HostAndPort;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.specto.hoverfly.junit5.api.HoverflyConfig;
 import io.specto.hoverfly.junit5.api.HoverflySimulate;
+import io.trino.plugin.credential.apikey.ApiKeyCredentialProviderPlugin;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -34,10 +35,17 @@ public class TestAnthropicFunctions
         return ImmutableMap.<String, String>builder()
                 .put("ai.provider", "anthropic")
                 .put("ai.model", "claude-3-5-sonnet-latest")
-                .put("ai.anthropic.api-key", "test")
+                .put("ai.anthropic.credential-provider.api-key.name", "static")
                 .put("ai.http-client.http-proxy", hoverflyAddress.toString())
                 .put("ai.http-client.trust-store-path", "src/test/resources/hoverfly/hoverfly.pem")
                 .buildOrThrow();
+    }
+
+    @Override
+    protected void initCredentials()
+    {
+        assertions.addPlugin(new ApiKeyCredentialProviderPlugin());
+        assertions.addCredentialProvider("static", "api_key", ImmutableMap.of("api-key", "test"));
     }
 
     @Test

--- a/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/TestOllamaFunctions.java
+++ b/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/TestOllamaFunctions.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.specto.hoverfly.junit5.api.HoverflySimulate;
+import io.trino.plugin.credential.apikey.ApiKeyCredentialProviderPlugin;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -34,9 +35,16 @@ public class TestOllamaFunctions
                 .put("ai.provider", "openai")
                 .put("ai.model", "llama3.3")
                 .put("ai.openai.endpoint", "http://localhost:11434")
-                .put("ai.openai.api-key", "test")
+                .put("ai.openai.credential-provider.inference.name", "static")
                 .put("ai.http-client.http-proxy", hoverflyAddress.toString())
                 .buildOrThrow();
+    }
+
+    @Override
+    protected void initCredentials()
+    {
+        assertions.addPlugin(new ApiKeyCredentialProviderPlugin());
+        assertions.addCredentialProvider("static", "api_key", ImmutableMap.of("api-key", "test"));
     }
 
     @Test

--- a/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/TestOpenAiConfig.java
+++ b/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/TestOpenAiConfig.java
@@ -29,8 +29,7 @@ class TestOpenAiConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(OpenAiConfig.class)
-                .setEndpoint(URI.create("https://api.openai.com"))
-                .setApiKey(null));
+                .setEndpoint(URI.create("https://api.openai.com")));
     }
 
     @Test
@@ -38,12 +37,10 @@ class TestOpenAiConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("ai.openai.endpoint", "https://api.example.com")
-                .put("ai.openai.api-key", "test-key")
                 .buildOrThrow();
 
         OpenAiConfig expected = new OpenAiConfig()
-                .setEndpoint(URI.create("https://api.example.com"))
-                .setApiKey("test-key");
+                .setEndpoint(URI.create("https://api.example.com"));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/TestOpenAiFunctions.java
+++ b/plugin/trino-ai-functions/src/test/java/io/trino/plugin/ai/functions/TestOpenAiFunctions.java
@@ -18,6 +18,7 @@ import com.google.common.net.HostAndPort;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.specto.hoverfly.junit5.api.HoverflyConfig;
 import io.specto.hoverfly.junit5.api.HoverflySimulate;
+import io.trino.plugin.credential.apikey.ApiKeyCredentialProviderPlugin;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -34,10 +35,17 @@ public class TestOpenAiFunctions
         return ImmutableMap.<String, String>builder()
                 .put("ai.provider", "openai")
                 .put("ai.model", "gpt-4o-mini")
-                .put("ai.openai.api-key", "test")
+                .put("ai.openai.credential-provider.inference.name", "static")
                 .put("ai.http-client.http-proxy", hoverflyAddress.toString())
                 .put("ai.http-client.trust-store-path", "src/test/resources/hoverfly/hoverfly.pem")
                 .buildOrThrow();
+    }
+
+    @Override
+    protected void initCredentials()
+    {
+        assertions.addPlugin(new ApiKeyCredentialProviderPlugin());
+        assertions.addCredentialProvider("static", "api_key", ImmutableMap.of("api-key", "test"));
     }
 
     @Test

--- a/plugin/trino-credential-provider-api-key/pom.xml
+++ b/plugin/trino-credential-provider-api-key/pom.xml
@@ -8,22 +8,12 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>trino-ai-functions</artifactId>
+    <artifactId>trino-credential-provider-api-key</artifactId>
     <packaging>trino-plugin</packaging>
     <name>${project.artifactId}</name>
-    <description>Trino - AI functions</description>
-
-    <properties>
-        <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
-        <dep.hoverfly.version>0.20.2</dep.hoverfly.version>
-    </properties>
+    <description>Trino - Credential provider - API key</description>
 
     <dependencies>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
@@ -42,26 +32,6 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>guice</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>http-client</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>json</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-cache</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 
         <dependency>
@@ -132,33 +102,6 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-trace</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.specto</groupId>
-            <artifactId>hoverfly-java</artifactId>
-            <version>${dep.hoverfly.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>io.specto</groupId>
-            <artifactId>hoverfly-java-junit5</artifactId>
-            <version>${dep.hoverfly.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-credential-provider-api-key</artifactId>
-            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-credential-provider-api-key/src/main/java/io/trino/plugin/credential/apikey/ApiKeyCredentialProvider.java
+++ b/plugin/trino-credential-provider-api-key/src/main/java/io/trino/plugin/credential/apikey/ApiKeyCredentialProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.apikey;
+
+import com.google.inject.Inject;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.credential.BearerTokenCredential;
+import io.trino.spi.security.credential.Credential;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.StringCredential;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static io.trino.spi.security.credential.CredentialProvider.assertSupportedTypes;
+import static java.util.Objects.requireNonNull;
+
+public class ApiKeyCredentialProvider
+        implements CredentialProvider
+{
+    private final String apiKey;
+    private BearerTokenCredential bearerTokenCredential;
+    private StringCredential stringCredential;
+
+    @Inject
+    public ApiKeyCredentialProvider(ApiKeyCredentialProviderConfig config)
+    {
+        this.apiKey = requireNonNull(config.getApiKey(), "apiKey is null");
+    }
+
+    @Override
+    public <T extends Credential> Optional<T> getCredential(ConnectorIdentity identity, Class<T> type)
+    {
+        assertSupportedTypes(this, type, BearerTokenCredential.class, StringCredential.class);
+
+        if (type.isAssignableFrom(BearerTokenCredential.class)) {
+            if (bearerTokenCredential == null) {
+                bearerTokenCredential = new BearerTokenCredential(apiKey, Instant.MAX);
+            }
+            return Optional.of((T) bearerTokenCredential);
+        }
+
+        if (stringCredential == null) {
+            stringCredential = new StringCredential(apiKey);
+        }
+        return Optional.of((T) stringCredential);
+    }
+}

--- a/plugin/trino-credential-provider-api-key/src/main/java/io/trino/plugin/credential/apikey/ApiKeyCredentialProviderConfig.java
+++ b/plugin/trino-credential-provider-api-key/src/main/java/io/trino/plugin/credential/apikey/ApiKeyCredentialProviderConfig.java
@@ -11,27 +11,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.ai.functions;
+package io.trino.plugin.credential.apikey;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import jakarta.validation.constraints.NotNull;
 
-import java.net.URI;
-
-public class OpenAiConfig
+public class ApiKeyCredentialProviderConfig
 {
-    private URI endpoint = URI.create("https://api.openai.com");
+    private String apiKey;
 
     @NotNull
-    public URI getEndpoint()
+    public String getApiKey()
     {
-        return endpoint;
+        return apiKey;
     }
 
-    @Config("ai.openai.endpoint")
-    public OpenAiConfig setEndpoint(URI endpoint)
+    @Config("api-key")
+    @ConfigSecuritySensitive
+    @ConfigDescription("The API key")
+    public ApiKeyCredentialProviderConfig setApiKey(String apiKey)
     {
-        this.endpoint = endpoint;
+        this.apiKey = apiKey;
         return this;
     }
 }

--- a/plugin/trino-credential-provider-api-key/src/main/java/io/trino/plugin/credential/apikey/ApiKeyCredentialProviderFactory.java
+++ b/plugin/trino-credential-provider-api-key/src/main/java/io/trino/plugin/credential/apikey/ApiKeyCredentialProviderFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.apikey;
+
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+
+import java.util.Map;
+
+public class ApiKeyCredentialProviderFactory
+        implements CredentialProviderFactory
+{
+    @Override
+    public String getFactoryName()
+    {
+        return "api_key";
+    }
+
+    @Override
+    public CredentialProvider create(String providerName, Map<String, String> config)
+    {
+        Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.credential-provider.%s".formatted(providerName),
+                new ApiKeyCredentialProviderModule());
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .disableSystemProperties()
+                .setRequiredConfigurationProperties(config)
+                .initialize();
+
+        return injector.getInstance(ApiKeyCredentialProvider.class);
+    }
+}

--- a/plugin/trino-credential-provider-api-key/src/main/java/io/trino/plugin/credential/apikey/ApiKeyCredentialProviderModule.java
+++ b/plugin/trino-credential-provider-api-key/src/main/java/io/trino/plugin/credential/apikey/ApiKeyCredentialProviderModule.java
@@ -11,27 +11,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.ai.functions;
+package io.trino.plugin.credential.apikey;
 
-import io.airlift.configuration.Config;
-import jakarta.validation.constraints.NotNull;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
 
-import java.net.URI;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
-public class OpenAiConfig
+public class ApiKeyCredentialProviderModule
+        implements Module
 {
-    private URI endpoint = URI.create("https://api.openai.com");
-
-    @NotNull
-    public URI getEndpoint()
+    @Override
+    public void configure(Binder binder)
     {
-        return endpoint;
-    }
-
-    @Config("ai.openai.endpoint")
-    public OpenAiConfig setEndpoint(URI endpoint)
-    {
-        this.endpoint = endpoint;
-        return this;
+        configBinder(binder).bindConfig(ApiKeyCredentialProviderConfig.class);
+        binder.bind(ApiKeyCredentialProvider.class).in(Scopes.SINGLETON);
     }
 }

--- a/plugin/trino-credential-provider-api-key/src/main/java/io/trino/plugin/credential/apikey/ApiKeyCredentialProviderPlugin.java
+++ b/plugin/trino-credential-provider-api-key/src/main/java/io/trino/plugin/credential/apikey/ApiKeyCredentialProviderPlugin.java
@@ -11,27 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.ai.functions;
+package io.trino.plugin.credential.apikey;
 
-import io.airlift.configuration.Config;
-import jakarta.validation.constraints.NotNull;
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Plugin;
+import io.trino.spi.security.credential.CredentialProviderFactory;
 
-import java.net.URI;
-
-public class OpenAiConfig
+public class ApiKeyCredentialProviderPlugin
+        implements Plugin
 {
-    private URI endpoint = URI.create("https://api.openai.com");
-
-    @NotNull
-    public URI getEndpoint()
+    @Override
+    public Iterable<CredentialProviderFactory> getCredentialProviderFactories()
     {
-        return endpoint;
-    }
-
-    @Config("ai.openai.endpoint")
-    public OpenAiConfig setEndpoint(URI endpoint)
-    {
-        this.endpoint = endpoint;
-        return this;
+        return ImmutableList.of(new ApiKeyCredentialProviderFactory());
     }
 }

--- a/plugin/trino-credential-provider-api-key/src/test/java/io/trino/plugin/credential/apikey/TestApiKeyCredentialProvider.java
+++ b/plugin/trino-credential-provider-api-key/src/test/java/io/trino/plugin/credential/apikey/TestApiKeyCredentialProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.apikey;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.credential.BearerTokenCredential;
+import io.trino.spi.security.credential.CredentialProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestApiKeyCredentialProvider
+{
+    @Test
+    public void test()
+    {
+        ApiKeyCredentialProviderFactory factory = new ApiKeyCredentialProviderFactory();
+        assertThat(factory.getFactoryName()).isEqualTo("api_key");
+
+        CredentialProvider provider = factory.create("my-name", ImmutableMap.of("api-key", "the-key-value"));
+        assertThat(provider).isInstanceOf(ApiKeyCredentialProvider.class);
+
+        ConnectorIdentity identity = ConnectorIdentity.ofUser("alice");
+        BearerTokenCredential credential = provider.getCredential(identity, BearerTokenCredential.class).orElseThrow();
+        assertThat(credential.bearerToken()).isEqualTo("the-key-value");
+
+        assertThat(credential.getHeaders()).isEqualTo(ImmutableMap.of("Authorization", "Bearer the-key-value"));
+    }
+}

--- a/plugin/trino-credential-provider-basic/pom.xml
+++ b/plugin/trino-credential-provider-basic/pom.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>484-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-credential-provider-basic</artifactId>
+    <packaging>trino-plugin</packaging>
+    <name>${project.artifactId}</name>
+    <description>Trino - Credential provider - Basic auth</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-trace</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProvider.java
+++ b/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.basic;
+
+import com.google.inject.Inject;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.credential.BasicCredential;
+import io.trino.spi.security.credential.Credential;
+import io.trino.spi.security.credential.CredentialProvider;
+
+import java.util.Optional;
+
+import static io.trino.spi.security.credential.CredentialProvider.assertSupportedTypes;
+import static java.util.Objects.requireNonNull;
+
+public class BasicCredentialProvider
+        implements CredentialProvider
+{
+    private final BasicCredential credential;
+
+    @Inject
+    public BasicCredentialProvider(BasicCredentialProviderConfig config)
+    {
+        requireNonNull(config, "config is null");
+        credential = new BasicCredential(config.getUsername(), config.getPassword());
+    }
+
+    @Override
+    public <T extends Credential> Optional<T> getCredential(ConnectorIdentity identity, Class<T> type)
+    {
+        assertSupportedTypes(this, type, BasicCredential.class);
+        return Optional.of((T) credential);
+    }
+}

--- a/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderConfig.java
+++ b/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.basic;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import jakarta.validation.constraints.NotNull;
+
+public class BasicCredentialProviderConfig
+{
+    private String username;
+    private String password;
+
+    @NotNull
+    public String getUsername()
+    {
+        return username;
+    }
+
+    @Config("username")
+    @ConfigDescription("Username")
+    public BasicCredentialProviderConfig setUsername(String username)
+    {
+        this.username = username;
+        return this;
+    }
+
+    @NotNull
+    public String getPassword()
+    {
+        return password;
+    }
+
+    @Config("password")
+    @ConfigSecuritySensitive
+    @ConfigDescription("Password")
+    public BasicCredentialProviderConfig setPassword(String password)
+    {
+        this.password = password;
+        return this;
+    }
+}

--- a/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderFactory.java
+++ b/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.basic;
+
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+
+import java.util.Map;
+
+public class BasicCredentialProviderFactory
+        implements CredentialProviderFactory
+{
+    @Override
+    public String getFactoryName()
+    {
+        return "basic";
+    }
+
+    @Override
+    public CredentialProvider create(String providerName, Map<String, String> config)
+    {
+        Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.credential-provider.%s".formatted(providerName),
+                new BasicCredentialProviderModule());
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .disableSystemProperties()
+                .setRequiredConfigurationProperties(config)
+                .initialize();
+
+        return injector.getInstance(BasicCredentialProvider.class);
+    }
+}

--- a/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderModule.java
+++ b/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderModule.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.basic;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class BasicCredentialProviderModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(BasicCredentialProviderConfig.class);
+        binder.bind(BasicCredentialProvider.class).in(Scopes.SINGLETON);
+    }
+}

--- a/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderPlugin.java
+++ b/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.basic;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Plugin;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+
+public class BasicCredentialProviderPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<CredentialProviderFactory> getCredentialProviderFactories()
+    {
+        return ImmutableList.of(new BasicCredentialProviderFactory());
+    }
+}

--- a/plugin/trino-credential-provider-basic/src/test/java/io/trino/plugin/credential/basic/TestBasicCredentialProvider.java
+++ b/plugin/trino-credential-provider-basic/src/test/java/io/trino/plugin/credential/basic/TestBasicCredentialProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.basic;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.credential.BasicCredential;
+import io.trino.spi.security.credential.CredentialProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestBasicCredentialProvider
+{
+    @Test
+    public void test()
+    {
+        BasicCredentialProviderFactory factory = new BasicCredentialProviderFactory();
+        assertThat(factory.getFactoryName()).isEqualTo("basic");
+
+        CredentialProvider provider = factory.create("my-name", ImmutableMap.of("username", "admin", "password", "hunter2"));
+        assertThat(provider).isInstanceOf(BasicCredentialProvider.class);
+
+        ConnectorIdentity identity = ConnectorIdentity.ofUser("alice");
+        BasicCredential credential = provider.getCredential(identity, BasicCredential.class).orElseThrow();
+        assertThat(credential.username()).isEqualTo("admin");
+        assertThat(credential.password()).isEqualTo("hunter2");
+
+        assertThat(credential.getHeaders()).isEqualTo(ImmutableMap.of("Authorization", "Basic YWRtaW46aHVudGVyMg=="));
+    }
+}

--- a/plugin/trino-credential-provider-oidc/pom.xml
+++ b/plugin/trino-credential-provider-oidc/pom.xml
@@ -8,22 +8,12 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>trino-ai-functions</artifactId>
+    <artifactId>trino-credential-provider-oidc</artifactId>
     <packaging>trino-plugin</packaging>
     <name>${project.artifactId}</name>
-    <description>Trino - AI functions</description>
-
-    <properties>
-        <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
-        <dep.hoverfly.version>0.20.2</dep.hoverfly.version>
-    </properties>
+    <description>Trino - Credential provider - RFC-8693</description>
 
     <dependencies>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
@@ -57,11 +47,6 @@
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-cache</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 
         <dependency>
@@ -132,33 +117,6 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-trace</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.specto</groupId>
-            <artifactId>hoverfly-java</artifactId>
-            <version>${dep.hoverfly.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>io.specto</groupId>
-            <artifactId>hoverfly-java-junit5</artifactId>
-            <version>${dep.hoverfly.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-credential-provider-api-key</artifactId>
-            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-credential-provider-oidc/src/main/java/io/trino/plugin/credential/oidc/ForOidcCredentialProviderClient.java
+++ b/plugin/trino-credential-provider-oidc/src/main/java/io/trino/plugin/credential/oidc/ForOidcCredentialProviderClient.java
@@ -11,27 +11,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.ai.functions;
+package io.trino.plugin.credential.oidc;
 
-import io.airlift.configuration.Config;
-import jakarta.validation.constraints.NotNull;
+import com.google.inject.BindingAnnotation;
 
-import java.net.URI;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
-public class OpenAiConfig
-{
-    private URI endpoint = URI.create("https://api.openai.com");
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-    @NotNull
-    public URI getEndpoint()
-    {
-        return endpoint;
-    }
-
-    @Config("ai.openai.endpoint")
-    public OpenAiConfig setEndpoint(URI endpoint)
-    {
-        this.endpoint = endpoint;
-        return this;
-    }
-}
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface ForOidcCredentialProviderClient {}

--- a/plugin/trino-credential-provider-oidc/src/main/java/io/trino/plugin/credential/oidc/OidcCredentialProvider.java
+++ b/plugin/trino-credential-provider-oidc/src/main/java/io/trino/plugin/credential/oidc/OidcCredentialProvider.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.oidc;
+
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.inject.Inject;
+import io.airlift.http.client.FormDataBodyBuilder;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StringResponseHandler;
+import io.airlift.json.JsonCodec;
+import io.trino.cache.EvictableCacheBuilder;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.credential.BearerTokenCredential;
+import io.trino.spi.security.credential.Credential;
+import io.trino.spi.security.credential.CredentialProvider;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
+import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.trino.spi.security.credential.CredentialProvider.assertSupportedTypes;
+import static java.util.Objects.requireNonNull;
+
+public class OidcCredentialProvider
+        implements CredentialProvider
+{
+    private static final JsonCodec<TokenExchangeResponse> TOKEN_EXCHANGE_RESPONSE_JSON_CODEC = jsonCodec(TokenExchangeResponse.class);
+    private final LoadingCache<CacheKey, BearerTokenCredential> cache;
+
+    @Inject
+    public OidcCredentialProvider(@ForOidcCredentialProviderClient HttpClient httpClient, OidcCredentialProviderConfig config)
+    {
+        requireNonNull(config, "config is null");
+        this.cache = EvictableCacheBuilder.newBuilder()
+                .maximumSize(config.getCacheSize())
+                .build(new CacheLoader<>()
+                {
+                    @Override
+                    public BearerTokenCredential load(CacheKey cacheKey)
+                    {
+                        Request request = preparePost()
+                                .setUri(config.getTokenUrl())
+                                .setMethod("POST")
+                                .setHeader(CONTENT_TYPE, "application/x-www-form-urlencoded")
+                                .setBodyGenerator(new FormDataBodyBuilder()
+                                        .addField("client_id", requireNonNull(config.getClientId(), "clientId is null"))
+                                        .addField("client_secret", requireNonNull(config.getClientSecret(), "clientSecret is null"))
+                                        .addField("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+                                        .addField("subject_token", cacheKey.parentAccessToken())
+                                        .addField("subject_token_type", "urn:ietf:params:oauth:token-type:access_token")
+                                        .addField("scope", config.getScopes())
+                                        .addField("audience", config.getAudience())
+                                        .build())
+                                .build();
+
+                        StringResponseHandler.StringResponse response = httpClient.execute(request, createStringResponseHandler());
+                        if (response.getStatusCode() != 200) {
+                            throw new IllegalStateException(config.getTokenUrl() + " returned " + response.getStatusCode() + ": " + response.getBody());
+                        }
+
+                        TokenExchangeResponse exchangeResponse = TOKEN_EXCHANGE_RESPONSE_JSON_CODEC.fromJson(response.getBody());
+                        return new BearerTokenCredential(exchangeResponse.accessToken(), Instant.now().plusSeconds(exchangeResponse.expiresIn()).minusSeconds(30));
+                    }
+                });
+    }
+
+    @Override
+    public <T extends Credential> Optional<T> getCredential(ConnectorIdentity identity, Class<T> type)
+    {
+        assertSupportedTypes(this, type, BearerTokenCredential.class);
+        String parentAccessToken = requireNonNull(identity.getExtraCredentials().get("oauth2_access_token"), "oauth2_access_token not found in extra credentials");
+
+        CacheKey cacheKey = new CacheKey(identity.getUser(), parentAccessToken);
+        BearerTokenCredential credential = cache.getUnchecked(cacheKey);
+        if (credential.isValid()) {
+            return Optional.of((T) credential);
+        }
+        cache.invalidate(cacheKey);
+        return Optional.of((T) cache.getUnchecked(cacheKey));
+    }
+
+    record CacheKey(String user, String parentAccessToken)
+    {
+        @Override
+        public boolean equals(Object o)
+        {
+            if (!(o instanceof CacheKey cacheKey)) {
+                return false;
+            }
+            return Objects.equals(user, cacheKey.user) && Objects.equals(parentAccessToken, cacheKey.parentAccessToken);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(user, parentAccessToken);
+        }
+    }
+}

--- a/plugin/trino-credential-provider-oidc/src/main/java/io/trino/plugin/credential/oidc/OidcCredentialProviderConfig.java
+++ b/plugin/trino-credential-provider-oidc/src/main/java/io/trino/plugin/credential/oidc/OidcCredentialProviderConfig.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.oidc;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+
+import java.net.URI;
+
+public class OidcCredentialProviderConfig
+{
+    private String clientId;
+    private String clientSecret;
+    private URI tokenUrl;
+    private String audience;
+    private String scopes;
+    private int cacheSize = 1024;
+
+    @AssertTrue
+    public boolean isHttpsEnabled()
+    {
+        return tokenUrl != null && tokenUrl.getScheme().equals("https");
+    }
+
+    @NotNull
+    public String getClientId()
+    {
+        return clientId;
+    }
+
+    @Config("client-id")
+    @ConfigDescription("Client ID")
+    public OidcCredentialProviderConfig setClientId(String clientId)
+    {
+        this.clientId = clientId;
+        return this;
+    }
+
+    @NotNull
+    public String getClientSecret()
+    {
+        return clientSecret;
+    }
+
+    @Config("client-secret")
+    @ConfigSecuritySensitive
+    @ConfigDescription("Client secret")
+    public OidcCredentialProviderConfig setClientSecret(String clientSecret)
+    {
+        this.clientSecret = clientSecret;
+        return this;
+    }
+
+    @NotNull
+    public URI getTokenUrl()
+    {
+        return tokenUrl;
+    }
+
+    @Config("token-url")
+    @ConfigDescription("The RFC-8693 token endpoint")
+    public OidcCredentialProviderConfig setTokenUrl(URI tokenUrl)
+    {
+        this.tokenUrl = tokenUrl;
+        return this;
+    }
+
+    @NotNull
+    public String getAudience()
+    {
+        return audience;
+    }
+
+    @Config("audience")
+    @ConfigDescription("Token audience")
+    public OidcCredentialProviderConfig setAudience(String audience)
+    {
+        this.audience = audience;
+        return this;
+    }
+
+    @NotNull
+    public String getScopes()
+    {
+        return scopes;
+    }
+
+    @Config("scopes")
+    @ConfigDescription("Token scopes")
+    public OidcCredentialProviderConfig setScopes(String scopes)
+    {
+        this.scopes = scopes;
+        return this;
+    }
+
+    public int getCacheSize()
+    {
+        return cacheSize;
+    }
+
+    @Config("cache-size")
+    @ConfigDescription("Size of the cache for resolved tokens")
+    public OidcCredentialProviderConfig setCacheSize(int cacheSize)
+    {
+        this.cacheSize = cacheSize;
+        return this;
+    }
+}

--- a/plugin/trino-credential-provider-oidc/src/main/java/io/trino/plugin/credential/oidc/OidcCredentialProviderFactory.java
+++ b/plugin/trino-credential-provider-oidc/src/main/java/io/trino/plugin/credential/oidc/OidcCredentialProviderFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.oidc;
+
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+
+import java.util.Map;
+
+public class OidcCredentialProviderFactory
+        implements CredentialProviderFactory
+{
+    @Override
+    public String getFactoryName()
+    {
+        return "oidc";
+    }
+
+    @Override
+    public CredentialProvider create(String providerName, Map<String, String> config)
+    {
+        Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.credential-provider.%s".formatted(providerName),
+                new OidcCredentialProviderModule());
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .disableSystemProperties()
+                .setRequiredConfigurationProperties(config)
+                .initialize();
+
+        return injector.getInstance(OidcCredentialProvider.class);
+    }
+}

--- a/plugin/trino-credential-provider-oidc/src/main/java/io/trino/plugin/credential/oidc/OidcCredentialProviderModule.java
+++ b/plugin/trino-credential-provider-oidc/src/main/java/io/trino/plugin/credential/oidc/OidcCredentialProviderModule.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.ai.functions;
+package io.trino.plugin.credential.oidc;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
@@ -19,20 +19,16 @@ import com.google.inject.Scopes;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
-import static io.trino.plugin.base.security.credential.CredentialProviderModule.credentialProvider;
 
-public class AnthropicModule
+public class OidcCredentialProviderModule
         implements Module
 {
     @Override
     public void configure(Binder binder)
     {
-        configBinder(binder).bindConfig(AnthropicConfig.class);
+        configBinder(binder).bindConfig(OidcCredentialProviderConfig.class);
+        httpClientBinder(binder).bindHttpClient("client", ForOidcCredentialProviderClient.class);
 
-        httpClientBinder(binder).bindHttpClient("ai", ForAiClient.class);
-        credentialProvider(binder, "api-key", "ai.anthropic");
-
-        binder.bind(AnthropicClient.class).in(Scopes.SINGLETON);
-        binder.bind(AiClient.class).to(AnthropicClient.class).in(Scopes.SINGLETON);
+        binder.bind(OidcCredentialProvider.class).in(Scopes.SINGLETON);
     }
 }

--- a/plugin/trino-credential-provider-oidc/src/main/java/io/trino/plugin/credential/oidc/OidcCredentialProviderPlugin.java
+++ b/plugin/trino-credential-provider-oidc/src/main/java/io/trino/plugin/credential/oidc/OidcCredentialProviderPlugin.java
@@ -11,27 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.ai.functions;
+package io.trino.plugin.credential.oidc;
 
-import io.airlift.configuration.Config;
-import jakarta.validation.constraints.NotNull;
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Plugin;
+import io.trino.spi.security.credential.CredentialProviderFactory;
 
-import java.net.URI;
-
-public class OpenAiConfig
+public class OidcCredentialProviderPlugin
+        implements Plugin
 {
-    private URI endpoint = URI.create("https://api.openai.com");
-
-    @NotNull
-    public URI getEndpoint()
+    @Override
+    public Iterable<CredentialProviderFactory> getCredentialProviderFactories()
     {
-        return endpoint;
-    }
-
-    @Config("ai.openai.endpoint")
-    public OpenAiConfig setEndpoint(URI endpoint)
-    {
-        this.endpoint = endpoint;
-        return this;
+        return ImmutableList.of(new OidcCredentialProviderFactory());
     }
 }

--- a/plugin/trino-credential-provider-oidc/src/main/java/io/trino/plugin/credential/oidc/TokenExchangeResponse.java
+++ b/plugin/trino-credential-provider-oidc/src/main/java/io/trino/plugin/credential/oidc/TokenExchangeResponse.java
@@ -11,27 +11,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.ai.functions;
+package io.trino.plugin.credential.oidc;
 
-import io.airlift.configuration.Config;
-import jakarta.validation.constraints.NotNull;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.net.URI;
-
-public class OpenAiConfig
+public record TokenExchangeResponse(String accessToken, long expiresIn)
 {
-    private URI endpoint = URI.create("https://api.openai.com");
-
-    @NotNull
-    public URI getEndpoint()
+    @JsonCreator
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public TokenExchangeResponse(@JsonProperty("access_token") String accessToken, @JsonProperty("expires_in") long expiresIn)
     {
-        return endpoint;
-    }
-
-    @Config("ai.openai.endpoint")
-    public OpenAiConfig setEndpoint(URI endpoint)
-    {
-        this.endpoint = endpoint;
-        return this;
+        this.accessToken = accessToken;
+        this.expiresIn = expiresIn;
     }
 }

--- a/plugin/trino-credential-provider-oidc/src/test/java/io/trino/plugin/credential/oidc/TestOidcCredentialProvider.java
+++ b/plugin/trino-credential-provider-oidc/src/test/java/io/trino/plugin/credential/oidc/TestOidcCredentialProvider.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.oidc;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.StaticBodyGenerator;
+import io.airlift.http.client.testing.TestingHttpClient;
+import io.airlift.http.client.testing.TestingResponse;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.credential.BearerTokenCredential;
+import io.trino.spi.security.credential.CredentialProvider;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
+import static io.airlift.http.client.HttpStatus.OK;
+import static java.net.URLDecoder.decode;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestOidcCredentialProvider
+{
+    @Test
+    public void testFactory()
+    {
+        OidcCredentialProviderFactory factory = new OidcCredentialProviderFactory();
+        assertThat(factory.getFactoryName()).isEqualTo("oidc");
+
+        CredentialProvider provider = factory.create("my-name", ImmutableMap.of(
+                "client-id", "trino-client",
+                "client-secret", "trino-client-secret",
+                "scopes", "openid email",
+                "audience", "external-client",
+                "token-url", "https://server/realms/master/protocol/openid-connect/token"));
+        assertThat(provider).isInstanceOf(OidcCredentialProvider.class);
+    }
+
+    @Test
+    public void test()
+    {
+        HttpClient httpClient = new TestingHttpClient(request -> {
+            assertThat(request.getMethod()).isEqualTo("POST");
+            assertThat(request.getUri().toASCIIString()).isEqualTo("https://server/realms/master/protocol/openid-connect/token");
+            assertThat(request.getHeader(CONTENT_TYPE)).isEqualTo("application/x-www-form-urlencoded");
+
+            String body = new String(((StaticBodyGenerator) request.getBodyGenerator()).getBody(), UTF_8);
+            Map<String, String> formValues = new HashSet<>(Arrays.asList(body.split("&"))).stream()
+                    .map(keyValue -> keyValue.split("="))
+                    .collect(toMap(keyValue -> decode(keyValue[0], US_ASCII), keyValue -> decode(keyValue[1], US_ASCII)));
+
+            assertThat(formValues).containsEntry("client_id", "trino-client");
+            assertThat(formValues).containsEntry("client_secret", "trino-client-secret");
+            assertThat(formValues).containsEntry("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange");
+            assertThat(formValues).containsEntry("subject_token", "the-base64-access-token");
+            assertThat(formValues).containsEntry("subject_token_type", "urn:ietf:params:oauth:token-type:access_token");
+            assertThat(formValues).containsEntry("scope", "openid email");
+            assertThat(formValues).containsEntry("audience", "external-client");
+
+            return TestingResponse.mockResponse(OK, JSON_UTF_8,
+                    """
+                    {
+                      "access_token": "abcd",
+                      "expires_in": 60
+                    }
+                    """);
+        });
+
+        OidcCredentialProviderConfig config = new OidcCredentialProviderConfig()
+                .setAudience("external-client")
+                .setClientId("trino-client")
+                .setClientSecret("trino-client-secret")
+                .setScopes("openid email")
+                .setTokenUrl(URI.create("https://server/realms/master/protocol/openid-connect/token"));
+
+        OidcCredentialProvider provider = new OidcCredentialProvider(httpClient, config);
+        ConnectorIdentity identity = ConnectorIdentity.forUser("alice").withExtraCredentials(ImmutableMap.of("oauth2_access_token", "the-base64-access-token")).build();
+        BearerTokenCredential credential = provider.getCredential(identity, BearerTokenCredential.class).orElseThrow();
+
+        assertThat(credential.getHeaders()).isEqualTo(ImmutableMap.of("Authorization", "Bearer abcd"));
+        assertThat(credential.bearerToken()).isEqualTo("abcd");
+        assertThat(credential.expiration()).isAfter(Instant.now());
+        assertThat(credential.expiration()).isBefore(Instant.now().plusSeconds(40));
+    }
+}

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlConnectorContext.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlConnectorContext.java
@@ -33,8 +33,10 @@ import io.trino.spi.PageSorter;
 import io.trino.spi.VersionEmbedder;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.MetadataProvider;
+import io.trino.spi.security.credential.CredentialResolver;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeOperators;
+import io.trino.testing.TestingCredentialResolver;
 import io.trino.type.InternalTypeManager;
 import io.trino.util.EmbedVersion;
 
@@ -113,5 +115,11 @@ public class TestingPostgreSqlConnectorContext
     public BlocksHashFactory getBlocksHashFactory()
     {
         return flatHashStrategyCompiler.createBlocksHashFactory();
+    }
+
+    @Override
+    public CredentialResolver getCredentialResolver()
+    {
+        return new TestingCredentialResolver();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,9 @@
         <module>plugin/trino-blob-cache-memory</module>
         <module>plugin/trino-cassandra</module>
         <module>plugin/trino-clickhouse</module>
+        <module>plugin/trino-credential-provider-api-key</module>
         <module>plugin/trino-credential-provider-basic</module>
+        <module>plugin/trino-credential-provider-oidc</module>
         <module>plugin/trino-datasketches</module>
         <module>plugin/trino-delta-lake</module>
         <module>plugin/trino-druid</module>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <module>plugin/trino-blob-cache-memory</module>
         <module>plugin/trino-cassandra</module>
         <module>plugin/trino-clickhouse</module>
+        <module>plugin/trino-credential-provider-basic</module>
         <module>plugin/trino-datasketches</module>
         <module>plugin/trino-delta-lake</module>
         <module>plugin/trino-druid</module>

--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -119,6 +119,7 @@ public final class DistributedQueryRunner
     private final List<TestingTrinoServer> servers = new CopyOnWriteArrayList<>();
     private final List<FunctionBundle> functionBundles = new CopyOnWriteArrayList<>(ImmutableList.of(CustomFunctionBundle.CUSTOM_FUNCTIONS));
     private final List<Plugin> plugins = new CopyOnWriteArrayList<>();
+    private final List<CredentialProviderRegistration> credentialProviders = new CopyOnWriteArrayList<>();
 
     private final Closer closer = Closer.create();
 
@@ -271,6 +272,8 @@ public final class DistributedQueryRunner
                 newServer -> {
                     functionBundles.forEach(newServer::addFunctions);
                     plugins.forEach(newServer::installPlugin);
+                    credentialProviders.forEach(registration ->
+                            newServer.addCredentialProvider(registration.name(), registration.factoryName(), registration.properties()));
                 }));
         servers.add(server);
 
@@ -692,6 +695,13 @@ public final class DistributedQueryRunner
     }
 
     @Override
+    public void addCredentialProvider(String name, String factoryName, Map<String, String> properties)
+    {
+        credentialProviders.add(new CredentialProviderRegistration(name, factoryName, properties));
+        servers.forEach(server -> server.addCredentialProvider(name, factoryName, properties));
+    }
+
+    @Override
     public final void close()
     {
         if (closed) {
@@ -1107,4 +1117,6 @@ public final class DistributedQueryRunner
         return Base64.getEncoder()
                 .encodeToString(Ciphers.createRandomAesEncryptionKey().getEncoded());
     }
+
+    private record CredentialProviderRegistration(String name, String factoryName, Map<String, String> properties) {}
 }


### PR DESCRIPTION
## Description
Proposal up for discussion created for @dain 
New version for https://github.com/trinodb/trino/pull/30125

This PR introduces injectable `CredentialProvider` instances, which can be used by plugins to obtain any credential. The first provider is implemented for OAuth2 [token exchange](https://www.keycloak.org/securing-apps/token-exchange) to get a credential on behalf of the current user. Also, a Basic auth provider is added.

## Design
Create directory: `etc/credential-provider` (just like `etc/catalog`)
Create properties file: `etc/credential-provider/keycloak.properties`
```
credential-provider.name=oidc
audience=
client-id=
client-secret=
scopes=
token-url=
```

For ai-functions (`inference` is the hardcoded name in the OpenAiClient)
```
ai.openai.endpoint=
ai.openai.credential-provider.inference.name=keycloak (just like the properties file)
```

# POC setup
To prove the example, the `OpenAIClient` has been updated to be able to login into an oauth hardened open api client.

With the following steps, this proof of concept can be run locally.

### Disable https validation
Remove the `isHttpsEnabled` assert in `OidcCredentialProviderConfig.java`

### /etc/hosts
`127.0.0.1 keycloak.local`

### docker setup
This docker compose runs a keycloak on port 8084 and a oauth secured localai on 8083.
 
docker-compose.yml
```
services:
  postgres:
    image: postgres:16
    container_name: keycloak-postgres
    restart: always
    environment:
      POSTGRES_DB: keycloak
      POSTGRES_USER: keycloak
      POSTGRES_PASSWORD: keycloakpass
    volumes:
      - postgres_data:/var/lib/postgresql/data
    ports:
      - "5432:5432"

  keycloak:
    image: quay.io/keycloak/keycloak:26.6
    command: start-dev
    container_name: keycloak.local
    environment:
      KEYCLOAK_ADMIN: admin
      KEYCLOAK_ADMIN_PASSWORD: admin

      KC_DB: postgres
      KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
      KC_DB_USERNAME: keycloak
      KC_DB_PASSWORD: keycloakpass

      # Required for OIDC redirects
      KC_HOSTNAME: keycloak.local
      KC_HTTP_PORT: 8084

      KC_HTTP_ENABLED: "true"
      KC_HOSTNAME_STRICT: "false"
    ports:
      - "8084:8084"
    depends_on:
      - postgres

  localai:
    # this is the easy setup, but as a query might take too long you might want to set up the gpu backed localai
    image: localai/localai:latest
    container_name: localai
    restart: unless-stopped
    healthcheck:
      test: ["CMD", "curl", "-f", "http://localhost:8080/readyz"]
      interval: 1m
      timeout: 20m
      retries: 5
    ports:
      - "8082:8080"
    environment:
      - DEBUG=true
      - MODELS_PATH=/models
    volumes:
      - ./models:/models

  oauth2-proxy:
    image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3
    container_name: oauth2-proxy
    restart: unless-stopped
    ports:
      - "8083:8083"
    depends_on:
      - localai
      - keycloak

    command:
      - --provider=keycloak-oidc
      - --http-address=0.0.0.0:8083
      - --upstream=http://localai:8080
      - --redirect-url=http://localhost:8083/oauth2/callback
      - --oidc-issuer-url=http://keycloak.local:8084/realms/master
      - --insecure-oidc-skip-issuer-verification=true
      - --client-id=localai-client
      - --client-secret=[ ENTER YOUR LOCALAI CLIENT-SECRET HERE LATER ]
      - --cookie-secret=[ PASTE openssl rand -base64 32 ]
      - --email-domain=*
      - --scope=openid profile email
      - --set-xauthrequest=true
      - --pass-access-token=true
      - --pass-authorization-header=true
      - --reverse-proxy=true
      - --skip-jwt-bearer-tokens=true

    environment:
      OAUTH2_PROXY_COOKIE_SECURE: "false"

volumes:
  postgres_data:
```

Start only the keycloak and postgres:
```
docker compose up keycloak postgres -d
```

### Configure keycloak
Follow these steps to configure a `trino-client` and a `localai-client` in the `master` realm:
```
master realm -> Users ->
Add user
username: yourname
Email, First name, Last name
[x] Email verified
-> Credentials tab
   -> Set password (2x)
      [ ] Temporary


master realm -> Clients
Create client
-> name trino-client
  -> General settings
    -> Client authentication [x]
    -> Standard Token exchange [x]
  -> Login settings
    -> Valid redirect URIs: https://localhost:8443/oauth2/callback
    -> Valid post logout URIs: https://localhost:8443/ui/logout/logout.html

Create client
-> name localai-client
  -> General settings
    -> Client authentication [x]
    -> Standard Token exchange [ ]
  -> Login settings
    -> Valid redirect URIs: http://localhost:8083/oauth2/callback


master realm -> Client scopes
Create scope ->
  -> name: trino-scope
  mappers -> Add mapper -> Configure a new mapper
  -> Type Audience
     -> name trino-audience-mapper
     -> included client audience: trino-client

Create scope ->
  -> name: localai-scope
  mappers -> Add mapper -> Configure a new mapper
  -> Type Audience
     -> name localai-audience-mapper
     -> included client audience: localai-client


master realm -> Clients
 -> trino-client
   -> Client scopes
     -> Add client scope
       -> trino-scope Add->Default
       -> localai-scope Add->Default
   -> Credentials
     -> Copy Client secret to a txt file we'll use later on

master realm -> Clients
 -> localai-client
   -> Client scopes
     -> Add client scope
       -> localai-scope Add->Default
   -> Credentials
     -> Copy Client secret and paste in docker-compose.yml
```

### Set up Trino
build the branch; `mvn clean install -DskipTests`

1. Create a directory in `~/bin/trino` (or anywhere you like)
2. In this directory, create a symlink to your Trino source: `ln -s /home/yourname/IdeaProjects/trino/core/trino-server/target`
3. Create file `start.sh` with content
```
#!/bin/bash
#!/bin/bash
HERE="$PWD"
cd target
rm -rf trino-server-*-SNAPSHOT/*
rmdir trino-server-*-SNAPSHOT
echo -n 'Unpacking...'
tar -xzf trino-server-*-SNAPSHOT.tar.gz
echo ' [ OK ]'
trino-server-*-SNAPSHOT/bin/launcher run -etc-dir "$HERE/data/etc"
```
4. `chmod +x start.sh`
5. Create a file `client.sh` with content
```
#!/bin/bash
java -jar /home/yourname/IdeaProjects/trino/client/trino-cli/target/trino-cli-*-SNAPSHOT-executable.jar --server https://localhost:8443 --external-authentication --insecure
```
6. Run `mkdir data/etc -p`
7. Enter this directory `~/bin/trino/data/etc`
8. Create directory `certs` and enter it
Follow these steps:
```
# Create CA
openssl genrsa -out ca.key 4096

openssl req -x509 -new -nodes \
  -key ca.key \
  -sha256 -days 3650 \
  -out ca.crt \
  -subj "/CN=trino-ca"

# Create Coordinator cert
openssl genrsa -out coordinator.key 4096

openssl req -new \
  -key coordinator.key \
  -out coordinator.csr \
  -subj "/CN=coordinator"

openssl x509 -req \
  -in coordinator.csr \
  -CA ca.crt \
  -CAkey ca.key \
  -CAcreateserial \
  -out coordinator.crt \
  -days 3650 \
  -sha256

# Coordinator keystore
keytool -importcert \
  -trustcacerts \
  -alias coordinator \
  -file coordinator.crt \
  -keystore coordinator.jks \
  -storepass changeit \
  -noprompt
```
10. Go back to `~/bin/trino/data/etc`
11. Create `config.properties` with the following content:
```
coordinator=true
node-scheduler.include-coordinator=true
discovery.uri=https://localhost:8443

# OIDC authentication
http-server.authentication.type=oauth2
http-server.https.enabled=true
http-server.https.port=8443
http-server.https.keystore.path=/home/yourname/bin/trino/data/etc/certs/coordinator.jks
http-server.https.keystore.key=changeit

web-ui.authentication.type=oauth2

# Keycloak (OIDC)
http-server.authentication.oauth2.issuer=http://keycloak.local:8084/realms/master
http-server.authentication.oauth2.client-id=trino-client
http-server.authentication.oauth2.client-secret=[PASTE THE CLIENT-SECRET FROM KEYCLOAK trino-client SETUP HERE]
http-server.authentication.oauth2.scopes=openid,profile,email
http-server.authentication.oauth2.principal-field=preferred_username
http-server.authentication.oauth2.refresh-tokens=true

http-server.https.enabled=true
http-server.http.enabled=false
http-server.http.port=8086

internal-communication.https.required=true
internal-communication.shared-secret=[RUN openssl rand 512 | base64 -w 0  AND PASTE THE RESULT HERE]
```
13. Create file `node.properties` with the following content:
```
node.environment=production
node.id=ffffffff-ffff-ffff-ffff-ffffffffffff
node.data-dir=/home/yourname/bin/trino/data
```
14. Create file `jvm.properties` with the content as described [here](https://trino.io/docs/current/installation/deployment.html#jvm-config)
15. Create directory `catalog` in `~/bin/trino/data/etc/` and enter it
16. Create file `llm.properties` with the following content:
```
connector.name=ai
ai.provider=openai
ai.model=ornith-1.0-9b
ai.openai.endpoint=http://localhost:8083
ai.openai.credential-provider.inference.name=keycloak
```
17. Create directory `credential-provider` in `etc` and enter it
18. Create file `keycloak.properties` with the following properties:
```
credential-provider.name=oidc
audience=localai-client
client-id=trino-client
client-secret=[PASTE THE CLIENT-SECRET FROM KEYCLOAK trino-client SETUP HERE]
scopes=openid profile
token-url=http://keycloak.local:8084/realms/master/protocol/openid-connect/token
```
19. Run `docker compose up localai oauth2-proxy -d`
20. Validate that you can access `http://localhost:8083` and that OAuth2 is used to log you into localai. Download a model and test if it works (note: cpu is slow, you want to use a gpu backed localai)
21. Go back to `~/bin/trino/` and run `./start.sh`
22. In a second terminal, run `./client.sh`
23. Run `select 1;`
24. The browser should open a login prompt for the coordinator, login with the user as created in keycloak. If the username is different from the local user, add argument `--user yourusername` to the `client.sh`
25. If the `select 1;` succeeds, you can run `select llm.ai.ai_gen('What is the answer to life, the universe and everything?');`
26. 
<img width="902" height="235" alt="Screenshot from 2026-06-30 01-15-36" src="https://github.com/user-attachments/assets/c3acce64-f680-44cb-afb7-945038115952" />
27. Check the logging in the Trino `start.sh` terminal  


## Things TODO
1. First we should make sure this is the right approach
2. Add junit tests
3. Split into separate PRs (?)


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( x ) Release notes are required, with the following suggested text:

```markdown
## General
* Add `CredentialProviders` interface to SPI to obtain on-behalf-of tokens to use to authenticate connected data sources
```

