### PR TITLE
Fix CREATE MATERIALIZED VIEW failure when a parameter is used in a view property

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
@@ -51,9 +51,11 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.execution.ParameterExtractor.bindParameters;
+import static io.trino.execution.ParameterExtractor.extractParameters;
 import static io.trino.metadata.MaterializedViewDefinition.DEFAULT_WHEN_STALE_BEHAVIOR;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.metadata.MetadataUtil.getRequiredCatalogHandle;
+import static io.trino.spi.StandardErrorCode.INVALID_PARAMETER_USAGE;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
 import static io.trino.spi.connector.ConnectorCapabilities.MATERIALIZED_VIEW_GRACE_PERIOD;
@@ -114,6 +116,11 @@ public class CreateMaterializedViewTask
     {
         QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
         Map<NodeRef<Parameter>, Expression> parameterLookup = bindParameters(statement, parameters);
+
+        List<Parameter> queryParameters = extractParameters(statement.getQuery());
+        if (!queryParameters.isEmpty()) {
+            throw semanticException(INVALID_PARAMETER_USAGE, queryParameters.getFirst(), "Query parameters are not allowed in the query of a materialized view");
+        }
 
         String sql = getFormattedSql(statement.getQuery(), sqlParser);
 

--- a/core/trino-main/src/main/java/io/trino/execution/ParameterExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/ParameterExtractor.java
@@ -14,11 +14,13 @@
 package io.trino.execution;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.sql.tree.CreateMaterializedView;
 import io.trino.sql.tree.DefaultTraversalVisitor;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.Parameter;
+import io.trino.sql.tree.Property;
 import io.trino.sql.tree.Statement;
 
 import java.util.ArrayList;
@@ -76,6 +78,16 @@ public final class ParameterExtractor
         public Void visitParameter(Parameter node, Void context)
         {
             parameters.add(node);
+            return null;
+        }
+
+        @Override
+        protected Void visitCreateMaterializedView(CreateMaterializedView node, Void context)
+        {
+            // The query is stored unbound in the view definition, so its parameters are not bindable.
+            for (Property property : node.getProperties()) {
+                process(property, context);
+            }
             return null;
         }
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
@@ -58,6 +58,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
 import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.INVALID_MATERIALIZED_VIEW_PROPERTY;
+import static io.trino.spi.StandardErrorCode.INVALID_PARAMETER_USAGE;
 import static io.trino.spi.StandardErrorCode.PERMISSION_DENIED;
 import static io.trino.spi.session.PropertyMetadata.integerProperty;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
@@ -230,6 +231,20 @@ class TestCreateMaterializedViewTask
             assertThat(properties.get("foo")).isEqualTo("property_value");
             return null;
         });
+    }
+
+    @Test
+    void testCreateMaterializedViewWithParameterInPropertyAndQuery()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(TEST_CATALOG_NAME)
+                .setSchema("schema")
+                .addPreparedStatement("stmt", "CREATE MATERIALIZED VIEW mv_parameterized_both WITH (foo = ?) AS SELECT * FROM mock_table WHERE b = ?")
+                .build();
+
+        assertTrinoExceptionThrownBy(() -> queryRunner.execute(session, "EXECUTE stmt USING 'property_value'"))
+                .hasErrorCode(INVALID_PARAMETER_USAGE)
+                .hasMessage("line 1:101: Query parameters are not allowed in the query of a materialized view");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
@@ -212,6 +212,27 @@ class TestCreateMaterializedViewTask
     }
 
     @Test
+    void testCreateMaterializedViewWithParameterizedProperty()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(TEST_CATALOG_NAME)
+                .setSchema("schema")
+                .addPreparedStatement("stmt", "CREATE MATERIALIZED VIEW IF NOT EXISTS mv_parameterized_property WITH (foo = ?) AS SELECT * FROM mock_table")
+                .build();
+
+        queryRunner.execute(session, "EXECUTE stmt USING 'property_value'");
+
+        queryRunner.inTransaction(transactionSession -> {
+            SchemaTableName viewName = SchemaTableName.schemaTableName("schema", "mv_parameterized_property");
+            Optional<ConnectorMaterializedViewDefinition> definitionOptional = metadata.getMaterializedView(transactionSession.toConnectorSession(), viewName);
+            assertThat(definitionOptional).isPresent();
+            Map<String, Object> properties = metadata.getMaterializedViewProperties(transactionSession.toConnectorSession(), viewName, definitionOptional.get());
+            assertThat(properties.get("foo")).isEqualTo("property_value");
+            return null;
+        });
+    }
+
+    @Test
     public void testCreateDenyPermission()
     {
         CreateMaterializedView statement = new CreateMaterializedView(

--- a/core/trino-main/src/test/java/io/trino/execution/TestParameterExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestParameterExtractor.java
@@ -68,7 +68,7 @@ public class TestParameterExtractor
     @Test
     public void testCreateMaterializedView()
     {
-        Statement statement = sqlParser.createStatement("CREATE MATERIALIZED VIEW mv WITH (partitioning = ARRAY[?]) AS SELECT c1 FROM test_table");
+        Statement statement = sqlParser.createStatement("CREATE MATERIALIZED VIEW mv WITH (partitioning = ARRAY[?]) AS SELECT c1 FROM test_table WHERE c2 = ?");
         assertThat(ParameterExtractor.extractParameters(statement))
                 .containsExactly(new Parameter(new NodeLocation(1, 56), 0));
         assertThat(ParameterExtractor.getParameterCount(statement)).isEqualTo(1);

--- a/core/trino-main/src/test/java/io/trino/execution/TestParameterExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestParameterExtractor.java
@@ -64,4 +64,13 @@ public class TestParameterExtractor
 
         assertThat(ParameterExtractor.getParameterCount(statement)).isEqualTo(1);
     }
+
+    @Test
+    public void testCreateMaterializedView()
+    {
+        Statement statement = sqlParser.createStatement("CREATE MATERIALIZED VIEW mv WITH (partitioning = ARRAY[?]) AS SELECT c1 FROM test_table");
+        assertThat(ParameterExtractor.extractParameters(statement))
+                .containsExactly(new Parameter(new NodeLocation(1, 56), 0));
+        assertThat(ParameterExtractor.getParameterCount(statement)).isEqualTo(1);
+    }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -825,19 +825,6 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
-    protected Void visitCreateMaterializedView(CreateMaterializedView node, C context)
-    {
-        // The query is deliberately not processed. A parameter cannot survive in a stored view
-        // definition, so binding one would replace an error at creation time with a materialized
-        // view that fails to read.
-        for (Property property : node.getProperties()) {
-            process(property, context);
-        }
-
-        return null;
-    }
-
-    @Override
     protected Void visitSetSession(SetSession node, C context)
     {
         process(node.getValue(), context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -825,6 +825,19 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
+    protected Void visitCreateMaterializedView(CreateMaterializedView node, C context)
+    {
+        // The query is deliberately not processed. A parameter cannot survive in a stored view
+        // definition, so binding one would replace an error at creation time with a materialized
+        // view that fails to read.
+        for (Property property : node.getProperties()) {
+            process(property, context);
+        }
+
+        return null;
+    }
+
+    @Override
     protected Void visitSetSession(SetSession node, C context)
     {
         process(node.getValue(), context);


### PR DESCRIPTION
## Description
The `DefaultTraversalVisitor` has no `visitCreateMaterializedView`, so `ParameterExtractor` finds no parameters in the statement and a bound parameter is rejected:

```java
PreparedStatement s = connection.prepareStatement(
        "CREATE MATERIALIZED VIEW mv WITH (storage_schema = ?) AS SELECT * FROM t");
s.setString(1, "staging");
s.execute();
// line 1:1: Incorrect number of parameters: expected 0 but found 1
```

This fix mirrors ee0b666d606 ("Process parameters for CREATE SCHEMA"), also `CREATE TABLE AS SELECT` and `ANALYZE`, etc do the same.

Only the properties are traversed and the query is excluded on purpose: a parameter cannot survive in a
stored view definition, so binding one would create a materialized view that fails on read.

## Additional context and related issues
**Pending**: Below items are not addressed here, but I'm happy to file or fix as follow-ups:
- Properties are not traversed for other statements, same root cause: `ALTER TABLE ... SET PROPERTIES`, `ALTER MATERIALIZED VIEW ... SET PROPERTIES`, `ALTER TABLE ... EXECUTE` (both `WHERE` and procedure arguments), `ALTER MATERIALIZED VIEW ... EXECUTE`, `CREATE CATALOG`, `CREATE BRANCH`, `SET TIME ZONE`, `CREATE VIEW`, `CREATE FUNCTION`, and column-level properties in `CREATE TABLE`.
- `CREATE VIEW` stores unbound parameters in the view definition, so the view fails on read with "Query takes no parameters". Fixing it means either not traversing the view query, or rejecting parameters in view definitions instead. (https://github.com/trinodb/trino/issues/22946 but in the other way)
- Error message/failpath change for a pre-existing issue as below: ~it can be fixed as a follow-up~ (addressed in this PR).
```sql
PREPARE p FROM CREATE MATERIALIZED VIEW mv WITH (foo = ?) AS SELECT * FROM t WHERE a = ?;
EXECUTE p USING 'v';
-- before: line 1:1: Incorrect number of parameters: expected 0 but found 1
-- after:  Query does not round-trip  (GENERIC_INTERNAL_ERROR)
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix failure when creating a materialized view with a query parameter in a view property
```
