### PR TITLE
Exclude delete files from Iceberg $partitions

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -1553,13 +1553,16 @@ The output of the query has the following columns:
     partition column values.
 * - `record_count`
   - `BIGINT`
-  - The number of records in the partition.
+  - The number of records in the data files of the partition. Records in
+    delete files are not counted.
 * - `file_count`
   - `BIGINT`
-  - The number of files mapped in the partition.
+  - The number of data files mapped in the partition. Delete files are not
+    counted.
 * - `total_size`
   - `BIGINT`
-  - The size of all the files in the partition.
+  - The size of all the data files in the partition. Delete files are not
+    included.
 * - `data`
   - `ROW(... ROW (min ..., max ... , null_count BIGINT, nan_count BIGINT))`
   - Partition range metadata.

--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -1563,6 +1563,18 @@ The output of the query has the following columns:
   - `BIGINT`
   - The size of all the data files in the partition. Delete files are not
     included.
+* - `position_delete_record_count`
+  - `BIGINT`
+  - The number of records in the position delete files of the partition.
+* - `position_delete_file_count`
+  - `BIGINT`
+  - The number of position delete files mapped in the partition.
+* - `equality_delete_record_count`
+  - `BIGINT`
+  - The number of records in the equality delete files of the partition.
+* - `equality_delete_file_count`
+  - `BIGINT`
+  - The number of equality delete files mapped in the partition.
 * - `data`
   - `ROW(... ROW (min ..., max ... , null_count BIGINT, nan_count BIGINT))`
   - Partition range metadata.

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/PartitionsView.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/PartitionsView.java
@@ -20,6 +20,7 @@ import io.trino.spi.connector.ConnectorViewDefinition.ViewColumn;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
+import org.apache.iceberg.FileContent;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.types.Types.NestedField;
@@ -89,10 +90,12 @@ public final class PartitionsView
             dataAggregationSql = "";
         }
 
+        // The $files table has one row per content file, so delete files have to be excluded to keep reporting data file metrics only
         String viewSql =
                 """
                 SELECT %s SUM(record_count) AS record_count, COUNT(*) AS file_count, SUM(file_size_in_bytes) AS total_size%s
                 FROM %s.%s.%s
+                WHERE content = %d
                 %s
                 """.formatted(
                         hasPartitionColumn ? "partition," : "",
@@ -100,6 +103,7 @@ public final class PartitionsView
                         quoted(catalogName),
                         quoted(schemaName),
                         quoted(tableName + "$files"),
+                        FileContent.DATA.id(),
                         hasPartitionColumn ? "GROUP BY 1" : "");
 
         return new ConnectorViewDefinition(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/PartitionsView.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/system/PartitionsView.java
@@ -65,7 +65,14 @@ public final class PartitionsView
             hasPartitionColumn = false;
         }
 
-        Stream.of("record_count", "file_count", "total_size")
+        Stream.of(
+                        "record_count",
+                        "file_count",
+                        "total_size",
+                        "position_delete_record_count",
+                        "position_delete_file_count",
+                        "equality_delete_record_count",
+                        "equality_delete_file_count")
                 .forEach(column -> viewColumns.add(new ViewColumn(column, BIGINT.getTypeId(), Optional.empty())));
 
         Set<Integer> identityPartitionIds = getIdentityPartitions(icebergTable.spec()).keySet().stream()
@@ -78,32 +85,44 @@ public final class PartitionsView
 
         Optional<RowType> dataColumnType = getMetricsColumnType(typeManager, nonPartitionPrimitiveColumns);
 
+        // The $files table has one row per content file, so every aggregate is restricted to the content it reports on
+        String dataFileFilter = contentFilter(FileContent.DATA);
+        String positionDeleteFilter = contentFilter(FileContent.POSITION_DELETES);
+        String equalityDeleteFilter = contentFilter(FileContent.EQUALITY_DELETES);
+
         boolean hasDataColumn;
         String dataAggregationSql;
         if (dataColumnType.isPresent()) {
             hasDataColumn = true;
             viewColumns.add(new ViewColumn("data", dataColumnType.get().getTypeId(), Optional.empty()));
-            dataAggregationSql = buildDataAggregation(typeManager, nonPartitionPrimitiveColumns);
+            dataAggregationSql = buildDataAggregation(typeManager, nonPartitionPrimitiveColumns, dataFileFilter);
         }
         else {
             hasDataColumn = false;
             dataAggregationSql = "";
         }
 
-        // The $files table has one row per content file, so delete files have to be excluded to keep reporting data file metrics only
         String viewSql =
                 """
-                SELECT %s SUM(record_count) AS record_count, COUNT(*) AS file_count, SUM(file_size_in_bytes) AS total_size%s
-                FROM %s.%s.%s
-                WHERE content = %d
-                %s
+                SELECT %1$s
+                    COALESCE(SUM(record_count) %2$s, 0) AS record_count,
+                    COUNT(*) %2$s AS file_count,
+                    COALESCE(SUM(file_size_in_bytes) %2$s, 0) AS total_size,
+                    COALESCE(SUM(record_count) %3$s, 0) AS position_delete_record_count,
+                    COUNT(*) %3$s AS position_delete_file_count,
+                    COALESCE(SUM(record_count) %4$s, 0) AS equality_delete_record_count,
+                    COUNT(*) %4$s AS equality_delete_file_count%5$s
+                FROM %6$s.%7$s.%8$s
+                %9$s
                 """.formatted(
                         hasPartitionColumn ? "partition," : "",
+                        dataFileFilter,
+                        positionDeleteFilter,
+                        equalityDeleteFilter,
                         hasDataColumn ? ", " + dataAggregationSql : "",
                         quoted(catalogName),
                         quoted(schemaName),
                         quoted(tableName + "$files"),
-                        FileContent.DATA.id(),
                         hasPartitionColumn ? "GROUP BY 1" : "");
 
         return new ConnectorViewDefinition(
@@ -117,26 +136,31 @@ public final class PartitionsView
                 ImmutableList.of());
     }
 
-    private static String buildDataAggregation(TypeManager typeManager, List<NestedField> nonPartitionColumns)
+    private static String contentFilter(FileContent content)
+    {
+        return "FILTER (WHERE content = %d)".formatted(content.id());
+    }
+
+    private static String buildDataAggregation(TypeManager typeManager, List<NestedField> nonPartitionColumns, String dataFileFilter)
     {
         ImmutableList.Builder<String> rowValues = ImmutableList.builder();
         ImmutableList.Builder<String> rowTypes = ImmutableList.builder();
 
         for (NestedField column : nonPartitionColumns) {
             String trinoTypeDisplayName = toTrinoType(column.type(), typeManager).getDisplayName();
-            rowValues.add(buildColumnAggregation(column.fieldId()));
+            rowValues.add(buildColumnAggregation(column.fieldId(), dataFileFilter));
             rowTypes.add(buildColumnRowType(column.name(), trinoTypeDisplayName));
         }
 
         return "CAST(ROW(%s) AS ROW(%s)) AS data".formatted(COMMA_JOINER.join(rowValues.build()), COMMA_JOINER.join(rowTypes.build()));
     }
 
-    private static String buildColumnAggregation(int fieldId)
+    private static String buildColumnAggregation(int fieldId, String dataFileFilter)
     {
-        String min = "MIN(lower_bounds.\"%1$d\")".formatted(fieldId);
-        String max = "MAX(upper_bounds.\"%1$d\")".formatted(fieldId);
-        String nullCount = "SUM(element_at(null_value_counts, %d))".formatted(fieldId);
-        String nanCount = "SUM(element_at(nan_value_counts, %d))".formatted(fieldId);
+        String min = "MIN(lower_bounds.\"%1$d\") %2$s".formatted(fieldId, dataFileFilter);
+        String max = "MAX(upper_bounds.\"%1$d\") %2$s".formatted(fieldId, dataFileFilter);
+        String nullCount = "SUM(element_at(null_value_counts, %d)) %s".formatted(fieldId, dataFileFilter);
+        String nanCount = "SUM(element_at(nan_value_counts, %d)) %s".formatted(fieldId, dataFileFilter);
 
         // we need this case to ensure that it is compatible with the current $partitions implementation
         return """

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1047,7 +1047,8 @@ public abstract class BaseIcebergConnectorTest
         String schema = getSession().getSchema().orElseThrow();
         assertThat(query("SELECT column_name FROM information_schema.columns WHERE table_schema = '" + schema + "' AND table_name = 'test_partitioned_table$partitions' "))
                 .skippingTypesCheck()
-                .matches("VALUES 'partition', 'record_count', 'file_count', 'total_size'");
+                .matches("VALUES 'partition', 'record_count', 'file_count', 'total_size', " +
+                        "'position_delete_record_count', 'position_delete_file_count', 'equality_delete_record_count', 'equality_delete_file_count'");
         assertThat(query("SELECT " +
                 "  record_count," +
                 "  file_count, " +
@@ -4543,6 +4544,7 @@ public abstract class BaseIcebergConnectorTest
                             "BIGINT '1', " +
                             // total_size is not exactly deterministic, so grab whatever value there is
                             "(SELECT total_size FROM \"test_partitions_with_conflict$partitions\"), " +
+                            "BIGINT '0', BIGINT '0', BIGINT '0', BIGINT '0', " +
                             "CAST(" +
                             "  ROW (" +
                             (partitioned ? "" : "  ROW(11, 11, 0, NULL), ") +
@@ -4568,6 +4570,7 @@ public abstract class BaseIcebergConnectorTest
                             "BIGINT '1', " +
                             // total_size is not exactly deterministic, so grab whatever value there is
                             "(SELECT total_size FROM \"test_partitions_with_conflict$partitions\"), " +
+                            "BIGINT '0', BIGINT '0', BIGINT '0', BIGINT '0', " +
                             "CAST(" +
                             "  ROW (" +
                             (partitioned ? "" : "  NULL, ") +
@@ -5187,7 +5190,8 @@ public abstract class BaseIcebergConnectorTest
         String schema = getSession().getSchema().orElseThrow();
         assertThat(query("SELECT column_name FROM information_schema.columns WHERE table_schema = '" + schema + "' AND table_name = 'test_all_types$partitions' "))
                 .skippingTypesCheck()
-                .matches("VALUES 'record_count', 'file_count', 'total_size', 'data'");
+                .matches("VALUES 'record_count', 'file_count', 'total_size', " +
+                        "'position_delete_record_count', 'position_delete_file_count', 'equality_delete_record_count', 'equality_delete_file_count', 'data'");
         if (format != AVRO) {
             assertThat(query("SELECT " +
                     "  record_count," +

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -160,6 +160,10 @@ public abstract class BaseIcebergSystemTables
                         "('record_count', 'bigint', '', '')," +
                         "('file_count', 'bigint', '', '')," +
                         "('total_size', 'bigint', '', '')," +
+                        "('position_delete_record_count', 'bigint', '', '')," +
+                        "('position_delete_file_count', 'bigint', '', '')," +
+                        "('equality_delete_record_count', 'bigint', '', '')," +
+                        "('equality_delete_file_count', 'bigint', '', '')," +
                         "('data', 'row(\"_bigint\" row(\"min\" bigint, \"max\" bigint, \"null_count\" bigint, \"nan_count\" bigint))', '', '')");
 
         MaterializedResult result = computeActual("SELECT * from test_schema.\"test_table$partitions\"");
@@ -174,9 +178,9 @@ public abstract class BaseIcebergSystemTables
         assertThat(rowsByPartition.get(LocalDate.parse("2019-09-10")).getField(1)).isEqualTo(2L);
 
         // Test if min/max values, null value count and nan value count are computed correctly.
-        assertThat(rowsByPartition.get(LocalDate.parse("2019-09-08")).getField(4)).isEqualTo(new MaterializedRow(DEFAULT_PRECISION, new MaterializedRow(DEFAULT_PRECISION, 0L, 0L, 0L, null)));
-        assertThat(rowsByPartition.get(LocalDate.parse("2019-09-09")).getField(4)).isEqualTo(new MaterializedRow(DEFAULT_PRECISION, new MaterializedRow(DEFAULT_PRECISION, 1L, 3L, 0L, null)));
-        assertThat(rowsByPartition.get(LocalDate.parse("2019-09-10")).getField(4)).isEqualTo(new MaterializedRow(DEFAULT_PRECISION, new MaterializedRow(DEFAULT_PRECISION, 4L, 5L, 0L, null)));
+        assertThat(rowsByPartition.get(LocalDate.parse("2019-09-08")).getField(8)).isEqualTo(new MaterializedRow(DEFAULT_PRECISION, new MaterializedRow(DEFAULT_PRECISION, 0L, 0L, 0L, null)));
+        assertThat(rowsByPartition.get(LocalDate.parse("2019-09-09")).getField(8)).isEqualTo(new MaterializedRow(DEFAULT_PRECISION, new MaterializedRow(DEFAULT_PRECISION, 1L, 3L, 0L, null)));
+        assertThat(rowsByPartition.get(LocalDate.parse("2019-09-10")).getField(8)).isEqualTo(new MaterializedRow(DEFAULT_PRECISION, new MaterializedRow(DEFAULT_PRECISION, 4L, 5L, 0L, null)));
     }
 
     @Test
@@ -209,6 +213,13 @@ public abstract class BaseIcebergSystemTables
                     .matches("VALUES (BIGINT '25', BIGINT '5')");
             assertThat(query("SELECT sum(total_size) FROM \"" + tableName + "$partitions\""))
                     .matches("SELECT sum(file_size_in_bytes) FROM \"" + tableName + "$files\" WHERE content = " + FileContent.DATA.id());
+
+            // Delete files are reported in their own columns instead
+            assertThat(query("SELECT sum(position_delete_record_count), sum(position_delete_file_count), sum(equality_delete_record_count), sum(equality_delete_file_count) " +
+                    "FROM \"" + tableName + "$partitions\""))
+                    .matches("VALUES (BIGINT '1', BIGINT '1', BIGINT '1', BIGINT '1')");
+            assertThat(query("SELECT position_delete_file_count, equality_delete_file_count FROM \"" + tableName + "$partitions\" WHERE partition.regionkey = 2"))
+                    .matches("VALUES (BIGINT '0', BIGINT '1')");
         }
     }
 
@@ -230,22 +241,22 @@ public abstract class BaseIcebergSystemTables
         assertThat(rowsByPartition.get(LocalDate.parse("2022-01-04")).getField(1)).isEqualTo(3L);
 
         // Test if min/max values, null value count and nan value count are computed correctly.
-        assertThat(rowsByPartition.get(LocalDate.parse("2022-01-01")).getField(4)).isEqualTo(new MaterializedRow(
+        assertThat(rowsByPartition.get(LocalDate.parse("2022-01-01")).getField(8)).isEqualTo(new MaterializedRow(
                 DEFAULT_PRECISION,
                 new MaterializedRow(DEFAULT_PRECISION, 1L, 1L, 0L, null),
                 new MaterializedRow(DEFAULT_PRECISION, 1.1d, 1.1d, 0L, null),
                 new MaterializedRow(DEFAULT_PRECISION, 1.2f, 1.2f, 0L, null)));
-        assertThat(rowsByPartition.get(LocalDate.parse("2022-01-02")).getField(4)).isEqualTo(new MaterializedRow(
+        assertThat(rowsByPartition.get(LocalDate.parse("2022-01-02")).getField(8)).isEqualTo(new MaterializedRow(
                 DEFAULT_PRECISION,
                 new MaterializedRow(DEFAULT_PRECISION, 2L, 2L, 0L, null),
                 new MaterializedRow(DEFAULT_PRECISION, null, null, 0L, nanCount(1L)),
                 new MaterializedRow(DEFAULT_PRECISION, 2.2f, 2.2f, 0L, null)));
-        assertThat(rowsByPartition.get(LocalDate.parse("2022-01-03")).getField(4)).isEqualTo(new MaterializedRow(
+        assertThat(rowsByPartition.get(LocalDate.parse("2022-01-03")).getField(8)).isEqualTo(new MaterializedRow(
                 DEFAULT_PRECISION,
                 new MaterializedRow(DEFAULT_PRECISION, 3L, 3L, 0L, null),
                 new MaterializedRow(DEFAULT_PRECISION, 3.3, 3.3d, 0L, null),
                 new MaterializedRow(DEFAULT_PRECISION, null, null, 0L, nanCount(1L))));
-        assertThat(rowsByPartition.get(LocalDate.parse("2022-01-04")).getField(4)).isEqualTo(new MaterializedRow(
+        assertThat(rowsByPartition.get(LocalDate.parse("2022-01-04")).getField(8)).isEqualTo(new MaterializedRow(
                 DEFAULT_PRECISION,
                 new MaterializedRow(DEFAULT_PRECISION, 4L, 6L, 0L, null),
                 new MaterializedRow(DEFAULT_PRECISION, null, null, 0L, nanCount(2L)),
@@ -306,7 +317,7 @@ public abstract class BaseIcebergSystemTables
         assertThat(resultAfterDrop.getRowCount()).isEqualTo(3);
         Map<LocalDate, MaterializedRow> rowsByPartitionAfterDrop = resultAfterDrop.getMaterializedRows().stream()
                 .collect(toImmutableMap(row -> ((LocalDate) ((MaterializedRow) row.getField(0)).getField(0)), Function.identity()));
-        assertThat(rowsByPartitionAfterDrop.get(LocalDate.parse("2019-09-08")).getField(4)).isEqualTo(new MaterializedRow(
+        assertThat(rowsByPartitionAfterDrop.get(LocalDate.parse("2019-09-08")).getField(8)).isEqualTo(new MaterializedRow(
                 DEFAULT_PRECISION,
                 new MaterializedRow(DEFAULT_PRECISION, 0L, 0L, 0L, null)));
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -180,6 +180,39 @@ public abstract class BaseIcebergSystemTables
     }
 
     @Test
+    public void testPartitionsTableWithDeleteFiles()
+            throws Exception
+    {
+        try (TestTable testTable = newTrinoTable("test_partitions_delete_files_", "WITH (partitioning = ARRAY['regionkey']) AS SELECT * FROM tpch.tiny.nation")) {
+            String tableName = testTable.getName();
+            Table icebergTable = loadTable(tableName);
+
+            assertThat(query("SELECT sum(record_count), sum(file_count) FROM \"" + tableName + "$partitions\""))
+                    .matches("VALUES (BIGINT '25', BIGINT '5')");
+
+            // Write a position delete file
+            assertUpdate("DELETE FROM " + tableName + " WHERE nationkey = 7", 1);
+
+            // Write an equality delete file
+            writeEqualityDeleteForTable(
+                    icebergTable,
+                    fileSystemFactory,
+                    Optional.of(icebergTable.spec()),
+                    Optional.of(new PartitionData(new Long[] {2L})),
+                    ImmutableMap.of("regionkey", 2L),
+                    Optional.empty());
+
+            // The $files table reports the delete files, but $partitions must keep aggregating data files only
+            assertThat(query("SELECT count(*) FROM \"" + tableName + "$files\" WHERE content != " + FileContent.DATA.id()))
+                    .matches("VALUES BIGINT '2'");
+            assertThat(query("SELECT sum(record_count), sum(file_count) FROM \"" + tableName + "$partitions\""))
+                    .matches("VALUES (BIGINT '25', BIGINT '5')");
+            assertThat(query("SELECT sum(total_size) FROM \"" + tableName + "$partitions\""))
+                    .matches("SELECT sum(file_size_in_bytes) FROM \"" + tableName + "$files\" WHERE content = " + FileContent.DATA.id());
+        }
+    }
+
+    @Test
     public void testPartitionsTableWithNan()
     {
         assertQuery("SELECT count(*) FROM test_schema.test_table_nan", "VALUES 6");


### PR DESCRIPTION
## Description

The `$partitions` metadata table reports delete files as if they were data files
on merge-on-read tables.

`PartitionsView` builds a view that aggregates over the `$files` table, which has
one row per *content* file — data files, position delete files and equality delete
files alike. The generated SQL carries no predicate on the `content` column, so
`record_count`, `file_count` and `total_size` all count delete files:

```sql
SELECT partition, SUM(record_count) AS record_count, COUNT(*) AS file_count, SUM(file_size_in_bytes) AS total_size, ...
FROM "catalog"."schema"."table$files"
GROUP BY 1
```

On a partitioned copy of `tpch.tiny.nation` with one position delete file and one
equality delete file, `SELECT sum(record_count), sum(file_count) FROM "…$partitions"`
returns `(27, 7)` where the table holds 25 rows in 5 data files.

The `data` column is affected as well: its `min`, `max` and `null_count` values come
from `lower_bounds`, `upper_bounds` and `null_value_counts` of every row in `$files`,
and equality delete files carry bounds keyed by the field ids of the data schema, so
they silently widen the reported ranges.

This is a regression from #28997, which replaced `PartitionsTable` with this view.
The removed `PartitionsTable` read `DataFile dataFile = fileScanTask.file()` and only
ever saw data files.

Two commits:

1. **Exclude delete files** — restores the documented semantics of `record_count`,
   `file_count`, `total_size` and `data`. This commit stands alone and can be merged
   on its own if you would rather not take the second one.
2. **Add delete file metrics** — adds `position_delete_record_count`,
   `position_delete_file_count`, `equality_delete_record_count` and
   `equality_delete_file_count`, the same columns Iceberg exposes on its own
   partitions metadata table, so the information excluded by the first commit is
   still reachable. Aggregates move from a `WHERE` predicate to a per-content
   `FILTER` clause, which also means a partition holding only delete files is listed
   again, with zero data files — again matching Iceberg.

## Additional context and related issues

- The documented column descriptions ("The number of records in the partition") already
  describe the corrected behavior; the docs are updated to say so explicitly.
- `$all_manifests` and `$manifests` disagree about the same manifest today for a related
  reason. Not addressed here.
- Column order places the four new columns after `total_size` and before `data`, matching
  Iceberg's ordering and keeping the Trino-specific `data` column last.
- Testing: `BaseIcebergSystemTables.testPartitionsTableWithDeleteFiles` writes both a
  position delete file and an equality delete file, then asserts `$partitions` agrees with
  `$files WHERE content = 0`. It fails on master with `(27, 7)` against the expected `(25, 5)`.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg connector
* Fix `record_count`, `file_count`, `total_size` and `data` in the `$partitions` metadata
  table counting delete files as data files on merge-on-read tables. ({issue}`ISSUE`)
* Add `position_delete_record_count`, `position_delete_file_count`,
  `equality_delete_record_count` and `equality_delete_file_count` columns to the
  `$partitions` metadata table. ({issue}`ISSUE`)
```
