### PR TITLE
Fix Iceberg add_files docs on partitioned tables

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -783,7 +783,8 @@ a object storage path specified with the required `location` parameter. The
 files must use the specified `format`, with `ORC` and `PARQUET` as valid values.
 The target Iceberg table must use the same format as the added files. The
 procedure does not validate file schemas for compatibility with the target
-Iceberg table. The `location` property is supported for partitioned tables.
+Iceberg table. The `location` property is not supported for partitioned
+tables.
 
 The following examples copy `ORC`-format files from the location
 `s3://my-bucket/a/path` into the Iceberg table `iceberg_customer_orders` in the


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The Iceberg connector docs state that `add_files` supports partitioned tables
when files are loaded from a location:

> The `location` property is supported for partitioned tables.

The procedure rejects a partitioned target table instead. `MigrationUtils#addFiles`,
which is the code path taken for the `location` argument, fails immediately when
the target table is partitioned:

https://github.com/trinodb/trino/blob/0f742342696a988ccbeb45d8119b2bfa9a4b55a1/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrationUtils.java#L165-L178

```java
checkProcedureArgument(partitionSpec.isUnpartitioned(), "The procedure does not support partitioned tables");
```

This is the intended behavior, not a bug — it is covered by a test:

https://github.com/trinodb/trino/blob/0f742342696a988ccbeb45d8119b2bfa9a4b55a1/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/procedure/TestIcebergAddFilesProcedure.java#L499-L517

Only `add_files_from_table` handles partitions, by resolving each partition
location from the metastore:

https://github.com/trinodb/trino/blob/0f742342696a988ccbeb45d8119b2bfa9a4b55a1/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrationUtils.java#L233-L242

This change inverts the sentence to match the behavior and points to
`add_files_from_table` as the alternative for partitioned tables.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Follow-up to #30915, which clarified the `iceberg.add-files-procedure.enabled`
wording in the same section.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
