### PR TITLE
Support running CALL procedure on a single worker

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CallProcedureRequest.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CallProcedureRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.SessionRepresentation;
+import io.trino.connector.CatalogHandle;
+import io.trino.spi.catalog.CatalogProperties;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.NullableValue;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public record CallProcedureRequest(
+        CatalogHandle catalogHandle,
+        CatalogProperties catalogProperties,
+        SchemaTableName procedureName,
+        List<NullableValue> argumentValues,
+        SessionRepresentation session)
+{
+    public CallProcedureRequest
+    {
+        requireNonNull(catalogHandle, "catalogHandle is null");
+        requireNonNull(catalogProperties, "catalogProperties is null");
+        requireNonNull(procedureName, "procedureName is null");
+        argumentValues = ImmutableList.copyOf(argumentValues);
+        requireNonNull(session, "session is null");
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/CallProcedureResponse.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CallProcedureResponse.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record CallProcedureResponse(Optional<Map<String, Long>> metrics, Optional<ExecutionFailureInfo> failure, boolean catalogNotLoaded)
+{
+    public CallProcedureResponse
+    {
+        requireNonNull(metrics, "metrics is null");
+        requireNonNull(failure, "failure is null");
+    }
+
+    public static CallProcedureResponse success(Optional<Map<String, Long>> metrics)
+    {
+        return new CallProcedureResponse(metrics, Optional.empty(), false);
+    }
+
+    public static CallProcedureResponse failure(ExecutionFailureInfo failure)
+    {
+        return new CallProcedureResponse(Optional.empty(), Optional.of(failure), false);
+    }
+
+    public static CallProcedureResponse catalogNotLoadedResponse()
+    {
+        return new CallProcedureResponse(Optional.empty(), Optional.empty(), true);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/CallTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CallTask.java
@@ -14,20 +14,28 @@
 package io.trino.execution;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
 import io.trino.Session;
 import io.trino.connector.CatalogHandle;
+import io.trino.execution.scheduler.NodeScheduler;
+import io.trino.execution.scheduler.NodeSelector;
 import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.CatalogManager;
 import io.trino.metadata.ProcedureRegistry;
 import io.trino.metadata.QualifiedObjectName;
+import io.trino.node.InternalNode;
 import io.trino.security.AccessControl;
-import io.trino.security.InjectedConnectorAccessControl;
 import io.trino.spi.TrinoException;
-import io.trino.spi.block.Block;
-import io.trino.spi.connector.ConnectorAccessControl;
-import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.catalog.CatalogProperties;
 import io.trino.spi.eventlistener.RoutineInfo;
+import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.procedure.Procedure;
 import io.trino.spi.procedure.Procedure.Argument;
 import io.trino.spi.type.Type;
@@ -42,29 +50,29 @@ import io.trino.sql.tree.Parameter;
 import io.trino.transaction.TransactionManager;
 
 import java.lang.invoke.MethodType;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.function.Predicate;
 
-import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.trino.execution.ParameterExtractor.bindParameters;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.metadata.MetadataUtil.getRequiredCatalogHandle;
 import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static io.trino.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static io.trino.spi.StandardErrorCode.PROCEDURE_CALL_FAILED;
-import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.sql.analyzer.ConstantEvaluator.evaluateConstant;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
-import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 
 public class CallTask
@@ -74,14 +82,27 @@ public class CallTask
     private final PlannerContext plannerContext;
     private final AccessControl accessControl;
     private final ProcedureRegistry procedureRegistry;
+    private final CatalogManager catalogManager;
+    private final Provider<NodeScheduler> nodeScheduler;
+    private final Provider<RemoteCallProcedureTask> remoteCallProcedureTask;
 
     @Inject
-    public CallTask(TransactionManager transactionManager, PlannerContext plannerContext, AccessControl accessControl, ProcedureRegistry procedureRegistry)
+    public CallTask(
+            TransactionManager transactionManager,
+            PlannerContext plannerContext,
+            AccessControl accessControl,
+            ProcedureRegistry procedureRegistry,
+            CatalogManager catalogManager,
+            Provider<NodeScheduler> nodeScheduler,
+            Provider<RemoteCallProcedureTask> remoteCallProcedureTask)
     {
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.procedureRegistry = requireNonNull(procedureRegistry, "procedureRegistry is null");
+        this.catalogManager = requireNonNull(catalogManager, "catalogManager is null");
+        this.nodeScheduler = requireNonNull(nodeScheduler, "nodeScheduler is null");
+        this.remoteCallProcedureTask = requireNonNull(remoteCallProcedureTask, "remoteCallProcedureTask is null");
     }
 
     @Override
@@ -166,7 +187,7 @@ public class CallTask
             Type type = argument.getType();
             Object value = evaluateConstant(expression, type, parameterLookup, plannerContext, session, accessControl);
 
-            values[index] = toTypeObjectValue(type, value);
+            values[index] = value;
         }
 
         // fill values with optional arguments defaults
@@ -175,7 +196,7 @@ public class CallTask
 
             if (!names.containsKey(argument.getName())) {
                 verify(argument.isOptional());
-                values[i] = toTypeObjectValue(argument.getType(), argument.getDefaultValue());
+                values[i] = argument.getDefaultValue();
             }
         }
 
@@ -188,48 +209,111 @@ public class CallTask
             }
         }
 
-        // insert session argument
-        List<Object> arguments = new ArrayList<>();
-        Iterator<Object> valuesIterator = asList(values).iterator();
-        for (Class<?> type : methodType.parameterList()) {
-            if (ConnectorSession.class.equals(type)) {
-                arguments.add(session.toConnectorSession(catalogHandle));
-            }
-            else if (ConnectorAccessControl.class.equals(type)) {
-                arguments.add(new InjectedConnectorAccessControl(accessControl, session.toSecurityContext(), procedureName.catalogName()));
-            }
-            else {
-                arguments.add(valuesIterator.next());
-            }
-        }
-
         accessControl.checkCanExecuteProcedure(session.toSecurityContext(), procedureName);
         stateMachine.setRoutines(ImmutableList.of(new RoutineInfo(procedureName.objectName(), session.getUser())));
 
-        try {
-            Object result = procedure.getMethodHandle().invokeWithArguments(arguments);
-            if (procedure.getMethodHandle().type().returnType() == Map.class && result != null) {
-                @SuppressWarnings("unchecked")
-                Map<String, Long> metrics = (Map<String, Long>) result;
-                if (!metrics.isEmpty()) {
-                    stateMachine.setCallResult(metrics);
-                }
-            }
+        if (procedure.executesOnWorker()) {
+            return callOnWorker(procedure, values, session, catalogHandle, procedureName, stateMachine);
         }
-        catch (Throwable t) {
-            if (t instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-            throwIfInstanceOf(t, TrinoException.class);
-            throw new TrinoException(PROCEDURE_CALL_FAILED, t);
-        }
+
+        Optional<Map<String, Long>> metrics = ProcedureInvoker.invoke(procedure, values, session, catalogHandle, accessControl, procedureName);
+        metrics.ifPresent(stateMachine::setCallResult);
 
         return immediateVoidFuture();
     }
 
-    private static Object toTypeObjectValue(Type type, Object value)
+    private ListenableFuture<Void> callOnWorker(
+            Procedure procedure,
+            Object[] values,
+            Session session,
+            CatalogHandle catalogHandle,
+            QualifiedObjectName procedureName,
+            QueryStateMachine stateMachine)
     {
-        Block block = writeNativeValue(type, value);
-        return type.getObjectValue(block, 0);
+        NodeSelector nodeSelector = nodeScheduler.get().createNodeSelector(session);
+        int clusterSize = nodeSelector.allNodes().size();
+        if (clusterSize == 0) {
+            throw new TrinoException(NO_NODES_AVAILABLE, "No nodes available to run procedure " + procedureName);
+        }
+        List<InternalNode> nodes = nodeSelector.selectRandomNodes(clusterSize, ImmutableSet.of()).stream()
+                .filter(node -> !node.isCoordinator())
+                .collect(toImmutableList());
+        if (nodes.isEmpty()) {
+            throw new TrinoException(NO_NODES_AVAILABLE, "No worker nodes available to run procedure " + procedureName);
+        }
+
+        CatalogProperties catalogProperties = catalogManager.getCatalogProperties(catalogHandle)
+                .orElseThrow(() -> new TrinoException(PROCEDURE_CALL_FAILED, "Catalog properties not found for " + catalogHandle));
+
+        ImmutableList.Builder<NullableValue> argumentValues = ImmutableList.builderWithExpectedSize(values.length);
+        for (int i = 0; i < values.length; i++) {
+            argumentValues.add(new NullableValue(procedure.getArguments().get(i).getType(), values[i]));
+        }
+
+        CallProcedureRequest request = new CallProcedureRequest(
+                catalogHandle,
+                catalogProperties,
+                procedureName.asSchemaTableName(),
+                argumentValues.build(),
+                session.toSessionRepresentation());
+
+        SettableFuture<Void> result = SettableFuture.create();
+        callOnNode(nodes.iterator(), request, procedureName, stateMachine, result);
+        return result;
+    }
+
+    /**
+     * Attempts the call on successive candidate nodes, retrying only when a node reports that it
+     * has not yet loaded the target catalog (catalogs propagate to workers asynchronously, so this
+     * is a transient, expected condition rather than a procedure failure). Any other failure fails
+     * fast, since procedures are not assumed to be idempotent.
+     */
+    private void callOnNode(
+            Iterator<InternalNode> candidateNodes,
+            CallProcedureRequest request,
+            QualifiedObjectName procedureName,
+            QueryStateMachine stateMachine,
+            SettableFuture<Void> result)
+    {
+        if (!candidateNodes.hasNext()) {
+            result.setException(new TrinoException(PROCEDURE_CALL_FAILED, "No node has loaded catalog for procedure " + procedureName));
+            return;
+        }
+        InternalNode node = candidateNodes.next();
+
+        ListenableFuture<JsonResponse<CallProcedureResponse>> future = remoteCallProcedureTask.get().call(node, request);
+        Futures.addCallback(future, new FutureCallback<>()
+        {
+            @Override
+            public void onSuccess(JsonResponse<CallProcedureResponse> response)
+            {
+                try {
+                    if (!response.hasValue()) {
+                        result.setException(new TrinoException(PROCEDURE_CALL_FAILED, "Failed to call procedure " + procedureName + " on node " + node + ": HTTP " + response.getStatusCode()));
+                        return;
+                    }
+                    CallProcedureResponse callProcedureResponse = response.getValue();
+                    if (callProcedureResponse.catalogNotLoaded()) {
+                        callOnNode(candidateNodes, request, procedureName, stateMachine, result);
+                        return;
+                    }
+                    if (callProcedureResponse.failure().isPresent()) {
+                        result.setException(callProcedureResponse.failure().get().toException());
+                        return;
+                    }
+                    callProcedureResponse.metrics().ifPresent(stateMachine::setCallResult);
+                    result.set(null);
+                }
+                catch (Throwable t) {
+                    result.setException(t);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t)
+            {
+                result.setException(new TrinoException(PROCEDURE_CALL_FAILED, "Failed to call procedure " + procedureName + " on node " + node, t));
+            }
+        }, directExecutor());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/ProcedureInvoker.java
+++ b/core/trino-main/src/main/java/io/trino/execution/ProcedureInvoker.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import io.trino.Session;
+import io.trino.connector.CatalogHandle;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.security.AccessControl;
+import io.trino.security.InjectedConnectorAccessControl;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.procedure.Procedure;
+import io.trino.spi.type.Type;
+
+import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static io.trino.spi.StandardErrorCode.PROCEDURE_CALL_FAILED;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
+
+/**
+ * Shared invocation logic used by {@link CallTask} (local, coordinator-side invocation) and the
+ * worker-side {@code CallProcedureResource} (remote invocation for procedures that opt into
+ * {@link Procedure#executesOnWorker()}).
+ */
+public final class ProcedureInvoker
+{
+    private ProcedureInvoker() {}
+
+    /**
+     * @param values procedure argument values in the procedure's declared argument order, in each
+     *         argument type's <b>native</b> stack representation (not object-value representation)
+     */
+    public static Optional<Map<String, Long>> invoke(
+            Procedure procedure,
+            Object[] values,
+            Session session,
+            CatalogHandle catalogHandle,
+            AccessControl accessControl,
+            QualifiedObjectName procedureName)
+    {
+        List<Object> arguments = bindArguments(procedure, values, session, catalogHandle, accessControl, procedureName);
+
+        try {
+            Object result = procedure.getMethodHandle().invokeWithArguments(arguments);
+            if (procedure.getMethodHandle().type().returnType() == Map.class && result != null) {
+                @SuppressWarnings("unchecked")
+                Map<String, Long> metrics = (Map<String, Long>) result;
+                if (!metrics.isEmpty()) {
+                    return Optional.of(metrics);
+                }
+            }
+            return Optional.empty();
+        }
+        catch (Throwable t) {
+            if (t instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throwIfInstanceOf(t, TrinoException.class);
+            throw new TrinoException(PROCEDURE_CALL_FAILED, t);
+        }
+    }
+
+    private static List<Object> bindArguments(
+            Procedure procedure,
+            Object[] values,
+            Session session,
+            CatalogHandle catalogHandle,
+            AccessControl accessControl,
+            QualifiedObjectName procedureName)
+    {
+        MethodType methodType = procedure.getMethodHandle().type();
+        List<Object> arguments = new ArrayList<>();
+        int argumentIndex = 0;
+        for (Class<?> type : methodType.parameterList()) {
+            if (ConnectorSession.class.equals(type)) {
+                arguments.add(session.toConnectorSession(catalogHandle));
+            }
+            else if (ConnectorAccessControl.class.equals(type)) {
+                arguments.add(new InjectedConnectorAccessControl(accessControl, session.toSecurityContext(), procedureName.catalogName()));
+            }
+            else {
+                Type argumentType = procedure.getArguments().get(argumentIndex).getType();
+                arguments.add(toTypeObjectValue(argumentType, values[argumentIndex]));
+                argumentIndex++;
+            }
+        }
+        return arguments;
+    }
+
+    private static Object toTypeObjectValue(Type type, Object value)
+    {
+        Block block = writeNativeValue(type, value);
+        return type.getObjectValue(block, 0);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/RemoteCallProcedureTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RemoteCallProcedureTask.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.inject.Inject;
+import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.json.JsonCodec;
+import io.trino.node.InternalNode;
+import io.trino.server.ForCallProcedure;
+
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
+import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
+import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static java.util.Objects.requireNonNull;
+
+public class RemoteCallProcedureTask
+{
+    private final HttpClient httpClient;
+    private final JsonCodec<CallProcedureRequest> requestCodec;
+    private final JsonCodec<CallProcedureResponse> responseCodec;
+
+    @Inject
+    public RemoteCallProcedureTask(
+            @ForCallProcedure HttpClient httpClient,
+            JsonCodec<CallProcedureRequest> requestCodec,
+            JsonCodec<CallProcedureResponse> responseCodec)
+    {
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.requestCodec = requireNonNull(requestCodec, "requestCodec is null");
+        this.responseCodec = requireNonNull(responseCodec, "responseCodec is null");
+    }
+
+    public ListenableFuture<JsonResponse<CallProcedureResponse>> call(InternalNode node, CallProcedureRequest callProcedureRequest)
+    {
+        requireNonNull(node, "node is null");
+        requireNonNull(callProcedureRequest, "callProcedureRequest is null");
+
+        Request request = preparePost()
+                .setUri(uriBuilderFrom(node.getInternalUri()).appendPath("/v1/callProcedure").build())
+                .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                .setBodyGenerator(jsonBodyGenerator(requestCodec, callProcedureRequest))
+                .build();
+
+        return httpClient.executeAsync(request, createFullJsonResponseHandler(responseCodec));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/CallProcedureResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/CallProcedureResource.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.trino.Session;
+import io.trino.connector.ConnectorServicesProvider;
+import io.trino.execution.CallProcedureRequest;
+import io.trino.execution.CallProcedureResponse;
+import io.trino.execution.ProcedureInvoker;
+import io.trino.metadata.ProcedureRegistry;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.SessionPropertyManager;
+import io.trino.security.AccessControl;
+import io.trino.server.security.ResourceSecurity;
+import io.trino.spi.predicate.NullableValue;
+import io.trino.spi.procedure.Procedure;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.server.security.ResourceSecurity.AccessType.INTERNAL_ONLY;
+import static io.trino.util.Failures.toFailure;
+import static java.util.Objects.requireNonNull;
+
+@Path("/v1/callProcedure")
+@ResourceSecurity(INTERNAL_ONLY)
+public class CallProcedureResource
+{
+    private final ProcedureRegistry procedureRegistry;
+    private final ConnectorServicesProvider connectorServicesProvider;
+    private final AccessControl accessControl;
+    private final SessionPropertyManager sessionPropertyManager;
+
+    @Inject
+    public CallProcedureResource(
+            ProcedureRegistry procedureRegistry,
+            ConnectorServicesProvider connectorServicesProvider,
+            AccessControl accessControl,
+            SessionPropertyManager sessionPropertyManager)
+    {
+        this.procedureRegistry = requireNonNull(procedureRegistry, "procedureRegistry is null");
+        this.connectorServicesProvider = requireNonNull(connectorServicesProvider, "connectorServicesProvider is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public CallProcedureResponse callProcedure(CallProcedureRequest request)
+    {
+        Procedure procedure;
+        try {
+            connectorServicesProvider.ensureCatalogsLoaded(ImmutableList.of(request.catalogProperties()));
+            procedure = procedureRegistry.resolve(request.catalogHandle(), request.procedureName());
+        }
+        catch (IllegalArgumentException e) {
+            // the target catalog failed to load, or was not loaded and ensureCatalogsLoaded
+            // could not load it (e.g. a transient error); the coordinator can retry on a different node
+            return CallProcedureResponse.catalogNotLoadedResponse();
+        }
+
+        try {
+            Session session = request.session().toSession(sessionPropertyManager);
+            QualifiedObjectName procedureName = new QualifiedObjectName(
+                    request.catalogHandle().getCatalogName().toString(),
+                    request.procedureName().getSchemaName(),
+                    request.procedureName().getTableName());
+
+            Object[] values = toNativeValues(request.argumentValues());
+            Optional<Map<String, Long>> metrics = ProcedureInvoker.invoke(procedure, values, session, request.catalogHandle(), accessControl, procedureName);
+            return CallProcedureResponse.success(metrics);
+        }
+        catch (RuntimeException e) {
+            return CallProcedureResponse.failure(toFailure(e));
+        }
+    }
+
+    private static Object[] toNativeValues(List<NullableValue> argumentValues)
+    {
+        Object[] values = new Object[argumentValues.size()];
+        for (int i = 0; i < argumentValues.size(); i++) {
+            values[i] = argumentValues.get(i).getValue();
+        }
+        return values;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -46,6 +46,8 @@ import io.trino.dispatcher.QueuedStatementResource;
 import io.trino.event.QueryMonitor;
 import io.trino.event.QueryMonitorConfig;
 import io.trino.exchange.ExchangeMetricsCollector;
+import io.trino.execution.CallProcedureRequest;
+import io.trino.execution.CallProcedureResponse;
 import io.trino.execution.ClusterSizeMonitor;
 import io.trino.execution.DynamicFiltersCollector.VersionedDynamicFilterDomains;
 import io.trino.execution.ExecutionFailureInfo;
@@ -60,6 +62,7 @@ import io.trino.execution.QueryManager;
 import io.trino.execution.QueryManagerConfig;
 import io.trino.execution.QueryPerformanceFetcher;
 import io.trino.execution.QueryPreparer;
+import io.trino.execution.RemoteCallProcedureTask;
 import io.trino.execution.RemoteTaskFactory;
 import io.trino.execution.SessionPropertyEvaluator;
 import io.trino.execution.StageInfo;
@@ -428,6 +431,12 @@ public class CoordinatorModule
         executionPolicyBinder.addBinding("phased").to(PhasedExecutionPolicy.class);
 
         install(new QueryExecutionFactoryModule());
+
+        // distributed CALL statement dispatch
+        jsonCodecBinder(binder).bindJsonCodec(CallProcedureRequest.class);
+        jsonCodecBinder(binder).bindJsonCodec(CallProcedureResponse.class);
+        binder.bind(RemoteCallProcedureTask.class).in(Scopes.SINGLETON);
+        install(internalHttpClientModule("call-procedure", ForCallProcedure.class).build());
 
         // cleanup
         closingBinder(binder).registerExecutor(Key.get(ExecutorService.class, ForStatementResource.class));

--- a/core/trino-main/src/main/java/io/trino/server/ForCallProcedure.java
+++ b/core/trino-main/src/main/java/io/trino/server/ForCallProcedure.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface ForCallProcedure {}

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -39,6 +39,8 @@ import io.trino.block.BlockJsonSerde;
 import io.trino.connector.system.SystemConnectorModule;
 import io.trino.dispatcher.DispatchManager;
 import io.trino.exchange.ExchangeMetricsCollector;
+import io.trino.execution.CallProcedureRequest;
+import io.trino.execution.CallProcedureResponse;
 import io.trino.execution.DynamicFilterConfig;
 import io.trino.execution.ExplainAnalyzeContext;
 import io.trino.execution.FailureInjector;
@@ -256,6 +258,12 @@ public class ServerMainModule
         jaxrsBinder(binder).bind(TaskResource.class);
         newExporter(binder).export(TaskResource.class).withGeneratedName();
         binder.bind(TaskManagementExecutor.class).in(Scopes.SINGLETON);
+
+        // call procedure (worker-side execution of CALL statements)
+        jaxrsBinder(binder).bind(CallProcedureResource.class);
+        jsonCodecBinder(binder).bindJsonCodec(CallProcedureRequest.class);
+        jsonCodecBinder(binder).bindJsonCodec(CallProcedureResponse.class);
+
         binder.bind(SqlTaskManager.class).in(Scopes.SINGLETON);
         binder.bind(TableExecuteContextManager.class).in(Scopes.SINGLETON);
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
@@ -21,6 +21,7 @@ import io.trino.connector.MockConnectorFactory;
 import io.trino.connector.MockConnectorPlugin;
 import io.trino.exchange.ExchangeMetricsCollector;
 import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.CatalogManager;
 import io.trino.metadata.CatalogProcedures;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.ProcedureRegistry;
@@ -144,7 +145,18 @@ public class TestCallTask
             PlannerContext plannerContext = plannerContextBuilder()
                     .withTransactionManager(transactionManager)
                     .build();
-            new CallTask(transactionManager, plannerContext, accessControl, procedureRegistry)
+            new CallTask(
+                    transactionManager,
+                    plannerContext,
+                    accessControl,
+                    procedureRegistry,
+                    CatalogManager.NO_CATALOGS,
+                    () -> {
+                        throw new UnsupportedOperationException();
+                    },
+                    () -> {
+                        throw new UnsupportedOperationException();
+                    })
                     .execute(
                             new Call(new NodeLocation(1, 1), QualifiedName.of("testing_procedure"), ImmutableList.of()),
                             stateMachine(transactionManager, plannerContext.getMetadata(), accessControl),

--- a/core/trino-spi/src/main/java/io/trino/spi/procedure/Procedure.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/procedure/Procedure.java
@@ -36,6 +36,7 @@ public class Procedure
     private final List<Argument> arguments;
     private final boolean requireNamedArguments;
     private final MethodHandle methodHandle;
+    private final boolean executeOnWorker;
 
     public Procedure(String schema, String name, List<Argument> arguments, MethodHandle methodHandle)
     {
@@ -44,11 +45,17 @@ public class Procedure
 
     public Procedure(String schema, String name, List<Argument> arguments, MethodHandle methodHandle, boolean requireNamedArguments)
     {
+        this(schema, name, arguments, methodHandle, requireNamedArguments, false);
+    }
+
+    public Procedure(String schema, String name, List<Argument> arguments, MethodHandle methodHandle, boolean requireNamedArguments, boolean executeOnWorker)
+    {
         this.schema = checkNotNullOrEmpty(schema, "schema").toLowerCase(ENGLISH);
         this.name = checkNotNullOrEmpty(name, "name").toLowerCase(ENGLISH);
         this.arguments = List.copyOf(requireNonNull(arguments, "arguments is null"));
         this.methodHandle = requireNonNull(methodHandle, "methodHandle is null");
         this.requireNamedArguments = requireNamedArguments;
+        this.executeOnWorker = executeOnWorker;
 
         Set<String> names = new HashSet<>();
         for (Argument argument : arguments) {
@@ -95,6 +102,11 @@ public class Procedure
     public boolean requiresNamedArguments()
     {
         return requireNamedArguments;
+    }
+
+    public boolean executesOnWorker()
+    {
+        return executeOnWorker;
     }
 
     @Override

--- a/core/trino-spi/src/test/java/io/trino/spi/procedure/TestProcedure.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/procedure/TestProcedure.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.procedure;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestProcedure
+{
+    private static final MethodHandle NOOP_METHOD_HANDLE;
+
+    static {
+        try {
+            NOOP_METHOD_HANDLE = MethodHandles.lookup().findStatic(TestProcedure.class, "noop", MethodType.methodType(void.class));
+        }
+        catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static void noop() {}
+
+    @Test
+    void testDefaultsToCoordinatorExecution()
+    {
+        Procedure fourArg = new Procedure("schema", "name", ImmutableList.of(), NOOP_METHOD_HANDLE);
+        assertThat(fourArg.executesOnWorker()).isFalse();
+
+        Procedure fiveArg = new Procedure("schema", "name", ImmutableList.of(), NOOP_METHOD_HANDLE, true);
+        assertThat(fiveArg.executesOnWorker()).isFalse();
+        assertThat(fiveArg.requiresNamedArguments()).isTrue();
+    }
+
+    @Test
+    void testExecuteOnWorkerOptIn()
+    {
+        Procedure procedure = new Procedure("schema", "name", ImmutableList.of(), NOOP_METHOD_HANDLE, false, true);
+        assertThat(procedure.executesOnWorker()).isTrue();
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestDistributedCallTask.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestDistributedCallTask.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.trino.annotation.UsedByGeneratedCode;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorPlugin;
+import io.trino.spi.Node;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.procedure.Procedure;
+import io.trino.spi.transaction.IsolationLevel;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.util.Reflection.methodHandle;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+// public to allow reflection to recordInvocation method
+public final class TestDistributedCallTask
+        extends AbstractTestQueryFramework
+{
+    private static final String CATALOG = "distributed_call_catalog";
+    private static final AtomicBoolean CALLED_ON_WORKER = new AtomicBoolean();
+    private static final AtomicBoolean CALLED_ON_COORDINATOR = new AtomicBoolean();
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        QueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder().setCatalog(CATALOG).setSchema("default").build())
+                .setWorkerCount(2)
+                .build();
+        queryRunner.installPlugin(new MockConnectorPlugin(new RecordingConnectorFactory()));
+        queryRunner.createCatalog(CATALOG, "recording_mock");
+        return queryRunner;
+    }
+
+    @Test
+    void testProcedureRunsOnWorker()
+    {
+        CALLED_ON_WORKER.set(false);
+        CALLED_ON_COORDINATOR.set(false);
+
+        getQueryRunner().execute("CALL test_worker_procedure()");
+
+        assertThat(CALLED_ON_WORKER.get()).isTrue();
+        assertThat(CALLED_ON_COORDINATOR.get()).isFalse();
+    }
+
+    @UsedByGeneratedCode
+    public static void recordInvocation(Node currentNode)
+    {
+        if (currentNode.isCoordinator()) {
+            CALLED_ON_COORDINATOR.set(true);
+        }
+        else {
+            CALLED_ON_WORKER.set(true);
+        }
+    }
+
+    private static class RecordingConnectorFactory
+            implements ConnectorFactory
+    {
+        private final ConnectorFactory delegateFactory = MockConnectorFactory.builder().build();
+
+        @Override
+        public String getName()
+        {
+            return "recording_mock";
+        }
+
+        @Override
+        public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+        {
+            Node currentNode = context.getCurrentNode();
+            MethodHandle methodHandle = methodHandle(TestDistributedCallTask.class, "recordInvocation", Node.class).bindTo(currentNode);
+            Procedure procedure = new Procedure("default", "test_worker_procedure", ImmutableList.of(), methodHandle, false, true);
+            return new RecordingConnector(delegateFactory.create(catalogName, config, context), procedure);
+        }
+    }
+
+    private static class RecordingConnector
+            implements Connector
+    {
+        private final Connector delegate;
+        private final Procedure procedure;
+
+        RecordingConnector(Connector delegate, Procedure procedure)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+            this.procedure = requireNonNull(procedure, "procedure is null");
+        }
+
+        @Override
+        public Set<Procedure> getProcedures()
+        {
+            return ImmutableSet.of(procedure);
+        }
+
+        @Override
+        public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
+        {
+            return delegate.beginTransaction(isolationLevel, readOnly, autoCommit);
+        }
+
+        @Override
+        public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transactionHandle)
+        {
+            return delegate.getMetadata(session, transactionHandle);
+        }
+
+        @Override
+        public void shutdown()
+        {
+            delegate.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds an opt-in flag to `Procedure` (`executeOnWorker`) so a stored procedure can run on a worker node instead of the coordinator. Some procedures do memory-intensive work; running them on the coordinator competes with cluster-management memory and can destabilize it. `CallTask` still resolves and binds arguments on the coordinator, then dispatches the actual invocation to a worker over a new internal-only endpoint.

## Release notes

```markdown
## General
* TBD. ({issue}`issuenumber`)
```
