### PR TITLE
Fix table_changes for partition values requiring URI encoding 

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -353,9 +353,14 @@ public class DeltaLakeSplitManager
 
     public static Location buildSplitPath(Location tableLocation, AddFileEntry addAction)
     {
+        return buildSplitPath(tableLocation, addAction.getPath());
+    }
+
+    public static Location buildSplitPath(Location tableLocation, String entryPath)
+    {
         // paths are relative to the table location or absolute in case of shallow cloned table and are RFC 2396 URIs
         // https://github.com/delta-io/delta/blob/master/PROTOCOL.md#add-file-and-remove-file
-        URI uri = URI.create(addAction.getPath());
+        URI uri = URI.create(entryPath);
 
         if (uri.isAbsolute()) {
             return Location.of(uri.getScheme() + ":" + uri.getSchemeSpecificPart());

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesSplitSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesSplitSource.java
@@ -14,7 +14,7 @@
 package io.trino.plugin.deltalake.functions.tablechanges;
 
 import com.google.common.collect.ImmutableList;
-import io.trino.filesystem.Locations;
+import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.plugin.deltalake.DeltaLakeFileSystemFactory;
 import io.trino.plugin.deltalake.DeltaLakeTableCredentials;
@@ -44,6 +44,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.plugin.deltalake.DeltaLakeConfig.DEFAULT_TRANSACTION_LOG_MAX_CACHED_SIZE;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_BAD_DATA;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_FILESYSTEM_ERROR;
+import static io.trino.plugin.deltalake.DeltaLakeSplitManager.buildSplitPath;
 import static io.trino.plugin.deltalake.functions.tablechanges.TableChangesFileType.CDF_FILE;
 import static io.trino.plugin.deltalake.functions.tablechanges.TableChangesFileType.DATA_FILE;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogDir;
@@ -153,7 +154,7 @@ public class TableChangesSplitSource
             String entryPath,
             Map<String, Optional<String>> canonicalPartitionValues)
     {
-        String path = Locations.appendPath(tableLocation, entryPath);
+        String path = buildSplitPath(Location.of(tableLocation), entryPath).toString();
         return new TableChangesSplit(
                 path,
                 length,

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -3233,6 +3233,27 @@ public class TestDeltaLakeConnectorTest
     }
 
     @Test
+    public void testReadCdfChangesOnPartitionValueRequiringEncoding()
+    {
+        String tableName = "test_cdf_partition_value_requiring_encoding_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (page_url VARCHAR, domain VARCHAR) " +
+                "WITH (change_data_feed_enabled = true, partitioned_by = ARRAY['domain'])");
+        assertUpdate("INSERT INTO " + tableName + " VALUES ('url1', 'do main')", 1);
+        assertUpdate("UPDATE " + tableName + " SET page_url = 'url2' WHERE domain = 'do main'", 1);
+
+        assertTableChangesQuery(
+                "SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + tableName + "'))",
+                """
+                VALUES
+                    ('url1', 'do main', 'insert', BIGINT '1'),
+                    ('url1', 'do main', 'update_preimage', BIGINT '2'),
+                    ('url2', 'do main', 'update_postimage', BIGINT '2')
+                """);
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
     public void testCdfWithNameMappingModeOnTableWithColumnDropped()
     {
         testCdfWithMappingModeOnTableWithColumnDropped(ColumnMappingMode.NAME);


### PR DESCRIPTION
## Description

`table_changes` fails to read change data for any file stored under a partition value that requires URI encoding (a space, `#`, `%`, and so on).

Paths in `add` and `cdc` entries are RFC 2396 URIs, so a partition value of `do main` is written to the transaction log as `domain=do%20main/...`. `DeltaLakeSplitManager.buildSplitPath` decodes those paths for the table scan, but `TableChangesSplitSource.mapToDeltaLakeTableChangesSplit` appended the raw entry path to the table location, so the reader requested an object key that literally contained `%20`, and the query failed with a file-not-found error even though the table scan reads the same file fine.

The first commit extracts the path handling of `buildSplitPath` into an overload taking the entry path, and the second reuses it in `TableChangesSplitSource`, so `table_changes` resolves paths exactly like the table scan, including the absolute-path case for shallow-cloned tables. Both the `add` and `cdc` branches go through this method, so inserts and updates are both covered.

Reproduction:

```sql
CREATE TABLE test_encoding (page_url varchar, domain varchar)
WITH (change_data_feed_enabled = true, partitioned_by = ARRAY['domain']);

INSERT INTO test_encoding VALUES ('url1', 'do main');

SELECT * FROM TABLE(system.table_changes(CURRENT_SCHEMA, 'test_encoding'));
-- before: fails opening .../domain=do%20main/part-....parquet
```

## Additional context and related issues

Added a regression test next to the existing partitioned change-data-feed tests.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake connector
* Fix `table_changes` failing to read change data for partition values that require URI encoding, such as values containing a space.
```

