### PR TITLE
Fix id collisions between AssignUniqueId operators

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/AssignUniqueIdOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/AssignUniqueIdOperator.java
@@ -37,9 +37,9 @@ public class AssignUniqueIdOperator
     private static final long ROW_IDS_PER_REQUEST = 1L << 20L;
     private static final long MAX_ROW_ID = 1L << 40L;
 
-    public static OperatorFactory createOperatorFactory(int operatorId, PlanNodeId planNodeId)
+    public static OperatorFactory createOperatorFactory(int operatorId, PlanNodeId planNodeId, AtomicLong valuePool)
     {
-        return createAdapterOperatorFactory(new Factory(operatorId, planNodeId));
+        return createAdapterOperatorFactory(new Factory(operatorId, planNodeId, valuePool));
     }
 
     private static class Factory
@@ -48,12 +48,9 @@ public class AssignUniqueIdOperator
         private final int operatorId;
         private final PlanNodeId planNodeId;
         private boolean closed;
+        // The unique id embeds only the stage and partition of the task, so all AssignUniqueId
+        // operators in a task must draw row ids from a single pool for their ids to be distinct
         private final AtomicLong valuePool;
-
-        private Factory(int operatorId, PlanNodeId planNodeId)
-        {
-            this(operatorId, planNodeId, new AtomicLong());
-        }
 
         private Factory(int operatorId, PlanNodeId planNodeId, AtomicLong valuePool)
         {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -303,6 +303,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -686,6 +687,8 @@ public class LocalExecutionPlanner
 
         // this is shared with all subContexts
         private final AtomicInteger nextPipelineId;
+        // this is shared with all subContexts; see AssignUniqueIdOperator.Factory for the rationale
+        private final AtomicLong assignUniqueIdValuePool;
 
         private int nextOperatorId;
         private boolean inputDriver = true;
@@ -696,19 +699,22 @@ public class LocalExecutionPlanner
             this(taskContext,
                     new ArrayList<>(),
                     Optional.empty(),
-                    new AtomicInteger(0));
+                    new AtomicInteger(0),
+                    new AtomicLong());
         }
 
         private LocalExecutionPlanContext(
                 TaskContext taskContext,
                 List<DriverFactory> driverFactories,
                 Optional<IndexSourceContext> indexSourceContext,
-                AtomicInteger nextPipelineId)
+                AtomicInteger nextPipelineId,
+                AtomicLong assignUniqueIdValuePool)
         {
             this.taskContext = taskContext;
             this.driverFactories = driverFactories;
             this.indexSourceContext = indexSourceContext;
             this.nextPipelineId = nextPipelineId;
+            this.assignUniqueIdValuePool = assignUniqueIdValuePool;
         }
 
         public void addDriverFactory(boolean outputDriver, PhysicalOperation physicalOperation, LocalExecutionPlanContext context)
@@ -802,6 +808,11 @@ public class LocalExecutionPlanner
             return nextOperatorId++;
         }
 
+        private AtomicLong getAssignUniqueIdValuePool()
+        {
+            return assignUniqueIdValuePool;
+        }
+
         private boolean isInputDriver()
         {
             return inputDriver;
@@ -815,12 +826,12 @@ public class LocalExecutionPlanner
         public LocalExecutionPlanContext createSubContext()
         {
             checkState(indexSourceContext.isEmpty(), "index build plan cannot have sub-contexts");
-            return new LocalExecutionPlanContext(taskContext, driverFactories, indexSourceContext, nextPipelineId);
+            return new LocalExecutionPlanContext(taskContext, driverFactories, indexSourceContext, nextPipelineId, assignUniqueIdValuePool);
         }
 
         public LocalExecutionPlanContext createIndexSourceSubContext(IndexSourceContext indexSourceContext)
         {
-            return new LocalExecutionPlanContext(taskContext, driverFactories, Optional.of(indexSourceContext), nextPipelineId);
+            return new LocalExecutionPlanContext(taskContext, driverFactories, Optional.of(indexSourceContext), nextPipelineId, assignUniqueIdValuePool);
         }
 
         public OptionalInt getDriverInstanceCount()
@@ -3645,7 +3656,8 @@ public class LocalExecutionPlanner
 
             OperatorFactory operatorFactory = AssignUniqueIdOperator.createOperatorFactory(
                     context.getNextOperatorId(),
-                    node.getId());
+                    node.getId(),
+                    context.getAssignUniqueIdValuePool());
             return new PhysicalOperation(operatorFactory, makeLayout(node), source);
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestAssignUniqueIdOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestAssignUniqueIdOperator.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.trino.RowPagesBuilder;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.sql.planner.plan.PlanNodeId;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.RowPagesBuilder.rowPagesBuilder;
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.operator.OperatorAssertion.toPages;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.TestingTaskContext.createTaskContext;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+final class TestAssignUniqueIdOperator
+{
+    private static final int ROWS_PER_PAGE = 1000;
+    private static final int PAGE_COUNT = 10;
+    private static final int TOTAL_ROWS = ROWS_PER_PAGE * PAGE_COUNT;
+
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
+    private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed(getClass().getSimpleName() + "-scheduledExecutor-%s"));
+
+    @AfterAll
+    void tearDown()
+    {
+        executor.shutdownNow();
+        scheduledExecutor.shutdownNow();
+    }
+
+    @Test
+    void testAssignUniqueIds()
+    {
+        OperatorFactory operatorFactory = AssignUniqueIdOperator.createOperatorFactory(0, new PlanNodeId("test"), new AtomicLong());
+        TaskContext taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
+
+        Set<Long> ids = new HashSet<>();
+        collectIds(operatorFactory, newDriverContext(taskContext, 0), ids);
+
+        assertThat(ids).hasSize(TOTAL_ROWS);
+    }
+
+    @Test
+    void testFactoriesSharingValuePoolProduceDistinctIds()
+    {
+        // Two AssignUniqueId nodes executing in the same task (e.g. the MERGE target and source
+        // sides of a colocated join) must not produce the same id for different rows
+        AtomicLong valuePool = new AtomicLong();
+        OperatorFactory targetFactory = AssignUniqueIdOperator.createOperatorFactory(0, new PlanNodeId("target"), valuePool);
+        OperatorFactory sourceFactory = AssignUniqueIdOperator.createOperatorFactory(1, new PlanNodeId("source"), valuePool);
+
+        // Both operators run in the same task, so the id mask is identical for the two sides
+        // and only the shared pool keeps their ids apart
+        TaskContext taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
+
+        Set<Long> ids = new HashSet<>();
+        collectIds(targetFactory, newDriverContext(taskContext, 0), ids);
+        collectIds(sourceFactory, newDriverContext(taskContext, 1), ids);
+
+        assertThat(ids).hasSize(2 * TOTAL_ROWS);
+    }
+
+    @Test
+    void testDuplicatedFactoriesProduceDistinctIds()
+    {
+        // Factories duplicated for additional pipelines (e.g. lookup outer drivers) share the pool
+        OperatorFactory operatorFactory = AssignUniqueIdOperator.createOperatorFactory(0, new PlanNodeId("test"), new AtomicLong());
+        OperatorFactory duplicateFactory = operatorFactory.duplicate();
+        TaskContext taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
+
+        Set<Long> ids = new HashSet<>();
+        collectIds(operatorFactory, newDriverContext(taskContext, 0), ids);
+        collectIds(duplicateFactory, newDriverContext(taskContext, 1), ids);
+
+        assertThat(ids).hasSize(2 * TOTAL_ROWS);
+    }
+
+    private static void collectIds(OperatorFactory operatorFactory, DriverContext driverContext, Set<Long> ids)
+    {
+        RowPagesBuilder pagesBuilder = rowPagesBuilder(BIGINT);
+        for (int page = 0; page < PAGE_COUNT; page++) {
+            pagesBuilder.addSequencePage(ROWS_PER_PAGE, 0);
+        }
+        List<Page> input = pagesBuilder.build();
+
+        List<Page> output = toPages(operatorFactory, driverContext, input);
+        for (Page page : output) {
+            assertThat(page.getChannelCount()).isEqualTo(2);
+            Block idBlock = page.getBlock(1);
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                assertThat(ids.add(BIGINT.getLong(idBlock, position))).isTrue();
+            }
+        }
+    }
+
+    private static DriverContext newDriverContext(TaskContext taskContext, int pipelineId)
+    {
+        return taskContext
+                .addPipelineContext(pipelineId, true, true, false)
+                .addDriverContext();
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -53,8 +53,10 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.optimizations.PlanNodeSearcher;
+import io.trino.sql.planner.plan.AssignUniqueId;
 import io.trino.sql.planner.plan.ExchangeNode;
 import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.OutputNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.TableWriterNode;
@@ -126,6 +128,7 @@ import static io.trino.SystemSessionProperties.DETERMINE_PARTITION_COUNT_FOR_WRI
 import static io.trino.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
 import static io.trino.SystemSessionProperties.IGNORE_STATS_CALCULATOR_FAILURES;
 import static io.trino.SystemSessionProperties.ITERATIVE_OPTIMIZER_TIMEOUT;
+import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.trino.SystemSessionProperties.MAX_HASH_PARTITION_COUNT;
 import static io.trino.SystemSessionProperties.MAX_WRITER_TASK_COUNT;
 import static io.trino.SystemSessionProperties.SCALE_WRITERS;
@@ -162,6 +165,7 @@ import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.REMOTE;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
 import static io.trino.testing.TestingConnectorSession.SESSION;
@@ -1283,6 +1287,55 @@ public abstract class BaseIcebergConnectorTest
 
         assertUpdate("DROP TABLE " + sourceTable);
         assertUpdate("DROP TABLE " + targetTable);
+    }
+
+    @Test // regression test for https://github.com/trinodb/trino/issues/30639
+    public void testMergeWithPartitionedJoinAndUnmodifiedRows()
+    {
+        // The join with a bucket-partitioned target is colocated with the table partitioning, so
+        // the target and source AssignUniqueId nodes execute in the same stage and must not
+        // assign the same id to different rows
+        try (TestTable target = newTrinoTable(
+                "test_merge_unique_id_target_",
+                "WITH (partitioning = ARRAY['bucket(k1, 16)', 'bucket(k2, 8)']) AS " +
+                        "SELECT 'a-' || CAST(i AS varchar) AS k1, 'b-' || CAST(i AS varchar) AS k2, " +
+                        "'UPDATED' AS value, TIMESTAMP '2026-01-01 00:00:00.000000' AS updated_at " +
+                        "FROM UNNEST(sequence(1, 20)) t(i)");
+                // Every fifth source row matches a target row, so matched and unmatched rows are
+                // interleaved and each AssignUniqueId driver assigns its first ids to both kinds
+                TestTable source = newTrinoTable(
+                        "test_merge_unique_id_source_",
+                        "AS SELECT " +
+                                "IF(i % 5 = 0, 'a-' || CAST(i / 5 AS varchar), 'x-' || CAST(i AS varchar)) AS k1, " +
+                                "IF(i % 5 = 0, 'b-' || CAST(i / 5 AS varchar), 'y-' || CAST(i AS varchar)) AS k2, " +
+                                "'DELETED' AS value, TIMESTAMP '2026-01-01 00:00:00.000000' AS updated_at " +
+                                "FROM UNNEST(sequence(1, 100)) t(i)")) {
+            Session session = Session.builder(getSession())
+                    .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "PARTITIONED")
+                    .setCatalogSessionProperty(ICEBERG_CATALOG, BUCKET_EXECUTION_ENABLED, "true")
+                    .build();
+
+            // Every row is excluded by a WHEN condition, so the merge must change nothing
+            // instead of failing with MERGE_TARGET_ROW_MULTIPLE_MATCHES
+            assertUpdate(
+                    session,
+                    "MERGE INTO %s t USING %s s ".formatted(target.getName(), source.getName()) +
+                            "ON t.k1 = s.k1 AND t.k2 = s.k2 " +
+                            "WHEN MATCHED AND s.updated_at > t.updated_at THEN UPDATE SET value = s.value, updated_at = s.updated_at " +
+                            "WHEN NOT MATCHED AND s.value <> 'DELETED' THEN INSERT (k1, k2, value, updated_at) VALUES (s.k1, s.k2, s.value, s.updated_at)",
+                    0,
+                    // Both AssignUniqueId nodes must be reachable from the join without crossing a
+                    // remote exchange, otherwise the test no longer exercises a shared task
+                    plan -> {
+                        JoinNode join = (JoinNode) searchFrom(plan.getRoot()).where(JoinNode.class::isInstance).findOnlyElement();
+                        assertThat(searchFrom(join)
+                                .recurseOnlyWhen(planNode -> !(planNode instanceof ExchangeNode exchange && exchange.getScope() == REMOTE))
+                                .where(AssignUniqueId.class::isInstance)
+                                .count())
+                                .isEqualTo(2);
+                    });
+            assertQuery("SELECT count(*) FROM " + target.getName(), "VALUES 20");
+        }
     }
 
     @Test


### PR DESCRIPTION
## Description

`AssignUniqueId` embeds only the stage id and partition id of the task in the id mask, while row ids were drawn from a per-factory pool starting at zero. Two `AssignUniqueId` nodes executing in the same task therefore assign the same ids to different rows.

`MERGE` hits this when the join is colocated with the partitioning of the target table (e.g. a bucket-partitioned Iceberg target with `join_distribution_type=PARTITIONED`): the target scan stays in the join stage, so the target and source `AssignUniqueId` nodes run in the same task. After the right join coalesces the two id columns, `MarkDistinct` over `(unique_id, case_number)` treats unrelated rows as duplicate matches and fails with a false `MERGE_TARGET_ROW_MULTIPLE_MATCHES`.

The fix shares a single row id pool (`AtomicLong`) across all `AssignUniqueId` operator factories in a task, held by `LocalExecutionPlanContext` and passed to every factory. Ids are then unique within the whole query: the stage/partition mask separates tasks, and the shared pool separates operators within a task. This follows the operator-level direction suggested by @Praveen2112 in the issue, and subsumes the factory-`duplicate()` pool sharing from commit 0e880c8cad.

There is no execution-time cost: the per-row path is unchanged, and the shared pool is touched once per 2^20 ids per driver (a single `getAndAdd`).

Validation:

- New `TestAssignUniqueIdOperator` covers id disjointness for factories sharing a pool and for duplicated factories.
- New `TestIssue30639` reproduces the issue end to end; it fails on current master with `One MERGE target table row matched more than one source row` and passes with this change. The test pins `bucket_execution_enabled` and asserts both `AssignUniqueId` nodes plan into one fragment, so it cannot become vacuous if planner defaults change.
- `TestMerge` passes unchanged; the plan shape is not affected.

## Additional context and related issues

- Fixes #30639
- Supersedes #30937, which addressed only the `MERGE` consumer by widening the `MarkDistinct` key; the regression test here is based on the reproducer by @Harmuth94 from that PR.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix false `MERGE_TARGET_ROW_MULTIPLE_MATCHES` failures for `MERGE` when the join is colocated with the partitioning of the target table. ({issue}`30639`)
```

