### PR TITLE
Preserve none() constraint when splitting Hudi predicates

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPredicates.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPredicates.java
@@ -29,6 +29,10 @@ public class HudiPredicates
 
     public static HudiPredicates from(TupleDomain<ColumnHandle> predicate)
     {
+        if (predicate.isNone()) {
+            return new HudiPredicates(TupleDomain.none(), TupleDomain.none());
+        }
+
         Map<HiveColumnHandle, Domain> partitionColumnPredicates = new HashMap<>();
         Map<HiveColumnHandle, Domain> regularColumnPredicates = new HashMap<>();
 

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiPredicates.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiPredicates.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hudi;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slices;
+import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.trino.metastore.HiveType.HIVE_STRING;
+import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
+import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
+import static io.trino.plugin.hive.HiveColumnHandle.createBaseColumn;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestHudiPredicates
+{
+    private static final HiveColumnHandle PARTITION_COLUMN = createBaseColumn("part", 0, HIVE_STRING, VARCHAR, PARTITION_KEY, Optional.empty());
+    private static final HiveColumnHandle REGULAR_COLUMN = createBaseColumn("col", 1, HIVE_STRING, VARCHAR, REGULAR, Optional.empty());
+
+    @Test
+    public void testNoneConstraintStaysNone()
+    {
+        HudiPredicates predicates = HudiPredicates.from(TupleDomain.none());
+
+        assertThat(predicates.getPartitionColumnPredicates().isNone()).isTrue();
+        assertThat(predicates.getRegularColumnPredicates().isNone()).isTrue();
+    }
+
+    @Test
+    public void testAllConstraintStaysAll()
+    {
+        HudiPredicates predicates = HudiPredicates.from(TupleDomain.all());
+
+        assertThat(predicates.getPartitionColumnPredicates().isAll()).isTrue();
+        assertThat(predicates.getRegularColumnPredicates().isAll()).isTrue();
+    }
+
+    @Test
+    public void testConstraintSplitByColumnType()
+    {
+        Domain partitionDomain = Domain.singleValue(VARCHAR, Slices.utf8Slice("p1"));
+        Domain regularDomain = Domain.singleValue(VARCHAR, Slices.utf8Slice("v1"));
+        TupleDomain<ColumnHandle> predicate = TupleDomain.withColumnDomains(ImmutableMap.of(
+                PARTITION_COLUMN, partitionDomain,
+                REGULAR_COLUMN, regularDomain));
+
+        HudiPredicates predicates = HudiPredicates.from(predicate);
+
+        assertThat(predicates.getPartitionColumnPredicates())
+                .isEqualTo(TupleDomain.withColumnDomains(ImmutableMap.of(PARTITION_COLUMN, partitionDomain)));
+        assertThat(predicates.getRegularColumnPredicates())
+                .isEqualTo(TupleDomain.withColumnDomains(ImmutableMap.of(REGULAR_COLUMN, regularDomain)));
+    }
+
+    @Test
+    public void testOnlyPartitionColumnConstraintLeavesRegularAll()
+    {
+        Domain partitionDomain = Domain.singleValue(VARCHAR, Slices.utf8Slice("p1"));
+        TupleDomain<ColumnHandle> predicate = TupleDomain.withColumnDomains(ImmutableMap.of(PARTITION_COLUMN, partitionDomain));
+
+        HudiPredicates predicates = HudiPredicates.from(predicate);
+
+        assertThat(predicates.getPartitionColumnPredicates())
+                .isEqualTo(TupleDomain.withColumnDomains(ImmutableMap.of(PARTITION_COLUMN, partitionDomain)));
+        assertThat(predicates.getRegularColumnPredicates().isAll()).isTrue();
+    }
+
+    @Test
+    public void testOnlyRegularColumnConstraintLeavesPartitionAll()
+    {
+        Domain regularDomain = Domain.singleValue(VARCHAR, Slices.utf8Slice("v1"));
+        TupleDomain<ColumnHandle> predicate = TupleDomain.withColumnDomains(ImmutableMap.of(REGULAR_COLUMN, regularDomain));
+
+        HudiPredicates predicates = HudiPredicates.from(predicate);
+
+        assertThat(predicates.getPartitionColumnPredicates().isAll()).isTrue();
+        assertThat(predicates.getRegularColumnPredicates())
+                .isEqualTo(TupleDomain.withColumnDomains(ImmutableMap.of(REGULAR_COLUMN, regularDomain)));
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

`HudiPredicates.from()` only inspected `TupleDomain.getDomains()`, which is empty for both `TupleDomain.none()` and `TupleDomain.all()`. A `none()` constraint therefore turned into `all()`.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
