### PR TITLE
Fix typos and invalid SQL example in docs

### DIFF
--- a/docs/src/main/sphinx/connector/lakehouse.md
+++ b/docs/src/main/sphinx/connector/lakehouse.md
@@ -14,7 +14,7 @@ The connector combines the features of the
 [Hive](/connector/hive), [Iceberg](/connector/iceberg),
 [Delta Lake](/connector/delta-lake), and [Hudi](/connector/hudi)
 connectors into a single connector. The configuration properties,
-session properties, table properties, and beahvior come from the underlying
+session properties, table properties, and behavior come from the underlying
 connectors. Please refer to the documentation for the underlying connectors
 for the table formats that you are using.
 
@@ -28,7 +28,7 @@ properties as appropriate:
 connector.name=lakehouse
 ```
 
-You must configure a [AWS Glue or a Hive metastore](/object-storage/metastores).
+You must configure an [AWS Glue or a Hive metastore](/object-storage/metastores).
 The `hive.metastore` property will also configure the Iceberg catalog.
 Do not specify `iceberg.catalog.type`.
 
@@ -80,7 +80,7 @@ CREATE TABLE iceberg_table (
   c3 DOUBLE
 )
 WITH (
-  type = 'ICEBERG'
+  type = 'ICEBERG',
   format = 'PARQUET',
   partitioning = ARRAY['c1', 'c2'],
   sorted_by = ARRAY['c3']

--- a/docs/src/main/sphinx/develop/connectors.md
+++ b/docs/src/main/sphinx/develop/connectors.md
@@ -160,7 +160,7 @@ WHERE url = 'https://github.com/trinodb/trino.git'
 (connector-metadata)=
 ## ConnectorMetadata
 
-The connector metadata interface allows Trino to get a lists of schemas,
+The connector metadata interface allows Trino to get a list of schemas,
 tables, columns, and other metadata about a particular data source.
 
 A basic read-only connector should implement the following methods:

--- a/docs/src/main/sphinx/sql/create-table.md
+++ b/docs/src/main/sphinx/sql/create-table.md
@@ -54,7 +54,7 @@ If `INCLUDING PROPERTIES` is specified, all the table properties are
 copied to the new table. If the `WITH` clause specifies the same property
 name as one of the copied properties, the value from the `WITH` clause
 will be used. The default behavior is `EXCLUDING PROPERTIES`. The
-`INCLUDING PROPERTIES` option maybe specified for at most one table.
+`INCLUDING PROPERTIES` option may be specified for at most one table.
 
 ## Examples
 


### PR DESCRIPTION
## Description

Fix a few typos and an invalid SQL example in the documentation:

- `docs/src/main/sphinx/connector/lakehouse.md`
  - `beahvior` → `behavior`
  - `a AWS Glue` → `an AWS Glue`
  - Add a missing comma after `type = 'ICEBERG'` in the `CREATE TABLE` example, which was invalid SQL as written
- `docs/src/main/sphinx/develop/connectors.md`: `a lists of schemas` → `a list of schemas`
- `docs/src/main/sphinx/sql/create-table.md`: `option maybe specified` → `option may be specified`

## Additional context and related issues

This is my first contribution to Trino, so I wanted to start with something small.
I'm a bit nervous — if I've missed any step of the process or anything else is
needed, please let me know and I'll be happy to fix it.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
