### PR TITLE
Optimize row construction for input references

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/RowConstructorCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/RowConstructorCodeGenerator.java
@@ -124,16 +124,14 @@ public class RowConstructorCodeGenerator
         return block;
     }
 
-    // Avoids inline BlockBuilder and Block creation logic for each field which reduces the generated code size
-    // for RowTypes with many fields significantly, but does so at the cost of virtual method dispatch
+    // Splits initialization across helper methods to keep generated methods small enough for the JVM and JIT
     private BytecodeNode generateExpressionForLargeRows(BytecodeGeneratorContext context)
     {
         BytecodeBlock block = new BytecodeBlock().setDescription("Constructor for " + rowType);
-        CallSiteBinder binder = context.getCallSiteBinder();
         Scope scope = context.getScope();
 
-        Variable fieldBuilders = scope.getOrCreateTempVariable(BlockBuilder[].class);
-        block.append(fieldBuilders.set(invokeStatic(RowConstructorCodeGenerator.class, "createFieldBlockBuildersForSingleRow", BlockBuilder[].class, constantType(binder, rowType))));
+        Variable fieldBlocks = scope.getOrCreateTempVariable(Block[].class);
+        block.append(fieldBlocks.set(newArray(type(Block[].class), arguments.size())));
 
         int field = 0;
         while (field < arguments.size()) {
@@ -142,13 +140,13 @@ public class RowConstructorCodeGenerator
             for (Parameter argument : context.getContextArguments()) {
                 block.getVariable(argument);
             }
-            block.getVariable(fieldBuilders);
+            block.getVariable(fieldBlocks);
             block.invokeVirtual(partialRowConstructor.method());
             field = partialRowConstructor.nextField();
         }
 
-        block.append(invokeStatic(RowConstructorCodeGenerator.class, "createSqlRowFromFieldBuildersForSingleRow", SqlRow.class, fieldBuilders));
-        scope.releaseTempVariableForReuse(fieldBuilders);
+        block.append(invokeStatic(RowConstructorCodeGenerator.class, "createSqlRowFromFieldBlocksForSingleRow", SqlRow.class, fieldBlocks));
+        scope.releaseTempVariableForReuse(fieldBlocks);
         block.append(context.wasNull().set(constantFalse()));
         return block;
     }
@@ -158,10 +156,10 @@ public class RowConstructorCodeGenerator
         ClassDefinition classDefinition = parentContext.getClassDefinition();
         CallSiteBinder binder = parentContext.getCallSiteBinder();
 
-        Parameter fieldBuilders = arg("fieldBuilders", BlockBuilder[].class);
+        Parameter fieldBlocks = arg("fieldBlocks", Block[].class);
 
         List<Parameter> parameters = new ArrayList<>(parentContext.getContextArguments());
-        parameters.add(fieldBuilders);
+        parameters.add(fieldBlocks);
 
         MethodDefinition methodDefinition = classDefinition.declareMethod(
                 a(PUBLIC),
@@ -191,21 +189,38 @@ public class RowConstructorCodeGenerator
         int field = start;
         while (field < arguments.size()) {
             Type fieldType = types.get(field);
+            BytecodeNode argument = context.generate(arguments.get(field));
 
             BytecodeBlock fieldInitialization = new BytecodeBlock();
-            fieldInitialization.append(blockBuilder.set(fieldBuilders.getElement(constantInt(field))));
 
-            fieldInitialization.comment("Clean wasNull and Generate + " + field + "-th field of row");
+            if (argument instanceof InputReferenceNode inputReference) {
+                fieldInitialization.comment("Reuse input block for " + field + "-th field of row");
+                fieldInitialization.append(fieldBlocks)
+                        .push(field)
+                        .append(inputReference.produceValueBlockAndPosition())
+                        .push(1)
+                        .invokeInterface(Block.class, "getRegion", Block.class, int.class, int.class)
+                        .putObjectArrayElement();
+            }
+            else {
+                fieldInitialization.append(blockBuilder.set(invokeStatic(
+                        RowConstructorCodeGenerator.class,
+                        "createBlockBuilderForSingleRow",
+                        BlockBuilder.class,
+                        constantType(binder, fieldType))));
+                fieldInitialization.comment("Clean wasNull and Generate + " + field + "-th field of row");
 
-            fieldInitialization.append(context.wasNull().set(constantFalse()));
-            fieldInitialization.append(context.generate(arguments.get(field)));
-            Variable fieldVariable = scope.getOrCreateTempVariable(binder.getAccessibleType(fieldType.getJavaType()));
-            fieldInitialization.putVariable(fieldVariable);
-            fieldInitialization.append(new IfStatement()
-                    .condition(context.wasNull())
-                    .ifTrue(blockBuilder.invoke("appendNull", BlockBuilder.class).pop())
-                    .ifFalse(constantType(binder, fieldType).writeValue(blockBuilder, fieldVariable).pop()));
-            scope.releaseTempVariableForReuse(fieldVariable);
+                fieldInitialization.append(context.wasNull().set(constantFalse()));
+                fieldInitialization.append(argument);
+                Variable fieldVariable = scope.getOrCreateTempVariable(binder.getAccessibleType(fieldType.getJavaType()));
+                fieldInitialization.putVariable(fieldVariable);
+                fieldInitialization.append(new IfStatement()
+                        .condition(context.wasNull())
+                        .ifTrue(blockBuilder.invoke("appendNull", BlockBuilder.class).pop())
+                        .ifFalse(constantType(binder, fieldType).writeValue(blockBuilder, fieldVariable).pop()));
+                scope.releaseTempVariableForReuse(fieldVariable);
+                fieldInitialization.append(fieldBlocks.setElement(field, blockBuilder.invoke("build", Block.class)));
+            }
 
             BytecodeBlock candidate = new BytecodeBlock()
                     .append(block)
@@ -238,27 +253,20 @@ public class RowConstructorCodeGenerator
     private record PartialRowConstructor(MethodDefinition method, int nextField) {}
 
     @UsedByGeneratedCode
-    public static BlockBuilder[] createFieldBlockBuildersForSingleRow(Type type)
+    public static BlockBuilder createBlockBuilderForSingleRow(Type type)
     {
-        if (!(type instanceof RowType rowType)) {
-            throw new IllegalArgumentException("Not a row type: " + type);
-        }
-        List<Type> fieldTypes = rowType.getFieldTypes();
-        BlockBuilder[] fieldBlockBuilders = new BlockBuilder[fieldTypes.size()];
-        for (int i = 0; i < fieldTypes.size(); i++) {
-            fieldBlockBuilders[i] = fieldTypes.get(i).createBlockBuilder(null, 1);
-        }
-        return fieldBlockBuilders;
+        return type.createBlockBuilder(null, 1);
     }
 
     @UsedByGeneratedCode
-    public static SqlRow createSqlRowFromFieldBuildersForSingleRow(BlockBuilder[] fieldBuilders)
+    public static SqlRow createSqlRowFromFieldBlocksForSingleRow(Block[] fieldBlocks)
     {
-        Block[] fieldBlocks = new Block[fieldBuilders.length];
-        for (int i = 0; i < fieldBuilders.length; i++) {
-            fieldBlocks[i] = fieldBuilders[i].build();
+        for (int i = 0; i < fieldBlocks.length; i++) {
+            if (fieldBlocks[i] == null) {
+                throw new IllegalArgumentException(format("field block is null for field %s", i));
+            }
             if (fieldBlocks[i].getPositionCount() != 1) {
-                throw new IllegalArgumentException(format("builder must only contain a single position, found: %s positions", fieldBlocks[i].getPositionCount()));
+                throw new IllegalArgumentException(format("field block must only contain a single position, found: %s positions", fieldBlocks[i].getPositionCount()));
             }
         }
         return new SqlRow(0, fieldBlocks);

--- a/core/trino-main/src/main/java/io/trino/sql/gen/RowConstructorCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/RowConstructorCodeGenerator.java
@@ -262,9 +262,6 @@ public class RowConstructorCodeGenerator
     public static SqlRow createSqlRowFromFieldBlocksForSingleRow(Block[] fieldBlocks)
     {
         for (int i = 0; i < fieldBlocks.length; i++) {
-            if (fieldBlocks[i] == null) {
-                throw new IllegalArgumentException(format("field block is null for field %s", i));
-            }
             if (fieldBlocks[i].getPositionCount() != 1) {
                 throw new IllegalArgumentException(format("field block must only contain a single position, found: %s positions", fieldBlocks[i].getPositionCount()));
             }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/RowConstructorCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/RowConstructorCodeGenerator.java
@@ -28,6 +28,7 @@ import io.trino.spi.block.BlockBuilderStatus;
 import io.trino.spi.block.SqlRow;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
+import io.trino.sql.gen.InputReferenceCompiler.InputReferenceNode;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.Row;
 
@@ -81,7 +82,19 @@ public class RowConstructorCodeGenerator
         block.append(fieldBlocks.set(newArray(type(Block[].class), arguments.size())));
 
         Variable blockBuilder = scope.getOrCreateTempVariable(BlockBuilder.class);
+
         for (int i = 0; i < arguments.size(); ++i) {
+            BytecodeNode argument = context.generate(arguments.get(i));
+            if (argument instanceof InputReferenceNode inputReference) {
+                block.comment("Reuse input block for " + i + "-th field of row");
+                block.getVariable(fieldBlocks)
+                        .push(i)
+                        .append(inputReference.produceValueBlockAndPosition())
+                        .push(1)
+                        .invokeInterface(Block.class, "getRegion", Block.class, int.class, int.class)
+                        .putObjectArrayElement();
+                continue;
+            }
             Type fieldType = types.get(i);
 
             block.append(blockBuilder.set(constantType(binder, fieldType).invoke(
@@ -92,7 +105,7 @@ public class RowConstructorCodeGenerator
 
             block.comment("Clean wasNull and Generate + " + i + "-th field of row");
             block.append(context.wasNull().set(constantFalse()));
-            block.append(context.generate(arguments.get(i)));
+            block.append(argument);
             Variable field = scope.getOrCreateTempVariable(binder.getAccessibleType(fieldType.getJavaType()));
             block.putVariable(field);
             block.append(new IfStatement()

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkRowConstructor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkRowConstructor.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.gen;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.SequencePageBuilder;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.project.PageProjection;
+import io.trino.operator.project.SelectedPositions;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.sql.ir.Coalesce;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.Row;
+import io.trino.sql.planner.Symbol;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static io.trino.type.CharVarcharCoercion.SQL_STANDARD;
+import static java.util.Collections.nCopies;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@State(Scope.Thread)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(2)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkRowConstructor
+{
+    private static final int POSITION_COUNT = 1024;
+
+    @Param({"16", "32", "48", "64", "80"})
+    private int fieldCount = 16;
+
+    @Param({"bigint", "varchar"})
+    private String type = "bigint";
+
+    @Param({"direct", "all-computed", "mixed"})
+    private String expressionShape = "direct";
+
+    private PageProjection projection;
+    private SourcePage inputPage;
+    private SelectedPositions selectedPositions;
+
+    @Setup
+    public void setup()
+    {
+        Type fieldType = switch (type) {
+            case "bigint" -> BIGINT;
+            case "varchar" -> VARCHAR;
+            default -> throw new IllegalArgumentException("Unsupported type: " + type);
+        };
+
+        String inputName = "$col_0";
+        Symbol inputSymbol = new Symbol(fieldType, inputName);
+        Expression input = new Reference(fieldType, inputName);
+        Row row = new Row(createFields(input), RowType.anonymous(nCopies(fieldCount, fieldType)));
+
+        TestingFunctionResolution functionResolution = new TestingFunctionResolution();
+        projection = functionResolution.getPageFunctionCompiler()
+                .compileProjection(row, ImmutableMap.of(inputSymbol, 0), SQL_STANDARD, Optional.empty())
+                .get();
+
+        Page page = SequencePageBuilder.createSequencePage(ImmutableList.of(fieldType), POSITION_COUNT);
+        inputPage = projection.getInputChannels().getInputChannels(SourcePage.create(page));
+        selectedPositions = SelectedPositions.positionsRange(0, POSITION_COUNT);
+    }
+
+    private List<Expression> createFields(Expression input)
+    {
+        Expression computedInput = new Coalesce(input, input);
+        return switch (expressionShape) {
+            case "direct" -> nCopies(fieldCount, input);
+            case "all-computed" -> nCopies(fieldCount, computedInput);
+            case "mixed" -> {
+                ImmutableList.Builder<Expression> fields = ImmutableList.builderWithExpectedSize(fieldCount);
+                for (int field = 0; field < fieldCount; field++) {
+                    fields.add(field % 2 == 0 ? input : computedInput);
+                }
+                yield fields.build();
+            }
+            default -> throw new IllegalArgumentException("Unsupported expression shape: " + expressionShape);
+        };
+    }
+
+    @Benchmark
+    public Block project()
+    {
+        return projection.project(SESSION, inputPage, selectedPositions);
+    }
+
+    @Test
+    void testBenchmark()
+    {
+        for (String expressionShape : ImmutableList.of("direct", "all-computed", "mixed")) {
+            this.expressionShape = expressionShape;
+            for (String type : ImmutableList.of("bigint", "varchar")) {
+                this.type = type;
+                for (int fieldCount : ImmutableList.of(16, 32, 48, 64, 80)) {
+                    this.fieldCount = fieldCount;
+                    setup();
+                    assertThat(project().getPositionCount()).isEqualTo(POSITION_COUNT);
+                }
+            }
+        }
+    }
+
+    static void main()
+            throws RunnerException
+    {
+        benchmark(BenchmarkRowConstructor.class)
+                .withOptions(options -> options.addProfiler(GCProfiler.class))
+                .run();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestPageFunctionCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestPageFunctionCompiler.java
@@ -110,6 +110,7 @@ import static io.trino.util.Reflection.constructorMethodHandle;
 import static io.trino.util.Reflection.field;
 import static io.trino.util.Reflection.methodHandle;
 import static java.lang.invoke.MethodHandles.insertArguments;
+import static java.util.Arrays.asList;
 import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -329,6 +330,69 @@ public class TestPageFunctionCompiler
         Page page = createLongBlockPage(0);
         Block result = project(projection, page, SelectedPositions.positionsRange(0, page.getPositionCount()));
         assertThat(hiddenType.getObjectValue(result, 0)).isEqualTo(42);
+    }
+
+    @Test
+    public void testRowConstructorWithInputReferences()
+    {
+        RowType rowType = RowType.anonymous(ImmutableList.of(BIGINT, BIGINT));
+        Expression row = new Row(
+                ImmutableList.of(
+                        new Reference(BIGINT, "$col_0"),
+                        new Reference(BIGINT, "$col_1")),
+                rowType);
+        PageProjection projection = FUNCTION_RESOLUTION.getPageFunctionCompiler()
+                .compileProjection(
+                        row,
+                        ImmutableMap.of(
+                                new Symbol(BIGINT, "$col_0"), 0,
+                                new Symbol(BIGINT, "$col_1"), 1),
+                        SQL_STANDARD,
+                        Optional.empty())
+                .get();
+
+        Page page = new Page(
+                createLongsBlock(11L, null, 33L, 44L),
+                createLongsBlock(101L, 102L, null, 104L));
+        Block result = project(projection, page, SelectedPositions.positionsList(new int[] {3, 1, 0}, 0, 3));
+
+        assertThat(result.getPositionCount()).isEqualTo(3);
+        assertThat(rowType.getObjectValue(result, 0)).isEqualTo(asList(44L, 104L));
+        assertThat(rowType.getObjectValue(result, 1)).isEqualTo(asList(null, 102L));
+        assertThat(rowType.getObjectValue(result, 2)).isEqualTo(asList(11L, 101L));
+    }
+
+    @Test
+    public void testRowConstructorWithEncodedInputReferences()
+    {
+        RowType rowType = RowType.anonymous(ImmutableList.of(BIGINT, BIGINT, BIGINT));
+        Expression row = new Row(
+                ImmutableList.of(
+                        new Reference(BIGINT, "$col_0"),
+                        new Reference(BIGINT, "$col_1"),
+                        new Reference(BIGINT, "$col_2")),
+                rowType);
+        PageProjection projection = FUNCTION_RESOLUTION.getPageFunctionCompiler()
+                .compileProjection(
+                        row,
+                        ImmutableMap.of(
+                                new Symbol(BIGINT, "$col_0"), 0,
+                                new Symbol(BIGINT, "$col_1"), 1,
+                                new Symbol(BIGINT, "$col_2"), 2),
+                        SQL_STANDARD,
+                        Optional.empty())
+                .get();
+
+        Page page = new Page(
+                DictionaryBlock.create(5, createLongsBlock(10L, null, 30L), new int[] {2, 0, 1, 2, 0}),
+                RunLengthEncodedBlock.create(createLongsBlock(7), 5),
+                RunLengthEncodedBlock.create(createLongsBlock((Long) null), 5));
+        Block result = project(projection, page, SelectedPositions.positionsRange(1, 3));
+
+        assertThat(result.getPositionCount()).isEqualTo(3);
+        assertThat(rowType.getObjectValue(result, 0)).isEqualTo(asList(10L, 7L, null));
+        assertThat(rowType.getObjectValue(result, 1)).isEqualTo(asList(null, 7L, null));
+        assertThat(rowType.getObjectValue(result, 2)).isEqualTo(asList(30L, 7L, null));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestPageFunctionCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestPageFunctionCompiler.java
@@ -35,6 +35,7 @@ import io.trino.spi.Page;
 import io.trino.spi.block.ArrayBlockBuilder;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.BlockBuilderStatus;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.MapBlockBuilder;
 import io.trino.spi.block.RunLengthEncodedBlock;
@@ -55,6 +56,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeDescriptor;
 import io.trino.spi.type.TypeOperators;
 import io.trino.sql.PlannerContext;
+import io.trino.sql.ir.Bind;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Coalesce;
 import io.trino.sql.ir.Constant;
@@ -71,6 +73,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -393,6 +396,149 @@ public class TestPageFunctionCompiler
         assertThat(rowType.getObjectValue(result, 0)).isEqualTo(asList(10L, 7L, null));
         assertThat(rowType.getObjectValue(result, 1)).isEqualTo(asList(null, 7L, null));
         assertThat(rowType.getObjectValue(result, 2)).isEqualTo(asList(30L, 7L, null));
+    }
+
+    @Test
+    public void testLargeRowConstructorWithEncodedInputReferences()
+    {
+        int fieldCount = MEGAMORPHIC_FIELD_COUNT + 1;
+        RowType rowType = RowType.anonymous(nCopies(fieldCount, BIGINT));
+        Expression row = new Row(nCopies(fieldCount, new Reference(BIGINT, "$col_0")), rowType);
+        PageProjection projection = FUNCTION_RESOLUTION.getPageFunctionCompiler()
+                .compileProjection(
+                        row,
+                        ImmutableMap.of(new Symbol(BIGINT, "$col_0"), 0),
+                        SQL_STANDARD,
+                        Optional.empty())
+                .get();
+
+        Page page = new Page(DictionaryBlock.create(5, createLongsBlock(10L, null, 30L), new int[] {2, 0, 1, 2, 0}));
+        Block result = project(projection, page, SelectedPositions.positionsRange(1, 3));
+
+        assertThat(result.getPositionCount()).isEqualTo(3);
+        assertThat(rowType.getObjectValue(result, 0)).isEqualTo(nCopies(fieldCount, 10L));
+        assertThat(rowType.getObjectValue(result, 1)).isEqualTo(nCopies(fieldCount, null));
+        assertThat(rowType.getObjectValue(result, 2)).isEqualTo(nCopies(fieldCount, 30L));
+    }
+
+    @Test
+    public void testLargeRowConstructorReusesInputBlocksWithPrivateJavaType()
+    {
+        HiddenFunctions hiddenFunctions = createHiddenFunctions();
+        HiddenType hiddenType = (HiddenType) hiddenFunctions.type();
+        int fieldCount = MEGAMORPHIC_FIELD_COUNT + 1;
+        RowType rowType = RowType.anonymous(nCopies(fieldCount, hiddenType));
+        Expression row = new Row(nCopies(fieldCount, new Reference(hiddenType, "$col_0")), rowType);
+        PageProjection projection = createFunctionResolution(hiddenType).getPageFunctionCompiler()
+                .compileProjection(
+                        row,
+                        ImmutableMap.of(new Symbol(hiddenType, "$col_0"), 0),
+                        SQL_STANDARD,
+                        Optional.empty())
+                .get();
+
+        BlockBuilder inputBuilder = hiddenType.createBlockBuilder(null, 2);
+        hiddenType.writeObject(inputBuilder, createHiddenValue(hiddenFunctions));
+        inputBuilder.appendNull();
+        Page page = new Page(inputBuilder.build());
+
+        hiddenType.resetGetObjectCalls();
+        hiddenType.resetCreateBlockBuilderCalls();
+        Block result = project(projection, page, SelectedPositions.positionsRange(0, page.getPositionCount()));
+        assertThat(hiddenType.getObjectCalls()).isZero();
+        assertThat(hiddenType.getCreateBlockBuilderCalls()).isZero();
+
+        assertThat(rowType.getObjectValue(result, 0)).isEqualTo(nCopies(fieldCount, 42));
+        assertThat(rowType.getObjectValue(result, 1)).isEqualTo(nCopies(fieldCount, null));
+        assertThat(hiddenType.getObjectCalls()).isZero();
+        assertThat(hiddenType.getCreateBlockBuilderCalls()).isZero();
+    }
+
+    @Test
+    public void testLargeRowConstructorWithMixedEncodedInputs()
+    {
+        // Exercise mixed direct and computed fields in both the first and last partial row constructors
+        int fieldCount = MEGAMORPHIC_FIELD_COUNT * 16 + 1;
+        int middleField = fieldCount / 2;
+        int nullField = fieldCount - 2;
+        int trailingComputedField = fieldCount - 1;
+        List<Expression> fields = new ArrayList<>(nCopies(fieldCount, new Reference(BIGINT, "$col_0")));
+        fields.set(0, ADD_10_EXPRESSION);
+        fields.set(middleField, new Reference(BIGINT, "$col_1"));
+        fields.set(nullField, new Reference(BIGINT, "$col_2"));
+        fields.set(trailingComputedField, ADD_10_EXPRESSION);
+
+        RowType rowType = RowType.anonymous(nCopies(fieldCount, BIGINT));
+        PageProjection projection = FUNCTION_RESOLUTION.getPageFunctionCompiler()
+                .compileProjection(
+                        new Row(fields, rowType),
+                        ImmutableMap.of(
+                                new Symbol(BIGINT, "$col_0"), 0,
+                                new Symbol(BIGINT, "$col_1"), 1,
+                                new Symbol(BIGINT, "$col_2"), 2),
+                        SQL_STANDARD,
+                        Optional.empty())
+                .get();
+
+        Page page = new Page(
+                DictionaryBlock.create(5, createLongsBlock(10L, null, 30L), new int[] {2, 0, 1, 2, 0}),
+                RunLengthEncodedBlock.create(createLongsBlock(7L), 5),
+                RunLengthEncodedBlock.create(createLongsBlock((Long) null), 5));
+        Block result = project(projection, page, SelectedPositions.positionsRange(1, 3));
+
+        List<Long> firstExpected = new ArrayList<>(nCopies(fieldCount, 10L));
+        firstExpected.set(0, 20L);
+        firstExpected.set(middleField, 7L);
+        firstExpected.set(nullField, null);
+        firstExpected.set(trailingComputedField, 20L);
+        List<Long> secondExpected = new ArrayList<>(nCopies(fieldCount, null));
+        secondExpected.set(middleField, 7L);
+        List<Long> thirdExpected = new ArrayList<>(nCopies(fieldCount, 30L));
+        thirdExpected.set(0, 40L);
+        thirdExpected.set(middleField, 7L);
+        thirdExpected.set(nullField, null);
+        thirdExpected.set(trailingComputedField, 40L);
+
+        assertThat(rowType.getObjectValue(result, 0)).isEqualTo(firstExpected);
+        assertThat(rowType.getObjectValue(result, 1)).isEqualTo(secondExpected);
+        assertThat(rowType.getObjectValue(result, 2)).isEqualTo(thirdExpected);
+    }
+
+    @Test
+    public void testLargeRowConstructorInHighArityLambda()
+    {
+        // The receiver, session, and 252 lambda arguments consume 254 of the 255 JVM parameter slots.
+        int lambdaArgumentCount = 252;
+        List<Symbol> lambdaArguments = new ArrayList<>(lambdaArgumentCount);
+        for (int i = 0; i < lambdaArgumentCount; i++) {
+            lambdaArguments.add(new Symbol(BIGINT, "argument_" + i));
+        }
+
+        int fieldCount = MEGAMORPHIC_FIELD_COUNT + 1;
+        RowType rowType = RowType.anonymous(nCopies(fieldCount, BIGINT));
+        Expression lambdaBody = new Row(
+                nCopies(fieldCount, new Reference(BIGINT, lambdaArguments.getLast().name())),
+                rowType);
+        Lambda lambda = new Lambda(lambdaArguments, lambdaBody);
+        List<Expression> boundValues = new ArrayList<>(nCopies(lambdaArgumentCount - 1, new Constant(BIGINT, 0L)));
+        Bind boundLambda = new Bind(boundValues, lambda);
+
+        ArrayType inputArrayType = new ArrayType(BIGINT);
+        ArrayType outputArrayType = new ArrayType(rowType);
+        ResolvedFunction transform = FUNCTION_RESOLUTION.resolveFunction(
+                ARRAY_TRANSFORM_NAME,
+                fromTypes(inputArrayType, new FunctionType(ImmutableList.of(BIGINT), rowType)));
+        PageProjection projection = FUNCTION_RESOLUTION.getPageFunctionCompiler()
+                .compileProjection(
+                        call(transform, new Reference(inputArrayType, "$col_0"), boundLambda),
+                        ImmutableMap.of(new Symbol(inputArrayType, "$col_0"), 0),
+                        SQL_STANDARD,
+                        Optional.empty())
+                .get();
+
+        Page page = createSingleArrayPage(inputArrayType, 11);
+        Block result = project(projection, page, SelectedPositions.positionsRange(0, page.getPositionCount()));
+        assertThat(outputArrayType.getObjectValue(result, 0)).isEqualTo(ImmutableList.of(nCopies(fieldCount, 11L)));
     }
 
     @Test
@@ -802,6 +948,8 @@ public class TestPageFunctionCompiler
 
         private final Constructor<?> constructor;
         private final Field valueField;
+        private int createBlockBuilderCalls;
+        private int getObjectCalls;
 
         private HiddenType(Class<?> javaType)
         {
@@ -833,12 +981,40 @@ public class TestPageFunctionCompiler
         @Override
         public Object getObject(Block block, int position)
         {
+            getObjectCalls++;
             try {
                 return constructor.newInstance(getSlice(block, position).getInt(0));
             }
             catch (ReflectiveOperationException e) {
                 throw new RuntimeException(e);
             }
+        }
+
+        @Override
+        public VariableWidthBlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+        {
+            createBlockBuilderCalls++;
+            return super.createBlockBuilder(blockBuilderStatus, expectedEntries);
+        }
+
+        private void resetCreateBlockBuilderCalls()
+        {
+            createBlockBuilderCalls = 0;
+        }
+
+        private int getCreateBlockBuilderCalls()
+        {
+            return createBlockBuilderCalls;
+        }
+
+        private void resetGetObjectCalls()
+        {
+            getObjectCalls = 0;
+        }
+
+        private int getObjectCalls()
+        {
+            return getObjectCalls;
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestPageFunctionCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestPageFunctionCompiler.java
@@ -422,11 +422,63 @@ public class TestPageFunctionCompiler
     }
 
     @Test
+    public void testRowConstructorWithMixedEncodedInputs()
+    {
+        int fieldCount = MEGAMORPHIC_FIELD_COUNT;
+        int middleField = fieldCount / 2;
+        List<Expression> fields = new ArrayList<>(nCopies(fieldCount, new Reference(BIGINT, "$col_0")));
+        fields.set(0, ADD_10_EXPRESSION);
+        fields.set(middleField, new Reference(BIGINT, "$col_1"));
+        fields.set(fieldCount - 1, ADD_10_EXPRESSION);
+
+        RowType rowType = RowType.anonymous(nCopies(fieldCount, BIGINT));
+        PageProjection projection = FUNCTION_RESOLUTION.getPageFunctionCompiler()
+                .compileProjection(
+                        new Row(fields, rowType),
+                        ImmutableMap.of(
+                                new Symbol(BIGINT, "$col_0"), 0,
+                                new Symbol(BIGINT, "$col_1"), 1),
+                        SQL_STANDARD,
+                        Optional.empty())
+                .get();
+
+        Page page = new Page(
+                DictionaryBlock.create(5, createLongsBlock(10L, null, 30L), new int[] {2, 0, 1, 2, 0}),
+                RunLengthEncodedBlock.create(createLongsBlock(7L), 5));
+        Block result = project(projection, page, SelectedPositions.positionsRange(1, 3));
+
+        List<Long> firstExpected = new ArrayList<>(nCopies(fieldCount, 10L));
+        firstExpected.set(0, 20L);
+        firstExpected.set(middleField, 7L);
+        firstExpected.set(fieldCount - 1, 20L);
+        List<Long> secondExpected = new ArrayList<>(nCopies(fieldCount, null));
+        secondExpected.set(middleField, 7L);
+        List<Long> thirdExpected = new ArrayList<>(nCopies(fieldCount, 30L));
+        thirdExpected.set(0, 40L);
+        thirdExpected.set(middleField, 7L);
+        thirdExpected.set(fieldCount - 1, 40L);
+
+        assertThat(rowType.getObjectValue(result, 0)).isEqualTo(firstExpected);
+        assertThat(rowType.getObjectValue(result, 1)).isEqualTo(secondExpected);
+        assertThat(rowType.getObjectValue(result, 2)).isEqualTo(thirdExpected);
+    }
+
+    @Test
+    public void testRowConstructorReusesInputBlocksWithPrivateJavaType()
+    {
+        assertRowConstructorReusesInputBlocksWithPrivateJavaType(MEGAMORPHIC_FIELD_COUNT);
+    }
+
+    @Test
     public void testLargeRowConstructorReusesInputBlocksWithPrivateJavaType()
+    {
+        assertRowConstructorReusesInputBlocksWithPrivateJavaType(MEGAMORPHIC_FIELD_COUNT + 1);
+    }
+
+    private void assertRowConstructorReusesInputBlocksWithPrivateJavaType(int fieldCount)
     {
         HiddenFunctions hiddenFunctions = createHiddenFunctions();
         HiddenType hiddenType = (HiddenType) hiddenFunctions.type();
-        int fieldCount = MEGAMORPHIC_FIELD_COUNT + 1;
         RowType rowType = RowType.anonymous(nCopies(fieldCount, hiddenType));
         Expression row = new Row(nCopies(fieldCount, new Reference(hiddenType, "$col_0")), rowType);
         PageProjection projection = createFunctionResolution(hiddenType).getPageFunctionCompiler()


### PR DESCRIPTION
<!-- Suggested title: Optimize row construction for input references -->

<!-- Thank you for submitting a pull request! Find more information at https://trino.io/development/process.html, at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #core-dev in Slack. -->

## Description

Improve the evaluation of `ROW` expressions containing direct input references.

Previously, every row field was evaluated into a Java value and then written to a newly created single-position block. This change recognizes fields compiled as direct `InputReferenceNode` expressions and uses the underlying value block and mapped position to obtain the corresponding single-position region. This avoids decoding and rebuilding direct input values while preserving value and null semantics.  
The optimization applies to both row-constructor code generation paths:

* Row constructors with up to 64 fields store direct input regions in the `Block[]` used to construct the `SqlRow`. Computed expressions continue to use a single-position `BlockBuilder`.
* Larger row constructors retain their generated partial methods and pass a single `Block[]` to them. Direct input fields store their regions in that array. Computed fields create a single-position builder only when needed, build the field block immediately, and store it in the same array.

Using one `Block[]` also keeps high-arity generated lambda methods within the JVM limit of 255 parameter slots.

## Additional context

Large row constructors are split into generated partial methods to keep generated bytecode below HotSpot's huge-method threshold and the JVM 64 KB method-size limit.

A generated instance method containing a session parameter and 252 lambda arguments already consumes 254 parameter slots including the receiver. Passing one `Block[]` uses the final available slot, while passing separate builder and block arrays would require 256 slots.

`InputReferenceNode.produceValueBlockAndPosition()` follows the current `VALUE_BLOCK_POSITION` ABI by unwrapping dictionary and run-length encoded inputs to their underlying value block and mapped position. Each resulting value-block region contains one position and can therefore be used by `SqlRow` with raw index zero.                                    
### Benchmark

Benchmark source is included in this PR as `core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkRowConstructor.java`.

Environment:

```text
CPU: Apple M3 Pro
JDK: Temurin 25.0
```

Baseline (`40b70400a8a`, current `master`):

```text
Benchmark                                                 (expressionShape) (fieldCount)    (type) Mode Cnt         Score       Error Units
BenchmarkRowConstructor.project                           direct                      16    bigint avgt  20       308.296 ±    10.306 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      16    bigint avgt  20   2181378.139 ±     0.071 B/op
BenchmarkRowConstructor.project                           direct                      16   varchar avgt  20       817.596 ±    42.595 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      16   varchar avgt  20   9926917.647 ±     0.293 B/op
BenchmarkRowConstructor.project                           direct                      32    bigint avgt  20       668.389 ±    16.661 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      32    bigint avgt  20   4673860.624 ±     0.121 B/op
BenchmarkRowConstructor.project                           direct                      32   varchar avgt  20      1615.189 ±    44.743 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      32   varchar avgt  20  19771723.157 ±     0.307 B/op
BenchmarkRowConstructor.project                           direct                      48    bigint avgt  20      1057.016 ±    26.133 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      48    bigint avgt  20   7264647.310 ±     0.192 B/op
BenchmarkRowConstructor.project                           direct                      48   varchar avgt  20      2299.554 ±    73.205 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      48   varchar avgt  20  29616527.946 ±     0.627 B/op
BenchmarkRowConstructor.project                           direct                      64    bigint avgt  20      1566.642 ±   100.937 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      64    bigint avgt  20   9658826.813 ±     0.702 B/op
BenchmarkRowConstructor.project                           direct                      64   varchar avgt  20      3518.410 ±   127.824 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      64   varchar avgt  20  39461336.365 ±     0.893 B/op
BenchmarkRowConstructor.project                           direct                      80    bigint avgt  20      1333.501 ±     8.675 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      80    bigint avgt  20  12347913.177 ±     0.103 B/op
BenchmarkRowConstructor.project                           direct                      80   varchar avgt  20      4466.640 ±    92.929 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      80   varchar avgt  20  49650206.719 ±     0.642 B/op
```

Current (`4dfe7c5b095`, local implementation):

```text
Benchmark                                                 (expressionShape) (fieldCount)    (type) Mode Cnt         Score       Error Units
BenchmarkRowConstructor.project                           direct                      16    bigint avgt  20        87.549 ±     8.131 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      16    bigint avgt  20    997632.604 ± 10947.611 B/op
BenchmarkRowConstructor.project                           direct                      16   varchar avgt  20       157.718 ±     1.459 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      16   varchar avgt  20   1095937.090 ±     0.012 B/op
BenchmarkRowConstructor.project                           direct                      32    bigint avgt  20       240.923 ±     1.015 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      32    bigint avgt  20   1986881.668 ±     0.018 B/op
BenchmarkRowConstructor.project                           direct                      32   varchar avgt  20       389.455 ±     0.994 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      32   varchar avgt  20   2208066.689 ±     0.009 B/op
BenchmarkRowConstructor.project                           direct                      48    bigint avgt  20       389.159 ±     8.771 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      48    bigint avgt  20   2939266.689 ±     0.062 B/op
BenchmarkRowConstructor.project                           direct                      48   varchar avgt  20       612.988 ±     2.620 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      48   varchar avgt  20   3271044.233 ±     0.017 B/op
BenchmarkRowConstructor.project                           direct                      64    bigint avgt  20       551.932 ±     3.396 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      64    bigint avgt  20   3891651.820 ±     0.047 B/op
BenchmarkRowConstructor.project                           direct                      64   varchar avgt  20       910.148 ±    27.498 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      64   varchar avgt  20   4334022.282 ±     0.192 B/op
BenchmarkRowConstructor.project                           direct                      80    bigint avgt  20       705.485 ±     1.742 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      80    bigint avgt  20   4794884.896 ±     0.072 B/op
BenchmarkRowConstructor.project                           direct                      80   varchar avgt  20      1134.879 ±     3.098 us/op
BenchmarkRowConstructor.project:gc.alloc.rate.norm        direct                      80   varchar avgt  20   5396999.868 ±     0.103 B/op
```


The output above retains the primary benchmark score and normalized allocation rows from the JMH command-line summary. Field counts 16 through 64 exercise the small-row path; the 80-field cases exercise the generated large-row path.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Improve evaluation performance and reduce memory allocations for `ROW` expressions containing direct column references.
```
