### PR TITLE
Reduce lock contention in TimeSharingTaskExecutor

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/executor/timesharing/TimeSharingTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/timesharing/TimeSharingTaskExecutor.java
@@ -71,10 +71,12 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.airlift.tracing.Tracing.noopTracer;
+import static io.airlift.units.Duration.succinctNanos;
 import static io.trino.execution.executor.timesharing.MultilevelSplitQueue.computeLevel;
 import static io.trino.util.EmbedVersion.testingVersionEmbedder;
 import static java.lang.Math.min;
 import static java.lang.String.format;
+import static java.lang.System.nanoTime;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
@@ -411,24 +413,11 @@ public class TimeSharingTaskExecutor
     private void splitFinished(PrioritizedSplitRunner split)
     {
         completedSplitsPerLevel.incrementAndGet(split.getPriority().getLevel());
+        long wallNanos = nanoTime() - split.getCreatedNanos();
+        boolean intermediate;
         synchronized (this) {
             allSplits.remove(split);
-
-            long wallNanos = System.nanoTime() - split.getCreatedNanos();
-            splitWallTime.add(Duration.succinctNanos(wallNanos));
-
-            if (intermediateSplits.remove(split)) {
-                intermediateSplitWallTime.add(wallNanos);
-                intermediateSplitScheduledTime.add(split.getScheduledNanos());
-                intermediateSplitWaitTime.add(split.getWaitNanos());
-                intermediateSplitCpuTime.add(split.getCpuTimeNanos());
-            }
-            else {
-                leafSplitWallTime.add(wallNanos);
-                leafSplitScheduledTime.add(split.getScheduledNanos());
-                leafSplitWaitTime.add(split.getWaitNanos());
-                leafSplitCpuTime.add(split.getCpuTimeNanos());
-            }
+            intermediate = intermediateSplits.remove(split);
 
             TimeSharingTaskHandle taskHandle = split.getTaskHandle();
             taskHandle.splitComplete(split);
@@ -438,7 +427,21 @@ public class TimeSharingTaskExecutor
             addNewEntrants();
             recordLeafSplitsSize();
         }
-        // call destroy outside of synchronized block as it is expensive and doesn't need a lock on the task executor
+        // record wall time stats and call destroy outside of the synchronized block;
+        // the stat sinks are thread safe and this lock is heavily contended
+        splitWallTime.add(succinctNanos(wallNanos));
+        if (intermediate) {
+            intermediateSplitWallTime.add(wallNanos);
+            intermediateSplitScheduledTime.add(split.getScheduledNanos());
+            intermediateSplitWaitTime.add(split.getWaitNanos());
+            intermediateSplitCpuTime.add(split.getCpuTimeNanos());
+        }
+        else {
+            leafSplitWallTime.add(wallNanos);
+            leafSplitScheduledTime.add(split.getScheduledNanos());
+            leafSplitWaitTime.add(split.getWaitNanos());
+            leafSplitCpuTime.add(split.getCpuTimeNanos());
+        }
         split.destroy();
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/executor/timesharing/TimeSharingTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/timesharing/TimeSharingTaskExecutor.java
@@ -39,6 +39,8 @@ import io.trino.execution.executor.TaskHandle;
 import io.trino.spi.TrinoException;
 import io.trino.spi.VersionEmbedder;
 import io.trino.tracing.TrinoAttributes;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import jakarta.annotation.Nullable;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import org.weakref.jmx.Managed;
@@ -301,9 +303,15 @@ public class TimeSharingTaskExecutor
         }
 
         // replace blocked splits that were terminated
-        synchronized (this) {
-            addNewEntrants();
-            recordLeafSplitsSize();
+        PendingUpdates pendingUpdates = new PendingUpdates();
+        try {
+            synchronized (this) {
+                addNewEntrants(pendingUpdates);
+                recordLeafSplitsSize(pendingUpdates);
+            }
+        }
+        finally {
+            pendingUpdates.flush();
         }
     }
 
@@ -315,21 +323,27 @@ public class TimeSharingTaskExecutor
     private boolean doRemoveTask(TimeSharingTaskHandle taskHandle)
     {
         List<PrioritizedSplitRunner> splits;
-        synchronized (this) {
-            tasks.remove(taskHandle);
+        PendingUpdates pendingUpdates = new PendingUpdates();
+        try {
+            synchronized (this) {
+                tasks.remove(taskHandle);
 
-            // Task is already destroyed
-            if (taskHandle.isDestroyed()) {
-                return false;
+                // Task is already destroyed
+                if (taskHandle.isDestroyed()) {
+                    return false;
+                }
+
+                splits = taskHandle.destroy();
+                // stop tracking splits (especially blocked splits which may never unblock)
+                allSplits.removeAll(splits);
+                intermediateSplits.removeAll(splits);
+                blockedSplits.keySet().removeAll(splits);
+                waitingSplits.removeAll(splits);
+                recordLeafSplitsSize(pendingUpdates);
             }
-
-            splits = taskHandle.destroy();
-            // stop tracking splits (especially blocked splits which may never unblock)
-            allSplits.removeAll(splits);
-            intermediateSplits.removeAll(splits);
-            blockedSplits.keySet().removeAll(splits);
-            waitingSplits.removeAll(splits);
-            recordLeafSplitsSize();
+        }
+        finally {
+            pendingUpdates.flush();
         }
 
         // call destroy outside of synchronized block as it is expensive and doesn't need a lock on the task executor
@@ -351,58 +365,64 @@ public class TimeSharingTaskExecutor
         TimeSharingTaskHandle handle = (TimeSharingTaskHandle) taskHandle;
         List<PrioritizedSplitRunner> splitsToDestroy = new ArrayList<>();
         List<ListenableFuture<Void>> finishedFutures = new ArrayList<>(taskSplits.size());
-        synchronized (this) {
-            for (SplitRunner taskSplit : taskSplits) {
-                TaskId taskId = handle.getTaskId();
-                int splitId = handle.getNextSplitId();
+        PendingUpdates pendingUpdates = new PendingUpdates();
+        try {
+            synchronized (this) {
+                for (SplitRunner taskSplit : taskSplits) {
+                    TaskId taskId = handle.getTaskId();
+                    int splitId = handle.getNextSplitId();
 
-                Span splitSpan = tracer.spanBuilder(intermediate ? "split (intermediate)" : "split (leaf)")
-                        .setParent(Context.current().with(taskSplit.getPipelineSpan()))
-                        .setAttribute(TrinoAttributes.QUERY_ID, taskId.queryId().toString())
-                        .setAttribute(TrinoAttributes.STAGE_ID, taskId.stageId().toString())
-                        .setAttribute(TrinoAttributes.TASK_ID, taskId.toString())
-                        .setAttribute(TrinoAttributes.PIPELINE_ID, taskId.stageId() + "-" + taskSplit.getPipelineId())
-                        .setAttribute(TrinoAttributes.SPLIT_ID, taskId + "-" + splitId)
-                        .startSpan();
+                    Span splitSpan = tracer.spanBuilder(intermediate ? "split (intermediate)" : "split (leaf)")
+                            .setParent(Context.current().with(taskSplit.getPipelineSpan()))
+                            .setAttribute(TrinoAttributes.QUERY_ID, taskId.queryId().toString())
+                            .setAttribute(TrinoAttributes.STAGE_ID, taskId.stageId().toString())
+                            .setAttribute(TrinoAttributes.TASK_ID, taskId.toString())
+                            .setAttribute(TrinoAttributes.PIPELINE_ID, taskId.stageId() + "-" + taskSplit.getPipelineId())
+                            .setAttribute(TrinoAttributes.SPLIT_ID, taskId + "-" + splitId)
+                            .startSpan();
 
-                PrioritizedSplitRunner prioritizedSplitRunner = new PrioritizedSplitRunner(
-                        handle,
-                        splitId,
-                        taskSplit,
-                        splitSpan,
-                        tracer,
-                        ticker,
-                        globalCpuTimeMicros,
-                        globalScheduledTimeMicros,
-                        blockedQuantaWallTime,
-                        unblockedQuantaWallTime);
+                    PrioritizedSplitRunner prioritizedSplitRunner = new PrioritizedSplitRunner(
+                            handle,
+                            splitId,
+                            taskSplit,
+                            splitSpan,
+                            tracer,
+                            ticker,
+                            globalCpuTimeMicros,
+                            globalScheduledTimeMicros,
+                            blockedQuantaWallTime,
+                            unblockedQuantaWallTime);
 
-                if (intermediate) {
-                    // add the runner to the handle so it can be destroyed if the task is canceled
-                    if (handle.recordIntermediateSplit(prioritizedSplitRunner)) {
-                        // Note: we do not record queued time for intermediate splits
-                        startIntermediateSplit(prioritizedSplitRunner);
+                    if (intermediate) {
+                        // add the runner to the handle so it can be destroyed if the task is canceled
+                        if (handle.recordIntermediateSplit(prioritizedSplitRunner)) {
+                            // Note: we do not record queued time for intermediate splits
+                            startIntermediateSplit(prioritizedSplitRunner);
+                        }
+                        else {
+                            splitsToDestroy.add(prioritizedSplitRunner);
+                        }
                     }
                     else {
-                        splitsToDestroy.add(prioritizedSplitRunner);
+                        // add this to the work queue for the task
+                        if (handle.enqueueSplit(prioritizedSplitRunner)) {
+                            // if task is under the limit for guaranteed splits, start one
+                            scheduleTaskIfNecessary(handle, pendingUpdates);
+                            // if globally we have more resources, start more
+                            addNewEntrants(pendingUpdates);
+                        }
+                        else {
+                            splitsToDestroy.add(prioritizedSplitRunner);
+                        }
                     }
-                }
-                else {
-                    // add this to the work queue for the task
-                    if (handle.enqueueSplit(prioritizedSplitRunner)) {
-                        // if task is under the limit for guaranteed splits, start one
-                        scheduleTaskIfNecessary(handle);
-                        // if globally we have more resources, start more
-                        addNewEntrants();
-                    }
-                    else {
-                        splitsToDestroy.add(prioritizedSplitRunner);
-                    }
-                }
 
-                finishedFutures.add(prioritizedSplitRunner.getFinishedFuture());
+                    finishedFutures.add(prioritizedSplitRunner.getFinishedFuture());
+                }
+                recordLeafSplitsSize(pendingUpdates);
             }
-            recordLeafSplitsSize();
+        }
+        finally {
+            pendingUpdates.flush();
         }
         for (PrioritizedSplitRunner split : splitsToDestroy) {
             split.destroy();
@@ -415,19 +435,25 @@ public class TimeSharingTaskExecutor
         completedSplitsPerLevel.incrementAndGet(split.getPriority().getLevel());
         long wallNanos = nanoTime() - split.getCreatedNanos();
         boolean intermediate;
-        synchronized (this) {
-            allSplits.remove(split);
-            intermediate = intermediateSplits.remove(split);
+        PendingUpdates pendingUpdates = new PendingUpdates();
+        try {
+            synchronized (this) {
+                allSplits.remove(split);
+                intermediate = intermediateSplits.remove(split);
 
-            TimeSharingTaskHandle taskHandle = split.getTaskHandle();
-            taskHandle.splitComplete(split);
+                TimeSharingTaskHandle taskHandle = split.getTaskHandle();
+                taskHandle.splitComplete(split);
 
-            scheduleTaskIfNecessary(taskHandle);
+                scheduleTaskIfNecessary(taskHandle, pendingUpdates);
 
-            addNewEntrants();
-            recordLeafSplitsSize();
+                addNewEntrants(pendingUpdates);
+                recordLeafSplitsSize(pendingUpdates);
+            }
         }
-        // record wall time stats and call destroy outside of the synchronized block;
+        finally {
+            pendingUpdates.flush();
+        }
+        // record wall time stats and call destroy outside the synchronized block;
         // the stat sinks are thread safe and this lock is heavily contended
         splitWallTime.add(succinctNanos(wallNanos));
         if (intermediate) {
@@ -445,7 +471,7 @@ public class TimeSharingTaskExecutor
         split.destroy();
     }
 
-    private synchronized void scheduleTaskIfNecessary(TimeSharingTaskHandle taskHandle)
+    private synchronized void scheduleTaskIfNecessary(TimeSharingTaskHandle taskHandle, PendingUpdates pendingUpdates)
     {
         // if task has less than the minimum guaranteed splits running,
         // immediately schedule new splits for this task.  This assures
@@ -460,12 +486,12 @@ public class TimeSharingTaskExecutor
             }
 
             startSplit(split);
-            splitQueuedTime.add(Duration.nanosSince(split.getCreatedNanos()));
+            pendingUpdates.recordSplitQueuedNanos(nanoTime() - split.getCreatedNanos());
         }
-        recordLeafSplitsSize();
+        recordLeafSplitsSize(pendingUpdates);
     }
 
-    private synchronized void addNewEntrants()
+    private synchronized void addNewEntrants(PendingUpdates pendingUpdates)
     {
         // Ignore intermediate splits when checking minimumNumberOfDrivers.
         // Otherwise with (for example) minimumNumberOfDrivers = 100, 200 intermediate splits
@@ -480,7 +506,7 @@ public class TimeSharingTaskExecutor
                 break;
             }
 
-            splitQueuedTime.add(Duration.nanosSince(split.getCreatedNanos()));
+            pendingUpdates.recordSplitQueuedNanos(nanoTime() - split.getCreatedNanos());
             startSplit(split);
         }
     }
@@ -522,17 +548,63 @@ public class TimeSharingTaskExecutor
         return null;
     }
 
-    private synchronized void recordLeafSplitsSize()
+    private synchronized void recordLeafSplitsSize(PendingUpdates pendingUpdates)
     {
         long now = ticker.read();
         long timeDifference = now - this.lastLeafSplitsSizeRecordTime;
         if (timeDifference > 0) {
-            this.leafSplitsSize.add(lastLeafSplitsSize, timeDifference);
+            pendingUpdates.recordLeafSplitsSizeSample(lastLeafSplitsSize, timeDifference);
             this.lastLeafSplitsSizeRecordTime = now;
         }
         // always record new lastLeafSplitsSize as it might have changed
         // even if timeDifference is 0
         this.lastLeafSplitsSize = allSplits.size() - intermediateSplits.size();
+    }
+
+    // Collects stat samples produced while holding the executor lock; flush() feeds the
+    // internally synchronized stat sinks after the lock is released.
+    private class PendingUpdates
+    {
+        @Nullable
+        private LongArrayList splitQueuedNanos;
+        // interleaved (leafSplitsCount, timeWeight) pairs
+        @Nullable
+        private LongArrayList leafSplitsSizeSamples;
+
+        void recordSplitQueuedNanos(long queuedNanos)
+        {
+            if (splitQueuedNanos == null) {
+                splitQueuedNanos = new LongArrayList();
+            }
+            splitQueuedNanos.add(queuedNanos);
+        }
+
+        void recordLeafSplitsSizeSample(long leafSplitsCount, long timeWeight)
+        {
+            if (leafSplitsSizeSamples == null) {
+                leafSplitsSizeSamples = new LongArrayList();
+            }
+            leafSplitsSizeSamples.add(leafSplitsCount);
+            leafSplitsSizeSamples.add(timeWeight);
+        }
+
+        @SuppressWarnings("checkstyle:IllegalToken")
+        void flush()
+        {
+            assert !Thread.holdsLock(TimeSharingTaskExecutor.this) : "Cannot flush while holding the executor lock";
+            if (splitQueuedNanos != null) {
+                for (int i = 0; i < splitQueuedNanos.size(); i++) {
+                    splitQueuedTime.add(succinctNanos(splitQueuedNanos.getLong(i)));
+                }
+                splitQueuedNanos = null;
+            }
+            if (leafSplitsSizeSamples != null) {
+                for (int i = 0; i < leafSplitsSizeSamples.size(); i += 2) {
+                    leafSplitsSize.add(leafSplitsSizeSamples.getLong(i), leafSplitsSizeSamples.getLong(i + 1));
+                }
+                leafSplitsSizeSamples = null;
+            }
+        }
     }
 
     private class TaskRunner

--- a/core/trino-main/src/main/java/io/trino/execution/executor/timesharing/TimeSharingTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/timesharing/TimeSharingTaskExecutor.java
@@ -397,7 +397,7 @@ public class TimeSharingTaskExecutor
                         // add the runner to the handle so it can be destroyed if the task is canceled
                         if (handle.recordIntermediateSplit(prioritizedSplitRunner)) {
                             // Note: we do not record queued time for intermediate splits
-                            startIntermediateSplit(prioritizedSplitRunner);
+                            startIntermediateSplit(prioritizedSplitRunner, pendingUpdates);
                         }
                         else {
                             splitsToDestroy.add(prioritizedSplitRunner);
@@ -485,8 +485,8 @@ public class TimeSharingTaskExecutor
                 return;
             }
 
-            startSplit(split);
             pendingUpdates.recordSplitQueuedNanos(nanoTime() - split.getCreatedNanos());
+            startSplit(split, pendingUpdates);
         }
         recordLeafSplitsSize(pendingUpdates);
     }
@@ -507,20 +507,21 @@ public class TimeSharingTaskExecutor
             }
 
             pendingUpdates.recordSplitQueuedNanos(nanoTime() - split.getCreatedNanos());
-            startSplit(split);
+            startSplit(split, pendingUpdates);
         }
     }
 
-    private synchronized void startIntermediateSplit(PrioritizedSplitRunner split)
+    private synchronized void startIntermediateSplit(PrioritizedSplitRunner split, PendingUpdates pendingUpdates)
     {
-        startSplit(split);
+        startSplit(split, pendingUpdates);
         intermediateSplits.add(split);
     }
 
-    private synchronized void startSplit(PrioritizedSplitRunner split)
+    private synchronized void startSplit(PrioritizedSplitRunner split, PendingUpdates pendingUpdates)
     {
         allSplits.add(split);
-        waitingSplits.offer(split);
+        // deferred to PendingUpdates.flush(); the queue has its own lock that need not nest inside the executor lock
+        pendingUpdates.offerSplit(split);
     }
 
     private synchronized PrioritizedSplitRunner pollNextSplitWorker()
@@ -561,15 +562,26 @@ public class TimeSharingTaskExecutor
         this.lastLeafSplitsSize = allSplits.size() - intermediateSplits.size();
     }
 
-    // Collects stat samples produced while holding the executor lock; flush() feeds the
-    // internally synchronized stat sinks after the lock is released.
+    // Collects updates produced while holding the executor lock and applies them in flush()
+    // after the lock is released: offers of started splits to the waiting queue, and
+    // samples for the internally synchronized stat sinks.
     private class PendingUpdates
     {
+        @Nullable
+        private ArrayList<PrioritizedSplitRunner> splitsToOffer;
         @Nullable
         private LongArrayList splitQueuedNanos;
         // interleaved (leafSplitsCount, timeWeight) pairs
         @Nullable
         private LongArrayList leafSplitsSizeSamples;
+
+        void offerSplit(PrioritizedSplitRunner split)
+        {
+            if (splitsToOffer == null) {
+                splitsToOffer = new ArrayList<>();
+            }
+            splitsToOffer.add(split);
+        }
 
         void recordSplitQueuedNanos(long queuedNanos)
         {
@@ -603,6 +615,15 @@ public class TimeSharingTaskExecutor
                     leafSplitsSize.add(leafSplitsSizeSamples.getLong(i), leafSplitsSizeSamples.getLong(i + 1));
                 }
                 leafSplitsSizeSamples = null;
+            }
+            if (splitsToOffer != null) {
+                for (PrioritizedSplitRunner split : splitsToOffer) {
+                    // best-effort; a split destroyed after this check is still offered and later discarded by TaskRunner via isFinished()
+                    if (!split.isDestroyed()) {
+                        waitingSplits.offer(split);
+                    }
+                }
+                splitsToOffer = null;
             }
         }
     }

--- a/core/trino-main/src/test/java/io/trino/execution/executor/timesharing/TestTimeSharingTaskExecutor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/timesharing/TestTimeSharingTaskExecutor.java
@@ -20,6 +20,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.testing.TestingTicker;
 import io.airlift.units.Duration;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.execution.SplitRunner;
 import io.trino.execution.StageId;
 import io.trino.execution.TaskId;
@@ -42,13 +43,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static io.airlift.tracing.Tracing.noopTracer;
 import static io.trino.execution.executor.timesharing.MultilevelSplitQueue.LEVEL_CONTRIBUTION_CAP;
 import static io.trino.execution.executor.timesharing.MultilevelSplitQueue.LEVEL_THRESHOLD_SECONDS;
+import static io.trino.testing.assertions.Assert.assertEventually;
+import static io.trino.util.EmbedVersion.testingVersionEmbedder;
 import static java.lang.Double.isNaN;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestTimeSharingTaskExecutor
 {
@@ -560,6 +565,70 @@ public class TestTimeSharingTaskExecutor
         }
     }
 
+    @Test
+    @Timeout(30)
+    public void testStartedSplitOfferedWhenEnqueueFails()
+            throws Exception
+    {
+        TestingTicker ticker = new TestingTicker();
+        AtomicInteger splitSpansCreated = new AtomicInteger();
+        Tracer throwingTracer = spanName -> {
+            if (spanName.startsWith("split") && splitSpansCreated.incrementAndGet() == 2) {
+                throw new RuntimeException("tracer failure");
+            }
+            return noopTracer().spanBuilder(spanName);
+        };
+        TimeSharingTaskExecutor taskExecutor = new TimeSharingTaskExecutor(4, 8, 3, 4, new Duration(10, MINUTES), testingVersionEmbedder(), throwingTracer, new MultilevelSplitQueue(2), ticker);
+        taskExecutor.start();
+        try {
+            TaskHandle taskHandle = taskExecutor.addTask(new TaskId(new StageId("test", 0), 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            TestingJob driver1 = new TestingJob(ticker, new Phaser(), new Phaser(), new Phaser(), 1, 0);
+            TestingJob driver2 = new TestingJob(ticker, new Phaser(), new Phaser(), new Phaser(), 1, 0);
+
+            assertThatThrownBy(() -> taskExecutor.enqueueSplits(taskHandle, false, ImmutableList.of(driver1, driver2)))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("tracer failure");
+
+            // first split was started before the failure; flush in the finally block offers it to the wait queue
+            driver1.getCompletedFuture().get(10, SECONDS);
+            assertThat(driver2.isStarted()).isFalse();
+            taskExecutor.removeTask(taskHandle);
+        }
+        finally {
+            taskExecutor.stop();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void testDestroyedBlockedSplitIsDiscardedAfterReoffer()
+            throws Exception
+    {
+        TimeSharingTaskExecutor taskExecutor = new TimeSharingTaskExecutor(4, 8, 3, 4, new TestingTicker());
+        taskExecutor.start();
+        try {
+            TaskHandle taskHandle = taskExecutor.addTask(new TaskId(new StageId("test", 0), 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+            BlockedSplit split = new BlockedSplit();
+            taskExecutor.enqueueSplits(taskHandle, false, ImmutableList.of(split));
+            assertEventually(new Duration(10, SECONDS), () -> assertThat(taskExecutor.getBlockedSplits()).isEqualTo(1));
+
+            // destroys the blocked split; the registered unblock listener still re-offers it to the wait queue
+            taskExecutor.removeTask(taskHandle);
+            split.unblock();
+
+            // the destroyed split drains through TaskRunner without reviving
+            assertEventually(new Duration(10, SECONDS), () -> {
+                assertThat(taskExecutor.getWaitingSplits()).isEqualTo(0);
+                assertThat(taskExecutor.getBlockedSplits()).isEqualTo(0);
+                assertThat(taskExecutor.getRunningSplits()).isEqualTo(0);
+                assertThat(taskExecutor.getTotalSplits()).isEqualTo(0);
+            });
+        }
+        finally {
+            taskExecutor.stop();
+        }
+    }
+
     private void assertSplitStates(int endIndex, TestingJob[] splits)
     {
         // assert that splits up to and including endIndex are all started
@@ -690,6 +759,57 @@ public class TestTimeSharingTaskExecutor
         public Future<Void> getCompletedFuture()
         {
             return completed;
+        }
+    }
+
+    private static class BlockedSplit
+            implements SplitRunner
+    {
+        private final SettableFuture<Void> blocked = SettableFuture.create();
+        private volatile boolean closed;
+
+        @Override
+        public int getPipelineId()
+        {
+            return 0;
+        }
+
+        @Override
+        public Span getPipelineSpan()
+        {
+            return Span.getInvalid();
+        }
+
+        @Override
+        public boolean isFinished()
+        {
+            return closed;
+        }
+
+        @Override
+        public ListenableFuture<Void> processFor(Duration duration)
+        {
+            if (closed) {
+                return immediateVoidFuture();
+            }
+            return blocked;
+        }
+
+        @Override
+        public String getInfo()
+        {
+            return "blocked split";
+        }
+
+        @Override
+        public void close()
+        {
+            closed = true;
+        }
+
+        public void unblock()
+        {
+            blocked.set(null);
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/executor/timesharing/TestTimeSharingTaskExecutor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/timesharing/TestTimeSharingTaskExecutor.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.OptionalInt;
@@ -527,6 +528,36 @@ public class TestTimeSharingTaskExecutor
         ticker.increment(1, TimeUnit.SECONDS);
         taskExecutor.enqueueSplits(testTaskHandle, true, ImmutableList.of(driver1));
         assertThat(taskExecutor.getLeafSplitsSize().getAllTime().getMax()).isEqualTo(2.0);
+    }
+
+    @Test
+    public void testSplitQueuedTimeRecordedPerStartedLeafSplit()
+            throws Exception
+    {
+        TestingTicker ticker = new TestingTicker();
+        TimeSharingTaskExecutor taskExecutor = new TimeSharingTaskExecutor(4, 8, 3, 4, ticker);
+        taskExecutor.start();
+        try {
+            TaskHandle taskHandle = taskExecutor.addTask(new TaskId(new StageId("test", 0), 0, 0), () -> 0, 10, new Duration(1, MILLISECONDS), OptionalInt.empty());
+
+            List<ListenableFuture<Void>> futures = new ArrayList<>(taskExecutor.enqueueSplits(taskHandle, false, ImmutableList.of(
+                    new TestingJob(ticker, new Phaser(), new Phaser(), new Phaser(), 1, 0),
+                    new TestingJob(ticker, new Phaser(), new Phaser(), new Phaser(), 1, 0),
+                    new TestingJob(ticker, new Phaser(), new Phaser(), new Phaser(), 1, 0),
+                    new TestingJob(ticker, new Phaser(), new Phaser(), new Phaser(), 1, 0))));
+            futures.addAll(taskExecutor.enqueueSplits(taskHandle, true, ImmutableList.of(
+                    new TestingJob(ticker, new Phaser(), new Phaser(), new Phaser(), 1, 0),
+                    new TestingJob(ticker, new Phaser(), new Phaser(), new Phaser(), 1, 0))));
+            for (ListenableFuture<Void> future : futures) {
+                future.get(10, SECONDS);
+            }
+
+            assertThat(taskExecutor.getSplitQueuedTime().getAllTime().snapshot().count()).isEqualTo(4.0);
+            taskExecutor.removeTask(taskHandle);
+        }
+        finally {
+            taskExecutor.stop();
+        }
     }
 
     private void assertSplitStates(int endIndex, TestingJob[] splits)


### PR DESCRIPTION
## Description

Reduces contention on the `TimeSharingTaskExecutor` global monitor. A JFR capture from a production cluster showed a hot worker spending 455s of thread time blocked on this monitor within a 22s window, mostly in `splitFinished`.

The synchronized region currently does work that takes further locks of its own: recording samples into internally synchronized stat sinks (`TimeStat`, `TimeDistribution`, `DistributionStat`) and offering splits into `MultilevelSplitQueue` (a `ReentrantLock` plus level target computation). Three commits move that work out of the critical section, each functional on its own:

1. Record split completion stats after releasing the executor lock in `splitFinished`.
2. Introduce `PendingUpdates`, a thread-confined accumulator. Queued-time and leaf-splits-size samples are recorded into it under the lock and applied in `flush()` after release. `flush()` runs in a `finally` block at every call site and asserts the executor lock is not held.
3. Defer `waitingSplits.offer` of newly started splits to `flush()`. Master already offers blocked and re-enqueued splits without holding the executor lock; this extends the same invariant to newly started splits. `flush()` skips destroyed splits best-effort; a split destroyed after the check is discarded by `TaskRunner` through the existing `isFinished()` destroyed checks, the same as on the existing offer paths.

The structure follows existing precedent for applying deferred work after a critical section (`LazyOutputBuffer` pending reads, `splitsToDestroy` in this file). The `try/finally` goes beyond that precedent because losing a deferred offer of a started split would permanently leak a driver slot.

Measured with a stress harness driving concurrent enqueue/finish cycles (16 runner threads, 500us two-quanta splits, 24 or 96 submitting tasks) on a 16-core Graviton host, medians of 3 runs. Throughput is submitter-bound and stays flat at ~15.6k splits/s; the improvement shows in monitor blocked time and enqueue latency.

| metric | baseline | commit 1 | commits 1+2 | full stack |
|---|---|---|---|---|
| blocked ms/s, 24 tasks | 216.0 | 147.2 | 102.0 | 76.0 |
| blocked ms/s, 96 tasks | 193.6 | 153.1 | 74.1 | 52.5 |
| enqueue p90 us, 24 tasks | 153 | 132 | 104 | 98 |
| enqueue p90 us, 96 tasks | 147 | 121 | 106 | 84 |

## Additional context and related issues

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Reduce task executor lock contention on workers. ({issue}`issuenumber`)
```
