### PR TITLE
Replay Delta Lake active files newest first

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -186,6 +186,7 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -2863,16 +2864,20 @@ public class DeltaLakeMetadata
             return ImmutableMap.of();
         }
 
-        ImmutableMap.Builder<String, DeletionVectorEntry> deletionVectors = ImmutableMap.builder();
         try (Stream<AddFileEntry> activeFiles = transactionLogAccess.getActiveFiles(session, handle, getTableCredentials(handle.toCredentialsHandle()), getSnapshot(session, handle))) {
-            Iterator<AddFileEntry> addFileEntryIterator = activeFiles.iterator();
-            while (addFileEntryIterator.hasNext()) {
-                AddFileEntry addFileEntry = addFileEntryIterator.next();
-                addFileEntry.getDeletionVector().ifPresent(deletionVector -> deletionVectors.put(addFileEntry.getPath(), deletionVector));
-            }
+            return collectLatestDeletionVectors(activeFiles.iterator());
         }
-        // The latest deletion vector contains all the past deleted rows
-        return deletionVectors.buildKeepingLast();
+    }
+
+    static Map<String, DeletionVectorEntry> collectLatestDeletionVectors(Iterator<AddFileEntry> activeFiles)
+    {
+        Map<String, DeletionVectorEntry> deletionVectors = new LinkedHashMap<>();
+        while (activeFiles.hasNext()) {
+            AddFileEntry addFileEntry = activeFiles.next();
+            addFileEntry.getDeletionVector().ifPresent(deletionVector -> deletionVectors.putIfAbsent(addFileEntry.getPath(), deletionVector));
+        }
+        // Active files are replayed newest first, and the latest deletion vector contains all the past deleted rows.
+        return ImmutableMap.copyOf(deletionVectors);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
@@ -13,13 +13,17 @@
  */
 package io.trino.plugin.deltalake.transactionlog;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.cache.Cache;
 import com.google.common.cache.Weigher;
+import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
 import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.inject.Inject;
 import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.units.DataSize;
@@ -58,6 +62,7 @@ import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.VarbinaryType;
+import jakarta.annotation.Nullable;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
@@ -481,25 +486,29 @@ public class TransactionLogAccess
     {
         List<Transaction> transactions = tableSnapshot.getTransactions();
         TrinoFileSystem fileSystem = fileSystemFactory.create(session, tableCredentials);
-        try (Stream<DeltaLakeTransactionLogEntry> checkpointEntries = tableSnapshot.getCheckpointTransactionLogEntries(
-                session,
-                ImmutableSet.of(ADD),
-                checkpointSchemaManager,
-                typeManager,
-                fileSystem,
-                fileFormatDataSourceStats,
-                Optional.of(new MetadataAndProtocolEntry(metadataEntry, protocolEntry)),
-                partitionConstraint,
-                Optional.of(addStatsMinMaxColumnFilter),
-                new BoundedExecutor(executorService, checkpointProcessingParallelism))) {
-            return activeAddEntries(checkpointEntries, transactions, fileSystem)
-                    .filter(partitionConstraint.isAll()
-                            ? _ -> true
-                            : addAction -> partitionMatchesPredicate(addAction.getCanonicalPartitionValues(), partitionConstraint.getDomains().orElseThrow()));
-        }
-        catch (IOException e) {
-            throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Error reading transaction log for " + tableSnapshot.getTable(), e);
-        }
+        Supplier<Stream<DeltaLakeTransactionLogEntry>> checkpointEntriesSupplier = () -> {
+            try {
+                return tableSnapshot.getCheckpointTransactionLogEntries(
+                        session,
+                        ImmutableSet.of(ADD),
+                        checkpointSchemaManager,
+                        typeManager,
+                        fileSystem,
+                        fileFormatDataSourceStats,
+                        Optional.of(new MetadataAndProtocolEntry(metadataEntry, protocolEntry)),
+                        partitionConstraint,
+                        Optional.of(addStatsMinMaxColumnFilter),
+                        new BoundedExecutor(executorService, checkpointProcessingParallelism));
+            }
+            catch (IOException e) {
+                throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Error reading transaction log for " + tableSnapshot.getTable(), e);
+            }
+        };
+
+        return activeAddEntries(checkpointEntriesSupplier, transactions, fileSystem)
+                .filter(partitionConstraint.isAll()
+                        ? _ -> true
+                        : addAction -> partitionMatchesPredicate(addAction.getCanonicalPartitionValues(), partitionConstraint.getDomains().orElseThrow()));
     }
 
     public static List<DeltaLakeColumnMetadata> columnsWithStats(MetadataEntry metadataEntry, ProtocolEntry protocolEntry, TypeManager typeManager)
@@ -518,48 +527,158 @@ public class TransactionLogAccess
                 .collect(toImmutableList());
     }
 
-    private Stream<AddFileEntry> activeAddEntries(Stream<DeltaLakeTransactionLogEntry> checkpointEntries, List<Transaction> transactions, TrinoFileSystem fileSystem)
+    @VisibleForTesting
+    static Stream<AddFileEntry> activeAddEntries(
+            Supplier<Stream<DeltaLakeTransactionLogEntry>> checkpointEntriesSupplier,
+            List<Transaction> transactions,
+            TrinoFileSystem fileSystem)
     {
-        Map<FileEntryKey, AddFileEntry> activeJsonEntries = new LinkedHashMap<>();
-        HashSet<FileEntryKey> removedFiles = new HashSet<>();
+        // Replay the JSON tail newest first and defer the checkpoint until it is needed. This
+        // lets a short-circuiting consumer stop before reconstructing the full snapshot.
+        ActiveAddEntriesIterator iterator = new ActiveAddEntriesIterator(checkpointEntriesSupplier, transactions, fileSystem);
+        return Streams.stream(iterator)
+                .onClose(iterator::close);
+    }
 
-        // The json entries containing the last few entries in the log need to be applied on top of the parquet snapshot:
-        // - Any files which have been removed need to be excluded
-        // - Any files with newer add actions need to be updated with the most recent metadata
-        transactions.forEach(transaction -> {
+    private record FileEntryKey(String path, Optional<String> deletionVectorId) {}
+
+    private static FileEntryKey fileEntryKey(AddFileEntry addFileEntry)
+    {
+        return new FileEntryKey(addFileEntry.getPath(), addFileEntry.getDeletionVector().map(DeletionVectorEntry::uniqueId));
+    }
+
+    private static FileEntryKey fileEntryKey(RemoveFileEntry removeFileEntry)
+    {
+        return new FileEntryKey(removeFileEntry.path(), removeFileEntry.deletionVector().map(DeletionVectorEntry::uniqueId));
+    }
+
+    private static final class ActiveAddEntriesIterator
+            extends AbstractIterator<AddFileEntry>
+            implements AutoCloseable
+    {
+        private final Supplier<Stream<DeltaLakeTransactionLogEntry>> checkpointEntriesSupplier;
+        private final Iterator<Transaction> transactions;
+        private final TrinoFileSystem fileSystem;
+        private final Set<FileEntryKey> addFilesFromJson = new HashSet<>();
+        private final Set<FileEntryKey> removedFiles = new HashSet<>();
+
+        private Iterator<AddFileEntry> currentAddEntries = ImmutableList.<AddFileEntry>of().iterator();
+        @GuardedBy("this")
+        @Nullable
+        private Stream<DeltaLakeTransactionLogEntry> checkpointEntries;
+        @Nullable
+        private Iterator<DeltaLakeTransactionLogEntry> checkpointIterator;
+        private volatile boolean closed;
+
+        private ActiveAddEntriesIterator(
+                Supplier<Stream<DeltaLakeTransactionLogEntry>> checkpointEntriesSupplier,
+                List<Transaction> transactions,
+                TrinoFileSystem fileSystem)
+        {
+            this.checkpointEntriesSupplier = requireNonNull(checkpointEntriesSupplier, "checkpointEntriesSupplier is null");
+            this.transactions = requireNonNull(transactions, "transactions is null").reversed().iterator();
+            this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
+        }
+
+        @Override
+        protected AddFileEntry computeNext()
+        {
+            if (closed) {
+                return endOfData();
+            }
+
+            try {
+                while (true) {
+                    if (currentAddEntries.hasNext()) {
+                        return currentAddEntries.next();
+                    }
+
+                    if (transactions.hasNext()) {
+                        currentAddEntries = loadActiveAddEntries(transactions.next());
+                        continue;
+                    }
+
+                    if (checkpointIterator == null) {
+                        Stream<DeltaLakeTransactionLogEntry> acquiredCheckpointEntries = checkpointEntriesSupplier.get();
+                        synchronized (this) {
+                            if (closed) {
+                                acquiredCheckpointEntries.close();
+                                return endOfData();
+                            }
+                            checkpointEntries = acquiredCheckpointEntries;
+                            checkpointIterator = checkpointEntries.iterator();
+                        }
+                    }
+                    while (checkpointIterator.hasNext()) {
+                        AddFileEntry addFileEntry = checkpointIterator.next().getAdd();
+                        if (addFileEntry == null) {
+                            continue;
+                        }
+
+                        FileEntryKey key = fileEntryKey(addFileEntry);
+                        if (!removedFiles.contains(key) && !addFilesFromJson.contains(key)) {
+                            return addFileEntry;
+                        }
+                    }
+
+                    close();
+                    return endOfData();
+                }
+            }
+            catch (RuntimeException | Error e) {
+                try {
+                    close();
+                }
+                catch (RuntimeException | Error closeFailure) {
+                    e.addSuppressed(closeFailure);
+                }
+                throw e;
+            }
+        }
+
+        private Iterator<AddFileEntry> loadActiveAddEntries(Transaction transaction)
+        {
             Map<FileEntryKey, AddFileEntry> addFilesInTransaction = new LinkedHashMap<>();
             Set<FileEntryKey> removedFilesInTransaction = new HashSet<>();
+
             try (Stream<DeltaLakeTransactionLogEntry> entries = transaction.transactionEntries().getEntries(fileSystem)) {
                 entries.forEach(deltaLakeTransactionLogEntry -> {
                     if (deltaLakeTransactionLogEntry.getAdd() != null) {
                         AddFileEntry add = deltaLakeTransactionLogEntry.getAdd();
-                        addFilesInTransaction.put(new FileEntryKey(add.getPath(), add.getDeletionVector().map(DeletionVectorEntry::uniqueId)), add);
+                        addFilesInTransaction.put(fileEntryKey(add), add);
                     }
                     else if (deltaLakeTransactionLogEntry.getRemove() != null) {
-                        RemoveFileEntry remove = deltaLakeTransactionLogEntry.getRemove();
-                        removedFilesInTransaction.add(new FileEntryKey(remove.path(), remove.deletionVector().map(DeletionVectorEntry::uniqueId)));
+                        removedFilesInTransaction.add(fileEntryKey(deltaLakeTransactionLogEntry.getRemove()));
                     }
                 });
             }
 
-            // Process 'remove' entries first because deletion vectors register both 'add' and 'remove' entries and the 'add' entry should be kept
+            // Process a transaction as a unit so an add in the same transaction as a remove
+            // keeps the current forward-replay semantics. Compacted log files are already action
+            // reconciled and can be treated as a single transaction.
+            List<AddFileEntry> activeAddEntries = addFilesInTransaction.entrySet().stream()
+                    .filter(entry -> !removedFiles.contains(entry.getKey()) && !addFilesFromJson.contains(entry.getKey()))
+                    .map(Map.Entry::getValue)
+                    .collect(toImmutableList());
+
             removedFiles.addAll(removedFilesInTransaction);
-            removedFilesInTransaction.forEach(activeJsonEntries::remove);
-            activeJsonEntries.putAll(addFilesInTransaction);
-        });
+            addFilesFromJson.addAll(addFilesInTransaction.keySet());
 
-        Stream<AddFileEntry> filteredCheckpointEntries = checkpointEntries
-                .map(DeltaLakeTransactionLogEntry::getAdd)
-                .filter(Objects::nonNull)
-                .filter(addEntry -> {
-                    FileEntryKey key = new FileEntryKey(addEntry.getPath(), addEntry.getDeletionVector().map(DeletionVectorEntry::uniqueId));
-                    return !removedFiles.contains(key) && !activeJsonEntries.containsKey(key);
-                });
+            return activeAddEntries.iterator();
+        }
 
-        return Stream.concat(filteredCheckpointEntries, activeJsonEntries.values().stream());
+        @Override
+        public synchronized void close()
+        {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            if (checkpointEntries != null) {
+                checkpointEntries.close();
+            }
+        }
     }
-
-    private record FileEntryKey(String path, Optional<String> deletionVectorId) {}
 
     public MetadataAndProtocolEntries getMetadataAndProtocolEntry(ConnectorSession session, TrinoFileSystem fileSystem, TableSnapshot tableSnapshot)
     {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -39,6 +39,8 @@ import io.trino.plugin.base.ConnectorContextModule;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastoreModule;
 import io.trino.plugin.deltalake.metastore.HiveMetastoreBackedDeltaLakeMetastore;
+import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
+import io.trino.plugin.deltalake.transactionlog.DeletionVectorEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
@@ -588,6 +590,36 @@ public class TestDeltaLakeMetadata
             assertThat(checksumTableHandle.getMetadataEntry()).isEqualTo(transactionLogTableHandle.getMetadataEntry());
             assertThat(checksumTableHandle.getProtocolEntry()).isEqualTo(transactionLogTableHandle.getProtocolEntry());
         }
+    }
+
+    @Test
+    public void testCollectLatestDeletionVectors()
+    {
+        DeletionVectorEntry newestDeletionVector = new DeletionVectorEntry("u", "new", OptionalInt.empty(), 1, 2);
+        DeletionVectorEntry olderDeletionVector = new DeletionVectorEntry("u", "old", OptionalInt.empty(), 1, 1);
+        AddFileEntry newestFile = new AddFileEntry(
+                "file.parquet",
+                ImmutableMap.of(),
+                1,
+                1,
+                true,
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of(),
+                Optional.of(newestDeletionVector));
+        AddFileEntry olderFile = new AddFileEntry(
+                "file.parquet",
+                ImmutableMap.of(),
+                1,
+                1,
+                true,
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of(),
+                Optional.of(olderDeletionVector));
+
+        assertThat(DeltaLakeMetadata.collectLatestDeletionVectors(ImmutableList.of(newestFile, olderFile).iterator()))
+                .isEqualTo(ImmutableMap.of("file.parquet", newestDeletionVector));
     }
 
     private static ConnectorSession loadMetadataFromChecksumFileSession(boolean enabled)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multiset;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.trino.filesystem.TrinoFileSystem;
@@ -39,6 +40,7 @@ import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.DateTimeEncoding;
 import io.trino.spi.type.Decimals;
@@ -76,6 +78,7 @@ import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorS
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.filesystem.tracing.FileSystemAttributes.FILE_LOCATION;
 import static io.trino.hdfs.HdfsTestUtils.HDFS_FILE_SYSTEM_FACTORY;
+import static io.trino.plugin.deltalake.DeltaLakeColumnType.PARTITION_KEY;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
 import static io.trino.plugin.deltalake.DeltaTestingConnectorSession.SESSION;
 import static io.trino.plugin.deltalake.TestingDeltaLakeUtils.createTable;
@@ -385,6 +388,44 @@ public class TestTransactionLogAccess
 
             assertThat(paths).isEqualTo(EXPECTED_ADD_FILE_PATHS);
         }
+    }
+
+    @Test
+    public void testReverseActiveAddEntriesAreLazy()
+            throws Exception
+    {
+        setupTransactionLogAccess(
+                "person_test_pruning",
+                getClass().getClassLoader().getResource("databricks73/person_test_pruning").toString(),
+                new DeltaLakeConfig().setTransactionLogMaxCachedFileSize(DataSize.ofBytes(0)),
+                Optional.empty());
+        MetadataEntry metadataEntry = transactionLogAccess.getMetadataEntry(SESSION, tracingFileSystemFactory.create(SESSION, tableLocation), tableSnapshot);
+        ProtocolEntry protocolEntry = transactionLogAccess.getProtocolEntry(SESSION, tracingFileSystemFactory.create(SESSION, tableLocation), tableSnapshot);
+        DeltaLakeColumnHandle ageColumn = new DeltaLakeColumnHandle(
+                "age",
+                IntegerType.INTEGER,
+                OptionalInt.empty(),
+                "age",
+                IntegerType.INTEGER,
+                PARTITION_KEY,
+                Optional.empty());
+        TupleDomain<DeltaLakeColumnHandle> partitionConstraint = TupleDomain.withColumnDomains(ImmutableMap.of(ageColumn, Domain.singleValue(IntegerType.INTEGER, 28L)));
+
+        assertFileSystemAccesses(
+                () -> {
+                    try (Stream<AddFileEntry> activeFiles = transactionLogAccess.getActiveFiles(
+                            SESSION,
+                            createTable(metadataEntry, protocolEntry),
+                            Optional.empty(),
+                            tableSnapshot,
+                            partitionConstraint,
+                            alwaysTrue())) {
+                        AddFileEntry addFileEntry = activeFiles.findFirst().orElseThrow();
+                        assertThat(addFileEntry.getCanonicalPartitionValues()).containsEntry("age", Optional.of("28"));
+                        assertThat(addFileEntry.getModificationTime()).isEqualTo(9999999L);
+                    }
+                },
+                ImmutableMultiset.of(new FileOperation("00000000000000000014.json", "InputFile.newStream")));
     }
 
     @Test

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestActiveAddEntriesIterator.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestActiveAddEntriesIterator.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.transactionlog;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.memory.MemoryFileSystem;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry.addFileEntry;
+import static io.trino.plugin.deltalake.transactionlog.TransactionLogAccess.activeAddEntries;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestActiveAddEntriesIterator
+{
+    @Test
+    void testCloseBeforeIterationDoesNotAcquireCheckpoint()
+    {
+        AtomicBoolean checkpointOpened = new AtomicBoolean();
+        Supplier<Stream<DeltaLakeTransactionLogEntry>> checkpointEntriesSupplier = () -> {
+            checkpointOpened.set(true);
+            return Stream.empty();
+        };
+
+        try (Stream<AddFileEntry> activeFiles = activeAddEntries(checkpointEntriesSupplier, ImmutableList.of(), new MemoryFileSystem())) {
+            activeFiles.close();
+            assertThat(checkpointOpened.get()).isFalse();
+        }
+    }
+
+    @Test
+    void testJsonReplayFailureDoesNotAcquireCheckpoint()
+            throws IOException
+    {
+        MemoryFileSystem fileSystem = new MemoryFileSystem();
+        Transaction transaction = createTransaction(fileSystem, "{invalid-json}\n");
+        AtomicBoolean checkpointOpened = new AtomicBoolean();
+        Supplier<Stream<DeltaLakeTransactionLogEntry>> checkpointEntriesSupplier = () -> {
+            checkpointOpened.set(true);
+            return Stream.empty();
+        };
+
+        try (Stream<AddFileEntry> activeFiles = activeAddEntries(checkpointEntriesSupplier, ImmutableList.of(transaction), fileSystem)) {
+            assertThatThrownBy(() -> activeFiles.iterator().hasNext())
+                    .isInstanceOf(RuntimeException.class);
+            assertThat(checkpointOpened.get()).isFalse();
+        }
+    }
+
+    @Test
+    void testCheckpointAcquisitionFailure()
+    {
+        RuntimeException acquisitionFailure = new RuntimeException("checkpoint acquisition failed");
+        Supplier<Stream<DeltaLakeTransactionLogEntry>> checkpointEntriesSupplier = () -> {
+            throw acquisitionFailure;
+        };
+
+        try (Stream<AddFileEntry> activeFiles = activeAddEntries(checkpointEntriesSupplier, ImmutableList.of(), new MemoryFileSystem())) {
+            assertThatThrownBy(() -> activeFiles.iterator().hasNext())
+                    .isSameAs(acquisitionFailure);
+        }
+    }
+
+    @Test
+    void testCheckpointReadFailureSuppressesCloseFailure()
+    {
+        RuntimeException readFailure = new RuntimeException("checkpoint read failed");
+        RuntimeException closeFailure = new RuntimeException("checkpoint close failed");
+        Stream<DeltaLakeTransactionLogEntry> checkpoint = Stream.<DeltaLakeTransactionLogEntry>generate(() -> {
+            throw readFailure;
+        }).onClose(() -> {
+            throw closeFailure;
+        });
+
+        try (Stream<AddFileEntry> activeFiles = activeAddEntries(() -> checkpoint, ImmutableList.of(), new MemoryFileSystem())) {
+            assertThatThrownBy(() -> activeFiles.iterator().hasNext())
+                    .isSameAs(readFailure);
+            assertThat(readFailure.getSuppressed()).containsExactly(closeFailure);
+        }
+    }
+
+    @Test
+    void testCloseAfterFirstCheckpointEntryClosesCheckpointStream()
+    {
+        AtomicBoolean checkpointClosed = new AtomicBoolean();
+        AddFileEntry file = createAddFileEntry(1, Optional.empty());
+        Stream<DeltaLakeTransactionLogEntry> checkpoint = Stream.generate(() -> addFileEntry(file))
+                .onClose(() -> checkpointClosed.set(true));
+
+        try (Stream<AddFileEntry> activeFiles = activeAddEntries(() -> checkpoint, ImmutableList.of(), new MemoryFileSystem())) {
+            assertThat(activeFiles.findFirst()).contains(file);
+            assertThat(checkpointClosed.get()).isFalse();
+        }
+        assertThat(checkpointClosed.get()).isTrue();
+    }
+
+    @Test
+    void testCheckpointExhaustionClosesCheckpointStream()
+    {
+        AtomicBoolean checkpointClosed = new AtomicBoolean();
+        AddFileEntry file = createAddFileEntry(1, Optional.empty());
+        Stream<DeltaLakeTransactionLogEntry> checkpoint = Stream.of(addFileEntry(file))
+                .onClose(() -> checkpointClosed.set(true));
+
+        try (Stream<AddFileEntry> activeFiles = activeAddEntries(() -> checkpoint, ImmutableList.of(), new MemoryFileSystem())) {
+            assertThat(activeFiles.toList()).containsExactly(file);
+            assertThat(checkpointClosed.get()).isTrue();
+        }
+    }
+
+    @Test
+    void testCloseDuringCheckpointAcquisitionClosesCheckpointStream()
+            throws Exception
+    {
+        CountDownLatch checkpointAcquisitionStarted = new CountDownLatch(1);
+        CountDownLatch finishCheckpointAcquisition = new CountDownLatch(1);
+        AtomicBoolean checkpointClosed = new AtomicBoolean();
+
+        Supplier<Stream<DeltaLakeTransactionLogEntry>> checkpointEntriesSupplier = () -> {
+            checkpointAcquisitionStarted.countDown();
+            assertThat(awaitUninterruptibly(finishCheckpointAcquisition, 10, SECONDS)).isTrue();
+            return Stream.<DeltaLakeTransactionLogEntry>empty()
+                    .onClose(() -> checkpointClosed.set(true));
+        };
+
+        try (ExecutorService iterationExecutor = newSingleThreadExecutor(daemonThreadsNamed("test-active-add-entries-iteration-%s"));
+                ExecutorService closeExecutor = newSingleThreadExecutor(daemonThreadsNamed("test-active-add-entries-close-%s"));
+                Stream<AddFileEntry> activeFiles = activeAddEntries(checkpointEntriesSupplier, ImmutableList.of(), new MemoryFileSystem())) {
+            Future<Boolean> checkpointIteration = iterationExecutor.submit(() -> activeFiles.iterator().hasNext());
+
+            try {
+                assertThat(checkpointAcquisitionStarted.await(10, SECONDS)).isTrue();
+
+                closeExecutor.submit(activeFiles::close).get(10, SECONDS);
+                finishCheckpointAcquisition.countDown();
+
+                assertThat(checkpointIteration.get(10, SECONDS)).isFalse();
+                assertThat(checkpointClosed.get()).isTrue();
+            }
+            finally {
+                finishCheckpointAcquisition.countDown();
+            }
+        }
+    }
+
+    @Test
+    void testAddWinsOverRemoveInSameTransaction()
+            throws IOException
+    {
+        assertAddWinsOverRemoveInSameTransaction(true);
+        assertAddWinsOverRemoveInSameTransaction(false);
+    }
+
+    private static void assertAddWinsOverRemoveInSameTransaction(boolean addFirst)
+            throws IOException
+    {
+        MemoryFileSystem fileSystem = new MemoryFileSystem();
+        String add =
+                """
+                {"add":{"path":"file.parquet","partitionValues":{},"size":1,"modificationTime":2,"dataChange":true}}
+                """;
+        String remove =
+                """
+                {"remove":{"path":"file.parquet","deletionTimestamp":1,"dataChange":true}}
+                """;
+        Transaction transaction = createTransaction(fileSystem, addFirst ? add + remove : remove + add);
+        AddFileEntry checkpointFile = createAddFileEntry(1, Optional.empty());
+
+        try (Stream<AddFileEntry> activeFiles = activeAddEntries(() -> Stream.of(addFileEntry(checkpointFile)), ImmutableList.of(transaction), fileSystem)) {
+            assertThat(activeFiles.toList())
+                    .extracting(AddFileEntry::getModificationTime)
+                    .containsExactly(2L);
+        }
+    }
+
+    @Test
+    void testRemovalMatchesDeletionVectorIdentity()
+            throws IOException
+    {
+        MemoryFileSystem fileSystem = new MemoryFileSystem();
+        DeletionVectorEntry removedDeletionVector = new DeletionVectorEntry("u", "vector", OptionalInt.of(1), 1, 1);
+        DeletionVectorEntry retainedDeletionVector = new DeletionVectorEntry("u", "vector", OptionalInt.of(2), 1, 1);
+        Transaction transaction = createTransaction(fileSystem,
+                """
+                {"remove":{"path":"file.parquet","deletionTimestamp":1,"dataChange":true,"deletionVector":{"storageType":"u","pathOrInlineDv":"vector","offset":1,"sizeInBytes":1,"cardinality":1}}}
+                """);
+        AddFileEntry removedFile = createAddFileEntry(1, Optional.of(removedDeletionVector));
+        AddFileEntry retainedFile = createAddFileEntry(1, Optional.of(retainedDeletionVector));
+
+        try (Stream<AddFileEntry> activeFiles = activeAddEntries(
+                () -> Stream.of(addFileEntry(removedFile), addFileEntry(retainedFile)),
+                ImmutableList.of(transaction),
+                fileSystem)) {
+            assertThat(activeFiles.toList()).containsExactly(retainedFile);
+        }
+    }
+
+    private static AddFileEntry createAddFileEntry(long modificationTime, Optional<DeletionVectorEntry> deletionVector)
+    {
+        return new AddFileEntry(
+                "file.parquet",
+                ImmutableMap.of(),
+                1,
+                modificationTime,
+                true,
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of(),
+                deletionVector);
+    }
+
+    private static Transaction createTransaction(MemoryFileSystem fileSystem, String contents)
+            throws IOException
+    {
+        Location transactionLogPath = Location.of("memory:///delta/00000000000000000001.json");
+        fileSystem.newOutputFile(transactionLogPath).createOrOverwrite(contents.getBytes(UTF_8));
+        TransactionLogEntries transactionLogEntries = new TransactionLogEntries(
+                1,
+                fileSystem.newInputFile(transactionLogPath),
+                DataSize.ofBytes(0));
+        return new Transaction(1, transactionLogEntries);
+    }
+}


### PR DESCRIPTION
## Description

Replay Delta Lake transaction-log tail commits newest first and return active files incrementally. Previously, active-file loading reconciled the entire JSON tail before returning its first file. A consumer that stops after finding a recent matching file can now avoid replaying older commits and opening the checkpoint.

The iterator reconciles each transaction as a unit and identifies logical files by path and deletion-vector unique ID. Deletion-vector collection keeps the newest entry with the changed iteration order. The returned stream owns the deferred checkpoint and closes it on exhaustion, early termination, or failure, including cancellation while checkpoint acquisition is in progress.

## Additional context and related issues

This changes active-file replay after snapshot loading. It does not change JSON-tail caching: small cached log files may already have been read while loading the snapshot, and each visited commit is still processed in full.

Regression coverage checks partition-filtered early termination with filesystem tracing, deletion-vector selection and identity, same-transaction add/remove reconciliation, checkpoint closure, cancellation during acquisition, and preservation of read failures when cleanup also fails.

Validation (Java 25.0.2):

- Built `trino-delta-lake` and its reactor dependencies with tests skipped. Frontend packaging was skipped because the local package registry denied unrelated frontend dependencies.
- `./mvnw -pl :trino-delta-lake -Dair.check.skip-all=true -Dtest=TestActiveAddEntriesIterator,TestTransactionLogAccess,TestDeltaLakeMetadata test`: 43 tests passed.
- `./mvnw -pl :trino-delta-lake validate`: passed, including formatting, license, and Checkstyle checks.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake connector
* Improve active-file loading by replaying recent transaction log commits first and deferring checkpoint reads until needed. ({issue}`issuenumber`)
```
