### PR TITLE
Enable Iceberg Parquet page skipping with column indexes

### DIFF
--- a/docs/src/main/sphinx/object-storage/file-formats.md
+++ b/docs/src/main/sphinx/object-storage/file-formats.md
@@ -94,8 +94,7 @@ with Parquet files performed by supported object storage connectors:
   - `true`
 * - `parquet.use-column-index`
   - Skip reading Parquet pages by using Parquet column indices. The equivalent
-    catalog session property is `parquet_use_column_index`. Only supported by
-    the Delta Lake and Hive connectors.
+    catalog session property is `parquet_use_column_index`.
   - `true`
 * - `parquet.ignore-statistics`
   - Ignore statistics from Parquet to allow querying files with corrupted or

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeParquetPageSkipping.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeParquetPageSkipping.java
@@ -15,21 +15,16 @@ package io.trino.plugin.deltalake;
 
 import com.google.common.io.Resources;
 import io.trino.plugin.hive.BaseTestParquetPageSkipping;
-import io.trino.spi.metrics.Count;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.QueryRunner.MaterializedResultWithPlan;
-import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Objects;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
-import static io.trino.parquet.reader.ParquetReader.COLUMN_INDEX_ROWS_FILTERED;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -178,23 +173,5 @@ public class TestDeltaLakeParquetPageSkipping
                 Files.getLastModifiedTime(dataFile).toMillis());
         Files.writeString(tableLocation.resolve("_delta_log").resolve("00000000000000000001.json"), addAction + "\n");
         return tableName;
-    }
-
-    private void assertUpdateWithPageSkipping(@Language("SQL") String sql, long expectedUpdateCount)
-    {
-        MaterializedResultWithPlan result = getDistributedQueryRunner().executeWithPlan(getSession(), sql);
-        assertThat(result.result().getUpdateCount()).hasValue(expectedUpdateCount);
-        long rowsFilteredByColumnIndex = getDistributedQueryRunner().getCoordinator()
-                .getQueryManager()
-                .getFullQueryInfo(result.queryId())
-                .getQueryStats()
-                .getOperatorSummaries()
-                .stream()
-                .filter(summary -> summary.getOperatorType().startsWith("TableScan") || summary.getOperatorType().startsWith("Scan"))
-                .map(summary -> summary.getConnectorMetrics().getMetrics().get(COLUMN_INDEX_ROWS_FILTERED))
-                .filter(Objects::nonNull)
-                .mapToLong(metric -> ((Count<?>) metric).getTotal())
-                .sum();
-        assertThat(rowsFilteredByColumnIndex).isGreaterThan(0);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestParquetPageSkipping.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestParquetPageSkipping.java
@@ -169,12 +169,7 @@ public abstract class BaseTestParquetPageSkipping
         assertThat(queryStatsWithColumnIndex.getPhysicalInputPositions()).isGreaterThan(0);
         assertThat(queryStatsWithColumnIndex.getPhysicalInputPositions())
                 .isLessThan(queryStatsWithoutColumnIndex.getPhysicalInputPositions());
-        Map<String, Metric<?>> metricsWithColumnIndex = getScanOperatorStats(resultWithColumnIndex.queryId())
-                .getConnectorMetrics()
-                .getMetrics();
-        assertThat(metricsWithColumnIndex).containsKey(COLUMN_INDEX_ROWS_FILTERED);
-        assertThat(((Count<?>) metricsWithColumnIndex.get(COLUMN_INDEX_ROWS_FILTERED)).getTotal())
-                .isGreaterThan(0);
+        assertThat(getColumnIndexRowsFiltered(resultWithColumnIndex.queryId())).isGreaterThan(0);
 
         assertEqualsIgnoreOrder(resultWithColumnIndex.result(), resultWithoutColumnIndex.result());
     }
@@ -215,6 +210,13 @@ public abstract class BaseTestParquetPageSkipping
                 .build();
     }
 
+    protected void assertUpdateWithPageSkipping(@Language("SQL") String sql, long expectedUpdateCount)
+    {
+        MaterializedResultWithPlan result = getDistributedQueryRunner().executeWithPlan(getSession(), sql);
+        assertThat(result.result().getUpdateCount()).hasValue(expectedUpdateCount);
+        assertThat(getColumnIndexRowsFiltered(result.queryId())).isGreaterThan(0);
+    }
+
     protected static String tableName(String tableNamePrefix)
     {
         return tableNamePrefix + "_" + randomNameSuffix();
@@ -235,5 +237,12 @@ public abstract class BaseTestParquetPageSkipping
                 .stream()
                 .filter(summary -> summary.getOperatorType().startsWith("TableScan") || summary.getOperatorType().startsWith("Scan"))
                 .collect(onlyElement());
+    }
+
+    private long getColumnIndexRowsFiltered(QueryId queryId)
+    {
+        Map<String, Metric<?>> metrics = getScanOperatorStats(queryId).getConnectorMetrics().getMetrics();
+        assertThat(metrics).containsKey(COLUMN_INDEX_ROWS_FILTERED);
+        return ((Count<?>) metrics.get(COLUMN_INDEX_ROWS_FILTERED)).getTotal();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -199,6 +199,7 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetSmallFi
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isOrcBloomFiltersEnabled;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isOrcNestedLazy;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isParquetIgnoreStatistics;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.isParquetUseColumnIndex;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isParquetVectorizedDecodingEnabled;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isUseFileSizeFromMetadata;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.useParquetBloomFilter;
@@ -681,8 +682,7 @@ public class IcebergPageSourceProvider
                             .withSmallFileThreshold(getParquetSmallFileThreshold(session))
                             .withIgnoreStatistics(isParquetIgnoreStatistics(session))
                             .withBloomFilter(useParquetBloomFilter(session))
-                            // TODO https://github.com/trinodb/trino/issues/11000
-                            .withUseColumnIndex(false)
+                            .withUseColumnIndex(isParquetUseColumnIndex(session))
                             .withVectorizedDecodingEnabled(isParquetVectorizedDecodingEnabled(session))
                             .build(),
                     predicate,
@@ -1286,7 +1286,7 @@ public class IcebergPageSourceProvider
                     memoryContext,
                     options,
                     exception -> handleException(dataSourceId, exception),
-                    Optional.empty(),
+                    Optional.of(parquetPredicate),
                     Optional.empty(),
                     parquetMetadata.getDecryptionContext());
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -83,6 +83,7 @@ public final class IcebergSessionProperties
     private static final String ORC_WRITER_MAX_DICTIONARY_MEMORY = "orc_writer_max_dictionary_memory";
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_USE_BLOOM_FILTER = "parquet_use_bloom_filter";
+    private static final String PARQUET_USE_COLUMN_INDEX = "parquet_use_column_index";
     private static final String PARQUET_MAX_READ_BLOCK_ROW_COUNT = "parquet_max_read_block_row_count";
     private static final String PARQUET_SMALL_FILE_THRESHOLD = "parquet_small_file_threshold";
     private static final String PARQUET_IGNORE_STATISTICS = "parquet_ignore_statistics";
@@ -230,6 +231,11 @@ public final class IcebergSessionProperties
                         PARQUET_USE_BLOOM_FILTER,
                         "Use Parquet Bloom filters",
                         parquetReaderConfig.isUseBloomFilter(),
+                        false))
+                .add(booleanProperty(
+                        PARQUET_USE_COLUMN_INDEX,
+                        "Use Parquet column index",
+                        parquetReaderConfig.isUseColumnIndex(),
                         false))
                 .add(integerProperty(
                         PARQUET_MAX_READ_BLOCK_ROW_COUNT,
@@ -567,6 +573,11 @@ public final class IcebergSessionProperties
     public static boolean useParquetBloomFilter(ConnectorSession session)
     {
         return session.getProperty(PARQUET_USE_BLOOM_FILTER, Boolean.class);
+    }
+
+    public static boolean isParquetUseColumnIndex(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_USE_COLUMN_INDEX, Boolean.class);
     }
 
     public static Duration getDynamicFilteringWaitTimeout(ConnectorSession session)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetPageSkipping.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetPageSkipping.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.io.Resources;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.metastore.HiveMetastore;
+import io.trino.parquet.metadata.BlockMetadata;
+import io.trino.parquet.metadata.ParquetMetadata;
+import io.trino.plugin.hive.BaseTestParquetPageSkipping;
+import io.trino.testing.QueryRunner;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.mapping.MappingUtil;
+import org.apache.iceberg.parquet.Parquet;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static com.google.common.io.Resources.getResource;
+import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static io.trino.plugin.iceberg.IcebergTestUtils.SESSION;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getFileSystemFactory;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getHiveMetastore;
+import static io.trino.plugin.iceberg.IcebergTestUtils.getParquetFileMetadata;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
+import static org.apache.iceberg.TableProperties.DEFAULT_NAME_MAPPING;
+import static org.apache.iceberg.TableProperties.PARQUET_PAGE_ROW_LIMIT;
+import static org.apache.iceberg.TableProperties.PARQUET_PAGE_SIZE_BYTES;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
+import static org.apache.iceberg.mapping.NameMappingParser.toJson;
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIcebergParquetPageSkipping
+        extends BaseTestParquetPageSkipping
+{
+    private TrinoFileSystem fileSystem;
+    private HiveMetastore metastore;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.builder()
+                .addIcebergProperty("iceberg.file-format", "PARQUET")
+                .addIcebergProperty("parquet.use-column-index", "true")
+                .addIcebergProperty("parquet.max-buffer-size", "1MB")
+                .build();
+    }
+
+    @BeforeAll
+    public void setUp()
+    {
+        fileSystem = getFileSystemFactory(getQueryRunner()).create(SESSION);
+        metastore = getHiveMetastore(getQueryRunner());
+    }
+
+    @Override
+    protected String createTableWithDataFile(String tableNamePrefix, String columnsDefinition, String resourceFileName)
+            throws Exception
+    {
+        String tableName = tableName(tableNamePrefix);
+        assertUpdate(format("CREATE TABLE %s %s WITH (format = 'PARQUET')", tableName, columnsDefinition));
+        BaseTable table = loadTable(tableName);
+        table.updateProperties()
+                .set(DEFAULT_NAME_MAPPING, toJson(MappingUtil.create(table.schema())))
+                .commit();
+        appendIndexedFile(tableName, resourceFileName, Optional.empty());
+        return tableName;
+    }
+
+    @Override
+    protected String timestampMillisType()
+    {
+        return "timestamp(6)";
+    }
+
+    @Test
+    public void testPartitionEvolutionDoesNotReturnEmpty()
+            throws Exception
+    {
+        String tableName = createTableWithDataFile(
+                "test_partition_evolution",
+                """
+                (
+                   orderkey bigint,
+                   custkey bigint,
+                   orderstatus varchar,
+                   totalprice double,
+                   orderdate date,
+                   orderpriority varchar,
+                   clerk varchar,
+                   shippriority integer,
+                   comment varchar,
+                   rvalues array(double))
+                """,
+                "parquet_page_skipping/orders_sorted_by_totalprice/data.parquet");
+        assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES partitioning = ARRAY['orderstatus']");
+        appendIndexedFile(
+                tableName,
+                "parquet_page_skipping/orders_sorted_by_totalprice/data.parquet",
+                Optional.of("O"));
+        @Language("SQL") String query = "SELECT orderkey FROM " + tableName +
+                " WHERE orderstatus = 'O' AND totalprice BETWEEN 100000 AND 131280";
+        assertThat(assertColumnIndexResults(query)).isGreaterThan(0);
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testPositionDeletesWithPageSkipping()
+            throws Exception
+    {
+        testDeletesWithPageSkipping(2);
+    }
+
+    @Test
+    public void testDeletionVectorsWithPageSkipping()
+            throws Exception
+    {
+        testDeletesWithPageSkipping(3);
+    }
+
+    private void testDeletesWithPageSkipping(int formatVersion)
+            throws Exception
+    {
+        String tableName = createParquetV2IndexedTable(formatVersion);
+        @Language("SQL") String neighbors = "SELECT id, payload FROM " + tableName + " WHERE id BETWEEN 8 AND 12 ORDER BY id";
+        assertQuery(neighbors, "VALUES (8, 'row-8'), (9, 'row-9'), (10, 'row-10'), (11, 'row-11'), (12, 'row-12')");
+
+        assertUpdateWithPageSkipping("DELETE FROM " + tableName + " WHERE id = 10", 1);
+        assertQuery(neighbors, "VALUES (8, 'row-8'), (9, 'row-9'), (11, 'row-11'), (12, 'row-12')");
+        assertQueryReturnsEmptyResult("SELECT id FROM " + tableName + " WHERE id = 10");
+        verifyFilteringWithColumnIndex("SELECT id, payload FROM " + tableName + " WHERE id BETWEEN 8 AND 12");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testParquetV2PageSkipping()
+            throws Exception
+    {
+        String tableName = createParquetV2IndexedTable(2);
+        assertParquetV2Pages(tableName);
+        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE id = 10");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testRowIdWithPageSkipping()
+            throws Exception
+    {
+        String tableName = createParquetV2IndexedTable(3, 2);
+        assertUpdateWithPageSkipping("DELETE FROM " + tableName + " WHERE id = 1500", 2);
+        assertQuery(
+                "SELECT id, \"$row_id\" FROM " + tableName + " WHERE id BETWEEN 1499 AND 1501",
+                "VALUES (1499, 1499), (1501, 1501), (1499, 3499), (1501, 3501)");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testUpdateWithPageSkipping()
+            throws Exception
+    {
+        testUpdateWithPageSkipping(2);
+        testUpdateWithPageSkipping(3);
+    }
+
+    private void testUpdateWithPageSkipping(int formatVersion)
+            throws Exception
+    {
+        String tableName = createParquetV2IndexedTable(formatVersion);
+        assertUpdateWithPageSkipping("UPDATE " + tableName + " SET payload = 'updated' WHERE id = 10", 1);
+        assertQuery(
+                "SELECT id, payload FROM " + tableName + " WHERE id BETWEEN 8 AND 12 ORDER BY id",
+                "VALUES (8, 'row-8'), (9, 'row-9'), (10, 'updated'), (11, 'row-11'), (12, 'row-12')");
+        verifyFilteringWithColumnIndex("SELECT id, payload FROM " + tableName + " WHERE id BETWEEN 8 AND 12");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testMergeWithPageSkipping()
+            throws Exception
+    {
+        testMergeWithPageSkipping(2);
+        testMergeWithPageSkipping(3);
+    }
+
+    private void testMergeWithPageSkipping(int formatVersion)
+            throws Exception
+    {
+        String tableName = createParquetV2IndexedTable(formatVersion);
+        assertUpdateWithPageSkipping(
+                "MERGE INTO " + tableName + " t USING (VALUES BIGINT '10') s(id) ON t.id = s.id " +
+                        "WHEN MATCHED THEN UPDATE SET payload = 'updated'",
+                1);
+        assertQuery(
+                "SELECT id, payload FROM " + tableName + " WHERE id BETWEEN 8 AND 12 ORDER BY id",
+                "VALUES (8, 'row-8'), (9, 'row-9'), (10, 'updated'), (11, 'row-11'), (12, 'row-12')");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    private String createParquetV2IndexedTable(int formatVersion)
+            throws Exception
+    {
+        return createParquetV2IndexedTable(formatVersion, 1);
+    }
+
+    private String createParquetV2IndexedTable(int formatVersion, int fileCopies)
+            throws Exception
+    {
+        String tableName = "test_iceberg_page_skipping_v2_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName +
+                " (id bigint, payload varchar) WITH (format = 'PARQUET', format_version = " + formatVersion + ")");
+        BaseTable table = loadTable(tableName);
+        Schema schema = table.schema();
+        AppendFiles append = table.newAppend();
+        for (int copy = 0; copy < fileCopies; copy++) {
+            String dataPath = table.location() + "/data/v2-indexed-" + randomNameSuffix() + ".parquet";
+            FileAppender<Record> writer = Parquet.write(table.io().newOutputFile(dataPath))
+                    .schema(schema)
+                    .createWriterFunc(GenericParquetWriter::create)
+                    .writerVersion(PARQUET_2_0)
+                    .set(PARQUET_ROW_GROUP_SIZE_BYTES, "4096")
+                    .set(PARQUET_PAGE_ROW_LIMIT, "32")
+                    .set(PARQUET_PAGE_SIZE_BYTES, "256")
+                    .build();
+            try {
+                Record record = GenericRecord.create(schema);
+                for (long id = 0; id < 2000; id++) {
+                    record.setField("id", id);
+                    record.setField("payload", "row-" + id);
+                    writer.add(record);
+                }
+            }
+            finally {
+                writer.close();
+            }
+            append.appendFile(DataFiles.builder(table.spec())
+                    .withPath(dataPath)
+                    .withFormat(FileFormat.PARQUET)
+                    .withFileSizeInBytes(writer.length())
+                    .withMetrics(writer.metrics())
+                    .build());
+        }
+        append.commit();
+        return tableName;
+    }
+
+    private BaseTable loadTable(String tableName)
+    {
+        return IcebergTestUtils.loadTable(tableName, metastore, getFileSystemFactory(getQueryRunner()), ICEBERG_CATALOG, "tpch");
+    }
+
+    private void assertParquetV2Pages(String tableName)
+            throws Exception
+    {
+        String filePath = (String) computeScalar(format("SELECT file_path FROM \"%s$files\"", tableName));
+        ParquetMetadata parquetMetadata = getParquetFileMetadata(fileSystem.newInputFile(Location.of(filePath)));
+        assertThat(parquetMetadata.getBlocks()).isNotEmpty();
+        boolean usesV2Pages = parquetMetadata.getBlocks().stream()
+                .flatMap(block -> block.columns().stream())
+                .anyMatch(column -> column.getEncodingStats() != null && column.getEncodingStats().usesV2Pages());
+        assertThat(usesV2Pages).isTrue();
+        boolean hasColumnIndex = parquetMetadata.getBlocks().stream()
+                .flatMap(block -> block.columns().stream())
+                .anyMatch(column -> column.getColumnIndexReference() != null);
+        assertThat(hasColumnIndex).isTrue();
+    }
+
+    private void appendIndexedFile(String tableName, String resourceName, Optional<String> orderstatus)
+            throws Exception
+    {
+        BaseTable table = loadTable(tableName);
+        String dataPath = table.location() + "/data/" + randomNameSuffix() + ".parquet";
+        byte[] parquetFileData = Resources.toByteArray(getResource(resourceName));
+        fileSystem.newOutputFile(Location.of(dataPath)).createOrOverwrite(parquetFileData);
+        ParquetMetadata parquetMetadata = getParquetFileMetadata(fileSystem.newInputFile(Location.of(dataPath)));
+        long recordCount = parquetMetadata.getBlocks().stream()
+                .mapToLong(BlockMetadata::rowCount)
+                .sum();
+        DataFiles.Builder builder = DataFiles.builder(table.spec())
+                .withPath(dataPath)
+                .withFormat(FileFormat.PARQUET)
+                .withFileSizeInBytes(parquetFileData.length)
+                .withRecordCount(recordCount);
+        orderstatus.ifPresent(value -> builder.withPartition(new PartitionData(new Object[] {value})));
+        table.newAppend()
+                .appendFile(builder.build())
+                .commit();
+    }
+}


### PR DESCRIPTION
## Description

Enable Iceberg Parquet page skipping for files that already have column and offset indexes.

Hive and Delta already skip unread Parquet pages when `parquet.use-column-index` is on. Iceberg still forced `withUseColumnIndex(false)` and passed `Optional.empty()` as the `ParquetReader` predicate, so `ParquetReader` never computed page-level row ranges.

This change:

* Adds Iceberg session property `parquet_use_column_index` (catalog `parquet.use-column-index`). Default is the shared Parquet reader default (`true`).
* Passes a Parquet predicate into `ParquetReader` unconditionally. The reader already checks `isUseColumnIndex()`. Predicate columns are matched to file columns by field ID in `getParquetTupleDomain`, so files whose column names differ from the Iceberg schema are handled. Position delete files are read through the same path, so their `file_path` and `pos` predicates skip pages too.
* Builds on #30976, which fixes Parquet file row indexes when pages are skipped and removes the same identity-path skip-off guard from Delta Lake. Iceberg DELETE, UPDATE, MERGE, and `$row_id` now skip pages and still match skip-off results.
* Fixes #11000

Reader-only. Trino Iceberg still does not write page indexes (https://github.com/trinodb/trino/issues/9359), so Iceberg CTAS/INSERT files will not skip. Spark-written Parquet that already has indexes will.

## Additional context and related issues

Kill switch:

```sql
SET SESSION iceberg.parquet_use_column_index = false;
```

`TestIcebergParquetPageSkipping` extends Hive `BaseTestParquetPageSkipping` as Delta Lake does, implementing `createTableWithDataFile` and `timestampMillisType`. Hive indexed fixtures are appended as Iceberg `DataFile`s with name mapping. That covers row-group pruning from page indexes, non-sequential page offsets (https://github.com/trinodb/trino/issues/9097), dotted column names, the INT96 column-index guard (https://github.com/trinodb/trino/issues/16801), and lineitem predicate filtering.

Iceberg-only tests:

* Partition-spec evolution does not return empty
* Parquet V2 indexed files still skip
* v2 position deletes, v3 deletion vectors, UPDATE, and MERGE skip pages and match skip-off results
* `$row_id` is checked across two data files so `first_row_id` is not always zero

`assertUpdateWithPageSkipping` is shared with Delta Lake in `BaseTestParquetPageSkipping`. Hive tables in that base class are not transactional, so DELETE and UPDATE tests stay in the Iceberg and Delta subclasses.

Related:

* https://github.com/trinodb/trino/issues/9359
* https://github.com/trinodb/trino/pull/30976

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Improve performance of querying Parquet files containing column indexes. ({issue}`11000`)
```