### PR TITLE
Fix Parquet reader row numbers when column index skips pages

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -75,6 +75,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.PrimitiveIterator;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.ObjLongConsumer;
@@ -134,6 +135,10 @@ public class ParquetReader
      * Index in the current group of the next row
      */
     private long nextRowInGroup;
+    // Row indexes within the current row group selected by the column index filter, null when every row is read
+    private PrimitiveIterator.OfLong currentGroupSelectedRows;
+    // File row numbers of the current batch, null unless the row number column is requested and the column index filter selected the rows
+    private long[] currentBatchRowNumbers;
     private int batchSize;
     private int nextBatchSize = INITIAL_BATCH_SIZE;
     private final Map<Integer, ColumnReader> columnReaders;
@@ -290,6 +295,8 @@ public class ParquetReader
         private final int expectedPageId = currentPageId;
         private final Block[] blocks = new Block[columnFields.size() + (appendRowNumberColumn ? 1 : 0)];
         private final int rowNumberColumnIndex = appendRowNumberColumn ? columnFields.size() : -1;
+        private final long batchStartRow = lastBatchStartRow();
+        private final long[] batchRowNumbers = currentBatchRowNumbers;
         private SelectedPositions selectedPositions;
 
         private long sizeInBytes;
@@ -323,6 +330,7 @@ public class ParquetReader
         {
             return INSTANCE_SIZE +
                     sizeOf(blocks) +
+                    sizeOf(batchRowNumbers) +
                     selectedPositions.retainedSizeInBytes();
         }
 
@@ -331,6 +339,9 @@ public class ParquetReader
         {
             consumer.accept(this, INSTANCE_SIZE);
             consumer.accept(blocks, sizeOf(blocks));
+            if (batchRowNumbers != null) {
+                consumer.accept(batchRowNumbers, sizeOf(batchRowNumbers));
+            }
             consumer.accept(selectedPositions, selectedPositions.retainedSizeInBytes());
             for (Block block : blocks) {
                 if (block != null) {
@@ -352,7 +363,7 @@ public class ParquetReader
             Block block = blocks[channel];
             if (block == null) {
                 if (channel == rowNumberColumnIndex) {
-                    block = selectedPositions.createRowNumberBlock(lastBatchStartRow());
+                    block = selectedPositions.createRowNumberBlock(batchStartRow, batchRowNumbers);
                 }
                 else {
                     try {
@@ -417,12 +428,17 @@ public class ParquetReader
             return block.getPositions(positions, 0, positionCount);
         }
 
-        public Block createRowNumberBlock(long startRowNumber)
+        public Block createRowNumberBlock(long batchStartRow, @Nullable long[] batchRowNumbers)
         {
             long[] rowNumbers = new long[positionCount];
             for (int i = 0; i < positionCount; i++) {
                 int position = positions == null ? i : positions[i];
-                rowNumbers[i] = startRowNumber + position;
+                if (batchRowNumbers == null) {
+                    rowNumbers[i] = batchStartRow + position;
+                }
+                else {
+                    rowNumbers[i] = batchRowNumbers[position];
+                }
             }
             return new LongArrayBlock(positionCount, Optional.empty(), rowNumbers);
         }
@@ -465,8 +481,21 @@ public class ParquetReader
         batchSize = toIntExact(min(batchSize, currentGroupRowCount - nextRowInGroup));
 
         nextRowInGroup += batchSize;
+        currentBatchRowNumbers = null;
+        if (appendRowNumberColumn && currentGroupSelectedRows != null) {
+            currentBatchRowNumbers = selectedBatchRowNumbers();
+        }
         columnReaders.values().forEach(reader -> reader.prepareNextRead(batchSize));
         return batchSize;
+    }
+
+    private long[] selectedBatchRowNumbers()
+    {
+        long[] rowNumbers = new long[batchSize];
+        for (int i = 0; i < batchSize; i++) {
+            rowNumbers[i] = firstRowIndexInGroup + currentGroupSelectedRows.nextLong();
+        }
+        return rowNumbers;
     }
 
     private boolean advanceToNextRowGroup()
@@ -491,6 +520,7 @@ public class ParquetReader
         firstRowIndexInGroup = rowGroupInfo.fileRowOffset();
         currentGroupRowCount = currentBlockMetadata.getRowCount();
         FilteredRowRanges currentGroupRowRanges = blockRowRanges[currentRowGroup];
+        currentGroupSelectedRows = null;
         log.debug("advanceToNextRowGroup dataSource %s, currentRowGroup %d, rowRanges %s, currentBlockMetadata %s", dataSource.getId(), currentRowGroup, currentGroupRowRanges, currentBlockMetadata);
         if (currentGroupRowRanges != null) {
             long rowCount = currentGroupRowRanges.getRowCount();
@@ -501,6 +531,7 @@ public class ParquetReader
                 return advanceToNextRowGroup();
             }
             currentGroupRowCount = rowCount;
+            currentGroupSelectedRows = currentGroupRowRanges.getParquetRowRanges().iterator();
         }
         nextRowInGroup = 0L;
         initializeColumnReaders();

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReader.java
@@ -20,12 +20,14 @@ import com.google.common.io.Resources;
 import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
 import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.parquet.Column;
 import io.trino.parquet.DiskRange;
 import io.trino.parquet.ParquetDataSource;
 import io.trino.parquet.ParquetDataSourceId;
 import io.trino.parquet.ParquetReaderOptions;
 import io.trino.parquet.metadata.BlockMetadata;
 import io.trino.parquet.metadata.ParquetMetadata;
+import io.trino.parquet.predicate.TupleDomainParquetPredicate;
 import io.trino.parquet.writer.ParquetWriterOptions;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
@@ -40,6 +42,9 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.Type;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.schema.MessageType;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -52,11 +57,18 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.parquet.ParquetTestUtils.createParquetReader;
 import static io.trino.parquet.ParquetTestUtils.generateInputPages;
 import static io.trino.parquet.ParquetTestUtils.writeParquetFile;
+import static io.trino.parquet.ParquetTypeUtils.constructField;
+import static io.trino.parquet.ParquetTypeUtils.getColumnIO;
+import static io.trino.parquet.ParquetTypeUtils.getDescriptors;
+import static io.trino.parquet.ParquetTypeUtils.lookupColumnByName;
+import static io.trino.parquet.predicate.PredicateUtils.buildPredicate;
+import static io.trino.parquet.predicate.PredicateUtils.getFilteredRowGroups;
 import static io.trino.parquet.reader.ParquetReader.COLUMN_INDEX_ROWS_FILTERED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DateType.DATE;
@@ -66,6 +78,7 @@ import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.joda.time.DateTimeZone.UTC;
 
 public class TestParquetReader
 {
@@ -140,14 +153,7 @@ public class TestParquetReader
                 ParquetReaderOptions.defaultOptions());
         ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
         assertThat(parquetMetadata.getBlocks()).hasSize(2);
-        // The predicate and the file are prepared so that page indexes will result in non-overlapping row ranges and eliminate the entire first row group
-        // while the second row group still has to be read
-        TupleDomain<String> predicate = TupleDomain.withColumnDomains(
-                ImmutableMap.of(
-                        "l_shipdate", Domain.multipleValues(DATE, ImmutableList.of(LocalDate.of(1993, 1, 1).toEpochDay(), LocalDate.of(1997, 1, 1).toEpochDay())),
-                        "l_commitdate", Domain.create(ValueSet.ofRanges(Range.greaterThan(DATE, LocalDate.of(1995, 1, 1).toEpochDay())), false)));
-
-        try (ParquetReader reader = createParquetReader(dataSource, parquetMetadata, ParquetReaderOptions.defaultOptions(), newSimpleAggregatedMemoryContext(), types, columnNames, predicate)) {
+        try (ParquetReader reader = createParquetReader(dataSource, parquetMetadata, ParquetReaderOptions.defaultOptions(), newSimpleAggregatedMemoryContext(), types, columnNames, sortedLineitemPageSkippingPredicate())) {
             SourcePage page = reader.nextPage();
             int rowsRead = 0;
             while (page != null) {
@@ -160,6 +166,46 @@ public class TestParquetReader
             // Column index should filter at least the first row group
             assertThat(((Count<?>) metrics.get(COLUMN_INDEX_ROWS_FILTERED)).getTotal())
                     .isGreaterThanOrEqualTo(parquetMetadata.getBlocks().get(0).rowCount());
+        }
+    }
+
+    @Test
+    public void testRowNumbersWithColumnIndex()
+            throws URISyntaxException, IOException
+    {
+        List<String> columnNames = ImmutableList.of("l_shipdate", "l_commitdate", "l_comment");
+        List<Type> types = ImmutableList.of(DATE, DATE, VARCHAR);
+        ParquetReaderOptions options = ParquetReaderOptions.defaultOptions();
+        File file = new File(Resources.getResource("lineitem_sorted_by_shipdate/data.parquet").toURI());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(new FileParquetDataSource(file, options), Optional.empty());
+
+        List<Slice> comments = new ArrayList<>();
+        try (ParquetReader reader = createParquetReader(new FileParquetDataSource(file, options), parquetMetadata, options, newSimpleAggregatedMemoryContext(), types, columnNames, TupleDomain.all())) {
+            for (SourcePage page = reader.nextPage(); page != null; page = reader.nextPage()) {
+                Block comment = page.getBlock(2);
+                for (int position = 0; position < comment.getPositionCount(); position++) {
+                    comments.add(VARCHAR.getSlice(comment, position));
+                }
+            }
+        }
+
+        try (ParquetReader reader = createParquetReaderWithRowNumbers(new FileParquetDataSource(file, options), parquetMetadata, options, types, columnNames, sortedLineitemPageSkippingPredicate())) {
+            int rowsRead = 0;
+            for (SourcePage page = reader.nextPage(); page != null; page = reader.nextPage()) {
+                rowsRead += page.getPositionCount();
+                // Drop the first position twice before loading the row number block
+                for (int i = 0; i < 2 && page.getPositionCount() > 1; i++) {
+                    int[] positions = IntStream.range(0, page.getPositionCount()).toArray();
+                    page.selectPositions(positions, 1, page.getPositionCount() - 1);
+                }
+                Block comment = page.getBlock(2);
+                Block rowNumber = page.getBlock(3);
+                for (int position = 0; position < page.getPositionCount(); position++) {
+                    assertThat(VARCHAR.getSlice(comment, position)).isEqualTo(comments.get(toIntExact(BIGINT.getLong(rowNumber, position))));
+                }
+            }
+            assertThat(rowsRead).isEqualTo(2387);
+            assertThat(reader.getMetrics().getMetrics()).containsKey(COLUMN_INDEX_ROWS_FILTERED);
         }
     }
 
@@ -205,6 +251,60 @@ public class TestParquetReader
             assertThat(blockValues(page.getBlock(0))).containsExactly(firstRow + 3, firstRow + 5);
             assertThat(blockValues(page.getBlock(1))).containsExactly((firstRow + 3) * 10, (firstRow + 5) * 10);
         }
+    }
+
+    // The predicate and the sorted file are prepared so that page indexes result in non-overlapping row ranges
+    // which eliminate the entire first row group while the second row group still has to be read
+    private static TupleDomain<String> sortedLineitemPageSkippingPredicate()
+    {
+        return TupleDomain.withColumnDomains(
+                ImmutableMap.of(
+                        "l_shipdate", Domain.multipleValues(DATE, ImmutableList.of(LocalDate.of(1993, 1, 1).toEpochDay(), LocalDate.of(1997, 1, 1).toEpochDay())),
+                        "l_commitdate", Domain.create(ValueSet.ofRanges(Range.greaterThan(DATE, LocalDate.of(1995, 1, 1).toEpochDay())), false)));
+    }
+
+    private static ParquetReader createParquetReaderWithRowNumbers(
+            ParquetDataSource dataSource,
+            ParquetMetadata parquetMetadata,
+            ParquetReaderOptions options,
+            List<Type> types,
+            List<String> columnNames,
+            TupleDomain<String> predicate)
+            throws IOException
+    {
+        MessageType fileSchema = parquetMetadata.getFileMetaData().getSchema();
+        MessageColumnIO messageColumnIO = getColumnIO(fileSchema, fileSchema);
+        ImmutableList.Builder<Column> columnFields = ImmutableList.builder();
+        for (int i = 0; i < types.size(); i++) {
+            columnFields.add(new Column(columnNames.get(i), constructField(types.get(i), lookupColumnByName(messageColumnIO, columnNames.get(i))).orElseThrow()));
+        }
+        Map<List<String>, ColumnDescriptor> descriptorsByPath = getDescriptors(fileSchema, fileSchema);
+        TupleDomain<ColumnDescriptor> parquetTupleDomain = predicate.transformKeys(columnName -> descriptorsByPath.get(ImmutableList.of(columnName)));
+        TupleDomainParquetPredicate parquetPredicate = buildPredicate(fileSchema, parquetTupleDomain, descriptorsByPath, UTC);
+        List<RowGroupInfo> rowGroups = getFilteredRowGroups(
+                0,
+                dataSource.getEstimatedSize(),
+                dataSource,
+                parquetMetadata,
+                ImmutableList.of(parquetTupleDomain),
+                ImmutableList.of(parquetPredicate),
+                descriptorsByPath,
+                UTC,
+                1000,
+                options);
+        return new ParquetReader(
+                Optional.empty(),
+                columnFields.build(),
+                true,
+                rowGroups,
+                dataSource,
+                UTC,
+                newSimpleAggregatedMemoryContext(),
+                options,
+                RuntimeException::new,
+                Optional.of(parquetPredicate),
+                Optional.empty(),
+                Optional.empty());
     }
 
     private static List<Long> blockValues(Block block)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
@@ -232,7 +232,7 @@ public class DeltaLakePageSourceProvider
                 .withMaxReadBlockSize(getParquetMaxReadBlockSize(session))
                 .withMaxReadBlockRowCount(getParquetMaxReadBlockRowCount(session))
                 .withSmallFileThreshold(getParquetSmallFileThreshold(session))
-                .withUseColumnIndex(!table.isMerge() && split.deletionVector().isEmpty() && isParquetUseColumnIndex(session))
+                .withUseColumnIndex(isParquetUseColumnIndex(session))
                 .withIgnoreStatistics(isParquetIgnoreStatistics(session))
                 .withVectorizedDecodingEnabled(isParquetVectorizedDecodingEnabled(session))
                 .build();

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeParquetPageSkipping.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeParquetPageSkipping.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.io.Resources;
+import io.trino.plugin.hive.BaseTestParquetPageSkipping;
+import io.trino.testing.QueryRunner;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static java.lang.String.format;
+
+public class TestDeltaLakeParquetPageSkipping
+        extends BaseTestParquetPageSkipping
+{
+    private Path catalogDir;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        catalogDir = Files.createTempDirectory("delta-page-skipping");
+        closeAfterClass(() -> deleteRecursively(catalogDir, ALLOW_INSECURE));
+
+        return DeltaLakeQueryRunner.builder()
+                .addDeltaProperty("fs.hadoop.enabled", "true")
+                .addDeltaProperty("hive.metastore.catalog.dir", catalogDir.toUri().toString())
+                .addDeltaProperty("parquet.use-column-index", "true")
+                .addDeltaProperty("parquet.max-buffer-size", "1MB")
+                .build();
+    }
+
+    @Override
+    protected String createTableWithDataFile(String tableNamePrefix, String columnsDefinition, String resourceFileName)
+            throws IOException
+    {
+        String tableName = tableName(tableNamePrefix);
+        Path tableLocation = catalogDir.resolve(tableName);
+        assertUpdate(format("CREATE TABLE %s %s WITH (location = '%s')", tableName, columnsDefinition, tableLocation.toUri()));
+
+        Path dataFile = tableLocation.resolve("data.parquet");
+        try (OutputStream output = Files.newOutputStream(dataFile)) {
+            Resources.copy(Resources.getResource(resourceFileName), output);
+        }
+        String addAction = format(
+                "{\"add\":{\"path\":\"data.parquet\",\"partitionValues\":{},\"size\":%d,\"modificationTime\":%d,\"dataChange\":true}}",
+                Files.size(dataFile),
+                Files.getLastModifiedTime(dataFile).toMillis());
+        Files.writeString(tableLocation.resolve("_delta_log").resolve("00000000000000000001.json"), addAction + "\n");
+        return tableName;
+    }
+
+    @Override
+    protected String timestampMillisType()
+    {
+        return "timestamp(3) with time zone";
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeParquetPageSkipping.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeParquetPageSkipping.java
@@ -15,20 +15,31 @@ package io.trino.plugin.deltalake;
 
 import com.google.common.io.Resources;
 import io.trino.plugin.hive.BaseTestParquetPageSkipping;
+import io.trino.spi.metrics.Count;
 import io.trino.testing.QueryRunner;
+import io.trino.testing.QueryRunner.MaterializedResultWithPlan;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.trino.parquet.reader.ParquetReader.COLUMN_INDEX_ROWS_FILTERED;
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDeltaLakeParquetPageSkipping
         extends BaseTestParquetPageSkipping
 {
+    private static final String LINEITEM_COLUMNS = "(suppkey bigint, extendedprice decimal(12, 2), shipmode varchar, comment varchar)";
+    // Rows sorted by suppkey, so this range lies in pages in the middle of the file
+    private static final String TARGET_ROWS_PREDICATE = "suppkey BETWEEN 25 AND 35";
+
     private Path catalogDir;
 
     @Override
@@ -41,6 +52,7 @@ public class TestDeltaLakeParquetPageSkipping
         return DeltaLakeQueryRunner.builder()
                 .addDeltaProperty("fs.hadoop.enabled", "true")
                 .addDeltaProperty("hive.metastore.catalog.dir", catalogDir.toUri().toString())
+                .addDeltaProperty("delta.enable-non-concurrent-writes", "true")
                 .addDeltaProperty("parquet.use-column-index", "true")
                 .addDeltaProperty("parquet.max-buffer-size", "1MB")
                 .build();
@@ -50,9 +62,111 @@ public class TestDeltaLakeParquetPageSkipping
     protected String createTableWithDataFile(String tableNamePrefix, String columnsDefinition, String resourceFileName)
             throws IOException
     {
+        return createTableWithDataFile(tableNamePrefix, columnsDefinition, resourceFileName, "");
+    }
+
+    @Override
+    protected String timestampMillisType()
+    {
+        return "timestamp(3) with time zone";
+    }
+
+    @Test
+    public void testDeleteWithPageSkipping()
+            throws Exception
+    {
+        testDeleteWithPageSkipping(false);
+        testDeleteWithPageSkipping(true);
+    }
+
+    private void testDeleteWithPageSkipping(boolean deletionVectorsEnabled)
+            throws Exception
+    {
+        String tableName = createLineitemTable(deletionVectorsEnabled);
+        long totalRows = assertColumnIndexResults("SELECT suppkey FROM " + tableName);
+        long targetRows = assertColumnIndexResults("SELECT suppkey FROM " + tableName + " WHERE " + TARGET_ROWS_PREDICATE);
+        assertThat(targetRows).isGreaterThan(0);
+
+        assertUpdateWithPageSkipping("DELETE FROM " + tableName + " WHERE " + TARGET_ROWS_PREDICATE, targetRows);
+
+        assertThat(assertColumnIndexResults("SELECT suppkey FROM " + tableName)).isEqualTo(totalRows - targetRows);
+        assertThat(assertColumnIndexResults("SELECT suppkey FROM " + tableName + " WHERE " + TARGET_ROWS_PREDICATE)).isEqualTo(0);
+        assertThat(assertColumnIndexResults("SELECT suppkey FROM " + tableName + " WHERE suppkey > 50")).isGreaterThan(0);
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testUpdateWithPageSkipping()
+            throws Exception
+    {
+        testUpdateWithPageSkipping(false);
+        testUpdateWithPageSkipping(true);
+    }
+
+    private void testUpdateWithPageSkipping(boolean deletionVectorsEnabled)
+            throws Exception
+    {
+        String tableName = createLineitemTable(deletionVectorsEnabled);
+        long totalRows = assertColumnIndexResults("SELECT suppkey FROM " + tableName);
+        long targetRows = assertColumnIndexResults("SELECT suppkey FROM " + tableName + " WHERE " + TARGET_ROWS_PREDICATE);
+        assertThat(targetRows).isGreaterThan(0);
+
+        assertUpdateWithPageSkipping("UPDATE " + tableName + " SET comment = 'updated' WHERE " + TARGET_ROWS_PREDICATE, targetRows);
+
+        assertThat(assertColumnIndexResults("SELECT suppkey FROM " + tableName)).isEqualTo(totalRows);
+        assertThat(assertColumnIndexResults("SELECT suppkey FROM " + tableName + " WHERE comment = 'updated'")).isEqualTo(targetRows);
+        assertThat(assertColumnIndexResults("SELECT suppkey FROM " + tableName + " WHERE comment = 'updated' AND NOT (" + TARGET_ROWS_PREDICATE + ")")).isEqualTo(0);
+        assertThat(assertColumnIndexResults("SELECT suppkey FROM " + tableName + " WHERE comment <> 'updated' AND " + TARGET_ROWS_PREDICATE)).isEqualTo(0);
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testMergeWithPageSkipping()
+            throws Exception
+    {
+        testMergeWithPageSkipping(false);
+        testMergeWithPageSkipping(true);
+    }
+
+    private void testMergeWithPageSkipping(boolean deletionVectorsEnabled)
+            throws Exception
+    {
+        String tableName = createLineitemTable(deletionVectorsEnabled);
+        long totalRows = assertColumnIndexResults("SELECT suppkey FROM " + tableName);
+        long targetRows = assertColumnIndexResults("SELECT suppkey FROM " + tableName + " WHERE " + TARGET_ROWS_PREDICATE);
+        assertThat(targetRows).isGreaterThan(0);
+
+        assertUpdateWithPageSkipping(
+                format(
+                        "MERGE INTO %s target USING (SELECT * FROM UNNEST(sequence(25, 35))) source(suppkey) " +
+                                "ON target.suppkey = source.suppkey AND target.%s " +
+                                "WHEN MATCHED THEN UPDATE SET comment = 'merged'",
+                        tableName,
+                        TARGET_ROWS_PREDICATE),
+                targetRows);
+
+        assertThat(assertColumnIndexResults("SELECT suppkey FROM " + tableName)).isEqualTo(totalRows);
+        assertThat(assertColumnIndexResults("SELECT suppkey FROM " + tableName + " WHERE comment = 'merged'")).isEqualTo(targetRows);
+        assertThat(assertColumnIndexResults("SELECT suppkey FROM " + tableName + " WHERE comment = 'merged' AND NOT (" + TARGET_ROWS_PREDICATE + ")")).isEqualTo(0);
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    private String createLineitemTable(boolean deletionVectorsEnabled)
+            throws IOException
+    {
+        return createTableWithDataFile(
+                "test_lineitem",
+                LINEITEM_COLUMNS,
+                "parquet_page_skipping/lineitem_sorted_by_suppkey/data.parquet",
+                ", deletion_vectors_enabled = " + deletionVectorsEnabled);
+    }
+
+    private String createTableWithDataFile(String tableNamePrefix, String columnsDefinition, String resourceFileName, String additionalTableProperties)
+            throws IOException
+    {
         String tableName = tableName(tableNamePrefix);
         Path tableLocation = catalogDir.resolve(tableName);
-        assertUpdate(format("CREATE TABLE %s %s WITH (location = '%s')", tableName, columnsDefinition, tableLocation.toUri()));
+        assertUpdate(format("CREATE TABLE %s %s WITH (location = '%s'%s)", tableName, columnsDefinition, tableLocation.toUri(), additionalTableProperties));
 
         Path dataFile = tableLocation.resolve("data.parquet");
         try (OutputStream output = Files.newOutputStream(dataFile)) {
@@ -66,9 +180,21 @@ public class TestDeltaLakeParquetPageSkipping
         return tableName;
     }
 
-    @Override
-    protected String timestampMillisType()
+    private void assertUpdateWithPageSkipping(@Language("SQL") String sql, long expectedUpdateCount)
     {
-        return "timestamp(3) with time zone";
+        MaterializedResultWithPlan result = getDistributedQueryRunner().executeWithPlan(getSession(), sql);
+        assertThat(result.result().getUpdateCount()).hasValue(expectedUpdateCount);
+        long rowsFilteredByColumnIndex = getDistributedQueryRunner().getCoordinator()
+                .getQueryManager()
+                .getFullQueryInfo(result.queryId())
+                .getQueryStats()
+                .getOperatorSummaries()
+                .stream()
+                .filter(summary -> summary.getOperatorType().startsWith("TableScan") || summary.getOperatorType().startsWith("Scan"))
+                .map(summary -> summary.getConnectorMetrics().getMetrics().get(COLUMN_INDEX_ROWS_FILTERED))
+                .filter(Objects::nonNull)
+                .mapToLong(metric -> ((Count<?>) metric).getTotal())
+                .sum();
+        assertThat(rowsFilteredByColumnIndex).isGreaterThan(0);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestParquetPageSkipping.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestParquetPageSkipping.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.Session;
+import io.trino.execution.QueryStats;
+import io.trino.operator.OperatorStats;
+import io.trino.spi.QueryId;
+import io.trino.spi.metrics.Count;
+import io.trino.spi.metrics.Metric;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.QueryRunner.MaterializedResultWithPlan;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static io.trino.parquet.reader.ParquetReader.COLUMN_INDEX_ROWS_FILTERED;
+import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Page skipping tests over Parquet files with column indexes, shared by connectors.
+ * Subclasses create a table backed by a data file from the {@code parquet_page_skipping} test resources.
+ */
+public abstract class BaseTestParquetPageSkipping
+        extends AbstractTestQueryFramework
+{
+    /**
+     * Creates a table over the given resource file and returns its name.
+     */
+    protected abstract String createTableWithDataFile(String tableNamePrefix, String columnsDefinition, String resourceFileName)
+            throws Exception;
+
+    /**
+     * Connector type for a Parquet INT96 timestamp column.
+     */
+    protected abstract String timestampMillisType();
+
+    @Test
+    public void testRowGroupPruningFromPageIndexes()
+            throws Exception
+    {
+        String tableName = createTableWithDataFile(
+                "test_row_group_pruning",
+                """
+                (
+                   orderkey bigint,
+                   custkey bigint,
+                   orderstatus varchar,
+                   totalprice double,
+                   orderdate date,
+                   orderpriority varchar,
+                   clerk varchar,
+                   shippriority integer,
+                   comment varchar,
+                   rvalues array(double))
+                """,
+                "parquet_page_skipping/orders_sorted_by_totalprice/data.parquet");
+
+        int rowCount = assertColumnIndexResults("SELECT * FROM " + tableName + " WHERE totalprice BETWEEN 100000 AND 131280 AND clerk = 'Clerk#000000624'");
+        assertThat(rowCount).isGreaterThan(0);
+
+        // `totalprice BETWEEN 51890 AND 51900` is chosen to lie between min/max values of row group
+        // but outside page level min/max boundaries to trigger pruning of row group using column index
+        assertRowGroupPruning("SELECT * FROM " + tableName + " WHERE totalprice BETWEEN 51890 AND 51900 AND orderkey > 0");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testPageSkippingWithNonSequentialOffsets()
+            throws Exception
+    {
+        String tableName = createTableWithDataFile("test_random", "(col double)", "parquet_page_skipping/random/data.parquet");
+        // These queries select a subset of pages which are stored at non-sequential offsets
+        // This reproduces the issue identified in https://github.com/trinodb/trino/issues/9097
+        for (double i = 0; i < 1; i += 0.1) {
+            assertColumnIndexResults(format("SELECT * FROM %s WHERE col BETWEEN %f AND %f", tableName, i - 0.00001, i + 0.00001));
+        }
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testFilteringOnColumnNameWithDot()
+            throws Exception
+    {
+        String nameInSql = "\"a.dot\"";
+        String tableName = createTableWithDataFile(
+                "test_column_name_with_dot",
+                format("(key varchar, %s varchar)", nameInSql),
+                "parquet_page_skipping/column_name_with_dot/data.parquet");
+
+        assertQuery("SELECT key FROM " + tableName + " WHERE " + nameInSql + " IS NULL", "VALUES ('null value')");
+        assertQuery("SELECT key FROM " + tableName + " WHERE " + nameInSql + " = 'abc'", "VALUES ('sample value')");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testUnsupportedColumnIndex()
+            throws Exception
+    {
+        // Test for https://github.com/trinodb/trino/issues/16801
+        String tableName = createTableWithDataFile(
+                "test_unsupported_column_index",
+                format("(stime %1$s, btime %1$s, detail varchar)", timestampMillisType()),
+                "parquet_page_skipping/unsupported_column_index/data.parquet");
+
+        assertQuery(
+                "SELECT detail, stime IS NULL, btime IS NULL FROM " + tableName + " WHERE btime >= timestamp '2023-03-27 13:30:00'",
+                "VALUES ('record_1', false, false)");
+
+        assertQuery(
+                "SELECT detail, stime IS NULL, btime IS NULL FROM " + tableName + " WHERE detail = 'record_2'",
+                "VALUES ('record_2', false, true)");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testFilteringWithColumnIndex()
+            throws Exception
+    {
+        String tableName = createTableWithDataFile(
+                "test_page_filtering",
+                "(suppkey bigint, extendedprice decimal(12, 2), shipmode varchar, comment varchar)",
+                "parquet_page_skipping/lineitem_sorted_by_suppkey/data.parquet");
+
+        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey = 10");
+        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey BETWEEN 25 AND 35");
+        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey >= 60");
+        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey <= 40");
+        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey IN (25, 35, 50, 80)");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    protected void verifyFilteringWithColumnIndex(@Language("SQL") String query)
+    {
+        QueryRunner queryRunner = getDistributedQueryRunner();
+        MaterializedResultWithPlan resultWithoutColumnIndex = queryRunner.executeWithPlan(
+                noParquetColumnIndexFiltering(getSession()),
+                query);
+        QueryStats queryStatsWithoutColumnIndex = getQueryStats(resultWithoutColumnIndex.queryId());
+        assertThat(queryStatsWithoutColumnIndex.getPhysicalInputPositions()).isGreaterThan(0);
+        Map<String, Metric<?>> metricsWithoutColumnIndex = getScanOperatorStats(resultWithoutColumnIndex.queryId())
+                .getConnectorMetrics()
+                .getMetrics();
+        assertThat(metricsWithoutColumnIndex).doesNotContainKey(COLUMN_INDEX_ROWS_FILTERED);
+
+        MaterializedResultWithPlan resultWithColumnIndex = queryRunner.executeWithPlan(getSession(), query);
+        QueryStats queryStatsWithColumnIndex = getQueryStats(resultWithColumnIndex.queryId());
+        assertThat(queryStatsWithColumnIndex.getPhysicalInputPositions()).isGreaterThan(0);
+        assertThat(queryStatsWithColumnIndex.getPhysicalInputPositions())
+                .isLessThan(queryStatsWithoutColumnIndex.getPhysicalInputPositions());
+        Map<String, Metric<?>> metricsWithColumnIndex = getScanOperatorStats(resultWithColumnIndex.queryId())
+                .getConnectorMetrics()
+                .getMetrics();
+        assertThat(metricsWithColumnIndex).containsKey(COLUMN_INDEX_ROWS_FILTERED);
+        assertThat(((Count<?>) metricsWithColumnIndex.get(COLUMN_INDEX_ROWS_FILTERED)).getTotal())
+                .isGreaterThan(0);
+
+        assertEqualsIgnoreOrder(resultWithColumnIndex.result(), resultWithoutColumnIndex.result());
+    }
+
+    protected int assertColumnIndexResults(String query)
+    {
+        MaterializedResult withColumnIndexing = computeActual(query);
+        MaterializedResult withoutColumnIndexing = computeActual(noParquetColumnIndexFiltering(getSession()), query);
+        assertEqualsIgnoreOrder(withColumnIndexing, withoutColumnIndexing);
+        return withoutColumnIndexing.getRowCount();
+    }
+
+    protected void assertRowGroupPruning(@Language("SQL") String sql)
+    {
+        assertQueryStats(
+                noParquetColumnIndexFiltering(getSession()),
+                sql,
+                queryStats -> {
+                    assertThat(queryStats.getPhysicalInputPositions()).isGreaterThan(0);
+                    assertThat(queryStats.getProcessedInputPositions()).isEqualTo(queryStats.getPhysicalInputPositions());
+                },
+                results -> assertThat(results.getRowCount()).isEqualTo(0));
+
+        assertQueryStats(
+                getSession(),
+                sql,
+                queryStats -> {
+                    assertThat(queryStats.getPhysicalInputPositions()).isEqualTo(0);
+                    assertThat(queryStats.getProcessedInputPositions()).isEqualTo(0);
+                },
+                results -> assertThat(results.getRowCount()).isEqualTo(0));
+    }
+
+    protected Session noParquetColumnIndexFiltering(Session session)
+    {
+        return Session.builder(session)
+                .setCatalogSessionProperty(session.getCatalog().orElseThrow(), "parquet_use_column_index", "false")
+                .build();
+    }
+
+    protected static String tableName(String tableNamePrefix)
+    {
+        return tableNamePrefix + "_" + randomNameSuffix();
+    }
+
+    private QueryStats getQueryStats(QueryId queryId)
+    {
+        return getDistributedQueryRunner().getCoordinator()
+                .getQueryManager()
+                .getFullQueryInfo(queryId)
+                .getQueryStats();
+    }
+
+    private OperatorStats getScanOperatorStats(QueryId queryId)
+    {
+        return getQueryStats(queryId)
+                .getOperatorSummaries()
+                .stream()
+                .filter(summary -> summary.getOperatorType().startsWith("TableScan") || summary.getOperatorType().startsWith("Scan"))
+                .collect(onlyElement());
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkipping.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkipping.java
@@ -16,38 +16,25 @@ package io.trino.plugin.hive;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import io.trino.Session;
-import io.trino.execution.QueryStats;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
-import io.trino.operator.OperatorStats;
-import io.trino.spi.QueryId;
-import io.trino.spi.metrics.Count;
-import io.trino.spi.metrics.Metric;
 import io.trino.spi.security.ConnectorIdentity;
-import io.trino.testing.AbstractTestQueryFramework;
-import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.QueryRunner.MaterializedResultWithPlan;
-import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
-import java.util.Map;
 import java.util.UUID;
 
-import static com.google.common.collect.MoreCollectors.onlyElement;
-import static io.trino.parquet.reader.ParquetReader.COLUMN_INDEX_ROWS_FILTERED;
 import static io.trino.plugin.hive.TestingHiveUtils.getConnectorService;
-import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestParquetPageSkipping
-        extends AbstractTestQueryFramework
+        extends BaseTestParquetPageSkipping
 {
     private TrinoFileSystem fileSystem;
 
@@ -68,101 +55,24 @@ public class TestParquetPageSkipping
         return queryRunner;
     }
 
-    @Test
-    public void testRowGroupPruningFromPageIndexes()
-            throws Exception
-    {
-        Location dataFile = copyInDataFile("parquet_page_skipping/orders_sorted_by_totalprice/data.parquet");
-
-        String tableName = "test_row_group_pruning_" + randomNameSuffix();
-        assertUpdate(
-                """
-                CREATE TABLE %s (
-                   orderkey bigint,
-                   custkey bigint,
-                   orderstatus varchar(1),
-                   totalprice double,
-                   orderdate date,
-                   orderpriority varchar(15),
-                   clerk varchar(15),
-                   shippriority integer,
-                   comment varchar(79),
-                   rvalues double array)
-                WITH (
-                   format = 'PARQUET',
-                   external_location = '%s')
-                """.formatted(tableName, dataFile.parentDirectory()));
-
-        int rowCount = assertColumnIndexResults("SELECT * FROM " + tableName + " WHERE totalprice BETWEEN 100000 AND 131280 AND clerk = 'Clerk#000000624'");
-        assertThat(rowCount).isGreaterThan(0);
-
-        // `totalprice BETWEEN 51890 AND 51900` is chosen to lie between min/max values of row group
-        // but outside page level min/max boundaries to trigger pruning of row group using column index
-        assertRowGroupPruning("SELECT * FROM " + tableName + " WHERE totalprice BETWEEN 51890 AND 51900 AND orderkey > 0");
-        assertUpdate("DROP TABLE " + tableName);
-    }
-
-    @Test
-    public void testPageSkippingWithNonSequentialOffsets()
+    @Override
+    protected String createTableWithDataFile(String tableNamePrefix, String columnsDefinition, String resourceFileName)
             throws IOException
     {
-        Location dataFile = copyInDataFile("parquet_page_skipping/random/data.parquet");
-        String tableName = "test_random_" + randomNameSuffix();
+        Location dataFile = copyInDataFile(resourceFileName);
+        String tableName = tableName(tableNamePrefix);
         assertUpdate(format(
-                "CREATE TABLE %s (col double) WITH (format = 'PARQUET', external_location = '%s')",
+                "CREATE TABLE %s %s WITH (format = 'PARQUET', external_location = '%s')",
                 tableName,
+                columnsDefinition,
                 dataFile.parentDirectory()));
-        // These queries select a subset of pages which are stored at non-sequential offsets
-        // This reproduces the issue identified in https://github.com/trinodb/trino/issues/9097
-        for (double i = 0; i < 1; i += 0.1) {
-            assertColumnIndexResults(format("SELECT * FROM %s WHERE col BETWEEN %f AND %f", tableName, i - 0.00001, i + 0.00001));
-        }
-        assertUpdate("DROP TABLE " + tableName);
+        return tableName;
     }
 
-    @Test
-    public void testFilteringOnColumnNameWithDot()
-            throws IOException
+    @Override
+    protected String timestampMillisType()
     {
-        Location dataFile = copyInDataFile("parquet_page_skipping/column_name_with_dot/data.parquet");
-
-        String nameInSql = "\"a.dot\"";
-        String tableName = "test_column_name_with_dot_" + randomNameSuffix();
-
-        assertUpdate(format(
-                "CREATE TABLE %s (key varchar(50), %s varchar(50)) WITH (format = 'PARQUET', external_location = '%s')",
-                tableName,
-                nameInSql,
-                dataFile.parentDirectory()));
-
-        assertQuery("SELECT key FROM " + tableName + " WHERE " + nameInSql + " IS NULL", "VALUES ('null value')");
-        assertQuery("SELECT key FROM " + tableName + " WHERE " + nameInSql + " = 'abc'", "VALUES ('sample value')");
-
-        assertUpdate("DROP TABLE " + tableName);
-    }
-
-    @Test
-    public void testUnsupportedColumnIndex()
-            throws IOException
-    {
-        String tableName = "test_unsupported_column_index_" + randomNameSuffix();
-
-        // Test for https://github.com/trinodb/trino/issues/16801
-        Location dataFile = copyInDataFile("parquet_page_skipping/unsupported_column_index/data.parquet");
-        assertUpdate(format(
-                "CREATE TABLE %s (stime timestamp(3), btime timestamp(3), detail varchar) WITH (format = 'PARQUET', external_location = '%s')",
-                tableName,
-                dataFile.parentDirectory()));
-
-        assertQuery(
-                "SELECT * FROM " + tableName + " WHERE btime >= timestamp '2023-03-27 13:30:00'",
-                "VALUES ('2023-03-31 18:00:00.000', '2023-03-31 18:00:00.000', 'record_1')");
-
-        assertQuery(
-                "SELECT * FROM " + tableName + " WHERE detail = 'record_2'",
-                "VALUES ('2023-03-31 18:00:00.000', null, 'record_2')");
-
-        assertUpdate("DROP TABLE " + tableName);
+        return "timestamp(3)";
     }
 
     @Test
@@ -215,108 +125,6 @@ public class TestParquetPageSkipping
             assertColumnIndexResults(format("SELECT orderkey, orderdate FROM %s WHERE %s IN (%s, %s, %s, %s)", tableName, sortByColumn, lowValue, middleLowValue, middleHighValue, highValue));
         }
         assertUpdate("DROP TABLE " + tableName);
-    }
-
-    @Test
-    public void testFilteringWithColumnIndex()
-            throws IOException
-    {
-        Location dataFile = copyInDataFile("parquet_page_skipping/lineitem_sorted_by_suppkey/data.parquet");
-        String tableName = "test_page_filtering_" + randomNameSuffix();
-        assertUpdate(format(
-                "CREATE TABLE %s (suppkey bigint, extendedprice decimal(12, 2), shipmode varchar(10), comment varchar(44)) " +
-                        "WITH (format = 'PARQUET', external_location = '%s')",
-                tableName,
-                dataFile.parentDirectory()));
-
-        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey = 10");
-        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey BETWEEN 25 AND 35");
-        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey >= 60");
-        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey <= 40");
-        verifyFilteringWithColumnIndex("SELECT * FROM " + tableName + " WHERE suppkey IN (25, 35, 50, 80)");
-
-        assertUpdate("DROP TABLE " + tableName);
-    }
-
-    private void verifyFilteringWithColumnIndex(@Language("SQL") String query)
-    {
-        QueryRunner queryRunner = getDistributedQueryRunner();
-        MaterializedResultWithPlan resultWithoutColumnIndex = queryRunner.executeWithPlan(
-                noParquetColumnIndexFiltering(getSession()),
-                query);
-        QueryStats queryStatsWithoutColumnIndex = getQueryStats(resultWithoutColumnIndex.queryId());
-        assertThat(queryStatsWithoutColumnIndex.getPhysicalInputPositions()).isGreaterThan(0);
-        Map<String, Metric<?>> metricsWithoutColumnIndex = getScanOperatorStats(resultWithoutColumnIndex.queryId())
-                .getConnectorMetrics()
-                .getMetrics();
-        assertThat(metricsWithoutColumnIndex).doesNotContainKey(COLUMN_INDEX_ROWS_FILTERED);
-
-        MaterializedResultWithPlan resultWithColumnIndex = queryRunner.executeWithPlan(getSession(), query);
-        QueryStats queryStatsWithColumnIndex = getQueryStats(resultWithColumnIndex.queryId());
-        assertThat(queryStatsWithColumnIndex.getPhysicalInputPositions()).isGreaterThan(0);
-        assertThat(queryStatsWithColumnIndex.getPhysicalInputPositions())
-                .isLessThan(queryStatsWithoutColumnIndex.getPhysicalInputPositions());
-        Map<String, Metric<?>> metricsWithColumnIndex = getScanOperatorStats(resultWithColumnIndex.queryId())
-                .getConnectorMetrics()
-                .getMetrics();
-        assertThat(metricsWithColumnIndex).containsKey(COLUMN_INDEX_ROWS_FILTERED);
-        assertThat(((Count<?>) metricsWithColumnIndex.get(COLUMN_INDEX_ROWS_FILTERED)).getTotal())
-                .isGreaterThan(0);
-
-        assertEqualsIgnoreOrder(resultWithColumnIndex.result(), resultWithoutColumnIndex.result());
-    }
-
-    private int assertColumnIndexResults(String query)
-    {
-        MaterializedResult withColumnIndexing = computeActual(query);
-        MaterializedResult withoutColumnIndexing = computeActual(noParquetColumnIndexFiltering(getSession()), query);
-        assertEqualsIgnoreOrder(withColumnIndexing, withoutColumnIndexing);
-        return withoutColumnIndexing.getRowCount();
-    }
-
-    private void assertRowGroupPruning(@Language("SQL") String sql)
-    {
-        assertQueryStats(
-                noParquetColumnIndexFiltering(getSession()),
-                sql,
-                queryStats -> {
-                    assertThat(queryStats.getPhysicalInputPositions()).isGreaterThan(0);
-                    assertThat(queryStats.getProcessedInputPositions()).isEqualTo(queryStats.getPhysicalInputPositions());
-                },
-                results -> assertThat(results.getRowCount()).isEqualTo(0));
-
-        assertQueryStats(
-                getSession(),
-                sql,
-                queryStats -> {
-                    assertThat(queryStats.getPhysicalInputPositions()).isEqualTo(0);
-                    assertThat(queryStats.getProcessedInputPositions()).isEqualTo(0);
-                },
-                results -> assertThat(results.getRowCount()).isEqualTo(0));
-    }
-
-    private Session noParquetColumnIndexFiltering(Session session)
-    {
-        return Session.builder(session)
-                .setCatalogSessionProperty(session.getCatalog().orElseThrow(), "parquet_use_column_index", "false")
-                .build();
-    }
-
-    private QueryStats getQueryStats(QueryId queryId)
-    {
-        return getDistributedQueryRunner().getCoordinator()
-                .getQueryManager()
-                .getFullQueryInfo(queryId)
-                .getQueryStats();
-    }
-
-    private OperatorStats getScanOperatorStats(QueryId queryId)
-    {
-        return getQueryStats(queryId)
-                .getOperatorSummaries()
-                .stream()
-                .filter(summary -> summary.getOperatorType().startsWith("TableScan") || summary.getOperatorType().startsWith("Scan"))
-                .collect(onlyElement());
     }
 
     private void buildSortedTables(String tableName, String sortByColumnName, String sortByColumnType)


### PR DESCRIPTION
## Description

`ParquetReader` derived the row number column from the count of selected rows, so when column index page skipping filtered pages the row numbers were positions among the selected rows instead of file row indexes. Delta Lake worked around this by disabling column indexes for merge and deletion vector reads.

The reader now iterates the selected row ranges to produce file row indexes. The Hive Parquet page skipping tests are shared with Delta Lake, and the Delta Lake workaround is removed.

## Additional context and related issues

Extracted from the review of #30971, which needs correct row numbers with page skipping for Iceberg.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake
* Improve performance of reading tables with deletion vectors and of `MERGE`, `UPDATE`, and `DELETE` when Parquet column indexes are enabled. ({issue}`30976`)
```
