### PR TITLE
Use table schema when reading Iceberg branches

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -2112,6 +2112,10 @@ SELECT *
 FROM example.testdb.customer_orders FOR VERSION AS OF 'test-branch';
 ```
 
+A branch is read with the current schema of the table, because a branch is a
+mutable reference that continues to receive writes. A tag, a snapshot ID, and a
+timestamp are read with the schema of the snapshot they resolve to.
+
 ##### Rolling back to a previous snapshot
 
 Use the `$snapshots` metadata table to determine the latest snapshot ID of the

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -108,7 +108,6 @@ import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.DiscretePredicates;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
-import io.trino.spi.connector.PointerType;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
@@ -367,6 +366,7 @@ import static io.trino.plugin.iceberg.IcebergUtil.getTopLevelColumns;
 import static io.trino.plugin.iceberg.IcebergUtil.loadDataManifestsFromSnapshot;
 import static io.trino.plugin.iceberg.IcebergUtil.newCreateTableTransaction;
 import static io.trino.plugin.iceberg.IcebergUtil.schemaFromMetadata;
+import static io.trino.plugin.iceberg.IcebergUtil.snapshotScan;
 import static io.trino.plugin.iceberg.IcebergUtil.validateOrcBloomFilterColumns;
 import static io.trino.plugin.iceberg.IcebergUtil.validateParquetBloomFilterColumns;
 import static io.trino.plugin.iceberg.IcebergUtil.verifyExtraProperties;
@@ -714,15 +714,18 @@ public class IcebergMetadata
         }
 
         if (endVersion.isPresent()) {
-            ConnectorTableVersion version = endVersion.get();
-            long snapshotId = getSnapshotIdFromVersion(session, table, version);
+            ResolvedVersion resolved = resolveVersion(session, table, endVersion.get());
+            // A branch is a mutable reference and reads with the table's current schema;
+            // a tag or snapshot ID reads with the schema of the snapshot it points to
+            Schema schema = resolved.branch().isPresent() ? table.schema() : schemaFor(table, resolved.snapshotId());
             return tableHandleForSnapshot(
                     session,
                     tableName,
                     table,
-                    OptionalLong.of(snapshotId),
-                    schemaForVersion(table, version, snapshotId),
-                    Optional.empty());
+                    OptionalLong.of(resolved.snapshotId()),
+                    schema,
+                    Optional.empty(),
+                    resolved.branch());
         }
         return tableHandleForCurrentSnapshot(session, tableName, table);
     }
@@ -750,7 +753,8 @@ public class IcebergMetadata
                 table,
                 getCurrentSnapshotId(table),
                 table.schema(),
-                Optional.of(table.spec()));
+                Optional.of(table.spec()),
+                Optional.empty());
     }
 
     private IcebergTableHandle tableHandleForSnapshot(
@@ -759,7 +763,8 @@ public class IcebergMetadata
             BaseTable table,
             OptionalLong tableSnapshotId,
             Schema tableSchema,
-            Optional<PartitionSpec> partitionSpec)
+            Optional<PartitionSpec> partitionSpec,
+            Optional<String> branch)
     {
         validateTableForTrino(table, tableSnapshotId);
         Map<String, String> tableProperties = table.properties();
@@ -783,7 +788,8 @@ public class IcebergMetadata
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                branch);
     }
 
     private Optional<IcebergTablePartitioning> getTablePartitioning(ConnectorSession session, Table icebergTable)
@@ -815,28 +821,19 @@ public class IcebergMetadata
                 partitionColumns));
     }
 
-    private static long getSnapshotIdFromVersion(ConnectorSession session, Table table, ConnectorTableVersion version)
+    private static ResolvedVersion resolveVersion(ConnectorSession session, Table table, ConnectorTableVersion version)
     {
         io.trino.spi.type.Type versionType = version.getVersionType();
         return switch (version.getPointerType()) {
-            case TEMPORAL -> getTemporalSnapshotIdFromVersion(session, table, version, versionType);
-            case TARGET_ID -> getTargetSnapshotIdFromVersion(table, version, versionType);
+            case TEMPORAL -> new ResolvedVersion(getTemporalSnapshotIdFromVersion(session, table, version, versionType), Optional.empty());
+            case TARGET_ID -> resolveTargetVersion(table, version, versionType);
         };
     }
 
-    private static Schema schemaForVersion(Table table, ConnectorTableVersion version, long snapshotId)
-    {
-        if (version.getPointerType() == PointerType.TARGET_ID && version.getVersionType() instanceof VarcharType) {
-            // A branch is a mutable reference, so it reads with the table's current schema.
-            // A tag reads with the schema of the snapshot it points to.
-            return schemaFor(table, ((Slice) version.getVersion()).toStringUtf8());
-        }
-        return schemaFor(table, snapshotId);
-    }
-
-    private static long getTargetSnapshotIdFromVersion(Table table, ConnectorTableVersion version, io.trino.spi.type.Type versionType)
+    private static ResolvedVersion resolveTargetVersion(Table table, ConnectorTableVersion version, io.trino.spi.type.Type versionType)
     {
         long snapshotId;
+        Optional<String> branch = Optional.empty();
         if (versionType == BIGINT) {
             snapshotId = (long) version.getVersion();
         }
@@ -847,6 +844,9 @@ public class IcebergMetadata
                 throw new TrinoException(INVALID_ARGUMENTS, "Cannot find snapshot with reference name: " + refName);
             }
             snapshotId = ref.snapshotId();
+            if (ref.isBranch()) {
+                branch = Optional.of(refName);
+            }
         }
         else {
             throw new TrinoException(NOT_SUPPORTED, "Unsupported type for table version: " + versionType.getDisplayName());
@@ -855,8 +855,10 @@ public class IcebergMetadata
         if (table.snapshot(snapshotId) == null) {
             throw new TrinoException(INVALID_ARGUMENTS, "Iceberg snapshot ID does not exists: " + snapshotId);
         }
-        return snapshotId;
+        return new ResolvedVersion(snapshotId, branch);
     }
+
+    private record ResolvedVersion(long snapshotId, Optional<String> branch) {}
 
     private static long getTemporalSnapshotIdFromVersion(ConnectorSession session, Table table, ConnectorTableVersion version, io.trino.spi.type.Type versionType)
     {
@@ -982,8 +984,7 @@ public class IcebergMetadata
                     .collect(toImmutableMap(IcebergColumnHandle::getId, identity()));
 
             Supplier<Map<StructLikeWrapperWithFieldIdToIndex, PartitionSpec>> lazyUniquePartitions = Suppliers.memoize(() -> {
-                TableScan tableScan = icebergTable.newScan()
-                        .useSnapshot(table.getSnapshotId().orElseThrow())
+                TableScan tableScan = snapshotScan(icebergTable, table)
                         .filter(toIcebergExpression(enforcedPredicate))
                         .planWith(icebergPlanningExecutor);
 
@@ -3661,7 +3662,8 @@ public class IcebergMetadata
                 table.isRecordScannedFiles(),
                 table.getMaxScannedFileSize(),
                 table.getConstraintColumns(),
-                table.getForAnalyze());
+                table.getForAnalyze(),
+                table.getBranch());
 
         return Optional.of(new LimitApplicationResult<>(table, false, false));
     }
@@ -3761,7 +3763,8 @@ public class IcebergMetadata
                         table.isRecordScannedFiles(),
                         table.getMaxScannedFileSize(),
                         newConstraintColumns,
-                        table.getForAnalyze()),
+                        table.getForAnalyze(),
+                        table.getBranch()),
                 remainingConstraint.transformKeys(ColumnHandle.class::cast),
                 extractionResult.remainingExpression(),
                 false));
@@ -3934,7 +3937,8 @@ public class IcebergMetadata
                 false, // recordScannedFiles does not affect stats
                 originalHandle.getMaxScannedFileSize(),
                 ImmutableSet.of(), // constraintColumns do not affect stats
-                Optional.empty()); // forAnalyze does not affect stats
+                Optional.empty(), // forAnalyze does not affect stats
+                Optional.empty()); // branch does not affect stats
         return getIncrementally(
                 tableStatisticsCache,
                 cacheKey,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -108,6 +108,7 @@ import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.DiscretePredicates;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
+import io.trino.spi.connector.PointerType;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
@@ -713,13 +714,14 @@ public class IcebergMetadata
         }
 
         if (endVersion.isPresent()) {
-            long snapshotId = getSnapshotIdFromVersion(session, table, endVersion.get());
+            ConnectorTableVersion version = endVersion.get();
+            long snapshotId = getSnapshotIdFromVersion(session, table, version);
             return tableHandleForSnapshot(
                     session,
                     tableName,
                     table,
                     OptionalLong.of(snapshotId),
-                    schemaFor(table, snapshotId),
+                    schemaForVersion(table, version, snapshotId),
                     Optional.empty());
         }
         return tableHandleForCurrentSnapshot(session, tableName, table);
@@ -820,6 +822,16 @@ public class IcebergMetadata
             case TEMPORAL -> getTemporalSnapshotIdFromVersion(session, table, version, versionType);
             case TARGET_ID -> getTargetSnapshotIdFromVersion(table, version, versionType);
         };
+    }
+
+    private static Schema schemaForVersion(Table table, ConnectorTableVersion version, long snapshotId)
+    {
+        if (version.getPointerType() == PointerType.TARGET_ID && version.getVersionType() instanceof VarcharType) {
+            // A branch is a mutable reference, so it reads with the table's current schema.
+            // A tag reads with the schema of the snapshot it points to.
+            return schemaFor(table, ((Slice) version.getVersion()).toStringUtf8());
+        }
+        return schemaFor(table, snapshotId);
     }
 
     private static long getTargetSnapshotIdFromVersion(Table table, ConnectorTableVersion version, io.trino.spi.type.Type versionType)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.Scan;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
 import org.apache.iceberg.metrics.InMemoryMetricsReporter;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.types.TypeUtil;
@@ -48,9 +49,9 @@ import java.util.concurrent.ExecutorService;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getMinimumAssignedSplitWeight;
+import static io.trino.plugin.iceberg.IcebergUtil.snapshotScan;
 import static io.trino.spi.connector.FixedSplitSource.emptySplitSource;
 import static java.util.Objects.requireNonNull;
-import static org.apache.iceberg.util.SnapshotUtil.schemaFor;
 
 public class IcebergSplitManager
         implements ConnectorSplitManager
@@ -151,14 +152,15 @@ public class IcebergSplitManager
             icebergMetadata.disableIncrementalRefresh();
         }
 
-        Schema schema = schemaFor(icebergTable, table.getSnapshotId().orElseThrow());
+        TableScan scan = snapshotScan(icebergTable, table);
+        // The scan binds filters and resolves column names against this schema, so the projection must be built from it
+        Schema schema = scan.schema();
         Set<Integer> projectedIds = table.getProjectedColumns().stream()
                 .map(IcebergColumnHandle::getId)
                 .filter(id -> schema.findField(id) != null) // Newly added column may not be found in current snapshot schema until new files are added
                 .collect(toImmutableSet());
 
-        return icebergTable.newScan()
-                .useSnapshot(table.getSnapshotId().orElseThrow())
+        return scan
                 .project(TypeUtil.select(schema, projectedIds)) // Using Scan.project method because Scan.select throws an exception for nested variant
                 .planWith(executor)
                 .metricsReporter(metricsReporter);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
@@ -77,6 +77,9 @@ public class IcebergTableHandle
     // ANALYZE only. Coordinator-only
     private final Optional<Boolean> forAnalyze;
 
+    // Branch the table was resolved through, if any. Coordinator-only
+    private final Optional<String> branch;
+
     @JsonCreator
     @DoNotCall // For JSON deserialization only
     public static IcebergTableHandle fromJsonForDeserializationOnly(
@@ -116,6 +119,7 @@ public class IcebergTableHandle
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
+                Optional.empty(),
                 Optional.empty());
     }
 
@@ -139,7 +143,8 @@ public class IcebergTableHandle
             boolean recordScannedFiles,
             Optional<DataSize> maxScannedFileSize,
             Set<IcebergColumnHandle> constraintColumns,
-            Optional<Boolean> forAnalyze)
+            Optional<Boolean> forAnalyze,
+            Optional<String> branch)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -165,6 +170,7 @@ public class IcebergTableHandle
         this.maxScannedFileSize = requireNonNull(maxScannedFileSize, "maxScannedFileSize is null");
         this.constraintColumns = ImmutableSet.copyOf(requireNonNull(constraintColumns, "constraintColumns is null"));
         this.forAnalyze = requireNonNull(forAnalyze, "forAnalyze is null");
+        this.branch = requireNonNull(branch, "branch is null");
     }
 
     @JsonProperty
@@ -291,6 +297,11 @@ public class IcebergTableHandle
         return forAnalyze;
     }
 
+    public Optional<String> getBranch()
+    {
+        return branch;
+    }
+
     public SchemaTableName getSchemaTableName()
     {
         return new SchemaTableName(schemaName, tableName);
@@ -323,7 +334,8 @@ public class IcebergTableHandle
                 recordScannedFiles,
                 maxScannedFileSize,
                 constraintColumns,
-                forAnalyze);
+                forAnalyze,
+                branch);
     }
 
     public IcebergTableHandle forAnalyze()
@@ -348,7 +360,8 @@ public class IcebergTableHandle
                 recordScannedFiles,
                 maxScannedFileSize,
                 constraintColumns,
-                Optional.of(true));
+                Optional.of(true),
+                branch);
     }
 
     public IcebergTableHandle forOptimize(boolean recordScannedFiles, DataSize maxScannedFileSize)
@@ -373,7 +386,8 @@ public class IcebergTableHandle
                 recordScannedFiles,
                 Optional.of(maxScannedFileSize),
                 constraintColumns,
-                forAnalyze);
+                forAnalyze,
+                branch);
     }
 
     public IcebergTableHandle withTablePartitioning(Optional<IcebergTablePartitioning> requiredTablePartitioning)
@@ -398,7 +412,8 @@ public class IcebergTableHandle
                 recordScannedFiles,
                 maxScannedFileSize,
                 constraintColumns,
-                forAnalyze);
+                forAnalyze,
+                branch);
     }
 
     @Override
@@ -430,7 +445,8 @@ public class IcebergTableHandle
                 Objects.equals(storageProperties, that.storageProperties) &&
                 Objects.equals(maxScannedFileSize, that.maxScannedFileSize) &&
                 Objects.equals(constraintColumns, that.constraintColumns) &&
-                Objects.equals(forAnalyze, that.forAnalyze);
+                Objects.equals(forAnalyze, that.forAnalyze) &&
+                Objects.equals(branch, that.branch);
     }
 
     @Override
@@ -455,7 +471,8 @@ public class IcebergTableHandle
                 recordScannedFiles,
                 maxScannedFileSize,
                 constraintColumns,
-                forAnalyze);
+                forAnalyze,
+                branch);
     }
 
     @Override
@@ -463,6 +480,7 @@ public class IcebergTableHandle
     {
         StringBuilder builder = new StringBuilder(getSchemaTableNameWithType().toString());
         snapshotId.ifPresent(snapshotId -> builder.append("@").append(snapshotId));
+        branch.ifPresent(branch -> builder.append(" branch=").append(branch));
         if (enforcedPredicate.isNone()) {
             builder.append(" constraint=FALSE");
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -71,12 +71,14 @@ import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableScan;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NotFoundException;
@@ -181,6 +183,7 @@ import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_ALREADY_EXISTS;
+import static io.trino.spi.StandardErrorCode.TRANSACTION_CONFLICT;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -1420,5 +1423,25 @@ public final class IcebergUtil
         catch (NotFoundException | UncheckedIOException e) {
             throw new TrinoException(ICEBERG_INVALID_METADATA, "Error accessing manifest file for table %s".formatted(icebergTable.name()), e);
         }
+    }
+
+    public static TableScan snapshotScan(Table table, IcebergTableHandle handle)
+    {
+        long snapshotId = handle.getSnapshotId().orElseThrow();
+        // Iceberg reads a branch with the table's current schema only when the scan names the ref; a scan
+        // pinned by snapshot ID alone is treated as time travel and binds filters against the snapshot's schema.
+        // Naming main leaves the scan unpinned and resolves the head at planning time, so main is read like an
+        // unversioned query: pinned to the snapshot the handle was resolved with.
+        Optional<String> branchName = handle.getBranch().filter(name -> !name.equals(SnapshotRef.MAIN_BRANCH));
+        if (branchName.isEmpty()) {
+            return table.newScan().useSnapshot(snapshotId);
+        }
+        // The handle's schema and predicates were resolved against the branch head, so the ref must still point there
+        String branch = branchName.orElseThrow();
+        SnapshotRef ref = table.refs().get(branch);
+        if (ref == null || ref.snapshotId() != snapshotId) {
+            throw new TrinoException(TRANSACTION_CONFLICT, "Branch %s of table %s changed during query planning".formatted(branch, table.name()));
+        }
+        return table.newScan().useRef(branch);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -187,7 +187,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                             false,
                             Optional.empty(),
                             ImmutableSet.of(),
-                            Optional.of(false)),
+                            Optional.of(false),
+                            Optional.empty()),
                     transaction);
 
             TupleDomain<ColumnHandle> splitPruningPredicate = TupleDomain.withColumnDomains(
@@ -248,7 +249,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                             false,
                             Optional.empty(),
                             ImmutableSet.of(),
-                            Optional.of(false)),
+                            Optional.of(false),
+                            Optional.empty()),
                     transaction);
 
             try (ConnectorPageSource emptyPageSource = createTestingPageSource(transaction, icebergConfig, split, tableHandle, ImmutableList.of(keyColumnHandle, dataColumnHandle), getDynamicFilter(splitPruningPredicate))) {
@@ -361,7 +363,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                             false,
                             Optional.empty(),
                             ImmutableSet.of(),
-                            Optional.of(false)),
+                            Optional.of(false),
+                            Optional.empty()),
                     transaction);
 
             // Simulate situations where the dynamic filter (e.g.: while performing a JOIN with another table) reduces considerably
@@ -519,7 +522,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                             false,
                             Optional.empty(),
                             ImmutableSet.of(),
-                            Optional.of(false)),
+                            Optional.of(false),
+                            Optional.empty()),
                     transaction);
 
             // Simulate situations where the dynamic filter (e.g.: while performing a JOIN with another table) reduces considerably

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -676,6 +676,7 @@ public class TestIcebergSplitSource
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                Optional.empty());
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -1603,15 +1603,16 @@ public class TestIcebergV2
     {
         try (TestTable table = newTrinoTable("test_reading_snapshot_reference_schema_", "(id integer, data varchar)", ImmutableList.of("(1, 'a')"))) {
             String tableName = table.getName();
-
-            Table icebergTable = loadTable(tableName);
-            long refSnapshotId = icebergTable.currentSnapshot().snapshotId();
-            icebergTable.manageSnapshots()
-                    .createTag("test-tag", refSnapshotId)
-                    .createBranch("test-branch", refSnapshotId)
-                    .commit();
+            long refSnapshotId = createTagAndBranchAtCurrentSnapshot(tableName);
 
             assertUpdate("ALTER TABLE " + tableName + " RENAME COLUMN data TO payload");
+
+            // A filter on the renamed column resolves through the same schema the scan is bound to
+            assertThat(query("SELECT id FROM " + tableName + " FOR VERSION AS OF 'test-branch' WHERE payload = 'a'"))
+                    .matches("VALUES 1");
+            assertThat(query("SELECT id FROM " + tableName + " FOR VERSION AS OF 'main' WHERE payload = 'a'"))
+                    .matches("VALUES 1");
+
             assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN data varchar");
 
             // Branch reads resolve names against the table's current schema and match data by field ID,
@@ -1620,6 +1621,8 @@ public class TestIcebergV2
                     .matches("VALUES VARCHAR 'a'");
             assertThat(query("SELECT data FROM " + tableName + " FOR VERSION AS OF 'test-branch'"))
                     .matches("VALUES CAST(NULL AS varchar)");
+            assertThat(query("SELECT id FROM " + tableName + " FOR VERSION AS OF 'test-branch' WHERE data = 'a'"))
+                    .returnsEmptyResult();
             assertThat(query("SELECT data FROM " + tableName + " FOR VERSION AS OF 'test-tag'"))
                     .matches("VALUES VARCHAR 'a'");
 
@@ -1642,17 +1645,33 @@ public class TestIcebergV2
     }
 
     @Test
+    public void testReadingBranchReferenceWithDeleteFilesAfterSchemaEvolution()
+    {
+        try (TestTable table = newTrinoTable("test_reading_branch_reference_delete_files_", "(id integer, data varchar)", ImmutableList.of("(1, 'a')", "(2, 'b')"))) {
+            String tableName = table.getName();
+            assertUpdate("DELETE FROM " + tableName + " WHERE id = 1", 1);
+            createTagAndBranchAtCurrentSnapshot(tableName);
+
+            assertUpdate("INSERT INTO " + tableName + " VALUES (3, 'c')", 1);
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN extra double");
+
+            // A filter on a column added after the branch head binds against the table's current schema,
+            // including when the branch head carries delete files
+            assertThat(query("SELECT id FROM " + tableName + " FOR VERSION AS OF 'test-branch' WHERE extra IS NULL"))
+                    .matches("VALUES 2");
+            assertThat(query("SELECT id FROM " + tableName + " FOR VERSION AS OF 'test-branch' WHERE extra = 1.0"))
+                    .returnsEmptyResult();
+            assertQueryFails("SELECT id FROM " + tableName + " FOR VERSION AS OF 'test-tag' WHERE extra IS NULL",
+                    ".*Column 'extra' cannot be resolved");
+        }
+    }
+
+    @Test
     public void testReadingSnapshotReferenceAfterPartitionEvolution()
     {
         try (TestTable table = newTrinoTable("test_reading_snapshot_reference_partition_", "(id integer, part integer)", ImmutableList.of("(1, 10)"))) {
             String tableName = table.getName();
-
-            Table icebergTable = loadTable(tableName);
-            long refSnapshotId = icebergTable.currentSnapshot().snapshotId();
-            icebergTable.manageSnapshots()
-                    .createTag("test-tag", refSnapshotId)
-                    .createBranch("test-branch", refSnapshotId)
-                    .commit();
+            createTagAndBranchAtCurrentSnapshot(tableName);
 
             assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES partitioning = ARRAY['part']");
             assertUpdate("INSERT INTO " + tableName + " VALUES (2, 20)", 1);
@@ -2148,6 +2167,17 @@ public class TestIcebergV2
         operations.commit(currentMetadata, currentMetadata.upgradeToFormatVersion(2));
 
         return table;
+    }
+
+    private long createTagAndBranchAtCurrentSnapshot(String tableName)
+    {
+        Table icebergTable = loadTable(tableName);
+        long snapshotId = icebergTable.currentSnapshot().snapshotId();
+        icebergTable.manageSnapshots()
+                .createTag("test-tag", snapshotId)
+                .createBranch("test-branch", snapshotId)
+                .commit();
+        return snapshotId;
     }
 
     private BaseTable loadTable(String tableName)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -57,6 +57,7 @@ import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.SortField;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
@@ -1595,6 +1596,50 @@ public class TestIcebergV2
                     ".*?Cannot find snapshot with reference name: test-wrong-ref");
             assertQueryFails("SELECT * FROM " + tableName + " FOR VERSION AS OF 'TEST-TAG'",
                     ".*?Cannot find snapshot with reference name: TEST-TAG");
+        }
+    }
+
+    @Test
+    public void testReadingSnapshotReferenceAfterSchemaEvolution()
+    {
+        try (TestTable table = newTrinoTable("test_reading_snapshot_reference_schema_", "(id integer, data varchar)")) {
+            String tableName = table.getName();
+            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'a')", 1);
+
+            Table icebergTable = loadTable(tableName);
+            long refSnapshotId = icebergTable.currentSnapshot().snapshotId();
+            icebergTable.manageSnapshots()
+                    .createTag("test-tag", refSnapshotId)
+                    .createBranch("test-branch", refSnapshotId)
+                    .commit();
+
+            assertUpdate("ALTER TABLE " + tableName + " RENAME COLUMN data TO payload");
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN data varchar");
+
+            // Branch reads resolve names against the table's current schema and match data by field ID,
+            // so the renamed column keeps its values and the reused name is a distinct, empty column
+            assertThat(query("SELECT payload FROM " + tableName + " FOR VERSION AS OF 'test-branch'"))
+                    .matches("VALUES VARCHAR 'a'");
+            assertThat(query("SELECT data FROM " + tableName + " FOR VERSION AS OF 'test-branch'"))
+                    .matches("VALUES CAST(NULL AS varchar)");
+            assertThat(query("SELECT data FROM " + tableName + " FOR VERSION AS OF 'test-tag'"))
+                    .matches("VALUES VARCHAR 'a'");
+
+            assertUpdate("ALTER TABLE " + tableName + " DROP COLUMN payload");
+            assertUpdate("ALTER TABLE " + tableName + " DROP COLUMN data");
+            assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN extra double");
+
+            // Branches read with the table's current schema
+            assertThat(query("SELECT * FROM " + tableName + " FOR VERSION AS OF 'test-branch'"))
+                    .matches("VALUES (1, CAST(NULL AS double))");
+            assertThat(query("SELECT * FROM " + tableName + " FOR VERSION AS OF '" + SnapshotRef.MAIN_BRANCH + "'"))
+                    .matches("VALUES (1, CAST(NULL AS double))");
+
+            // Tags and snapshot IDs read with the schema of the snapshot they point to
+            assertThat(query("SELECT * FROM " + tableName + " FOR VERSION AS OF 'test-tag'"))
+                    .matches("VALUES (1, VARCHAR 'a')");
+            assertThat(query("SELECT * FROM " + tableName + " FOR VERSION AS OF " + refSnapshotId))
+                    .matches("VALUES (1, VARCHAR 'a')");
         }
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -57,7 +57,6 @@ import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.SortField;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
@@ -1602,9 +1601,8 @@ public class TestIcebergV2
     @Test
     public void testReadingSnapshotReferenceAfterSchemaEvolution()
     {
-        try (TestTable table = newTrinoTable("test_reading_snapshot_reference_schema_", "(id integer, data varchar)")) {
+        try (TestTable table = newTrinoTable("test_reading_snapshot_reference_schema_", "(id integer, data varchar)", ImmutableList.of("(1, 'a')"))) {
             String tableName = table.getName();
-            assertUpdate("INSERT INTO " + tableName + " VALUES (1, 'a')", 1);
 
             Table icebergTable = loadTable(tableName);
             long refSnapshotId = icebergTable.currentSnapshot().snapshotId();
@@ -1632,7 +1630,7 @@ public class TestIcebergV2
             // Branches read with the table's current schema
             assertThat(query("SELECT * FROM " + tableName + " FOR VERSION AS OF 'test-branch'"))
                     .matches("VALUES (1, CAST(NULL AS double))");
-            assertThat(query("SELECT * FROM " + tableName + " FOR VERSION AS OF '" + SnapshotRef.MAIN_BRANCH + "'"))
+            assertThat(query("SELECT * FROM " + tableName + " FOR VERSION AS OF 'main'"))
                     .matches("VALUES (1, CAST(NULL AS double))");
 
             // Tags and snapshot IDs read with the schema of the snapshot they point to
@@ -1640,6 +1638,35 @@ public class TestIcebergV2
                     .matches("VALUES (1, VARCHAR 'a')");
             assertThat(query("SELECT * FROM " + tableName + " FOR VERSION AS OF " + refSnapshotId))
                     .matches("VALUES (1, VARCHAR 'a')");
+        }
+    }
+
+    @Test
+    public void testReadingSnapshotReferenceAfterPartitionEvolution()
+    {
+        try (TestTable table = newTrinoTable("test_reading_snapshot_reference_partition_", "(id integer, part integer)", ImmutableList.of("(1, 10)"))) {
+            String tableName = table.getName();
+
+            Table icebergTable = loadTable(tableName);
+            long refSnapshotId = icebergTable.currentSnapshot().snapshotId();
+            icebergTable.manageSnapshots()
+                    .createTag("test-tag", refSnapshotId)
+                    .createBranch("test-branch", refSnapshotId)
+                    .commit();
+
+            assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES partitioning = ARRAY['part']");
+            assertUpdate("INSERT INTO " + tableName + " VALUES (2, 20)", 1);
+
+            // Partition evolution is metadata-only; the refs still point at the
+            // pre-evolution snapshot, so only the old data is visible through them
+            assertThat(query("SELECT * FROM " + tableName + " FOR VERSION AS OF 'test-branch'"))
+                    .matches("VALUES (1, 10)");
+            assertThat(query("SELECT * FROM " + tableName + " FOR VERSION AS OF 'test-tag'"))
+                    .matches("VALUES (1, 10)");
+            assertThat(query("SELECT id FROM " + tableName + " FOR VERSION AS OF 'test-branch' WHERE part = 10"))
+                    .matches("VALUES 1");
+            assertThat(query("SELECT * FROM " + tableName))
+                    .matches("VALUES (1, 10), (2, 20)");
         }
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
@@ -177,7 +177,8 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                Optional.empty());
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle fullColumn = partialColumn.getBaseColumn();
@@ -262,7 +263,8 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                Optional.empty());
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle column = IcebergColumnHandle.optional(primitiveColumnIdentity(1, "a")).columnType(INTEGER).build();
@@ -314,7 +316,8 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                Optional.empty());
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle columnA = IcebergColumnHandle.optional(primitiveColumnIdentity(0, "a")).columnType(INTEGER).build();
@@ -376,7 +379,8 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                Optional.empty());
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle bigintColumn = IcebergColumnHandle.optional(primitiveColumnIdentity(1, "just_bigint")).columnType(BIGINT).build();


### PR DESCRIPTION
## Description

`FOR VERSION AS OF '<ref>'` resolves a named ref to its head snapshot and then reads with that snapshot's schema, which is the tag rule. Iceberg defines branch reads differently: a branch is a mutable reference, so it is read with the table's current schema, while a tag is read with the schema of the snapshot it points to ([Schema selection with branches and tags](https://iceberg.apache.org/docs/latest/branching/#schema-selection-with-branches-and-tags)). As a result, any schema evolution since the branch's head commit is not reflected when reading the branch (including `FOR VERSION AS OF 'main'`), and Trino disagrees with Spark and Flink on the same query. See #30970 for the full analysis and worked examples.

The schema is chosen twice, once when the table handle is built and again when Iceberg binds the scan, so the fix has two parts.

`getTableHandle` resolves every version to a snapshot ID as before, and when the version is a ref name that resolves to a branch, it also keeps the branch name. A branch reads with `table.schema()`; a tag, snapshot ID, or timestamp keeps `schemaFor(table, snapshotId)`. The branch name is carried on the table handle for the scan.

Both scan sites build the scan through `IcebergUtil.snapshotScan`. Iceberg treats `useSnapshot(id)` as time travel and binds the scan, its filters, and its partition specs to that snapshot's schema, so a column added after the branch head cannot bind there. `useRef(branch)` binds `table.schema()` instead, so a non-main branch scans by ref.

A ref scan resolves the head from the current metadata rather than from the handle. `snapshotScan` therefore checks that the ref still points at the handle's snapshot and fails with `TRANSACTION_CONFLICT` if the branch moved, rather than silently reading a different snapshot or schema. Within a query the catalog serves analysis and split planning the same cached metadata, so the check should not fire in practice; it guards that invariant.

`main` and every other version keep `useSnapshot`. `useRef("main")` returns an unpinned scan, and at the current snapshot Iceberg skips the spec rebinding, so `FOR VERSION AS OF 'main'` behaves exactly like the unversioned read.

The split manager's projection is built from `scan.schema()` so that field IDs and column-stats names bind against the same schema the scan uses.

Tests: `testReadingSnapshotReferenceAfterSchemaEvolution` covers rename, name reuse, drop, and add, with branch and `main` reads seeing the table schema and tag and snapshot-ID reads keeping the snapshot schema. `testReadingBranchReferenceWithDeleteFilesAfterSchemaEvolution` filters on a column added after a branch head that carries delete files. `testReadingSnapshotReferenceAfterPartitionEvolution` documents that the branch/tag distinction is specific to schema selection, since readers resolve partition specs per manifest.

## Additional context and related issues

- Fixes #30970

Note for reviewers: this changes visible results for `FOR VERSION AS OF '<branch>'` when the table schema has evolved since the branch's head snapshot: the query returns the table's columns instead of the snapshot's. The old behavior contradicts Iceberg's documented semantics and other engines, so this is treated as a bug fix.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Iceberg
* Fix `FOR VERSION AS OF` on a branch reading with the schema of the branch's head snapshot instead of the table's current schema. ({issue}`30970`)
```


