### PR TITLE
Fix system truststore initialization on Linux clients

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
+++ b/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
@@ -356,32 +356,37 @@ public final class OkHttpUtil
     private static KeyStore loadSystemKeyStore(Optional<String> keyStoreType)
             throws IOException, GeneralSecurityException
     {
-        return loadSystemStore(keyStoreType, KEYSTORE_MACOS, KEYSTORE_WINDOWS_MY);
+        Optional<String> systemStoreType = getSystemStoreType(keyStoreType, KEYSTORE_WINDOWS_MY);
+        KeyStore store = KeyStore.getInstance(systemStoreType.orElseGet(KeyStore::getDefaultType));
+        store.load(null, null);
+        return store;
     }
 
     private static KeyStore loadSystemTrustStore(Optional<String> trustStoreType)
             throws IOException, GeneralSecurityException
     {
-        return loadSystemStore(trustStoreType, KEYSTORE_MACOS, KEYSTORE_WINDOWS_ROOT);
+        Optional<String> systemStoreType = getSystemStoreType(trustStoreType, KEYSTORE_WINDOWS_ROOT);
+        if (systemStoreType.isPresent()) {
+            KeyStore store = KeyStore.getInstance(systemStoreType.get());
+            store.load(null, null);
+            return store;
+        }
+        return null;
     }
 
-    private static KeyStore loadSystemStore(Optional<String> storeType, String mac, String windows)
-            throws IOException, GeneralSecurityException
+    private static Optional<String> getSystemStoreType(Optional<String> storeType, String windows)
     {
         String osName = Optional.ofNullable(StandardSystemProperty.OS_NAME.value()).orElse("");
-        Optional<String> systemStoreType = storeType;
-        if (!systemStoreType.isPresent()) {
-            if (osName.contains("Windows")) {
-                systemStoreType = Optional.of(windows);
-            }
-            else if (osName.contains("Mac")) {
-                systemStoreType = Optional.of(mac);
-            }
+        if (storeType.isPresent()) {
+            return storeType;
         }
-
-        KeyStore store = KeyStore.getInstance(systemStoreType.orElseGet(KeyStore::getDefaultType));
-        store.load(null, null);
-        return store;
+        if (osName.contains("Windows")) {
+            return Optional.of(windows);
+        }
+        if (osName.contains("Mac")) {
+            return Optional.of(KEYSTORE_MACOS);
+        }
+        return Optional.empty();
     }
 
     public static void setupKerberos(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fixes #19353

Currently, the CLI attempts to load an empty keystore when passing `--use-system-truststore` on Linux, which directly triggers an `InvalidAlgorithmParameterException` inside `TrustManagerFactory`. Returning `null` for the truststore when the OS is unrecognized lets the JVM automatically fall back to its default cacerts list.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Local testing confirms that the JVM successfully picks up the default system truststore without throwing exceptions on Linux environments, which I verified matches the expected behavior for non-Windows/Mac OS.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## CLI
* Fix `--use-system-truststore` not loading default Java truststore on Linux. ({issue}`19353`)
```
