### PR TITLE
Fix Delta Lake checkpoint deletion-vector identity

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointBuilder.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointBuilder.java
@@ -15,6 +15,7 @@ package io.trino.plugin.deltalake.transactionlog.checkpoint;
 
 import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
+import io.trino.plugin.deltalake.transactionlog.DeletionVectorEntry;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
@@ -24,6 +25,7 @@ import jakarta.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -32,8 +34,8 @@ public class CheckpointBuilder
     private MetadataEntry metadataEntry;
     private ProtocolEntry protocolEntry;
     private final Map<String, TransactionEntry> transactionEntries = new HashMap<>();
-    private final Map<String, AddFileEntry> addFileEntries = new HashMap<>();
-    private final Map<String, RemoveFileEntry> removeFileEntries = new HashMap<>();
+    private final Map<FileEntryKey, AddFileEntry> addFileEntries = new HashMap<>();
+    private final Map<FileEntryKey, RemoveFileEntry> removeFileEntries = new HashMap<>();
 
     public void addLogEntry(DeltaLakeTransactionLogEntry logEntry)
     {
@@ -69,8 +71,9 @@ public class CheckpointBuilder
         if (entry == null) {
             return;
         }
-        addFileEntries.put(entry.getPath(), entry);
-        removeFileEntries.remove(entry.getPath());
+        FileEntryKey key = new FileEntryKey(entry.getPath(), entry.getDeletionVector().map(DeletionVectorEntry::uniqueId));
+        addFileEntries.put(key, entry);
+        removeFileEntries.remove(key);
     }
 
     private void handleRemoveFileEntry(@Nullable RemoveFileEntry entry)
@@ -78,8 +81,9 @@ public class CheckpointBuilder
         if (entry == null) {
             return;
         }
-        removeFileEntries.put(entry.path(), entry);
-        addFileEntries.remove(entry.path());
+        FileEntryKey key = new FileEntryKey(entry.path(), entry.deletionVector().map(DeletionVectorEntry::uniqueId));
+        removeFileEntries.put(key, entry);
+        addFileEntries.remove(key);
     }
 
     public CheckpointEntries build()
@@ -93,4 +97,6 @@ public class CheckpointBuilder
                 ImmutableSet.copyOf(addFileEntries.values()),
                 ImmutableSet.copyOf(removeFileEntries.values()));
     }
+
+    private record FileEntryKey(String path, Optional<String> deletionVectorId) {}
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -461,7 +461,7 @@ public class CheckpointEntryIterator
             return null;
         }
         RowType type = removeType.orElseThrow();
-        int removeFields = 4;
+        int removeFields = 5;
         SqlRow removeEntryRow = getRow(block, pagePosition);
         log.debug("Block %s has %s fields", block, removeEntryRow.getFieldCount());
         if (removeEntryRow.getFieldCount() != removeFields) {
@@ -470,11 +470,8 @@ public class CheckpointEntryIterator
                     format("Expected block %s to have %d children, but found %s", block, removeFields, removeEntryRow.getFieldCount()));
         }
         CheckpointFieldReader remove = new CheckpointFieldReader(removeEntryRow, type);
-        Optional<DeletionVectorEntry> deletionVector = Optional.empty();
-        if (deletionVectorsEnabled) {
-            deletionVector = Optional.ofNullable(remove.getRow("deletionVector"))
-                    .map(row -> parseDeletionVectorFromParquet(row, removeDeletionVectorType.orElseThrow()));
-        }
+        Optional<DeletionVectorEntry> deletionVector = Optional.ofNullable(remove.getRow("deletionVector"))
+                .map(row -> parseDeletionVectorFromParquet(row, removeDeletionVectorType.orElseThrow()));
         RemoveFileEntry result = new RemoveFileEntry(
                 remove.getString("path"),
                 remove.getMap(stringMap, "partitionValues"),

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointSchemaManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointSchemaManager.java
@@ -90,7 +90,8 @@ public class CheckpointSchemaManager
                 RowType.field("path", VARCHAR),
                 RowType.field("partitionValues", stringMap),
                 RowType.field("deletionTimestamp", BIGINT),
-                RowType.field("dataChange", BOOLEAN)));
+                RowType.field("dataChange", BOOLEAN),
+                RowType.field("deletionVector", DELETION_VECTORS_TYPE)));
 
         sidecarEntryType = RowType.from(ImmutableList.<RowType.Field>builder()
                 .add(RowType.field("path", VARCHAR))

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
@@ -450,7 +450,7 @@ public class CheckpointWriter
         ((RowBlockBuilder) entryBlockBuilder).buildEntry(builders -> {
             writeString(builders.get(0), type, 0, "storageType", deletionVector.get().storageType());
             writeString(builders.get(1), type, 1, "pathOrInlineDv", deletionVector.get().pathOrInlineDv());
-            writeLong(builders.get(2), type, 2, "offset", (long) deletionVector.get().offset().orElse(0));
+            writeLong(builders.get(2), type, 2, "offset", deletionVector.get().offset().isPresent() ? (long) deletionVector.get().offset().getAsInt() : null);
             writeLong(builders.get(3), type, 3, "sizeInBytes", (long) deletionVector.get().sizeInBytes());
             writeLong(builders.get(4), type, 4, "cardinality", deletionVector.get().cardinality());
         });
@@ -544,6 +544,7 @@ public class CheckpointWriter
             writeStringMap(fieldBuilders.get(1), entryType, 1, "partitionValues", removeFileEntry.partitionValues());
             writeLong(fieldBuilders.get(2), entryType, 2, "deletionTimestamp", removeFileEntry.deletionTimestamp());
             writeBoolean(fieldBuilders.get(3), entryType, 3, "dataChange", removeFileEntry.dataChange());
+            writeDeletionVector(fieldBuilders.get(4), entryType, removeFileEntry.deletionVector(), 4);
         });
 
         // null for others

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
@@ -450,7 +450,7 @@ public class CheckpointWriter
         ((RowBlockBuilder) entryBlockBuilder).buildEntry(builders -> {
             writeString(builders.get(0), type, 0, "storageType", deletionVector.get().storageType());
             writeString(builders.get(1), type, 1, "pathOrInlineDv", deletionVector.get().pathOrInlineDv());
-            writeLong(builders.get(2), type, 2, "offset", deletionVector.get().offset().isPresent() ? (long) deletionVector.get().offset().getAsInt() : null);
+            writeLong(builders.get(2), type, 2, "offset", deletionVector.get().offset().isPresent() ? (long) deletionVector.get().offset().orElseThrow() : null);
             writeLong(builders.get(3), type, 3, "sizeInBytes", (long) deletionVector.get().sizeInBytes());
             writeLong(builders.get(4), type, 4, "cardinality", deletionVector.get().cardinality());
         });

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointBuilder.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointBuilder.java
@@ -14,22 +14,30 @@
 package io.trino.plugin.deltalake.transactionlog.checkpoint;
 
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
+import io.trino.plugin.deltalake.transactionlog.DeletionVectorEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.deltalake.transactionlog.RemoveFileEntry;
 import io.trino.plugin.deltalake.transactionlog.TransactionEntry;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 
+import static com.google.common.io.Resources.getResource;
+import static com.google.common.io.Resources.readLines;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry.addFileEntry;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry.metadataEntry;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry.protocolEntry;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry.removeFileEntry;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry.transactionEntry;
+import static io.trino.plugin.deltalake.transactionlog.TransactionLogParser.parseJson;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestCheckpointBuilder
@@ -78,5 +86,82 @@ public class TestCheckpointBuilder
                 Set.of(addA2),
                 Set.of(removeB, removeC));
         assertThat(expectedCheckpoint).isEqualTo(builder.build());
+    }
+
+    @Test
+    public void testDeletionVectorAddsBeforeRemoves()
+    {
+        assertDeletionVectorUpdates(true);
+    }
+
+    @Test
+    public void testDeletionVectorRemovesBeforeAdds()
+    {
+        assertDeletionVectorUpdates(false);
+    }
+
+    private static void assertDeletionVectorUpdates(boolean addBeforeRemove)
+    {
+        CheckpointBuilder builder = new CheckpointBuilder();
+        builder.addLogEntry(metadataEntry(new MetadataEntry("1", "", "", new MetadataEntry.Format("parquet", Map.of()), "", List.of(), Map.of(), 1)));
+        builder.addLogEntry(protocolEntry(new ProtocolEntry(3, 7, Optional.of(Set.of("deletionVectors")), Optional.of(Set.of("deletionVectors")))));
+
+        Optional<DeletionVectorEntry> previousDeletionVector = Optional.empty();
+        builder.addLogEntry(addFileEntry(new AddFileEntry("a", Map.of(), 1, 1, true, Optional.empty(), Optional.empty(), Map.of(), previousDeletionVector)));
+        List<RemoveFileEntry> tombstones = new ArrayList<>();
+        for (DeletionVectorEntry deletionVector : List.of(
+                new DeletionVectorEntry("p", "file:///deletion_vector_1.bin", OptionalInt.of(1), 34, 1),
+                new DeletionVectorEntry("p", "file:///deletion_vector_1.bin", OptionalInt.of(39), 36, 2),
+                new DeletionVectorEntry("p", "file:///deletion_vector_2.bin", OptionalInt.of(1), 38, 3))) {
+            AddFileEntry add = new AddFileEntry("a", Map.of(), 1, 1, true, Optional.empty(), Optional.empty(), Map.of(), Optional.of(deletionVector));
+            RemoveFileEntry remove = new RemoveFileEntry("a", Map.of(), 1, true, previousDeletionVector);
+            if (addBeforeRemove) {
+                builder.addLogEntry(addFileEntry(add));
+                builder.addLogEntry(removeFileEntry(remove));
+            }
+            else {
+                builder.addLogEntry(removeFileEntry(remove));
+                builder.addLogEntry(addFileEntry(add));
+            }
+            tombstones.add(remove);
+            CheckpointEntries checkpoint = builder.build();
+            assertThat(checkpoint.addFileEntries()).containsExactly(add);
+            assertThat(checkpoint.removeFileEntries()).containsExactlyInAnyOrderElementsOf(tombstones);
+            previousDeletionVector = Optional.of(deletionVector);
+        }
+
+        RemoveFileEntry remove = new RemoveFileEntry("a", Map.of(), 2, true, previousDeletionVector);
+        builder.addLogEntry(removeFileEntry(remove));
+        tombstones.add(remove);
+        assertThat(builder.build().addFileEntries()).isEmpty();
+        assertThat(builder.build().removeFileEntries()).containsExactlyInAnyOrderElementsOf(tombstones);
+
+        AddFileEntry restored = new AddFileEntry("a", Map.of(), 1, 1, true, Optional.empty(), Optional.empty(), Map.of(), previousDeletionVector);
+        builder.addLogEntry(addFileEntry(restored));
+        tombstones.remove(remove);
+        assertThat(builder.build().addFileEntries()).containsExactly(restored);
+        assertThat(builder.build().removeFileEntries()).containsExactlyInAnyOrderElementsOf(tombstones);
+    }
+
+    @Test
+    public void testCheckpointFromDeletionVectorTransaction()
+            throws IOException
+    {
+        CheckpointBuilder builder = new CheckpointBuilder();
+        for (int version = 0; version <= 2; version++) {
+            for (String line : readLines(getResource("deltalake/deletion_vector_pages/_delta_log/%020d.json".formatted(version)), UTF_8)) {
+                builder.addLogEntry(parseJson(line));
+            }
+        }
+
+        CheckpointEntries checkpoint = builder.build();
+        assertThat(checkpoint.addFileEntries())
+                .extracting(AddFileEntry::getPath)
+                .containsExactlyInAnyOrder(
+                        "part-00000-8e78760d-6337-4ce4-a7b8-3ce3e7c5be44-c000.snappy.parquet",
+                        "part-00000-2007aafe-e829-46a6-b6cf-97f6ec686718.c000.snappy.parquet");
+        assertThat(checkpoint.removeFileEntries())
+                .extracting(RemoveFileEntry::path)
+                .containsExactly("part-00000-8e78760d-6337-4ce4-a7b8-3ce3e7c5be44-c000.snappy.parquet");
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
@@ -29,6 +29,7 @@ import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
 import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
 import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
+import io.trino.plugin.deltalake.transactionlog.DeletionVectorEntry;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
@@ -913,7 +914,7 @@ public class TestCheckpointEntryIterator
                                 ImmutableMap.of("part_key", "2023-01-01 00:00:00"),
                                 1000,
                                 true,
-                                Optional.empty()))
+                                Optional.of(new DeletionVectorEntry("p", "file:///deletion_vector.bin", OptionalInt.of(1), 34, 1))))
                 .collect(toImmutableSet());
 
         CheckpointEntries entries = new CheckpointEntries(
@@ -955,7 +956,9 @@ public class TestCheckpointEntryIterator
 
         assertThat(Iterators.size(metadataAndProtocolEntryIterator)).isEqualTo(2);
         assertThat(Iterators.size(addEntryIterator)).isEqualTo(1);
-        assertThat(Iterators.size(removeEntryIterator)).isEqualTo(numRemoveEntries);
+        assertThat(ImmutableList.copyOf(removeEntryIterator))
+                .extracting(DeltaLakeTransactionLogEntry::getRemove)
+                .containsExactlyInAnyOrderElementsOf(removeEntries);
         assertThat(Iterators.size(txnEntryIterator)).isEqualTo(0);
 
         assertThat(metadataAndProtocolEntryIterator.getCompletedPositions().orElseThrow()).isEqualTo(3L);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
@@ -26,6 +26,7 @@ import io.trino.parquet.ParquetReaderOptions;
 import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
 import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
+import io.trino.plugin.deltalake.transactionlog.DeletionVectorEntry;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
@@ -52,6 +53,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.google.common.base.Predicates.alwaysTrue;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -61,6 +63,10 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.hdfs.HdfsTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.hdfs.HdfsTestUtils.HDFS_FILE_SYSTEM_STATS;
 import static io.trino.plugin.deltalake.DeltaTestingConnectorSession.SESSION;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry.addFileEntry;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry.metadataEntry;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry.protocolEntry;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry.removeFileEntry;
 import static io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator.EntryType.ADD;
 import static io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator.EntryType.METADATA;
 import static io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator.EntryType.PROTOCOL;
@@ -80,6 +86,20 @@ public class TestCheckpointWriter
 {
     private final TypeManager typeManager = TESTING_TYPE_MANAGER;
     private final CheckpointSchemaManager checkpointSchemaManager = new CheckpointSchemaManager(typeManager);
+
+    @Test
+    public void testDeletionVectorRoundtrip()
+            throws IOException
+    {
+        assertDeletionVectorRoundtrip(false);
+    }
+
+    @Test
+    public void testRestoredFileWithoutDeletionVectorRoundtrip()
+            throws IOException
+    {
+        assertDeletionVectorRoundtrip(true);
+    }
 
     @Test
     public void testCheckpointWriteReadJsonRoundtrip()
@@ -430,6 +450,54 @@ public class TestCheckpointWriter
         assertThat(fileStatistics.getMinValues().get()).isEmpty();
         assertThat(fileStatistics.getMaxValues().get()).isEmpty();
         assertThat(fileStatistics.getNullCount().get()).isEmpty();
+    }
+
+    private void assertDeletionVectorRoundtrip(boolean restoreWithoutDeletionVector)
+            throws IOException
+    {
+        MetadataEntry metadata = new MetadataEntry(
+                "metadataId",
+                "",
+                "",
+                new MetadataEntry.Format("parquet", ImmutableMap.of()),
+                "{\"type\":\"struct\",\"fields\":[{\"name\":\"value\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}",
+                ImmutableList.of(),
+                ImmutableMap.of("delta.enableDeletionVectors", "true"),
+                1);
+        ProtocolEntry protocol = new ProtocolEntry(3, 7, Optional.of(ImmutableSet.of("deletionVectors")), Optional.of(ImmutableSet.of("deletionVectors")));
+        CheckpointBuilder builder = new CheckpointBuilder();
+        builder.addLogEntry(metadataEntry(metadata));
+        builder.addLogEntry(protocolEntry(protocol));
+        AddFileEntry original = new AddFileEntry("a", ImmutableMap.of(), 1, 1, true, Optional.empty(), Optional.empty(), ImmutableMap.of(), Optional.empty());
+        builder.addLogEntry(addFileEntry(original));
+
+        Optional<DeletionVectorEntry> previousDeletionVector = Optional.empty();
+        for (DeletionVectorEntry deletionVector : ImmutableList.of(
+                new DeletionVectorEntry("i", "inline", OptionalInt.empty(), 34, 1),
+                new DeletionVectorEntry("p", "file:///deletion_vector.bin", OptionalInt.of(1), 36, 2),
+                new DeletionVectorEntry("p", "file:///deletion_vector.bin", OptionalInt.of(39), 38, 3))) {
+            builder.addLogEntry(removeFileEntry(new RemoveFileEntry("a", ImmutableMap.of(), 1, true, previousDeletionVector)));
+            builder.addLogEntry(addFileEntry(new AddFileEntry("a", ImmutableMap.of(), 1, 1, true, Optional.empty(), Optional.empty(), ImmutableMap.of(), Optional.of(deletionVector))));
+            previousDeletionVector = Optional.of(deletionVector);
+        }
+        if (restoreWithoutDeletionVector) {
+            builder.addLogEntry(removeFileEntry(new RemoveFileEntry("a", ImmutableMap.of(), 2, true, previousDeletionVector)));
+            builder.addLogEntry(addFileEntry(original));
+        }
+
+        CheckpointEntries expected = builder.build();
+        CheckpointEntries entries = expected;
+        for (int checkpoint = 0; checkpoint < 2; checkpoint++) {
+            File targetFile = Files.createTempFile("testDeletionVectorRoundtrip-", ".checkpoint.parquet").toFile();
+            targetFile.deleteOnExit();
+            String targetPath = targetFile.toURI().toString();
+            targetFile.delete();
+            new CheckpointWriter(typeManager, checkpointSchemaManager, "test").write(entries, createOutputFile(targetPath));
+
+            entries = readCheckpoint(targetPath, metadata, protocol, true);
+            assertThat(entries.addFileEntries()).containsExactlyElementsOf(expected.addFileEntries());
+            assertThat(entries.removeFileEntries()).containsExactlyInAnyOrderElementsOf(expected.removeFileEntries());
+        }
     }
 
     private AddFileEntry makeComparable(AddFileEntry original)


### PR DESCRIPTION
## Description

Preserve live files when a Delta Lake checkpoint includes deletion-vector updates. A valid transaction can add a file with a new deletion vector before removing the previous logical file at the same path. CheckpointBuilder previously keyed both actions only by path, so the remove also discarded the live add and subsequent checkpoint-based reads omitted its rows.

Key add and remove actions by path and deletion-vector unique ID, matching normal transaction-log replay. Keep tombstones for earlier logical versions of the same physical file. Write and read the deletion-vector descriptor on remove entries so those identities survive checkpoint serialization. Preserve an absent vector offset as NULL, since substituting zero changes the logical file identity.

## Additional context and related issues

The existing Spark/Delta `deletion_vector_pages` fixture contains this action order. Its version 2 has two active files, including a file with 20,000 remaining live rows; the previous builder retained only the other file.

The regression tests cover both action orders, transitions from no deletion vector to successive vectors, different offsets in the same vector file, tombstone retention, and removal/restoration. Two write/read regressions verify that repeated checkpoint rewrites preserve active files and tombstones, including a file restored without a deletion vector. The existing REMOVE-only reader test also verifies that deletion-vector descriptors survive when ADD entries are not requested.

## Reproduction and validation

After building the module dependencies:

```sh
./mvnw -pl plugin/trino-delta-lake -DbranchScopedLocalRepo.enabled=true \
  -Dtest=TestCheckpointBuilder,TestCheckpointWriter,TestCheckpointEntryIterator test modernizer:modernizer
./mvnw -pl plugin/trino-delta-lake -DbranchScopedLocalRepo.enabled=true validate
```

With the new tests and the original production code, 3 of 4 CheckpointBuilder tests fail. The two serialization regressions also fail before preserving remove-entry deletion vectors. Restoring only the old reader guard makes the REMOVE-only regression fail with missing descriptors. With the complete fix, all 21 tests across the three checkpoint classes pass, including older checkpoint fixtures. Normal Maven checks, including Modernizer, Checkstyle, and Airstyle formatting, pass on Java 25.0.4.1.

## Downsides

Checkpoints retain separate tombstones for earlier deletion-vector identities at the same path, increasing their size compared with incorrectly discarding those entries.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake connector
* Fix missing rows after writing checkpoints for tables with deletion-vector updates. ({issue}`30985`)
```
