### PR TITLE
Preserve aggregate results for outer joins without criteria

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -123,6 +123,12 @@ public class PushAggregationThroughOuterJoin
     {
         JoinNode join = captures.get(JOIN);
 
+        // Without grouping keys, aggregation over an empty inner source produces a row. For example,
+        // count(*) would return 0 instead of counting the null-extended row produced by the outer join.
+        if (join.getCriteria().isEmpty()) {
+            return Result.empty();
+        }
+
         if (join.getFilter().isPresent()
                 || !(join.getType() == JoinType.LEFT || join.getType() == JoinType.RIGHT)
                 || !groupsOnAllColumns(aggregation, getOuterTable(join).getOutputSymbols())

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushAggregationThroughOuterJoin.java
@@ -221,6 +221,42 @@ public class TestPushAggregationThroughOuterJoin
     }
 
     @Test
+    public void testDoesNotFireForLeftJoinWithoutCriteria()
+    {
+        tester().assertThat(new PushAggregationThroughOuterJoin())
+                .on(p -> p.aggregation(ab -> ab
+                        .source(p.join(
+                                LEFT,
+                                p.values(ImmutableList.of(p.symbol("COL1", BIGINT)), ImmutableList.of(ImmutableList.of(new Constant(BIGINT, 10L)))),
+                                p.values(p.symbol("COL2", BIGINT)),
+                                ImmutableList.of(),
+                                ImmutableList.of(p.symbol("COL1", BIGINT)),
+                                ImmutableList.of(p.symbol("COL2", BIGINT)),
+                                Optional.empty()))
+                        .addAggregation(p.symbol("COUNT", BIGINT), PlanBuilder.aggregation("count", ImmutableList.of()), ImmutableList.of())
+                        .singleGroupingSet(p.symbol("COL1", BIGINT))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireForRightJoinWithoutCriteria()
+    {
+        tester().assertThat(new PushAggregationThroughOuterJoin())
+                .on(p -> p.aggregation(ab -> ab
+                        .source(p.join(
+                                RIGHT,
+                                p.values(p.symbol("COL2", BIGINT)),
+                                p.values(ImmutableList.of(p.symbol("COL1", BIGINT)), ImmutableList.of(ImmutableList.of(new Constant(BIGINT, 10L)))),
+                                ImmutableList.of(),
+                                ImmutableList.of(p.symbol("COL2", BIGINT)),
+                                ImmutableList.of(p.symbol("COL1", BIGINT)),
+                                Optional.empty()))
+                        .addAggregation(p.symbol("COUNT", BIGINT), PlanBuilder.aggregation("count", ImmutableList.of()), ImmutableList.of())
+                        .singleGroupingSet(p.symbol("COL1", BIGINT))))
+                .doesNotFire();
+    }
+
+    @Test
     public void testDoesNotFireWhenMultipleGroupingSets()
     {
         tester().assertThat(new PushAggregationThroughOuterJoin())

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
@@ -375,4 +375,37 @@ public class TestJoin
                 .skippingTypesCheck()
                 .matches("VALUES ('a', 'x', 'a', 'x'), ('b', null, 'b', null), (null, 'z', null, 'z')");
     }
+
+    @Test
+    public void testCountOverOuterJoinWithEmptyInnerSide()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT count(*)
+                FROM (VALUES 1) l(a)
+                LEFT JOIN (SELECT * FROM UNNEST(CAST(ARRAY[] AS array(integer)))) r(b) ON true
+                """))
+                .matches("VALUES BIGINT '1'");
+
+        assertThat(assertions.query(
+                """
+                SELECT count(*)
+                FROM (SELECT * FROM UNNEST(CAST(ARRAY[] AS array(integer)))) l(a)
+                RIGHT JOIN (VALUES 1) r(b) ON true
+                """))
+                .matches("VALUES BIGINT '1'");
+    }
+
+    @Test
+    public void testGroupedCountOverOuterJoinWithEmptyInnerSide()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT a, count(*)
+                FROM (SELECT DISTINCT a FROM (VALUES 1, 2) t(a)) l
+                LEFT JOIN (SELECT * FROM UNNEST(CAST(ARRAY[] AS array(integer)))) r(b) ON true
+                GROUP BY a
+                """))
+                .matches("VALUES (1, BIGINT '1'), (2, BIGINT '1')");
+    }
 }


### PR DESCRIPTION
## Description

Preserve aggregate results when an outer join has no equijoin criteria. Pushing aggregation below such a join creates a global aggregation, which emits a row even when its input is empty. That changes `count(*)` over the preserved outer row from `1` to `0`.

```sql
SELECT count(*)
FROM (VALUES 1) l(a)
LEFT JOIN (
    SELECT * FROM UNNEST(CAST(ARRAY[] AS array(integer)))
) r(b) ON true;
```

This returns `0` before the fix and `1` afterward. The rule now skips joins without equijoin criteria. Regressions cover LEFT and RIGHT joins and grouped counts.

## Additional context and related issues

Existing equijoin aggregation pushdown remains covered by the rule tests. The five new regressions failed before the production change. Afterward, all 25 tests in `TestJoin` and `TestPushAggregationThroughOuterJoin` passed. Maven `validate`, including Checkstyle and Airstyle, passed for `core/trino-main`.

```sh
./mvnw -pl core/trino-main -Dtest=TestJoin,TestPushAggregationThroughOuterJoin -Dair.check.skip-all=true test
./mvnw -pl core/trino-main validate
```

## Downsides

Aggregations over outer joins without equijoin criteria can process more intermediate rows because this pushdown is no longer applied.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix incorrect aggregate results for outer joins without equijoin criteria when the inner input is empty.
```
