### PR TITLE
Fix decimal average overflow scaling

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DecimalAverageAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DecimalAverageAggregation.java
@@ -160,7 +160,7 @@ public final class DecimalAverageAggregation
         long overflow = state.getOverflow();
         if (overflow != 0) {
             BigDecimal sum = new BigDecimal(Int128.valueOf(decimal[offset], decimal[offset + 1]).toBigInteger(), type.getScale());
-            sum = sum.add(new BigDecimal(OVERFLOW_MULTIPLIER.multiply(BigInteger.valueOf(overflow))));
+            sum = sum.add(new BigDecimal(OVERFLOW_MULTIPLIER.multiply(BigInteger.valueOf(overflow)), type.getScale()));
 
             BigDecimal count = BigDecimal.valueOf(state.getLong());
             return Decimals.encodeScaledValue(sum.divide(count, type.getScale(), HALF_UP), type.getScale());

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestDecimalAverageAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestDecimalAverageAggregation.java
@@ -22,6 +22,8 @@ import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.Int128;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -160,6 +162,27 @@ public class TestDecimalAverageAggregation
                 .divide(BigInteger.valueOf(4));
 
         assertAverageEquals(state, expectedAverage);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 18, 38})
+    public void testOverflowWithScale(int scale)
+    {
+        DecimalType type = createDecimalType(38, scale);
+        BigInteger value = Decimals.MAX_UNSCALED_DECIMAL.toBigInteger();
+        for (BigInteger number : ImmutableList.of(value, value.negate())) {
+            LongDecimalWithOverflowAndLongState state = new LongDecimalWithOverflowAndLongStateFactory().createSingleState();
+            addToState(type, state, number);
+            addToState(type, state, number);
+            assertThat(state.getOverflow()).isNotZero();
+            assertThat(average(state, type).toBigInteger()).isEqualTo(number);
+
+            LongDecimalWithOverflowAndLongState otherState = new LongDecimalWithOverflowAndLongStateFactory().createSingleState();
+            addToState(type, otherState, number);
+            addToState(type, otherState, number);
+            DecimalAverageAggregation.combine(state, otherState);
+            assertThat(average(state, type).toBigInteger()).isEqualTo(number);
+        }
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestAggregation.java
@@ -41,6 +41,33 @@ public class TestAggregation
     }
 
     @Test
+    public void testDecimalAverageWithScaledOverflow()
+    {
+        assertThat(assertions.query("SELECT avg(x) FROM UNNEST(CAST(ARRAY[0.9, 0.9] AS array(decimal(38,38)))) t(x)"))
+                .matches("VALUES CAST(0.9 AS decimal(38,38))");
+    }
+
+    @Test
+    public void testDecimalAverageWithoutOverflow()
+    {
+        assertThat(assertions.query("SELECT avg(x) FROM UNNEST(CAST(ARRAY[0.8, 0.8] AS array(decimal(38,38)))) t(x)"))
+                .matches("VALUES CAST(0.8 AS decimal(38,38))");
+    }
+
+    @Test
+    public void testDecimalAverageWithScaledOverflowAndZeroValues()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT avg(x)
+                FROM UNNEST(concat(
+                    ARRAY[DECIMAL '9000000000000000000000000000000000000.0', DECIMAL '9000000000000000000000000000000000000.0'],
+                    repeat(CAST(0 AS decimal(38,1)), 98))) t(x)
+                """))
+                .matches("VALUES CAST(DECIMAL '180000000000000000000000000000000000.0' AS decimal(38,1))");
+    }
+
+    @Test
     public void testQuantifiedComparison()
     {
         assertThat(assertions.query("SELECT v > ALL (VALUES 1) FROM (VALUES (1, 1), (1, 2)) t(k, v) GROUP BY k"))


### PR DESCRIPTION
## Description

Apply the decimal scale to both parts of the sum reconstructed by `avg(decimal)`. The wrapped 128-bit sum already uses the input scale, but its overflow contribution was added with scale zero. This could produce an incorrect average or report overflow even when the result was representable.

```sql
SELECT avg(x)
FROM UNNEST(CAST(ARRAY[0.9, 0.9] AS array(decimal(38,38)))) t(x);
```

Before the fix this fails with `Decimal overflow`; afterward it returns `0.9` at scale 38. A separate regression covers a silently incorrect result when large values are averaged together with zeros.

## Additional context and related issues

The change preserves the existing accumulator and rounding behavior. Tests cover positive and negative overflow, scales 1, 2, 18, and 38, and combining overflowing partial states. Existing scale-zero and non-overflow cases remain covered.

Before the production change, six of the seven selected cases failed and the non-overflow control passed. Afterward, all 18 tests in `TestDecimalAverageAggregation` and `TestAggregation` passed. Module validation, including Checkstyle and Airstyle, passed.

```sh
./mvnw -pl core/trino-main -Dtest=TestDecimalAverageAggregation,TestAggregation -Dair.check.skip-all=true test
./mvnw -pl core/trino-main validate
```

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix incorrect results or spurious overflow failures when averaging high-precision decimal values.
```
