### PR TITLE
Fix filtering of extended CASE with NULL operand

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -608,7 +608,7 @@ public class PlanOptimizers
                         costCalculator,
                         ImmutableSet.<Rule<?>>builder()
                                 .add(new InlineProjectIntoFilter())
-                                .add(new SimplifyFilterPredicate(metadata))
+                                .add(new SimplifyFilterPredicate(plannerContext))
                                 .addAll(columnPruningRules)
                                 .add(new InlineProjections())
                                 .addAll(new PushFilterThroughCountAggregation(plannerContext).rules()) // must run after PredicatePushDown and after TransformFilteringSemiJoinToInnerJoin

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyFilterPredicate.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyFilterPredicate.java
@@ -14,18 +14,22 @@
 package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
-import io.trino.metadata.Metadata;
+import io.trino.sql.PlannerContext;
 import io.trino.sql.ir.Case;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.IrExpressions;
+import io.trino.sql.ir.Lambda;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Match;
 import io.trino.sql.ir.MatchClause;
 import io.trino.sql.ir.WhenClause;
+import io.trino.sql.ir.optimizer.IrExpressionOptimizer;
+import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.FilterNode;
 
@@ -42,8 +46,11 @@ import static io.trino.sql.ir.IrExpressions.comparison;
 import static io.trino.sql.ir.IrExpressions.not;
 import static io.trino.sql.ir.IrUtils.combineConjuncts;
 import static io.trino.sql.ir.IrUtils.extractConjuncts;
+import static io.trino.sql.ir.IrUtils.preOrder;
+import static io.trino.sql.ir.optimizer.IrExpressionOptimizer.newOptimizer;
 import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
 import static io.trino.sql.planner.plan.Patterns.filter;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Simplify conditional expressions in filter predicate.
@@ -57,7 +64,8 @@ public class SimplifyFilterPredicate
         implements Rule<FilterNode>
 {
     private static final Pattern<FilterNode> PATTERN = filter();
-    private final Metadata metadata;
+    private final PlannerContext plannerContext;
+    private final IrExpressionOptimizer optimizer;
 
     @Override
     public Pattern<FilterNode> getPattern()
@@ -65,9 +73,10 @@ public class SimplifyFilterPredicate
         return PATTERN;
     }
 
-    public SimplifyFilterPredicate(Metadata metadata)
+    public SimplifyFilterPredicate(PlannerContext plannerContext)
     {
-        this.metadata = metadata;
+        this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
+        this.optimizer = newOptimizer(plannerContext);
     }
 
     @Override
@@ -83,7 +92,7 @@ public class SimplifyFilterPredicate
                     Optional.of((Expression) Logical.and(nullIf.first(), isFalseOrNullPredicate(context.getSession(), nullIf.second()))) :
                     switch (conjunct) {
                         case Case expression -> simplify(context.getSession(), expression);
-                        case Match expression -> simplify(expression);
+                        case Match expression -> simplify(context, expression);
                         case null, default -> Optional.empty();
                     };
 
@@ -208,24 +217,57 @@ public class SimplifyFilterPredicate
         return Optional.empty();
     }
 
-    private static Optional<Expression> simplify(Match caseExpression)
+    private Optional<Expression> simplify(Context context, Match match)
     {
-        Optional<Expression> defaultValue = Optional.of(caseExpression.defaultValue());
+        Expression defaultValue = match.defaultValue();
 
-        if (caseExpression.operand() instanceof Constant literal && literal.value() == null) {
-            return defaultValue;
+        if (match.operand() instanceof Constant operand && operand.value() == null && noClauseMatchesNull(context, match)) {
+            return Optional.of(defaultValue);
         }
 
-        List<Expression> results = caseExpression.clauses().stream()
+        List<Expression> results = match.clauses().stream()
                 .map(MatchClause::result)
                 .collect(toImmutableList());
-        if (results.stream().allMatch(result -> result.equals(TRUE)) && defaultValue.get().equals(TRUE)) {
+        if (results.stream().allMatch(result -> result.equals(TRUE)) && defaultValue.equals(TRUE)) {
             return Optional.of(TRUE);
         }
-        if (results.stream().allMatch(SimplifyFilterPredicate::isNotTrue) && isNotTrue(defaultValue.get())) {
+        if (results.stream().allMatch(SimplifyFilterPredicate::isNotTrue) && isNotTrue(defaultValue)) {
             return Optional.of(FALSE);
         }
         return Optional.empty();
+    }
+
+    /// Whether a NULL operand necessarily selects the default value, i.e. no clause predicate can be
+    /// true for it. A bare-equality clause is such a predicate, since a comparison with NULL is NULL,
+    /// while an extended-CASE clause like `IS NOT DISTINCT FROM x` matches a NULL operand.
+    private boolean noClauseMatchesNull(Context context, Match match)
+    {
+        for (MatchClause clause : match.clauses()) {
+            Lambda predicate = clause.lambda();
+            // the operand parameter comes last, after the values a Bind captures
+            Symbol parameter = predicate.arguments().getLast();
+            if (rebinds(predicate.body(), parameter)) {
+                // an inner lambda parameter of the same name would be bound to NULL along with the operand
+                return false;
+            }
+            Expression body = optimizer.process(
+                            predicate.body(),
+                            context.getSession(),
+                            context.getSymbolAllocator(),
+                            ImmutableMap.of(parameter, new Constant(parameter.type(), null)))
+                    .orElse(predicate.body());
+            if (!isNotTrue(body)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean rebinds(Expression expression, Symbol parameter)
+    {
+        return preOrder(expression)
+                .anyMatch(expr -> expr instanceof Lambda lambda && lambda.arguments().stream()
+                        .anyMatch(argument -> argument.name().equals(parameter.name())));
     }
 
     private static boolean isNotTrue(Expression expression)
@@ -236,6 +278,6 @@ public class SimplifyFilterPredicate
 
     private Expression isFalseOrNullPredicate(Session session, Expression expression)
     {
-        return not(metadata, getCharVarcharCoercion(session), comparison(metadata, getCharVarcharCoercion(session), IDENTICAL, expression, TRUE));
+        return not(plannerContext.getMetadata(), getCharVarcharCoercion(session), comparison(plannerContext.getMetadata(), getCharVarcharCoercion(session), IDENTICAL, expression, TRUE));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyFilterPredicate.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyFilterPredicate.java
@@ -20,11 +20,13 @@ import io.trino.metadata.TestingFunctionResolution;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.sql.ir.Bind;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Case;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.IrExpressions;
+import io.trino.sql.ir.Lambda;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Match;
 import io.trino.sql.ir.MatchClause;
@@ -67,7 +69,7 @@ public class TestSimplifyFilterPredicate
     public void testSimplifyIfExpression()
     {
         // true result iff the condition is true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), TRUE, FALSE),
                         p.values(p.symbol("a"))))
@@ -77,7 +79,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // true result iff the condition is true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), TRUE, new Constant(BOOLEAN, null)),
                         p.values(p.symbol("a"))))
@@ -87,7 +89,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // true result iff the condition is null or false
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), FALSE, TRUE),
                         p.values(p.symbol("a"))))
@@ -97,7 +99,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // true result iff the condition is null or false
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), new Constant(BOOLEAN, null), TRUE),
                         p.values(p.symbol("a"))))
@@ -107,7 +109,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // always true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), TRUE, TRUE),
                         p.values(p.symbol("a"))))
@@ -117,7 +119,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // always false
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), FALSE, FALSE),
                         p.values(p.symbol("a"))))
@@ -127,7 +129,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // both results equal
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), comparison(GREATER_THAN, new Reference(INTEGER, "b"), new Constant(INTEGER, 0L)), comparison(GREATER_THAN, new Reference(INTEGER, "b"), new Constant(INTEGER, 0L))),
                         p.values(p.symbol("a"), p.symbol("b"))))
@@ -140,7 +142,7 @@ public class TestSimplifyFilterPredicate
         Call randomFunction = new Call(
                 tester().getMetadata().resolveBuiltinFunction(getCharVarcharCoercion(TEST_SESSION), "random", ImmutableList.of()),
                 ImmutableList.of());
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(
                                 new Reference(BOOLEAN, "a"),
@@ -150,7 +152,7 @@ public class TestSimplifyFilterPredicate
                 .doesNotFire();
 
         // always null (including the default) -> simplified to FALSE
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), new Constant(BOOLEAN, null)),
                         p.values(p.symbol("a"))))
@@ -160,7 +162,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // condition is true -> first branch
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(TRUE, new Reference(BOOLEAN, "a"), not(new Reference(BOOLEAN, "a"))),
                         p.values(p.symbol("a"))))
@@ -170,7 +172,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // condition is true -> second branch
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(FALSE, new Reference(BOOLEAN, "a"), not(new Reference(BOOLEAN, "a"))),
                         p.values(p.symbol("a"))))
@@ -180,7 +182,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // condition is true, no second branch -> the result is null, simplified to FALSE
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(FALSE, new Reference(BOOLEAN, "a")),
                         p.values(p.symbol("a"))))
@@ -190,7 +192,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // not known result (`b`) - cannot optimize
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         ifExpression(new Reference(BOOLEAN, "a"), TRUE, new Reference(BOOLEAN, "b")),
                         p.values(p.symbol("a"), p.symbol("b"))))
@@ -201,7 +203,7 @@ public class TestSimplifyFilterPredicate
     public void testSimplifyNullIfExpression()
     {
         // NULLIF(x, y) returns true if and only if: x != y AND x = true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         nullIf(emptySymbolAllocator(), new Reference(BOOLEAN, "a"), new Reference(BOOLEAN, "b")),
                         p.values(p.symbol("a"), p.symbol("b"))))
@@ -216,7 +218,7 @@ public class TestSimplifyFilterPredicate
     @Test
     public void testSimplifySearchedCaseExpression()
     {
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), TRUE),
@@ -227,7 +229,7 @@ public class TestSimplifyFilterPredicate
                 .doesNotFire();
 
         // all results true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), TRUE),
@@ -241,7 +243,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // all results not true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), FALSE),
@@ -255,7 +257,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // all results not true (including default null result)
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), FALSE),
@@ -269,7 +271,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // one result true, and remaining results not true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), FALSE),
@@ -283,7 +285,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // first result true, and remaining results not true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), TRUE),
@@ -297,7 +299,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // all results not true, and default true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), FALSE),
@@ -314,7 +316,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // all conditions not true - return the default
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(FALSE, new Reference(BOOLEAN, "a")),
@@ -328,7 +330,7 @@ public class TestSimplifyFilterPredicate
                                 values("a", "b")));
 
         // all conditions not true, no default specified - return false
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(FALSE, new Reference(BOOLEAN, "a")),
@@ -342,7 +344,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // not true conditions preceding true condition - return the result associated with the true condition
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(FALSE, new Reference(BOOLEAN, "a")),
@@ -356,7 +358,7 @@ public class TestSimplifyFilterPredicate
                                 values("a", "b")));
 
         // remove not true condition and move the result associated with the first true condition to default
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(FALSE, new Reference(BOOLEAN, "a")),
@@ -370,7 +372,7 @@ public class TestSimplifyFilterPredicate
                                 values("a", "b")));
 
         // move the result associated with the first true condition to default
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "b"), new Constant(INTEGER, 0L)), new Reference(BOOLEAN, "a")),
@@ -388,7 +390,7 @@ public class TestSimplifyFilterPredicate
                                 values("a", "b")));
 
         // cannot remove any clause
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Case(ImmutableList.of(
                                 new WhenClause(comparison(LESS_THAN, new Reference(INTEGER, "b"), new Constant(INTEGER, 0L)), new Reference(BOOLEAN, "a")),
@@ -399,9 +401,105 @@ public class TestSimplifyFilterPredicate
     }
 
     @Test
+    public void testNullOperandCanMatch()
+    {
+        Symbol operand = new Symbol(INTEGER, "operand");
+        // an extended CASE predicate, unlike a bare-equality one, can be true for a NULL operand
+        Lambda matchesNull = new Lambda(ImmutableList.of(operand), comparison(IDENTICAL, operand.toSymbolReference(), new Reference(INTEGER, "a")));
+
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
+                .on(p -> p.filter(
+                        new Match(new Constant(INTEGER, null), ImmutableList.of(new MatchClause(matchesNull, TRUE)), FALSE),
+                        p.values(p.symbol("a", INTEGER))))
+                .doesNotFire();
+
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
+                .on(p -> p.filter(
+                        new Match(new Constant(INTEGER, null), ImmutableList.of(new MatchClause(matchesNull, FALSE)), TRUE),
+                        p.values(p.symbol("a", INTEGER))))
+                .doesNotFire();
+
+        // a preceding clause that cannot match NULL does not make the following one unreachable
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
+                .on(p -> p.filter(
+                        new Match(
+                                new Constant(INTEGER, null),
+                                ImmutableList.of(
+                                        equalityClause(new Constant(INTEGER, 1L), FALSE),
+                                        new MatchClause(matchesNull, TRUE)),
+                                FALSE),
+                        p.values(p.symbol("a", INTEGER))))
+                .doesNotFire();
+
+        // an extended CASE predicate that rejects NULL, like a bare-equality one, cannot match
+        Lambda rejectsNull = new Lambda(ImmutableList.of(operand), comparison(GREATER_THAN, operand.toSymbolReference(), new Constant(INTEGER, 5L)));
+
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
+                .on(p -> p.filter(
+                        new Match(new Constant(INTEGER, null), ImmutableList.of(new MatchClause(rejectsNull, TRUE)), FALSE),
+                        p.values(p.symbol("a", INTEGER))))
+                .matches(
+                        filter(
+                                FALSE,
+                                values("a")));
+
+        // the operand parameter of a clause that captures values comes last, so binding it is what decides
+        Symbol captured = new Symbol(INTEGER, "captured");
+        MatchClause capturingClause = new MatchClause(
+                new Bind(
+                        ImmutableList.of(new Reference(INTEGER, "a")),
+                        new Lambda(
+                                ImmutableList.of(captured, operand),
+                                comparison(EQUAL, operand.toSymbolReference(), captured.toSymbolReference()))),
+                TRUE);
+
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
+                .on(p -> p.filter(
+                        new Match(new Constant(INTEGER, null), ImmutableList.of(capturingClause), FALSE),
+                        p.values(p.symbol("a", INTEGER))))
+                .matches(
+                        filter(
+                                FALSE,
+                                values("a")));
+
+        // a predicate that ignores the operand can be true for it, so only binding the operand parameter decides
+        Symbol capturedCondition = new Symbol(BOOLEAN, "captured_condition");
+        MatchClause ignoringClause = new MatchClause(
+                new Bind(
+                        ImmutableList.of(new Reference(BOOLEAN, "b")),
+                        new Lambda(ImmutableList.of(capturedCondition, operand), capturedCondition.toSymbolReference())),
+                TRUE);
+
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
+                .on(p -> p.filter(
+                        new Match(new Constant(INTEGER, null), ImmutableList.of(ignoringClause), FALSE),
+                        p.values(p.symbol("a", INTEGER), p.symbol("b", BOOLEAN))))
+                .doesNotFire();
+
+        // the results agree, so the clause that applies does not matter
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
+                .on(p -> p.filter(
+                        new Match(new Constant(INTEGER, null), ImmutableList.of(new MatchClause(matchesNull, TRUE)), TRUE),
+                        p.values(p.symbol("a", INTEGER))))
+                .matches(
+                        filter(
+                                TRUE,
+                                values("a")));
+
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
+                .on(p -> p.filter(
+                        new Match(new Constant(INTEGER, null), ImmutableList.of(new MatchClause(matchesNull, NULL_BOOLEAN)), FALSE),
+                        p.values(p.symbol("a", INTEGER))))
+                .matches(
+                        filter(
+                                FALSE,
+                                values("a")));
+    }
+
+    @Test
     public void testSimplifySimpleCaseExpression()
     {
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Match(
                                 new Reference(BOOLEAN, "a"),
@@ -412,8 +510,8 @@ public class TestSimplifyFilterPredicate
                         p.values(p.symbol("a"), p.symbol("b"))))
                 .doesNotFire();
 
-        // comparison with null returns null - no WHEN branch matches, return default value
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        // every clause compares with the operand, and a comparison with null is null, so no clause matches
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Match(
                                 new Constant(BOOLEAN, null),
@@ -427,8 +525,8 @@ public class TestSimplifyFilterPredicate
                                 new Reference(BOOLEAN, "b"),
                                 values("a", "b")));
 
-        // comparison with null returns null - no WHEN branch matches, the result is default null, simplified to FALSE
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        // as above, and the default null result is simplified to FALSE
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Match(
                                 new Constant(BOOLEAN, null),
@@ -443,7 +541,7 @@ public class TestSimplifyFilterPredicate
                                 values("a")));
 
         // all results true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Match(
                                 new Reference(INTEGER, "a"),
@@ -458,7 +556,7 @@ public class TestSimplifyFilterPredicate
                                 values("a", "b")));
 
         // all results not true
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Match(
                                 new Reference(INTEGER, "a"),
@@ -473,7 +571,7 @@ public class TestSimplifyFilterPredicate
                                 values("a", "b")));
 
         // all results not true (including default null result)
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(
                         new Match(
                                 new Reference(INTEGER, "a"),
@@ -494,7 +592,7 @@ public class TestSimplifyFilterPredicate
         Call random = new Call(FUNCTIONS.resolveFunction("random", ImmutableList.of()), ImmutableList.of());
         Expression condition = ifExpression(comparison(LESS_THAN, random, new Constant(DOUBLE, 0.5)), NULL_BOOLEAN, FALSE);
 
-        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getPlannerContext()))
                 .on(p -> p.filter(ifExpression(condition, FALSE, TRUE), p.values(1)))
                 .matches(filter(not(comparison(IDENTICAL, condition, TRUE)), values(1)));
     }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestExtendedCase.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestExtendedCase.java
@@ -221,6 +221,73 @@ public class TestExtendedCase
     }
 
     @Test
+    public void testNullOperandInFilter()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT x
+                FROM UNNEST(ARRAY[NULL, 1]) t(x)
+                WHERE CASE CAST(NULL AS integer) WHEN IS NOT DISTINCT FROM x THEN true ELSE false END
+                """))
+                .matches("VALUES CAST(NULL AS integer)");
+    }
+
+    @Test
+    public void testNullOperandInFilterWithTrueDefault()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT x
+                FROM UNNEST(ARRAY[NULL, 1]) t(x)
+                WHERE CASE CAST(NULL AS integer) WHEN IS NOT DISTINCT FROM x THEN false ELSE true END
+                """))
+                .matches("VALUES 1");
+    }
+
+    @Test
+    public void testNullOperandInFilterWithPrecedingClause()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT x
+                FROM UNNEST(ARRAY[NULL, 1]) t(x)
+                WHERE CASE CAST(NULL AS integer)
+                          WHEN 1 THEN false
+                          WHEN IS NOT DISTINCT FROM x THEN true
+                          ELSE false
+                      END
+                """))
+                .matches("VALUES CAST(NULL AS integer)");
+    }
+
+    @Test
+    public void testNullOperandControls()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT x, CASE CAST(NULL AS integer) WHEN IS NOT DISTINCT FROM x THEN true ELSE false END
+                FROM UNNEST(ARRAY[NULL, 1]) t(x)
+                """))
+                .matches("VALUES (CAST(NULL AS integer), true), (1, false)");
+
+        assertThat(assertions.query(
+                """
+                SELECT x
+                FROM UNNEST(ARRAY[NULL, 1]) t(x)
+                WHERE CASE WHEN CAST(NULL AS integer) IS NOT DISTINCT FROM x THEN true ELSE false END
+                """))
+                .matches("VALUES CAST(NULL AS integer)");
+
+        assertThat(assertions.query(
+                """
+                SELECT x
+                FROM UNNEST(ARRAY[NULL, 1]) t(x)
+                WHERE CASE CAST(NULL AS integer) WHEN x THEN false ELSE true END
+                """))
+                .matches("VALUES CAST(NULL AS integer), 1");
+    }
+
+    @Test
     public void testTypeReconciliation()
     {
         // The operand is evaluated once, so all clauses must agree on a single operand type. The


### PR DESCRIPTION
## Description

`SimplifyFilterPredicate` folded a `Match` with a `NULL` operand to its default value, assuming no
clause can match `NULL`. Since #29446 generalized clauses to lambda predicates that no longer holds:
`WHEN IS NOT DISTINCT FROM x` does match a `NULL` operand.

```sql
SELECT x
FROM UNNEST(ARRAY[NULL, 1]) t(x)
WHERE CASE CAST(NULL AS integer) WHEN IS NOT DISTINCT FROM x THEN true ELSE false END;
```

returns no rows instead of the `NULL` row, and with `THEN`/`ELSE` swapped it returns the `NULL` row
it should drop.

The simplification is kept for clauses that cannot match `NULL`: bind the clause's operand parameter
to `NULL` and check that the predicate folds to something other than true. Bare equality and other
`NULL`-rejecting predicates, e.g. `WHEN > 5`, still simplify.

## Additional context and related issues

Broken by #29446, so released versions are affected.

The rule retains the existing `NOT (condition IDENTICAL TRUE)` rewrite for nullable conditions,
preserving single evaluation of nondeterministic expressions.

All 37 tests in `TestSimplifyFilterPredicate`, `TestExtendedCase`, and `TestExpressions` pass on
Java 25.0.4.1. This includes the NULL-clause regressions and the nullable nondeterministic-condition
regressions. Normal Maven checks, including Airstyle, Checkstyle, and Modernizer, pass.

After building module dependencies:

```sh
./mvnw -pl core/trino-main -DbranchScopedLocalRepo.enabled=true \
  -Dtest=TestSimplifyFilterPredicate,TestExtendedCase,TestExpressions test modernizer:modernizer
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix missing or unexpected rows when filtering with extended `CASE` expressions whose operand is `NULL`. ({issue}`30992`)
```
