### PR TITLE
Fix nullable nondeterministic filter evaluation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyFilterPredicate.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyFilterPredicate.java
@@ -22,7 +22,6 @@ import io.trino.sql.ir.Case;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.IrExpressions;
-import io.trino.sql.ir.IsNull;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Match;
 import io.trino.sql.ir.MatchClause;
@@ -38,6 +37,8 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.SystemSessionProperties.getCharVarcharCoercion;
 import static io.trino.sql.ir.Booleans.FALSE;
 import static io.trino.sql.ir.Booleans.TRUE;
+import static io.trino.sql.ir.ComparisonOperator.IDENTICAL;
+import static io.trino.sql.ir.IrExpressions.comparison;
 import static io.trino.sql.ir.IrExpressions.not;
 import static io.trino.sql.ir.IrUtils.combineConjuncts;
 import static io.trino.sql.ir.IrUtils.extractConjuncts;
@@ -235,6 +236,6 @@ public class SimplifyFilterPredicate
 
     private Expression isFalseOrNullPredicate(Session session, Expression expression)
     {
-        return Logical.or(new IsNull(expression), not(metadata, getCharVarcharCoercion(session), expression));
+        return not(metadata, getCharVarcharCoercion(session), comparison(metadata, getCharVarcharCoercion(session), IDENTICAL, expression, TRUE));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyFilterPredicate.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyFilterPredicate.java
@@ -14,20 +14,23 @@
 package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.spi.function.OperatorType;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
 import io.trino.sql.ir.Call;
 import io.trino.sql.ir.Case;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
 import io.trino.sql.ir.IrExpressions;
-import io.trino.sql.ir.IsNull;
 import io.trino.sql.ir.Logical;
 import io.trino.sql.ir.Match;
 import io.trino.sql.ir.MatchClause;
 import io.trino.sql.ir.Reference;
 import io.trino.sql.ir.WhenClause;
+import io.trino.sql.planner.DomainTranslator;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import org.junit.jupiter.api.Test;
@@ -42,16 +45,17 @@ import static io.trino.sql.ir.Booleans.NULL_BOOLEAN;
 import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.ComparisonOperator.EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN;
+import static io.trino.sql.ir.ComparisonOperator.IDENTICAL;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN;
 import static io.trino.sql.ir.IrExpressions.ifExpression;
 import static io.trino.sql.ir.Logical.Operator.AND;
-import static io.trino.sql.ir.Logical.Operator.OR;
 import static io.trino.sql.ir.TestingIr.comparison;
 import static io.trino.sql.ir.TestingIr.nullIf;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.sql.planner.TestingSymbolAllocator.emptySymbolAllocator;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSimplifyFilterPredicate
         extends BaseRuleTest
@@ -89,7 +93,7 @@ public class TestSimplifyFilterPredicate
                         p.values(p.symbol("a"))))
                 .matches(
                         filter(
-                                new Logical(OR, ImmutableList.of(new IsNull(new Reference(BOOLEAN, "a")), not(new Reference(BOOLEAN, "a")))),
+                                not(comparison(IDENTICAL, new Reference(BOOLEAN, "a"), TRUE)),
                                 values("a")));
 
         // true result iff the condition is null or false
@@ -99,7 +103,7 @@ public class TestSimplifyFilterPredicate
                         p.values(p.symbol("a"))))
                 .matches(
                         filter(
-                                new Logical(OR, ImmutableList.of(new IsNull(new Reference(BOOLEAN, "a")), not(new Reference(BOOLEAN, "a")))),
+                                not(comparison(IDENTICAL, new Reference(BOOLEAN, "a"), TRUE)),
                                 values("a")));
 
         // always true
@@ -205,9 +209,7 @@ public class TestSimplifyFilterPredicate
                         filter(
                                 new Logical(AND, ImmutableList.of(
                                         new Reference(BOOLEAN, "a"),
-                                        new Logical(OR, ImmutableList.of(
-                                                new IsNull(new Reference(BOOLEAN, "b")),
-                                                not(new Reference(BOOLEAN, "b")))))),
+                                        not(comparison(IDENTICAL, new Reference(BOOLEAN, "b"), TRUE)))),
                                 values("a", "b")));
     }
 
@@ -277,7 +279,7 @@ public class TestSimplifyFilterPredicate
                         p.values(p.symbol("a"))))
                 .matches(
                         filter(
-                                new Logical(AND, ImmutableList.of(new Logical(OR, ImmutableList.of(new IsNull(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))), not(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))))), new Logical(OR, ImmutableList.of(new IsNull(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))), not(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))))), comparison(GREATER_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)))),
+                                new Logical(AND, ImmutableList.of(not(comparison(IDENTICAL, comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), TRUE)), not(comparison(IDENTICAL, comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), TRUE)), comparison(GREATER_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)))),
                                 values("a")));
 
         // first result true, and remaining results not true
@@ -306,15 +308,9 @@ public class TestSimplifyFilterPredicate
                 .matches(
                         filter(
                                 new Logical(AND, ImmutableList.of(
-                                        new Logical(OR, ImmutableList.of(
-                                                new IsNull(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))),
-                                                not(comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))))),
-                                        new Logical(OR, ImmutableList.of(
-                                                new IsNull(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))),
-                                                not(comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))))),
-                                        new Logical(OR, ImmutableList.of(
-                                                new IsNull(comparison(GREATER_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))),
-                                                not(comparison(GREATER_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L))))))),
+                                        not(comparison(IDENTICAL, comparison(LESS_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), TRUE)),
+                                        not(comparison(IDENTICAL, comparison(EQUAL, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), TRUE)),
+                                        not(comparison(IDENTICAL, comparison(GREATER_THAN, new Reference(INTEGER, "a"), new Constant(INTEGER, 0L)), TRUE)))),
                                 values("a")));
 
         // all conditions not true - return the default
@@ -490,6 +486,29 @@ public class TestSimplifyFilterPredicate
                         filter(
                                 FALSE,
                                 values("a", "b")));
+    }
+
+    @Test
+    public void testNullableNonDeterministicCondition()
+    {
+        Call random = new Call(FUNCTIONS.resolveFunction("random", ImmutableList.of()), ImmutableList.of());
+        Expression condition = ifExpression(comparison(LESS_THAN, random, new Constant(DOUBLE, 0.5)), NULL_BOOLEAN, FALSE);
+
+        tester().assertThat(new SimplifyFilterPredicate(FUNCTIONS.getMetadata()))
+                .on(p -> p.filter(ifExpression(condition, FALSE, TRUE), p.values(1)))
+                .matches(filter(not(comparison(IDENTICAL, condition, TRUE)), values(1)));
+    }
+
+    @Test
+    public void testFalseOrNullPredicateDomain()
+    {
+        Symbol symbol = new Symbol(BOOLEAN, "a");
+        Expression predicate = not(comparison(IDENTICAL, symbol.toSymbolReference(), TRUE));
+        DomainTranslator.ExtractionResult result = DomainTranslator.getExtractionResult(PLANNER_CONTEXT, TEST_SESSION, predicate);
+
+        assertThat(result.getTupleDomain())
+                .isEqualTo(TupleDomain.withColumnDomains(ImmutableMap.of(symbol, Domain.singleValue(BOOLEAN, true).complement())));
+        assertThat(result.getRemainingExpression()).isEqualTo(TRUE);
     }
 
     private static Expression not(Expression expression)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestExpressions.java
@@ -89,4 +89,32 @@ public class TestExpressions
         // the Let-bound operand may itself fail, in which case TRY must swallow the failure
         assertThat(assertions.query("SELECT try(nullif(x / 0, 1)) FROM (VALUES 1) t(x)")).matches("VALUES cast(null AS integer)");
     }
+
+    @Test
+    public void testNullableNonDeterministicConditionsInFilter()
+    {
+        // The inner IF is always false or NULL, so these predicates must retain every row.
+        assertThat(assertions.query("SELECT count(*) FROM UNNEST(sequence(1, 1000)) t(x) WHERE IF(IF(random() < 0.5, CAST(NULL AS boolean), false), false, true)"))
+                .matches("VALUES BIGINT '1000'");
+
+        assertThat(assertions.query("SELECT count(*) FROM UNNEST(sequence(1, 1000)) t(x) WHERE CASE WHEN IF(random() < 0.5, CAST(NULL AS boolean), false) THEN false WHEN x < 0 THEN NULL ELSE true END"))
+                .matches("VALUES BIGINT '1000'");
+
+        assertThat(assertions.query("SELECT count(*) FROM UNNEST(sequence(1, 1000)) t(x) WHERE NULLIF(true, IF(random() < 0.5, CAST(NULL AS boolean), false))"))
+                .matches("VALUES BIGINT '1000'");
+    }
+
+    @Test
+    public void testNullableNonDeterministicConditionInProjection()
+    {
+        assertThat(assertions.query("SELECT count_if(IF(IF(random() < 0.5, CAST(NULL AS boolean), false), false, true)) FROM UNNEST(sequence(1, 1000)) t(x)"))
+                .matches("VALUES BIGINT '1000'");
+    }
+
+    @Test
+    public void testNullableIfConditionInFilter()
+    {
+        assertThat(assertions.query("SELECT x FROM UNNEST(ARRAY[true, false, NULL]) t(x) WHERE IF(x, false, true)"))
+                .matches("VALUES false, CAST(NULL AS boolean)");
+    }
 }


### PR DESCRIPTION
## Description

Evaluate nullable nondeterministic conditions once when simplifying IF, searched CASE, and boolean NULLIF filters. The previous `condition IS NULL OR NOT condition` rewrite could evaluate the condition twice and discard rows that the original filter must retain.

```sql
SELECT count(*)
FROM UNNEST(sequence(1, 1000)) t(x)
WHERE IF(IF(random() < 0.5, CAST(NULL AS boolean), false), false, true);
```

The inner IF can only return false or NULL, so every row must pass the filter and the count must be 1,000. With the old rewrite, a first evaluation returning false followed by a second returning NULL makes the rewritten predicate NULL, incorrectly discarding the row.

Use `condition IS DISTINCT FROM TRUE`, represented as `NOT (condition IDENTICAL TRUE)`, for all conditions. This preserves the false-or-NULL truth table with one evaluation, without a separate deterministic rewrite.

## Additional context and related issues

Regression tests cover IF, searched CASE, and NULLIF filters with nullable nondeterministic conditions, plus a projection control and ordinary true/false/NULL inputs. A domain test verifies that the rewritten boolean-symbol predicate extracts the false-or-NULL domain without a residual filter.

For deterministic compound conditions, the new form can prevent domain extraction and connector predicate pushdown. https://github.com/trinodb/trino/pull/31026 addresses that follow-up. This PR does not include the domain-translator change or a deterministic comparison-range regression.

The [CI run for commit 478db6902ac2ef0158a9a03eb4b3bc63e232347b](https://github.com/trinodb/trino/actions/runs/34154514152) passed, including the [core/trino-main tests](https://github.com/trinodb/trino/actions/runs/34154514152/job/101843842516).

Focused validation commands:

```sh
./mvnw -pl core/trino-main -Dtest=TestSimplifyFilterPredicate,TestExpressions -Dair.check.skip-all=true test
./mvnw -pl core/trino-main validate
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix missing rows when filtering with IF, CASE, or NULLIF expressions containing nullable nondeterministic conditions. ({issue}`30993`)
```
