### PR TITLE
Throw TrinoException on hash array allocation error

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinHashSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinHashSupplier.java
@@ -19,6 +19,7 @@ import io.trino.operator.HashArraySizeSupplier;
 import io.trino.operator.IncrementalLoadFactorHashArraySizeSupplier;
 import io.trino.operator.PagesHashStrategy;
 import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.sql.gen.JoinFilterFunctionCompiler.JoinFilterFunctionFactory;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
@@ -33,6 +34,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.operator.join.JoinHashSupplier.PagesHashType.BIGINT;
 import static io.trino.operator.join.JoinHashSupplier.PagesHashType.DEFAULT;
 import static io.trino.operator.join.JoinUtils.channelsToPages;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.util.Objects.requireNonNull;
 
 public class JoinHashSupplier
@@ -66,6 +68,7 @@ public class JoinHashSupplier
             HashArraySizeSupplier hashArraySizeSupplier,
             OptionalInt singleBigintJoinChannel)
     {
+        hashArraySizeSupplier = handleSizeLimit(hashArraySizeSupplier);
         this.session = requireNonNull(session, "session is null");
         this.addresses = requireNonNull(addresses, "addresses is null");
         this.filterFunctionFactory = requireNonNull(filterFunctionFactory, "filterFunctionFactory is null");
@@ -129,6 +132,7 @@ public class JoinHashSupplier
             OptionalInt singleBigintJoinChannel,
             HashArraySizeSupplier hashArraySizeSupplier)
     {
+        hashArraySizeSupplier = handleSizeLimit(hashArraySizeSupplier);
         long result = 0;
         if (sortChannel.isPresent()) {
             result += SortedPositionLinks.getEstimatedRetainedSizeInBytes(positionCount);
@@ -142,6 +146,19 @@ public class JoinHashSupplier
             case DEFAULT -> DefaultPagesHash.getEstimatedRetainedSizeInBytes(positionCount, hashArraySizeSupplier, addresses, channels, blocksSizeInBytes);
         };
         return result;
+    }
+
+    private static HashArraySizeSupplier handleSizeLimit(HashArraySizeSupplier delegate)
+    {
+        requireNonNull(delegate, "delegate is null");
+        return expectedCount -> {
+            try {
+                return delegate.getHashArraySize(expectedCount);
+            }
+            catch (IllegalArgumentException e) {
+                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to determine hash table size: " + e.getMessage(), e);
+            }
+        };
     }
 
     private static long getPageInstancesRetainedSizeInBytes(List<ObjectArrayList<Block>> channels)

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestHashJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestHashJoinOperator.java
@@ -30,6 +30,7 @@ import io.trino.execution.TaskStateMachine;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.Driver;
 import io.trino.operator.DriverContext;
+import io.trino.operator.IncrementalLoadFactorHashArraySizeSupplier;
 import io.trino.operator.NullSafeHashCompiler;
 import io.trino.operator.Operator;
 import io.trino.operator.OperatorAssertion;
@@ -60,6 +61,7 @@ import io.trino.sql.planner.PartitionFunctionProvider;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.TestingTaskContext;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -97,8 +99,10 @@ import static io.trino.operator.join.JoinTestUtils.innerJoinOperatorFactory;
 import static io.trino.operator.join.JoinTestUtils.instantiateBuildDrivers;
 import static io.trino.operator.join.JoinTestUtils.runDriverInThread;
 import static io.trino.operator.join.JoinTestUtils.setupBuildSide;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static java.util.Arrays.asList;
 import static java.util.Collections.nCopies;
 import static java.util.Collections.singletonList;
@@ -140,6 +144,22 @@ public class TestHashJoinOperator
     {
         testInnerJoin(true);
         testInnerJoin(false);
+    }
+
+    @Test
+    public void testHashTableSizeLimit()
+    {
+        assertTrinoExceptionThrownBy(() -> JoinHashSupplier.getEstimatedRetainedSizeInBytes(
+                1_000_000_001,
+                new LongArrayList(),
+                ImmutableList.of(),
+                0,
+                OptionalInt.empty(),
+                OptionalInt.empty(),
+                new IncrementalLoadFactorHashArraySizeSupplier(1)))
+                .hasErrorCode(GENERIC_INTERNAL_ERROR)
+                .hasMessage("Failed to determine hash table size: Too large (1000000001 expected elements with load factor 0.75)")
+                .hasCauseInstanceOf(IllegalArgumentException.class);
     }
 
     private void testInnerJoin(boolean parallelBuild)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

A `java.lang.IllegalArgumentException` is thrown directly from `HashCommon.arraySize()` when declaring an array. This change wraps it in `TrinoException`.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
A user-visible error changes. Not worth a rn.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
