### PR TITLE
Fix silent overflow in date_add for timestamp

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/DateAdd.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/DateAdd.java
@@ -30,6 +30,7 @@ import static io.trino.spi.type.Timestamps.round;
 import static io.trino.type.DateTimes.getMicrosOfMilli;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 import static io.trino.type.DateTimes.scaleEpochMillisToMicros;
+import static java.lang.Math.addExact;
 
 @Description("Add the specified amount of time to the given timestamp")
 @ScalarFunction("date_add")
@@ -55,7 +56,7 @@ public final class DateAdd
                 epochMillis = round(epochMillis, (int) (3 - precision));
             }
 
-            return scaleEpochMillisToMicros(epochMillis) + microsOfMilli;
+            return addExact(scaleEpochMillisToMicros(epochMillis), microsOfMilli);
         }
         catch (IllegalArgumentException | ArithmeticException e) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e.getMessage());

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/DateAdd.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/DateAdd.java
@@ -26,6 +26,7 @@ import io.trino.spi.type.StandardTypes;
 import org.joda.time.chrono.ISOChronology;
 
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.type.Timestamps.round;
 import static io.trino.type.DateTimes.getMicrosOfMilli;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
@@ -58,7 +59,10 @@ public final class DateAdd
 
             return addExact(scaleEpochMillisToMicros(epochMillis), microsOfMilli);
         }
-        catch (IllegalArgumentException | ArithmeticException e) {
+        catch (ArithmeticException e) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Timestamp out of range", e);
+        }
+        catch (IllegalArgumentException e) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e.getMessage());
         }
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampOperators.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampOperators.java
@@ -31,6 +31,7 @@ import static io.trino.type.DateTimes.getMicrosOfMilli;
 import static io.trino.type.DateTimes.rescale;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 import static io.trino.type.DateTimes.scaleEpochMillisToMicros;
+import static java.lang.Math.addExact;
 import static java.lang.Math.multiplyExact;
 
 public final class TimestampOperators
@@ -109,7 +110,7 @@ public final class TimestampOperators
         {
             long fractionMicros = getMicrosOfMilli(timestamp);
             long result = MONTH_OF_YEAR_UTC.add(scaleEpochMicrosToMillis(timestamp), interval);
-            return scaleEpochMillisToMicros(result) + fractionMicros;
+            return addExact(scaleEpochMillisToMicros(result), fractionMicros);
         }
 
         @LiteralParameters("p")

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampOperators.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampOperators.java
@@ -54,7 +54,7 @@ public final class TimestampOperators
             // scale to micros
             interval = multiplyExact(interval, MICROSECONDS_PER_MILLISECOND);
 
-            return timestamp + interval;
+            return addExact(timestamp, interval);
         }
 
         @LiteralParameters({"p", "u"})
@@ -64,7 +64,7 @@ public final class TimestampOperators
                 @SqlType("timestamp(p)") LongTimestamp timestamp,
                 @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long interval)
         {
-            return new LongTimestamp(timestamp.getEpochMicros() + multiplyExact(interval, MICROSECONDS_PER_MILLISECOND), timestamp.getPicosOfMicro());
+            return new LongTimestamp(addExact(timestamp.getEpochMicros(), multiplyExact(interval, MICROSECONDS_PER_MILLISECOND)), timestamp.getPicosOfMicro());
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampOperators.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampOperators.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.scalar.timestamp;
 
+import io.trino.spi.TrinoException;
 import io.trino.spi.function.Constraint;
 import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarOperator;
@@ -22,6 +23,7 @@ import io.trino.spi.type.StandardTypes;
 import org.joda.time.DateTimeField;
 import org.joda.time.chrono.ISOChronology;
 
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.OperatorType.ADD;
 import static io.trino.spi.function.OperatorType.SUBTRACT;
 import static io.trino.spi.type.TimestampType.MAX_SHORT_PRECISION;
@@ -51,10 +53,15 @@ public final class TimestampOperators
                 @SqlType("timestamp(p)") long timestamp,
                 @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long interval)
         {
-            // scale to micros
-            interval = multiplyExact(interval, MICROSECONDS_PER_MILLISECOND);
+            try {
+                // scale to micros
+                interval = multiplyExact(interval, MICROSECONDS_PER_MILLISECOND);
 
-            return addExact(timestamp, interval);
+                return addExact(timestamp, interval);
+            }
+            catch (ArithmeticException e) {
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Timestamp out of range", e);
+            }
         }
 
         @LiteralParameters({"p", "u"})
@@ -64,7 +71,7 @@ public final class TimestampOperators
                 @SqlType("timestamp(p)") LongTimestamp timestamp,
                 @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long interval)
         {
-            return new LongTimestamp(addExact(timestamp.getEpochMicros(), multiplyExact(interval, MICROSECONDS_PER_MILLISECOND)), timestamp.getPicosOfMicro());
+            return new LongTimestamp(add(timestamp.getEpochMicros(), interval), timestamp.getPicosOfMicro());
         }
     }
 
@@ -95,6 +102,7 @@ public final class TimestampOperators
         }
     }
 
+    // fallible
     @ScalarOperator(ADD)
     public static final class TimestampPlusIntervalYearToMonth
     {
@@ -108,9 +116,14 @@ public final class TimestampOperators
                 @SqlType("timestamp(p)") long timestamp,
                 @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long interval)
         {
-            long fractionMicros = getMicrosOfMilli(timestamp);
-            long result = MONTH_OF_YEAR_UTC.add(scaleEpochMicrosToMillis(timestamp), interval);
-            return addExact(scaleEpochMillisToMicros(result), fractionMicros);
+            try {
+                long fractionMicros = getMicrosOfMilli(timestamp);
+                long result = MONTH_OF_YEAR_UTC.add(scaleEpochMicrosToMillis(timestamp), interval);
+                return addExact(scaleEpochMillisToMicros(result), fractionMicros);
+            }
+            catch (IllegalArgumentException | ArithmeticException e) {
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Timestamp out of range", e);
+            }
         }
 
         @LiteralParameters("p")
@@ -125,6 +138,7 @@ public final class TimestampOperators
         }
     }
 
+    // fallible
     @ScalarOperator(ADD)
     public static final class IntervalYearToMonthPlusTimestamp
     {
@@ -149,6 +163,7 @@ public final class TimestampOperators
         }
     }
 
+    // fallible
     @ScalarOperator(SUBTRACT)
     public static final class TimestampMinusIntervalYearToMonth
     {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampOperators.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampOperators.java
@@ -217,6 +217,8 @@ public final class TimestampOperators
     @ScalarOperator(SUBTRACT)
     public static final class TimestampMinusTimestamp
     {
+        private static final int HALF_MILLISECOND_IN_MICROS = MICROSECONDS_PER_MILLISECOND / 2;
+
         private TimestampMinusTimestamp() {}
 
         @LiteralParameters("p")
@@ -225,19 +227,7 @@ public final class TimestampOperators
                 @SqlType("timestamp(p)") long left,
                 @SqlType("timestamp(p)") long right)
         {
-            // The difference in microseconds can overflow a long, while the difference in milliseconds cannot, so
-            // subtract the milliseconds and round the sub-millisecond remainder separately.
-            long millis = floorDiv(left, MICROSECONDS_PER_MILLISECOND) - floorDiv(right, MICROSECONDS_PER_MILLISECOND);
-            int microsOfMilli = floorMod(left, MICROSECONDS_PER_MILLISECOND) - floorMod(right, MICROSECONDS_PER_MILLISECOND);
-
-            // round half up, as roundDiv does
-            if (microsOfMilli >= MICROSECONDS_PER_MILLISECOND / 2) {
-                return millis + 1;
-            }
-            if (microsOfMilli < -(MICROSECONDS_PER_MILLISECOND / 2)) {
-                return millis - 1;
-            }
-            return millis;
+            return subtract(left, 0, right, 0);
         }
 
         @LiteralParameters("p")
@@ -246,7 +236,25 @@ public final class TimestampOperators
                 @SqlType("timestamp(p)") LongTimestamp left,
                 @SqlType("timestamp(p)") LongTimestamp right)
         {
-            return subtract(left.getEpochMicros(), right.getEpochMicros());
+            return subtract(left.getEpochMicros(), left.getPicosOfMicro(), right.getEpochMicros(), right.getPicosOfMicro());
+        }
+
+        private static long subtract(long leftEpochMicros, int leftPicosOfMicro, long rightEpochMicros, int rightPicosOfMicro)
+        {
+            // The difference in microseconds can overflow a long, while the difference in milliseconds cannot, so
+            // subtract the milliseconds and round the sub-millisecond remainder separately.
+            long millis = floorDiv(leftEpochMicros, MICROSECONDS_PER_MILLISECOND) - floorDiv(rightEpochMicros, MICROSECONDS_PER_MILLISECOND);
+            int microsOfMilli = floorMod(leftEpochMicros, MICROSECONDS_PER_MILLISECOND) - floorMod(rightEpochMicros, MICROSECONDS_PER_MILLISECOND);
+            int picosOfMicro = leftPicosOfMicro - rightPicosOfMicro;
+
+            // round half up, as roundDiv does; the picoseconds decide the exact half-millisecond ties
+            if (microsOfMilli > HALF_MILLISECOND_IN_MICROS || (microsOfMilli == HALF_MILLISECOND_IN_MICROS && picosOfMicro >= 0)) {
+                return millis + 1;
+            }
+            if (microsOfMilli < -HALF_MILLISECOND_IN_MICROS || (microsOfMilli == -HALF_MILLISECOND_IN_MICROS && picosOfMicro < 0)) {
+                return millis - 1;
+            }
+            return millis;
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampOperators.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/TimestampOperators.java
@@ -26,14 +26,13 @@ import org.joda.time.chrono.ISOChronology;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.OperatorType.ADD;
 import static io.trino.spi.function.OperatorType.SUBTRACT;
-import static io.trino.spi.type.TimestampType.MAX_SHORT_PRECISION;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
-import static io.trino.spi.type.Timestamps.round;
 import static io.trino.type.DateTimes.getMicrosOfMilli;
-import static io.trino.type.DateTimes.rescale;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 import static io.trino.type.DateTimes.scaleEpochMillisToMicros;
 import static java.lang.Math.addExact;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
 import static java.lang.Math.multiplyExact;
 
 public final class TimestampOperators
@@ -226,12 +225,19 @@ public final class TimestampOperators
                 @SqlType("timestamp(p)") long left,
                 @SqlType("timestamp(p)") long right)
         {
-            long interval = left - right;
+            // The difference in microseconds can overflow a long, while the difference in milliseconds cannot, so
+            // subtract the milliseconds and round the sub-millisecond remainder separately.
+            long millis = floorDiv(left, MICROSECONDS_PER_MILLISECOND) - floorDiv(right, MICROSECONDS_PER_MILLISECOND);
+            int microsOfMilli = floorMod(left, MICROSECONDS_PER_MILLISECOND) - floorMod(right, MICROSECONDS_PER_MILLISECOND);
 
-            interval = round(interval, 3);
-            interval = rescale(interval, MAX_SHORT_PRECISION, 3);
-
-            return interval;
+            // round half up, as roundDiv does
+            if (microsOfMilli >= MICROSECONDS_PER_MILLISECOND / 2) {
+                return millis + 1;
+            }
+            if (microsOfMilli < -(MICROSECONDS_PER_MILLISECOND / 2)) {
+                return millis - 1;
+            }
+            return millis;
         }
 
         @LiteralParameters("p")

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/TimestampWithTimeZoneOperators.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/TimestampWithTimeZoneOperators.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.scalar.timestamptz;
 
+import io.trino.spi.TrinoException;
 import io.trino.spi.function.Constraint;
 import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarOperator;
@@ -20,6 +21,7 @@ import io.trino.spi.function.SqlType;
 import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.spi.type.StandardTypes;
 
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.OperatorType.ADD;
 import static io.trino.spi.function.OperatorType.SUBTRACT;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
@@ -28,11 +30,13 @@ import static io.trino.spi.type.DateTimeEncoding.unpackZoneKey;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
 import static io.trino.type.DateTimes.roundToNearest;
 import static io.trino.util.DateTimeZoneIndex.unpackChronology;
+import static java.lang.Math.addExact;
 
 public final class TimestampWithTimeZoneOperators
 {
     private TimestampWithTimeZoneOperators() {}
 
+    // fallible
     @ScalarOperator(ADD)
     public static final class TimestampPlusIntervalDayToSecond
     {
@@ -45,7 +49,12 @@ public final class TimestampWithTimeZoneOperators
                 @SqlType("timestamp(p) with time zone") long packedEpochMillis,
                 @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long interval)
         {
-            return packDateTimeWithZone(unpackMillisUtc(packedEpochMillis) + interval, unpackZoneKey(packedEpochMillis));
+            try {
+                return packDateTimeWithZone(addExact(unpackMillisUtc(packedEpochMillis), interval), unpackZoneKey(packedEpochMillis));
+            }
+            catch (IllegalArgumentException | ArithmeticException e) {
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Timestamp out of range", e);
+            }
         }
 
         @LiteralParameters({"p", "u"})
@@ -55,10 +64,16 @@ public final class TimestampWithTimeZoneOperators
                 @SqlType("timestamp(p) with time zone") LongTimestampWithTimeZone timestamp,
                 @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long interval)
         {
-            return LongTimestampWithTimeZone.fromEpochMillisAndFraction(timestamp.getEpochMillis() + interval, timestamp.getPicosOfMilli(), timestamp.getTimeZoneKey());
+            try {
+                return LongTimestampWithTimeZone.fromEpochMillisAndFraction(addExact(timestamp.getEpochMillis(), interval), timestamp.getPicosOfMilli(), timestamp.getTimeZoneKey());
+            }
+            catch (IllegalArgumentException | ArithmeticException e) {
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Timestamp out of range", e);
+            }
         }
     }
 
+    // fallible
     @ScalarOperator(ADD)
     public static final class IntervalDayToSecondPlusTimestamp
     {
@@ -85,6 +100,7 @@ public final class TimestampWithTimeZoneOperators
         }
     }
 
+    // fallible
     @ScalarOperator(ADD)
     public static final class TimestampPlusIntervalYearToMonth
     {
@@ -96,10 +112,15 @@ public final class TimestampWithTimeZoneOperators
                 @SqlType("timestamp(p) with time zone") long packedEpochMillis,
                 @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long interval)
         {
-            long epochMillis = unpackMillisUtc(packedEpochMillis);
-            long result = unpackChronology(packedEpochMillis).monthOfYear().add(epochMillis, interval);
+            try {
+                long epochMillis = unpackMillisUtc(packedEpochMillis);
+                long result = unpackChronology(packedEpochMillis).monthOfYear().add(epochMillis, interval);
 
-            return packDateTimeWithZone(result, unpackZoneKey(packedEpochMillis));
+                return packDateTimeWithZone(result, unpackZoneKey(packedEpochMillis));
+            }
+            catch (IllegalArgumentException | ArithmeticException e) {
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Timestamp out of range", e);
+            }
         }
 
         @LiteralParameters("p")
@@ -108,13 +129,19 @@ public final class TimestampWithTimeZoneOperators
                 @SqlType("timestamp(p) with time zone") LongTimestampWithTimeZone timestamp,
                 @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long interval)
         {
-            long epochMillis = timestamp.getEpochMillis();
-            long result = unpackChronology(timestamp.getTimeZoneKey()).monthOfYear().add(epochMillis, interval);
+            try {
+                long epochMillis = timestamp.getEpochMillis();
+                long result = unpackChronology(timestamp.getTimeZoneKey()).monthOfYear().add(epochMillis, interval);
 
-            return LongTimestampWithTimeZone.fromEpochMillisAndFraction(result, timestamp.getPicosOfMilli(), timestamp.getTimeZoneKey());
+                return LongTimestampWithTimeZone.fromEpochMillisAndFraction(result, timestamp.getPicosOfMilli(), timestamp.getTimeZoneKey());
+            }
+            catch (IllegalArgumentException | ArithmeticException e) {
+                throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Timestamp out of range", e);
+            }
         }
     }
 
+    // fallible
     @ScalarOperator(ADD)
     public static final class IntervalYearToMonthPlusTimestamp
     {
@@ -139,6 +166,7 @@ public final class TimestampWithTimeZoneOperators
         }
     }
 
+    // fallible
     @ScalarOperator(SUBTRACT)
     public static final class TimestampMinusIntervalYearToMonth
     {
@@ -163,6 +191,7 @@ public final class TimestampWithTimeZoneOperators
         }
     }
 
+    // fallible
     @ScalarOperator(SUBTRACT)
     public static final class TimestampMinusIntervalDayToSecond
     {

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestOperators.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestOperators.java
@@ -22,9 +22,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
@@ -431,21 +432,23 @@ public class TestOperators
         // The interval is stored as milliseconds in a long. The TIMESTAMP +/- INTERVAL_DAY_TO_SECOND
         // operators scale the interval up by 1000 (to microseconds) using Math.multiplyExact, which
         // overflows for sufficiently large intervals. Such intervals are reachable via multiplication.
-        // The operator does not wrap the ArithmeticException, so we cannot use assertTrinoExceptionThrownBy.
-        assertThatThrownBy(assertions.expression("a + b")
+        assertTrinoExceptionThrownBy(assertions.expression("a + b")
                 .binding("a", "TIMESTAMP '2020-05-01 12:34:56'")
                 .binding("b", "INTERVAL '1' SECOND * 9223372036854775")::evaluate)
-                .hasMessageContaining("long overflow");
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
 
-        assertThatThrownBy(assertions.expression("a + b")
+        assertTrinoExceptionThrownBy(assertions.expression("a + b")
                 .binding("a", "INTERVAL '1' SECOND * 9223372036854775")
                 .binding("b", "TIMESTAMP '2020-05-01 12:34:56'")::evaluate)
-                .hasMessageContaining("long overflow");
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
 
-        assertThatThrownBy(assertions.expression("a - b")
+        assertTrinoExceptionThrownBy(assertions.expression("a - b")
                 .binding("a", "TIMESTAMP '2020-05-01 12:34:56'")
                 .binding("b", "INTERVAL '1' SECOND * 9223372036854775")::evaluate)
-                .hasMessageContaining("long overflow");
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
@@ -3130,6 +3130,18 @@ public class TestTimestamp
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
                 .hasMessageMatching("Value cannot fit in an int: .*");
 
+        // the sub-millisecond part is added back after the result has been scaled to microseconds, and that addition can overflow
+        assertThat(assertions.expression("date_add('millisecond', 9223372036854775, TIMESTAMP '1970-01-01 00:00:00.000807')")).matches("TIMESTAMP '294247-01-10 04:00:54.775807'");
+        assertTrinoExceptionThrownBy(assertions.expression("date_add('millisecond', 9223372036854775, TIMESTAMP '1970-01-01 00:00:00.000808')")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("long overflow");
+        assertTrinoExceptionThrownBy(assertions.expression("date_add('month', 1, TIMESTAMP '294246-12-10 04:00:54.775999')")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("long overflow");
+        assertTrinoExceptionThrownBy(assertions.expression("date_add('month', 1, TIMESTAMP '294246-12-10 04:00:54.775999999999')")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("long overflow");
+
         assertTrinoExceptionThrownBy(assertions.expression("date_diff('foo', TIMESTAMP '2001-01-31 19:34:55', TIMESTAMP '2005-09-10 13:31:00')")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
                 .hasMessage("'foo' is not a valid TIMESTAMP field");

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
@@ -3322,6 +3322,18 @@ public class TestTimestamp
 
         assertThat(assertions.operator(ADD, "INTERVAL '3' year", "TIMESTAMP '2001-1-22 03:04:05.321'"))
                 .matches("TIMESTAMP '2004-01-22 03:04:05.321'");
+
+        // the sub-millisecond part is added back after the result has been scaled to microseconds, and that addition can overflow
+        assertThat(assertions.operator(ADD, "TIMESTAMP '294246-12-10 04:00:54.775807'", "INTERVAL '1' month"))
+                .matches("TIMESTAMP '294247-01-10 04:00:54.775807'");
+        assertThatThrownBy(() -> assertions.operator(ADD, "TIMESTAMP '294246-12-10 04:00:54.775808'", "INTERVAL '1' month").evaluate())
+                .hasMessage("long overflow");
+        assertThatThrownBy(() -> assertions.operator(ADD, "TIMESTAMP '294246-12-10 04:00:54.775808000000'", "INTERVAL '1' month").evaluate())
+                .hasMessage("long overflow");
+        assertThatThrownBy(() -> assertions.operator(ADD, "INTERVAL '1' month", "TIMESTAMP '294246-12-10 04:00:54.775808'").evaluate())
+                .hasMessage("long overflow");
+        assertThatThrownBy(() -> assertions.operator(ADD, "INTERVAL '1' month", "TIMESTAMP '294246-12-10 04:00:54.775808000000'").evaluate())
+                .hasMessage("long overflow");
     }
 
     @Test
@@ -3332,6 +3344,11 @@ public class TestTimestamp
 
         assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '2001-1-22 03:04:05.321'", "INTERVAL '3' month"))
                 .matches("TIMESTAMP '2000-10-22 03:04:05.321'");
+
+        // subtracting from the smallest representable timestamp underflows
+        String minTimestamp = "date_add('millisecond', -9223372036854775, TIMESTAMP '1970-01-01 00:00:00.000000')";
+        assertThatThrownBy(() -> assertions.operator(SUBTRACT, minTimestamp, "INTERVAL '1' month").evaluate())
+                .hasMessage("long overflow");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
@@ -3334,6 +3334,18 @@ public class TestTimestamp
                 .hasMessage("long overflow");
         assertThatThrownBy(() -> assertions.operator(ADD, "INTERVAL '1' month", "TIMESTAMP '294246-12-10 04:00:54.775808000000'").evaluate())
                 .hasMessage("long overflow");
+
+        // adding a day-to-second interval can push the timestamp past the largest representable value
+        assertThat(assertions.operator(ADD, "TIMESTAMP '294247-01-10 04:00:53.775807'", "INTERVAL '1' second"))
+                .matches("TIMESTAMP '294247-01-10 04:00:54.775807'");
+        assertThatThrownBy(() -> assertions.operator(ADD, "TIMESTAMP '294247-01-10 04:00:54.775807'", "INTERVAL '1' second").evaluate())
+                .hasMessage("long overflow");
+        assertThatThrownBy(() -> assertions.operator(ADD, "TIMESTAMP '294247-01-10 04:00:54.775807000000'", "INTERVAL '1' second").evaluate())
+                .hasMessage("long overflow");
+        assertThatThrownBy(() -> assertions.operator(ADD, "INTERVAL '1' second", "TIMESTAMP '294247-01-10 04:00:54.775807'").evaluate())
+                .hasMessage("long overflow");
+        assertThatThrownBy(() -> assertions.operator(ADD, "INTERVAL '1' second", "TIMESTAMP '294247-01-10 04:00:54.775807000000'").evaluate())
+                .hasMessage("long overflow");
     }
 
     @Test
@@ -3348,6 +3360,8 @@ public class TestTimestamp
         // subtracting from the smallest representable timestamp underflows
         String minTimestamp = "date_add('millisecond', -9223372036854775, TIMESTAMP '1970-01-01 00:00:00.000000')";
         assertThatThrownBy(() -> assertions.operator(SUBTRACT, minTimestamp, "INTERVAL '1' month").evaluate())
+                .hasMessage("long overflow");
+        assertThatThrownBy(() -> assertions.operator(SUBTRACT, minTimestamp, "INTERVAL '1' second").evaluate())
                 .hasMessage("long overflow");
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
@@ -32,6 +32,7 @@ import java.util.function.BiFunction;
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.server.testing.TestingTrinoServer.SESSION_START_TIME_PROPERTY;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.OperatorType.ADD;
 import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.INDETERMINATE;
@@ -3103,20 +3104,23 @@ public class TestTimestamp
         assertThat(assertions.expression("date_add('millisecond', " + value + ", TIMESTAMP '0001-01-01 00:00:00.000000000000')")).matches("TIMESTAMP '0001-01-31 00:00:00.000000000000'");
 
         assertTrinoExceptionThrownBy(assertions.expression("date_add('day', " + value + ", TIMESTAMP '0001-01-01 00:00:00')")::evaluate)
-                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
-                .hasMessage("long overflow");
-        assertThatThrownBy(() -> assertions.expression("date_add('day', " + value + ", TIMESTAMP '0001-01-01 00:00:00.000000000000')").evaluate())
-                .hasMessage("long overflow");
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.expression("date_add('day', " + value + ", TIMESTAMP '0001-01-01 00:00:00.000000000000')")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
         assertTrinoExceptionThrownBy(assertions.expression("date_add('week', " + value + ", TIMESTAMP '0001-01-01 00:00:00')")::evaluate)
-                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
-                .hasMessage("long overflow");
-        assertThatThrownBy(() -> assertions.expression("date_add('week', " + value + ", TIMESTAMP '0001-01-01 00:00:00.000000000000')").evaluate())
-                .hasMessage("long overflow");
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.expression("date_add('week', " + value + ", TIMESTAMP '0001-01-01 00:00:00.000000000000')")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
         assertTrinoExceptionThrownBy(assertions.expression("date_add('month', " + value + ", TIMESTAMP '0001-01-01 00:00:00')")::evaluate)
-                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
-                .hasMessage("long overflow");
-        assertThatThrownBy(() -> assertions.expression("date_add('month', " + value + ", TIMESTAMP '0001-01-01 00:00:00.000000000000')").evaluate())
-                .hasMessage("long overflow");
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.expression("date_add('month', " + value + ", TIMESTAMP '0001-01-01 00:00:00.000000000000')")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
         assertTrinoExceptionThrownBy(assertions.expression("date_add('quarter', " + value + ", TIMESTAMP '0001-01-01 00:00:00')")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
                 .hasMessageMatching("Magnitude of add amount is too large: .*");
@@ -3124,23 +3128,23 @@ public class TestTimestamp
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
                 .hasMessageMatching("Magnitude of add amount is too large: .*");
         assertTrinoExceptionThrownBy(assertions.expression("date_add('year', " + value + ", TIMESTAMP '0001-01-01 00:00:00')")::evaluate)
-                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
-                .hasMessageMatching("Value cannot fit in an int: .*");
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
         assertTrinoExceptionThrownBy(assertions.expression("date_add('year', " + value + ", TIMESTAMP '0001-01-01 00:00:00.000000000000')")::evaluate)
-                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
-                .hasMessageMatching("Value cannot fit in an int: .*");
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
 
         // the sub-millisecond part is added back after the result has been scaled to microseconds, and that addition can overflow
         assertThat(assertions.expression("date_add('millisecond', 9223372036854775, TIMESTAMP '1970-01-01 00:00:00.000807')")).matches("TIMESTAMP '294247-01-10 04:00:54.775807'");
         assertTrinoExceptionThrownBy(assertions.expression("date_add('millisecond', 9223372036854775, TIMESTAMP '1970-01-01 00:00:00.000808')")::evaluate)
-                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
-                .hasMessage("long overflow");
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
         assertTrinoExceptionThrownBy(assertions.expression("date_add('month', 1, TIMESTAMP '294246-12-10 04:00:54.775999')")::evaluate)
-                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
-                .hasMessage("long overflow");
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
         assertTrinoExceptionThrownBy(assertions.expression("date_add('month', 1, TIMESTAMP '294246-12-10 04:00:54.775999999999')")::evaluate)
-                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
-                .hasMessage("long overflow");
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
 
         assertTrinoExceptionThrownBy(assertions.expression("date_diff('foo', TIMESTAMP '2001-01-31 19:34:55', TIMESTAMP '2005-09-10 13:31:00')")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
@@ -3326,26 +3330,38 @@ public class TestTimestamp
         // the sub-millisecond part is added back after the result has been scaled to microseconds, and that addition can overflow
         assertThat(assertions.operator(ADD, "TIMESTAMP '294246-12-10 04:00:54.775807'", "INTERVAL '1' month"))
                 .matches("TIMESTAMP '294247-01-10 04:00:54.775807'");
-        assertThatThrownBy(() -> assertions.operator(ADD, "TIMESTAMP '294246-12-10 04:00:54.775808'", "INTERVAL '1' month").evaluate())
-                .hasMessage("long overflow");
-        assertThatThrownBy(() -> assertions.operator(ADD, "TIMESTAMP '294246-12-10 04:00:54.775808000000'", "INTERVAL '1' month").evaluate())
-                .hasMessage("long overflow");
-        assertThatThrownBy(() -> assertions.operator(ADD, "INTERVAL '1' month", "TIMESTAMP '294246-12-10 04:00:54.775808'").evaluate())
-                .hasMessage("long overflow");
-        assertThatThrownBy(() -> assertions.operator(ADD, "INTERVAL '1' month", "TIMESTAMP '294246-12-10 04:00:54.775808000000'").evaluate())
-                .hasMessage("long overflow");
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "TIMESTAMP '294246-12-10 04:00:54.775808'", "INTERVAL '1' month")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "TIMESTAMP '294246-12-10 04:00:54.775808000000'", "INTERVAL '1' month")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "INTERVAL '1' month", "TIMESTAMP '294246-12-10 04:00:54.775808'")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "INTERVAL '1' month", "TIMESTAMP '294246-12-10 04:00:54.775808000000'")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        // joda rejects the month arithmetic itself
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "TIMESTAMP '2020-01-01 00:00:00'", "INTERVAL '178956970' year")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
 
         // adding a day-to-second interval can push the timestamp past the largest representable value
         assertThat(assertions.operator(ADD, "TIMESTAMP '294247-01-10 04:00:53.775807'", "INTERVAL '1' second"))
                 .matches("TIMESTAMP '294247-01-10 04:00:54.775807'");
-        assertThatThrownBy(() -> assertions.operator(ADD, "TIMESTAMP '294247-01-10 04:00:54.775807'", "INTERVAL '1' second").evaluate())
-                .hasMessage("long overflow");
-        assertThatThrownBy(() -> assertions.operator(ADD, "TIMESTAMP '294247-01-10 04:00:54.775807000000'", "INTERVAL '1' second").evaluate())
-                .hasMessage("long overflow");
-        assertThatThrownBy(() -> assertions.operator(ADD, "INTERVAL '1' second", "TIMESTAMP '294247-01-10 04:00:54.775807'").evaluate())
-                .hasMessage("long overflow");
-        assertThatThrownBy(() -> assertions.operator(ADD, "INTERVAL '1' second", "TIMESTAMP '294247-01-10 04:00:54.775807000000'").evaluate())
-                .hasMessage("long overflow");
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "TIMESTAMP '294247-01-10 04:00:54.775807'", "INTERVAL '1' second")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "TIMESTAMP '294247-01-10 04:00:54.775807000000'", "INTERVAL '1' second")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "INTERVAL '1' second", "TIMESTAMP '294247-01-10 04:00:54.775807'")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "INTERVAL '1' second", "TIMESTAMP '294247-01-10 04:00:54.775807000000'")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
     }
 
     @Test
@@ -3359,10 +3375,12 @@ public class TestTimestamp
 
         // subtracting from the smallest representable timestamp underflows
         String minTimestamp = "date_add('millisecond', -9223372036854775, TIMESTAMP '1970-01-01 00:00:00.000000')";
-        assertThatThrownBy(() -> assertions.operator(SUBTRACT, minTimestamp, "INTERVAL '1' month").evaluate())
-                .hasMessage("long overflow");
-        assertThatThrownBy(() -> assertions.operator(SUBTRACT, minTimestamp, "INTERVAL '1' second").evaluate())
-                .hasMessage("long overflow");
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, minTimestamp, "INTERVAL '1' month")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, minTimestamp, "INTERVAL '1' second")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
@@ -3316,6 +3316,16 @@ public class TestTimestamp
                 .matches("INTERVAL '0 00:00:00.000' DAY TO SECOND");
         assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '1970-01-01 00:00:00.000000'", "TIMESTAMP '1970-01-01 00:00:00.000501'"))
                 .matches("INTERVAL '-0 00:00:00.001' DAY TO SECOND");
+
+        // a picosecond either side of the tie decides which way it rounds
+        assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '1970-01-01 00:00:00.000500000000'", "TIMESTAMP '1970-01-01 00:00:00.000000000000'"))
+                .matches("INTERVAL '0 00:00:00.001' DAY TO SECOND");
+        assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '1970-01-01 00:00:00.000500000000'", "TIMESTAMP '1970-01-01 00:00:00.000000000001'"))
+                .matches("INTERVAL '0 00:00:00.000' DAY TO SECOND");
+        assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '1970-01-01 00:00:00.000000000000'", "TIMESTAMP '1970-01-01 00:00:00.000500000000'"))
+                .matches("INTERVAL '0 00:00:00.000' DAY TO SECOND");
+        assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '1970-01-01 00:00:00.000000000000'", "TIMESTAMP '1970-01-01 00:00:00.000500000001'"))
+                .matches("INTERVAL '-0 00:00:00.001' DAY TO SECOND");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
@@ -3298,6 +3298,24 @@ public class TestTimestamp
 
         assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '2016-03-29 03:04:05.321'", "TIMESTAMP '2017-03-30 14:15:16.432'"))
                 .matches("INTERVAL '-366 11:11:11.111' DAY TO SECOND");
+
+        // the difference in microseconds overflows a long, the difference in milliseconds does not
+        assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '294247-01-10 04:00:54.775807'", "TIMESTAMP '1970-01-01 00:00:00.000000'"))
+                .matches("INTERVAL '106751991 04:00:54.776' DAY TO SECOND");
+        assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '1970-01-01 00:00:00.000000'", "TIMESTAMP '294247-01-10 04:00:54.775807'"))
+                .matches("INTERVAL '-106751991 04:00:54.776' DAY TO SECOND");
+        assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '294247-01-10 04:00:54.775807000000'", "TIMESTAMP '1970-01-01 00:00:00.000000000000'"))
+                .matches("INTERVAL '106751991 04:00:54.776' DAY TO SECOND");
+
+        // half a millisecond rounds up in either direction, as it did before
+        assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '1970-01-01 00:00:00.000500'", "TIMESTAMP '1970-01-01 00:00:00.000000'"))
+                .matches("INTERVAL '0 00:00:00.001' DAY TO SECOND");
+        assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '1970-01-01 00:00:00.000499'", "TIMESTAMP '1970-01-01 00:00:00.000000'"))
+                .matches("INTERVAL '0 00:00:00.000' DAY TO SECOND");
+        assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '1970-01-01 00:00:00.000000'", "TIMESTAMP '1970-01-01 00:00:00.000500'"))
+                .matches("INTERVAL '0 00:00:00.000' DAY TO SECOND");
+        assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '1970-01-01 00:00:00.000000'", "TIMESTAMP '1970-01-01 00:00:00.000501'"))
+                .matches("INTERVAL '-0 00:00:00.001' DAY TO SECOND");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
@@ -32,6 +32,7 @@ import static io.trino.server.testing.TestingTrinoServer.SESSION_START_TIME_PROP
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.INVALID_LITERAL;
+import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.OperatorType.ADD;
 import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
@@ -471,6 +472,26 @@ public class TestTimestampWithTimeZone
         assertThat(assertions.operator(ADD, "INTERVAL '3' month", "TIMESTAMP '2001-1-22 03:04:05.321 +05:09'"))
                 .matches("TIMESTAMP '2001-04-22 03:04:05.321 +05:09'");
 
+        // the time zone is packed into the low bits of the epoch millis, so the representable range is the same at every precision
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "TIMESTAMP '73326-09-11 20:14:45.247 UTC'", "INTERVAL '1' second")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "TIMESTAMP '73326-09-11 20:14:45.2470000 UTC'", "INTERVAL '1' second")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "TIMESTAMP '73326-09-11 20:14:45.247 UTC'", "INTERVAL '1' month")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "TIMESTAMP '73326-09-11 20:14:45.2470000 UTC'", "INTERVAL '1' month")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "INTERVAL '1' second", "TIMESTAMP '73326-09-11 20:14:45.2470000 UTC'")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "INTERVAL '1' month", "TIMESTAMP '73326-09-11 20:14:45.2470000 UTC'")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+
         assertThat(assertions.operator(ADD, "TIMESTAMP '2001-1-22 03:04:05.321 +05:09'", "INTERVAL '3' year"))
                 .matches("TIMESTAMP '2004-01-22 03:04:05.321 +05:09'");
 
@@ -486,6 +507,20 @@ public class TestTimestampWithTimeZone
 
         assertThat(assertions.operator(SUBTRACT, "TIMESTAMP '2001-1-22 03:04:05.321 +05:09'", "INTERVAL '3' month"))
                 .matches("TIMESTAMP '2000-10-22 03:04:05.321 +05:09'");
+
+        // subtracting a negative interval runs past the largest representable value
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, "TIMESTAMP '73326-09-11 20:14:45.247 UTC'", "INTERVAL '-1' second")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, "TIMESTAMP '73326-09-11 20:14:45.2470000 UTC'", "INTERVAL '-1' second")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, "TIMESTAMP '73326-09-11 20:14:45.247 UTC'", "INTERVAL '-1' month")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, "TIMESTAMP '73326-09-11 20:14:45.2470000 UTC'", "INTERVAL '-1' month")::evaluate)
+                .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
+                .hasMessage("Timestamp out of range");
     }
 
     @Test
@@ -2709,17 +2744,20 @@ public class TestTimestampWithTimeZone
         assertTrinoExceptionThrownBy(assertions.expression("date_add('day', " + value + ", TIMESTAMP '0001-01-01 00:00:00 Asia/Kathmandu')")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
                 .hasMessageMatching("Millis overflow: .*");
-        assertThatThrownBy(() -> assertions.expression("date_add('day', " + value + ", TIMESTAMP '0001-01-01 00:00:00.000000000000 Asia/Kathmandu')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("date_add('day', " + value + ", TIMESTAMP '0001-01-01 00:00:00.000000000000 Asia/Kathmandu')")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
                 .hasMessageMatching("Millis overflow: .*");
         assertTrinoExceptionThrownBy(assertions.expression("date_add('week', " + value + ", TIMESTAMP '0001-01-01 00:00:00 Asia/Kathmandu')")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
                 .hasMessageMatching("Millis overflow: .*");
-        assertThatThrownBy(() -> assertions.expression("date_add('week', " + value + ", TIMESTAMP '0001-01-01 00:00:00.000000000000 Asia/Kathmandu')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("date_add('week', " + value + ", TIMESTAMP '0001-01-01 00:00:00.000000000000 Asia/Kathmandu')")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
                 .hasMessageMatching("Millis overflow: .*");
         assertTrinoExceptionThrownBy(assertions.expression("date_add('month', " + value + ", TIMESTAMP '0001-01-01 00:00:00 Asia/Kathmandu')")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
                 .hasMessageMatching("Millis overflow: .*");
-        assertThatThrownBy(() -> assertions.expression("date_add('month', " + value + ", TIMESTAMP '0001-01-01 00:00:00.000000000000 Asia/Kathmandu')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("date_add('month', " + value + ", TIMESTAMP '0001-01-01 00:00:00.000000000000 Asia/Kathmandu')")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
                 .hasMessageMatching("Millis overflow: .*");
         assertTrinoExceptionThrownBy(assertions.expression("date_add('quarter', " + value + ", TIMESTAMP '0001-01-01 00:00:00 Asia/Kathmandu')")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT)

--- a/core/trino-main/src/test/java/io/trino/type/TestLongTimestampWithTimeZoneType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestLongTimestampWithTimeZoneType.java
@@ -36,6 +36,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestLongTimestampWithTimeZoneType
         extends AbstractTestType
 {
+    // the time zone occupies the low 12 bits of the packed value, so the epoch millis is a signed 52-bit number
+    private static final long MIN_EPOCH_MILLIS = -(1L << 51);
+    private static final long MAX_EPOCH_MILLIS = (1L << 51) - 1;
+
     public TestLongTimestampWithTimeZoneType()
     {
         super(TIMESTAMP_TZ_MICROS, SqlTimestampWithTimeZone.class, createTestBlock());
@@ -68,10 +72,10 @@ public class TestLongTimestampWithTimeZoneType
     @Test
     public void testPreviousValue()
     {
-        LongTimestampWithTimeZone minValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MIN_VALUE, 0, UTC_KEY);
-        LongTimestampWithTimeZone nextToMinValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MIN_VALUE, 1_000_000, UTC_KEY);
-        LongTimestampWithTimeZone previousToMaxValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MAX_VALUE, 998_000_000, UTC_KEY);
-        LongTimestampWithTimeZone maxValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MAX_VALUE, 999_000_000, UTC_KEY);
+        LongTimestampWithTimeZone minValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(MIN_EPOCH_MILLIS, 0, UTC_KEY);
+        LongTimestampWithTimeZone nextToMinValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(MIN_EPOCH_MILLIS, 1_000_000, UTC_KEY);
+        LongTimestampWithTimeZone previousToMaxValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(MAX_EPOCH_MILLIS, 998_000_000, UTC_KEY);
+        LongTimestampWithTimeZone maxValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(MAX_EPOCH_MILLIS, 999_000_000, UTC_KEY);
 
         assertThat(type.getPreviousValue(minValue))
                 .isEqualTo(Optional.empty());
@@ -84,7 +88,7 @@ public class TestLongTimestampWithTimeZoneType
                 .isEqualTo(Optional.of(LongTimestampWithTimeZone.fromEpochMillisAndFraction(1483228799999L, 999_000_000, getTimeZoneKeyForOffset(0))));
 
         assertThat(type.getPreviousValue(previousToMaxValue))
-                .isEqualTo(Optional.of(LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MAX_VALUE, 997_000_000, UTC_KEY)));
+                .isEqualTo(Optional.of(LongTimestampWithTimeZone.fromEpochMillisAndFraction(MAX_EPOCH_MILLIS, 997_000_000, UTC_KEY)));
         assertThat(type.getPreviousValue(maxValue))
                 .isEqualTo(Optional.of(previousToMaxValue));
     }
@@ -92,15 +96,15 @@ public class TestLongTimestampWithTimeZoneType
     @Test
     public void testNextValue()
     {
-        LongTimestampWithTimeZone minValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MIN_VALUE, 0, UTC_KEY);
-        LongTimestampWithTimeZone nextToMinValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MIN_VALUE, 1_000_000, UTC_KEY);
-        LongTimestampWithTimeZone previousToMaxValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MAX_VALUE, 998_000_000, UTC_KEY);
-        LongTimestampWithTimeZone maxValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MAX_VALUE, 999_000_000, UTC_KEY);
+        LongTimestampWithTimeZone minValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(MIN_EPOCH_MILLIS, 0, UTC_KEY);
+        LongTimestampWithTimeZone nextToMinValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(MIN_EPOCH_MILLIS, 1_000_000, UTC_KEY);
+        LongTimestampWithTimeZone previousToMaxValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(MAX_EPOCH_MILLIS, 998_000_000, UTC_KEY);
+        LongTimestampWithTimeZone maxValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(MAX_EPOCH_MILLIS, 999_000_000, UTC_KEY);
 
         assertThat(type.getNextValue(minValue))
                 .isEqualTo(Optional.of(nextToMinValue));
         assertThat(type.getNextValue(nextToMinValue))
-                .isEqualTo(Optional.of(LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MIN_VALUE, 2_000_000, UTC_KEY)));
+                .isEqualTo(Optional.of(LongTimestampWithTimeZone.fromEpochMillisAndFraction(MIN_EPOCH_MILLIS, 2_000_000, UTC_KEY)));
 
         assertThat(type.getNextValue(getSampleValue()))
                 .isEqualTo(Optional.of(LongTimestampWithTimeZone.fromEpochMillisAndFraction(1111, 1_000_000, getTimeZoneKeyForOffset(0))));
@@ -120,10 +124,10 @@ public class TestLongTimestampWithTimeZoneType
         Type type = createTimestampWithTimeZoneType(precision);
 
         // there is no value before the minimum
-        assertThat(type.getPreviousValue(LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MIN_VALUE, 0, UTC_KEY)))
+        assertThat(type.getPreviousValue(LongTimestampWithTimeZone.fromEpochMillisAndFraction(MIN_EPOCH_MILLIS, 0, UTC_KEY)))
                 .isEqualTo(Optional.empty());
-        assertThat(type.getPreviousValue(LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MIN_VALUE, step, UTC_KEY)))
-                .isEqualTo(Optional.of(LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MIN_VALUE, 0, UTC_KEY)));
+        assertThat(type.getPreviousValue(LongTimestampWithTimeZone.fromEpochMillisAndFraction(MIN_EPOCH_MILLIS, step, UTC_KEY)))
+                .isEqualTo(Optional.of(LongTimestampWithTimeZone.fromEpochMillisAndFraction(MIN_EPOCH_MILLIS, 0, UTC_KEY)));
 
         // stepping down stays within the same millisecond (time zone doesn't matter for ordering)
         assertThat(type.getPreviousValue(LongTimestampWithTimeZone.fromEpochMillisAndFraction(1111, step * 5, getTimeZoneKeyForOffset(2))))
@@ -133,8 +137,8 @@ public class TestLongTimestampWithTimeZoneType
                 .isEqualTo(Optional.of(LongTimestampWithTimeZone.fromEpochMillisAndFraction(1110, PICOSECONDS_PER_MILLISECOND - step, UTC_KEY)));
 
         // near the maximum
-        assertThat(type.getPreviousValue(LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MAX_VALUE, PICOSECONDS_PER_MILLISECOND - step, UTC_KEY)))
-                .isEqualTo(Optional.of(LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MAX_VALUE, PICOSECONDS_PER_MILLISECOND - 2 * step, UTC_KEY)));
+        assertThat(type.getPreviousValue(LongTimestampWithTimeZone.fromEpochMillisAndFraction(MAX_EPOCH_MILLIS, PICOSECONDS_PER_MILLISECOND - step, UTC_KEY)))
+                .isEqualTo(Optional.of(LongTimestampWithTimeZone.fromEpochMillisAndFraction(MAX_EPOCH_MILLIS, PICOSECONDS_PER_MILLISECOND - 2 * step, UTC_KEY)));
     }
 
     @ParameterizedTest
@@ -144,10 +148,10 @@ public class TestLongTimestampWithTimeZoneType
         Type type = createTimestampWithTimeZoneType(precision);
 
         // there is no value after the maximum
-        assertThat(type.getNextValue(LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MAX_VALUE, PICOSECONDS_PER_MILLISECOND - step, UTC_KEY)))
+        assertThat(type.getNextValue(LongTimestampWithTimeZone.fromEpochMillisAndFraction(MAX_EPOCH_MILLIS, PICOSECONDS_PER_MILLISECOND - step, UTC_KEY)))
                 .isEqualTo(Optional.empty());
-        assertThat(type.getNextValue(LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MAX_VALUE, PICOSECONDS_PER_MILLISECOND - 2 * step, UTC_KEY)))
-                .isEqualTo(Optional.of(LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MAX_VALUE, PICOSECONDS_PER_MILLISECOND - step, UTC_KEY)));
+        assertThat(type.getNextValue(LongTimestampWithTimeZone.fromEpochMillisAndFraction(MAX_EPOCH_MILLIS, PICOSECONDS_PER_MILLISECOND - 2 * step, UTC_KEY)))
+                .isEqualTo(Optional.of(LongTimestampWithTimeZone.fromEpochMillisAndFraction(MAX_EPOCH_MILLIS, PICOSECONDS_PER_MILLISECOND - step, UTC_KEY)));
 
         // stepping up stays within the same millisecond (time zone doesn't matter for ordering)
         assertThat(type.getNextValue(LongTimestampWithTimeZone.fromEpochMillisAndFraction(1111, step * 4, getTimeZoneKeyForOffset(2))))

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DateTimeEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DateTimeEncoding.java
@@ -33,11 +33,16 @@ public final class DateTimeEncoding
         return millisUtc << MILLIS_SHIFT >> MILLIS_SHIFT == millisUtc;
     }
 
-    private static long pack(long millisUtc, short timeZoneKey)
+    static void checkMillisUtcInRange(long millisUtc)
     {
         if (!isValidMillisUtc(millisUtc)) {
             throw new IllegalArgumentException("Millis overflow: " + millisUtc);
         }
+    }
+
+    private static long pack(long millisUtc, short timeZoneKey)
+    {
+        checkMillisUtcInRange(millisUtc);
 
         return (millisUtc << MILLIS_SHIFT) | (timeZoneKey & TIME_ZONE_MASK);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DateTimeEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DateTimeEncoding.java
@@ -24,9 +24,18 @@ public final class DateTimeEncoding
     private static final int TIME_ZONE_MASK = 0xFFF;
     private static final int MILLIS_SHIFT = 12;
 
+    /**
+     * Every {@code timestamp with time zone} value is stored with the time zone packed into the low bits of the epoch
+     * millis, so millis that do not survive the shift cannot be represented, regardless of the declared precision.
+     */
+    static boolean isValidMillisUtc(long millisUtc)
+    {
+        return millisUtc << MILLIS_SHIFT >> MILLIS_SHIFT == millisUtc;
+    }
+
     private static long pack(long millisUtc, short timeZoneKey)
     {
-        if (millisUtc << MILLIS_SHIFT >> MILLIS_SHIFT != millisUtc) {
+        if (!isValidMillisUtc(millisUtc)) {
             throw new IllegalArgumentException("Millis overflow: " + millisUtc);
         }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZone.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZone.java
@@ -17,7 +17,10 @@ import java.util.Objects;
 import java.util.StringJoiner;
 
 import static io.airlift.slice.SizeOf.instanceSize;
+import static io.trino.spi.type.DateTimeEncoding.checkMillisUtcInRange;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MILLISECOND;
+import static java.lang.Math.addExact;
+import static java.lang.Math.multiplyExact;
 
 public final class LongTimestampWithTimeZone
         implements Comparable<LongTimestampWithTimeZone>
@@ -31,7 +34,7 @@ public final class LongTimestampWithTimeZone
     public static LongTimestampWithTimeZone fromEpochSecondsAndFraction(long epochSecond, long fractionInPicos, TimeZoneKey timeZoneKey)
     {
         return fromEpochMillisAndFraction(
-                epochSecond * 1_000 + fractionInPicos / 1_000_000_000,
+                addExact(multiplyExact(epochSecond, 1_000), fractionInPicos / 1_000_000_000),
                 (int) (fractionInPicos % 1_000_000_000),
                 timeZoneKey);
     }
@@ -54,6 +57,7 @@ public final class LongTimestampWithTimeZone
         if (picosOfMilli >= PICOSECONDS_PER_MILLISECOND) {
             throw new IllegalArgumentException("picosOfMilli must be < " + PICOSECONDS_PER_MILLISECOND);
         }
+        checkMillisUtcInRange(epochMillis);
         this.epochMillis = epochMillis;
         this.picosOfMilli = picosOfMilli;
         this.timeZoneKey = timeZoneKey;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/LongTimestampWithTimeZoneType.java
@@ -40,6 +40,7 @@ import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.trino.spi.function.OperatorType.READ_VALUE;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
+import static io.trino.spi.type.DateTimeEncoding.isValidMillisUtc;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.DateTimeEncoding.unpackZoneKey;
@@ -160,7 +161,7 @@ final class LongTimestampWithTimeZoneType
         int picosOfMilli = timestampWithTimeZone.getPicosOfMilli();
         picosOfMilli -= toIntExact(rescale(1, 0, 12 - getPrecision()));
         if (picosOfMilli < 0) {
-            if (epochMillis == Long.MIN_VALUE) {
+            if (!isValidMillisUtc(epochMillis - 1)) {
                 return Optional.empty();
             }
             epochMillis--;
@@ -178,7 +179,7 @@ final class LongTimestampWithTimeZoneType
         int picosOfMilli = timestampWithTimeZone.getPicosOfMilli();
         picosOfMilli += toIntExact(rescale(1, 0, 12 - getPrecision()));
         if (picosOfMilli >= PICOSECONDS_PER_MILLISECOND) {
-            if (epochMillis == Long.MAX_VALUE) {
+            if (!isValidMillisUtc(epochMillis + 1)) {
                 return Optional.empty();
             }
             epochMillis++;

--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSource.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSource.java
@@ -635,17 +635,17 @@ class FakerPageSource
         LongTimestampWithTimeZoneRange range = LongTimestampWithTimeZoneRange.of(genericRange, tzType.getPrecision());
         int picosOfMilliHigh = (int) POWERS_OF_TEN[tzType.getPrecision() - 3] - 1;
         return blockBuilder -> {
-            long millis = numberBetween(range.low.getEpochMillis(), range.high.getEpochMillis());
+            long millis = numberBetween(range.lowEpochMillis(), range.highEpochMillis());
             int picosOfMilli;
-            if (millis == range.low.getEpochMillis()) {
+            if (millis == range.lowEpochMillis()) {
                 picosOfMilli = numberBetween(
-                        range.low.getPicosOfMilli(),
-                        range.low.getEpochMillis() == range.high.getEpochMillis() ?
-                                range.high.getPicosOfMilli()
+                        range.lowPicosOfMilli(),
+                        range.lowEpochMillis() == range.highEpochMillis() ?
+                                range.highPicosOfMilli()
                                 : picosOfMilliHigh);
             }
-            else if (millis == range.high.getEpochMillis()) {
-                picosOfMilli = numberBetween(0, range.high.getPicosOfMilli());
+            else if (millis == range.highEpochMillis()) {
+                picosOfMilli = numberBetween(0, range.highPicosOfMilli());
             }
             else {
                 picosOfMilli = numberBetween(0, picosOfMilliHigh);
@@ -923,7 +923,11 @@ class FakerPageSource
         }
     }
 
-    private record LongTimestampWithTimeZoneRange(LongTimestampWithTimeZone low, LongTimestampWithTimeZone high, int factor, short defaultTZ, long step)
+    /**
+     * The bounds are exclusive at one end and the picoseconds are scaled down by {@code factor}, so neither bound is
+     * necessarily a value that {@code timestamp with time zone} can represent. They are kept as plain numbers.
+     */
+    private record LongTimestampWithTimeZoneRange(long lowEpochMillis, int lowPicosOfMilli, long highEpochMillis, int highPicosOfMilli, int factor, short defaultTZ, long step)
     {
         static LongTimestampWithTimeZoneRange of(Range range, int precision)
         {
@@ -943,25 +947,26 @@ class FakerPageSource
                 throw new TrinoException(INVALID_ROW_FILTER, "Range boundaries for timestamp with time zone columns must have the same time zone");
             }
             int factor = (int) POWERS_OF_TEN[12 - precision];
-            int lowPicosOfMilli = roundDiv(low.getPicosOfMilli(), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0);
-            low = fromEpochMillisAndFraction(
-                    low.getEpochMillis() - (lowPicosOfMilli < 0 ? 1 : 0),
-                    (lowPicosOfMilli + factor) % factor,
-                    low.getTimeZoneKey());
-            int highPicosOfMilli = roundDiv(high.getPicosOfMilli(), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0);
-            high = fromEpochMillisAndFraction(
-                    high.getEpochMillis() + (highPicosOfMilli > factor ? 1 : 0),
-                    highPicosOfMilli % factor,
-                    high.getTimeZoneKey());
-            return new LongTimestampWithTimeZoneRange(low, high, factor, defaultTZ, step);
+            int lowPicos = roundDiv(low.getPicosOfMilli(), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0);
+            int highPicos = roundDiv(high.getPicosOfMilli(), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0);
+            return new LongTimestampWithTimeZoneRange(
+                    low.getEpochMillis() - (lowPicos < 0 ? 1 : 0),
+                    (lowPicos + factor) % factor,
+                    high.getEpochMillis() + (highPicos > factor ? 1 : 0),
+                    highPicos % factor,
+                    factor,
+                    defaultTZ,
+                    step);
         }
 
         LongTimestampWithTimeZone at(long index, long stepFactor)
         {
             // TODO support nanosecond increments
             // TODO handle exclusive high
-            long millis = low.getEpochMillis() + roundDiv(index * step, stepFactor);
-            return fromEpochMillisAndFraction(step > 0 ? Math.min(millis, high.getEpochMillis()) : Math.max(millis, high.getEpochMillis()), 0, defaultTZ);
+            long millis = lowEpochMillis + roundDiv(index * step, stepFactor);
+            // highEpochMillis is exclusive when no picoseconds of it are included
+            long lastEpochMillis = highPicosOfMilli > 0 ? highEpochMillis : highEpochMillis - 1;
+            return fromEpochMillisAndFraction(step > 0 ? Math.min(millis, lastEpochMillis) : Math.max(millis, lastEpochMillis), 0, defaultTZ);
         }
     }
 


### PR DESCRIPTION
## Description

Timestamp arithmetic could overflow silently and return a wrong timestamp instead of failing. Each fix is a separate commit.

`date_add` on `timestamp` re-adds the sub-millisecond part of the input after the result has been scaled back to microseconds, and that addition was unchecked:

```sql
SELECT date_add('month', 1, TIMESTAMP '294246-12-10 04:00:54.775999');
-- -290308-12-21 19:59:05.224383
```

The same shape appears in the `timestamp` + `interval` operators, in both `INTERVAL YEAR TO MONTH` and `INTERVAL DAY TO SECOND`:

```sql
SELECT TIMESTAMP '294246-12-10 04:00:54.775999' + INTERVAL '1' MONTH;
-- -290308-12-21 19:59:05.224383
SELECT TIMESTAMP '294247-01-10 04:00:54.775807' + INTERVAL '1' SECOND;
-- -290308-12-21 19:59:06.224191
```

All of these now fail instead of returning a wrong value.

`TIMESTAMP - TIMESTAMP` was wrong in a different way: it subtracted in microseconds and then rounded to milliseconds with `round()` followed by `rescale()`, which scales the rounded value back up by 1000 only for `rescale()` to divide it again, and that round trip overflows. Here the correct answer *is* representable as `INTERVAL DAY TO SECOND`, so it now returns the right value rather than failing:

```sql
SELECT TIMESTAMP '294247-01-10 04:00:54.775807' - TIMESTAMP '1970-01-01 00:00:00.000000';
-- was -106751991 04:00:54.775, now 106751991 04:00:54.776
```

At precision 7 and above the same operator also dropped `picosOfMicro` before rounding, so a difference within a picosecond of an exact half-millisecond rounded the wrong way; the picosecond difference is now carried into the rounding, where it decides those ties and nothing else.

Two follow-on commits make the failures usable rather than internal errors:

- Overflow escaped as a bare `ArithmeticException`, so the query failed with `GENERIC_INTERNAL_ERROR` even though the inputs were at fault. It is now `NUMERIC_VALUE_OUT_OF_RANGE`, matching interval arithmetic and the date to timestamp cast. `date_add` previously reported `INVALID_FUNCTION_ARGUMENT` with the JVM's `long overflow` text, so the same overflow was reported one way by `date_add` and another by the operators; both now agree. `IllegalArgumentException` from the joda field arithmetic keeps `INVALID_FUNCTION_ARGUMENT`, because its message names the offending argument.

- `timestamp with time zone` had the same problem at precision 4 and above, but it could not be fixed in the operator: every value of the type is stored with the time zone packed into the low bits of the epoch millis, and `LongTimestampWithTimeZone` accepted millis outside that range, so the failure came from `LongTimestampWithTimeZoneType.writeObject` after the operator had already returned. The range is now checked on construction, and the operators report `NUMERIC_VALUE_OUT_OF_RANGE`. This also fixes `getPreviousValue`/`getNextValue`, which used `Long.MIN_VALUE`/`Long.MAX_VALUE` as the domain endpoints and could therefore return a value that cannot be stored.

## Additional context and related issues

One adjacent problem is **not** addressed here:

- `date_add` on `timestamp with time zone` reports an out-of-range result as `INVALID_FUNCTION_ARGUMENT` with the internal `Millis overflow: <millis>` text, where `date_add` on `timestamp` reports `NUMERIC_VALUE_OUT_OF_RANGE`.

## Release notes

(x) Release notes are required, with the following suggested text:

```
# General
* Fix `date_add` and timestamp arithmetic with intervals returning an incorrect
  timestamp instead of failing when the result is out of range. ({issue}`31002`)
* Fix subtraction of two `timestamp` values returning an incorrect interval for
  differences that overflow when computed in microseconds. ({issue}`31002`)
```
