### PR TITLE
Fail product tests on unpinned container images

### DIFF
--- a/testing/trino-product-tests/src/test/java/io/trino/tests/framework/TestImageNameSubstitutorRegistration.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/framework/TestImageNameSubstitutorRegistration.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.framework;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.testing.containers.RequireVersionedImageSubstitutor;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.utility.ImageNameSubstitutor;
+
+import java.util.ServiceLoader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link RequireVersionedImageSubstitutor} is registered as a Testcontainers
+ * {@link ImageNameSubstitutor} service, so every container started by product tests is checked
+ * for a pinned image. Guards against the service registration being lost or misspelled.
+ */
+class TestImageNameSubstitutorRegistration
+{
+    @Test
+    void testSubstitutorIsRegistered()
+    {
+        assertThat(ImmutableList.copyOf(ServiceLoader.load(ImageNameSubstitutor.class)))
+                .hasAtLeastOneElementOfType(RequireVersionedImageSubstitutor.class);
+    }
+}

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/framework/TestTrinoProductTestContainer.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/framework/TestTrinoProductTestContainer.java
@@ -24,6 +24,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
 
+import static io.trino.testing.containers.TrinoTestImages.getLastReleasedTrinoVersion;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -36,6 +37,7 @@ class TestTrinoProductTestContainer
 {
     @Container
     static TrinoContainer trino = TrinoProductTestContainer.builder()
+            .withVersion(getLastReleasedTrinoVersion())
             .build();
 
     @Test
@@ -62,7 +64,7 @@ class TestTrinoProductTestContainer
     {
         // Verify builder pattern works correctly
         TrinoContainer container = TrinoProductTestContainer.builder()
-                .withVersion("latest")
+                .withVersion(getLastReleasedTrinoVersion())
                 .build();
         assertThat(container).isNotNull();
         // Don't start the container, just verify it's configured

--- a/testing/trino-product-tests/src/test/resources/META-INF/services/org.testcontainers.utility.ImageNameSubstitutor
+++ b/testing/trino-product-tests/src/test/resources/META-INF/services/org.testcontainers.utility.ImageNameSubstitutor
@@ -1,0 +1,1 @@
+io.trino.testing.containers.RequireVersionedImageSubstitutor

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/RequireVersionedImageSubstitutor.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/RequireVersionedImageSubstitutor.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.containers;
+
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.ImageNameSubstitutor;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Fails fast when a container would run an unpinned image. Testcontainers invokes the
+ * configured substitutor for every image it resolves, so registering this globally (via
+ * {@code META-INF/services/org.testcontainers.utility.ImageNameSubstitutor}) enforces the rule
+ * across every container in the JVM, not only the images this project defines.
+ * <p>
+ * Both an untagged reference and an explicit {@code :latest} tag resolve to the version part
+ * {@code latest}, which pulls a mutable image and makes runs non-reproducible. Images must instead
+ * be pinned to an explicit version tag or digest.
+ */
+public class RequireVersionedImageSubstitutor
+        extends ImageNameSubstitutor
+{
+    @Override
+    public DockerImageName apply(DockerImageName original)
+    {
+        checkArgument(
+                !original.getVersionPart().equals("latest"),
+                "Container image must be pinned to an explicit version or digest, not latest or untagged: %s. " +
+                        "For the Trino image, set the '%s' system property to the locally built image.",
+                original.asCanonicalNameString(),
+                TrinoTestImages.TRINO_IMAGE_PROPERTY);
+        return original;
+    }
+
+    @Override
+    protected String getDescription()
+    {
+        return RequireVersionedImageSubstitutor.class.getSimpleName();
+    }
+}

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TrinoTestImages.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TrinoTestImages.java
@@ -13,9 +13,18 @@
  */
 package io.trino.testing.containers;
 
+import io.trino.testing.TestingProperties;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Integer.parseInt;
+
 public final class TrinoTestImages
 {
     private static final String DEFAULT_TRINO_IMAGE = "trinodb/trino:latest";
+    private static final Pattern PROJECT_VERSION = Pattern.compile("(\\d+)(?:-SNAPSHOT)?");
 
     public static final String TRINO_IMAGE_PROPERTY = "trino.product-tests.image";
 
@@ -24,5 +33,17 @@ public final class TrinoTestImages
     public static String getDefaultTrinoImage()
     {
         return System.getProperty(TRINO_IMAGE_PROPERTY, DEFAULT_TRINO_IMAGE);
+    }
+
+    /**
+     * The last released Trino version, for tests exercising container plumbing rather than the code
+     * under development. The project version itself is not published as an image yet.
+     */
+    public static String getLastReleasedTrinoVersion()
+    {
+        String projectVersion = TestingProperties.getProjectVersion();
+        Matcher matcher = PROJECT_VERSION.matcher(projectVersion);
+        checkState(matcher.matches(), "Unrecognized project version: %s", projectVersion);
+        return String.valueOf(parseInt(matcher.group(1)) - 1);
     }
 }

--- a/testing/trino-testing-containers/src/test/java/io/trino/testing/containers/TestRequireVersionedImageSubstitutor.java
+++ b/testing/trino-testing-containers/src/test/java/io/trino/testing/containers/TestRequireVersionedImageSubstitutor.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.containers;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestRequireVersionedImageSubstitutor
+{
+    private final RequireVersionedImageSubstitutor substitutor = new RequireVersionedImageSubstitutor();
+
+    @Test
+    void testVersionedImagePasses()
+    {
+        DockerImageName image = DockerImageName.parse("ghcr.io/trinodb/testing/hive3.1:123");
+        assertThat(substitutor.apply(image)).isSameAs(image);
+    }
+
+    @Test
+    void testDigestPinnedImagePasses()
+    {
+        DockerImageName image = DockerImageName.parse("trinodb/trino@sha256:0000000000000000000000000000000000000000000000000000000000000000");
+        assertThat(substitutor.apply(image)).isSameAs(image);
+    }
+
+    @Test
+    void testExplicitLatestRejected()
+    {
+        assertThatThrownBy(() -> substitutor.apply(DockerImageName.parse("trinodb/trino:latest")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be pinned")
+                .hasMessageContaining("trinodb/trino:latest");
+    }
+
+    @Test
+    void testUntaggedImageRejected()
+    {
+        // An untagged reference resolves to the version part "latest"
+        assertThatThrownBy(() -> substitutor.apply(DockerImageName.parse("trinodb/trino")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be pinned");
+    }
+}

--- a/testing/trino-testing-services/src/main/java/io/trino/testing/TestingProperties.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testing/TestingProperties.java
@@ -56,7 +56,9 @@ public final class TestingProperties
 
     public static String getDockerImagesVersion()
     {
-        return getProjectProperty("docker.images.version");
+        String version = getProjectProperty("docker.images.version");
+        checkArgument(!version.isEmpty() && !version.equals("latest"), "docker.images.version must be pinned to an explicit version, was '%s'", version);
+        return version;
     }
 
     private static String getProjectProperty(String name)


### PR DESCRIPTION
Product-test environments pull container images by name, and it is easy to reference one without a version tag or with an explicit ":latest". Both resolve to a mutable image: the run then depends on whatever ":latest" happens to point at, which is non-reproducible and can silently pick up an incompatible image, or one that no longer exists for images published under versioned tags only. The mistake is invisible in review because the code still compiles and usually still runs locally.

Enforce the invariant instead of relying on reviewers. Testcontainers invokes a configured ImageNameSubstitutor for every image it resolves, so a single substitutor registered via ServiceLoader validates every container started by a product test - the images defined here as well as those from Testcontainers modules - without touching each call site. RequireVersionedImageSubstitutor rejects any image whose version part is "latest" (both untagged references and an explicit ":latest" map to it), while explicit tags and digests pass through. The service registration lives only in trino-product-tests test resources, so the check is scoped to product tests.

As a side effect this enforces the existing convention that the Trino image must be overridden to the locally built image: its default is trinodb/trino:latest, so forgetting to set trino.product-tests.image now fails fast with a clear message rather than silently pulling a stale published image.

Also assert docker.images.version is a pinned version at its source in TestingProperties, which feeds every ghcr.io/trinodb/testing image.
