### PR TITLE
Increase Hadoop container startup timeout and add a retry

### DIFF
--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/azure/AzureEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/azure/AzureEnvironment.java
@@ -64,6 +64,7 @@ public class AzureEnvironment
     private static final Duration HIVE_METASTORE_STARTUP_TIMEOUT = Duration.ofMinutes(4);
     private static final Duration HIVE_METASTORE_STARTUP_POLL_INTERVAL = Duration.ofSeconds(2);
     private static final int HIVE_METASTORE_STABLE_SUCCESS_POLL_COUNT = 3;
+    // azure needs more start up time headroom than the other environments
     private static final Duration HADOOP_STARTUP_TIMEOUT = Duration.ofMinutes(12);
     private static final String AZURE_URI_SCHEME = "abfs";
     private static final String AZURE_ENDPOINT = "dfs.core.windows.net";

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/gcs/GcsEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/gcs/GcsEnvironment.java
@@ -22,7 +22,6 @@ import io.trino.tests.product.TableFormatsTestEnvironment;
 import org.intellij.lang.annotations.Language;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.Transferable;
 
 import java.io.IOException;
@@ -67,7 +66,6 @@ public class GcsEnvironment
     private static final Duration HIVE_METASTORE_STARTUP_TIMEOUT = Duration.ofMinutes(4);
     private static final Duration HIVE_METASTORE_STARTUP_POLL_INTERVAL = Duration.ofSeconds(2);
     private static final int HIVE_METASTORE_STABLE_SUCCESS_POLL_COUNT = 3;
-    private static final Duration HADOOP_STARTUP_TIMEOUT = Duration.ofMinutes(6);
     private static final String GCS_CONNECTOR_VERSION = "hadoop2-2.2.24";
     private static final String GCS_CONNECTOR_SHA256 = "ff2136d22ac84fab91e3eea0886d5e59f8acbabb19e46ff91dbcd1f2db0925d6";
 
@@ -107,8 +105,6 @@ public class GcsEnvironment
                 .withNetwork(network)
                 .withNetworkAliases(HadoopContainer.HOST_NAME);
         configureHadoop(hadoop, gcpCredentialsJson, gcpStorageBucket, gcsTestDirectory);
-        hadoop.waitingFor(Wait.forLogMessage(".*success: socks-proxy entered RUNNING state.*", 1)
-                .withStartupTimeout(HADOOP_STARTUP_TIMEOUT));
         hadoop.start();
         waitForHiveMetastoreStable();
 

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/HadoopContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/HadoopContainer.java
@@ -45,6 +45,9 @@ import static java.util.Objects.requireNonNull;
 public class HadoopContainer
         extends GenericContainer<HadoopContainer>
 {
+    // 3 minutes was observed as not enough on CI
+    private static final Duration STARTUP_TIMEOUT = Duration.ofMinutes(6);
+
     private static final String DEFAULT_IMAGE = "ghcr.io/trinodb/testing/hive3.1";
     private static final String KERBERIZED_IMAGE = "ghcr.io/trinodb/testing/hive3.1-kerberos";
 
@@ -109,7 +112,7 @@ public class HadoopContainer
         // Wait for socks-proxy to enter RUNNING state - this is the last service started by supervisord
         // Note: Don't use Wait.forListeningPort() as HDFS port 9000 binds to container IP, not 0.0.0.0
         waitingFor(Wait.forLogMessage(".*success: socks-proxy entered RUNNING state.*", 1)
-                .withStartupTimeout(Duration.ofMinutes(3)));
+                .withStartupTimeout(STARTUP_TIMEOUT));
     }
 
     @Override

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/HadoopContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/HadoopContainer.java
@@ -113,6 +113,7 @@ public class HadoopContainer
         // Note: Don't use Wait.forListeningPort() as HDFS port 9000 binds to container IP, not 0.0.0.0
         waitingFor(Wait.forLogMessage(".*success: socks-proxy entered RUNNING state.*", 1)
                 .withStartupTimeout(STARTUP_TIMEOUT));
+        withStartupAttempts(2);
     }
 
     @Override


### PR DESCRIPTION
## Description

The Kerberos environments intermittently fail before any test runs, because the Hadoop
container never reaches readiness:

```
ContainerLaunchException: Container startup failed for image ghcr.io/trinodb/testing/hive3.1
Caused by: Timed out waiting for log output matching '.*success: socks-proxy entered RUNNING state.*'
```

**Allow more time.** `HadoopContainer` gave supervisord three minutes. `GcsEnvironment` and
`AzureEnvironment` already overrode that same wait for the same image with six and twelve
minutes, so three has been judged too short twice. This raises the default to six, matching
`GcsEnvironment`, whose override then duplicates it and is removed.

**Retry once.** Rerunning the failed job passes, so the failure is transient — #30611
records four occurrences since August, each cleared by a rerun. `withStartupAttempts(2)`
gets that recovery within the run: `tryStart()` stops the failed container before
rethrowing, so the second attempt starts clean. Verified locally that the second attempt
runs and leaves nothing behind.

- Related to #30611

## Additional context and related issues

`HadoopContainer` is constructed in 25 places, so this affects every Hadoop-based product
test. Neither change alters behaviour when the container starts in time.

Two costs: a rerun lands on a fresh runner whereas an attempt retries on the same host, so
the retry will not cover every case the rerun evidence does; and a genuinely broken
environment now takes two full waits to report.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.