### PR TITLE
Remove stray TODO leading to semantics change

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
@@ -964,7 +964,6 @@ public final class StringFunctions
         return Chars.padSpaces(slice, toIntExact(x));
     }
 
-    // TODO: implement N arguments char concat
     @Description("Concatenates given character strings")
     // Given CHAR type max length, if the result type is valid, allocation cannot fail.
     @ScalarFunction(neverFails = true)


### PR DESCRIPTION
Currently, `concat(a_char, a_char, a_char...)` works. It works by coercing `char` values to `varchar` (trimming trailing spaces), and so is not consistent with `concat(a_char, a_char)` which retains trailing spaces.  If we were to act upon the TODO being removed, we would need to add implement `concat(a_char, a_char, a_char...)` consistently with the 2-arg version, so preserving the trailing spaces. This would be semantically breaking change though.

- follows https://github.com/trinodb/trino/issues/9988
