### PR TITLE
Account TopN pages by retained size

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/RowReferencePageManager.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RowReferencePageManager.java
@@ -233,12 +233,17 @@ public final class RowReferencePageManager
     private final class PageAccounting
     {
         private static final int COMPACTION_MIN_FILL_MULTIPLIER = 2;
+        // Copy a page once when its backing arrays retain over 12.5% and at least 4 KB more than the data they hold;
+        // block builders size their arrays from the previous page, so retained pages commonly carry unused capacity
+        private static final int COMPACTION_MAX_SLACK_DIVISOR = 8;
+        private static final long COMPACTION_MIN_SLACK_BYTES = 4 * 1024;
 
         private final int pageId;
         private Page page;
         private long[] rowIds;
         // Start off locked to give the caller time to declare which rows to reference
         private boolean lockedPage = true;
+        private boolean compacted;
         private int activePositions;
 
         public PageAccounting(int pageId, Page page)
@@ -310,7 +315,20 @@ public final class RowReferencePageManager
         public boolean isCompactionEligible()
         {
             // Compaction is only allowed if the page is unlocked
-            return !lockedPage && activePositions * COMPACTION_MIN_FILL_MULTIPLIER < page.getPositionCount();
+            if (lockedPage) {
+                return false;
+            }
+            return activePositions * COMPACTION_MIN_FILL_MULTIPLIER < page.getPositionCount() || hasExcessRetainedBytes();
+        }
+
+        private boolean hasExcessRetainedBytes()
+        {
+            if (compacted) {
+                return false;
+            }
+            long sizeInBytes = page.getSizeInBytes();
+            long slackBytes = page.getRetainedSizeInBytes() - sizeInBytes;
+            return slackBytes > Math.max(sizeInBytes / COMPACTION_MAX_SLACK_DIVISOR, COMPACTION_MIN_SLACK_BYTES);
         }
 
         public void compact()
@@ -318,6 +336,10 @@ public final class RowReferencePageManager
             checkState(!lockedPage, "Should not attempt compaction when page is locked");
 
             if (activePositions == page.getPositionCount()) {
+                if (hasExcessRetainedBytes()) {
+                    page.compact();
+                    compacted = true;
+                }
                 return;
             }
 
@@ -338,11 +360,12 @@ public final class RowReferencePageManager
             // Compact page
             page = page.copyPositions(positionsToKeep, 0, positionsToKeep.length);
             rowIds = newRowIds;
+            compacted = true;
         }
 
         public long sizeOf()
         {
-            return PAGE_ACCOUNTING_INSTANCE_SIZE + page.getSizeInBytes() + SizeOf.sizeOf(rowIds);
+            return PAGE_ACCOUNTING_INSTANCE_SIZE + page.getRetainedSizeInBytes() + SizeOf.sizeOf(rowIds);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestRowReferencePageManager.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestRowReferencePageManager.java
@@ -16,12 +16,14 @@ package io.trino.operator;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.DictionaryBlock;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.Math.toIntExact;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -302,6 +304,112 @@ public class TestRowReferencePageManager
             assertThat(extractValue(pageManager, id2)).isEqualTo(2L);
             assertThat(id0).isEqualTo(id2);
         }
+    }
+
+    @Test
+    public void testRetainedSizeAccounting()
+    {
+        RowReferencePageManager pageManager = new RowReferencePageManager();
+
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 2, 1_000_000);
+        VARCHAR.writeString(blockBuilder, "a");
+        VARCHAR.writeString(blockBuilder, "b");
+        Page page = new Page(blockBuilder.build());
+        long retainedBefore = page.getRetainedSizeInBytes();
+        assertThat(retainedBefore).isGreaterThan(1_000_000);
+
+        long id0;
+        long id1;
+        try (RowReferencePageManager.LoadCursor cursor = pageManager.add(page)) {
+            assertThat(cursor.advance()).isTrue();
+            id0 = cursor.allocateRowId();
+            assertThat(cursor.advance()).isTrue();
+            id1 = cursor.allocateRowId();
+        }
+        assertThat(pageManager.getPageBytes()).isGreaterThanOrEqualTo(retainedBefore);
+
+        // Fully referenced page is still a compaction candidate because of the slack
+        assertThat(pageManager.getCompactionCandidateCount()).isEqualTo(1);
+        pageManager.compactIfNeeded();
+        assertThat(pageManager.getCompactionCandidateCount()).isEqualTo(0);
+        assertThat(pageManager.getPageBytes()).isLessThan(retainedBefore / 100);
+        assertThat(extractString(pageManager, id0)).isEqualTo("a");
+        assertThat(extractString(pageManager, id1)).isEqualTo("b");
+
+        pageManager.dereference(id0);
+        assertThat(pageManager.getCompactionCandidateCount()).isEqualTo(0);
+        assertThat(extractString(pageManager, id1)).isEqualTo("b");
+
+        pageManager.dereference(id1);
+        assertThat(pageManager.getPageBytes()).isEqualTo(0);
+    }
+
+    @Test
+    public void testBuilderResetSkewCompaction()
+    {
+        RowReferencePageManager pageManager = new RowReferencePageManager();
+
+        // Builder sized to 1.25x the value, matching the block builder reset skew
+        int valueLength = 1_000_000;
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 1, valueLength * 5 / 4);
+        VARCHAR.writeString(blockBuilder, "z".repeat(valueLength));
+        Page page = new Page(blockBuilder.build());
+        long retainedBefore = page.getRetainedSizeInBytes();
+        assertThat(retainedBefore).isGreaterThan(valueLength * 5L / 4);
+
+        long id;
+        try (RowReferencePageManager.LoadCursor cursor = pageManager.add(page)) {
+            assertThat(cursor.advance()).isTrue();
+            id = cursor.allocateRowId();
+        }
+        assertThat(pageManager.getPageBytes()).isGreaterThanOrEqualTo(retainedBefore);
+
+        assertThat(pageManager.getCompactionCandidateCount()).isEqualTo(1);
+        pageManager.compactIfNeeded();
+        assertThat(pageManager.getCompactionCandidateCount()).isEqualTo(0);
+        assertThat(pageManager.getPageBytes()).isLessThan(valueLength + 4096);
+        assertThat(extractString(pageManager, id)).hasSize(valueLength);
+    }
+
+    @Test
+    public void testSharedDictionaryPages()
+    {
+        RowReferencePageManager pageManager = new RowReferencePageManager();
+
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 2);
+        VARCHAR.writeString(blockBuilder, "x".repeat(100_000));
+        VARCHAR.writeString(blockBuilder, "y".repeat(100_000));
+        Block dictionary = blockBuilder.build();
+        Page page0 = new Page(DictionaryBlock.create(1, dictionary, new int[] {0}));
+        Page page1 = new Page(DictionaryBlock.create(1, dictionary, new int[] {1}));
+
+        long id0;
+        long id1;
+        try (RowReferencePageManager.LoadCursor cursor = pageManager.add(page0)) {
+            assertThat(cursor.advance()).isTrue();
+            id0 = cursor.allocateRowId();
+        }
+        try (RowReferencePageManager.LoadCursor cursor = pageManager.add(page1)) {
+            assertThat(cursor.advance()).isTrue();
+            id1 = cursor.allocateRowId();
+        }
+
+        // Each page is charged for the whole shared dictionary until it is copied
+        long pageBytesBeforeCompaction = pageManager.getPageBytes();
+        assertThat(pageBytesBeforeCompaction).isGreaterThanOrEqualTo(2 * dictionary.getRetainedSizeInBytes());
+        assertThat(pageManager.getCompactionCandidateCount()).isEqualTo(2);
+        pageManager.compactIfNeeded();
+        assertThat(pageManager.getCompactionCandidateCount()).isEqualTo(0);
+        assertThat(pageManager.getPageBytes()).isLessThan(pageBytesBeforeCompaction / 2 + 1024);
+        assertThat(extractString(pageManager, id0)).isEqualTo("x".repeat(100_000));
+        assertThat(extractString(pageManager, id1)).isEqualTo("y".repeat(100_000));
+    }
+
+    private static String extractString(RowReferencePageManager pageManager, long rowId)
+    {
+        Page page = pageManager.getPage(rowId);
+        int position = pageManager.getPosition(rowId);
+        return VARCHAR.getSlice(page.getBlock(0), position).toStringUtf8();
     }
 
     private static long extractValue(RowReferencePageManager pageManager, long rowId)


### PR DESCRIPTION
## Description

`RowReferencePageManager` charged retained TopN pages at `page.getSizeInBytes()`, which excludes the unused capacity of the backing arrays. Block builders reset to 1.25x the previous page, so pages produced by projections pin up to 25% more heap than reported. With wide rows and a small TopN limit, this under-count was enough for a worker to run out of heap rather than fail the query.

* `PageAccounting.sizeOf()` now uses `page.getRetainedSizeInBytes()`, as `PagesIndex` does.
* Pages whose retained size exceeds logical size by more than max(size/8, 4 KB) are compacted once. Fully referenced pages use `Page.compact()` in place, partially referenced pages use the existing `copyPositions` path.

JMH (topN=10, positions=10000, addPageCalls=100, ops/s, higher is better):

| Benchmark | groupCount | baseline | branch |
|---|---|---|---|
| GroupedTopNRankBuilder | 1 | 24.14 ± 0.49 | 23.65 ± 0.47 |
| GroupedTopNRankBuilder | 10000 | 8.43 ± 0.14 | 8.35 ± 0.28 |
| GroupedTopNRowNumberBuilder | 1 | 56.30 ± 2.12 | 56.41 ± 1.08 |
| GroupedTopNRowNumberBuilder | 10000 | 45.75 ± 2.82 | 42.95 ± 0.54 |

## Additional context and related issues

Found from a worker heap dump where TopN page managers held ~20% more heap than the memory pool reported for them.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix worker out of memory errors when `row_number` or `rank` TopN queries retain wide rows.
```
