### PR TITLE
Release sort buffer memory promptly when sorted writes are aborted

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
@@ -376,7 +376,9 @@ public class TableWriterOperator
     public void close()
             throws Exception
     {
+        // closer runs in reverse registration order, so the sink memory is released after the abort completes
         AutoCloseableCloser closer = AutoCloseableCloser.create();
+        closer.register(pageSinkMemoryContext::close);
         if (!closed) {
             closed = true;
             if (!committed) {
@@ -385,7 +387,6 @@ public class TableWriterOperator
         }
         closer.register(() -> statisticAggregationOperator.getOperatorContext().destroy());
         closer.register(statisticAggregationOperator);
-        closer.register(pageSinkMemoryContext::close);
         closer.close();
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestTableWriterOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTableWriterOperator.java
@@ -251,6 +251,28 @@ public class TestTableWriterOperator
         assertThat(info.getStatisticsCpuTime().getValue(NANOSECONDS)).isGreaterThan(0);
     }
 
+    @Test
+    public void testCloseReleasesPageSinkMemoryAfterAbort()
+            throws Exception
+    {
+        TableWriteInfoTestPageSink pageSink = new TableWriteInfoTestPageSink();
+        PageSinkManager pageSinkManager = new PageSinkManager(CatalogServiceProvider.singleton(TEST_CATALOG_HANDLE, new ConstantPageSinkProvider(pageSink)));
+        TableWriterOperator operator = (TableWriterOperator) createTableWriterOperator(
+                pageSinkManager,
+                new DevNullOperatorFactory(1, new PlanNodeId("test")),
+                ImmutableList.of(BIGINT, VARBINARY));
+        MemoryTrackingContext memoryContext = operator.getOperatorContext().getOperatorMemoryContext();
+        pageSink.setMemoryContext(memoryContext);
+
+        operator.addInput(rowPagesBuilder(BIGINT).row(42).buildPage());
+        assertThat(memoryContext.getUserMemory()).isGreaterThan(0);
+
+        operator.close();
+
+        assertThat(pageSink.getUserMemoryDuringAbort()).isGreaterThan(0);
+        assertThat(memoryContext.getUserMemory()).isEqualTo(0);
+    }
+
     private void assertMemoryIsReleased(TableWriterOperator tableWriterOperator)
     {
         OperatorContext tableWriterOperatorOperatorContext = tableWriterOperator.getOperatorContext();
@@ -384,6 +406,18 @@ public class TestTableWriterOperator
             implements ConnectorPageSink
     {
         private final List<Page> pages = new ArrayList<>();
+        private MemoryTrackingContext memoryContext;
+        private long userMemoryDuringAbort;
+
+        void setMemoryContext(MemoryTrackingContext memoryContext)
+        {
+            this.memoryContext = memoryContext;
+        }
+
+        long getUserMemoryDuringAbort()
+        {
+            return userMemoryDuringAbort;
+        }
 
         @Override
         public CompletableFuture<?> appendPage(Page page)
@@ -419,6 +453,12 @@ public class TestTableWriterOperator
         }
 
         @Override
-        public void abort() {}
+        public void abort()
+        {
+            if (memoryContext != null) {
+                userMemoryDuringAbort = memoryContext.getUserMemory();
+            }
+            pages.clear();
+        }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SortingFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SortingFileWriter.java
@@ -182,6 +182,7 @@ public final class SortingFileWriter
     @Override
     public void rollback()
     {
+        sortBuffer.clear();
         RollbackAction rollbackAction = createRollbackAction(fileSystem, tempFiles);
         try (Closer closer = Closer.create()) {
             closer.register(outputWriter::rollback);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SortingFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SortingFileWriter.java
@@ -195,11 +195,9 @@ public final class SortingFileWriter
 
     private static RollbackAction createRollbackAction(TrinoFileSystem fileSystem, Queue<TempFile> tempFiles)
     {
-        return () -> {
-            for (TempFile file : tempFiles) {
-                cleanupFile(fileSystem, file.location());
-            }
-        };
+        return () -> cleanupFiles(fileSystem, tempFiles.stream()
+                .map(TempFile::location)
+                .collect(toImmutableList()));
     }
 
     @Override
@@ -243,7 +241,7 @@ public final class SortingFileWriter
         }
     }
 
-    private void mergeFiles(Iterable<TempFile> files, Consumer<Page> consumer)
+    private void mergeFiles(Collection<TempFile> files, Consumer<Page> consumer)
     {
         try (Closer closer = Closer.create()) {
             Collection<Iterator<Page>> iterators = new ArrayList<>();
@@ -257,9 +255,9 @@ public final class SortingFileWriter
             new MergingPageIterator(iterators, sortTypes, sortFields, sortOrders, typeOperators)
                     .forEachRemaining(page -> consumer.accept(stripPage(page)));
 
-            for (TempFile tempFile : files) {
-                fileSystem.deleteFile(tempFile.location());
-            }
+            fileSystem.deleteFiles(files.stream()
+                    .map(TempFile::location)
+                    .collect(toImmutableList()));
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -277,7 +275,7 @@ public final class SortingFileWriter
             tempFilesWrittenBytes += writer.getWrittenBytes();
         }
         catch (IOException | UncheckedIOException e) {
-            cleanupFile(fileSystem, tempFile);
+            cleanupFiles(fileSystem, ImmutableList.of(tempFile));
             throw new TrinoException(HIVE_WRITER_DATA_ERROR, "Failed to write temporary file: " + tempFile, e);
         }
     }
@@ -310,13 +308,21 @@ public final class SortingFileWriter
         return page.getColumns(keepChannels);
     }
 
-    private static void cleanupFile(TrinoFileSystem fileSystem, Location location)
+    private static void cleanupFiles(TrinoFileSystem fileSystem, List<Location> locations)
     {
         try {
-            fileSystem.deleteFile(location);
+            fileSystem.deleteFiles(locations);
         }
         catch (IOException e) {
-            log.warn(e, "Failed to delete temporary file: %s", location);
+            log.warn(e, "Failed to bulk delete %s temporary files, deleting one at a time", locations.size());
+            for (Location location : locations) {
+                try {
+                    fileSystem.deleteFile(location);
+                }
+                catch (IOException fileException) {
+                    log.warn(fileException, "Failed to delete temporary file: %s", location);
+                }
+            }
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SortBuffer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SortBuffer.java
@@ -104,6 +104,11 @@ public class SortBuffer
         Iterator<Page> sortedPages = pageSorter.sort(types, pages, sortFields, sortOrders, rowCount);
         sortedPages.forEachRemaining(consumer);
 
+        clear();
+    }
+
+    public void clear()
+    {
         pages.clear();
         rowCount = 0;
         usedMemoryBytes = 0;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestSortingFileWriter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestSortingFileWriter.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.memory.MemoryFileSystem;
+import io.trino.spi.Page;
+import io.trino.spi.block.LongArrayBlock;
+import io.trino.spi.type.TypeOperators;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.plugin.hive.HiveTestUtils.PAGE_SORTER;
+import static io.trino.spi.connector.SortOrder.ASC_NULLS_FIRST;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSortingFileWriter
+{
+    private static final Location TEMP_DIRECTORY = Location.of("memory:///temp/");
+
+    @Test
+    public void testRollbackReleasesMemoryAndDeletesTempFiles()
+            throws IOException
+    {
+        TrinoFileSystem fileSystem = new MemoryFileSystem();
+        SortingFileWriter writer = new SortingFileWriter(
+                fileSystem,
+                TEMP_DIRECTORY.appendPath("sort"),
+                new NoOpFileWriter(),
+                DataSize.of(1, MEGABYTE),
+                100,
+                ImmutableList.of(BIGINT),
+                ImmutableList.of(0),
+                ImmutableList.of(ASC_NULLS_FIRST),
+                PAGE_SORTER,
+                new TypeOperators(),
+                ImmutableList.of());
+        long emptyMemoryUsage = writer.getMemoryUsage();
+
+        for (int i = 0; i < 100; i++) {
+            writer.appendRows(createPage(10_000));
+        }
+        assertThat(writer.getMemoryUsage()).isGreaterThan(emptyMemoryUsage);
+        assertThat(listFiles(fileSystem)).isNotEmpty();
+
+        writer.rollback();
+
+        assertThat(writer.getMemoryUsage()).isEqualTo(emptyMemoryUsage);
+        assertThat(listFiles(fileSystem)).isEmpty();
+    }
+
+    private static Page createPage(int positionCount)
+    {
+        long[] values = new long[positionCount];
+        for (int i = 0; i < positionCount; i++) {
+            values[i] = positionCount - i;
+        }
+        return new Page(new LongArrayBlock(positionCount, Optional.empty(), values));
+    }
+
+    private static List<Location> listFiles(TrinoFileSystem fileSystem)
+            throws IOException
+    {
+        ImmutableList.Builder<Location> locations = ImmutableList.builder();
+        FileIterator iterator = fileSystem.listFiles(TEMP_DIRECTORY);
+        while (iterator.hasNext()) {
+            locations.add(iterator.next().location());
+        }
+        return locations.build();
+    }
+
+    private static class NoOpFileWriter
+            implements FileWriter
+    {
+        @Override
+        public long getWrittenBytes()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getMemoryUsage()
+        {
+            return 0;
+        }
+
+        @Override
+        public void appendRows(Page dataPage) {}
+
+        @Override
+        public RollbackAction commit()
+        {
+            return () -> {};
+        }
+
+        @Override
+        public void rollback() {}
+
+        @Override
+        public long getValidationCpuNanos()
+        {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
## Description

When a task with sorted writes fails, `TableWriterOperator.close` aborts the page sink, and `SortingFileWriter.rollback` deletes every temp file with one blocking file system call each. Three problems make heap outlive its memory reservation during that teardown:

* `SortingFileWriter.rollback` never dropped the buffered pages, so each writer kept up to `writer-sort-buffer-size` of data alive until the driver was garbage collected.
* Temp files were deleted one by one, so an abort with many temp files on object storage took minutes.
* `TableWriterOperator.close` released the page sink memory context before the abort ran, so the memory pool saw the reservation go to zero while the pages were still on the heap. New queries were admitted against memory that was still occupied.

Each commit addresses one of these:

1. `SortBuffer.clear()` is called at the start of `rollback`, so the buffered pages become unreachable as soon as the abort starts.
2. Temp files are removed with `TrinoFileSystem.deleteFiles`, falling back to per-file deletes when the bulk call fails.
3. The page sink memory context is closed after `pageSink.abort()` completes.

## Additional context and related issues

Observed on a worker heap dump where writer drivers of two already-failed queries held about 40 GB of sort buffers with no reservation in the memory pool, while a third query filled the rest of the heap. The teardown threads were blocked in per-file temp file deletes at the time of the dump.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Hive, Iceberg
* Release sort buffer memory promptly and delete temporary files in bulk when a sorted write is aborted. ({issue}`31018`)
```
