### PR TITLE
Avoid duplicate field index lookup

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Scope.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Scope.java
@@ -346,7 +346,7 @@ public class Scope
     private ResolvedField asResolvedField(Field field, int fieldIndexOffset, boolean local)
     {
         int relationFieldIndex = relation.indexOf(field);
-        int hierarchyFieldIndex = relation.indexOf(field) + fieldIndexOffset;
+        int hierarchyFieldIndex = relationFieldIndex + fieldIndexOffset;
         return new ResolvedField(this, field, hierarchyFieldIndex, relationFieldIndex, local);
     }
 


### PR DESCRIPTION
## Description

Reuse the field index already resolved in Scope.asResolvedField when calculating the hierarchy field index. This avoids a duplicate lookup in RelationType for every resolved field without changing behavior.

## Additional context and related issues

Validation:
- ./mvnw -pl core/trino-main -am -DskipTests install
- ./mvnw -pl core/trino-main -Dtest=TestScope test

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

## Section
* Fix some things.