### PR TITLE
Add Web UI authenticated statement endpoint

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
@@ -245,6 +245,13 @@ public class QueuedStatementResource
         return Response.noContent().build();
     }
 
+    public void checkQueryOwner(QueryId queryId, String slug, long token, String user)
+    {
+        if (!getQuery(queryId, slug, token).sessionContext.getIdentity().getUser().equals(user)) {
+            throw new NotFoundException("Query not found");
+        }
+    }
+
     private Query getQuery(QueryId queryId, String slug, long token)
     {
         Query query = queryManager.getQuery(queryId);

--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
@@ -169,6 +169,19 @@ public class ExecutingStatementResource
         throw new NotFoundException("Query not found");
     }
 
+    public void checkQueryOwner(QueryId queryId, String slug, long token, String user)
+    {
+        try {
+            if (!queryManager.getQuerySlug(queryId).isValid(EXECUTING_QUERY, slug, token) ||
+                    !queryManager.getQuerySession(queryId).getUser().equals(user)) {
+                throw new NotFoundException("Query not found");
+            }
+        }
+        catch (NoSuchElementException e) {
+            throw new NotFoundException("Query not found");
+        }
+    }
+
     protected Query getQuery(QueryId queryId, String slug, long token)
     {
         Query query = queries.get(queryId);

--- a/core/trino-main/src/main/java/io/trino/server/ui/UiStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/UiStatementResource.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.ui;
+
+import com.google.inject.Inject;
+import io.trino.client.QueryResults;
+import io.trino.dispatcher.QueuedStatementResource;
+import io.trino.server.ExternalUriInfo;
+import io.trino.server.protocol.ExecutingStatementResource;
+import io.trino.server.security.ResourceSecurity;
+import io.trino.spi.QueryId;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+
+import java.net.URI;
+import java.util.List;
+
+import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
+import static io.trino.server.ServletSecurityUtils.authenticatedIdentity;
+import static io.trino.server.security.ResourceSecurity.AccessType.WEB_UI;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static java.util.Objects.requireNonNull;
+
+@Path("/ui/api/statement")
+@ResourceSecurity(WEB_UI)
+@Produces(APPLICATION_JSON)
+public class UiStatementResource
+{
+    private static final String UI_REQUEST_HEADER = "X-Trino-UI-Request";
+
+    private final QueuedStatementResource queuedStatementResource;
+    private final ExecutingStatementResource executingStatementResource;
+
+    @Inject
+    public UiStatementResource(QueuedStatementResource queuedStatementResource, ExecutingStatementResource executingStatementResource)
+    {
+        this.queuedStatementResource = requireNonNull(queuedStatementResource, "queuedStatementResource is null");
+        this.executingStatementResource = requireNonNull(executingStatementResource, "executingStatementResource is null");
+    }
+
+    @POST
+    public Response postStatement(
+            String statement,
+            @Context HttpServletRequest servletRequest,
+            @Context HttpHeaders headers,
+            @BeanParam ExternalUriInfo externalUriInfo)
+    {
+        String user = checkRequest(servletRequest, headers);
+        checkUserHeaders(headers, user);
+        // Keep the X-Trino-UI-Request header so protocol detection rejects configured alternate headers.
+        return queuedStatementResource.postStatement(statement, servletRequest, headers, externalUriInfo);
+    }
+
+    @GET
+    @Path("queued/{queryId}/{slug}/{token}")
+    public void getQueuedResults(
+            @PathParam("queryId") QueryId queryId,
+            @PathParam("slug") String slug,
+            @PathParam("token") long token,
+            @Context HttpServletRequest servletRequest,
+            @Context HttpHeaders headers,
+            @BeanParam ExternalUriInfo externalUriInfo,
+            @Suspended AsyncResponse asyncResponse)
+    {
+        String user = checkRequest(servletRequest, headers);
+        queuedStatementResource.checkQueryOwner(queryId, slug, token, user);
+        queuedStatementResource.getStatus(queryId, slug, token, externalUriInfo, asyncResponse);
+    }
+
+    @GET
+    @Path("executing/{queryId}/{slug}/{token}")
+    public void getExecutingResults(
+            @PathParam("queryId") QueryId queryId,
+            @PathParam("slug") String slug,
+            @PathParam("token") long token,
+            @Context HttpServletRequest servletRequest,
+            @Context HttpHeaders headers,
+            @BeanParam ExternalUriInfo externalUriInfo,
+            @Suspended AsyncResponse asyncResponse)
+    {
+        String user = checkRequest(servletRequest, headers);
+        executingStatementResource.checkQueryOwner(queryId, slug, token, user);
+        executingStatementResource.getQueryResults(queryId, slug, token, externalUriInfo, asyncResponse);
+    }
+
+    private static String checkRequest(HttpServletRequest request, HttpHeaders headers)
+    {
+        if (!List.of("true").equals(headers.getRequestHeader(UI_REQUEST_HEADER))) {
+            throw new ForbiddenException("Missing or invalid " + UI_REQUEST_HEADER);
+        }
+        return authenticatedIdentity(request).orElseThrow(ForbiddenException::new).getUser();
+    }
+
+    private static void checkUserHeaders(HttpHeaders headers, String user)
+    {
+        for (String header : List.of(TRINO_HEADERS.requestUser(), TRINO_HEADERS.requestOriginalUser())) {
+            List<String> values = headers.getRequestHeader(header);
+            if (values != null && values.stream().anyMatch(value -> !value.trim().equals(user))) {
+                throw new ForbiddenException("Statement user must match the authenticated Web UI user");
+            }
+        }
+    }
+
+    // Adapt only the outgoing response: executing queries cache their canonical QueryResults.
+    public static class ResponseFilter
+            implements ContainerResponseFilter
+    {
+        @Context
+        private ResourceInfo resourceInfo;
+
+        @Override
+        public void filter(ContainerRequestContext request, ContainerResponseContext response)
+        {
+            if (resourceInfo.getResourceClass() == UiStatementResource.class && response.getEntity() instanceof QueryResults results) {
+                String statementPath = ExternalUriInfo.from(request).absolutePath("/v1/statement").getRawPath();
+                response.setEntity(withUiNextUri(results, statementPath));
+            }
+        }
+    }
+
+    static QueryResults withUiNextUri(QueryResults results, String statementPath)
+    {
+        URI nextUri = results.getNextUri();
+        if (nextUri == null) {
+            return results;
+        }
+        String path = nextUri.getRawPath();
+        if (!path.startsWith(statementPath + "/")) {
+            throw new IllegalArgumentException("Unexpected statement continuation path: " + path);
+        }
+        String uiPath = statementPath.substring(0, statementPath.length() - "/v1/statement".length()) + "/ui/api/statement";
+        URI uiNextUri = UriBuilder.fromUri(nextUri).replacePath(uiPath + path.substring(statementPath.length())).build();
+        return new QueryResults(
+                results.getId(),
+                results.getInfoUri(),
+                results.getPartialCancelUri(),
+                uiNextUri,
+                results.getColumns(),
+                results.getRawData(),
+                results.getStats(),
+                results.getError(),
+                results.getWarnings(),
+                results.getUpdateType(),
+                results.getUpdateCount());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/ui/WebUiModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/WebUiModule.java
@@ -37,6 +37,8 @@ public class WebUiModule
             jaxrsBinder(binder).bind(ClusterResource.class);
             jaxrsBinder(binder).bind(ClusterStatsResource.class);
             jaxrsBinder(binder).bind(UiQueryResource.class);
+            jaxrsBinder(binder).bind(UiStatementResource.class);
+            jaxrsBinder(binder).bind(UiStatementResource.ResponseFilter.class);
         }
         else {
             binder.bind(WebUiAuthenticationFilter.class).to(DisabledWebUiAuthenticationFilter.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestUiStatementResource.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestUiStatementResource.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.ui;
+
+import io.trino.client.QueryResults;
+import io.trino.client.StatementStats;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.List;
+import java.util.OptionalDouble;
+import java.util.OptionalLong;
+
+import static io.trino.server.ui.UiStatementResource.withUiNextUri;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestUiStatementResource
+{
+    @Test
+    void testContinuationUris()
+    {
+        for (String prefix : List.of("", "/proxy", "/proxy%20prefix")) {
+            for (String state : List.of("queued", "executing")) {
+                URI nextUri = URI.create("https://coordinator:8443" + prefix + "/v1/statement/" + state + "/query/slug/1?key=a%2Fb#fragment");
+                QueryResults original = results(nextUri);
+                QueryResults adapted = withUiNextUri(original, prefix + "/v1/statement");
+                assertThat(adapted.getNextUri()).isEqualTo(URI.create(nextUri.toString().replace("/v1/statement/", "/ui/api/statement/")));
+                assertThat(original.getNextUri()).isEqualTo(nextUri);
+                assertThat(adapted.getInfoUri()).isEqualTo(original.getInfoUri());
+                assertThat(adapted.getPartialCancelUri()).isEqualTo(original.getPartialCancelUri());
+                assertThat(adapted.getStats()).isSameAs(original.getStats());
+            }
+        }
+    }
+
+    @Test
+    void testTerminalResults()
+    {
+        QueryResults results = results(null);
+        assertThat(withUiNextUri(results, "/v1/statement")).isSameAs(results);
+    }
+
+    private static QueryResults results(URI nextUri)
+    {
+        return new QueryResults(
+                "query",
+                URI.create("https://coordinator/ui/query.html?query"),
+                URI.create("https://coordinator/v1/statement/executing/partialCancel/query/1/slug/1"),
+                nextUri,
+                null,
+                null,
+                StatementStats.builder()
+                        .setState("RUNNING")
+                        .setProgressPercentage(OptionalDouble.empty())
+                        .setRunningPercentage(OptionalDouble.empty())
+                        .build(),
+                null,
+                List.of(),
+                null,
+                OptionalLong.empty());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
@@ -13,6 +13,7 @@
  */
 package io.trino.server.ui;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.Hashing;
@@ -25,6 +26,7 @@ import io.airlift.http.server.HttpConfig;
 import io.airlift.http.server.HttpServerConfig;
 import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.testing.TestingHttpServer;
+import io.airlift.json.JsonMapperProvider;
 import io.airlift.node.NodeInfo;
 import io.airlift.security.pem.PemReader;
 import io.jsonwebtoken.Claims;
@@ -56,6 +58,7 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.UriBuilder;
 import okhttp3.FormBody;
 import okhttp3.JavaNetCookieJar;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -232,6 +235,101 @@ public class TestWebUi
             server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticators(TestWebUi::authenticate);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
             testFormAuthentication(server, httpServerInfo, AUTHENTICATED_USER, TEST_PASSWORD, true);
+        }
+    }
+
+    @Test
+    public void testStatementWithFormAuthentication()
+            throws Exception
+    {
+        try (TestingTrinoServer server = TestingTrinoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(SECURE_PROPERTIES)
+                        .put("http-server.authentication.type", "PASSWORD")
+                        .put("password-authenticator.config-files", passwordConfigDummy.toString())
+                        .buildOrThrow())
+                .build()) {
+            server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticators((user, password) -> {
+                if (!TEST_PASSWORD.equals(password)) {
+                    throw new AccessDeniedException("Invalid credentials");
+                }
+                return new BasicPrincipal(user);
+            });
+            URI baseUri = server.getInstance(Key.get(HttpServerInfo.class)).getHttpsUri();
+            OkHttpClient alice = client.newBuilder().cookieJar(new JavaNetCookieJar(new CookieManager())).build();
+            OkHttpClient bob = client.newBuilder().cookieJar(new JavaNetCookieJar(new CookieManager())).build();
+            logIn(baseUri, alice, "alice", TEST_PASSWORD, true);
+            logIn(baseUri, bob, "bob", TEST_PASSWORD, true);
+
+            Request submission = new Request.Builder()
+                    .url(baseUri.resolve("/ui/api/statement").toString())
+                    .header("X-Trino-UI-Request", "true")
+                    .post(RequestBody.create("SELECT current_user", MediaType.get("text/plain")))
+                    .build();
+            assertStatementResponseCode(client, submission, 401);
+            assertStatementResponseCode(alice, submission.newBuilder().removeHeader("X-Trino-UI-Request").build(), 403);
+            assertStatementResponseCode(alice, submission.newBuilder().header("X-Trino-UI-Request", "false").build(), 403);
+            assertStatementResponseCode(alice, submission.newBuilder().addHeader("X-Trino-UI-Request", "true").build(), 403);
+            assertStatementResponseCode(alice, submission.newBuilder().header("X-Trino-User", "bob").build(), 403);
+            assertStatementResponseCode(alice, submission.newBuilder().header("X-Trino-Original-User", "bob").build(), 403);
+            // A Web UI cookie does not authenticate the standard client endpoint.
+            assertStatementResponseCode(alice, submission.newBuilder().url(baseUri.resolve("/v1/statement").toString()).build(), 401);
+
+            JsonNode results = statementResults(alice, submission);
+            assertThat(results.path("nextUri").asText()).contains("/ui/api/statement/queued/");
+            boolean sawExecuting = false;
+            boolean sawUser = false;
+            for (int page = 0; page < 100 && results.hasNonNull("nextUri"); page++) {
+                URI nextUri = URI.create(results.get("nextUri").asText());
+                assertThat(nextUri.getPath()).startsWith("/ui/api/statement/");
+                sawExecuting |= nextUri.getPath().startsWith("/ui/api/statement/executing/");
+                Request next = new Request.Builder()
+                        .url(nextUri.toString())
+                        .header("X-Trino-UI-Request", "true")
+                        .build();
+                assertStatementResponseCode(client, next, 401);
+                assertStatementResponseCode(bob, next, 404);
+                assertStatementResponseCode(alice, next.newBuilder()
+                        .url(next.url().newBuilder().setPathSegment(5, "invalid-slug").build())
+                        .build(), 404);
+                assertStatementResponseCode(alice, next.newBuilder().removeHeader("X-Trino-UI-Request").build(), 403);
+                results = statementResults(alice, next);
+                assertThat(results.hasNonNull("error")).as(results.toString()).isFalse();
+                if (results.hasNonNull("data")) {
+                    assertThat(results.get("data").get(0).get(0).asText()).isEqualTo("alice");
+                    sawUser = true;
+                }
+                if (nextUri.getPath().startsWith("/ui/api/statement/executing/")) {
+                    // Replaying the page through the standard route must not return a mutated cached result.
+                    Request standard = next.newBuilder()
+                            .url(nextUri.toString().replace("/ui/api/statement/", "/v1/statement/"))
+                            .build();
+                    JsonNode standardResults = statementResults(client, standard);
+                    if (standardResults.hasNonNull("nextUri")) {
+                        assertThat(URI.create(standardResults.get("nextUri").asText()).getPath()).startsWith("/v1/statement/");
+                    }
+                }
+            }
+            assertThat(results.hasNonNull("nextUri")).isFalse();
+            assertThat(sawExecuting).isTrue();
+            assertThat(sawUser).isTrue();
+        }
+    }
+
+    private static void assertStatementResponseCode(OkHttpClient client, Request request, int status)
+            throws IOException
+    {
+        try (Response response = client.newCall(request).execute()) {
+            assertThat(response.code()).isEqualTo(status);
+        }
+    }
+
+    private static JsonNode statementResults(OkHttpClient client, Request request)
+            throws IOException
+    {
+        try (Response response = client.newCall(request).execute()) {
+            assertThat(response.code()).isEqualTo(200);
+            return new JsonMapperProvider().get().readTree(response.body().string());
         }
     }
 


### PR DESCRIPTION
## Description

Authenticated Web UI users cannot submit SQL using their existing session: the session cookie is scoped to `/ui`, while `/v1/statement` uses client authentication. This prevents an embedded query editor from reusing the Web UI login.

Add `/ui/api/statement` to support query submission and pagination using the existing Web UI authentication mechanism.
* Delegate submission and queued/executing result retrieval to the existing statement resources.
* Return `nextUri` links under `/ui/api/statement`.
* Require `X-Trino-UI-Request: true` as a CSRF safeguard.
* Require SQL user headers to match the authenticated Web UI user and restrict result retrieval to the query owner.
* Leave `/v1/statement` behavior unchanged.

Includes authentication, ownership, pagination, and URL-rewriting tests.

For cancellation, `query-ui`/`js-client` can reuse `PUT /ui/api/query/{queryId}/killed`, as the Web UI does today.

## Additional context and related issues

This enables an embedded Query UI to reuse the Web UI’s configured authentication mechanism without introducing a separate client login flow.

Related:
* https://github.com/trinodb/trino-query-ui/issues/61
* https://github.com/trinodb/trino-js-client/issues/985

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Web UI
* Add support for SQL submission and result retrieval using Web UI authentication through `/ui/api/statement`. ({issue}`issuenumber`)
```
