### PR TITLE
Add pluggable credential providers to SPI

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorContextInstance.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorContextInstance.java
@@ -25,6 +25,7 @@ import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorExpressionEvaluator;
 import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.function.FunctionBundleFactory;
+import io.trino.spi.security.credential.CredentialResolver;
 import io.trino.spi.type.TypeManager;
 
 import static java.util.Objects.requireNonNull;
@@ -44,6 +45,7 @@ public class ConnectorContextInstance
     private final BlocksHashFactory blocksHashFactory;
     private final ConnectorExpressionEvaluator evaluator;
     private final ConnectorCacheFactory cacheFactory;
+    private final CredentialResolver credentialResolver;
 
     public ConnectorContextInstance(
             OpenTelemetry openTelemetry,
@@ -57,7 +59,8 @@ public class ConnectorContextInstance
             FunctionBundleFactory functionBundleFactory,
             BlocksHashFactory blocksHashFactory,
             ConnectorExpressionEvaluator evaluator,
-            ConnectorCacheFactory cacheFactory)
+            ConnectorCacheFactory cacheFactory,
+            CredentialResolver credentialResolver)
     {
         this.openTelemetry = requireNonNull(openTelemetry, "openTelemetry is null");
         this.tracer = requireNonNull(tracer, "tracer is null");
@@ -71,6 +74,7 @@ public class ConnectorContextInstance
         this.blocksHashFactory = requireNonNull(blocksHashFactory, "blocksHashFactory is null");
         this.evaluator = requireNonNull(evaluator, "evaluator is null");
         this.cacheFactory = requireNonNull(cacheFactory, "cacheFactory is null");
+        this.credentialResolver = requireNonNull(credentialResolver, "credentialResolver is null");
     }
 
     @Override
@@ -143,5 +147,11 @@ public class ConnectorContextInstance
     public ConnectorCacheFactory getCacheFactory()
     {
         return cacheFactory;
+    }
+
+    @Override
+    public CredentialResolver getCredentialResolver()
+    {
+        return credentialResolver;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
@@ -41,6 +41,7 @@ import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorExpressionEvaluator;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.spi.connector.ConnectorName;
+import io.trino.spi.security.credential.CredentialResolver;
 import io.trino.spi.type.TypeManager;
 import io.trino.sql.planner.OptimizerConfig;
 import io.trino.transaction.TransactionManager;
@@ -80,6 +81,7 @@ public class DefaultCatalogFactory
     private final SecretsResolver secretsResolver;
     private final ConnectorExpressionEvaluator evaluator;
     private final CacheManagerRegistry cacheManagerRegistry;
+    private final CredentialResolver credentialResolver;
 
     @Inject
     public DefaultCatalogFactory(
@@ -98,7 +100,8 @@ public class DefaultCatalogFactory
             OptimizerConfig optimizerConfig,
             SecretsResolver secretsResolver,
             ConnectorExpressionEvaluator evaluator,
-            CacheManagerRegistry cacheManagerRegistry)
+            CacheManagerRegistry cacheManagerRegistry,
+            CredentialResolver credentialResolver)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
@@ -116,6 +119,7 @@ public class DefaultCatalogFactory
         this.secretsResolver = requireNonNull(secretsResolver, "secretsResolver is null");
         this.evaluator = requireNonNull(evaluator, "evaluator is null");
         this.cacheManagerRegistry = requireNonNull(cacheManagerRegistry, "cacheManagerRegistry is null");
+        this.credentialResolver = requireNonNull(credentialResolver, "credentialResolver is null");
     }
 
     @Override
@@ -211,7 +215,8 @@ public class DefaultCatalogFactory
                 new InternalFunctionBundleFactory(),
                 blocksHashFactory,
                 evaluator,
-                cacheManagerRegistry.createConnectorCacheFactory(catalogName));
+                cacheManagerRegistry.createConnectorCacheFactory(catalogName),
+                credentialResolver);
 
         try (ThreadContextClassLoader _ = new ThreadContextClassLoader(connectorFactory.getClass().getClassLoader())) {
             // TODO: connector factory should take CatalogName

--- a/core/trino-main/src/main/java/io/trino/security/credential/CredentialProviderRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/security/credential/CredentialProviderRegistry.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+import io.trino.spi.security.credential.CredentialResolver;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class CredentialProviderRegistry
+        implements CredentialResolver
+{
+    public static final Pattern VALID_NAME = Pattern.compile("[a-z][a-z0-9-]*");
+    private static final Pattern VALID_FACTORY_NAME = Pattern.compile("[a-z][a-z0-9_]*");
+
+    private final CredentialProviderStore credentialProviderStore;
+    private final Map<String, CredentialProviderFactory> factories = new ConcurrentHashMap<>();
+    private final Map<String, CredentialProvider> credentialProviders = new ConcurrentHashMap<>();
+
+    @Inject
+    public CredentialProviderRegistry(CredentialProviderStore credentialProviderStore)
+    {
+        this.credentialProviderStore = requireNonNull(credentialProviderStore, "credentialProviderStore is null");
+    }
+
+    public void addCredentialProviderFactory(CredentialProviderFactory credentialProviderFactory)
+    {
+        if (!VALID_FACTORY_NAME.matcher(credentialProviderFactory.getFactoryName()).matches()) {
+            throw new IllegalArgumentException("Invalid credential provider factory name: %s, should match %s".formatted(credentialProviderFactory.getFactoryName(), VALID_FACTORY_NAME.pattern()));
+        }
+        if (factories.putIfAbsent(credentialProviderFactory.getFactoryName(), credentialProviderFactory) != null) {
+            throw new IllegalArgumentException(format("Credential provider factory '%s' is already registered", credentialProviderFactory.getFactoryName()));
+        }
+    }
+
+    public void loadCredentialProviders()
+    {
+        credentialProviderStore.loadCredentialProviders(factories, credentialProviders);
+        for (String provider : credentialProviders.keySet()) {
+            if (!VALID_NAME.matcher(provider).matches()) {
+                throw new IllegalArgumentException("Invalid credential provider name: %s, should match %s".formatted(provider, VALID_NAME.pattern()));
+            }
+        }
+    }
+
+    @Override
+    public Optional<CredentialProvider> get(String providerName)
+    {
+        return Optional.ofNullable(credentialProviders.get(providerName));
+    }
+
+    @Override
+    public Set<String> loadedProviders()
+    {
+        return ImmutableSet.copyOf(credentialProviders.keySet());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/security/credential/CredentialProviderStore.java
+++ b/core/trino-main/src/main/java/io/trino/security/credential/CredentialProviderStore.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+
+import java.util.Map;
+
+public interface CredentialProviderStore
+{
+    void loadCredentialProviders(Map<String, CredentialProviderFactory> factories, Map<String, CredentialProvider> credentialProviders);
+}

--- a/core/trino-main/src/main/java/io/trino/security/credential/CredentialProviderStoreModule.java
+++ b/core/trino-main/src/main/java/io/trino/security/credential/CredentialProviderStoreModule.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.trino.spi.security.credential.CredentialResolver;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class CredentialProviderStoreModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(FileCredentialProviderStoreConfig.class);
+        binder.bind(FileCredentialProviderStore.class).in(Scopes.SINGLETON);
+        binder.bind(CredentialProviderStore.class).to(FileCredentialProviderStore.class).in(Scopes.SINGLETON);
+
+        binder.bind(CredentialProviderRegistry.class).in(Scopes.SINGLETON);
+        binder.bind(CredentialResolver.class).to(CredentialProviderRegistry.class).in(Scopes.SINGLETON);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/security/credential/FileCredentialProviderStore.java
+++ b/core/trino-main/src/main/java/io/trino/security/credential/FileCredentialProviderStore.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.airlift.configuration.secrets.SecretsResolver;
+import io.airlift.log.Logger;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
+import static java.util.Objects.requireNonNull;
+
+public class FileCredentialProviderStore
+        implements CredentialProviderStore
+{
+    private static final Logger LOG = Logger.get(FileCredentialProviderStore.class);
+    private final File credentialProviderConfigDir;
+    private final SecretsResolver secretsResolver;
+
+    @Inject
+    public FileCredentialProviderStore(FileCredentialProviderStoreConfig config, SecretsResolver secretsResolver)
+    {
+        this.credentialProviderConfigDir = requireNonNull(config, "config is null").getCredentialProviderConfigDir();
+        this.secretsResolver = requireNonNull(secretsResolver, "secretsResolver is null");
+    }
+
+    @Override
+    public void loadCredentialProviders(Map<String, CredentialProviderFactory> factories, Map<String, CredentialProvider> credentialProviders)
+    {
+        if (!credentialProviderConfigDir.isDirectory()) {
+            LOG.warn("Credential providers directory does not exist or is not a directory: " + credentialProviderConfigDir.getAbsolutePath());
+        }
+
+        listCredentialProviderFiles(credentialProviderConfigDir)
+                .stream()
+                .map(file -> new CredentialProviderConfigFile(file.getName().replace(".properties", ""), file))
+                .filter(configFile -> !credentialProviders.containsKey(configFile.name()))
+                .map(CredentialProviderConfigFile::loadProperties)
+                .forEach(properties -> {
+                    CredentialProviderFactory credentialProviderFactory = factories.get(properties.factoryName());
+                    if (credentialProviderFactory == null) {
+                        throw new IllegalStateException("Credential provider factory %s not found in: [%s]".formatted(properties.factoryName(), String.join(", ", factories.keySet())));
+                    }
+                    Map<String, String> config = secretsResolver.getResolvedConfiguration(properties.properties());
+                    credentialProviders.put(properties.providerName(), credentialProviderFactory.create(properties.providerName(), config));
+                });
+    }
+
+    private static List<File> listCredentialProviderFiles(File credentialProvidersDirectory)
+    {
+        if (credentialProvidersDirectory == null || !credentialProvidersDirectory.isDirectory()) {
+            return ImmutableList.of();
+        }
+
+        File[] files = credentialProvidersDirectory.listFiles();
+        if (files == null) {
+            return ImmutableList.of();
+        }
+        return Arrays.stream(files)
+                .filter(File::isFile)
+                .filter(file -> file.getName().endsWith(".properties"))
+                .collect(toImmutableList());
+    }
+
+    public record CredentialProviderConfigFile(String name, File file)
+    {
+        public CredentialProviderProperties loadProperties()
+        {
+            Map<String, String> properties;
+            try {
+                properties = new HashMap<>(loadPropertiesFrom(file.getPath()));
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException("Error reading catalog property file " + file, e);
+            }
+
+            String factoryName = properties.remove("credential-provider.name");
+            checkState(factoryName != null, "Credential provider configuration %s does not contain 'credential-provider.name'", file.getAbsoluteFile());
+
+            return new CredentialProviderProperties(name, factoryName.strip(), properties);
+        }
+    }
+
+    public record CredentialProviderProperties(String providerName, String factoryName, Map<String, String> properties) {}
+}

--- a/core/trino-main/src/main/java/io/trino/security/credential/FileCredentialProviderStoreConfig.java
+++ b/core/trino-main/src/main/java/io/trino/security/credential/FileCredentialProviderStoreConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.NotNull;
+
+import java.io.File;
+
+public class FileCredentialProviderStoreConfig
+{
+    private File configDir = new File("etc/credential-provider");
+
+    @Config("credential-provider.config-dir")
+    @ConfigDescription("Directory where credential provider property files are located")
+    public FileCredentialProviderStoreConfig setCredentialProviderConfigDir(File configDir)
+    {
+        this.configDir = configDir;
+        return this;
+    }
+
+    @NotNull
+    public File getCredentialProviderConfigDir()
+    {
+        return configDir;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/PluginManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/PluginManager.java
@@ -32,6 +32,7 @@ import io.trino.metadata.LanguageFunctionEngineManager;
 import io.trino.metadata.TypeRegistry;
 import io.trino.security.AccessControlManager;
 import io.trino.security.GroupProviderManager;
+import io.trino.security.credential.CredentialProviderRegistry;
 import io.trino.server.protocol.spooling.SpoolingManagerRegistry;
 import io.trino.server.security.CertificateAuthenticatorManager;
 import io.trino.server.security.HeaderAuthenticatorManager;
@@ -51,6 +52,7 @@ import io.trino.spi.security.GroupProviderFactory;
 import io.trino.spi.security.HeaderAuthenticatorFactory;
 import io.trino.spi.security.PasswordAuthenticatorFactory;
 import io.trino.spi.security.SystemAccessControlFactory;
+import io.trino.spi.security.credential.CredentialProviderFactory;
 import io.trino.spi.session.SessionPropertyConfigurationManagerFactory;
 import io.trino.spi.spool.SpoolingManagerFactory;
 import io.trino.spi.type.ParametricType;
@@ -115,6 +117,7 @@ public class PluginManager
     private final ExchangeManagerRegistry exchangeManagerRegistry;
     private final SpoolingManagerRegistry spoolingManagerRegistry;
     private final CacheManagerRegistry cacheManagerRegistry;
+    private final CredentialProviderRegistry credentialProviderRegistry;
     private final SessionPropertyDefaults sessionPropertyDefaults;
     private final TypeRegistry typeRegistry;
     private final BlockEncodingManager blockEncodingManager;
@@ -141,7 +144,8 @@ public class PluginManager
             HandleResolver handleResolver,
             ExchangeManagerRegistry exchangeManagerRegistry,
             SpoolingManagerRegistry spoolingManagerRegistry,
-            CacheManagerRegistry cacheManagerRegistry)
+            CacheManagerRegistry cacheManagerRegistry,
+            CredentialProviderRegistry credentialProviderRegistry)
     {
         this.pluginsProvider = requireNonNull(pluginsProvider, "pluginsProvider is null");
         this.catalogStoreManager = requireNonNull(catalogStoreManager, "catalogStoreManager is null");
@@ -162,6 +166,7 @@ public class PluginManager
         this.exchangeManagerRegistry = requireNonNull(exchangeManagerRegistry, "exchangeManagerRegistry is null");
         this.spoolingManagerRegistry = requireNonNull(spoolingManagerRegistry, "spoolingManagerRegistry is null");
         this.cacheManagerRegistry = requireNonNull(cacheManagerRegistry, "cacheManagerRegistry is null");
+        this.credentialProviderRegistry = requireNonNull(credentialProviderRegistry, "credentialProviderRegistry is null");
     }
 
     @Override
@@ -313,6 +318,11 @@ public class PluginManager
         for (BlobCacheManagerFactory factory : plugin.getBlobCacheManagerFactories()) {
             log.info("Registering blob cache manager %s", factory.getName());
             cacheManagerRegistry.addBlobCacheManagerFactory(factory);
+        }
+
+        for (CredentialProviderFactory factory : plugin.getCredentialProviderFactories()) {
+            log.info("Registering credential provider %s", factory.getFactoryName());
+            credentialProviderRegistry.addCredentialProviderFactory(factory);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/Server.java
+++ b/core/trino-main/src/main/java/io/trino/server/Server.java
@@ -50,6 +50,8 @@ import io.trino.node.NodeManagerModule;
 import io.trino.security.AccessControlManager;
 import io.trino.security.AccessControlModule;
 import io.trino.security.GroupProviderManager;
+import io.trino.security.credential.CredentialProviderRegistry;
+import io.trino.security.credential.CredentialProviderStoreModule;
 import io.trino.server.protocol.spooling.SpoolingManagerRegistry;
 import io.trino.server.security.CertificateAuthenticatorManager;
 import io.trino.server.security.HeaderAuthenticatorManager;
@@ -111,6 +113,7 @@ public class Server
                 .add(new NodeModule())
                 .add(new NodeStateManagerModule())
                 .add(new PrefixObjectNameGeneratorModule("io.trino"))
+                .add(new CredentialProviderStoreModule())
                 .add(new ServerMainModule(trinoVersion))
                 .add(new ServerSecurityModule())
                 .add(new TracingModule("trino", trinoVersion))
@@ -135,6 +138,8 @@ public class Server
 
             var catalogStoreManager = injector.getInstance(Key.get(new TypeLiteral<Optional<CatalogStoreManager>>() {}));
             catalogStoreManager.ifPresent(CatalogStoreManager::loadConfiguredCatalogStore);
+
+            injector.getInstance(CredentialProviderRegistry.class).loadCredentialProviders();
 
             ConnectorServicesProvider connectorServicesProvider = injector.getInstance(ConnectorServicesProvider.class);
             connectorServicesProvider.loadInitialCatalogs();

--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -75,6 +75,7 @@ import io.trino.security.AccessControl;
 import io.trino.security.AccessControlConfig;
 import io.trino.security.AccessControlManager;
 import io.trino.security.GroupProviderManager;
+import io.trino.security.credential.CredentialProviderRegistry;
 import io.trino.server.NodeStateManager;
 import io.trino.server.NodeStateManager.CurrentNodeState;
 import io.trino.server.PluginInstaller;
@@ -111,6 +112,8 @@ import io.trino.sql.planner.NodePartitioningManager;
 import io.trino.sql.planner.Plan;
 import io.trino.testing.ProcedureTester;
 import io.trino.testing.TestingAccessControlManager;
+import io.trino.testing.TestingCredentialProviderStore;
+import io.trino.testing.TestingCredentialProviderStoreModule;
 import io.trino.testing.TestingEventListenerManager;
 import io.trino.testing.TestingGroupProvider;
 import io.trino.testing.TestingGroupProviderManager;
@@ -224,6 +227,8 @@ public class TestingTrinoServer
     private final ExchangeManagerRegistry exchangeManagerRegistry;
     private final CacheManagerRegistry cacheManagerRegistry;
     private final SpoolingManagerRegistry spoolingManagerRegistry;
+    private final TestingCredentialProviderStore credentialProviderStore;
+    private final CredentialProviderRegistry credentialProviderRegistry;
 
     public static class TestShutdownAction
             implements ShutdownAction
@@ -319,6 +324,7 @@ public class TestingTrinoServer
                 .add(new CatalogManagerModule())
                 .add(new TransactionManagerModule())
                 .add(new NodeManagerModule(VERSION))
+                .add(new TestingCredentialProviderStoreModule())
                 .add(new ServerMainModule(VERSION))
                 .add(new TestingWarningCollectorModule())
                 .add(binder -> {
@@ -439,6 +445,8 @@ public class TestingTrinoServer
         exchangeManagerRegistry = injector.getInstance(ExchangeManagerRegistry.class);
         cacheManagerRegistry = injector.getInstance(CacheManagerRegistry.class);
         spoolingManagerRegistry = injector.getInstance(SpoolingManagerRegistry.class);
+        credentialProviderStore = injector.getInstance(TestingCredentialProviderStore.class);
+        credentialProviderRegistry = injector.getInstance(CredentialProviderRegistry.class);
 
         systemAccessControlConfiguration.ifPresentOrElse(
                 configuration -> {
@@ -730,6 +738,12 @@ public class TestingTrinoServer
                 attemptId,
                 injectionType,
                 errorType);
+    }
+
+    public void addCredentialProvider(String name, String factoryName, Map<String, String> properties)
+    {
+        credentialProviderStore.addCredentialProvider(name, factoryName, properties);
+        credentialProviderRegistry.loadCredentialProviders();
     }
 
     private static Path tempDirectory()

--- a/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
+++ b/core/trino-main/src/main/java/io/trino/testing/PlanTester.java
@@ -141,6 +141,8 @@ import io.trino.operator.table.ExcludeColumnsFunction;
 import io.trino.plugin.base.security.AllowAllSystemAccessControl;
 import io.trino.security.AllowAllAccessControl;
 import io.trino.security.GroupProviderManager;
+import io.trino.security.credential.CredentialProviderRegistry;
+import io.trino.security.credential.CredentialProviderStore;
 import io.trino.server.PluginManager;
 import io.trino.server.ServerConfig;
 import io.trino.server.SessionPropertyDefaults;
@@ -351,6 +353,7 @@ public class PlanTester
     private final StatementAnalyzerFactory statementAnalyzerFactory;
     private final JsonCodec<Expression> expressionCodec;
     private final InternalConnectorExpressionEvaluator evaluator;
+    private final CredentialProviderRegistry credentialProviderRegistry;
     private boolean printPlan;
 
     public static PlanTester create(Session defaultSession)
@@ -443,6 +446,10 @@ public class PlanTester
         FunctionManager functionManager = new FunctionManager(createFunctionProvider(catalogManager), globalFunctionCatalog, languageFunctionManager);
         this.plannerContext = new PlannerContext(metadata, typeOperators, blockEncodingSerde, typeManager, functionManager, languageFunctionManager, tracer, expressionCodec);
         this.evaluator = new InternalConnectorExpressionEvaluator(plannerContext);
+
+        CredentialProviderStore credentialProviderStore = new TestingCredentialProviderStore();
+        this.credentialProviderRegistry = new CredentialProviderRegistry(credentialProviderStore);
+
         NodeInfo nodeInfo = new NodeInfo("test");
         catalogFactory.setCatalogFactory(new DefaultCatalogFactory(
                 metadata,
@@ -460,7 +467,8 @@ public class PlanTester
                 optimizerConfig,
                 secretsResolver,
                 evaluator,
-                cacheManagerRegistry));
+                cacheManagerRegistry,
+                credentialProviderRegistry));
         this.splitManager = new SplitManager(createSplitManagerProvider(catalogManager), tracer, new QueryManagerConfig());
         this.pageSourceManager = new PageSourceManager(createPageSourceProviderFactory(catalogManager));
         this.pageSinkManager = new PageSinkManager(createPageSinkProvider(catalogManager));
@@ -531,6 +539,7 @@ public class PlanTester
                 new SpoolingEnabledConfig(),
                 noop(),
                 noopTracer());
+
         this.pluginManager = new PluginManager(
                 (_, _) -> {},
                 Optional.empty(),
@@ -550,7 +559,8 @@ public class PlanTester
                 new HandleResolver(),
                 exchangeManagerRegistry,
                 spoolingManagerRegistry,
-                cacheManagerRegistry);
+                cacheManagerRegistry,
+                credentialProviderRegistry);
 
         catalogManager.registerGlobalSystemConnector(globalSystemConnector);
         languageFunctionManager.setPlannerContext(plannerContext);

--- a/core/trino-main/src/main/java/io/trino/testing/QueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/QueryRunner.java
@@ -131,5 +131,7 @@ public interface QueryRunner
 
     void loadBlobCacheManager(String name, Map<String, String> properties);
 
+    void addCredentialProvider(String name, String factoryName, Map<String, String> properties);
+
     record MaterializedResultWithPlan(QueryId queryId, Optional<Plan> queryPlan, MaterializedResult result) {}
 }

--- a/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/StandaloneQueryRunner.java
@@ -345,4 +345,10 @@ public final class StandaloneQueryRunner
     {
         server.loadBlobCacheManager(name, properties);
     }
+
+    @Override
+    public void addCredentialProvider(String name, String factoryName, Map<String, String> properties)
+    {
+        server.addCredentialProvider(name, factoryName, properties);
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/testing/TestingConnectorContext.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingConnectorContext.java
@@ -32,6 +32,7 @@ import io.trino.spi.cache.ConnectorCacheFactory;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.function.FunctionBundleFactory;
+import io.trino.spi.security.credential.CredentialResolver;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeOperators;
 import io.trino.util.EmbedVersion;
@@ -123,5 +124,11 @@ public final class TestingConnectorContext
     public ConnectorCacheFactory getCacheFactory()
     {
         return new TestingConnectorCacheFactory();
+    }
+
+    @Override
+    public CredentialResolver getCredentialResolver()
+    {
+        return new TestingCredentialResolver();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/testing/TestingCredentialProviderStore.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingCredentialProviderStore.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import io.trino.security.credential.CredentialProviderStore;
+import io.trino.spi.TrinoException;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+
+public class TestingCredentialProviderStore
+        implements CredentialProviderStore
+{
+    private final Map<String, CredentialProviderProperties> providers = new ConcurrentHashMap<>();
+
+    public void addCredentialProvider(String name, String factoryName, Map<String, String> properties)
+    {
+        providers.put(name, new CredentialProviderProperties(factoryName, properties));
+    }
+
+    @Override
+    public void loadCredentialProviders(Map<String, CredentialProviderFactory> factories, Map<String, CredentialProvider> credentialProviders)
+    {
+        providers.forEach((name, properties) -> {
+            CredentialProviderFactory factory = factories.get(properties.factoryName());
+            if (factory == null) {
+                throw new TrinoException(CONFIGURATION_INVALID, "Factory not found: " + properties.factoryName());
+            }
+            if (!credentialProviders.containsKey(name)) {
+                credentialProviders.put(name, factory.create(name, properties.config()));
+            }
+        });
+    }
+
+    private record CredentialProviderProperties(String factoryName, Map<String, String> config) {}
+}

--- a/core/trino-main/src/main/java/io/trino/testing/TestingCredentialProviderStoreModule.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingCredentialProviderStoreModule.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.trino.security.credential.CredentialProviderRegistry;
+import io.trino.security.credential.CredentialProviderStore;
+import io.trino.security.credential.FileCredentialProviderStoreConfig;
+import io.trino.spi.security.credential.CredentialResolver;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class TestingCredentialProviderStoreModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(FileCredentialProviderStoreConfig.class);
+        binder.bind(TestingCredentialProviderStore.class).in(Scopes.SINGLETON);
+        binder.bind(CredentialProviderStore.class).to(TestingCredentialProviderStore.class).in(Scopes.SINGLETON);
+
+        binder.bind(CredentialProviderRegistry.class).in(Scopes.SINGLETON);
+        binder.bind(CredentialResolver.class).to(CredentialProviderRegistry.class).in(Scopes.SINGLETON);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/testing/TestingCredentialResolver.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingCredentialResolver.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialResolver;
+
+import java.util.Optional;
+import java.util.Set;
+
+public class TestingCredentialResolver
+        implements CredentialResolver
+{
+    @Override
+    public Optional<CredentialProvider> get(String providerName)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public Set<String> loadedProviders()
+    {
+        return Set.of();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/security/credential/TestCredentialProviderRegistry.java
+++ b/core/trino-main/src/test/java/io/trino/security/credential/TestCredentialProviderRegistry.java
@@ -1,0 +1,402 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.security.credential;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.name.Named;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import io.airlift.slice.Slice;
+import io.trino.plugin.base.ConnectorContextModule;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionDependencies;
+import io.trino.spi.function.FunctionDependencyDeclaration;
+import io.trino.spi.function.FunctionId;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.InvocationConvention;
+import io.trino.spi.function.ScalarFunctionAdapter;
+import io.trino.spi.function.ScalarFunctionImplementation;
+import io.trino.spi.function.SchemaFunctionName;
+import io.trino.spi.function.Signature;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.Identity;
+import io.trino.spi.security.credential.Credential;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+import io.trino.spi.transaction.IsolationLevel;
+import io.trino.sql.SqlPath;
+import io.trino.sql.query.QueryAssertions;
+import jakarta.validation.constraints.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
+import static io.trino.plugin.base.security.credential.CredentialProviderModule.credentialProvider;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.security.credential.CredentialProvider.assertSupportedTypes;
+import static io.trino.spi.type.TypeDescriptor.mapType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.lang.invoke.MethodType.methodType;
+import static java.util.Collections.nCopies;
+import static java.util.Objects.requireNonNull;
+
+public class TestCredentialProviderRegistry
+{
+    @Test
+    public void test()
+    {
+        try (QueryAssertions assertions = new QueryAssertions(testSessionBuilder()
+                .setPath(SqlPath.buildPath("test_catalog_name.test_schema_name", Optional.empty()))
+                .setIdentity(Identity.ofUser("test_user"))
+                .build())) {
+            assertions.addPlugin(new TestPlugin());
+            assertions.addCredentialProvider("my-configured-provider", "test_provider_factory_name", Map.of("username", "admin", "password", "welcome123"));
+            assertions.getQueryRunner().createCatalog("test_catalog_name", "test_connector_name", Map.of("credential-provider.my-code-named-provider.name", "my-configured-provider"));
+            assertions.function("greeting", "'hello'")
+                    .assertThat()
+                    .isEqualTo("hello world from test_user as admin: welcome123");
+        }
+    }
+
+    public static class TestPlugin
+            implements Plugin
+    {
+        @Override
+        public Iterable<ConnectorFactory> getConnectorFactories()
+        {
+            return ImmutableSet.of(new TestConnectorFactory());
+        }
+
+        @Override
+        public Iterable<CredentialProviderFactory> getCredentialProviderFactories()
+        {
+            return ImmutableList.of(new TestCredentialProviderFactory());
+        }
+    }
+
+    public static class TestConnectorFactory
+            implements ConnectorFactory
+    {
+        @Override
+        public String getName()
+        {
+            return "test_connector_name";
+        }
+
+        @Override
+        public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+        {
+            checkStrictSpiVersionMatch(context, this);
+
+            Bootstrap app = new Bootstrap(
+                    "io.trino.bootstrap.catalog." + catalogName,
+                    new TestModule(),
+                    new ConnectorContextModule(catalogName, context));
+
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .disableSystemProperties()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+
+            return injector.getInstance(Connector.class);
+        }
+    }
+
+    public enum TestTransactionHandle
+            implements ConnectorTransactionHandle
+    {
+        INSTANCE
+    }
+
+    public static class TestMetadata
+            implements ConnectorMetadata
+    {
+        private static final String SCHEMA_NAME = "test_schema_name";
+
+        private final List<FunctionMetadata> functions;
+
+        @Inject
+        public TestMetadata(List<FunctionMetadata> functions)
+        {
+            this.functions = ImmutableList.copyOf(requireNonNull(functions, "functions is null"));
+        }
+
+        @Override
+        public Collection<FunctionMetadata> listFunctions(ConnectorSession session, String schemaName)
+        {
+            return schemaName.equals(SCHEMA_NAME) ? functions : List.of();
+        }
+
+        @Override
+        public Collection<FunctionMetadata> getFunctions(ConnectorSession session, SchemaFunctionName name)
+        {
+            if (!name.schemaName().equals(SCHEMA_NAME)) {
+                return List.of();
+            }
+            return functions.stream()
+                    .filter(function -> function.getCanonicalName().equals(name.functionName()))
+                    .toList();
+        }
+
+        @Override
+        public FunctionMetadata getFunctionMetadata(ConnectorSession session, FunctionId functionId)
+        {
+            return functions.stream()
+                    .filter(function -> function.getFunctionId().equals(functionId))
+                    .findFirst()
+                    .orElseThrow();
+        }
+
+        @Override
+        public FunctionDependencyDeclaration getFunctionDependencies(ConnectorSession session, FunctionId functionId, BoundSignature boundSignature)
+        {
+            return FunctionDependencyDeclaration.builder()
+                    .addType(mapType(VARCHAR.getTypeDescriptor(), VARCHAR.getTypeDescriptor()))
+                    .build();
+        }
+    }
+
+    public static class TestConnector
+            implements Connector
+    {
+        private final FunctionProvider functionProvider;
+        private final ConnectorMetadata metadata;
+
+        @Override
+        public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit)
+        {
+            return TestTransactionHandle.INSTANCE;
+        }
+
+        @Inject
+        public TestConnector(FunctionProvider functionProvider, ConnectorMetadata metadata)
+        {
+            this.functionProvider = requireNonNull(functionProvider, "functionProvider is null");
+            this.metadata = requireNonNull(metadata, "metadata is null");
+        }
+
+        @Override
+        public Optional<FunctionProvider> getFunctionProvider()
+        {
+            return Optional.of(functionProvider);
+        }
+
+        @Override
+        public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transactionHandle)
+        {
+            return metadata;
+        }
+
+        @Override
+        public void shutdown() {}
+    }
+
+    public static class TestModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            credentialProvider(binder, "my-code-named-provider");
+            binder.bind(TestConnector.class).in(SINGLETON);
+            binder.bind(Connector.class).to(TestConnector.class).in(SINGLETON);
+
+            binder.bind(TestMetadata.class).in(SINGLETON);
+            binder.bind(ConnectorMetadata.class).to(TestMetadata.class).in(SINGLETON);
+
+            binder.bind(TestFunctionProvider.class).in(SINGLETON);
+            binder.bind(FunctionProvider.class).to(TestFunctionProvider.class).in(SINGLETON);
+        }
+
+        @Provides
+        public static List<FunctionMetadata> getFunctionMetadata(TestFunctionProvider functions)
+        {
+            return functions.getFunctions();
+        }
+    }
+
+    public static class TestFunctionProvider
+            implements FunctionProvider
+    {
+        private final MethodHandle methodHandle;
+        private static final List<FunctionMetadata> FUNCTIONS = ImmutableList.of(FunctionMetadata.scalarBuilder("greeting")
+                .description("Greet the planet")
+                .signature(Signature.builder()
+                        .returnType(VARCHAR.getTypeDescriptor())
+                        .argumentTypes(List.of(VARCHAR.getTypeDescriptor()))
+                        .build())
+                .build());
+
+        private final CredentialProvider credentialProvider;
+
+        @Inject
+        public TestFunctionProvider(@Named("my-code-named-provider") CredentialProvider credentialProvider)
+                throws Exception
+        {
+            this.credentialProvider = requireNonNull(credentialProvider, "credentialProvider is null");
+            methodHandle = lookup().findVirtual(TestFunctionProvider.class, "greeting", methodType(Slice.class, ConnectorSession.class, Slice.class));
+        }
+
+        public List<FunctionMetadata> getFunctions()
+        {
+            return FUNCTIONS;
+        }
+
+        @Override
+        public ScalarFunctionImplementation getScalarFunctionImplementation(
+                FunctionId functionId,
+                BoundSignature boundSignature,
+                FunctionDependencies functionDependencies,
+                InvocationConvention invocationConvention)
+        {
+            return ScalarFunctionImplementation.builder()
+                    .methodHandle(ScalarFunctionAdapter.adapt(
+                            this.methodHandle.bindTo(this),
+                            boundSignature.getReturnType(),
+                            boundSignature.getArgumentTypes(),
+                            new InvocationConvention(
+                                    nCopies(boundSignature.getArity(), NEVER_NULL),
+                                    FAIL_ON_NULL,
+                                    true,
+                                    false),
+                            invocationConvention))
+                    .build();
+        }
+
+        public Slice greeting(ConnectorSession session, Slice greeting)
+        {
+            TestCredential credential = credentialProvider.getCredential(session.getIdentity(), TestCredential.class).orElseThrow();
+            return utf8Slice("%s world from %s: %s".formatted(greeting.toStringUtf8(), credential.username(), credential.password()));
+        }
+    }
+
+    public record TestCredential(String username, String password)
+            implements Credential {}
+
+    public static class TestCredentialProvider
+            implements CredentialProvider
+    {
+        private final TestCredentialProviderConfig config;
+
+        @Inject
+        public TestCredentialProvider(TestCredentialProviderConfig config)
+        {
+            this.config = requireNonNull(config, "config is null");
+        }
+
+        @Override
+        public <T extends Credential> Optional<T> getCredential(ConnectorIdentity identity, Class<T> type)
+        {
+            assertSupportedTypes(this, type, TestCredential.class);
+            return Optional.of((T) new TestCredential("%s as %s".formatted(identity.getUser(), config.getUsername()), config.getPassword()));
+        }
+    }
+
+    public static class TestCredentialProviderConfig
+    {
+        private String username;
+        private String password;
+
+        @NotNull
+        public String getUsername()
+        {
+            return username;
+        }
+
+        @Config("username")
+        public TestCredentialProviderConfig setUsername(String username)
+        {
+            this.username = username;
+            return this;
+        }
+
+        @NotNull
+        public String getPassword()
+        {
+            return password;
+        }
+
+        @Config("password")
+        @ConfigSecuritySensitive
+        public TestCredentialProviderConfig setPassword(String password)
+        {
+            this.password = password;
+            return this;
+        }
+    }
+
+    public static class TestCredentialProviderFactory
+            implements CredentialProviderFactory
+    {
+        @Override
+        public String getFactoryName()
+        {
+            return "test_provider_factory_name";
+        }
+
+        @Override
+        public CredentialProvider create(String providerName, Map<String, String> config)
+        {
+            Bootstrap app = new Bootstrap(
+                    "io.trino.bootstrap.credential-provider.%s".formatted(providerName),
+                    new TestCredentialProviderModule());
+
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .disableSystemProperties()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+
+            return injector.getInstance(TestCredentialProvider.class);
+        }
+    }
+
+    public static class TestCredentialProviderModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            configBinder(binder).bindConfig(TestCredentialProviderConfig.class);
+            binder.bind(TestCredentialProvider.class).in(SINGLETON);
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -143,6 +143,11 @@ public class QueryAssertions
         runner.installPlugin(plugin);
     }
 
+    public void addCredentialProvider(String name, String factoryName, Map<String, String> properties)
+    {
+        runner.addCredentialProvider(name, factoryName, properties);
+    }
+
     @CheckReturnValue
     public AssertProvider<QueryAssert> query(@Language("SQL") String query)
     {

--- a/core/trino-server/src/main/provisio/trino.xml
+++ b/core/trino-server/src/main/provisio/trino.xml
@@ -40,6 +40,12 @@
         </artifact>
     </artifactSet>
 
+    <artifactSet to="plugin/credential-provider-basic">
+        <artifact id="${project.groupId}:trino-credential-provider-basic:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
     <artifactSet to="plugin/datasketches">
         <artifact id="${project.groupId}:trino-datasketches:zip:${project.version}">
             <unpack />

--- a/core/trino-spi/src/main/java/io/trino/spi/Plugin.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Plugin.java
@@ -26,6 +26,7 @@ import io.trino.spi.security.GroupProviderFactory;
 import io.trino.spi.security.HeaderAuthenticatorFactory;
 import io.trino.spi.security.PasswordAuthenticatorFactory;
 import io.trino.spi.security.SystemAccessControlFactory;
+import io.trino.spi.security.credential.CredentialProviderFactory;
 import io.trino.spi.session.SessionPropertyConfigurationManagerFactory;
 import io.trino.spi.spool.SpoolingManagerFactory;
 import io.trino.spi.type.ParametricType;
@@ -124,6 +125,11 @@ public interface Plugin
     }
 
     default Iterable<BlobCacheManagerFactory> getBlobCacheManagerFactories()
+    {
+        return emptyList();
+    }
+
+    default Iterable<CredentialProviderFactory> getCredentialProviderFactories()
     {
         return emptyList();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
@@ -24,6 +24,7 @@ import io.trino.spi.Unstable;
 import io.trino.spi.VersionEmbedder;
 import io.trino.spi.cache.ConnectorCacheFactory;
 import io.trino.spi.function.FunctionBundleFactory;
+import io.trino.spi.security.credential.CredentialResolver;
 import io.trino.spi.type.TypeManager;
 
 import java.util.Optional;
@@ -108,5 +109,11 @@ public interface ConnectorContext
     default ConnectorCacheFactory getCacheFactory()
     {
         return _ -> Optional.empty();
+    }
+
+    @Unstable
+    default CredentialResolver getCredentialResolver()
+    {
+        throw new UnsupportedOperationException();
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/BasicCredential.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/BasicCredential.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+import java.util.Base64;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public record BasicCredential(String username, String password)
+        implements HttpHeadersCredential
+{
+    @Override
+    public Map<String, String> getHeaders()
+    {
+        return Map.of("Authorization", "Basic %s".formatted(Base64.getEncoder().encodeToString("%s:%s".formatted(username, password).getBytes(UTF_8))));
+    }
+
+    @Override
+    public String toString()
+    {
+        return "BasicCredential{username=%s, password=[REDACTED]}".formatted(username);
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/BearerTokenCredential.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/BearerTokenCredential.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record BearerTokenCredential(String bearerToken, Instant expiration)
+        implements HttpHeadersCredential
+{
+    public boolean isValid()
+    {
+        return expiration().isAfter(Instant.now());
+    }
+
+    @Override
+    public Map<String, String> getHeaders()
+    {
+        return Map.of("Authorization", "Bearer %s".formatted(bearerToken));
+    }
+
+    @Override
+    public String toString()
+    {
+        return "BearerTokenCredential{bearerToken=[REDACTED], expiration=%s}".formatted(expiration);
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/Credential.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/Credential.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+public interface Credential {}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/CredentialProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/CredentialProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.security.ConnectorIdentity;
+
+import java.util.Optional;
+
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
+
+public interface CredentialProvider
+{
+    <T extends Credential> Optional<T> getCredential(ConnectorIdentity identity, Class<T> type);
+
+    @SafeVarargs
+    static void assertSupportedTypes(CredentialProvider provider, Class<? extends Credential> type, Class<? extends Credential>... supportedTypes)
+    {
+        for (Class<? extends Credential> supportedType : supportedTypes) {
+            if (type.isAssignableFrom(supportedType)) {
+                return;
+            }
+        }
+
+        throw new TrinoException(CONFIGURATION_INVALID, "Configured %s does not return %s but only one of: [%s]".formatted(
+                provider.getClass().getSimpleName(),
+                type.getSimpleName(),
+                stream(supportedTypes).map(Class::getSimpleName).collect(joining(", "))));
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/CredentialProviderFactory.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/CredentialProviderFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+import java.util.Map;
+
+public interface CredentialProviderFactory
+{
+    String getFactoryName();
+
+    CredentialProvider create(String providerName, Map<String, String> config);
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/CredentialResolver.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/CredentialResolver.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface CredentialResolver
+{
+    Optional<CredentialProvider> get(String providerName);
+
+    Set<String> loadedProviders();
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/HttpHeadersCredential.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/HttpHeadersCredential.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+import java.util.Map;
+
+public interface HttpHeadersCredential
+        extends Credential
+{
+    Map<String, String> getHeaders();
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/security/credential/StringCredential.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/credential/StringCredential.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.security.credential;
+
+public record StringCredential(String value)
+        implements Credential
+{
+    @Override
+    public String toString()
+    {
+        return "StringCredential[value=[REDACTED]]";
+    }
+}

--- a/docs/src/main/sphinx/security.md
+++ b/docs/src/main/sphinx/security.md
@@ -63,3 +63,12 @@ security/ranger-access-control
 security/internal-communication
 security/secrets
 ```
+
+
+## Credential providers
+
+```{toctree}
+:maxdepth: 1
+
+security/credential-providers
+```

--- a/docs/src/main/sphinx/security/credential-providers.md
+++ b/docs/src/main/sphinx/security/credential-providers.md
@@ -1,0 +1,36 @@
+# Credential providers
+A credential provider is a separate module to be configured and to be linked to
+a connector. This way, a connector can obtain a per-user credential to be used
+to authenticate when connecting to a data source.
+
+:::{list-table} Server configuration
+:widths: 50 50
+:header-rows: 1
+
+* - Property name
+  - Description
+* - `credential-provider.config-dir`
+  -  The directory for the named properties files. Defaults to 
+     `etc/credential-provider`
+:::
+
+## Configuration
+To configure credential providers, create a named properties file
+in `etc/credential-provider`, for example `test.properties`. This 
+name can be used in the connector properties to connect to a data source, for
+example `credential-provider.database.name=test`. The name `database` is
+chosen by the developer of the connector and describes where the credential 
+is used for. A connector may need multiple credential providers for 
+different purposes (`database`, `storage`, etc.).
+
+(security-supported-credential-providers)=
+## Supported credential providers
+
+(security-credential-provider-basic)=
+### Basic auth
+
+```none
+credential-provider.name=basic
+username=admin
+password=welcome123!
+```

--- a/docs/src/main/sphinx/security/overview.md
+++ b/docs/src/main/sphinx/security/overview.md
@@ -157,3 +157,9 @@ More information is available with the documentation for individual
 
 {doc}`Secrets management <secrets>` can be used for the catalog properties files
 content.
+
+(security-credential-providers)=
+## Credential providers
+
+Connectors may support the usage of one or more {doc}`credential providers 
+<credential-providers>` to provide authentication to connector data sources.

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ConnectorContextModule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ConnectorContextModule.java
@@ -28,6 +28,7 @@ import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorExpressionEvaluator;
 import io.trino.spi.connector.MetadataProvider;
+import io.trino.spi.security.credential.CredentialResolver;
 import io.trino.spi.type.TypeManager;
 
 import static java.util.Objects.requireNonNull;
@@ -61,5 +62,6 @@ public class ConnectorContextModule
         binder.bind(PageIndexerFactory.class).toInstance(context.getPageIndexerFactory());
         binder.bind(BlocksHashFactory.class).toInstance(context.getBlocksHashFactory());
         binder.bind(ConnectorExpressionEvaluator.class).toInstance(context.getExpressionEvaluator());
+        binder.bind(CredentialResolver.class).toInstance(context.getCredentialResolver());
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/CredentialProviderConfig.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/CredentialProviderConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security.credential;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.NotNull;
+
+public class CredentialProviderConfig
+{
+    private String name;
+
+    @Config("name")
+    @ConfigDescription("The name of the properties file in the etc/credential-provider directory")
+    public CredentialProviderConfig setName(String name)
+    {
+        this.name = name;
+        return this;
+    }
+
+    @NotNull
+    public String getName()
+    {
+        return name;
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/CredentialProviderModule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/CredentialProviderModule.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security.credential;
+
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialResolver;
+
+import java.util.regex.Pattern;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
+
+public class CredentialProviderModule
+        implements Module
+{
+    private static final Pattern VALID_NAME = Pattern.compile("[a-z][a-z0-9-]*");
+
+    protected final Named named;
+    private final String prefix;
+
+    protected CredentialProviderModule(String name, String prefix)
+    {
+        this.named = Names.named(requireNonNull(name, "name is null"));
+        this.prefix = prefix;
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        String prefix = this.prefix == null ? "" : "%s.".formatted(this.prefix);
+        configBinder(binder).bindConfig(CredentialProviderConfig.class, named, "%scredential-provider.%s".formatted(prefix, named.value()));
+        binder.bind(CredentialProvider.class).annotatedWith(named).toProvider(new CredentialProviderProvider(named)).in(SINGLETON);
+    }
+
+    public static void credentialProvider(Binder binder, String name)
+    {
+        credentialProvider(binder, name, null);
+    }
+
+    public static void credentialProvider(Binder binder, String name, String prefix)
+    {
+        if (!VALID_NAME.matcher(name).matches()) {
+            throw new IllegalArgumentException("Invalid credential provider name: %s, should match %s".formatted(name, VALID_NAME.pattern()));
+        }
+        binder.install(new CredentialProviderModule(name, prefix));
+    }
+
+    private static class CredentialProviderProvider
+            implements Provider<CredentialProvider>
+    {
+        private final Named named;
+        private Injector injector;
+
+        public CredentialProviderProvider(Named named)
+        {
+            this.named = requireNonNull(named, "named is null");
+        }
+
+        @Inject
+        public void setInjector(Injector injector)
+        {
+            this.injector = injector;
+        }
+
+        @Override
+        public CredentialProvider get()
+        {
+            requireNonNull(injector, "injector is null");
+            CredentialResolver credentialResolver = injector.getInstance(CredentialResolver.class);
+            String name = injector.getInstance(Key.get(CredentialProviderConfig.class, named)).getName();
+
+            // When the credential provider plugin is not loaded yet,
+            // use the lazy provider as it should be resolvable when all plugins are loaded
+            return credentialResolver.get(name).orElseGet(() -> new LazyCredentialProvider(credentialResolver, name));
+        }
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/HttpHeadersCredentialUtil.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/HttpHeadersCredentialUtil.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security.credential;
+
+import io.airlift.http.client.HeaderName;
+import io.airlift.http.client.Request;
+import io.trino.spi.security.credential.HttpHeadersCredential;
+
+public class HttpHeadersCredentialUtil
+{
+    private HttpHeadersCredentialUtil() {}
+
+    public static Request.Builder applyHeaders(Request.Builder request, HttpHeadersCredential header)
+    {
+        header.getHeaders().forEach((key, value) -> request.setHeader(HeaderName.of(key), value));
+        return request;
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/LazyCredentialProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/credential/LazyCredentialProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.security.credential;
+
+import com.google.inject.Inject;
+import io.trino.spi.TrinoException;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.credential.Credential;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialResolver;
+
+import java.util.Optional;
+
+import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
+import static java.util.Objects.requireNonNull;
+
+public class LazyCredentialProvider
+        implements CredentialProvider
+{
+    private final CredentialResolver credentialResolver;
+    private final String name;
+    private CredentialProvider credentialProvider;
+
+    @Inject
+    public LazyCredentialProvider(CredentialResolver credentialResolver, String name)
+    {
+        this.credentialResolver = requireNonNull(credentialResolver, "credentialResolver is null");
+        this.name = requireNonNull(name, "name is null");
+    }
+
+    @Override
+    public <T extends Credential> Optional<T> getCredential(ConnectorIdentity identity, Class<T> type)
+    {
+        if (credentialProvider == null) {
+            credentialProvider = credentialResolver.get(name).orElseThrow(() -> new TrinoException(CONFIGURATION_INVALID, "Credential provider %s not configured. Loaded: [%s]".formatted(name, String.join(", ", credentialResolver.loadedProviders()))));
+        }
+        return credentialProvider.getCredential(identity, type);
+    }
+}

--- a/plugin/trino-credential-provider-basic/pom.xml
+++ b/plugin/trino-credential-provider-basic/pom.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>484-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-credential-provider-basic</artifactId>
+    <packaging>trino-plugin</packaging>
+    <name>${project.artifactId}</name>
+    <description>Trino - Credential provider - Basic auth</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-trace</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProvider.java
+++ b/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.basic;
+
+import com.google.inject.Inject;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.credential.BasicCredential;
+import io.trino.spi.security.credential.Credential;
+import io.trino.spi.security.credential.CredentialProvider;
+
+import java.util.Optional;
+
+import static io.trino.spi.security.credential.CredentialProvider.assertSupportedTypes;
+import static java.util.Objects.requireNonNull;
+
+public class BasicCredentialProvider
+        implements CredentialProvider
+{
+    private final BasicCredential credential;
+
+    @Inject
+    public BasicCredentialProvider(BasicCredentialProviderConfig config)
+    {
+        requireNonNull(config, "config is null");
+        credential = new BasicCredential(config.getUsername(), config.getPassword());
+    }
+
+    @Override
+    public <T extends Credential> Optional<T> getCredential(ConnectorIdentity identity, Class<T> type)
+    {
+        assertSupportedTypes(this, type, BasicCredential.class);
+        return Optional.of((T) credential);
+    }
+}

--- a/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderConfig.java
+++ b/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.basic;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import jakarta.validation.constraints.NotNull;
+
+public class BasicCredentialProviderConfig
+{
+    private String username;
+    private String password;
+
+    @NotNull
+    public String getUsername()
+    {
+        return username;
+    }
+
+    @Config("username")
+    @ConfigDescription("Username")
+    public BasicCredentialProviderConfig setUsername(String username)
+    {
+        this.username = username;
+        return this;
+    }
+
+    @NotNull
+    public String getPassword()
+    {
+        return password;
+    }
+
+    @Config("password")
+    @ConfigSecuritySensitive
+    @ConfigDescription("Password")
+    public BasicCredentialProviderConfig setPassword(String password)
+    {
+        this.password = password;
+        return this;
+    }
+}

--- a/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderFactory.java
+++ b/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.basic;
+
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.trino.spi.security.credential.CredentialProvider;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+
+import java.util.Map;
+
+public class BasicCredentialProviderFactory
+        implements CredentialProviderFactory
+{
+    @Override
+    public String getFactoryName()
+    {
+        return "basic";
+    }
+
+    @Override
+    public CredentialProvider create(String providerName, Map<String, String> config)
+    {
+        Bootstrap app = new Bootstrap(
+                "io.trino.bootstrap.credential-provider.%s".formatted(providerName),
+                new BasicCredentialProviderModule());
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .disableSystemProperties()
+                .setRequiredConfigurationProperties(config)
+                .initialize();
+
+        return injector.getInstance(BasicCredentialProvider.class);
+    }
+}

--- a/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderModule.java
+++ b/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderModule.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.basic;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class BasicCredentialProviderModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(BasicCredentialProviderConfig.class);
+        binder.bind(BasicCredentialProvider.class).in(Scopes.SINGLETON);
+    }
+}

--- a/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderPlugin.java
+++ b/plugin/trino-credential-provider-basic/src/main/java/io/trino/plugin/credential/basic/BasicCredentialProviderPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.basic;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Plugin;
+import io.trino.spi.security.credential.CredentialProviderFactory;
+
+public class BasicCredentialProviderPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<CredentialProviderFactory> getCredentialProviderFactories()
+    {
+        return ImmutableList.of(new BasicCredentialProviderFactory());
+    }
+}

--- a/plugin/trino-credential-provider-basic/src/test/java/io/trino/plugin/credential/basic/TestBasicCredentialProvider.java
+++ b/plugin/trino-credential-provider-basic/src/test/java/io/trino/plugin/credential/basic/TestBasicCredentialProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.credential.basic;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.security.credential.BasicCredential;
+import io.trino.spi.security.credential.CredentialProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestBasicCredentialProvider
+{
+    @Test
+    public void test()
+    {
+        BasicCredentialProviderFactory factory = new BasicCredentialProviderFactory();
+        assertThat(factory.getFactoryName()).isEqualTo("basic");
+
+        CredentialProvider provider = factory.create("my-name", ImmutableMap.of("username", "admin", "password", "hunter2"));
+        assertThat(provider).isInstanceOf(BasicCredentialProvider.class);
+
+        ConnectorIdentity identity = ConnectorIdentity.ofUser("alice");
+        BasicCredential credential = provider.getCredential(identity, BasicCredential.class).orElseThrow();
+        assertThat(credential.username()).isEqualTo("admin");
+        assertThat(credential.password()).isEqualTo("hunter2");
+
+        assertThat(credential.getHeaders()).isEqualTo(ImmutableMap.of("Authorization", "Basic YWRtaW46aHVudGVyMg=="));
+    }
+}

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlConnectorContext.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlConnectorContext.java
@@ -33,8 +33,10 @@ import io.trino.spi.PageSorter;
 import io.trino.spi.VersionEmbedder;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.MetadataProvider;
+import io.trino.spi.security.credential.CredentialResolver;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeOperators;
+import io.trino.testing.TestingCredentialResolver;
 import io.trino.type.InternalTypeManager;
 import io.trino.util.EmbedVersion;
 
@@ -113,5 +115,11 @@ public class TestingPostgreSqlConnectorContext
     public BlocksHashFactory getBlocksHashFactory()
     {
         return flatHashStrategyCompiler.createBlocksHashFactory();
+    }
+
+    @Override
+    public CredentialResolver getCredentialResolver()
+    {
+        return new TestingCredentialResolver();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <module>plugin/trino-blob-cache-memory</module>
         <module>plugin/trino-cassandra</module>
         <module>plugin/trino-clickhouse</module>
+        <module>plugin/trino-credential-provider-basic</module>
         <module>plugin/trino-datasketches</module>
         <module>plugin/trino-delta-lake</module>
         <module>plugin/trino-druid</module>

--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -119,6 +119,7 @@ public final class DistributedQueryRunner
     private final List<TestingTrinoServer> servers = new CopyOnWriteArrayList<>();
     private final List<FunctionBundle> functionBundles = new CopyOnWriteArrayList<>(ImmutableList.of(CustomFunctionBundle.CUSTOM_FUNCTIONS));
     private final List<Plugin> plugins = new CopyOnWriteArrayList<>();
+    private final List<CredentialProviderRegistration> credentialProviders = new CopyOnWriteArrayList<>();
 
     private final Closer closer = Closer.create();
 
@@ -271,6 +272,8 @@ public final class DistributedQueryRunner
                 newServer -> {
                     functionBundles.forEach(newServer::addFunctions);
                     plugins.forEach(newServer::installPlugin);
+                    credentialProviders.forEach(registration ->
+                            newServer.addCredentialProvider(registration.name(), registration.factoryName(), registration.properties()));
                 }));
         servers.add(server);
 
@@ -692,6 +695,13 @@ public final class DistributedQueryRunner
     }
 
     @Override
+    public void addCredentialProvider(String name, String factoryName, Map<String, String> properties)
+    {
+        credentialProviders.add(new CredentialProviderRegistration(name, factoryName, properties));
+        servers.forEach(server -> server.addCredentialProvider(name, factoryName, properties));
+    }
+
+    @Override
     public final void close()
     {
         if (closed) {
@@ -1107,4 +1117,6 @@ public final class DistributedQueryRunner
         return Base64.getEncoder()
                 .encodeToString(Ciphers.createRandomAesEncryptionKey().getEncoded());
     }
+
+    private record CredentialProviderRegistration(String name, String factoryName, Map<String, String> properties) {}
 }


### PR DESCRIPTION
## Description
Many connectors are struggling with credentials for plugin data sources. The goal of this PR is to separate the problem and fix it forever :)

## Design
In this PR, a `CredentialProvider` is an object on which a connector can invoke `#getCredential(ConnectorIdentity.class, ExpectedCredential.class)`. The `CredentialProvider` in the connector is named after its purpose, for example `metastore` in the Hive connector: `@Named("metastore") CredentialProvider metastoreCredentialProvider`. An additional provider can be injected by a new unique name, for example `@Named("storage") CredentialProvider storageCredentialProvider`.

Any plugin can register one or more `CredentialProviderFactory`, for example the basic auth provider in this PR.

The credential providers are created by adding `.properties` files to `etc/credential-provider`, for example:

_basic_admin.properties_
```
credential-provider.name=basic
username=admin
password=welcome123
```

In the properties of the using connector, this credential provider is linked:
```
connector.name=myconnector
credential-provider.metastore.name=basic_admin
credential-provider.storage.name=...
```

## Ultimate goal
This PR only adds the credential provider inner workings in trino-server and adds testing classes.

A working example can be found here: https://github.com/trinodb/trino/pull/30944 
This PR also adds oauth2 token exchange to the credential providers

## Additional note
`BasicCredential` implements `HttpHeadersCredential`, which is a superclass to be used for all login types where http headers can be used. In case of `BasicCredential`, that would be `"Authorization": "Basic (base64)"`. This would support the Authorization for a bearer token or a session cookie or (...). The idea is that it does not matter what kind of Credential provider implementation is configured, as long as it gives something to do a valid http request.


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( x ) Release notes are required, with the following suggested text:

```markdown
## Section
* Add credential provider support to the SPI
```
