### PR TITLE
Fix faker ignoring min/max on high-precision timestamp columns

### DIFF
--- a/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSource.java
+++ b/plugin/trino-faker/src/main/java/io/trino/plugin/faker/FakerPageSource.java
@@ -91,6 +91,8 @@ import static io.trino.spi.type.UuidType.UUID;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
 import static java.lang.Math.toIntExact;
 import static java.lang.System.arraycopy;
 import static java.util.Objects.requireNonNull;
@@ -603,6 +605,8 @@ class FakerPageSource
                 tzType.writeObject(blockBuilder, new LongTimestamp(epochMicros * range.factor, 0));
             };
         }
+        // numberBetween excludes the high bound
+        int picosOfMicroHigh = (int) POWERS_OF_TEN[tzType.getPrecision() - 6];
         return blockBuilder -> {
             long epochMicros = numberBetween(range.low.getEpochMicros(), range.high.getEpochMicros());
             int picosOfMicro;
@@ -611,13 +615,13 @@ class FakerPageSource
                         range.low.getPicosOfMicro(),
                         range.low.getEpochMicros() == range.high.getEpochMicros() ?
                                 range.high.getPicosOfMicro()
-                                : (int) POWERS_OF_TEN[tzType.getPrecision() - 6] - 1);
+                                : picosOfMicroHigh);
             }
             else if (epochMicros == range.high.getEpochMicros()) {
                 picosOfMicro = numberBetween(0, range.high.getPicosOfMicro());
             }
             else {
-                picosOfMicro = numberBetween(0, (int) POWERS_OF_TEN[tzType.getPrecision() - 6] - 1);
+                picosOfMicro = numberBetween(0, picosOfMicroHigh);
             }
             tzType.writeObject(blockBuilder, new LongTimestamp(epochMicros, picosOfMicro * range.factor));
         };
@@ -633,7 +637,8 @@ class FakerPageSource
             };
         }
         LongTimestampWithTimeZoneRange range = LongTimestampWithTimeZoneRange.of(genericRange, tzType.getPrecision());
-        int picosOfMilliHigh = (int) POWERS_OF_TEN[tzType.getPrecision() - 3] - 1;
+        // numberBetween excludes the high bound
+        int picosOfMilliHigh = (int) POWERS_OF_TEN[tzType.getPrecision() - 3];
         return blockBuilder -> {
             long millis = numberBetween(range.lowEpochMillis(), range.highEpochMillis());
             int picosOfMilli;
@@ -875,14 +880,16 @@ class FakerPageSource
                 return new LongTimestampRange(low, high, factor, step);
             }
             factor = (int) POWERS_OF_TEN[12 - precision];
-            int lowPicosOfMicro = roundDiv(low.getPicosOfMicro(), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0);
+            int unitsPerMicro = PICOSECONDS_PER_MICROSECOND / factor;
+            // an unbounded bound keeps the extreme epoch value, so its fraction must not carry
+            int lowPicosOfMicro = range.isLowUnbounded() ? 0 : roundDiv(low.getPicosOfMicro(), factor) + (range.isLowInclusive() ? 0 : 1);
+            int highPicosOfMicro = range.isHighUnbounded() ? unitsPerMicro - 1 : roundDiv(high.getPicosOfMicro(), factor) + (range.isHighInclusive() ? 1 : 0);
             low = new LongTimestamp(
-                    low.getEpochMicros() - (lowPicosOfMicro < 0 ? 1 : 0),
-                    (lowPicosOfMicro + factor) % factor);
-            int highPicosOfMicro = roundDiv(high.getPicosOfMicro(), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0);
+                    low.getEpochMicros() + floorDiv(lowPicosOfMicro, unitsPerMicro),
+                    floorMod(lowPicosOfMicro, unitsPerMicro));
             high = new LongTimestamp(
-                    high.getEpochMicros() + (highPicosOfMicro > factor ? 1 : 0),
-                    highPicosOfMicro % factor);
+                    high.getEpochMicros() + floorDiv(highPicosOfMicro, unitsPerMicro),
+                    floorMod(highPicosOfMicro, unitsPerMicro));
             return new LongTimestampRange(low, high, factor, step);
         }
 
@@ -947,13 +954,15 @@ class FakerPageSource
                 throw new TrinoException(INVALID_ROW_FILTER, "Range boundaries for timestamp with time zone columns must have the same time zone");
             }
             int factor = (int) POWERS_OF_TEN[12 - precision];
-            int lowPicos = roundDiv(low.getPicosOfMilli(), factor) + (!range.isLowUnbounded() && !range.isLowInclusive() ? 1 : 0);
-            int highPicos = roundDiv(high.getPicosOfMilli(), factor) + (!range.isHighUnbounded() && range.isHighInclusive() ? 1 : 0);
+            int unitsPerMilli = PICOSECONDS_PER_MILLISECOND / factor;
+            // an unbounded bound keeps the extreme epoch value, so its fraction must not carry
+            int lowPicos = range.isLowUnbounded() ? 0 : roundDiv(low.getPicosOfMilli(), factor) + (range.isLowInclusive() ? 0 : 1);
+            int highPicos = range.isHighUnbounded() ? unitsPerMilli - 1 : roundDiv(high.getPicosOfMilli(), factor) + (range.isHighInclusive() ? 1 : 0);
             return new LongTimestampWithTimeZoneRange(
-                    low.getEpochMillis() - (lowPicos < 0 ? 1 : 0),
-                    (lowPicos + factor) % factor,
-                    high.getEpochMillis() + (highPicos > factor ? 1 : 0),
-                    highPicos % factor,
+                    low.getEpochMillis() + floorDiv(lowPicos, unitsPerMilli),
+                    floorMod(lowPicos, unitsPerMilli),
+                    high.getEpochMillis() + floorDiv(highPicos, unitsPerMilli),
+                    floorMod(highPicos, unitsPerMilli),
                     factor,
                     defaultTZ,
                     step);

--- a/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
+++ b/plugin/trino-faker/src/test/java/io/trino/plugin/faker/TestFakerQueries.java
@@ -284,6 +284,12 @@ final class TestFakerQueries
                 .add(new TestDataType("rnd_timestamptz0", "timestamp(0) with time zone", Map.of("min", "2022-03-21 00:00:00 +01:00", "max", "2022-03-21 00:00:01 +01:00"), "count(distinct rnd_timestamptz0)", "2"))
                 .add(new TestDataType("rnd_timestamptz6", "timestamp(6) with time zone", Map.of("min", "2022-03-21 00:00:00.000000 +01:00", "max", "2022-03-21 00:00:00.000001 +01:00"), "count(distinct rnd_timestamptz6)", "2"))
                 .add(new TestDataType("rnd_timestamptz9", "timestamp(9) with time zone", Map.of("min", "2022-03-21 00:00:00.000000000 +01:00", "max", "2022-03-21 00:00:00.000000001 +01:00"), "count(distinct rnd_timestamptz9)", "2"))
+                // an inclusive high bound at the top unit of a millisecond or microsecond must carry
+                // into the next one, and at maximum precision the fraction must survive normalization
+                .add(new TestDataType("rnd_timestamp9_carry", "timestamp(9)", Map.of("min", "2022-03-21 00:00:00.000000998", "max", "2022-03-21 00:00:00.000000999"), "count(distinct rnd_timestamp9_carry)", "2"))
+                .add(new TestDataType("rnd_timestamp12", "timestamp(12)", Map.of("min", "2022-03-21 00:00:00.000000000001", "max", "2022-03-21 00:00:00.000000000002"), "count(distinct rnd_timestamp12)", "2"))
+                .add(new TestDataType("rnd_timestamptz6_carry", "timestamp(6) with time zone", Map.of("min", "2022-03-21 00:00:00.000998 +01:00", "max", "2022-03-21 00:00:00.000999 +01:00"), "count(distinct rnd_timestamptz6_carry)", "2"))
+                .add(new TestDataType("rnd_timestamptz12", "timestamp(12) with time zone", Map.of("min", "2022-03-21 00:00:00.000000000001 +01:00", "max", "2022-03-21 00:00:00.000000000002 +01:00"), "count(distinct rnd_timestamptz12)", "2"))
                 .add(new TestDataType("rnd_time", "time", Map.of("min", "01:02:03.456", "max", "01:02:03.457"), "count(distinct rnd_time)", "2"))
                 .add(new TestDataType("rnd_time0", "time(0)", Map.of("min", "01:02:03", "max", "01:02:04"), "count(distinct rnd_time0)", "2"))
                 .add(new TestDataType("rnd_time6", "time(6)", Map.of("min", "01:02:03.000456", "max", "01:02:03.000457"), "count(distinct rnd_time6)", "2"))


### PR DESCRIPTION
A timestamp(12) column with min and max one picosecond apart produced 1000 distinct values spanning the whole microsecond, and the same range on timestamp(12) with time zone collapsed to a single value.

Faker splits such a bound into whole microseconds / milliseconds plus a fraction counted in units of the column's precision, but divided and wrapped that fraction by `factor`, the picoseconds per unit, rather than by the number of units. So at the maximum precision, where a unit is one picosecond and factor is 1, the fraction was always erased, and an inclusive high bound sitting on the top unit kept an impossible fraction instead of rolling into the next microsecond.

The generators also passed the last valid fraction where numberBetween wants an exclusive bound, so the top unit was never generated.