### PR TITLE
Report memory during ordered aggregation prepareFinal

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/AggregationOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/AggregationOperator.java
@@ -161,7 +161,7 @@ public class AggregationOperator
         for (int i = 0; i < aggregates.size(); i++) {
             Aggregator aggregator = aggregates.get(i);
             BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(i);
-            aggregator.evaluate(blockBuilder);
+            aggregator.evaluate(blockBuilder, UpdateMemory.NOOP);
         }
 
         state = State.FINISHED;

--- a/core/trino-main/src/main/java/io/trino/operator/AggregationOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/AggregationOperator.java
@@ -134,12 +134,19 @@ public class AggregationOperator
         checkState(needsInput(), "Operator is already finishing");
         requireNonNull(page, "page is null");
 
-        long memorySize = 0;
         for (Aggregator aggregate : aggregates) {
             aggregate.processPage(page);
+        }
+        updateMemoryUsage();
+    }
+
+    private boolean updateMemoryUsage()
+    {
+        long memorySize = 0;
+        for (Aggregator aggregate : aggregates) {
             memorySize += aggregate.getEstimatedSize();
         }
-        userMemoryContext.setBytes(memorySize);
+        return userMemoryContext.setBytes(memorySize).isDone();
     }
 
     @Override
@@ -157,11 +164,15 @@ public class AggregationOperator
         // so a new PageBuilder is constructed (instead of using PageBuilder.reset)
         PageBuilder pageBuilder = new PageBuilder(1, types);
 
+        // an aggregator can grow while producing final output (e.g. ordered aggregation replaying
+        // its buffered pages into a distinct hash); report that growth as it happens
+        UpdateMemory updateMemory = this::updateMemoryUsage;
+
         pageBuilder.declarePosition();
         for (int i = 0; i < aggregates.size(); i++) {
             Aggregator aggregator = aggregates.get(i);
             BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(i);
-            aggregator.evaluate(blockBuilder, UpdateMemory.NOOP);
+            aggregator.evaluate(blockBuilder, updateMemory);
         }
 
         state = State.FINISHED;

--- a/core/trino-main/src/main/java/io/trino/operator/HashAggregationOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HashAggregationOperator.java
@@ -555,7 +555,7 @@ public class HashAggregationOperator
             }
 
             for (AggregatorFactory aggregatorFactory : aggregatorFactories) {
-                aggregatorFactory.createAggregator(aggregationMetrics).evaluate(output.getBlockBuilder(channel));
+                aggregatorFactory.createAggregator(aggregationMetrics).evaluate(output.getBlockBuilder(channel), UpdateMemory.NOOP);
                 channel++;
             }
         }

--- a/core/trino-main/src/main/java/io/trino/operator/StreamingAggregationOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/StreamingAggregationOperator.java
@@ -252,7 +252,7 @@ public class StreamingAggregationOperator
             return ofResult(outputPage, outputPages.isEmpty());
         }
 
-        private void updateMemoryUsage()
+        private boolean updateMemoryUsage()
         {
             long memorySize = pageBuilder.getRetainedSizeInBytes();
             for (Page output : outputPages) {
@@ -266,7 +266,7 @@ public class StreamingAggregationOperator
                 memorySize += currentGroup.getRetainedSizeInBytes();
             }
 
-            userMemoryContext.setBytes(memorySize);
+            return userMemoryContext.setBytes(memorySize).isDone();
         }
 
         private void processInput(Page page)
@@ -317,7 +317,7 @@ public class StreamingAggregationOperator
             }
             int offset = groupByTypes.size();
             for (int i = 0; i < aggregates.size(); i++) {
-                aggregates.get(i).evaluate(pageBuilder.getBlockBuilder(offset + i), UpdateMemory.NOOP);
+                aggregates.get(i).evaluate(pageBuilder.getBlockBuilder(offset + i), this::updateMemoryUsage);
             }
 
             if (pageBuilder.isFull()) {

--- a/core/trino-main/src/main/java/io/trino/operator/StreamingAggregationOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/StreamingAggregationOperator.java
@@ -317,7 +317,7 @@ public class StreamingAggregationOperator
             }
             int offset = groupByTypes.size();
             for (int i = 0; i < aggregates.size(); i++) {
-                aggregates.get(i).evaluate(pageBuilder.getBlockBuilder(offset + i));
+                aggregates.get(i).evaluate(pageBuilder.getBlockBuilder(offset + i), UpdateMemory.NOOP);
             }
 
             if (pageBuilder.isFull()) {

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/Accumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/Accumulator.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.aggregation;
 
+import io.trino.operator.UpdateMemory;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -29,5 +30,5 @@ public interface Accumulator
 
     void evaluateIntermediate(BlockBuilder blockBuilder);
 
-    void evaluateFinal(BlockBuilder blockBuilder);
+    void evaluateFinal(BlockBuilder blockBuilder, UpdateMemory updateMemory);
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorCompiler.java
@@ -211,7 +211,7 @@ public final class AccumulatorCompiler
             generateGroupedEvaluateFinal(definition, stateFields, implementation.getOutputFunction(), callSiteBinder);
         }
         else {
-            generateEvaluateFinal(definition, "evaluateFinal", stateFields, implementation.getOutputFunction(), callSiteBinder);
+            generateEvaluateFinal(definition, "evaluateFinal", true, stateFields, implementation.getOutputFunction(), callSiteBinder);
         }
 
         if (grouped) {
@@ -292,7 +292,7 @@ public final class AccumulatorCompiler
                 implementation.getInputFunction(),
                 callSiteBinder);
 
-        generateEvaluateFinal(definition, "output", stateFields, implementation.getOutputFunction(), callSiteBinder);
+        generateEvaluateFinal(definition, "output", false, stateFields, implementation.getOutputFunction(), callSiteBinder);
         generateGetEstimatedSize(definition, stateFields);
 
         Class<? extends WindowAccumulator> windowAccumulatorClass = defineHiddenClass(definition, WindowAccumulator.class, callSiteBinder.getClassData());
@@ -934,16 +934,23 @@ public final class AccumulatorCompiler
     private static void generateEvaluateFinal(
             ClassDefinition definition,
             String methodName,
+            boolean acceptUpdateMemory,
             List<FieldDefinition> stateFields,
             MethodHandle outputFunction,
             CallSiteBinder callSiteBinder)
     {
         Parameter out = arg("out", BlockBuilder.class);
+        List<Parameter> parameters = new ArrayList<>();
+        parameters.add(out);
+        if (acceptUpdateMemory) {
+            // the callback is only used by accumulators that move data while producing final output
+            parameters.add(arg("updateMemory", UpdateMemory.class));
+        }
         MethodDefinition method = definition.declareMethod(
                 a(PUBLIC),
                 methodName,
                 type(void.class),
-                out);
+                parameters);
 
         BytecodeBlock body = method.getBody();
         Variable thisVariable = method.getThis();

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorCompiler.java
@@ -25,6 +25,7 @@ import io.airlift.bytecode.control.ForLoop;
 import io.airlift.bytecode.control.IfStatement;
 import io.airlift.bytecode.expression.BytecodeExpression;
 import io.airlift.bytecode.expression.BytecodeExpressions;
+import io.trino.operator.UpdateMemory;
 import io.trino.operator.window.InternalWindowIndex;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
@@ -967,7 +968,8 @@ public final class AccumulatorCompiler
         MethodDefinition method = definition.declareMethod(
                 a(PUBLIC),
                 "prepareFinal",
-                type(void.class));
+                type(void.class),
+                arg("updateMemory", UpdateMemory.class));
         method.getBody().ret();
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/Aggregator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/Aggregator.java
@@ -15,6 +15,7 @@ package io.trino.operator.aggregation;
 
 import com.google.common.primitives.Ints;
 import io.trino.operator.AggregationMetrics;
+import io.trino.operator.UpdateMemory;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -92,13 +93,13 @@ public class Aggregator
         }
     }
 
-    public void evaluate(BlockBuilder blockBuilder)
+    public void evaluate(BlockBuilder blockBuilder, UpdateMemory updateMemory)
     {
         if (step.isOutputPartial()) {
             accumulator.evaluateIntermediate(blockBuilder);
         }
         else {
-            accumulator.evaluateFinal(blockBuilder);
+            accumulator.evaluateFinal(blockBuilder, updateMemory);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
@@ -280,6 +280,7 @@ public class DistinctAccumulatorFactory
         {
             // release hash memory after all inputs have been added
             hash = null;
+            accumulator.prepareFinal(updateMemory);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
@@ -276,7 +276,7 @@ public class DistinctAccumulatorFactory
         }
 
         @Override
-        public void prepareFinal()
+        public void prepareFinal(UpdateMemory updateMemory)
         {
             // release hash memory after all inputs have been added
             hash = null;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DistinctAccumulatorFactory.java
@@ -171,11 +171,11 @@ public class DistinctAccumulatorFactory
         }
 
         @Override
-        public void evaluateFinal(BlockBuilder blockBuilder)
+        public void evaluateFinal(BlockBuilder blockBuilder, UpdateMemory updateMemory)
         {
             // release hash memory since it's no longer needed
             hash = null;
-            accumulator.evaluateFinal(blockBuilder);
+            accumulator.evaluateFinal(blockBuilder, updateMemory);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/GroupedAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/GroupedAccumulator.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.aggregation;
 
+import io.trino.operator.UpdateMemory;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -31,5 +32,5 @@ public interface GroupedAccumulator
 
     void evaluateFinal(int groupId, BlockBuilder output);
 
-    void prepareFinal();
+    void prepareFinal(UpdateMemory updateMemory);
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/GroupedAggregator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/GroupedAggregator.java
@@ -15,6 +15,7 @@ package io.trino.operator.aggregation;
 
 import com.google.common.primitives.Ints;
 import io.trino.operator.AggregationMetrics;
+import io.trino.operator.UpdateMemory;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -100,9 +101,9 @@ public class GroupedAggregator
         }
     }
 
-    public void prepareFinal()
+    public void prepareFinal(UpdateMemory updateMemory)
     {
-        accumulator.prepareFinal();
+        accumulator.prepareFinal(updateMemory);
     }
 
     public void evaluate(int groupId, BlockBuilder output)

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
@@ -282,6 +282,7 @@ public class OrderedAccumulatorFactory
             });
             // release pagesIndex memory after transferring its contents into the accumulator
             pagesIndex = null;
+            accumulator.prepareFinal(updateMemory);
         }
 
         private static int[] extractGroupIds(Page page)

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
@@ -18,6 +18,7 @@ import com.google.common.primitives.Ints;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.PagesIndex.Factory;
 import io.trino.operator.PagesIndexOrdering;
+import io.trino.operator.UpdateMemory;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -264,7 +265,7 @@ public class OrderedAccumulatorFactory
         }
 
         @Override
-        public void prepareFinal()
+        public void prepareFinal(UpdateMemory updateMemory)
         {
             checkState(pagesIndex != null, "prepareFinal() already called");
             pagesIndex.sort(pagesIndexOrdering);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
@@ -277,6 +277,8 @@ public class OrderedAccumulatorFactory
                         extractGroupIds(page),
                         page.getColumns(argumentChannels),
                         mask);
+                // result ignored, prepareFinal cannot yield
+                updateMemory.update();
             });
             // release pagesIndex memory after transferring its contents into the accumulator
             pagesIndex = null;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
@@ -176,6 +176,8 @@ public class OrderedAccumulatorFactory
             pagesIterator.forEachRemaining(arguments -> {
                 mask.reset(arguments.getPositionCount());
                 accumulator.addInput(arguments.getColumns(argumentChannels), mask);
+                // result ignored, evaluateFinal cannot yield
+                updateMemory.update();
             });
             // release pagesIndex memory after transferring its contents into the accumulator
             pagesIndex = null;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
@@ -167,7 +167,7 @@ public class OrderedAccumulatorFactory
         }
 
         @Override
-        public void evaluateFinal(BlockBuilder blockBuilder)
+        public void evaluateFinal(BlockBuilder blockBuilder, UpdateMemory updateMemory)
         {
             checkState(pagesIndex != null, "evaluateFinal() already called");
             pagesIndex.sort(pagesIndexOrdering);
@@ -179,7 +179,7 @@ public class OrderedAccumulatorFactory
             });
             // release pagesIndex memory after transferring its contents into the accumulator
             pagesIndex = null;
-            accumulator.evaluateFinal(blockBuilder);
+            accumulator.evaluateFinal(blockBuilder, updateMemory);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -230,7 +230,7 @@ public class InMemoryHashAggregationBuilder
     {
         groupByHash.startReleasingOutput();
         for (GroupedAggregator groupedAggregator : groupedAggregators) {
-            groupedAggregator.prepareFinal();
+            groupedAggregator.prepareFinal(updateMemory);
         }
         // Always update the current memory usage after calling GroupedAggregator#prepareFinal(), since it can increase
         // memory consumption significantly in some situations. This also captures any memory usage reduction the

--- a/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
@@ -26,6 +26,9 @@ import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.GroupByHashYieldAssertion.GroupByHashYieldResult;
 import io.trino.operator.HashAggregationOperator.HashAggregationOperatorFactory;
+import io.trino.operator.aggregation.AccumulatorFactory;
+import io.trino.operator.aggregation.AggregatorFactory;
+import io.trino.operator.aggregation.OrderedAccumulatorFactory;
 import io.trino.operator.aggregation.TestingAggregationFunction;
 import io.trino.operator.aggregation.builder.HashAggregationBuilder;
 import io.trino.operator.aggregation.builder.InMemoryHashAggregationBuilder;
@@ -34,7 +37,9 @@ import io.trino.plugin.base.metrics.LongCount;
 import io.trino.plugin.base.metrics.TDigestHistogram;
 import io.trino.spi.Page;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.block.PageBuilderStatus;
+import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.metrics.Metric;
 import io.trino.spi.metrics.Metrics;
 import io.trino.spi.type.Type;
@@ -80,6 +85,7 @@ import static io.trino.operator.OperatorAssertion.toMaterializedResult;
 import static io.trino.operator.OperatorAssertion.toPages;
 import static io.trino.operator.SpillMetrics.SPILL_COUNT_METRIC_NAME;
 import static io.trino.operator.SpillMetrics.SPILL_DATA_SIZE;
+import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -307,6 +313,76 @@ public class TestHashAggregationOperator
             toPages(operator, input.iterator(), revokeMemoryWhenAddingPages);
             assertThat(operator.getOperatorContext().getOperatorStats().getUserMemoryReservation().toBytes()).isEqualTo(0);
             assertThat(operator.getOperatorContext().getOperatorStats().getRevocableMemoryReservation().toBytes()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    public void testDistinctOrderedAggregationMemoryReservation()
+            throws Exception
+    {
+        TestingAggregationFunction arrayAgg = FUNCTION_RESOLUTION.getAggregateFunction("array_agg", fromTypes(BIGINT));
+        AccumulatorFactory distinctOrderedFactory = new OrderedAccumulatorFactory(
+                arrayAgg.getDistinctFactory(),
+                ImmutableList.of(BIGINT),
+                ImmutableList.of(0),
+                ImmutableList.of(0),
+                ImmutableList.of(ASC_NULLS_LAST),
+                new PagesIndex.TestingFactory(false));
+        AggregatorFactory aggregatorFactory = new AggregatorFactory(
+                distinctOrderedFactory,
+                SINGLE,
+                arrayAgg.getIntermediateType(),
+                arrayAgg.getFinalType(),
+                ImmutableList.of(0),
+                OptionalInt.empty(),
+                false, // spillable
+                ImmutableList.of());
+
+        // a single group with all values distinct
+        int positionsPerPage = 100_000;
+        int pageCount = 4;
+        List<Page> input = new ArrayList<>();
+        for (int page = 0; page < pageCount; page++) {
+            long[] values = new long[positionsPerPage];
+            for (int i = 0; i < positionsPerPage; i++) {
+                values[i] = ((long) page * positionsPerPage) + i;
+            }
+            input.add(new Page(
+                    new LongArrayBlock(positionsPerPage, Optional.empty(), values),
+                    RunLengthEncodedBlock.create(BIGINT, 0L, positionsPerPage)));
+        }
+
+        DriverContext driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION, DataSize.of(64, Unit.MEGABYTE))
+                .addPipelineContext(0, true, true, false)
+                .addDriverContext();
+
+        HashAggregationOperatorFactory operatorFactory = new HashAggregationOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                ImmutableList.of(BIGINT),
+                Ints.asList(1),
+                ImmutableList.of(),
+                SINGLE,
+                true,
+                ImmutableList.of(aggregatorFactory),
+                OptionalInt.empty(),
+                100_000,
+                Optional.of(DataSize.of(16, MEGABYTE)),
+                false,
+                succinctBytes(0),
+                succinctBytes(0),
+                new DummySpillerFactory(),
+                hashStrategyCompiler,
+                Optional.empty());
+
+        // while prepareFinal replays the buffered rows into the distinct hash, the buffered values,
+        // the pages index addresses and the hash entries must all be reserved at the same time
+        long rows = (long) pageCount * positionsPerPage;
+        long expectedPeak = rows * Long.BYTES + rows * Long.BYTES + rows * 2 * Long.BYTES;
+        try (Operator operator = operatorFactory.createOperator(driverContext)) {
+            toPages(operator, input.iterator());
+            assertThat(operator.getOperatorContext().getOperatorStats().getPeakUserMemoryReservation().toBytes())
+                    .isGreaterThan(expectedPeak);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/AggregationTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/AggregationTestUtils.java
@@ -18,6 +18,7 @@ import com.google.common.primitives.Ints;
 import io.trino.block.BlockAssertions;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.AggregationMetrics;
+import io.trino.operator.UpdateMemory;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -104,7 +105,7 @@ public final class AggregationTestUtils
     public static Block getIntermediateBlock(Type intermediateType, Aggregator aggregator)
     {
         BlockBuilder blockBuilder = intermediateType.createBlockBuilder(null, 1000);
-        aggregator.evaluate(blockBuilder);
+        aggregator.evaluate(blockBuilder, UpdateMemory.NOOP);
         return blockBuilder.build();
     }
 
@@ -118,7 +119,7 @@ public final class AggregationTestUtils
     public static Block getFinalBlock(Type finalType, Aggregator aggregator)
     {
         BlockBuilder blockBuilder = finalType.createBlockBuilder(null, 1000);
-        aggregator.evaluate(blockBuilder);
+        aggregator.evaluate(blockBuilder, UpdateMemory.NOOP);
         return blockBuilder.build();
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestOrderedAccumulatorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestOrderedAccumulatorFactory.java
@@ -18,6 +18,7 @@ import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.UpdateMemory;
 import io.trino.spi.Page;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.LongArrayBlock;
 import org.junit.jupiter.api.Test;
 
@@ -79,6 +80,54 @@ public class TestOrderedAccumulatorFactory
         // the delegate's growth is visible as the replay progresses
         assertThat(sizeAtUpdate.getLast()).isGreaterThan(sizeAtUpdate.getFirst());
         // the buffered pages and the delegate's hash are released once the replay is done
+        assertThat(accumulator.getEstimatedSize()).isLessThan(sizeAtUpdate.getLast());
+        assertThat(accumulator.getEstimatedSize()).isLessThan(sizeAtUpdate.getFirst());
+    }
+
+    // the non-grouped twin of the test above: the replay happens in evaluateFinal instead of prepareFinal
+    @Test
+    public void testEvaluateFinalReportsMemoryWhileReplaying()
+    {
+        TestingAggregationFunction arrayAgg = FUNCTION_RESOLUTION.getAggregateFunction("array_agg", fromTypes(BIGINT));
+        OrderedAccumulatorFactory factory = new OrderedAccumulatorFactory(
+                arrayAgg.getDistinctFactory(),
+                ImmutableList.of(BIGINT),
+                ImmutableList.of(0),      // argument channels
+                ImmutableList.of(0),      // order-by channels
+                ImmutableList.of(ASC_NULLS_LAST),
+                new PagesIndex.TestingFactory(false));
+
+        Accumulator accumulator = factory.createAccumulator(ImmutableList.of());
+
+        // buffer enough distinct rows that getSortedPages yields multiple pages to replay
+        int positionsPerPage = 100_000;
+        for (int page = 0; page < 4; page++) {
+            long[] values = new long[positionsPerPage];
+            for (int i = 0; i < positionsPerPage; i++) {
+                values[i] = ((long) page * positionsPerPage) + i;
+            }
+            accumulator.addInput(
+                    new Page(new LongArrayBlock(positionsPerPage, Optional.empty(), values)),
+                    AggregationMask.createSelectAll(positionsPerPage));
+        }
+        // the delegate has seen no input yet, so this is what the buffered pages alone weigh
+        long bufferedPagesSize = accumulator.getEstimatedSize();
+
+        List<Long> sizeAtUpdate = new ArrayList<>();
+        UpdateMemory updateMemory = () -> {
+            sizeAtUpdate.add(accumulator.getEstimatedSize());
+            return true;
+        };
+        BlockBuilder output = arrayAgg.getFinalType().createBlockBuilder(null, 1);
+        accumulator.evaluateFinal(output, updateMemory);
+
+        // memory is reported repeatedly during the replay, not just once after it
+        assertThat(sizeAtUpdate).hasSizeGreaterThan(1);
+        // the buffered pages and the delegate's growth are counted at the same moment
+        assertThat(sizeAtUpdate.getFirst()).isGreaterThan(bufferedPagesSize);
+        // the delegate's growth is visible as the replay progresses
+        assertThat(sizeAtUpdate.getLast()).isGreaterThan(sizeAtUpdate.getFirst());
+        // the buffered pages and the delegate's hash are released once the output is produced
         assertThat(accumulator.getEstimatedSize()).isLessThan(sizeAtUpdate.getLast());
         assertThat(accumulator.getEstimatedSize()).isLessThan(sizeAtUpdate.getFirst());
     }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestOrderedAccumulatorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestOrderedAccumulatorFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.PagesIndex;
+import io.trino.operator.UpdateMemory;
+import io.trino.spi.Page;
+import io.trino.spi.block.LongArrayBlock;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestOrderedAccumulatorFactory
+{
+    private static final TestingFunctionResolution FUNCTION_RESOLUTION = new TestingFunctionResolution();
+
+    // prepareFinal replays the buffered pages into the delegate (for a distinct aggregation, this is
+    // where its hash fills up); the transient peak must be reported while the buffer is still held
+    @Test
+    public void testPrepareFinalReportsMemoryWhileReplaying()
+    {
+        OrderedAccumulatorFactory factory = new OrderedAccumulatorFactory(
+                FUNCTION_RESOLUTION.getAggregateFunction("array_agg", fromTypes(BIGINT)).getDistinctFactory(),
+                ImmutableList.of(BIGINT),
+                ImmutableList.of(0),      // argument channels
+                ImmutableList.of(0),      // order-by channels
+                ImmutableList.of(ASC_NULLS_LAST),
+                new PagesIndex.TestingFactory(false));
+
+        GroupedAccumulator accumulator = factory.createGroupedAccumulator(ImmutableList.of());
+        accumulator.setGroupCount(1);
+
+        // buffer enough distinct rows that getSortedPages yields multiple pages to replay
+        int positionsPerPage = 100_000;
+        for (int page = 0; page < 4; page++) {
+            long[] values = new long[positionsPerPage];
+            for (int i = 0; i < positionsPerPage; i++) {
+                values[i] = ((long) page * positionsPerPage) + i;
+            }
+            accumulator.addInput(
+                    new int[positionsPerPage], // all rows in group 0
+                    new Page(new LongArrayBlock(positionsPerPage, Optional.empty(), values)),
+                    AggregationMask.createSelectAll(positionsPerPage));
+        }
+        // the delegate has seen no input yet, so this is what the buffered pages alone weigh
+        long bufferedPagesSize = accumulator.getEstimatedSize();
+
+        List<Long> sizeAtUpdate = new ArrayList<>();
+        UpdateMemory updateMemory = () -> {
+            sizeAtUpdate.add(accumulator.getEstimatedSize());
+            return true;
+        };
+        accumulator.prepareFinal(updateMemory);
+
+        // memory is reported repeatedly during the replay, not just once after it
+        assertThat(sizeAtUpdate).hasSizeGreaterThan(1);
+        // the buffered pages and the delegate's growth are counted at the same moment
+        assertThat(sizeAtUpdate.getFirst()).isGreaterThan(bufferedPagesSize);
+        // the delegate's growth is visible as the replay progresses
+        assertThat(sizeAtUpdate.getLast()).isGreaterThan(sizeAtUpdate.getFirst());
+        // the buffered pages are released once the replay is done
+        assertThat(accumulator.getEstimatedSize()).isLessThan(sizeAtUpdate.getLast());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestOrderedAccumulatorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestOrderedAccumulatorFactory.java
@@ -78,7 +78,8 @@ public class TestOrderedAccumulatorFactory
         assertThat(sizeAtUpdate.getFirst()).isGreaterThan(bufferedPagesSize);
         // the delegate's growth is visible as the replay progresses
         assertThat(sizeAtUpdate.getLast()).isGreaterThan(sizeAtUpdate.getFirst());
-        // the buffered pages are released once the replay is done
+        // the buffered pages and the delegate's hash are released once the replay is done
         assertThat(accumulator.getEstimatedSize()).isLessThan(sizeAtUpdate.getLast());
+        assertThat(accumulator.getEstimatedSize()).isLessThan(sizeAtUpdate.getFirst());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestingAggregationFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestingAggregationFunction.java
@@ -99,6 +99,11 @@ public class TestingAggregationFunction
         return createAggregatorFactory(step, inputChannels, maskChannel, factory);
     }
 
+    public DistinctAccumulatorFactory getDistinctFactory()
+    {
+        return distinctFactory;
+    }
+
     public AggregatorFactory createDistinctAggregatorFactory(Step step, List<Integer> inputChannels, OptionalInt maskChannel)
     {
         return createAggregatorFactory(step, inputChannels, maskChannel, distinctFactory);

--- a/plugin/trino-ml/src/test/java/io/trino/plugin/ml/TestEvaluateClassifierPredictions.java
+++ b/plugin/trino-ml/src/test/java/io/trino/plugin/ml/TestEvaluateClassifierPredictions.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.RowPageBuilder;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.AggregationMetrics;
+import io.trino.operator.UpdateMemory;
 import io.trino.operator.aggregation.Aggregator;
 import io.trino.operator.aggregation.TestingAggregationFunction;
 import io.trino.spi.Page;
@@ -45,7 +46,7 @@ public class TestEvaluateClassifierPredictions
         Aggregator aggregator = aggregation.createAggregatorFactory(SINGLE, ImmutableList.of(0, 1), OptionalInt.empty()).createAggregator(new AggregationMetrics());
         aggregator.processPage(getPage());
         BlockBuilder finalOut = VARCHAR.createBlockBuilder(null, 1);
-        aggregator.evaluate(finalOut);
+        aggregator.evaluate(finalOut, UpdateMemory.NOOP);
         Block block = finalOut.build();
 
         String output = VARCHAR.getSlice(block, 0).toStringUtf8();

--- a/plugin/trino-ml/src/test/java/io/trino/plugin/ml/TestLearnAggregations.java
+++ b/plugin/trino-ml/src/test/java/io/trino/plugin/ml/TestLearnAggregations.java
@@ -18,6 +18,7 @@ import io.airlift.slice.Slice;
 import io.trino.RowPageBuilder;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.AggregationMetrics;
+import io.trino.operator.UpdateMemory;
 import io.trino.operator.aggregation.Aggregator;
 import io.trino.operator.aggregation.TestingAggregationFunction;
 import io.trino.plugin.ml.type.ClassifierParametricType;
@@ -86,7 +87,7 @@ public class TestLearnAggregations
     {
         aggregator.processPage(getPage());
         BlockBuilder finalOut = aggregator.getType().createBlockBuilder(null, 1);
-        aggregator.evaluate(finalOut);
+        aggregator.evaluate(finalOut, UpdateMemory.NOOP);
         Block block = finalOut.build();
         Slice slice = aggregator.getType().getSlice(block, 0);
         Model deserialized = ModelUtils.deserialize(slice);


### PR DESCRIPTION
Ordered aggregation buffers all input in a `PagesIndex` and replays it into the delegate accumulator when producing final output — in `prepareFinal` for the grouped accumulator, in `evaluateFinal` for the non-grouped one. For `array_agg(DISTINCT ... ORDER BY ...)` this replay is where the distinct hash fills up, and it had two problems:

1. Memory was only reserved outside the replay, so the transient peak (full buffer still held while the hash grows) was invisible to the memory pool — a worker could blow past its pool without the memory limit or low-memory killer engaging. On the non-grouped path, `AggregationOperator` never reserved after `addInput` at all.
2. On the grouped path the delegates were never finalized, so the distinct hash stayed alive until the operator was closed.

Commits 1 and 4 mechanically thread `UpdateMemory` through `GroupedAccumulator.prepareFinal` and `Accumulator.evaluateFinal`. Commits 2 and 5 report memory as the replay progresses on each path (the distinct count isn't known upfront, so the reservation is caught up per page rather than pre-reserved). Commit 3 propagates `prepareFinal` through the ordering and distinct wrappers, releasing the hash after the replay.

Verified end-to-end: `array_agg(DISTINCT x ORDER BY x)` over ~6M rows / 1.5M distinct values now reports ~97.5MB peak instead of ~72.5MB — the difference matches the previously untracked hash. `TestHashAggregationOperator` gains an operator-level test asserting the peak reservation covers the buffer and the hash together; `TestOrderedAccumulatorFactory` pins the accumulator-level behavior on both paths.

## Release notes

(x) Release notes are required, with the following suggested text:

# General
* Account for memory used by aggregations with both `DISTINCT` and `ORDER BY` when producing final results. Queries that previously could exhaust worker memory can now fail with an exceeded-memory-limit error instead. ({issue}`31039`)