### PR TITLE
Reject case-insensitive duplicate columns

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1585,7 +1585,8 @@ class StatementAnalyzer
             Set<String> names = new HashSet<>();
             for (Field field : descriptor.getVisibleFields()) {
                 String fieldName = field.getName()
-                        .orElseThrow(() -> semanticException(MISSING_COLUMN_NAME, node, "Column name not specified at position %s", descriptor.indexOf(field) + 1));
+                        .orElseThrow(() -> semanticException(MISSING_COLUMN_NAME, node, "Column name not specified at position %s", descriptor.indexOf(field) + 1))
+                        .toLowerCase(ENGLISH);
                 if (!names.add(fieldName)) {
                     throw semanticException(DUPLICATE_COLUMN_NAME, node, "Column name '%s' specified more than once", fieldName);
                 }

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -3479,6 +3479,9 @@ public class TestAnalyzer
         assertFails("CREATE TABLE test AS SELECT 1 a, 2 a")
                 .hasErrorCode(DUPLICATE_COLUMN_NAME)
                 .hasMessage("line 1:1: Column name 'a' specified more than once");
+        assertFails("CREATE TABLE test AS SELECT 1 AS \"A\", 2 AS \"a\"")
+                .hasErrorCode(DUPLICATE_COLUMN_NAME)
+                .hasMessage("line 1:1: Column name 'a' specified more than once");
         assertFails("CREATE TABLE test AS SELECT null a")
                 .hasErrorCode(COLUMN_TYPE_UNKNOWN)
                 .hasMessage("line 1:1: Column type is unknown: a");
@@ -3570,9 +3573,20 @@ public class TestAnalyzer
         assertFails("CREATE VIEW test AS SELECT 1 a, 2 a")
                 .hasErrorCode(DUPLICATE_COLUMN_NAME)
                 .hasMessage("line 1:1: Column name 'a' specified more than once");
+        assertFails("CREATE VIEW test AS SELECT 1 AS \"A\", 2 AS \"a\"")
+                .hasErrorCode(DUPLICATE_COLUMN_NAME)
+                .hasMessage("line 1:1: Column name 'a' specified more than once");
         assertFails("CREATE VIEW test AS SELECT null a")
                 .hasErrorCode(COLUMN_TYPE_UNKNOWN)
                 .hasMessage("line 1:1: Column type is unknown: a");
+    }
+
+    @Test
+    public void testCreateMaterializedViewColumns()
+    {
+        assertFails("CREATE MATERIALIZED VIEW test AS SELECT 1 AS \"A\", 2 AS \"a\"")
+                .hasErrorCode(DUPLICATE_COLUMN_NAME)
+                .hasMessage("line 1:1: Column name 'a' specified more than once");
     }
 
     @Test


### PR DESCRIPTION
## Description

  Reject case-insensitively duplicate query output column names when creating tables, views, and materialized views.

  ## Additional context and related issues

  - Fixes #30450

  ## Release notes

  ( ) This is not user-visible or is docs only, and no release notes are required.
  ( ) Release notes are required. Please propose a release note for me.
  (x) Release notes are required, with the following suggested text:

  ```markdown
  ## General
  * Fix failure when creating a view or materialized view with case-insensitively duplicate output column names. ({issue}`30450`)
  ```