### PR TITLE
Prevent CREATE TABLE over an existing view

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
@@ -87,6 +87,7 @@ import static io.trino.sql.analyzer.TypeDescriptorTranslator.toTypeDescriptor;
 import static io.trino.sql.tree.LikeClause.PropertiesOption.EXCLUDING;
 import static io.trino.sql.tree.LikeClause.PropertiesOption.INCLUDING;
 import static io.trino.sql.tree.SaveMode.FAIL;
+import static io.trino.sql.tree.SaveMode.IGNORE;
 import static io.trino.sql.tree.SaveMode.REPLACE;
 import static io.trino.type.UnknownType.UNKNOWN;
 import static java.util.Locale.ENGLISH;
@@ -151,6 +152,12 @@ public class CreateTableTask
                 throw semanticException(TABLE_ALREADY_EXISTS, statement, "Table '%s' already exists", tableName);
             }
             return immediateVoidFuture();
+        }
+        if (plannerContext.getMetadata().isView(session, tableName)) {
+            if (statement.getSaveMode() == IGNORE) {
+                return immediateVoidFuture();
+            }
+            throw semanticException(TABLE_ALREADY_EXISTS, statement, "View '%s' already exists, cannot create a table with the same name", tableName);
         }
 
         String catalogName = tableName.catalogName();

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -953,11 +953,25 @@ class StatementAnalyzer
                 }
                 throw semanticException(TABLE_ALREADY_EXISTS, node, "Destination table '%s' already exists", targetTable);
             }
-
-            validateProperties(node.getProperties(), scope);
-
             String catalogName = targetTable.catalogName();
             CatalogHandle catalogHandle = getRequiredCatalogHandle(metadata, session, node, catalogName);
+            if (metadata.isView(session, targetTable)) {
+                if (node.getSaveMode() == IGNORE) {
+                    analysis.setCreate(new Analysis.Create(
+                            Optional.of(targetTable),
+                            Optional.empty(),
+                            Optional.empty(),
+                            node.isWithData(),
+                            true,
+                            false));
+                    analysis.setUpdateType("CREATE TABLE");
+                    analysis.setUpdateTarget(catalogHandle.getVersion(), targetTable, Optional.empty(), Optional.of(ImmutableList.of()));
+                    return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
+                }
+                throw semanticException(TABLE_ALREADY_EXISTS, node, "View '%s' already exists, cannot create a table with the same name", targetTable);
+            }
+
+            validateProperties(node.getProperties(), scope);
             Map<String, Object> properties = tablePropertyManager.getProperties(
                     catalogName,
                     catalogHandle,

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateTableTask.java
@@ -28,6 +28,8 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTableVersion;
+import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.connector.ConnectorViewDefinition.ViewColumn;
 import io.trino.spi.connector.SaveMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.type.TimestampType;
@@ -56,7 +58,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
@@ -65,6 +69,7 @@ import static io.trino.spi.StandardErrorCode.INVALID_DEFAULT_COLUMN_VALUE;
 import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.PERMISSION_DENIED;
+import static io.trino.spi.StandardErrorCode.TABLE_ALREADY_EXISTS;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.CharType.createCharType;
@@ -200,6 +205,67 @@ class TestCreateTableTask
             assertThat(metadata.getCreateTableCallCount()).isEqualTo(1);
             assertThat(metadata.getReceivedTableMetadata().get(0).getColumns())
                     .isEqualTo(ImmutableList.of(new ColumnMetadata("a", BIGINT)));
+            return null;
+        });
+    }
+
+    @Test
+    void testCreateTableOverExistingViewFails()
+    {
+        metadata.registerView(new SchemaTableName("schema", "existing_view"));
+        CreateTable statement = new CreateTable(
+                new NodeLocation(1, 1),
+                QualifiedName.of("existing_view"),
+                ImmutableList.of(new ColumnDefinition(QualifiedName.of("a"), toSqlType(BIGINT), true, emptyList(), Optional.empty())),
+                FAIL,
+                ImmutableList.of(),
+                Optional.empty());
+
+        queryRunner.inTransaction(transactionSession -> {
+            assertTrinoExceptionThrownBy(() -> getFutureValue(createTableTask.internalExecute(statement, transactionSession, emptyList(), _ -> {}, WarningCollector.NOOP)))
+                    .hasErrorCode(TABLE_ALREADY_EXISTS)
+                    .hasMessageContaining("already exists");
+            assertThat(metadata.getCreateTableCallCount()).isEqualTo(0);
+            return null;
+        });
+    }
+
+    @Test
+    void testReplaceTableOverExistingViewFails()
+    {
+        metadata.registerView(new SchemaTableName("schema", "existing_view"));
+        CreateTable statement = new CreateTable(
+                new NodeLocation(1, 1),
+                QualifiedName.of("existing_view"),
+                ImmutableList.of(new ColumnDefinition(QualifiedName.of("a"), toSqlType(BIGINT), true, emptyList(), Optional.empty())),
+                REPLACE,
+                ImmutableList.of(),
+                Optional.empty());
+
+        queryRunner.inTransaction(transactionSession -> {
+            assertTrinoExceptionThrownBy(() -> getFutureValue(createTableTask.internalExecute(statement, transactionSession, emptyList(), _ -> {}, WarningCollector.NOOP)))
+                    .hasErrorCode(TABLE_ALREADY_EXISTS)
+                    .hasMessageContaining("already exists");
+            assertThat(metadata.getCreateTableCallCount()).isEqualTo(0);
+            return null;
+        });
+    }
+
+    @Test
+    void testCreateTableIfNotExistsOverExistingViewIsIgnored()
+    {
+        metadata.registerView(new SchemaTableName("schema", "existing_view"));
+        CreateTable statement = new CreateTable(
+                new NodeLocation(1, 1),
+                QualifiedName.of("existing_view"),
+                ImmutableList.of(new ColumnDefinition(QualifiedName.of("a"), toSqlType(BIGINT), true, emptyList(), Optional.empty())),
+                IGNORE,
+                ImmutableList.of(),
+                Optional.empty());
+
+        queryRunner.inTransaction(transactionSession -> {
+            getFutureValue(createTableTask.internalExecute(statement, transactionSession, emptyList(), _ -> {}, WarningCollector.NOOP));
+            assertThat(metadata.getCreateTableCallCount()).isEqualTo(0);
             return null;
         });
     }
@@ -586,6 +652,12 @@ class TestCreateTableTask
             implements ConnectorMetadata
     {
         private final List<ConnectorTableMetadata> tables = new CopyOnWriteArrayList<>();
+        private final Set<SchemaTableName> views = new CopyOnWriteArraySet<>();
+
+        public void registerView(SchemaTableName viewName)
+        {
+            views.add(viewName);
+        }
 
         @Override
         public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, SaveMode saveMode)
@@ -606,6 +678,29 @@ class TestCreateTableTask
                 return new TestingTableHandle(tableName);
             }
             return null;
+        }
+
+        @Override
+        public Optional<ConnectorViewDefinition> getView(ConnectorSession session, SchemaTableName viewName)
+        {
+            if (views.contains(viewName)) {
+                return Optional.of(new ConnectorViewDefinition(
+                        "SELECT a FROM some_table",
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId(), Optional.empty())),
+                        Optional.empty(),
+                        Optional.empty(),
+                        true,
+                        ImmutableList.of()));
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public boolean isView(ConnectorSession session, SchemaTableName viewName)
+        {
+            return views.contains(viewName);
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -185,6 +185,7 @@ import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.StandardErrorCode.PERMISSION_DENIED;
 import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.SYNTAX_ERROR;
+import static io.trino.spi.StandardErrorCode.TABLE_ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.TABLE_HAS_NO_COLUMNS;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.TOO_MANY_ARGUMENTS;
@@ -3511,6 +3512,18 @@ public class TestAnalyzer
         assertFails("CREATE TABLE test(x) WITH (p1 = 'p1', \"p1\" = 'p2') AS SELECT null")
                 .hasErrorCode(DUPLICATE_PROPERTY)
                 .hasMessageMatching(".* Duplicate property: p1");
+    }
+
+    @Test
+    public void testCreateTableAsOverExistingViewFails()
+    {
+        // v1 is a view in tpch.s1 (registered in setup)
+        assertFails("CREATE TABLE v1 AS SELECT 1")
+                .hasErrorCode(TABLE_ALREADY_EXISTS)
+                .hasMessageContaining("already exists");
+        assertFails("CREATE OR REPLACE TABLE v1 AS SELECT 1")
+                .hasErrorCode(TABLE_ALREADY_EXISTS)
+                .hasMessageContaining("already exists");
     }
 
     @Test


### PR DESCRIPTION
## Description

Prevent `CREATE TABLE` / `CREATE OR REPLACE TABLE` (both the column-list form and the CTAS form) from silently "succeeding" when the target name is an existing **view**.

Previously the engine only consulted `getTableHandle()`, which returns empty for a view, so creation proceeded down the "table does not exist" path. For Iceberg on the Hive metastore, the resulting metastore `createTable` collision is silently swallowed by `BridgingHiveMetastore` (because new Iceberg tables never set the `trino_query_id` table parameter, so `expectedQueryId` is `null`), the statement reports success, the view is left untouched, and the written data files are orphaned in storage.

This mirrors the existing view guard in `CreateViewTask` (which already checks `isView()`) into both table-creation paths, so the collision is detected before any data is written:

- `FAIL` and `REPLACE` save modes now throw `TABLE_ALREADY_EXISTS` when the target is an existing view.
- `IGNORE` (`IF NOT EXISTS`) remains a silent no-op, preserving idempotency semantics.

The fix is engine-level (connector-agnostic).

## Additional context and related issues

* Fixes #31041

Root-cause detail (Iceberg/HMS): `AbstractMetastoreTableOperations.getRefreshedLocation()` throws `TableNotFoundException` for a `presto_view`, so `IcebergMetadata.getTableHandle()` returns empty; the create path then reaches `commitNewTable()`, whose metastore `createTable` collides with the view and is swallowed by `BridgingHiveMetastore.createTable()`.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Core
* Prevent `CREATE OR REPLACE TABLE` from silently succeeding and leaving orphaned
  data files when a view with the same name already exists. The statement now fails
  with `TABLE_ALREADY_EXISTS`. ({issue}`31041`)
```
