### PR TITLE
Use the Kerberos Hive image for Kerberos test environments

### DIFF
--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/HiveKerberosEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/HiveKerberosEnvironment.java
@@ -518,7 +518,7 @@ public class HiveKerberosEnvironment
      */
     protected HadoopContainer createKerberosBaseHadoopContainer()
     {
-        return new HadoopContainer();
+        return HadoopContainer.kerberized();
     }
 
     /**
@@ -611,11 +611,10 @@ public class HiveKerberosEnvironment
                ls -la /etc/krb5.conf
                ls -la ${KEYTAB_DIR}/
 
-               echo "=== Ensuring Kerberos workstation tools are available ==="
+               echo "=== Verifying Kerberos workstation tools are available ==="
                if ! command -v kinit >/dev/null 2>&1; then
-                   yum install -y -q krb5-workstation
-               else
-                   echo "krb5-workstation already present; skipping yum install"
+                   echo "FATAL: kinit missing; expected it from the kerberized image" >&2
+                   exit 1
                fi
 
                echo "=== Configuring supervisord child process environment for Kerberos ==="

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TwoKerberosHivesEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TwoKerberosHivesEnvironment.java
@@ -236,7 +236,7 @@ public class TwoKerberosHivesEnvironment
 
     private HadoopContainer createKerberosHadoopContainer(String hostName, String keytabDirName, String initDirName)
     {
-        HadoopContainer container = HadoopContainer.withHostName(hostName)
+        HadoopContainer container = HadoopContainer.kerberizedWithHostName(hostName)
                 .withNetwork(network)
                 .withNetworkAliases(hostName);
 
@@ -280,11 +280,10 @@ public class TwoKerberosHivesEnvironment
                HIVE_CONF="/opt/hive/conf"
                KEYTAB_DIR="%2$s"
 
-               echo "=== Ensuring Kerberos workstation tools are available ==="
+               echo "=== Verifying Kerberos workstation tools are available ==="
                if ! command -v kinit >/dev/null 2>&1; then
-                   yum install -y -q krb5-workstation
-               else
-                   echo "krb5-workstation already present; skipping yum install"
+                   echo "FATAL: kinit missing; expected it from the kerberized image" >&2
+                   exit 1
                fi
 
                echo "=== Configuring supervisord for Kerberos ==="

--- a/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TwoMixedHivesEnvironment.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/tests/product/hive/TwoMixedHivesEnvironment.java
@@ -211,7 +211,7 @@ public class TwoMixedHivesEnvironment
 
     private HadoopContainer createKerberosHadoopContainer()
     {
-        HadoopContainer container = new HadoopContainer()
+        HadoopContainer container = HadoopContainer.kerberized()
                 .withNetwork(network)
                 .withNetworkAliases(HADOOP1_HOST);
 
@@ -255,11 +255,10 @@ public class TwoMixedHivesEnvironment
                HIVE_CONF="/opt/hive/conf"
                KEYTAB_DIR="%1$s"
 
-               echo "=== Ensuring Kerberos workstation tools are available ==="
+               echo "=== Verifying Kerberos workstation tools are available ==="
                if ! command -v kinit >/dev/null 2>&1; then
-                   yum install -y -q krb5-workstation
-               else
-                   echo "krb5-workstation already present; skipping yum install"
+                   echo "FATAL: kinit missing; expected it from the kerberized image" >&2
+                   exit 1
                fi
 
                echo "=== Configuring supervisord for Kerberos ==="


### PR DESCRIPTION
## Description

The Kerberos Hive product test environments build on the plain `hive3.1` image and install
`krb5-workstation` at container startup:

```bash
if ! command -v kinit >/dev/null 2>&1; then
    yum install -y -q krb5-workstation
fi
```

This runs from `/etc/hadoop-init.d/00-kerberos-init.sh`, before supervisord. It is the only
package install on a container startup path in the stack — every other one happens at image
build time — and it is bounded by the 3 minute readiness deadline. When the mirror is slow,
supervisord never starts, `socks-proxy` never enters `RUNNING`, and the environment fails
before any test runs.

`hive3.1-kerberos` already exists and already installs exactly these packages at build time,
and `HadoopContainer.kerberized()` / `kerberizedWithHostName()` already exist to select it —
they simply have no callers. This wires them up and drops the runtime install.

- Relates to #30611
- Relates to #31007

## Additional context and related issues

**The failure.** Container log at the moment the readiness wait expired, from
[SuiteHdfsImpersonation on 2026-09-01](https://github.com/trinodb/trino/actions/runs/33553430125/job/100010781139):

```
Running /etc/hadoop-init.d/00-kerberos-init.sh
=== Verifying Kerberos files exist ===        (all keytabs present)
=== Ensuring Kerberos workstation tools are available ===
Failed to set locale, defaulting to C.UTF-8   <- yum's own output
<end of log>
```

Same signature on
[2026-08-28](https://github.com/trinodb/trino/actions/runs/33175004890/job/98863690791)
(`HiveKerberosCrossRealmHdfsImpersonationEnvironment`), and #30611 records four occurrences
since August across `SuiteHdfsImpersonation` and `SuiteTwoHives`.

**Measurement.** I stressed both suites — 74 jobs, 315 container starts, 0 startup failures
([run 1](https://github.com/trinodb/trino/actions/runs/34187129726),
[run 2](https://github.com/trinodb/trino/actions/runs/34252941776)) — logging time to
readiness. The container is consistently ~17s. All the variance is the install:

| `yum install krb5-workstation` | |
| --- | --- |
| min | 16s |
| median | 19s (10% of the 180s deadline) |
| max | [110s](https://github.com/trinodb/trino/actions/runs/34252941776/job/102154187450) (61% of the deadline) |

That 110s install produced a 127s container start, on a container that otherwise takes 17s.
A slightly worse mirror crosses 180s. Timings are from the `TwoKerberosHives` environments,
whose init script output is visible in streamed logs; `HiveKerberosEnvironment`'s output only
appears in the failure dump, but both run the same step.

**Why this shape.** It explains what a timeout increase would not: the flake is
Kerberos-exclusive (only these three environments inject this script; the ~20 other
`HadoopContainer` users do not), position-independent (`TwoKerberosHivesEnvironment` fails as
the *first* environment in its suite, so it is not resource accumulation), and cleared by a
rerun (a new mirror).

**Prior art.** The pre-JUnit launcher did this correctly — `HadoopKerberos` selected
`hadoopBaseImage + "-kerberized"`, and no runtime package install existed anywhere in that
tree. The runtime install arrived with the JUnit migration (#30476) with no stated rationale.

**Risk.** `HadoopContainer` infers `kerberizedImage` from the image name, which suppresses
`shouldOverride{Core,Hdfs,Hive}SiteXml()`. That is what the flag is for — the kerberized image
ships those configs — but it is a real behavioural change, so `SuiteHdfsImpersonation` and
`SuiteTwoHives` should both be green before this merges.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
