### PR TITLE
Fix WITH SESSION failure when catalog properties already exist

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/SessionPropertyResolver.java
+++ b/core/trino-main/src/main/java/io/trino/sql/SessionPropertyResolver.java
@@ -114,7 +114,9 @@ public class SessionPropertyResolver
         systemProperties.putAll(session.getSystemProperties());
         systemProperties.putAll(resolvedSessionProperties.systemProperties());
 
-        Map<String, Map<String, String>> catalogProperties = new HashMap<>(session.getCatalogProperties());
+        Map<String, Map<String, String>> catalogProperties = new HashMap<>();
+        session.getCatalogProperties()
+                .forEach((catalog, properties) -> catalogProperties.put(catalog, new HashMap<>(properties)));
         for (Entry<String, Map<String, String>> catalogEntry : resolvedSessionProperties.catalogProperties().entrySet()) {
             catalogProperties.computeIfAbsent(catalogEntry.getKey(), _ -> new HashMap<>())
                     .putAll(catalogEntry.getValue());

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestInlineSession.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestInlineSession.java
@@ -54,6 +54,7 @@ public class TestInlineSession
         QueryRunner runner = new StandaloneQueryRunner(session);
         MockConnectorPlugin mockConnectorPlugin = new MockConnectorPlugin(MockConnectorFactory.builder()
                 .withSessionProperty(stringProperty("catalog_property", "Test catalog property", "", false))
+                .withSessionProperty(stringProperty("other_catalog_property", "Other test catalog property", "", false))
                 .build());
 
         runner.installPlugin(mockConnectorPlugin);
@@ -124,6 +125,20 @@ public class TestInlineSession
 
         assertThat(assertions.execute("WITH SESSION mock.catalog_property = CAST(true AS varchar) SELECT 1").getSession().getCatalogProperties("mock"))
                 .isEqualTo(Map.of("catalog_property", "true"));
+    }
+
+    @Test
+    void testExistingCatalogSessionProperties()
+    {
+        Session session = assertions.sessionBuilder()
+                .setCatalogSessionProperty(MOCK_CATALOG, "catalog_property", "false")
+                .build();
+
+        assertThat(assertions.execute(session, "WITH SESSION mock.catalog_property = 'true' SELECT 1").getSession().getCatalogProperties("mock"))
+                .isEqualTo(Map.of("catalog_property", "true"));
+
+        assertThat(assertions.execute(session, "WITH SESSION mock.other_catalog_property = 'true' SELECT 1").getSession().getCatalogProperties("mock"))
+                .isEqualTo(Map.of("catalog_property", "false", "other_catalog_property", "true"));
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Fix bug in the `WITH SESSION` implementation where ImmutableMaps are written to.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

When a session already loads a catalog's properties and then they are overridden using `WITH SESSION` queries fail:

```
trino> SET SESSION iceberg.bucket_execution_enabled = false;
SET SESSION

trino> WITH SESSION iceberg.bucket_execution_enabled = true SELECT * FROM tpch.tiny.nation;
Query 20260908_212550_00034_igyyg failed: Internal error
java.lang.UnsupportedOperationException
	at com.google.common.collect.ImmutableMap.putAll(ImmutableMap.java:959)
	at io.trino.sql.SessionPropertyResolver.overrideProperties(SessionPropertyResolver.java:120)
	at io.trino.sql.SessionPropertyResolver.prepareSession(SessionPropertyResolver.java:69)
	at io.trino.sql.SessionPropertyResolver.lambda$getSessionPropertiesApplier$1(SessionPropertyResolver.java:63)
	at io.trino.execution.QueryStateMachine.beginWithTicker(QueryStateMachine.java:348)
	at io.trino.execution.QueryStateMachine.begin(QueryStateMachine.java:273)
	at io.trino.dispatcher.LocalDispatchQueryFactory.createDispatchQuery(LocalDispatchQueryFactory.java:126)
	at io.trino.dispatcher.DispatchManager.createQueryInternal(DispatchManager.java:245)
	at io.trino.dispatcher.DispatchManager.lambda$createQuery$0(DispatchManager.java:195)
	at io.opentelemetry.context.Context.lambda$wrap$1(Context.java:242)
	at io.airlift.concurrent.BoundedExecutor.drainQueue(BoundedExecutor.java:80)
	at io.trino.$gen.Trino_testversion___.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)

```

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix session property override bug in the `WITH SESSION` syntax. 
```
