### PR TITLE
[WIP] Expire old Delta transaction logs

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -597,6 +597,29 @@ measure to ensure that files are retained as expected. The minimum value for
 this property is `0s`. There is a minimum retention session property as well,
 `vacuum_min_retention`.
 
+### Transaction log expiration
+
+After writing a checkpoint, Trino automatically removes expired transaction JSON
+files and classic checkpoints. It reads `delta.logRetentionDuration` from the
+table's Delta metadata, with a default of `interval 30 days`. The expiration
+cutoff is rounded down to midnight UTC. Setting `delta.enableExpiredLogCleanup`
+to `false` in the Delta metadata disables cleanup. These Delta properties are
+not exposed as Trino table properties.
+
+Cleanup preserves a complete checkpoint and the transaction files needed to
+replay retained versions. It supports single-file and multipart classic
+checkpoints. It also removes expired version checksum files named with exactly
+20 digits followed by `.crc`. Other checksum files, including local dot-CRC and
+checkpoint CRC files, are left untouched. Cleanup skips tables with unsupported
+layouts or features, including v2 checkpoints, sidecars, checkpoint protection,
+and coordinated commits. Cleanup failures are logged and do not fail an already
+committed write.
+
+Expired history is unavailable for time travel and change data feed consumers.
+Choose a log retention period that covers their required history. Log expiration
+does not delete data files or prune checkpoint tombstones, and is separate from
+the `VACUUM` procedure.
+
 (delta-lake-data-management)=
 ### Data management
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
@@ -38,6 +38,7 @@ import io.trino.plugin.deltalake.statistics.ExtendedStatistics;
 import io.trino.plugin.deltalake.statistics.ExtendedStatisticsAccess;
 import io.trino.plugin.deltalake.statistics.MetaDirStatisticsAccess;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
+import io.trino.plugin.deltalake.transactionlog.TransactionLogCleanup;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointSchemaManager;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointWriterManager;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.LastCheckpoint;
@@ -109,6 +110,7 @@ public class DeltaLakeModule
         binder.bind(CheckpointSchemaManager.class).in(Scopes.SINGLETON);
         jsonCodecBinder(binder).bindJsonCodec(LastCheckpoint.class);
         binder.bind(CheckpointWriterManager.class).in(Scopes.SINGLETON);
+        binder.bind(TransactionLogCleanup.class).in(Scopes.SINGLETON);
         binder.bind(TransactionLogAccess.class).in(Scopes.SINGLETON);
         newExporter(binder).export(TransactionLogAccess.class)
                 .as(generator -> generator.generatedNameOf(TransactionLogAccess.class, catalogName.get().toString()));

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MetadataEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MetadataEntry.java
@@ -22,13 +22,18 @@ import io.airlift.slice.SizeOf;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.ColumnMappingMode;
 import io.trino.spi.TrinoException;
 
+import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
@@ -51,6 +56,10 @@ public class MetadataEntry
     public static final String DELTA_CHANGE_DATA_FEED_ENABLED_PROPERTY = "delta.enableChangeDataFeed";
 
     private static final String DELTA_CHECKPOINT_INTERVAL_PROPERTY = "delta.checkpointInterval";
+    private static final String DELTA_ENABLE_EXPIRED_LOG_CLEANUP_PROPERTY = "delta.enableExpiredLogCleanup";
+    private static final String DELTA_LOG_RETENTION_DURATION_PROPERTY = "delta.logRetentionDuration";
+    private static final Pattern RETENTION_INTERVAL_PART = Pattern.compile(
+            "\\G\\s*([+-]?\\s*(?:\\d+(?:\\.\\d{0,9})?|\\.\\d{1,9}))\\s+(weeks?|days?|hours?|minutes?|seconds?|milliseconds?|microseconds?)(?=\\s|$)");
 
     private final String id;
     private final String name;
@@ -168,6 +177,63 @@ public class MetadataEntry
         }
         catch (NumberFormatException e) {
             throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, format("Invalid value for %s property: %s", DELTA_CHECKPOINT_INTERVAL_PROPERTY, value));
+        }
+    }
+
+    @JsonIgnore
+    public boolean isExpiredLogCleanupEnabled()
+    {
+        if (configuration == null || !configuration.containsKey(DELTA_ENABLE_EXPIRED_LOG_CLEANUP_PROPERTY)) {
+            return true;
+        }
+        String value = configuration.get(DELTA_ENABLE_EXPIRED_LOG_CLEANUP_PROPERTY);
+        if (!"true".equalsIgnoreCase(value) && !"false".equalsIgnoreCase(value)) {
+            throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Invalid value for %s property: %s".formatted(DELTA_ENABLE_EXPIRED_LOG_CLEANUP_PROPERTY, value));
+        }
+        return Boolean.parseBoolean(value);
+    }
+
+    @JsonIgnore
+    public Duration getLogRetentionDuration()
+    {
+        if (configuration == null || !configuration.containsKey(DELTA_LOG_RETENTION_DURATION_PROPERTY)) {
+            return Duration.ofDays(30);
+        }
+        String value = configuration.get(DELTA_LOG_RETENTION_DURATION_PROPERTY);
+        try {
+            checkArgument(value != null, "Retention interval is null");
+            String interval = value.strip().toLowerCase(ENGLISH).replaceFirst("^interval\\s+", "");
+            Matcher matcher = RETENTION_INTERVAL_PART.matcher(interval);
+            Duration duration = Duration.ZERO;
+            int end = 0;
+            while (matcher.find()) {
+                String number = matcher.group(1).replaceAll("\\s", "");
+                String unit = matcher.group(2).replaceFirst("s$", "");
+                Duration part;
+                if (unit.equals("second")) {
+                    BigDecimal seconds = new BigDecimal(number);
+                    part = Duration.ofSeconds(seconds.toBigInteger().longValueExact(), seconds.remainder(BigDecimal.ONE).movePointRight(9).longValueExact());
+                }
+                else {
+                    long amount = parseLong(number);
+                    part = switch (unit) {
+                        case "week" -> Duration.ofDays(Math.multiplyExact(amount, 7));
+                        case "day" -> Duration.ofDays(amount);
+                        case "hour" -> Duration.ofHours(amount);
+                        case "minute" -> Duration.ofMinutes(amount);
+                        case "millisecond" -> Duration.ofMillis(amount);
+                        case "microsecond" -> Duration.ofNanos(Math.multiplyExact(amount, 1000));
+                        default -> throw new IllegalArgumentException("Unsupported interval unit: " + unit);
+                    };
+                }
+                duration = duration.plus(part);
+                end = matcher.end();
+            }
+            checkArgument(end > 0 && end == interval.length() && !duration.isNegative(), "Invalid retention interval");
+            return duration;
+        }
+        catch (IllegalArgumentException | ArithmeticException e) {
+            throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Invalid value for %s property: %s".formatted(DELTA_LOG_RETENTION_DURATION_PROPERTY, value), e);
         }
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogCleanup.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogCleanup.java
@@ -1,0 +1,333 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.transactionlog;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ListMultimap;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.trino.filesystem.FileEntry;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.spi.connector.SchemaTableName;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeTableFeatures.V2_CHECKPOINT_FEATURE_NAME;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toMap;
+
+public final class TransactionLogCleanup
+{
+    private static final Logger log = Logger.get(TransactionLogCleanup.class);
+
+    private static final int DELETE_BATCH_SIZE = 1000;
+    private static final Pattern JSON_FILE = Pattern.compile("^(\\d{20})\\.json$");
+    private static final Pattern VERSION_CHECKSUM = Pattern.compile("^(\\d{20})\\.crc$");
+    private static final Pattern SINGLE_CHECKPOINT = Pattern.compile("^(\\d{20})\\.checkpoint\\.parquet$");
+    private static final Pattern MULTIPART_CHECKPOINT = Pattern.compile("^(\\d{20})\\.checkpoint\\.(\\d{10})\\.(\\d{10})\\.parquet$");
+    private static final Pattern CHECKPOINT_FILE = Pattern.compile("^\\d{20}\\.checkpoint\\..*$");
+    private static final Pattern CHECKPOINT_CRC = Pattern.compile("^\\.?\\d{20}\\.checkpoint\\..*\\.crc$");
+    private static final Pattern V2_CHECKPOINT = Pattern.compile(
+            "^\\d{20}\\.checkpoint\\.[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\.(json|parquet)$");
+    private static final Pattern COMPACTED_LOG = Pattern.compile("^\\d{20}\\.\\d{20}\\.compacted\\.json$");
+
+    private static final Set<String> UNSUPPORTED_FEATURES = Set.of(
+            V2_CHECKPOINT_FEATURE_NAME,
+            "checkpointProtection",
+            "catalogManaged",
+            "coordinatedCommits",
+            "commitCoordinator-preview");
+
+    private final Clock clock;
+
+    @Inject
+    public TransactionLogCleanup()
+    {
+        this(Clock.systemUTC());
+    }
+
+    @VisibleForTesting
+    TransactionLogCleanup(Clock clock)
+    {
+        this.clock = requireNonNull(clock, "clock is null");
+    }
+
+    public void cleanup(
+            SchemaTableName table,
+            TrinoFileSystem fileSystem,
+            Location transactionLogDirectory,
+            long newCheckpointVersion,
+            MetadataEntry metadataEntry,
+            ProtocolEntry protocolEntry)
+    {
+        try {
+            cleanupInternal(fileSystem, transactionLogDirectory, newCheckpointVersion, metadataEntry, protocolEntry);
+        }
+        catch (IOException | RuntimeException e) {
+            log.warn(e, "Failed to clean transaction log for table %s", table);
+        }
+    }
+
+    private void cleanupInternal(
+            TrinoFileSystem fileSystem,
+            Location transactionLogDirectory,
+            long newCheckpointVersion,
+            MetadataEntry metadataEntry,
+            ProtocolEntry protocolEntry)
+            throws IOException
+    {
+        if (!metadataEntry.isExpiredLogCleanupEnabled() || hasUnsupportedProtocol(protocolEntry) || hasUnsupportedMetadata(metadataEntry)) {
+            return;
+        }
+
+        List<FileEntry> jsonFiles = new ArrayList<>();
+        List<FileEntry> versionChecksums = new ArrayList<>();
+        ListMultimap<Long, CheckpointPart> checkpointParts = ArrayListMultimap.create();
+        FileIterator iterator = fileSystem.listFiles(transactionLogDirectory);
+        while (iterator.hasNext()) {
+            FileEntry file = iterator.next();
+            if (!file.location().parentDirectory().equals(transactionLogDirectory)) {
+                if (isUnsupportedNestedLayout(transactionLogDirectory, file.location())) {
+                    return;
+                }
+                continue;
+            }
+
+            String name = file.location().fileName();
+            Matcher json = JSON_FILE.matcher(name);
+            if (json.matches()) {
+                jsonFiles.add(file);
+                continue;
+            }
+            if (VERSION_CHECKSUM.matcher(name).matches()) {
+                versionChecksums.add(file);
+                continue;
+            }
+            Matcher singleCheckpoint = SINGLE_CHECKPOINT.matcher(name);
+            if (singleCheckpoint.matches()) {
+                checkpointParts.put(Long.parseLong(singleCheckpoint.group(1)), new CheckpointPart(file, 1, 1, true));
+                continue;
+            }
+            Matcher multipartCheckpoint = MULTIPART_CHECKPOINT.matcher(name);
+            if (multipartCheckpoint.matches()) {
+                checkpointParts.put(
+                        Long.parseLong(multipartCheckpoint.group(1)),
+                        new CheckpointPart(file, Integer.parseInt(multipartCheckpoint.group(2)), Integer.parseInt(multipartCheckpoint.group(3)), false));
+                continue;
+            }
+            if (V2_CHECKPOINT.matcher(name).matches() || COMPACTED_LOG.matcher(name).matches()) {
+                return;
+            }
+            if (CHECKPOINT_FILE.matcher(name).matches() && !CHECKPOINT_CRC.matcher(name).matches()) {
+                return;
+            }
+        }
+
+        jsonFiles.sort(Comparator.comparingLong(TransactionLogCleanup::fileVersion));
+
+        Map<Long, List<CheckpointPart>> checkpoints = checkpointParts.asMap().entrySet().stream()
+                .collect(toMap(Map.Entry::getKey, entry -> ImmutableList.copyOf(entry.getValue())));
+        List<CheckpointPart> newCheckpoint = checkpoints.get(newCheckpointVersion);
+        if (newCheckpoint == null || !isCompleteCheckpoint(newCheckpoint)) {
+            return;
+        }
+        if (jsonFiles.stream().noneMatch(file -> fileVersion(file) == newCheckpointVersion)) {
+            return;
+        }
+
+        Instant cutoff = clock.instant().minus(metadataEntry.getLogRetentionDuration()).truncatedTo(ChronoUnit.DAYS);
+        long boundaryVersion = oldestNonexpiredVersion(jsonFiles, cutoff).orElse(newCheckpointVersion);
+        for (Map.Entry<Long, List<CheckpointPart>> checkpoint : checkpoints.entrySet()) {
+            boolean recentlyModified = false;
+            for (CheckpointPart part : checkpoint.getValue()) {
+                recentlyModified |= part.file().lastModified().isAfter(cutoff);
+            }
+            if (checkpoint.getKey() < boundaryVersion && recentlyModified) {
+                boundaryVersion = checkpoint.getKey();
+            }
+        }
+        for (FileEntry versionChecksum : versionChecksums) {
+            long checksumVersion = fileVersion(versionChecksum);
+            if (checksumVersion < boundaryVersion && versionChecksum.lastModified().isAfter(cutoff)) {
+                boundaryVersion = checksumVersion;
+            }
+        }
+
+        // Keep a replay anchor at or before the retained history, not just the newest checkpoint.
+        long anchorVersion = -1;
+        for (Map.Entry<Long, List<CheckpointPart>> checkpoint : checkpoints.entrySet()) {
+            long checkpointVersion = checkpoint.getKey();
+            if (checkpointVersion <= boundaryVersion && checkpointVersion <= newCheckpointVersion && isCompleteCheckpoint(checkpoint.getValue())) {
+                anchorVersion = Math.max(anchorVersion, checkpointVersion);
+            }
+        }
+        if (anchorVersion < 0 || !hasContiguousJson(jsonFiles, anchorVersion, newCheckpointVersion)) {
+            return;
+        }
+
+        ImmutableList.Builder<Location> filesToDelete = ImmutableList.builder();
+        for (FileEntry jsonFile : jsonFiles) {
+            if (fileVersion(jsonFile) < anchorVersion && !jsonFile.lastModified().isAfter(cutoff)) {
+                filesToDelete.add(jsonFile.location());
+            }
+        }
+        for (Map.Entry<Long, List<CheckpointPart>> checkpoint : checkpoints.entrySet()) {
+            if (checkpoint.getKey() < anchorVersion &&
+                    isCompleteCheckpoint(checkpoint.getValue()) &&
+                    checkpoint.getValue().stream().allMatch(part -> !part.file().lastModified().isAfter(cutoff))) {
+                checkpoint.getValue().forEach(part -> filesToDelete.add(part.file().location()));
+            }
+        }
+        for (FileEntry versionChecksum : versionChecksums) {
+            if (fileVersion(versionChecksum) < anchorVersion && !versionChecksum.lastModified().isAfter(cutoff)) {
+                filesToDelete.add(versionChecksum.location());
+            }
+        }
+
+        List<Location> deletions = filesToDelete.build();
+        for (int start = 0; start < deletions.size(); start += DELETE_BATCH_SIZE) {
+            fileSystem.deleteFiles(deletions.subList(start, Math.min(start + DELETE_BATCH_SIZE, deletions.size())));
+        }
+    }
+
+    private static boolean hasUnsupportedProtocol(ProtocolEntry protocolEntry)
+    {
+        return UNSUPPORTED_FEATURES.stream()
+                .anyMatch(feature -> protocolEntry.readerFeaturesContains(feature) || protocolEntry.writerFeaturesContains(feature));
+    }
+
+    private static boolean hasUnsupportedMetadata(MetadataEntry metadataEntry)
+    {
+        if (metadataEntry.getConfiguration() == null) {
+            return false;
+        }
+        String checkpointPolicy = metadataEntry.getConfiguration().get("delta.checkpointPolicy");
+        if (checkpointPolicy != null && !checkpointPolicy.equalsIgnoreCase("classic")) {
+            return true;
+        }
+        return metadataEntry.getConfiguration().keySet().stream()
+                .anyMatch(key -> key.startsWith("delta.coordinatedCommits.") || key.startsWith("delta.commitCoordinator."));
+    }
+
+    private static boolean isUnsupportedNestedLayout(Location transactionLogDirectory, Location file)
+    {
+        String relativePath = file.toString().substring(transactionLogDirectory.toString().length());
+        if (relativePath.startsWith("/")) {
+            relativePath = relativePath.substring(1);
+        }
+        return relativePath.startsWith("_sidecars/") ||
+                relativePath.startsWith("_commits/") ||
+                relativePath.startsWith("_staged_commits/");
+    }
+
+    private static long fileVersion(FileEntry file)
+    {
+        return Long.parseLong(file.location().fileName().substring(0, 20));
+    }
+
+    private static OptionalLong oldestNonexpiredVersion(List<FileEntry> jsonFiles, Instant cutoff)
+    {
+        Instant previousAdjusted = null;
+        long adjustmentRunStart = -1;
+        for (int index = 0; index < jsonFiles.size(); index++) {
+            FileEntry file = jsonFiles.get(index);
+            Instant adjusted = file.lastModified();
+            if (previousAdjusted != null && !adjusted.isAfter(previousAdjusted)) {
+                // Retain the start of an adjustment run so cleanup cannot change time-travel timestamps.
+                if (adjustmentRunStart < 0) {
+                    adjustmentRunStart = fileVersion(jsonFiles.get(index - 1));
+                }
+                adjusted = plusOneMillisecond(previousAdjusted);
+            }
+            else {
+                adjustmentRunStart = -1;
+            }
+            if (adjusted.isAfter(cutoff)) {
+                return OptionalLong.of(adjustmentRunStart >= 0 ? adjustmentRunStart : fileVersion(file));
+            }
+            previousAdjusted = adjusted;
+        }
+        return OptionalLong.empty();
+    }
+
+    private static Instant plusOneMillisecond(Instant instant)
+    {
+        if (instant.isAfter(Instant.MAX.minusMillis(1))) {
+            return Instant.MAX;
+        }
+        return instant.plusMillis(1);
+    }
+
+    private static boolean isCompleteCheckpoint(List<CheckpointPart> parts)
+    {
+        if (parts.stream().anyMatch(part -> part.file().length() == 0)) {
+            return false;
+        }
+        if (parts.size() == 1 && parts.getFirst().single()) {
+            return true;
+        }
+        if (parts.isEmpty() || parts.stream().anyMatch(CheckpointPart::single)) {
+            return false;
+        }
+
+        int partCount = parts.getFirst().partCount();
+        if (partCount <= 0 || parts.size() != partCount || parts.stream().anyMatch(part -> part.partCount() != partCount)) {
+            return false;
+        }
+        Set<Integer> ordinals = new HashSet<>();
+        for (CheckpointPart part : parts) {
+            if (part.partNumber() <= 0 || part.partNumber() > partCount || !ordinals.add(part.partNumber())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean hasContiguousJson(List<FileEntry> jsonFiles, long startVersion, long endVersion)
+    {
+        long expectedVersion = startVersion;
+        for (FileEntry file : jsonFiles) {
+            long version = fileVersion(file);
+            if (version < startVersion) {
+                continue;
+            }
+            if (version > endVersion) {
+                break;
+            }
+            if (version != expectedVersion) {
+                return false;
+            }
+            expectedVersion++;
+        }
+        return expectedVersion == endVersion + 1;
+    }
+
+    private record CheckpointPart(FileEntry file, int partNumber, int partCount, boolean single) {}
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriterManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriterManager.java
@@ -29,6 +29,7 @@ import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot.MetadataAndProtocolEntry;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
+import io.trino.plugin.deltalake.transactionlog.TransactionLogCleanup;
 import io.trino.spi.NodeVersion;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
@@ -64,6 +65,7 @@ public class CheckpointWriterManager
     private final DeltaLakeFileSystemFactory fileSystemFactory;
     private final String trinoVersion;
     private final TransactionLogAccess transactionLogAccess;
+    private final TransactionLogCleanup transactionLogCleanup;
     private final FileFormatDataSourceStats fileFormatDataSourceStats;
     private final JsonCodec<LastCheckpoint> lastCheckpointCodec;
     private final Executor executorService;
@@ -76,6 +78,7 @@ public class CheckpointWriterManager
             DeltaLakeFileSystemFactory fileSystemFactory,
             NodeVersion nodeVersion,
             TransactionLogAccess transactionLogAccess,
+            TransactionLogCleanup transactionLogCleanup,
             FileFormatDataSourceStats fileFormatDataSourceStats,
             JsonCodec<LastCheckpoint> lastCheckpointCodec,
             DeltaLakeConfig deltaLakeConfig,
@@ -86,6 +89,7 @@ public class CheckpointWriterManager
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.trinoVersion = nodeVersion.toString();
         this.transactionLogAccess = requireNonNull(transactionLogAccess, "transactionLogAccess is null");
+        this.transactionLogCleanup = requireNonNull(transactionLogCleanup, "transactionLogCleanup is null");
         this.fileFormatDataSourceStats = requireNonNull(fileFormatDataSourceStats, "fileFormatDataSourceStats is null");
         this.lastCheckpointCodec = requireNonNull(lastCheckpointCodec, "lastCheckpointCodec is null");
         this.executorService = requireNonNull(executorService, "ExecutorService is null");
@@ -175,6 +179,8 @@ public class CheckpointWriterManager
             Location checkpointPath = transactionLogDir.appendPath(LAST_CHECKPOINT_FILENAME);
             TrinoOutputFile outputFile = fileSystem.newOutputFile(checkpointPath);
             outputFile.createOrOverwrite(lastCheckpointCodec.toJsonBytes(newLastCheckpoint));
+
+            transactionLogCleanup.cleanup(table, fileSystem, transactionLogDir, newCheckpointVersion, checkpointEntries.metadataEntry(), checkpointEntries.protocolEntry());
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -70,6 +70,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -458,6 +460,47 @@ public class TestDeltaLakeBasic
             assertUpdate("INSERT INTO " + table.getName() + " VALUES 'version12'", 1);
             assertThat(query("TABLE " + table.getName()))
                     .matches("VALUES varchar 'version12'");
+        }
+    }
+
+    @Test
+    void testCheckpointCleansExpiredTransactionLog()
+            throws Exception
+    {
+        try (TestTable table = newTrinoTable(
+                "test_checkpoint_cleans_expired_transaction_log",
+                "(id integer) WITH (checkpoint_interval = 1, change_data_feed_enabled = true)")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 1", 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 2", 1);
+
+            Path transactionLog = Path.of(getTableLocation(table.getName()).replace("file://", "")).resolve("_delta_log");
+            Instant expired = Instant.now().minus(Duration.ofDays(60));
+            setLastModifiedTime(transactionLog, "00000000000000000000.json", expired);
+            setLastModifiedTime(transactionLog, "00000000000000000001.json", expired.plusSeconds(1));
+            setLastModifiedTime(transactionLog, "00000000000000000001.checkpoint.parquet", expired.plusSeconds(1));
+
+            Instant retained = Instant.now().minus(Duration.ofDays(1));
+            setLastModifiedTime(transactionLog, "00000000000000000002.json", retained);
+            setLastModifiedTime(transactionLog, "00000000000000000002.checkpoint.parquet", retained);
+
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES 3", 1);
+
+            assertThat(transactionLog.resolve("00000000000000000000.json")).doesNotExist();
+            assertThat(transactionLog.resolve("00000000000000000001.json")).doesNotExist();
+            assertThat(transactionLog.resolve("00000000000000000001.checkpoint.parquet")).doesNotExist();
+            assertThat(transactionLog.resolve("00000000000000000002.json")).exists();
+            assertThat(transactionLog.resolve("00000000000000000002.checkpoint.parquet")).exists();
+            assertThat(transactionLog.resolve("00000000000000000003.json")).exists();
+            assertThat(transactionLog.resolve("00000000000000000003.checkpoint.parquet")).exists();
+
+            assertUpdate("CALL system.flush_metadata_cache(schema_name => CURRENT_SCHEMA, table_name => '" + table.getName() + "')");
+            assertQuery("TABLE " + table.getName(), "VALUES 1, 2, 3");
+            assertQuery("SELECT * FROM " + table.getName() + " FOR VERSION AS OF 2", "VALUES 1, 2");
+            assertQueryFails("SELECT * FROM " + table.getName() + " FOR VERSION AS OF 1", "Delta Lake snapshot ID does not exists: 1");
+            assertThat(computeActual("SELECT version FROM \"" + table.getName() + "$history\"").getOnlyColumnAsSet())
+                    .containsExactlyInAnyOrder(2L, 3L);
+            assertThat(query("SELECT id, _change_type, _commit_version FROM TABLE(system.table_changes(CURRENT_SCHEMA, '" + table.getName() + "', 2))"))
+                    .matches("VALUES (3, VARCHAR 'insert', BIGINT '3')");
         }
     }
 
@@ -2178,6 +2221,58 @@ public class TestDeltaLakeBasic
         assertThat(query("SELECT * FROM " + tableName + " FOR TIMESTAMP AS OF TIMESTAMP '2023-10-16 06:53:26.526 UTC'")).matches("VALUES 1, 2, 3, 4, 5, 6, 7");
 
         assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    void testTransactionLogCleanupRetainsMultipartCheckpointAnchor()
+            throws Exception
+    {
+        String tableName = "test_cleanup_multipart_checkpoint_" + randomNameSuffix();
+        Path tableLocation = catalogDir.resolve(tableName);
+        copyDirectoryContents(new File(Resources.getResource("deltalake/multipart_checkpoint").toURI()).toPath(), tableLocation);
+        assertUpdate("CALL system.register_table(CURRENT_SCHEMA, '%s', '%s')".formatted(tableName, tableLocation.toUri()));
+
+        try {
+            for (int value = 8; value <= 11; value++) {
+                assertUpdate("INSERT INTO " + tableName + " VALUES " + value, 1);
+            }
+
+            Path transactionLog = tableLocation.resolve("_delta_log");
+            Instant expired = Instant.now().minus(Duration.ofDays(60));
+            for (int version = 0; version <= 5; version++) {
+                setLastModifiedTime(transactionLog, "%020d.json".formatted(version), expired.plusSeconds(version));
+            }
+
+            Instant retained = Instant.now().minus(Duration.ofDays(1));
+            for (int version = 6; version <= 11; version++) {
+                setLastModifiedTime(transactionLog, "%020d.json".formatted(version), retained.plusSeconds(version));
+            }
+            setLastModifiedTime(transactionLog, "00000000000000000006.checkpoint.0000000001.0000000002.parquet", retained);
+            setLastModifiedTime(transactionLog, "00000000000000000006.checkpoint.0000000002.0000000002.parquet", retained);
+
+            assertUpdate("INSERT INTO " + tableName + " VALUES 12", 1);
+
+            assertThat(transactionLog.resolve("00000000000000000000.json")).doesNotExist();
+            assertThat(transactionLog.resolve("00000000000000000005.json")).doesNotExist();
+            assertThat(transactionLog.resolve("00000000000000000006.json")).exists();
+            assertThat(transactionLog.resolve("00000000000000000006.checkpoint.0000000001.0000000002.parquet")).exists();
+            assertThat(transactionLog.resolve("00000000000000000006.checkpoint.0000000002.0000000002.parquet")).exists();
+            assertThat(transactionLog.resolve("00000000000000000012.checkpoint.parquet")).exists();
+
+            assertUpdate("CALL system.flush_metadata_cache(schema_name => CURRENT_SCHEMA, table_name => '" + tableName + "')");
+            assertThat(query("SELECT * FROM " + tableName + " FOR VERSION AS OF 6")).matches("VALUES 1, 2, 3, 4, 5, 6");
+            assertThat(query("SELECT * FROM " + tableName)).matches("VALUES 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12");
+            assertQueryFails("SELECT * FROM " + tableName + " FOR VERSION AS OF 5", "Delta Lake snapshot ID does not exists: 5");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    private static void setLastModifiedTime(Path directory, String fileName, Instant lastModified)
+            throws IOException
+    {
+        Files.setLastModifiedTime(directory.resolve(fileName), FileTime.from(lastModified));
     }
 
     @Test

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -33,6 +33,7 @@ import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
+import io.trino.plugin.deltalake.transactionlog.TransactionLogCleanup;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointSchemaManager;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointWriterManager;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.LastCheckpoint;
@@ -214,6 +215,7 @@ public class TestDeltaLakeSplitManager
                 new DefaultDeltaLakeFileSystemFactory(HDFS_FILE_SYSTEM_FACTORY, new NoOpTableCredentialsProvider()),
                 new NodeVersion("test_version"),
                 transactionLogAccess,
+                new TransactionLogCleanup(),
                 new FileFormatDataSourceStats(),
                 jsonCodec(LastCheckpoint.class),
                 new DeltaLakeConfig(),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestMetadataEntry.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestMetadataEntry.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.transactionlog;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.TrinoException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestMetadataEntry
+{
+    @Test
+    void testLogCleanupDefaults()
+    {
+        MetadataEntry metadata = MetadataEntry.builder().build();
+        assertThat(metadata.isExpiredLogCleanupEnabled()).isTrue();
+        assertThat(metadata.getLogRetentionDuration()).isEqualTo(Duration.ofDays(30));
+        metadata = MetadataEntry.builder().setConfiguration(ImmutableMap.of()).build();
+        assertThat(metadata.isExpiredLogCleanupEnabled()).isTrue();
+        assertThat(metadata.getLogRetentionDuration()).isEqualTo(Duration.ofDays(30));
+    }
+
+    @Test
+    void testLogCleanupEnabled()
+    {
+        for (String value : List.of("true", "TRUE", "false", "FALSE")) {
+            assertThat(MetadataEntry.builder().setConfiguration(ImmutableMap.of("delta.enableExpiredLogCleanup", value)).build().isExpiredLogCleanupEnabled())
+                    .isEqualTo(Boolean.parseBoolean(value));
+        }
+    }
+
+    @Test
+    void testInvalidLogCleanupEnabled()
+    {
+        assertThatThrownBy(() -> MetadataEntry.builder().setConfiguration(ImmutableMap.of("delta.enableExpiredLogCleanup", "yes")).build().isExpiredLogCleanupEnabled())
+                .isInstanceOf(TrinoException.class)
+                .hasMessageContaining("delta.enableExpiredLogCleanup");
+    }
+
+    @Test
+    void testLogRetentionDuration()
+    {
+        Map<String, Long> intervals = ImmutableMap.<String, Long>builder()
+                .put("interval 30 days", 2592000000L)
+                .put("2 weeks", 1209600000L)
+                .put("INTERVAL 1 WEEK 2 DAYS 3 HOURS 4 MINUTES 5 SECONDS 6 MILLISECONDS", 788645006L)
+                .put("interval 1 day -1 hour", 82800000L)
+                .put("0 seconds", 0L)
+                .put("+ 1 second", 1000L)
+                .put("1.5 seconds", 1500L)
+                .put(".001 second", 1L)
+                .put("1000 microseconds", 1L)
+                .buildOrThrow();
+        intervals.forEach((value, milliseconds) -> assertThat(metadataWithRetention(value).getLogRetentionDuration())
+                .as(value)
+                .isEqualTo(Duration.ofMillis(milliseconds)));
+    }
+
+    @Test
+    void testInvalidLogRetentionDuration()
+    {
+        for (String value : List.of("", "interval", "30d", "garbage", "1 month", "1 year", "-1 day", "-0.000001 seconds", "1.5 days", "1 day trailing", "1 day1 hour", "1 nanosecond", "1.1234567890 seconds", "9223372036854775807 days", "9223372036854775807 seconds 1 second")) {
+            assertThatThrownBy(() -> metadataWithRetention(value).getLogRetentionDuration())
+                    .as(value)
+                    .isInstanceOf(TrinoException.class)
+                    .hasMessageContaining("delta.logRetentionDuration");
+        }
+    }
+
+    private static MetadataEntry metadataWithRetention(String value)
+    {
+        return MetadataEntry.builder().setConfiguration(ImmutableMap.of("delta.logRetentionDuration", value)).build();
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTransactionLogCleanup.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestTransactionLogCleanup.java
@@ -1,0 +1,612 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.transactionlog;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.filesystem.FileEntry;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoOutputFile;
+import io.trino.spi.connector.SchemaTableName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+final class TestTransactionLogCleanup
+{
+    private static final Instant NOW = Instant.parse("2025-02-15T12:00:00Z");
+    private static final Instant EXPIRED = Instant.parse("2025-01-15T00:00:00Z");
+    private static final Instant CUTOFF = Instant.parse("2025-01-16T00:00:00Z");
+    private static final Instant RECENT = Instant.parse("2025-02-01T00:00:00Z");
+    private static final Location LOG_DIRECTORY = Location.of("memory:///table/_delta_log");
+    private static final SchemaTableName TABLE = new SchemaTableName("schema", "table");
+    private static final ProtocolEntry CLASSIC_PROTOCOL = new ProtocolEntry(1, 2, Optional.empty(), Optional.empty());
+
+    private final TransactionLogCleanup cleanup = new TransactionLogCleanup(Clock.fixed(NOW, ZoneOffset.UTC));
+
+    @Test
+    void testDefaultRetentionDeletesExpiredPrefixAndPreservesReplayChain()
+    {
+        TestingFileSystem fileSystem = new TestingFileSystem();
+        addJsonRange(fileSystem, 0, 5, EXPIRED);
+        fileSystem.setLastModified(jsonName(3), RECENT);
+        fileSystem.setLastModified(jsonName(4), RECENT.plusSeconds(1));
+        fileSystem.setLastModified(jsonName(5), RECENT.plusSeconds(2));
+        fileSystem.add(checkpointName(0), EXPIRED, 1);
+        fileSystem.add(checkpointName(2), EXPIRED, 1);
+        fileSystem.add(checkpointName(5), RECENT, 1);
+        fileSystem.add("_last_checkpoint", RECENT, 1);
+        fileSystem.add("notes.txt", EXPIRED, 1);
+        fileSystem.add("_trino_meta/statistics", EXPIRED, 1);
+        fileSystem.reverseListing = true;
+
+        cleanup(fileSystem, 5, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.names()).containsExactlyInAnyOrder(
+                jsonName(2),
+                jsonName(3),
+                jsonName(4),
+                jsonName(5),
+                checkpointName(2),
+                checkpointName(5),
+                "_last_checkpoint",
+                "notes.txt",
+                "_trino_meta/statistics");
+    }
+
+    @Test
+    void testCustomRetentionAndCutoffEquality()
+    {
+        TestingFileSystem fileSystem = new TestingFileSystem();
+        fileSystem.add(jsonName(0), CUTOFF, 1);
+        fileSystem.add(jsonName(1), CUTOFF.plusSeconds(1), 1);
+        fileSystem.add(jsonName(2), CUTOFF.plusSeconds(2), 1);
+        fileSystem.add(checkpointName(0), CUTOFF, 1);
+        fileSystem.add(checkpointName(1), CUTOFF.plusSeconds(1), 1);
+        fileSystem.add(checkpointName(2), CUTOFF.plusSeconds(2), 1);
+
+        cleanup(fileSystem, 2, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.names()).containsExactlyInAnyOrder(jsonName(1), jsonName(2), checkpointName(1), checkpointName(2));
+
+        TestingFileSystem customRetention = new TestingFileSystem();
+        addJsonRange(customRetention, 0, 2, NOW.minus(Duration.ofDays(3)));
+        customRetention.add(checkpointName(2), NOW.minus(Duration.ofDays(3)), 1);
+        cleanup(customRetention, 2, metadata(true, Duration.ofDays(2)), CLASSIC_PROTOCOL);
+        assertThat(customRetention.names()).containsExactlyInAnyOrder(jsonName(2), checkpointName(2));
+    }
+
+    @Test
+    void testDisabledCleanupDoesNothing()
+    {
+        TestingFileSystem fileSystem = completeExpiredLog(2);
+
+        cleanup(fileSystem, 2, metadata(false, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.deletedBatches).isEmpty();
+    }
+
+    @Test
+    void testCompleteMultipartCheckpointIsDeletedAsFamily()
+    {
+        TestingFileSystem fileSystem = completeExpiredLog(4);
+        fileSystem.add(multipartCheckpointName(1, 2, 2), EXPIRED, 1);
+        fileSystem.add(multipartCheckpointName(1, 1, 2), EXPIRED, 1);
+        fileSystem.add(checkpointName(3), EXPIRED, 1);
+
+        cleanup(fileSystem, 4, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.names()).containsExactlyInAnyOrder(jsonName(4), checkpointName(4));
+    }
+
+    @Test
+    void testIncompleteCheckpointFamiliesAreRetainedWithoutBlockingCleanup()
+    {
+        for (String checkpoint : List.of(
+                multipartCheckpointName(1, 1, 2),
+                format("%020d.checkpoint.0000000000.0000000002.parquet", 1))) {
+            TestingFileSystem fileSystem = completeExpiredLog(3);
+            fileSystem.add(checkpoint, EXPIRED, 1);
+
+            cleanup(fileSystem, 3, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+            assertThat(fileSystem.names()).as(checkpoint).containsExactlyInAnyOrder(jsonName(3), checkpointName(3), checkpoint);
+        }
+    }
+
+    @Test
+    void testRecentIncompleteCheckpointPinsRetainedBoundary()
+    {
+        TestingFileSystem fileSystem = completeExpiredLog(5);
+        fileSystem.add(checkpointName(0), EXPIRED, 1);
+        fileSystem.add(multipartCheckpointName(2, 1, 2), RECENT, 1);
+
+        cleanup(fileSystem, 5, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.deletedBatches).isEmpty();
+    }
+
+    @Test
+    void testMalformedCheckpointNameFailsClosed()
+    {
+        TestingFileSystem fileSystem = completeExpiredLog(3);
+        fileSystem.add(format("%020d.checkpoint.bad.parquet", 1), EXPIRED, 1);
+
+        cleanup(fileSystem, 3, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.deletedBatches).isEmpty();
+    }
+
+    @Test
+    void testMissingJsonGapFailsClosed()
+    {
+        TestingFileSystem fileSystem = completeExpiredLog(4);
+        fileSystem.remove(jsonName(3));
+        fileSystem.add(checkpointName(2), EXPIRED, 1);
+        fileSystem.setLastModified(jsonName(2), RECENT);
+        fileSystem.setLastModified(jsonName(4), RECENT.plusSeconds(2));
+
+        cleanup(fileSystem, 4, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.deletedBatches).isEmpty();
+    }
+
+    @Test
+    void testRequiresNonemptyNewCheckpointAndItsJson()
+    {
+        TestingFileSystem emptyCheckpoint = completeExpiredLog(2);
+        emptyCheckpoint.add(checkpointName(2), EXPIRED, 0);
+        cleanup(emptyCheckpoint, 2, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+        assertThat(emptyCheckpoint.deletedBatches).isEmpty();
+
+        TestingFileSystem incompleteCheckpoint = completeExpiredLog(2);
+        incompleteCheckpoint.remove(checkpointName(2));
+        incompleteCheckpoint.add(multipartCheckpointName(2, 1, 2), EXPIRED, 1);
+        cleanup(incompleteCheckpoint, 2, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+        assertThat(incompleteCheckpoint.deletedBatches).isEmpty();
+
+        TestingFileSystem missingJson = completeExpiredLog(2);
+        missingJson.remove(jsonName(2));
+        cleanup(missingJson, 2, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+        assertThat(missingJson.deletedBatches).isEmpty();
+    }
+
+    @Test
+    void testDeletesExpiredVersionChecksumsBelowAnchor()
+    {
+        TestingFileSystem fileSystem = completeExpiredLog(2);
+        fileSystem.add(versionChecksumName(0), EXPIRED, 1);
+        fileSystem.add(versionChecksumName(2), EXPIRED, 1);
+        fileSystem.add(versionChecksumName(3), EXPIRED, 1);
+
+        cleanup(fileSystem, 2, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.names()).containsExactlyInAnyOrder(
+                jsonName(2), checkpointName(2), versionChecksumName(2), versionChecksumName(3));
+    }
+
+    @Test
+    void testRecentVersionChecksumPinsRetainedAnchor()
+    {
+        TestingFileSystem fileSystem = completeExpiredLog(5);
+        fileSystem.add(checkpointName(2), EXPIRED, 1);
+        fileSystem.add(versionChecksumName(2), RECENT, 1);
+
+        cleanup(fileSystem, 5, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.names()).containsExactlyInAnyOrder(
+                jsonName(2),
+                jsonName(3),
+                jsonName(4),
+                jsonName(5),
+                checkpointName(2),
+                checkpointName(5),
+                versionChecksumName(2));
+    }
+
+    @Test
+    void testPreservesUnknownFilesCrcAndNestedTrinoMetadata()
+    {
+        TestingFileSystem fileSystem = completeExpiredLog(2);
+        fileSystem.add(".00000000000000000000.crc", EXPIRED, 1);
+        fileSystem.add(".00000000000000000000.checkpoint.parquet.crc", EXPIRED, 1);
+        fileSystem.add("unrecognized", EXPIRED, 1);
+        fileSystem.add("_trino_meta/data", EXPIRED, 1);
+
+        cleanup(fileSystem, 2, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.names()).containsExactlyInAnyOrder(
+                jsonName(2),
+                checkpointName(2),
+                ".00000000000000000000.crc",
+                ".00000000000000000000.checkpoint.parquet.crc",
+                "unrecognized",
+                "_trino_meta/data");
+    }
+
+    @Test
+    void testUnsupportedLayoutsAndFeaturesFailClosed()
+    {
+        for (String unsupportedFile : List.of(
+                "00000000000000000001.00000000000000000002.compacted.json",
+                "00000000000000000002.checkpoint.123e4567-e89b-12d3-a456-426614174000.parquet",
+                "_sidecars/part.parquet",
+                "_commits/00000000000000000002.json",
+                "_staged_commits/00000000000000000002.123e4567-e89b-12d3-a456-426614174000.json")) {
+            TestingFileSystem fileSystem = completeExpiredLog(2);
+            fileSystem.add(unsupportedFile, EXPIRED, 1);
+            cleanup(fileSystem, 2, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+            assertThat(fileSystem.deletedBatches).as(unsupportedFile).isEmpty();
+        }
+
+        for (String feature : List.of("v2Checkpoint", "checkpointProtection", "catalogManaged", "coordinatedCommits", "commitCoordinator-preview")) {
+            TestingFileSystem fileSystem = completeExpiredLog(2);
+            ProtocolEntry protocol = new ProtocolEntry(3, 7, Optional.of(ImmutableSet.of(feature)), Optional.of(ImmutableSet.of(feature)));
+            cleanup(fileSystem, 2, metadata(true, Duration.ofDays(30)), protocol);
+            assertThat(fileSystem.deletedBatches).as(feature).isEmpty();
+        }
+
+        TestingFileSystem fileSystem = completeExpiredLog(2);
+        cleanup(fileSystem,
+                2,
+                metadata(true, Duration.ofDays(30), ImmutableMap.of("delta.checkpointPolicy", "v2")),
+                CLASSIC_PROTOCOL);
+        assertThat(fileSystem.deletedBatches).isEmpty();
+
+        TestingFileSystem coordinatedCommits = completeExpiredLog(2);
+        cleanup(coordinatedCommits,
+                2,
+                metadata(true, Duration.ofDays(30), ImmutableMap.of("delta.coordinatedCommits.commitCoordinator-preview", "{}")),
+                CLASSIC_PROTOCOL);
+        assertThat(coordinatedCommits.deletedBatches).isEmpty();
+    }
+
+    @Test
+    void testConcurrentVersionsAboveSuppliedCheckpointArePreserved()
+    {
+        TestingFileSystem fileSystem = completeExpiredLog(3);
+        fileSystem.add(jsonName(4), EXPIRED.plusSeconds(4), 1);
+        fileSystem.add(jsonName(5), EXPIRED.plusSeconds(5), 1);
+
+        cleanup(fileSystem, 3, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.names()).containsExactlyInAnyOrder(jsonName(3), jsonName(4), jsonName(5), checkpointName(3));
+    }
+
+    @Test
+    void testEqualExpiredCommitTimestampsAllowCleanup()
+    {
+        TestingFileSystem fileSystem = completeExpiredLog(3);
+        fileSystem.setLastModified(jsonName(1), EXPIRED);
+        fileSystem.setLastModified(jsonName(2), EXPIRED);
+        fileSystem.setLastModified(jsonName(3), EXPIRED);
+
+        cleanup(fileSystem, 3, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.names()).containsExactlyInAnyOrder(jsonName(3), checkpointName(3));
+    }
+
+    @Test
+    void testTimestampAdjustmentRunCrossingCutoffIsRetained()
+    {
+        TestingFileSystem fileSystem = new TestingFileSystem();
+        Instant justBeforeCutoff = CUTOFF.minusMillis(1);
+        for (int version = 0; version <= 3; version++) {
+            fileSystem.add(jsonName(version), justBeforeCutoff, 1);
+        }
+        fileSystem.add(checkpointName(0), justBeforeCutoff, 1);
+        fileSystem.add(checkpointName(3), justBeforeCutoff, 1);
+
+        cleanup(fileSystem, 3, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.deletedBatches).isEmpty();
+    }
+
+    @Test
+    void testRecentOldCheckpointPinsRetainedAnchor()
+    {
+        TestingFileSystem fileSystem = completeExpiredLog(5);
+        fileSystem.add(checkpointName(0), EXPIRED, 1);
+        fileSystem.add(checkpointName(2), RECENT, 1);
+
+        cleanup(fileSystem, 5, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.names()).containsExactlyInAnyOrder(
+                jsonName(2), jsonName(3), jsonName(4), jsonName(5), checkpointName(2), checkpointName(5));
+    }
+
+    @Test
+    void testListAndDeleteFailuresNeverEscapeCommittedWrite()
+    {
+        TestingFileSystem listFailure = completeExpiredLog(2);
+        listFailure.failList = true;
+        assertThatCode(() -> cleanup(listFailure, 2, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL))
+                .doesNotThrowAnyException();
+
+        TestingFileSystem deleteFailure = completeExpiredLog(2);
+        deleteFailure.failDelete = true;
+        assertThatCode(() -> cleanup(deleteFailure, 2, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL))
+                .doesNotThrowAnyException();
+        assertThat(deleteFailure.names()).contains(jsonName(2), checkpointName(2));
+    }
+
+    @Test
+    void testPartialMultipartCheckpointDeletionDoesNotBlockLaterCleanup()
+    {
+        TestingFileSystem fileSystem = completeExpiredLog(5);
+        String firstPart = multipartCheckpointName(1, 1, 2);
+        String remainingPart = multipartCheckpointName(1, 2, 2);
+        fileSystem.add(firstPart, EXPIRED, 1);
+        fileSystem.add(remainingPart, EXPIRED, 1);
+        fileSystem.add(checkpointName(3), EXPIRED, 1);
+        fileSystem.failDeleteAfterRemoving(firstPart);
+
+        cleanup(fileSystem, 5, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+        assertThat(fileSystem.names()).doesNotContain(firstPart);
+
+        cleanup(fileSystem, 5, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.names()).containsExactlyInAnyOrder(jsonName(5), checkpointName(5), remainingPart);
+    }
+
+    @Test
+    void testDeletesInBatchesOfAtMostOneThousand()
+    {
+        TestingFileSystem fileSystem = completeExpiredLog(1005);
+
+        cleanup(fileSystem, 1005, metadata(true, Duration.ofDays(30)), CLASSIC_PROTOCOL);
+
+        assertThat(fileSystem.deletedBatches).hasSize(2);
+        assertThat(fileSystem.deletedBatches.get(0)).hasSize(1000);
+        assertThat(fileSystem.deletedBatches.get(1)).hasSize(5);
+        assertThat(fileSystem.names()).containsExactlyInAnyOrder(jsonName(1005), checkpointName(1005));
+    }
+
+    private void cleanup(TestingFileSystem fileSystem, long checkpointVersion, MetadataEntry metadata, ProtocolEntry protocol)
+    {
+        cleanup.cleanup(TABLE, fileSystem, LOG_DIRECTORY, checkpointVersion, metadata, protocol);
+    }
+
+    private static TestingFileSystem completeExpiredLog(long checkpointVersion)
+    {
+        TestingFileSystem fileSystem = new TestingFileSystem();
+        addJsonRange(fileSystem, 0, checkpointVersion, EXPIRED);
+        fileSystem.add(checkpointName(checkpointVersion), EXPIRED, 1);
+        return fileSystem;
+    }
+
+    private static void addJsonRange(TestingFileSystem fileSystem, long start, long end, Instant firstModified)
+    {
+        for (long version = start; version <= end; version++) {
+            fileSystem.add(jsonName(version), firstModified.plusSeconds(version - start), 1);
+        }
+    }
+
+    private static String jsonName(long version)
+    {
+        return format("%020d.json", version);
+    }
+
+    private static String checkpointName(long version)
+    {
+        return format("%020d.checkpoint.parquet", version);
+    }
+
+    private static String versionChecksumName(long version)
+    {
+        return format("%020d.crc", version);
+    }
+
+    private static String multipartCheckpointName(long version, int part, int parts)
+    {
+        return format("%020d.checkpoint.%010d.%010d.parquet", version, part, parts);
+    }
+
+    private static MetadataEntry metadata(boolean cleanupEnabled, Duration retention)
+    {
+        return metadata(cleanupEnabled, retention, ImmutableMap.of());
+    }
+
+    private static MetadataEntry metadata(boolean cleanupEnabled, Duration retention, Map<String, String> configuration)
+    {
+        return MetadataEntry.builder()
+                .setConfiguration(ImmutableMap.<String, String>builder()
+                        .putAll(configuration)
+                        .put("delta.enableExpiredLogCleanup", Boolean.toString(cleanupEnabled))
+                        .put("delta.logRetentionDuration", "interval %s seconds".formatted(retention.toSeconds()))
+                        .buildOrThrow())
+                .build();
+    }
+
+    private static class TestingFileSystem
+            implements TrinoFileSystem
+    {
+        private final Map<Location, FileEntry> files = new LinkedHashMap<>();
+        private final List<List<Location>> deletedBatches = new ArrayList<>();
+        private boolean reverseListing;
+        private boolean failList;
+        private boolean failDelete;
+        private Location deleteBeforeFailure;
+
+        void add(String relativePath, Instant lastModified, long length)
+        {
+            Location location = LOG_DIRECTORY.appendPath(relativePath);
+            files.put(location, new FileEntry(location, length, lastModified, Optional.empty()));
+        }
+
+        void remove(String relativePath)
+        {
+            files.remove(LOG_DIRECTORY.appendPath(relativePath));
+        }
+
+        void setLastModified(String relativePath, Instant lastModified)
+        {
+            Location location = LOG_DIRECTORY.appendPath(relativePath);
+            FileEntry entry = files.get(location);
+            files.put(location, new FileEntry(location, entry.length(), lastModified, Optional.empty()));
+        }
+
+        Set<String> names()
+        {
+            return files.keySet().stream()
+                    .map(location -> location.toString().substring(LOG_DIRECTORY.toString().length() + 1))
+                    .collect(toSet());
+        }
+
+        void failDeleteAfterRemoving(String relativePath)
+        {
+            deleteBeforeFailure = LOG_DIRECTORY.appendPath(relativePath);
+        }
+
+        @Override
+        public FileIterator listFiles(Location location)
+                throws IOException
+        {
+            if (failList) {
+                throw new IOException("list failed");
+            }
+            List<FileEntry> listing = new ArrayList<>(files.values());
+            if (reverseListing) {
+                Collections.reverse(listing);
+            }
+            return new FileIterator()
+            {
+                private int index;
+
+                @Override
+                public boolean hasNext()
+                {
+                    return index < listing.size();
+                }
+
+                @Override
+                public FileEntry next()
+                {
+                    return listing.get(index++);
+                }
+            };
+        }
+
+        @Override
+        public void deleteFiles(Collection<Location> locations)
+                throws IOException
+        {
+            deletedBatches.add(ImmutableList.copyOf(locations));
+            if (deleteBeforeFailure != null) {
+                assertThat(locations).contains(deleteBeforeFailure);
+                files.remove(deleteBeforeFailure);
+                deleteBeforeFailure = null;
+                throw new IOException("delete failed");
+            }
+            if (failDelete) {
+                locations.stream().findFirst().ifPresent(files::remove);
+                throw new IOException("delete failed");
+            }
+            locations.forEach(files::remove);
+        }
+
+        @Override
+        public TrinoInputFile newInputFile(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TrinoInputFile newInputFile(Location location, long length)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TrinoInputFile newInputFile(Location location, long length, Instant lastModified)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public TrinoOutputFile newOutputFile(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void deleteFile(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void deleteDirectory(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void renameFile(Location source, Location target)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<Boolean> directoryExists(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void createDirectory(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void renameDirectory(Location source, Location target)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<Location> listDirectories(Location location)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<Location> createTemporaryDirectory(Location targetPath, String temporaryPrefix, String relativePrefix)
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriterManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriterManager.java
@@ -1,0 +1,353 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.transactionlog.checkpoint;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.local.LocalFileSystem;
+import io.trino.filesystem.tracking.TrackingFileSystem;
+import io.trino.parquet.ParquetReaderOptions;
+import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
+import io.trino.plugin.deltalake.DeltaLakeConfig;
+import io.trino.plugin.deltalake.DeltaLakeFileSystemFactory;
+import io.trino.plugin.deltalake.DeltaLakeTableCredentials;
+import io.trino.plugin.deltalake.metastore.FileSystemCredentials;
+import io.trino.plugin.deltalake.metastore.VendedCredentialsHandle;
+import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
+import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
+import io.trino.plugin.deltalake.transactionlog.TransactionLogCleanup;
+import io.trino.plugin.deltalake.transactionlog.reader.FileSystemTransactionLogReaderFactory;
+import io.trino.plugin.deltalake.transactionlog.reader.TransactionLogReader;
+import io.trino.plugin.hive.parquet.ParquetReaderConfig;
+import io.trino.spi.NodeVersion;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaTableName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.ref.Cleaner;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.trino.plugin.deltalake.DeltaLakeConfig.DEFAULT_TRANSACTION_LOG_MAX_CACHED_SIZE;
+import static io.trino.plugin.deltalake.DeltaTestingConnectorSession.SESSION;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+final class TestCheckpointWriterManager
+{
+    private static final SchemaTableName TABLE = new SchemaTableName("schema", "table");
+    private static final long CHECKPOINT_VERSION = 2;
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void testCleanupUsesCredentialFileSystemAndCustomRetentionFromMetadata()
+            throws Exception
+    {
+        Fixture fixture = createFixture(
+                "custom-retention",
+                ImmutableMap.of("delta.logRetentionDuration", "interval 1 day"),
+                FailureMode.NONE);
+
+        fixture.writeCheckpoint();
+
+        assertThat(fixture.fileSystemFactory.requestedCredentials()).contains(fixture.tableCredentials);
+        assertThat(fixture.fileSystem.listCalls()).isOne();
+        assertThat(fixture.fileSystem.deletedFiles())
+                .extracting(Location::fileName)
+                .containsExactlyInAnyOrder(jsonName(0), jsonName(1), checkpointName(0));
+        assertThat(fixture.transactionLogDirectory.resolve(jsonName(0))).doesNotExist();
+        assertThat(fixture.transactionLogDirectory.resolve(jsonName(1))).doesNotExist();
+        assertCheckpointPublished(fixture.transactionLogDirectory);
+    }
+
+    @Test
+    void testCleanupDisabledThroughMetadata()
+            throws Exception
+    {
+        Fixture fixture = createFixture(
+                "disabled",
+                ImmutableMap.of(
+                        "delta.enableExpiredLogCleanup", "false",
+                        "delta.logRetentionDuration", "interval 0 seconds"),
+                FailureMode.NONE);
+
+        fixture.writeCheckpoint();
+
+        assertThat(fixture.fileSystem.listCalls()).isZero();
+        assertThat(fixture.fileSystem.deletedFiles()).isEmpty();
+        assertThat(fixture.transactionLogDirectory.resolve(jsonName(0))).exists();
+        assertThat(fixture.transactionLogDirectory.resolve(checkpointName(0))).exists();
+        assertCheckpointPublished(fixture.transactionLogDirectory);
+    }
+
+    @Test
+    void testCleanupFailureDoesNotFailCheckpointPublication()
+            throws Exception
+    {
+        for (FailureMode failureMode : List.of(FailureMode.LIST, FailureMode.DELETE)) {
+            Fixture fixture = createFixture(
+                    failureMode.name().toLowerCase(Locale.ENGLISH),
+                    ImmutableMap.of("delta.logRetentionDuration", "interval 1 day"),
+                    failureMode);
+
+            assertThatCode(fixture::writeCheckpoint).doesNotThrowAnyException();
+
+            assertThat(fixture.fileSystem.listCalls()).isOne();
+            assertThat(fixture.fileSystem.failureTriggered()).isTrue();
+            assertCheckpointPublished(fixture.transactionLogDirectory);
+        }
+    }
+
+    private Fixture createFixture(String name, Map<String, String> configuration, FailureMode failureMode)
+            throws Exception
+    {
+        String tableLocation = "local:///" + name;
+        Path transactionLogDirectory = temporaryDirectory.resolve(name).resolve("_delta_log");
+        Files.createDirectories(transactionLogDirectory);
+
+        Files.writeString(transactionLogDirectory.resolve(jsonName(0)), transactionLog(configuration));
+        Files.writeString(transactionLogDirectory.resolve(jsonName(1)), transactionEntry(1));
+        Files.writeString(transactionLogDirectory.resolve(jsonName(2)), transactionEntry(2));
+        Files.writeString(transactionLogDirectory.resolve(checkpointName(0)), "old checkpoint");
+
+        FileTime expired = FileTime.from(Instant.now().minus(Duration.ofDays(2)));
+        for (String fileName : List.of(jsonName(0), jsonName(1), jsonName(2), checkpointName(0))) {
+            Files.setLastModifiedTime(transactionLogDirectory.resolve(fileName), expired);
+        }
+
+        TrinoFileSystem localFileSystem = new LocalFileSystem(temporaryDirectory);
+        RecordingFileSystem recordingFileSystem = new RecordingFileSystem(localFileSystem, failureMode);
+        DeltaLakeTableCredentials tableCredentials = new DeltaLakeTableCredentials(
+                VendedCredentialsHandle.empty(tableLocation),
+                new TestingFileSystemCredentials());
+        TestingDeltaLakeFileSystemFactory fileSystemFactory = new TestingDeltaLakeFileSystemFactory(recordingFileSystem);
+
+        TransactionLogReader transactionLogReader = (_, startVersion, endVersion, maxCachedFileSize) ->
+                TransactionLogTail.loadNewTail(localFileSystem, tableLocation, startVersion, endVersion, maxCachedFileSize);
+        TableSnapshot snapshot = TableSnapshot.load(
+                SESSION,
+                transactionLogReader,
+                TABLE,
+                Optional.empty(),
+                tableLocation,
+                ParquetReaderOptions.defaultOptions(),
+                true,
+                32,
+                DEFAULT_TRANSACTION_LOG_MAX_CACHED_SIZE,
+                Optional.empty());
+
+        DeltaLakeConfig config = new DeltaLakeConfig();
+        CheckpointSchemaManager checkpointSchemaManager = new CheckpointSchemaManager(TESTING_TYPE_MANAGER);
+        FileFormatDataSourceStats fileFormatDataSourceStats = new FileFormatDataSourceStats();
+        TransactionLogAccess transactionLogAccess = new TransactionLogAccess(
+                TESTING_TYPE_MANAGER,
+                checkpointSchemaManager,
+                config,
+                fileFormatDataSourceStats,
+                fileSystemFactory,
+                new ParquetReaderConfig(),
+                newDirectExecutorService(),
+                new FileSystemTransactionLogReaderFactory(fileSystemFactory));
+        CheckpointWriterManager checkpointWriterManager = new CheckpointWriterManager(
+                TESTING_TYPE_MANAGER,
+                checkpointSchemaManager,
+                fileSystemFactory,
+                new NodeVersion("test"),
+                transactionLogAccess,
+                new TransactionLogCleanup(),
+                fileFormatDataSourceStats,
+                jsonCodec(LastCheckpoint.class),
+                config,
+                newDirectExecutorService());
+        return new Fixture(transactionLogDirectory, tableCredentials, fileSystemFactory, recordingFileSystem, checkpointWriterManager, snapshot);
+    }
+
+    private static void assertCheckpointPublished(Path transactionLogDirectory)
+            throws IOException
+    {
+        assertThat(transactionLogDirectory.resolve(checkpointName(CHECKPOINT_VERSION))).isNotEmptyFile();
+        assertThat(transactionLogDirectory.resolve("_last_checkpoint")).isNotEmptyFile();
+        LastCheckpoint lastCheckpoint = jsonCodec(LastCheckpoint.class)
+                .fromJson(Files.readString(transactionLogDirectory.resolve("_last_checkpoint")));
+        assertThat(lastCheckpoint.version()).isEqualTo(CHECKPOINT_VERSION);
+    }
+
+    private static String transactionLog(Map<String, String> configuration)
+    {
+        String configurationJson = configuration.entrySet().stream()
+                .map(entry -> "\"%s\":\"%s\"".formatted(entry.getKey(), entry.getValue()))
+                .collect(joining(",", "{", "}"));
+        return """
+               {"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
+               {"metaData":{"id":"test","format":{"provider":"parquet","options":{}},"schemaString":"{\\"type\\":\\"struct\\",\\"fields\\":[{\\"name\\":\\"value\\",\\"type\\":\\"integer\\",\\"nullable\\":true,\\"metadata\\":{}}]}","partitionColumns":[],"configuration":%s,"createdTime":0}}
+               """.formatted(configurationJson);
+    }
+
+    private static String transactionEntry(long version)
+    {
+        return "{\"txn\":{\"appId\":\"test\",\"version\":%s,\"lastUpdated\":0}}\n".formatted(version);
+    }
+
+    private static String jsonName(long version)
+    {
+        return "%020d.json".formatted(version);
+    }
+
+    private static String checkpointName(long version)
+    {
+        return "%020d.checkpoint.parquet".formatted(version);
+    }
+
+    private record Fixture(
+            Path transactionLogDirectory,
+            DeltaLakeTableCredentials tableCredentials,
+            TestingDeltaLakeFileSystemFactory fileSystemFactory,
+            RecordingFileSystem fileSystem,
+            CheckpointWriterManager checkpointWriterManager,
+            TableSnapshot snapshot)
+    {
+        void writeCheckpoint()
+        {
+            checkpointWriterManager.writeCheckpoint(SESSION, snapshot, Optional.of(tableCredentials));
+        }
+    }
+
+    private static final class TestingDeltaLakeFileSystemFactory
+            implements DeltaLakeFileSystemFactory
+    {
+        private final TrinoFileSystem fileSystem;
+        private Optional<DeltaLakeTableCredentials> requestedCredentials = Optional.empty();
+
+        private TestingDeltaLakeFileSystemFactory(TrinoFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+
+        @Override
+        public TrinoFileSystem create(ConnectorSession session, Optional<DeltaLakeTableCredentials> tableCredentials)
+        {
+            requestedCredentials = tableCredentials;
+            return fileSystem;
+        }
+
+        @Override
+        public TrinoFileSystem create(ConnectorSession session, String tableLocation)
+        {
+            throw new AssertionError("Unexpected location-based filesystem creation");
+        }
+
+        private Optional<DeltaLakeTableCredentials> requestedCredentials()
+        {
+            return requestedCredentials;
+        }
+    }
+
+    private static final class RecordingFileSystem
+            extends TrackingFileSystem
+    {
+        private static final Cleaner CLEANER = Cleaner.create();
+
+        private final FailureMode failureMode;
+        private final ImmutableList.Builder<Location> deletedFiles = ImmutableList.builder();
+        private int listCalls;
+        private boolean failureTriggered;
+
+        private RecordingFileSystem(TrinoFileSystem delegate, FailureMode failureMode)
+        {
+            super(delegate, CLEANER);
+            this.failureMode = failureMode;
+        }
+
+        @Override
+        public FileIterator listFiles(Location location)
+                throws IOException
+        {
+            listCalls++;
+            if (failureMode == FailureMode.LIST) {
+                failureTriggered = true;
+                throw new IOException("list failed");
+            }
+            return super.listFiles(location);
+        }
+
+        @Override
+        public void deleteFiles(Collection<Location> locations)
+                throws IOException
+        {
+            deletedFiles.addAll(locations);
+            if (failureMode == FailureMode.DELETE) {
+                failureTriggered = true;
+                throw new IOException("delete failed");
+            }
+            super.deleteFiles(locations);
+        }
+
+        private int listCalls()
+        {
+            return listCalls;
+        }
+
+        private List<Location> deletedFiles()
+        {
+            return deletedFiles.build();
+        }
+
+        private boolean failureTriggered()
+        {
+            return failureTriggered;
+        }
+    }
+
+    private static final class TestingFileSystemCredentials
+            implements FileSystemCredentials
+    {
+        @Override
+        public Map<String, String> asExtraCredentials()
+        {
+            return ImmutableMap.of();
+        }
+
+        @Override
+        public boolean isValid()
+        {
+            return true;
+        }
+    }
+
+    private enum FailureMode
+    {
+        NONE,
+        LIST,
+        DELETE,
+    }
+}


### PR DESCRIPTION
## Description

Expire transaction JSON, classic checkpoints, and version checksums after successfully writing a checkpoint and `_last_checkpoint`. Honor `delta.logRetentionDuration` (default `interval 30 days`) and `delta.enableExpiredLogCleanup` (default `true`).

Cleanup preserves a complete checkpoint and the contiguous JSON history needed to replay retained versions. It supports single-file and multipart classic checkpoints, skips unsupported layouts such as v2 checkpoints and coordinated commits, and leaves data files and checkpoint tombstones untouched. Listing or deletion failures do not fail an already committed write. Incomplete checkpoint leftovers are retained without blocking subsequent cleanup.

This changes behavior for existing tables using the default properties: expired history can become unavailable to time travel, `$history`, and lagging CDF consumers. Tables can opt out with `delta.enableExpiredLogCleanup=false` in their Delta metadata. These properties are not exposed as Trino table properties.

## Additional context and related issues

Related to #16207. Opening as a draft to discuss the checkpoint trigger and conservative classic-checkpoint scope.

I favor checkpoint-triggered cleanup because it applies the table's existing Delta retention policy rather than introducing a separate Trino policy. [Spark Delta publishes the checkpoint and `_last_checkpoint` before running cleanup](https://github.com/delta-io/delta/blob/8d19b379ecfd5aff5949fc9e4b6f3f8800078072/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala#L350-L388). [delta-rs also runs automatic post-commit cleanup after attempting any due checkpoint](https://github.com/delta-io/delta-rs/blob/f1ee79e17e6c6b0df3ff4382a117f80aa2ace766/crates/core/src/kernel/transaction/mod.rs#L1052-L1113). Both honor the same opt-out and default to 30-day retention. Their precise triggers and cutoff calculations differ; this implementation does not claim full algorithmic parity. It uses Spark's UTC-day cutoff and conservatively retains a replay anchor.

Verified on Temurin 25: 141 focused tests pass, including checkpoint publication, credential propagation, opt-out, custom retention, partial deletion retries, time travel, history, and CDF. Module validation and the documentation build pass. Error Prone compilation passes with aggregate checks skipped to avoid formatting/checkstyle failures in generated ANTLR sources; handwritten-source validation passes separately.

The default connector suite reported 1,202 tests with zero failures/errors and 74 skipped, but did not finish before the local timeout. Docker Desktop failed to pull the Hive test image with a `meta.db: read-only file system` error. This is not a claim that the full suite passed.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake connector
* {{breaking}} Automatically remove expired transaction logs after checkpoint
  creation according to `delta.logRetentionDuration`, which defaults to 30 days.
  Expired history is no longer available for time travel or change data feed
  queries. Set `delta.enableExpiredLogCleanup=false` in the Delta table metadata
  to disable cleanup. ({issue}`16207`)
```

Towards DF-915
