### PR TITLE
Bound memory of dictionary buffering in partitioned output

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/PagePartitioner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PagePartitioner.java
@@ -138,6 +138,7 @@ public class PagePartitioner
         }
 
         int outputPositionCount = replicatesAnyRow && !hasAnyRowBeenReplicated ? page.getPositionCount() + positionsAppenders.length - 1 : page.getPositionCount();
+        long outputSizeInBytes = flushBeforeFlattening(page);
         if (positionsAppenders.length == 1) {
             // single output partition, skip partition calculation and append the entire page to the output partition
             checkState(partitionFunction.partitionCount() == 1, "partitionFunction must be single partition");
@@ -157,7 +158,7 @@ public class PagePartitioner
         else {
             partitionPageByColumn(page);
         }
-        long outputSizeInBytes = flushPositionsAppenders(false);
+        outputSizeInBytes += flushPositionsAppenders(false);
         updateMemoryUsage();
         operatorContext.recordOutput(outputSizeInBytes, outputPositionCount);
     }
@@ -465,6 +466,24 @@ public class PagePartitioner
             Arrays.fill(positionsAppenders, null);
             memoryContext.close();
         }
+    }
+
+    /**
+     * Enqueues output partitions which would flatten a buffered dictionary large enough to fill a page,
+     * keeping the dictionary encoding and avoiding the allocation that flattening it requires.
+     */
+    private long flushBeforeFlattening(Page page)
+    {
+        long outputSizeInBytes = 0;
+        for (int partition = 0; partition < positionsAppenders.length; partition++) {
+            PositionsAppenderPageBuilder partitionPageBuilder = positionsAppenders[partition];
+            if (partitionPageBuilder.requiresFlushBeforeFlattening(page)) {
+                Page pagePartition = partitionPageBuilder.build();
+                outputSizeInBytes += pagePartition.getSizeInBytes();
+                enqueuePage(pagePartition, partition);
+            }
+        }
+        return adjustFlushedOutputSizeWithEagerlyReportedBytes(outputSizeInBytes);
     }
 
     private long flushPositionsAppenders(boolean force)

--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
@@ -155,6 +155,27 @@ public final class PositionsAppenderPageBuilder
         return declaredPositions == 0;
     }
 
+    /**
+     * True when appending {@code page} flattens a buffered dictionary whose flattened size already fills a page.
+     */
+    public boolean requiresFlushBeforeFlattening(Page page)
+    {
+        if (declaredPositions == 0 || !appendFlattensDictionary(page)) {
+            return false;
+        }
+        return computeAppenderSizes().getDirectSizeInBytes() >= maxPageSizeInBytes;
+    }
+
+    private boolean appendFlattensDictionary(Page page)
+    {
+        for (int channel = 0; channel < channelAppenders.length; channel++) {
+            if (channelAppenders[channel].appendFlattensDictionary(page.getBlock(channel))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public Optional<Page> flushOrFlattenBeforeRelease()
     {
         if (declaredPositions == 0) {

--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
@@ -32,8 +32,7 @@ public final class PositionsAppenderPageBuilder
     private static final int DEFAULT_INITIAL_EXPECTED_ENTRIES = 8;
     @VisibleForTesting
     static final int MAX_POSITION_COUNT = PageProcessor.MAX_BATCH_SIZE * 4;
-    // Maximum page size before being considered full based on current direct appender size and if RLE channels were converted to direct. Currently,
-    // dictionary mode appenders still under-report because computing their equivalent size if converted to direct is prohibitively expensive.
+    // Maximum page size before being considered full based on current direct appender size and if RLE and dictionary channels were converted to direct.
     private static final int MAXIMUM_DIRECT_SIZE_MULTIPLIER = 8;
 
     private final UnnestingPositionsAppender[] channelAppenders;

--- a/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
@@ -57,6 +57,7 @@ public final class UnnestingPositionsAppender
 
     @Nullable
     private ValueBlock dictionary;
+    private double averageDictionaryEntrySizeInBytes;
     private DictionaryIdsBuilder dictionaryIdsBuilder;
 
     @Nullable
@@ -83,8 +84,7 @@ public final class UnnestingPositionsAppender
             case DictionaryBlock dictionaryBlock -> {
                 ValueBlock dictionary = dictionaryBlock.getDictionary();
                 if (state == State.UNINITIALIZED) {
-                    state = State.DICTIONARY;
-                    this.dictionary = dictionary;
+                    startDictionary(dictionary);
                     dictionaryIdsBuilder.appendRange(dictionaryBlock, offset, length);
                 }
                 else if (state == State.DICTIONARY && this.dictionary == dictionary) {
@@ -127,8 +127,7 @@ public final class UnnestingPositionsAppender
             case DictionaryBlock dictionaryBlock -> {
                 ValueBlock dictionary = dictionaryBlock.getDictionary();
                 if (state == State.UNINITIALIZED) {
-                    state = State.DICTIONARY;
-                    this.dictionary = dictionary;
+                    startDictionary(dictionary);
                     dictionaryIdsBuilder.appendPositions(positions, dictionaryBlock);
                 }
                 else if (state == State.DICTIONARY && this.dictionary == dictionary) {
@@ -196,12 +195,21 @@ public final class UnnestingPositionsAppender
         }
     }
 
+    private void startDictionary(ValueBlock dictionary)
+    {
+        state = State.DICTIONARY;
+        this.dictionary = dictionary;
+        // computed once per dictionary because the flattened size is estimated on every fullness check
+        this.averageDictionaryEntrySizeInBytes = dictionary.getSizeInBytes() / (double) dictionary.getPositionCount();
+    }
+
     private void transitionToDirect()
     {
         if (state == State.DICTIONARY) {
             int[] dictionaryIds = dictionaryIdsBuilder.getDictionaryIds();
             delegate.append(IntArrayList.wrap(dictionaryIds, dictionaryIdsBuilder.size()), dictionary);
             dictionary = null;
+            averageDictionaryEntrySizeInBytes = 0;
             dictionaryIdsBuilder = dictionaryIdsBuilder.newBuilderLike();
         }
         else if (state == State.RLE) {
@@ -229,6 +237,7 @@ public final class UnnestingPositionsAppender
     {
         state = State.UNINITIALIZED;
         dictionary = null;
+        averageDictionaryEntrySizeInBytes = 0;
         dictionaryIdsBuilder = dictionaryIdsBuilder.newBuilderLike();
         rleValue = null;
         rlePositionCount = 0;
@@ -254,8 +263,12 @@ public final class UnnestingPositionsAppender
     void addSizesToAccumulator(PositionsAppenderSizeAccumulator accumulator)
     {
         long sizeInBytes = getSizeInBytes();
-        // dictionary size is not included due to the expense of the calculation, so this will under-report for dictionaries
-        long directSizeInBytes = (rleValue == null) ? sizeInBytes : (rleValue.getSizeInBytes() * rlePositionCount);
+        long directSizeInBytes = switch (state) {
+            case UNINITIALIZED, DIRECT -> sizeInBytes;
+            case RLE -> rleValue.getSizeInBytes() * rlePositionCount;
+            // buffered ids expand to the average dictionary entry size when flattened
+            case DICTIONARY -> (long) (averageDictionaryEntrySizeInBytes * dictionaryIdsBuilder.size());
+        };
         accumulator.accumulate(sizeInBytes, directSizeInBytes);
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
@@ -279,6 +279,17 @@ public final class UnnestingPositionsAppender
         }
     }
 
+    /**
+     * True when appending positions from {@code source} flattens the buffered dictionary into the delegate.
+     */
+    public boolean appendFlattensDictionary(Block source)
+    {
+        if (state != State.DICTIONARY) {
+            return false;
+        }
+        return !(source instanceof DictionaryBlock dictionaryBlock) || dictionaryBlock.getDictionary() != dictionary;
+    }
+
     public boolean shouldForceFlushBeforeRelease()
     {
         if (state == State.DICTIONARY && dictionary != null) {

--- a/core/trino-main/src/test/java/io/trino/operator/output/BenchmarkPartitionedOutputOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/BenchmarkPartitionedOutputOperator.java
@@ -123,7 +123,7 @@ public class BenchmarkPartitionedOutputOperator
     {
         PartitionedOutputOperator operator = data.createPartitionedOutputOperator();
         for (int i = 0; i < data.getPageCount(); i++) {
-            operator.addInput(data.getDataPage());
+            operator.addInput(data.getDataPage(i));
         }
         operator.finish();
     }
@@ -164,7 +164,7 @@ public class BenchmarkPartitionedOutputOperator
 
         private List<Type> types;
         private int pageCount;
-        private Page dataPage;
+        private List<Page> dataPages;
         private Blackhole blackhole;
 
         public enum TestType
@@ -250,6 +250,8 @@ public class BenchmarkPartitionedOutputOperator
             ARRAY_BIGINT(new ArrayType(BigintType.BIGINT), 1000),
             // Flat array of VARCHAR data channel, flat BIGINT partition channel.
             ARRAY_VARCHAR(new ArrayType(VarcharType.VARCHAR), 1000),
+            // Dictionary array of VARCHAR data channel, flat BIGINT partition channel, input switches to a new dictionary 8 times.
+            DICTIONARY_ARRAY_VARCHAR_ROTATING(new ArrayType(VarcharType.VARCHAR), 1000, PageTestUtils::createRandomDictionaryPage, 8),
             // Flat array of array of BIGINT data channel, flat BIGINT partition channel.
             ARRAY_ARRAY_BIGINT(new ArrayType(new ArrayType(BigintType.BIGINT)), 1000),
             // Flat map<BIGINT, BIGINT> data channel, flat BIGINT partition channel.
@@ -290,6 +292,7 @@ public class BenchmarkPartitionedOutputOperator
 
             private final Type type;
             private final int pageCount;
+            private final int distinctPageCount;
 
             private final PageGenerator pageGenerator;
 
@@ -300,14 +303,25 @@ public class BenchmarkPartitionedOutputOperator
 
             TestType(Type type, int pageCount, PageGenerator pageGenerator)
             {
+                this(type, pageCount, pageGenerator, 1);
+            }
+
+            TestType(Type type, int pageCount, PageGenerator pageGenerator, int distinctPageCount)
+            {
                 this.type = requireNonNull(type, "type is null");
                 this.pageCount = pageCount;
+                this.distinctPageCount = distinctPageCount;
                 this.pageGenerator = requireNonNull(pageGenerator, "pageGenerator is null");
             }
 
             public PageGenerator getPageGenerator()
             {
                 return pageGenerator;
+            }
+
+            public int getDistinctPageCount()
+            {
+                return distinctPageCount;
             }
 
             public int getPageCount()
@@ -360,9 +374,10 @@ public class BenchmarkPartitionedOutputOperator
             this.type = requireNonNull(type, "type is null");
         }
 
-        public Page getDataPage()
+        public Page getDataPage(int index)
         {
-            return dataPage;
+            // each input page is used for a contiguous run of the benchmark iteration
+            return dataPages.get(index * dataPages.size() / pageCount);
         }
 
         @Setup
@@ -378,7 +393,9 @@ public class BenchmarkPartitionedOutputOperator
             // and in case of unit test it will be null
             this.blackhole = blackhole;
             types = type.getTypes(channelCount);
-            dataPage = type.getPageGenerator().createPage(types, positionCount, nullRate);
+            dataPages = IntStream.range(0, type.getDistinctPageCount())
+                    .mapToObj(_ -> type.getPageGenerator().createPage(types, positionCount, nullRate))
+                    .collect(toImmutableList());
             pageCount = type.getPageCount();
             types = ImmutableList.<Type>builder()
                     .addAll(types)

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
@@ -128,6 +128,50 @@ public class TestPositionsAppenderPageBuilder
     }
 
     @Test
+    public void testFullOnDictionaryDirectSizeInBytes()
+    {
+        int maxPageBytes = 1000;
+        int maxDirectSize = 1000;
+        PositionsAppenderPageBuilder pageBuilder = PositionsAppenderPageBuilder.withMaxPageSize(
+                maxPageBytes,
+                maxDirectSize,
+                List.of(VARCHAR),
+                new PositionsAppenderFactory(new BlockTypeOperators()));
+
+        BlockBuilder dictionaryBuilder = VARCHAR.createBlockBuilder(null, 2);
+        VARCHAR.writeString(dictionaryBuilder, "first");
+        VARCHAR.writeString(dictionaryBuilder, "second");
+        Block valueBlock = dictionaryBuilder.build();
+        Block dictionaryBlock = DictionaryBlock.create(10, valueBlock, new int[] {0, 1, 0, 1, 0, 1, 0, 1, 0, 1});
+        Page inputPage = new Page(dictionaryBlock);
+
+        IntArrayList positions = IntArrayList.wrap(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+        pageBuilder.appendToOutputPartition(inputPage, positions);
+        PositionsAppenderSizeAccumulator sizeAccumulator = pageBuilder.computeAppenderSizes();
+        assertThat(sizeAccumulator.getSizeInBytes())
+                .as("dictionary mode reports the ids size only")
+                .isEqualTo(Integer.BYTES * 10);
+        assertThat(sizeAccumulator.getDirectSizeInBytes())
+                .as("direct size is the average dictionary entry size per buffered id")
+                .isEqualTo(valueBlock.getSizeInBytes() * 10 / valueBlock.getPositionCount());
+        assertThat(pageBuilder.isFull()).isFalse();
+
+        // Keep inserting until the direct size limit is reached
+        while (pageBuilder.computeAppenderSizes().getDirectSizeInBytes() < maxDirectSize) {
+            pageBuilder.appendToOutputPartition(inputPage, positions);
+        }
+        assertThat(pageBuilder.isFull()).isTrue();
+
+        Page result = pageBuilder.build();
+        assertThat(result.getPositionCount())
+                .as("builder is full well before the position count limit")
+                .isLessThan(PositionsAppenderPageBuilder.MAX_POSITION_COUNT);
+        assertThat(result.getBlock(0))
+                .as("flushing preserves the dictionary encoding")
+                .isInstanceOf(DictionaryBlock.class);
+    }
+
+    @Test
     public void testFlushUsefulDictionariesOnRelease()
     {
         int maxPageBytes = 100;

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
@@ -172,6 +172,68 @@ public class TestPositionsAppenderPageBuilder
     }
 
     @Test
+    public void testFlushDictionaryBeforeFlattening()
+    {
+        int maxPageBytes = 100;
+        int maxDirectSize = 1000;
+        PositionsAppenderPageBuilder pageBuilder = PositionsAppenderPageBuilder.withMaxPageSize(
+                maxPageBytes,
+                maxDirectSize,
+                List.of(VARCHAR),
+                new PositionsAppenderFactory(new BlockTypeOperators()));
+
+        int[] ids = new int[] {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
+        Page inputPage = new Page(DictionaryBlock.create(10, createVarcharDictionary(), ids));
+        pageBuilder.appendToOutputPartition(inputPage, IntArrayList.wrap(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+
+        assertThat(pageBuilder.isFull()).isFalse();
+        assertThat(pageBuilder.computeAppenderSizes().getDirectSizeInBytes()).isGreaterThanOrEqualTo(maxPageBytes);
+        assertThat(pageBuilder.requiresFlushBeforeFlattening(inputPage))
+                .as("appending the same dictionary does not flatten")
+                .isFalse();
+
+        Page pageWithOtherDictionary = new Page(DictionaryBlock.create(10, createVarcharDictionary(), ids));
+        assertThat(pageBuilder.requiresFlushBeforeFlattening(pageWithOtherDictionary))
+                .as("pageBuilder should flush before flattening the dictionary")
+                .isTrue();
+        Page flushedPage = pageBuilder.build();
+        assertThat(flushedPage.getPositionCount()).isEqualTo(10);
+        assertThat(flushedPage.getBlock(0) instanceof DictionaryBlock)
+                .as("result should be dictionary encoded")
+                .isTrue();
+    }
+
+    @Test
+    public void testFlattenSmallDictionaryWithoutFlushing()
+    {
+        int maxPageBytes = 1000;
+        int maxDirectSize = maxPageBytes * 8;
+        PositionsAppenderPageBuilder pageBuilder = PositionsAppenderPageBuilder.withMaxPageSize(
+                maxPageBytes,
+                maxDirectSize,
+                List.of(VARCHAR),
+                new PositionsAppenderFactory(new BlockTypeOperators()));
+
+        int[] ids = new int[] {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
+        Page inputPage = new Page(DictionaryBlock.create(10, createVarcharDictionary(), ids));
+        pageBuilder.appendToOutputPartition(inputPage, IntArrayList.wrap(new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+
+        assertThat(pageBuilder.computeAppenderSizes().getDirectSizeInBytes()).isLessThan(maxPageBytes);
+        Page pageWithOtherDictionary = new Page(DictionaryBlock.create(10, createVarcharDictionary(), ids));
+        assertThat(pageBuilder.requiresFlushBeforeFlattening(pageWithOtherDictionary))
+                .as("flattening a dictionary that fits in the current page does not flush")
+                .isFalse();
+    }
+
+    private static Block createVarcharDictionary()
+    {
+        BlockBuilder dictionaryBuilder = VARCHAR.createBlockBuilder(null, 2);
+        VARCHAR.writeString(dictionaryBuilder, "first");
+        VARCHAR.writeString(dictionaryBuilder, "second");
+        return dictionaryBuilder.build();
+    }
+
+    @Test
     public void testFlushUsefulDictionariesOnRelease()
     {
         int maxPageBytes = 100;


### PR DESCRIPTION
## Description

`UnnestingPositionsAppender` in dictionary mode reports its direct size as 4 bytes per buffered position, the size of the ids alone, so `PositionsAppenderPageBuilder.isFull()` never fires on the byte limits and the builder fills to `MAX_POSITION_COUNT` (32768) rows per output partition. The first input page carrying a different dictionary instance flattens that whole run in one allocation, in the same loop, for every output partition.

This estimates the flattened size from the average dictionary entry size, so the existing direct size limit bounds the buffer. It also flushes the buffered dictionary page instead of flattening it when the estimate already reaches `maxPageSizeInBytes`, since flattening at that point only materializes bytes that are handed to the output buffer immediately afterwards.

## Additional context and related issues

Found in worker heap dumps where a single `PagePartitioner` retained almost the entire heap, spread over roughly 200 partition builders, with the allocating thread inside `UnnestingPositionsAppender.transitionToDirect`. The under-reporting is deliberate in the current code (`// dictionary size is not included due to the expense of the calculation, so this will under-report for dictionaries`), and it is invisible in telemetry because these buffers are charged to the task rather than to the operator. Severity scales with the width of a materialized row, so the same plan shape is harmless for narrow rows and fatal for wide ones such as `array(varchar)` produced by an unnest.

`BenchmarkPartitionedOutputOperator` replayed a single `Page` instance, so the buffered dictionary never changed and neither the flatten nor the flush path was reachable. It can now generate several input pages per type, and `DICTIONARY_ARRAY_VARCHAR_ROTATING` switches dictionary 8 times over the iteration. Results at `compressionCodec=NONE`, `channelCount=1`, `nullRate=0.2`, `positionCount=8192`, ms/op:

| type | partitionCount | master | this change |
| --- | --- | --- | --- |
| BIGINT | 2 | 272.9 | 276.9 |
| BIGINT | 256 | 350.1 | 368.1 |
| DICTIONARY_BIGINT | 2 | 298.2 | 299.1 |
| DICTIONARY_BIGINT | 256 | 403.4 | 414.2 |
| DICTIONARY_VARCHAR | 2 | 362.8 | 364.6 |
| DICTIONARY_VARCHAR | 256 | 422.8 | 428.0 |
| DICTIONARY_ARRAY_VARCHAR_ROTATING | 2 | 139.7 | 128.3 |
| DICTIONARY_ARRAY_VARCHAR_ROTATING | 256 | 159.5 | 113.6 |

The BIGINT and DICTIONARY_BIGINT gaps at 256 partitions did not reproduce on a longer run with 4 forks (391.0 vs 366.1 and 404.4 vs 408.7), so the non rotating cases are at parity within measurement noise on this machine.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Reduce peak memory usage of partitioned output when input pages are dictionary encoded.
```
