### PR TITLE
Remove date_add with zero amount

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
@@ -363,6 +363,16 @@ public final class DateTimeFunctions
         }
     }
 
+    public static boolean isValidDateUnit(Slice unit)
+    {
+        for (DateTimeFieldProvider dateField : DATE_FIELDS) {
+            if (dateField.match(unit)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static DateTimeField getDateField(ISOChronology chronology, Slice unit)
     {
         for (DateTimeFieldProvider dateField : DATE_FIELDS) {
@@ -371,6 +381,16 @@ public final class DateTimeFunctions
             }
         }
         throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unit.toStringUtf8() + "' is not a valid DATE field");
+    }
+
+    public static boolean isValidTimestampUnit(Slice unit)
+    {
+        for (DateTimeFieldProvider timestampField : TIMESTAMP_FIELDS) {
+            if (timestampField.match(unit)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static DateTimeField getTimestampField(ISOChronology chronology, Slice unit)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/TimeField.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/TimeField.java
@@ -40,6 +40,16 @@ public enum TimeField
         this.name = name.getBytes(US_ASCII);
     }
 
+    public static boolean isValidUnit(Slice unit)
+    {
+        for (TimeField field : VALUES) {
+            if (field.matches(unit)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static TimeField match(Slice unit)
     {
         for (TimeField field : VALUES) {

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionOptimizer.java
@@ -57,6 +57,7 @@ import io.trino.sql.ir.optimizer.rule.FlattenLogical;
 import io.trino.sql.ir.optimizer.rule.InlineTrivialLet;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantCaseClauses;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantCoalesceArguments;
+import io.trino.sql.ir.optimizer.rule.RemoveRedundantDateAdd;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantInItems;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantLogicalTerms;
 import io.trino.sql.ir.optimizer.rule.RemoveRedundantMatchClauses;
@@ -114,6 +115,7 @@ public class IrExpressionOptimizer
                 new RemoveRedundantCaseClauses(),
                 new RemoveRedundantTry(context),
                 new RemoveRedundantInItems(context),
+                new RemoveRedundantDateAdd(),
                 new SimplifyContinuousInValues(context),
                 new SimplifyRedundantCast(),
                 new SimplifyRedundantTryCast(context),

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/RemoveRedundantDateAdd.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/rule/RemoveRedundantDateAdd.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer.rule;
+
+import io.airlift.slice.Slice;
+import io.trino.Session;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.operator.scalar.TimeField;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimeWithTimeZoneType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.optimizer.IrOptimizerRule;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.metadata.GlobalFunctionCatalog.builtinFunctionName;
+import static io.trino.operator.scalar.DateTimeFunctions.isValidDateUnit;
+import static io.trino.operator.scalar.DateTimeFunctions.isValidTimestampUnit;
+
+/**
+ * Replaces {@code date_add(unit, 0, x)} with {@code x}. Adding zero of any unit leaves the value
+ * unchanged, so the call does not need to be evaluated at runtime.
+ * <p>
+ * The unit must be a constant that {@code date_add} accepts for {@code x}'s type, so that a call
+ * with an invalid unit keeps failing.
+ */
+public class RemoveRedundantDateAdd
+        implements IrOptimizerRule
+{
+    @Override
+    public Optional<Expression> apply(Expression expression, Session session, SymbolAllocator symbolAllocator, Map<Symbol, Expression> bindings)
+    {
+        if (expression instanceof Call(ResolvedFunction function, List<Expression> arguments)
+                && function.name().equals(builtinFunctionName("date_add"))
+                && arguments.size() == 3) {
+            Expression unitExpression = arguments.get(0);
+            Expression amountExpression = arguments.get(1);
+            Expression dateTime = arguments.get(2);
+            if (unitExpression instanceof Constant(VarcharType _, Slice unit)
+                    && amountExpression instanceof Constant(Type _, Long amount)
+                    && amount == 0
+                    && isKnownValidUnit(dateTime.type(), unit)) {
+                return Optional.of(dateTime);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isKnownValidUnit(Type type, Slice unit)
+    {
+        return switch (type) {
+            case DateType _ -> isValidDateUnit(unit);
+            case TimeType _, TimeWithTimeZoneType _ -> TimeField.isValidUnit(unit);
+            case TimestampType _, TimestampWithTimeZoneType _ -> isValidTimestampUnit(unit);
+            default -> false;
+        };
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
@@ -3152,6 +3152,11 @@ public class TestTimestamp
         assertTrinoExceptionThrownBy(assertions.expression("date_diff('foo', TIMESTAMP '2001-01-31 19:34:55.111111111111', TIMESTAMP '2005-09-10 13:31:00.999999999999')")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
                 .hasMessage("'foo' is not a valid TIMESTAMP field");
+
+        assertThat(assertions.expression("date_add('millisecond', 0, TIMESTAMP '2020-05-10 12:34:56')")).matches("TIMESTAMP '2020-05-10 12:34:56'");
+        assertTrinoExceptionThrownBy(assertions.expression("date_add('invalid', 0, TIMESTAMP '2020-05-10 12:34:56')")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("'invalid' is not a valid TIMESTAMP field");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestRemoveRedundantDateAdd.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestRemoveRedundantDateAdd.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.spi.type.Type;
+import io.trino.sql.ir.Call;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.ir.optimizer.rule.RemoveRedundantDateAdd;
+import jakarta.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.TimeType.createTimeType;
+import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.analyzer.TypeDescriptorProvider.fromTypes;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.sql.planner.TestingSymbolAllocator.emptySymbolAllocator;
+import static io.trino.testing.TestingSession.testSession;
+import static io.trino.transaction.InMemoryTransactionManager.createTestTransactionManager;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestRemoveRedundantDateAdd
+{
+    private static final TestingFunctionResolution FUNCTIONS = new TestingFunctionResolution(createTestTransactionManager(), PLANNER_CONTEXT);
+
+    @Test
+    void testRemoveNoopDateAdd()
+    {
+        for (Type type : ImmutableList.of(DATE, createTimestampType(0), createTimestampType(9), createTimestampWithTimeZoneType(3))) {
+            Reference value = new Reference(type, "x");
+            assertThat(optimize(dateAdd("day", 0L, value)))
+                    .describedAs("date_add('day', 0, %s)".formatted(type))
+                    .isEqualTo(Optional.of(value));
+        }
+
+        for (Type type : ImmutableList.of(createTimeType(3), createTimeWithTimeZoneType(12), createTimestampType(6))) {
+            Reference value = new Reference(type, "x");
+            assertThat(optimize(dateAdd("second", 0L, value)))
+                    .describedAs("date_add('second', 0, %s)".formatted(type))
+                    .isEqualTo(Optional.of(value));
+        }
+    }
+
+    @Test
+    void testUnitMixedCase()
+    {
+        Reference value = new Reference(createTimestampType(3), "x");
+        assertThat(optimize(dateAdd("Quarter", 0L, value)))
+                .isEqualTo(Optional.of(value));
+        assertThat(optimize(dateAdd("qUArTeR", 0L, value)))
+                .isEqualTo(Optional.of(value));
+    }
+
+    @Test
+    void testNonZeroAmount()
+    {
+        assertThat(optimize(dateAdd("day", 1L, new Reference(createTimestampType(3), "x"))))
+                .isEmpty();
+    }
+
+    // Keep date_add with invalid unit. Do not mask failures.
+    @Test
+    void testInvalidUnit()
+    {
+        assertThat(optimize(dateAdd("millisecond", 0L, new Reference(DATE, "x"))))
+                .describedAs("date_add rejects sub-day units for date")
+                .isEmpty();
+
+        assertThat(optimize(dateAdd("day", 0L, new Reference(createTimeType(3), "x"))))
+                .describedAs("date_add rejects units above hour for time")
+                .isEmpty();
+
+        assertThat(optimize(dateAdd("millennium", 0L, new Reference(createTimestampType(3), "x"))))
+                .describedAs("date_add rejects unknown units")
+                .isEmpty();
+    }
+
+    // handled by other optimizers
+    @Test
+    void testNullArguments()
+    {
+        Reference value = new Reference(createTimestampType(3), "x");
+        assertThat(optimize(dateAdd(null, 0L, value)))
+                .describedAs("null unit")
+                .isEmpty();
+        assertThat(optimize(dateAdd("day", null, value)))
+                .describedAs("null amount")
+                .isEmpty();
+
+        Constant nullValue = new Constant(createTimestampType(3), null);
+        assertThat(optimize(dateAdd("day", 0L, nullValue)))
+                .describedAs("null value")
+                .isEqualTo(Optional.of(nullValue));
+    }
+
+    @Test
+    void testNonConstantUnit()
+    {
+        Reference value = new Reference(createTimestampType(3), "x");
+        Call call = new Call(
+                FUNCTIONS.resolveFunction("date_add", fromTypes(VARCHAR, BIGINT, value.type())),
+                ImmutableList.of(new Reference(VARCHAR, "unit"), new Constant(BIGINT, 0L), value));
+        assertThat(optimize(call))
+                .isEmpty();
+    }
+
+    @Test
+    void testNonConstantAmount()
+    {
+        Reference value = new Reference(createTimestampType(3), "x");
+        Call call = new Call(
+                FUNCTIONS.resolveFunction("date_add", fromTypes(VARCHAR, BIGINT, value.type())),
+                ImmutableList.of(new Constant(VARCHAR, utf8Slice("day")), new Reference(BIGINT, "amount"), value));
+        assertThat(optimize(call))
+                .isEmpty();
+    }
+
+    private static Call dateAdd(@Nullable String unit, @Nullable Long amount, Expression value)
+    {
+        return new Call(
+                FUNCTIONS.resolveFunction("date_add", fromTypes(VARCHAR, BIGINT, value.type())),
+                ImmutableList.of(
+                        new Constant(VARCHAR, unit == null ? null : utf8Slice(unit)),
+                        new Constant(BIGINT, amount),
+                        value));
+    }
+
+    private static Optional<Expression> optimize(Expression expression)
+    {
+        return new RemoveRedundantDateAdd().apply(expression, testSession(), emptySymbolAllocator(), ImmutableMap.of());
+    }
+}


### PR DESCRIPTION
date_add(unit, 0, x) leaves the value unchanged, so the call can be replaced with x when the unit is a constant valid for x's type.
