### PR TITLE
Fix unpushed VARCHAR predicates in Snowflake connector

### DIFF
--- a/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/SnowflakeClient.java
+++ b/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/SnowflakeClient.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.snowflake;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.trino.plugin.base.aggregation.AggregateFunctionRewriter;
@@ -34,6 +35,7 @@ import io.trino.plugin.jdbc.LongWriteFunction;
 import io.trino.plugin.jdbc.ObjectReadFunction;
 import io.trino.plugin.jdbc.ObjectWriteFunction;
 import io.trino.plugin.jdbc.PredicatePushdownController;
+import io.trino.plugin.jdbc.PreparedQuery;
 import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.SliceWriteFunction;
@@ -63,6 +65,7 @@ import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.Chars;
 import io.trino.spi.type.DateTimeEncoding;
@@ -79,7 +82,9 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
@@ -147,6 +152,7 @@ import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.math.RoundingMode.UNNECESSARY;
 import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 public class SnowflakeClient
         extends BaseJdbcClient
@@ -199,6 +205,29 @@ public class SnowflakeClient
                         .add(new ImplementRegrIntercept())
                         .add(new ImplementRegrSlope())
                         .build());
+    }
+
+    @Override
+    protected Map<String, CaseSensitivity> getCaseSensitivityForColumns(
+            ConnectorSession session,
+            Connection connection,
+            SchemaTableName schemaTableName,
+            RemoteTableName remoteTableName)
+    {
+        // Snowflake's INFORMATION_SCHEMA.COLUMNS does not expose collation, so probe actual column
+        // metadata instead. Snowflake VARCHAR/CHAR columns are case sensitive by default.
+        PreparedQuery preparedQuery = new PreparedQuery(format("SELECT * FROM %s", quoted(remoteTableName)), ImmutableList.of());
+        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(this, session, connection, preparedQuery, Optional.empty())) {
+            ResultSetMetaData metadata = preparedStatement.getMetaData();
+            ImmutableMap.Builder<String, CaseSensitivity> columns = ImmutableMap.builder();
+            for (int column = 1; column <= metadata.getColumnCount(); column++) {
+                columns.put(metadata.getColumnLabel(column), metadata.isCaseSensitive(column) ? CASE_SENSITIVE : CASE_INSENSITIVE);
+            }
+            return columns.buildOrThrow();
+        }
+        catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, "Failed to get case sensitivity for columns. " + requireNonNullElse(e.getMessage(), e), e);
+        }
     }
 
     @Override

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConnectorTest.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConnectorTest.java
@@ -157,6 +157,16 @@ public class TestSnowflakeConnectorTest
     }
 
     @Test
+    public void testIsNotNullAndLimitPushdown()
+    {
+        // Regression test: a VARCHAR column reported as case sensitive should get FULL_PUSHDOWN,
+        // letting both the IS NOT NULL filter and the LIMIT push down to Snowflake instead of
+        // Trino reading the whole column and applying both locally.
+        assertThat(query("SELECT comment FROM nation WHERE comment IS NOT NULL LIMIT 3"))
+                .isFullyPushedDown();
+    }
+
+    @Test
     public void testViews()
     {
         String tableName = "test_view_" + randomNameSuffix();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Adds `getCaseSensitivityForColumns()` to `SnowflakeClient`. Without it, every VARCHAR/CHAR column defaults to `CASE_INSENSITIVE`, which routes them through `PredicatePushdownController.CASE_INSENSITIVE_CHARACTER_PUSHDOWN` -- a controller that only pushes discrete value sets. Non-discrete predicates like `IS NOT NULL` are left unpushed, which in turn leaves a `FilterNode` between `LIMIT` and the table scan, blocking `LIMIT` pushdown too. Net effect: queries like `SELECT col FROM t WHERE col IS NOT NULL LIMIT 3` read back the entire column and filter/limit locally instead of in Snowflake.

Snowflake string columns are case sensitive by default, but `information_schema.columns.collation_name` isn't populated on Snowflake, so there's no catalog query to read real per-column collation from (unlike `SqlServerClient`). This mirrors `MySqlClient`'s approach instead: probe real case sensitivity via `ResultSetMetaData.isCaseSensitive()` on a lightweight prepared query -- the same mechanism `BaseJdbcClient` already uses for its own query-passthrough path.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- Fixes #31060

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes
(x) Release notes are required, with the following suggested text:

```markdown
## Snowflake connector
* Fix predicate and limit pushdown for `VARCHAR`/`CHAR` columns. ({issue}`31060`)
```
