### PR TITLE
Disable broken JDK EA on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         include:
           - { java-version: 25.0.4, cache: 'true', cleanup-node: true }
           - { java-version: 26, cache: 'restore', cleanup-node: true }
-          - { java-version: 27-ea, cache: 'restore', cleanup-node: true }
+          #- { java-version: 27-ea, cache: 'restore', cleanup-node: true }
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7.0.1


### PR DESCRIPTION
Install Java action currently fails for 27-ea JDK. Disable temporarily.

example: https://github.com/trinodb/trino/actions/runs/34402919580/job/102638903724

```

Run actions/setup-java@v6.0.0
32s
Run actions/setup-java@v6.0.0
Installed distributions
    Trying to resolve the latest version from remote
    Resolved latest version as 27.0.0+35.0.ea
    Trying to download...
    Downloading Java 27.0.0+35.0.ea (Temurin-Hotspot) from https://github.com/adoptium/temurin27-binaries/releases/download/jdk-27%2B35-ea-beta/OpenJDK27U-jdk_x64_linux_hotspot_27_35-ea.tar.gz ...
    Error: Java setup process failed due to: Checksum verification failed for Temurin-Hotspot version 27.0.0+35.0.ea: sha256 expected 8f2b21d827d4bccc7b3fe0ef0cdc4b5d1ffaa47b587bb3c8dcb8eec3e57c95b0, actual bc2676d99d27fb3bb28fd8cef928d8eb1f20eb388b72d291875ed8b08b25bff4.
    Error: Checksum verification failed for Temurin-Hotspot version 27.0.0+35.0.ea: sha256 expected 8f2b21d827d4bccc7b3fe0ef0cdc4b5d1ffaa47b587bb3c8dcb8eec3e57c95b0, actual bc2676d99d27fb3bb28fd8cef928d8eb1f20eb388b72d291875ed8b08b25bff4.

```
