### PR TITLE
Fix IrExpressionEvaluator result for IN with empty list

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
@@ -122,6 +122,16 @@ public class InCodeGenerator
         Type type = valueExpression.type();
         Class<?> javaType = type.getJavaType();
 
+        if (testExpressions.isEmpty()) {
+            // an empty IN list is an empty disjunction, i.e. false, regardless of the value
+            return new BytecodeBlock()
+                    .comment("IN ()")
+                    .append(generatorContext.generate(valueExpression))
+                    .pop(javaType)
+                    .append(generatorContext.wasNull().set(constantFalse()))
+                    .push(false);
+        }
+
         SwitchGenerationCase switchGenerationCase = checkSwitchGenerationCase(type, testExpressions);
 
         MethodHandle equalsMethodHandle = generatorContext.getScalarFunctionImplementation(resolvedEqualsFunction, simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL)).getMethodHandle();

--- a/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ir/optimizer/IrExpressionEvaluator.java
@@ -226,6 +226,11 @@ public class IrExpressionEvaluator
     {
         Object value = evaluate(expression.value(), session, bindings);
 
+        if (expression.valueList().isEmpty()) {
+            // an empty IN list is an empty disjunction, i.e. false, regardless of the value
+            return false;
+        }
+
         if (value == null) {
             return null;
         }

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestInCodeGenerator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestInCodeGenerator.java
@@ -13,16 +13,29 @@
  */
 package io.trino.sql.gen;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slices;
 import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.project.PageProjection;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.SourcePage;
 import io.trino.sql.ir.Constant;
 import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.In;
+import io.trino.sql.ir.Reference;
+import io.trino.sql.planner.Symbol;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import static io.trino.block.BlockAssertions.createLongsBlock;
+import static io.trino.operator.project.SelectedPositions.positionsRange;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -33,11 +46,34 @@ import static io.trino.sql.gen.InCodeGenerator.SwitchGenerationCase.SET_CONTAINS
 import static io.trino.sql.gen.InCodeGenerator.checkSwitchGenerationCase;
 import static io.trino.sql.ir.IrExpressions.call;
 import static io.trino.sql.ir.IrExpressions.constantNull;
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static io.trino.type.CharVarcharCoercion.SQL_STANDARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestInCodeGenerator
 {
     private final TestingFunctionResolution functionResolution = new TestingFunctionResolution();
+
+    @Test
+    void testEmptyList()
+    {
+        PageProjection projection = functionResolution.getPageFunctionCompiler()
+                .compileProjection(
+                        new In(new Reference(BIGINT, "value"), ImmutableList.of()),
+                        ImmutableMap.of(new Symbol(BIGINT, "value"), 0),
+                        SQL_STANDARD,
+                        Optional.empty())
+                .get();
+
+        Page page = new Page(createLongsBlock(1L, null));
+        SourcePage inputPage = projection.getInputChannels().getInputChannels(SourcePage.create(page));
+        Block result = projection.project(SESSION, inputPage, positionsRange(0, page.getPositionCount()));
+
+        assertThat(BOOLEAN.getObjectValue(result, 0)).isEqualTo(false);
+        assertThat(BOOLEAN.getObjectValue(result, 1))
+                .describedAs("null value")
+                .isEqualTo(false);
+    }
 
     @Test
     public void testInteger()

--- a/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestIrExpressionEvaluator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ir/optimizer/TestIrExpressionEvaluator.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.ir.optimizer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.ir.Constant;
+import io.trino.sql.ir.Expression;
+import io.trino.sql.ir.In;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.testing.TestingSession.testSession;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIrExpressionEvaluator
+{
+    @Test
+    void testIn()
+    {
+        assertThat(evaluate(new In(new Constant(BIGINT, null), ImmutableList.of())))
+                .describedAs("null value, empty list")
+                .isEqualTo(false);
+
+        assertThat(evaluate(new In(new Constant(BIGINT, 1L), ImmutableList.of())))
+                .describedAs("empty list")
+                .isEqualTo(false);
+
+        assertThat(evaluate(new In(new Constant(BIGINT, null), ImmutableList.of(new Constant(BIGINT, 1L)))))
+                .describedAs("null value")
+                .isNull();
+    }
+
+    private static Object evaluate(Expression expression)
+    {
+        return new IrExpressionEvaluator(PLANNER_CONTEXT).evaluate(expression, testSession(), ImmutableMap.of());
+    }
+}


### PR DESCRIPTION
An empty IN list is an empty disjunction, so the result is false even when the value is null. The evaluator returned null instead, disagreeing with the EvaluateIn optimizer rule.

- fixes https://github.com/trinodb/trino/issues/31064