### PR TITLE
Fix Delta Lake temporal time travel skipping versions

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TemporalTimeTravelUtil.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TemporalTimeTravelUtil.java
@@ -168,7 +168,7 @@ public final class TemporalTimeTravelUtil
         ImmutableList.Builder<Callable<Long>> versionSearchTasks = ImmutableList.builder();
         for (long start = 0; start <= end; start += maxLinearSearchSize) {
             long head = start;
-            long tail = start + maxLinearSearchSize - 1;
+            long tail = Math.min(end, start + maxLinearSearchSize - 1);
             versionSearchTasks.add(() -> searchTowardsHeadLinear(fileSystem, head, tail, transactionLogDir, epochMillis));
         }
         try {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -2272,6 +2272,28 @@ public class TestDeltaLakeBasic
     }
 
     /**
+     * @see deltalake.multipart_checkpoint
+     */
+    @Test
+    public void testTemporalTimeTravelUtilParallelSearchWithPartialFinalRange()
+            throws Exception
+    {
+        String tableName = "test_time_travel_util_parallel_partial_range_" + randomNameSuffix();
+        Path tableLocation = catalogDir.resolve(tableName);
+        copyDirectoryContents(new File(Resources.getResource("deltalake/multipart_checkpoint").toURI()).toPath(), tableLocation);
+        assertUpdate("CALL system.register_table(CURRENT_SCHEMA, '%s', '%s')".formatted(tableName, tableLocation.toUri()));
+
+        try (ExecutorService executorService = Executors.newCachedThreadPool()) {
+            // Version 5's commit timestamp
+            long version5CommitTimeMillis = Instant.parse("2023-10-16T06:53:09.907Z").toEpochMilli();
+            assertThat(findLatestVersionUsingTemporal(FILE_SYSTEM, tableLocation.toString(), version5CommitTimeMillis, executorService, 5)).isEqualTo(5);
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    /**
      * @see deltalake.partition_values_parsed
      */
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

The final search range in `searchTowardsHeadParallel()` wasn't capped
at the last pre-checkpoint version, so it could start at a nonexistent
version and skip that range entirely — causing `FOR TIMESTAMP AS OF`
to return a stale version. This caps the range and adds a regression
test.

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- Fixes https://github.com/trinodb/trino/issues/31057

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Delta Lake
* Fix incorrect query results for `FOR TIMESTAMP AS OF` when the last checkpoint version is not an exact multiple of the linear search size.  ({issue}`31057`)
```
