### PR TITLE
Fix IN equality over REAL NaN and time/timestamp with time zone

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
@@ -54,6 +54,7 @@ import static io.trino.spi.function.OperatorType.INDETERMINATE;
 import static io.trino.sql.gen.BytecodeUtils.ifWasNullPopAndGoto;
 import static io.trino.sql.gen.BytecodeUtils.invoke;
 import static io.trino.sql.gen.BytecodeUtils.loadConstant;
+import static io.trino.util.FastutilSetHelper.isDirectLongComparisonValidType;
 import static io.trino.util.FastutilSetHelper.toFastutilHashSet;
 import static java.lang.Math.toIntExact;
 
@@ -94,7 +95,10 @@ public class InCodeGenerator
             return SwitchGenerationCase.SET_CONTAINS;
         }
 
-        if (type.getJavaType() != long.class) {
+        // A white-list is used to select types eligible for DIRECT_SWITCH.
+        // For other types the long representation is not a faithful identity, e.g. REAL NaN
+        // is equal to itself bit-wise, but the EQUAL operator returns false for it.
+        if (!isDirectLongComparisonValidType(type)) {
             return SwitchGenerationCase.HASH_SWITCH;
         }
         for (Expression expression : values) {
@@ -184,8 +188,6 @@ public class InCodeGenerator
 
         switch (switchGenerationCase) {
             case DIRECT_SWITCH -> {
-                // A white-list is used to select types eligible for DIRECT_SWITCH.
-                // For these types, it's safe to not use Trino HASH_CODE and EQUAL operator.
                 for (Object constantValue : constantValues) {
                     switchBuilder.addCase(toIntExact((Long) constantValue), jump(match));
                 }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/columnar/InColumnarFilterGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/columnar/InColumnarFilterGenerator.java
@@ -89,6 +89,7 @@ import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.generateBlockPosi
 import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.generateGetInputChannels;
 import static io.trino.sql.gen.columnar.ColumnarFilterCompiler.updateOutputPositions;
 import static io.trino.util.CompilerUtils.makeClassName;
+import static io.trino.util.FastutilSetHelper.isDirectLongComparisonValidType;
 import static io.trino.util.FastutilSetHelper.toFastutilHashSet;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -206,8 +207,6 @@ public class InColumnarFilterGenerator
         }
 
         if (useSwitchCase) {
-            // A white-list is used to select types eligible for DIRECT_SWITCH.
-            // For these types, it's safe to not use Trino HASH_CODE and EQUAL operator.
             LabelNode end = new LabelNode("end");
             LabelNode match = new LabelNode("match");
             LabelNode defaultLabel = new LabelNode("default");
@@ -287,7 +286,10 @@ public class InColumnarFilterGenerator
             return false;
         }
 
-        if (type.getJavaType() != long.class) {
+        // A white-list is used to select types eligible for switch case generation.
+        // For other types the long representation is not a faithful identity, e.g. REAL NaN
+        // is equal to itself bit-wise, but the EQUAL operator returns false for it.
+        if (!isDirectLongComparisonValidType(type)) {
             return false;
         }
         for (Expression expression : values) {

--- a/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
+++ b/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
@@ -452,10 +452,12 @@ public final class FastutilSetHelper
         return new LongBitSetFilter(values, min, max);
     }
 
-    private static boolean isDirectLongComparisonValidType(Type type)
+    /**
+     * Types for which the {@code long} representation can be compared and hashed directly,
+     * instead of going through the type specific EQUAL and HASH_CODE operators.
+     */
+    public static boolean isDirectLongComparisonValidType(Type type)
     {
-        // Types for which we can safely use equality and hashCode on the stored long value
-        // instead of going through type specific methods
         return type instanceof TinyintType ||
                 type instanceof SmallintType ||
                 type instanceof IntegerType ||

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
@@ -3051,6 +3051,21 @@ public class TestTimestampWithTimeZone
                 .neverFails();
     }
 
+    @Test
+    public void testIn()
+    {
+        // A short IN list of values close to the epoch makes the compiler switch over the raw long representation,
+        // which packs the time zone, while equality compares the instant only.
+        // A single-element list would be rewritten to an equality comparison.
+        assertThat(assertions.expression("a IN (TIMESTAMP '1970-01-01 01:00:00 Europe/Warsaw', TIMESTAMP '1970-01-01 00:00:02 UTC')")
+                .binding("a", "TIMESTAMP '1970-01-01 00:00:00 UTC'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a IN (TIMESTAMP '1970-01-01 01:00:00 Europe/Warsaw', TIMESTAMP '1970-01-01 00:00:02 UTC')")
+                .binding("a", "TIMESTAMP '1970-01-01 00:00:01 UTC'"))
+                .isEqualTo(false);
+    }
+
     private BiFunction<Session, QueryRunner, Object> timestampWithTimeZone(int precision, int year, int month, int day, int hour, int minute, int second, long picoOfSecond, TimeZoneKey timeZoneKey)
     {
         return (_, _) -> {

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestInCodeGenerator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestInCodeGenerator.java
@@ -39,6 +39,7 @@ import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.gen.InCodeGenerator.SwitchGenerationCase.DIRECT_SWITCH;
 import static io.trino.sql.gen.InCodeGenerator.SwitchGenerationCase.HASH_SWITCH;
@@ -48,6 +49,7 @@ import static io.trino.sql.ir.IrExpressions.call;
 import static io.trino.sql.ir.IrExpressions.constantNull;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.type.CharVarcharCoercion.SQL_STANDARD;
+import static java.lang.Float.floatToRawIntBits;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestInCodeGenerator
@@ -139,6 +141,29 @@ public class TestInCodeGenerator
 
         values.add(new Constant(DATE, 33L));
         assertThat(checkSwitchGenerationCase(DATE, values)).isEqualTo(SET_CONTAINS);
+    }
+
+    @Test
+    public void testReal()
+    {
+        // REAL is not eligible for DIRECT_SWITCH: the underlying long is the raw float bits,
+        // for which direct comparison disagrees with the EQUAL operator (e.g. for NaN)
+        List<Expression> values = new ArrayList<>();
+        values.add(new Constant(REAL, (long) floatToRawIntBits(1.5f)));
+        values.add(new Constant(REAL, (long) floatToRawIntBits(2.5f)));
+        values.add(new Constant(REAL, (long) floatToRawIntBits(Float.NaN)));
+        assertThat(checkSwitchGenerationCase(REAL, values)).isEqualTo(HASH_SWITCH);
+
+        values.add(constantNull(REAL));
+        assertThat(checkSwitchGenerationCase(REAL, values)).isEqualTo(HASH_SWITCH);
+
+        for (int i = 5; i <= 7; ++i) {
+            values.add(new Constant(REAL, (long) floatToRawIntBits(i + 0.5f)));
+        }
+        assertThat(checkSwitchGenerationCase(REAL, values)).isEqualTo(HASH_SWITCH);
+
+        values.add(new Constant(REAL, (long) floatToRawIntBits(8.5f)));
+        assertThat(checkSwitchGenerationCase(REAL, values)).isEqualTo(SET_CONTAINS);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestRealOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRealOperators.java
@@ -306,6 +306,31 @@ public class TestRealOperators
     }
 
     @Test
+    public void testIn()
+    {
+        assertThat(assertions.expression("a IN (REAL '12.34')")
+                .binding("a", "REAL '12.34'"))
+                .isEqualTo(true);
+
+        assertThat(assertions.expression("a IN (REAL '12.34')")
+                .binding("a", "REAL '23.45'"))
+                .isEqualTo(false);
+
+        // NaN is not equal to itself, also when the IN list is small enough for a switch over raw float bits
+        assertThat(assertions.expression("a IN (REAL 'NaN')")
+                .binding("a", "REAL 'NaN'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a IN (REAL '12.34', REAL 'NaN', REAL '23.45')")
+                .binding("a", "REAL 'NaN'"))
+                .isEqualTo(false);
+
+        assertThat(assertions.expression("a IN (REAL '1', REAL '2', REAL '3', REAL '4', REAL '5', REAL '6', REAL '7', REAL 'NaN')")
+                .binding("a", "REAL 'NaN'"))
+                .isEqualTo(false);
+    }
+
+    @Test
     public void testNotEqual()
     {
         assertThat(assertions.expression("a <> b")


### PR DESCRIPTION
InCodeGenerator and InColumnarFilterGenerator generated a switch over the raw long representation for every type whose Java type is long. That is only a faithful identity for some of them: REAL stores raw float bits, so `REAL 'NaN' IN (REAL 'NaN')` matched bit-wise and returned true, while the EQUAL operator (and the interpreter) return false. The types with a packed time zone are affected the same way, in the other direction.

Reuse the existing FastutilSetHelper whitelist to decide when direct long comparison is valid; other long-backed types now go through EQUAL and HASH_CODE.

- fixes https://github.com/trinodb/trino/issues/31069
- fixes https://github.com/trinodb/trino/issues/31080