### PR TITLE
Fix DomainTranslator's IDENTICAL over a coerced cast

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -696,11 +696,12 @@ public final class DomainTranslator
             // Handle comparisons against a non-NaN value when the compared value might be NaN
             return switch (comparisonOperator) {
                 /*
-                 For comparison operators: EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL,
-                 the Domain should not contain NaN, but complemented Domain should contain NaN. It is currently not supported.
+                 For comparison operators: EQUAL, IDENTICAL, GREATER_THAN, GREATER_THAN_OR_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL,
+                 the Domain should not contain NaN, but complemented Domain should contain NaN (for IDENTICAL, null as well).
+                 It is currently not supported.
                  Currently, NaN is only included when ValueSet.isAll().
 
-                 For comparison operators: NOT_EQUAL, IS_DISTINCT_FROM,
+                 For comparison operator NOT_EQUAL,
                  the Domain should consist of ranges (which do not sum to the whole ValueSet), and NaN.
                  Currently, NaN is only included when ValueSet.isAll().
                   */

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -98,7 +98,6 @@ import static io.trino.sql.ir.Booleans.TRUE;
 import static io.trino.sql.ir.ComparisonOperator.EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN;
 import static io.trino.sql.ir.ComparisonOperator.GREATER_THAN_OR_EQUAL;
-import static io.trino.sql.ir.ComparisonOperator.IDENTICAL;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN;
 import static io.trino.sql.ir.ComparisonOperator.LESS_THAN_OR_EQUAL;
 import static io.trino.sql.ir.ComparisonOperator.NOT_EQUAL;
@@ -572,13 +571,10 @@ public final class DomainTranslator
 
             // superset of possible values, for the "normal case"
             ValueSet valueSet;
-            boolean nullAllowed = false;
 
             switch (operator) {
-                case EQUAL, IDENTICAL -> {
-                    valueSet = dateStringRanges(date, sourceType);
-                    nullAllowed = operator == IDENTICAL;
-                }
+                // the value is not null, so a null source value satisfies neither EQUAL (unknown) nor IDENTICAL (false)
+                case EQUAL, IDENTICAL -> valueSet = dateStringRanges(date, sourceType);
                 case NOT_EQUAL -> {
                     if (date.getDayOfMonth() < 10) {
                         // TODO: possible to handle but cumbersome
@@ -601,7 +597,7 @@ public final class DomainTranslator
                     Range.greaterThan(sourceType, utf8Slice("9"))));
 
             return Optional.of(new ExtractionResult(
-                    TupleDomain.withColumnDomains(ImmutableMap.of(sourceSymbol, Domain.create(valueSet, nullAllowed))),
+                    TupleDomain.withColumnDomains(ImmutableMap.of(sourceSymbol, Domain.create(valueSet, false))),
                     originalExpression));
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -823,9 +823,10 @@ public final class DomainTranslator
                     yield or(comparison(metadata, getCharVarcharCoercion(session), EQUAL, symbolExpression, coercedLiteral),
                             comparison(metadata, getCharVarcharCoercion(session), NOT_EQUAL, symbolExpression, coercedLiteral));
                 }
+                // IDENTICAL is null-safe, so an unsatisfiable predicate is FALSE, not "false for all non-null values"
                 case IDENTICAL -> coercedValueIsEqualToOriginal ?
-                        TRUE :
-                        comparison(metadata, getCharVarcharCoercion(session), comparisonOperator, symbolExpression, coercedLiteral);
+                        comparison(metadata, getCharVarcharCoercion(session), comparisonOperator, symbolExpression, coercedLiteral) :
+                        FALSE;
             };
         }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
@@ -924,6 +924,16 @@ public class TestDomainTranslator
                                 Range.greaterThan(VARCHAR, utf8Slice("9"))),
                         false)));
 
+        // IDENTICAL, same as = because the value is not null
+        assertPredicateDerives(
+                comparison(IDENTICAL, cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2005-9-10")))),
+                tupleDomain(C_VARCHAR, Domain.create(ValueSet.ofRanges(
+                                Range.lessThan(VARCHAR, utf8Slice("1")),
+                                Range.range(VARCHAR, utf8Slice("2005-09-10"), true, utf8Slice("2005-09-11"), false),
+                                Range.range(VARCHAR, utf8Slice("2005-9-10"), true, utf8Slice("2005-9-11"), false),
+                                Range.greaterThan(VARCHAR, utf8Slice("9"))),
+                        false)));
+
         // !=
         assertPredicateDerives(
                 notEqual(cast(C_VARCHAR, DATE), new Constant(DATE, (long) DateTimeUtils.parseDate(utf8Slice("2005-9-10")))),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -834,6 +835,28 @@ public class TestDomainTranslator
         assertPredicateIsAlwaysFalse(equal(cast(C_TINYINT, DOUBLE), nanDouble));
         assertPredicateIsAlwaysFalse(equal(cast(C_SMALLINT, DOUBLE), nanDouble));
         assertPredicateIsAlwaysFalse(equal(cast(C_INTEGER, DOUBLE), nanDouble));
+    }
+
+    @Test
+    public void testIdenticalOverCoercedCast()
+    {
+        Expression decimal425 = new Constant(createDecimalType(20, 1), Decimals.encodeScaledValue(new BigDecimal("42.5"), 1));
+
+        // CAST(c_integer AS bigint) IS NOT DISTINCT FROM BIGINT '42' holds exactly for c_integer = 42
+        assertPredicateTranslates(
+                comparison(IDENTICAL, cast(C_INTEGER, BIGINT), bigintLiteral(42L)),
+                tupleDomain(C_INTEGER, Domain.singleValue(INTEGER, 42L)));
+        assertPredicateTranslates(
+                isDistinctFrom(cast(C_INTEGER, BIGINT), bigintLiteral(42L)),
+                tupleDomain(C_INTEGER, Domain.create(ValueSet.ofRanges(Range.lessThan(INTEGER, 42L), Range.greaterThan(INTEGER, 42L)), true)));
+
+        // no integer value casts to BIGINT '2147483648'
+        assertPredicateIsAlwaysFalse(comparison(IDENTICAL, cast(C_INTEGER, BIGINT), bigintLiteral(Integer.MAX_VALUE + 1L)));
+        assertPredicateIsAlwaysTrue(isDistinctFrom(cast(C_INTEGER, BIGINT), bigintLiteral(Integer.MAX_VALUE + 1L)));
+
+        // no bigint value casts to DECIMAL '42.5'
+        assertPredicateIsAlwaysFalse(comparison(IDENTICAL, cast(C_BIGINT, createDecimalType(20, 1)), decimal425));
+        assertPredicateIsAlwaysTrue(isDistinctFrom(cast(C_BIGINT, createDecimalType(20, 1)), decimal425));
     }
 
     @Test
@@ -1658,7 +1681,7 @@ public class TestDomainTranslator
 
     private static Expression isDistinctFrom(Symbol symbol, Expression expression)
     {
-        return not(comparison(IDENTICAL, symbol.toSymbolReference(), expression));
+        return isDistinctFrom(symbol.toSymbolReference(), expression);
     }
 
     private Call like(Symbol symbol, String pattern)
@@ -1761,6 +1784,11 @@ public class TestDomainTranslator
     private static Expression lessThanOrEqual(Expression left, Expression right)
     {
         return comparison(LESS_THAN_OR_EQUAL, left, right);
+    }
+
+    private static Expression isDistinctFrom(Expression left, Expression right)
+    {
+        return not(comparison(IDENTICAL, left, right));
     }
 
     private static Expression not(Expression expression)


### PR DESCRIPTION
The two arms of the IDENTICAL case in rewriteComparisonExpression were swapped when 85feebc20d3 replaced IS_DISTINCT_FROM with the negated IDENTICAL operator: a literal that round-trips through the coercion yielded TRUE (dropping the predicate), and one that does not yielded a comparison against the rounded literal (matching a wrong value) instead of FALSE.

Since IDENTICAL is null-safe, an unsatisfiable predicate is plain FALSE, unlike EQUAL which needs an expression that is false only for non-null values.

- fixes https://github.com/trinodb/trino/issues/31084