### PR TITLE
Add DIRECT transformation subtypes to column lineage

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -272,8 +272,8 @@ public class Analysis
 
     // row id field for update/delete queries
     private final Map<NodeRef<Table>, FieldReference> rowIdField = new LinkedHashMap<>();
-    // Column lineage: for each output field, the transformation type of every source column that feeds it.
-    private final Map<Field, Map<SourceColumn, ColumnTransformationType>> originColumnDetails = new LinkedHashMap<>();
+    // for each output field, the transformation types of every source column that feeds it
+    private final Map<Field, Map<SourceColumn, Set<ColumnTransformationType>>> originColumnDetails = new LinkedHashMap<>();
     private final Multimap<NodeRef<Expression>, Field> fieldLineage = ArrayListMultimap.create();
 
     private Optional<TableExecuteHandle> tableExecuteHandle = Optional.empty();
@@ -289,13 +289,14 @@ public class Analysis
     private final Map<NodeRef<Table>, List<Field>> materializedViewStorageTableFields = new LinkedHashMap<>();
 
     /**
-     * Combines the transformation types found when the same source column reaches one output column through several
-     * paths (for example a UNION branch, or a column referenced twice). Keep the lowest rank, so any path that still
-     * exposes the raw value wins.
+     * Merges the transformation types found when the same source column reaches one output column through several paths
+     * (for example the branches of a UNION, or a column referenced twice). Iteration order is preserved for deterministic emission.
      */
-    public static ColumnTransformationType combineAcrossPaths(ColumnTransformationType left, ColumnTransformationType right)
+    public static Set<ColumnTransformationType> mergeAcrossPaths(Set<ColumnTransformationType> left, Set<ColumnTransformationType> right)
     {
-        return left.getDerivationRank() <= right.getDerivationRank() ? left : right;
+        Set<ColumnTransformationType> merged = new LinkedHashSet<>(left);
+        merged.addAll(right);
+        return merged;
     }
 
     /**
@@ -1458,26 +1459,27 @@ public class Analysis
 
     public void addSourceColumns(Field field, Set<SourceColumn> sourceColumns, ColumnTransformationType transformationType)
     {
-        Map<SourceColumn, ColumnTransformationType> edges = originColumnDetails.computeIfAbsent(field, _ -> new LinkedHashMap<>());
+        Map<SourceColumn, Set<ColumnTransformationType>> edges = originColumnDetails.computeIfAbsent(field, _ -> new LinkedHashMap<>());
+        Set<ColumnTransformationType> localTypes = ImmutableSet.of(transformationType);
         for (SourceColumn sourceColumn : sourceColumns) {
-            edges.merge(sourceColumn, transformationType, Analysis::combineAcrossPaths);
+            edges.merge(sourceColumn, localTypes, Analysis::mergeAcrossPaths);
         }
     }
 
-    public void addSourceColumns(Field field, Map<SourceColumn, ColumnTransformationType> sourceColumnTransformationTypes)
+    public void addSourceColumns(Field field, Map<SourceColumn, Set<ColumnTransformationType>> sourceColumnTransformationTypes)
     {
-        Map<SourceColumn, ColumnTransformationType> edges = originColumnDetails.computeIfAbsent(field, _ -> new LinkedHashMap<>());
-        sourceColumnTransformationTypes.forEach((sourceColumn, transformationType) -> edges.merge(sourceColumn, transformationType, Analysis::combineAcrossPaths));
+        Map<SourceColumn, Set<ColumnTransformationType>> edges = originColumnDetails.computeIfAbsent(field, _ -> new LinkedHashMap<>());
+        sourceColumnTransformationTypes.forEach((sourceColumn, transformationTypes) -> edges.merge(sourceColumn, transformationTypes, Analysis::mergeAcrossPaths));
     }
 
     public Set<SourceColumn> getSourceColumns(Field field)
     {
         return originColumnDetails.getOrDefault(field, ImmutableMap.of()).entrySet().stream()
-                .map(entry -> entry.getKey().withTransformationType(entry.getValue()))
+                .map(entry -> entry.getKey().withTransformationTypes(entry.getValue()))
                 .collect(toImmutableSet());
     }
 
-    public Map<SourceColumn, ColumnTransformationType> getSourceColumnTransformationTypes(Field field)
+    public Map<SourceColumn, Set<ColumnTransformationType>> getSourceColumnTransformationTypes(Field field)
     {
         return ImmutableMap.copyOf(originColumnDetails.getOrDefault(field, ImmutableMap.of()));
     }
@@ -2481,19 +2483,19 @@ public class Analysis
     {
         private final QualifiedObjectName tableName;
         private final String columnName;
-        private final Optional<ColumnTransformationType> transformationType;
+        private final Set<ColumnTransformationType> transformationTypes;
 
         public SourceColumn(QualifiedObjectName tableName, String columnName)
         {
-            this(tableName, columnName, Optional.empty());
+            this(tableName, columnName, ImmutableSet.of());
         }
 
         @JsonCreator
-        public SourceColumn(@JsonProperty("tableName") QualifiedObjectName tableName, @JsonProperty("columnName") String columnName, @JsonProperty("transformationType") Optional<ColumnTransformationType> transformationType)
+        public SourceColumn(@JsonProperty("tableName") QualifiedObjectName tableName, @JsonProperty("columnName") String columnName, @JsonProperty("transformationTypes") Set<ColumnTransformationType> transformationTypes)
         {
             this.tableName = requireNonNull(tableName, "tableName is null");
             this.columnName = requireNonNull(columnName, "columnName is null");
-            this.transformationType = requireNonNull(transformationType, "transformationType is null");
+            this.transformationTypes = transformationTypes == null ? ImmutableSet.of() : ImmutableSet.copyOf(transformationTypes);
         }
 
         @JsonProperty
@@ -2509,22 +2511,22 @@ public class Analysis
         }
 
         @JsonProperty
-        public Optional<ColumnTransformationType> getTransformationType()
+        public Set<ColumnTransformationType> getTransformationTypes()
         {
-            return transformationType;
+            return transformationTypes;
         }
 
-        public SourceColumn withTransformationType(ColumnTransformationType transformationType)
+        public SourceColumn withTransformationTypes(Set<ColumnTransformationType> transformationTypes)
         {
-            return new SourceColumn(tableName, columnName, Optional.of(transformationType));
+            return new SourceColumn(tableName, columnName, transformationTypes);
         }
 
         public ColumnDetail getColumnDetail()
         {
-            return new ColumnDetail(tableName.catalogName(), tableName.schemaName(), tableName.objectName(), columnName, transformationType);
+            return new ColumnDetail(tableName.catalogName(), tableName.schemaName(), tableName.objectName(), columnName, transformationTypes);
         }
 
-        // transformationType is excluded from equals/hashCode: it is advisory derivation metadata, not identity.
+        // transformationTypes is excluded from equals/hashCode: it is advisory derivation metadata, not identity.
         @Override
         public int hashCode()
         {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -45,6 +45,7 @@ import io.trino.spi.eventlistener.ColumnDetail;
 import io.trino.spi.eventlistener.ColumnInfo;
 import io.trino.spi.eventlistener.ColumnLineageInfo;
 import io.trino.spi.eventlistener.ColumnMaskReferenceInfo;
+import io.trino.spi.eventlistener.ColumnTransformationType;
 import io.trino.spi.eventlistener.MaterializedViewReferenceInfo;
 import io.trino.spi.eventlistener.RoutineInfo;
 import io.trino.spi.eventlistener.RowFilterReferenceInfo;
@@ -271,7 +272,8 @@ public class Analysis
 
     // row id field for update/delete queries
     private final Map<NodeRef<Table>, FieldReference> rowIdField = new LinkedHashMap<>();
-    private final Multimap<Field, SourceColumn> originColumnDetails = ArrayListMultimap.create();
+    // Column lineage: for each output field, the transformation type of every source column that feeds it.
+    private final Map<Field, Map<SourceColumn, ColumnTransformationType>> originColumnDetails = new LinkedHashMap<>();
     private final Multimap<NodeRef<Expression>, Field> fieldLineage = ArrayListMultimap.create();
 
     private Optional<TableExecuteHandle> tableExecuteHandle = Optional.empty();
@@ -285,6 +287,26 @@ public class Analysis
     private final Set<NodeRef<Relation>> aliasedRelations = new LinkedHashSet<>();
     private final Set<NodeRef<TableFunctionInvocation>> polymorphicTableFunctions = new LinkedHashSet<>();
     private final Map<NodeRef<Table>, List<Field>> materializedViewStorageTableFields = new LinkedHashMap<>();
+
+    /**
+     * Combines the transformation types found when the same source column reaches one output column through several
+     * paths (for example a UNION branch, or a column referenced twice). Keep the lowest rank, so any path that still
+     * exposes the raw value wins.
+     */
+    public static ColumnTransformationType combineAcrossPaths(ColumnTransformationType left, ColumnTransformationType right)
+    {
+        return left.getDerivationRank() <= right.getDerivationRank() ? left : right;
+    }
+
+    /**
+     * Combines the transformation types found one step along a single path: how the source reached this field
+     * (upstream) composed with what this expression does to it (local). Keep the highest rank, so once a value
+     * is aggregated upstream the edge stays aggregated.
+     */
+    public static ColumnTransformationType combineAlongPath(ColumnTransformationType left, ColumnTransformationType right)
+    {
+        return left.getDerivationRank() >= right.getDerivationRank() ? left : right;
+    }
 
     public Analysis(@Nullable Statement root, Map<NodeRef<Parameter>, Expression> parameters, QueryType queryType)
     {
@@ -1434,14 +1456,30 @@ public class Analysis
                 .collect(toImmutableList());
     }
 
-    public void addSourceColumns(Field field, Set<SourceColumn> sourceColumn)
+    public void addSourceColumns(Field field, Set<SourceColumn> sourceColumns, ColumnTransformationType transformationType)
     {
-        originColumnDetails.putAll(field, sourceColumn);
+        Map<SourceColumn, ColumnTransformationType> edges = originColumnDetails.computeIfAbsent(field, _ -> new LinkedHashMap<>());
+        for (SourceColumn sourceColumn : sourceColumns) {
+            edges.merge(sourceColumn, transformationType, Analysis::combineAcrossPaths);
+        }
+    }
+
+    public void addSourceColumns(Field field, Map<SourceColumn, ColumnTransformationType> sourceColumnTransformationTypes)
+    {
+        Map<SourceColumn, ColumnTransformationType> edges = originColumnDetails.computeIfAbsent(field, _ -> new LinkedHashMap<>());
+        sourceColumnTransformationTypes.forEach((sourceColumn, transformationType) -> edges.merge(sourceColumn, transformationType, Analysis::combineAcrossPaths));
     }
 
     public Set<SourceColumn> getSourceColumns(Field field)
     {
-        return ImmutableSet.copyOf(originColumnDetails.get(field));
+        return originColumnDetails.getOrDefault(field, ImmutableMap.of()).entrySet().stream()
+                .map(entry -> entry.getKey().withTransformationType(entry.getValue()))
+                .collect(toImmutableSet());
+    }
+
+    public Map<SourceColumn, ColumnTransformationType> getSourceColumnTransformationTypes(Field field)
+    {
+        return ImmutableMap.copyOf(originColumnDetails.getOrDefault(field, ImmutableMap.of()));
     }
 
     public void addExpressionFields(Expression expression, Collection<Field> fields)
@@ -1449,11 +1487,9 @@ public class Analysis
         fieldLineage.putAll(NodeRef.of(expression), fields);
     }
 
-    public Set<SourceColumn> getExpressionSourceColumns(Expression expression)
+    public Collection<Field> getExpressionFields(Expression expression)
     {
-        return fieldLineage.get(NodeRef.of(expression)).stream()
-                .flatMap(field -> getSourceColumns(field).stream())
-                .collect(toImmutableSet());
+        return ImmutableList.copyOf(fieldLineage.get(NodeRef.of(expression)));
     }
 
     public void setRowIdField(Table table, FieldReference field)
@@ -2445,12 +2481,19 @@ public class Analysis
     {
         private final QualifiedObjectName tableName;
         private final String columnName;
+        private final Optional<ColumnTransformationType> transformationType;
+
+        public SourceColumn(QualifiedObjectName tableName, String columnName)
+        {
+            this(tableName, columnName, Optional.empty());
+        }
 
         @JsonCreator
-        public SourceColumn(@JsonProperty("tableName") QualifiedObjectName tableName, @JsonProperty("columnName") String columnName)
+        public SourceColumn(@JsonProperty("tableName") QualifiedObjectName tableName, @JsonProperty("columnName") String columnName, @JsonProperty("transformationType") Optional<ColumnTransformationType> transformationType)
         {
             this.tableName = requireNonNull(tableName, "tableName is null");
             this.columnName = requireNonNull(columnName, "columnName is null");
+            this.transformationType = requireNonNull(transformationType, "transformationType is null");
         }
 
         @JsonProperty
@@ -2465,11 +2508,23 @@ public class Analysis
             return columnName;
         }
 
-        public ColumnDetail getColumnDetail()
+        @JsonProperty
+        public Optional<ColumnTransformationType> getTransformationType()
         {
-            return new ColumnDetail(tableName.catalogName(), tableName.schemaName(), tableName.objectName(), columnName);
+            return transformationType;
         }
 
+        public SourceColumn withTransformationType(ColumnTransformationType transformationType)
+        {
+            return new SourceColumn(tableName, columnName, Optional.of(transformationType));
+        }
+
+        public ColumnDetail getColumnDetail()
+        {
+            return new ColumnDetail(tableName.catalogName(), tableName.schemaName(), tableName.objectName(), columnName, transformationType);
+        }
+
+        // transformationType is excluded from equals/hashCode: it is advisory derivation metadata, not identity.
         @Override
         public int hashCode()
         {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -5318,22 +5318,36 @@ class StatementAnalyzer
 
         /**
          * Classifies how a single-column SELECT expression derives its value such as {@code a + sum(b)}.
-         * A field is AGGREGATION only if every reference is inside an aggregate; otherwise TRANSFORMATION.
-         * Each field's local subtype is composed with its upstream subtype via {@link Analysis#combineAlongPath}.
-         * Duplicate edges to the same source column are merged via {@link Analysis#combineAcrossPaths}
+         * A field is AGGREGATION only if every reference is inside an aggregate, and TRANSFORMATION otherwise;
+         * a bare scalar subquery instead passes the subquery's own subtype through unchanged.
+         * Each upstream subtype of the field is composed with the field's local subtype via {@link Analysis#combineAlongPath},
+         * and edges to the same source column arriving through several fields are merged via {@link Analysis#mergeAcrossPaths}
+         * so every distinct subtype is preserved.
          */
-        private Map<SourceColumn, ColumnTransformationType> classifyTransformationTypes(Expression expression)
+        private Map<SourceColumn, Set<ColumnTransformationType>> classifyTransformationTypes(Expression expression)
         {
             Set<Field> freeFields = new LinkedHashSet<>();
             Set<Field> aggregatedFields = new LinkedHashSet<>();
             collectFreeAndAggregatedFields(expression, freeFields, aggregatedFields);
-            Map<SourceColumn, ColumnTransformationType> result = new LinkedHashMap<>();
+            Map<SourceColumn, Set<ColumnTransformationType>> result = new LinkedHashMap<>();
             for (Field field : analysis.getExpressionFields(expression)) {
-                ColumnTransformationType local = aggregatedFields.contains(field) && !freeFields.contains(field)
-                        ? ColumnTransformationType.AGGREGATION
-                        : ColumnTransformationType.TRANSFORMATION;
-                analysis.getSourceColumnTransformationTypes(field).forEach((sourceColumn, upstream) ->
-                        result.merge(sourceColumn, Analysis.combineAlongPath(upstream, local), Analysis::combineAcrossPaths));
+                ColumnTransformationType local;
+                // A bare scalar subquery just copies its single output column up, so we forward the subtype that column already determined in its own scope rather than relabel it.
+                // combineAlongPath(upstream, local) then reduces to upstream, since local = IDENTITY is the neutral element (lowest rank) that changes nothing.
+                if (expression instanceof SubqueryExpression) {
+                    local = ColumnTransformationType.IDENTITY;
+                }
+                else {
+                    local = aggregatedFields.contains(field) && !freeFields.contains(field)
+                            ? ColumnTransformationType.AGGREGATION
+                            : ColumnTransformationType.TRANSFORMATION;
+                }
+                analysis.getSourceColumnTransformationTypes(field).forEach((sourceColumn, upstreamTypes) -> {
+                    Set<ColumnTransformationType> composed = upstreamTypes.stream()
+                            .map(upstream -> Analysis.combineAlongPath(upstream, local))
+                            .collect(Collectors.toCollection(LinkedHashSet::new));
+                    result.merge(sourceColumn, composed, Analysis::mergeAcrossPaths);
+                });
             }
             return result;
         }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -74,6 +74,7 @@ import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.PointerType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableProcedureMetadata;
+import io.trino.spi.eventlistener.ColumnTransformationType;
 import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.spi.function.FunctionKind;
 import io.trino.spi.function.OperatorType;
@@ -148,6 +149,7 @@ import io.trino.sql.tree.CreateTable;
 import io.trino.sql.tree.CreateTableAsSelect;
 import io.trino.sql.tree.CreateView;
 import io.trino.sql.tree.Deallocate;
+import io.trino.sql.tree.DefaultExpressionTraversalVisitor;
 import io.trino.sql.tree.Delete;
 import io.trino.sql.tree.Deny;
 import io.trino.sql.tree.DereferenceExpression;
@@ -300,6 +302,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -1725,7 +1728,7 @@ class StatementAnalyzer
 
                 outputFields.addAll(expressionOutputs);
                 mappings.put(NodeRef.of(expression), expressionOutputs);
-                expressionOutputs.forEach(field -> analysis.addSourceColumns(field, analysis.getExpressionSourceColumns(expression)));
+                expressionOutputs.forEach(field -> analysis.addSourceColumns(field, classifyTransformationTypes(expression)));
             }
 
             Optional<Field> ordinalityField = Optional.empty();
@@ -2656,7 +2659,7 @@ class StatementAnalyzer
                                 inputField.getOriginColumnName(),
                                 inputField.isAliased());
                         fieldBuilder.add(field);
-                        analysis.addSourceColumns(field, analysis.getSourceColumns(inputField));
+                        analysis.addSourceColumns(field, analysis.getSourceColumnTransformationTypes(inputField));
                     }
                 }
                 fields = fieldBuilder.build();
@@ -2676,7 +2679,7 @@ class StatementAnalyzer
                                 inputField.getOriginColumnName(),
                                 inputField.isAliased());
                         fieldBuilder.add(field);
-                        analysis.addSourceColumns(field, analysis.getSourceColumns(inputField));
+                        analysis.addSourceColumns(field, analysis.getSourceColumnTransformationTypes(inputField));
                     }
                 }
                 fields = fieldBuilder.build();
@@ -2803,7 +2806,7 @@ class StatementAnalyzer
                     .build();
             analyzeFiltersAndMasks(table, name, new RelationType(viewFields), accessControlScope);
             analysis.registerTable(table, freshStorageTable, name, getBranchName(table), session.getIdentity().getUser(), accessControlScope, Optional.of(originalSql));
-            viewFields.forEach(field -> analysis.addSourceColumns(field, ImmutableSet.of(new SourceColumn(name, field.getName().orElseThrow()))));
+            viewFields.forEach(field -> analysis.addSourceColumns(field, ImmutableSet.of(new SourceColumn(name, field.getName().orElseThrow())), ColumnTransformationType.IDENTITY));
             return createAndAssignScope(table, scope, viewFields);
         }
 
@@ -2894,7 +2897,7 @@ class StatementAnalyzer
                 ColumnHandle columnHandle = columnHandles.get(column.getName());
                 checkArgument(columnHandle != null, "Unknown field %s", field);
                 analysis.setColumn(field, columnHandle);
-                analysis.addSourceColumns(field, ImmutableSet.of(new SourceColumn(tableName, column.getName())));
+                analysis.addSourceColumns(field, ImmutableSet.of(new SourceColumn(tableName, column.getName())), ColumnTransformationType.IDENTITY);
             }
             return fields.build();
         }
@@ -3138,7 +3141,7 @@ class StatementAnalyzer
             Streams.forEachPair(
                     descriptor.getAllFields().stream(),
                     inputFields.stream(),
-                    (newField, field) -> analysis.addSourceColumns(newField, analysis.getSourceColumns(field)));
+                    (newField, field) -> analysis.addSourceColumns(newField, analysis.getSourceColumnTransformationTypes(field)));
 
             return createAndAssignScope(relation, scope, descriptor);
         }
@@ -3753,12 +3756,8 @@ class StatementAnalyzer
                         .build();
 
                 int index = i; // Variable used in Lambda should be final
-                analysis.addSourceColumns(
-                        outputDescriptorFields[index],
-                        childrenTypes.stream()
-                                .map(relationType -> relationType.getFieldByIndex(index))
-                                .flatMap(field -> analysis.getSourceColumns(field).stream())
-                                .collect(toImmutableSet()));
+                childrenTypes.forEach(relationType ->
+                        analysis.addSourceColumns(outputDescriptorFields[index], analysis.getSourceColumnTransformationTypes(relationType.getFieldByIndex(index))));
             }
 
             for (int i = 0; i < relations.size(); i++) {
@@ -5265,7 +5264,7 @@ class StatementAnalyzer
                         }
 
                         Field newField = Field.newUnqualified(name, field.getType(), field.getOriginTable(), field.getOriginBranch(), field.getOriginColumnName(), false);
-                        analysis.addSourceColumns(newField, analysis.getSourceColumns(field));
+                        analysis.addSourceColumns(newField, analysis.getSourceColumnTransformationTypes(field));
                         outputFields.add(newField);
                     }
                 }
@@ -5302,10 +5301,10 @@ class StatementAnalyzer
 
                     Field newField = Field.newUnqualified(field.map(Identifier::getValue), analysis.getType(expression), originTable, originBranch, originColumn, column.getAlias().isPresent()); // TODO don't use analysis as a side-channel. Use outputExpressions to look up the type
                     if (originTable.isPresent()) {
-                        analysis.addSourceColumns(newField, ImmutableSet.of(new SourceColumn(originTable.get(), originColumn.orElseThrow())));
+                        analysis.addSourceColumns(newField, ImmutableSet.of(new SourceColumn(originTable.get(), originColumn.orElseThrow())), ColumnTransformationType.IDENTITY);
                     }
                     else {
-                        analysis.addSourceColumns(newField, analysis.getExpressionSourceColumns(expression));
+                        analysis.addSourceColumns(newField, classifyTransformationTypes(expression));
                     }
                     outputFields.add(newField);
                 }
@@ -5315,6 +5314,79 @@ class StatementAnalyzer
             }
 
             return createAndAssignScope(node, scope, outputFields.build());
+        }
+
+        /**
+         * Classifies how a single-column SELECT expression derives its value such as {@code a + sum(b)}.
+         * A field is AGGREGATION only if every reference is inside an aggregate; otherwise TRANSFORMATION.
+         * Each field's local subtype is composed with its upstream subtype via {@link Analysis#combineAlongPath}.
+         * Duplicate edges to the same source column are merged via {@link Analysis#combineAcrossPaths}
+         */
+        private Map<SourceColumn, ColumnTransformationType> classifyTransformationTypes(Expression expression)
+        {
+            Set<Field> freeFields = new LinkedHashSet<>();
+            Set<Field> aggregatedFields = new LinkedHashSet<>();
+            collectFreeAndAggregatedFields(expression, freeFields, aggregatedFields);
+            Map<SourceColumn, ColumnTransformationType> result = new LinkedHashMap<>();
+            for (Field field : analysis.getExpressionFields(expression)) {
+                ColumnTransformationType local = aggregatedFields.contains(field) && !freeFields.contains(field)
+                        ? ColumnTransformationType.AGGREGATION
+                        : ColumnTransformationType.TRANSFORMATION;
+                analysis.getSourceColumnTransformationTypes(field).forEach((sourceColumn, upstream) ->
+                        result.merge(sourceColumn, Analysis.combineAlongPath(upstream, local), Analysis::combineAcrossPaths));
+            }
+            return result;
+        }
+
+        /**
+         * Splits the column-reference fields of {@code expression} into {@code freeFields} (reached outside any
+         * aggregate, so their raw values survive) and {@code aggregatedFields} (reached inside one). A field used
+         * both ways lands in both sets; the caller treats presence in {@code freeFields} as raw-exposing. Scalar
+         * subqueries are not traversed (see {@link DefaultExpressionTraversalVisitor}), so their fields appear in neither.
+         */
+        private void collectFreeAndAggregatedFields(Expression expression, Set<Field> freeFields, Set<Field> aggregatedFields)
+        {
+            new DefaultExpressionTraversalVisitor<Boolean>()
+            {
+                @Override
+                protected Void visitFunctionCall(FunctionCall node, Boolean insideAggregate)
+                {
+                    // Windowed calls like sum(a) OVER (...) are per-row, not aggregating.
+                    // FILTER and ORDER BY appear only on aggregates (filtered and ordered-set).
+                    // Once inside an aggregate, stay inside for the whole subtree.
+                    boolean insideThisAggregate = node.getWindow().isEmpty()
+                            && (functionResolver.isAggregationFunction(session, node.getName(), accessControl)
+                            || node.getFilter().isPresent()
+                            || node.getOrderBy().isPresent());
+                    return super.visitFunctionCall(node, insideAggregate || insideThisAggregate);
+                }
+
+                @Override
+                protected Void visitIdentifier(Identifier node, Boolean insideAggregate)
+                {
+                    addReferencedField(node, insideAggregate);
+                    return null;
+                }
+
+                @Override
+                protected Void visitDereferenceExpression(DereferenceExpression node, Boolean insideAggregate)
+                {
+                    if (analysis.getColumnReferenceFields().containsKey(NodeRef.of(node))) {
+                        addReferencedField(node, insideAggregate);
+                        return null;
+                    }
+                    // Not a column reference (e.g. row-field access); recurse to the resolvable base.
+                    return super.visitDereferenceExpression(node, insideAggregate);
+                }
+
+                private void addReferencedField(Expression node, boolean insideAggregate)
+                {
+                    ResolvedField resolved = analysis.getColumnReferenceFields().get(NodeRef.of(node));
+                    if (resolved != null) {
+                        (insideAggregate ? aggregatedFields : freeFields).add(resolved.getField());
+                    }
+                }
+            }.process(expression, false);
         }
 
         private Scope computeAndAssignOrderByScope(OrderBy node, Scope sourceScope, Scope outputScope)
@@ -5507,7 +5579,7 @@ class StatementAnalyzer
                         .aliased(!allColumns.getAliases().isEmpty() || field.isAliased())
                         .build();
                 itemOutputFieldBuilder.add(newField);
-                analysis.addSourceColumns(newField, analysis.getSourceColumns(field));
+                analysis.addSourceColumns(newField, analysis.getSourceColumnTransformationTypes(field));
 
                 Type type = field.getType();
                 if (node.getSelect().isDistinct() && !type.isComparable()) {
@@ -6323,7 +6395,7 @@ class StatementAnalyzer
             Streams.forEachPair(
                     newDescriptor.getAllFields().stream(),
                     oldDescriptor.getAllFields().stream(),
-                    (newField, field) -> analysis.addSourceColumns(newField, analysis.getSourceColumns(field)));
+                    (newField, field) -> analysis.addSourceColumns(newField, analysis.getSourceColumnTransformationTypes(field)));
             return scope.withRelationType(newDescriptor);
         }
 

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalysisCombinators.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalysisCombinators.java
@@ -17,6 +17,8 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.spi.eventlistener.ColumnDetail;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
 import static io.trino.spi.eventlistener.ColumnTransformationType.AGGREGATION;
 import static io.trino.spi.eventlistener.ColumnTransformationType.IDENTITY;
 import static io.trino.spi.eventlistener.ColumnTransformationType.TRANSFORMATION;
@@ -25,11 +27,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestAnalysisCombinators
 {
     @Test
-    public void testCombineAcrossPathsKeepsMostExposing()
+    public void testMergeAcrossPathsKeepsEveryDistinctSubtype()
     {
-        assertThat(Analysis.combineAcrossPaths(IDENTITY, AGGREGATION)).isEqualTo(IDENTITY);
-        assertThat(Analysis.combineAcrossPaths(AGGREGATION, TRANSFORMATION)).isEqualTo(TRANSFORMATION);
-        assertThat(Analysis.combineAcrossPaths(AGGREGATION, AGGREGATION)).isEqualTo(AGGREGATION);
+        // A source column reaching an output through several paths keeps every subtype, not just the most exposing one.
+        assertThat(Analysis.mergeAcrossPaths(Set.of(IDENTITY), Set.of(AGGREGATION))).containsExactlyInAnyOrder(IDENTITY, AGGREGATION);
+        assertThat(Analysis.mergeAcrossPaths(Set.of(AGGREGATION), Set.of(TRANSFORMATION))).containsExactlyInAnyOrder(AGGREGATION, TRANSFORMATION);
+        assertThat(Analysis.mergeAcrossPaths(Set.of(AGGREGATION), Set.of(AGGREGATION))).containsExactly(AGGREGATION);
     }
 
     @Test
@@ -41,19 +44,19 @@ public class TestAnalysisCombinators
     }
 
     @Test
-    public void testSourceColumnCarriesSubtypeButExcludesItFromEquals()
+    public void testSourceColumnCarriesSubtypesButExcludesThemFromEquals()
     {
         QualifiedObjectName table = new QualifiedObjectName("c", "s", "t");
         Analysis.SourceColumn plain = new Analysis.SourceColumn(table, "col");
-        Analysis.SourceColumn typed = plain.withTransformationType(AGGREGATION);
+        Analysis.SourceColumn typed = plain.withTransformationTypes(Set.of(AGGREGATION));
 
-        assertThat(plain.getTransformationType()).isEmpty();
-        assertThat(typed.getTransformationType()).contains(AGGREGATION);
+        assertThat(plain.getTransformationTypes()).isEmpty();
+        assertThat(typed.getTransformationTypes()).containsExactly(AGGREGATION);
         assertThat(typed).isEqualTo(plain);
         assertThat(typed.hashCode()).isEqualTo(plain.hashCode());
 
         ColumnDetail detail = typed.getColumnDetail();
-        assertThat(detail.getTransformationType()).contains(AGGREGATION);
+        assertThat(detail.getTransformationTypes()).containsExactly(AGGREGATION);
         assertThat(detail.getCatalog()).isEqualTo("c");
         assertThat(detail.getColumnName()).isEqualTo("col");
     }

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalysisCombinators.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalysisCombinators.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.analyzer;
+
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.spi.eventlistener.ColumnDetail;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.spi.eventlistener.ColumnTransformationType.AGGREGATION;
+import static io.trino.spi.eventlistener.ColumnTransformationType.IDENTITY;
+import static io.trino.spi.eventlistener.ColumnTransformationType.TRANSFORMATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestAnalysisCombinators
+{
+    @Test
+    public void testCombineAcrossPathsKeepsMostExposing()
+    {
+        assertThat(Analysis.combineAcrossPaths(IDENTITY, AGGREGATION)).isEqualTo(IDENTITY);
+        assertThat(Analysis.combineAcrossPaths(AGGREGATION, TRANSFORMATION)).isEqualTo(TRANSFORMATION);
+        assertThat(Analysis.combineAcrossPaths(AGGREGATION, AGGREGATION)).isEqualTo(AGGREGATION);
+    }
+
+    @Test
+    public void testCombineAlongPathAggregationSticks()
+    {
+        assertThat(Analysis.combineAlongPath(IDENTITY, TRANSFORMATION)).isEqualTo(TRANSFORMATION);
+        assertThat(Analysis.combineAlongPath(AGGREGATION, TRANSFORMATION)).isEqualTo(AGGREGATION);
+        assertThat(Analysis.combineAlongPath(IDENTITY, IDENTITY)).isEqualTo(IDENTITY);
+    }
+
+    @Test
+    public void testSourceColumnCarriesSubtypeButExcludesItFromEquals()
+    {
+        QualifiedObjectName table = new QualifiedObjectName("c", "s", "t");
+        Analysis.SourceColumn plain = new Analysis.SourceColumn(table, "col");
+        Analysis.SourceColumn typed = plain.withTransformationType(AGGREGATION);
+
+        assertThat(plain.getTransformationType()).isEmpty();
+        assertThat(typed.getTransformationType()).contains(AGGREGATION);
+        assertThat(typed).isEqualTo(plain);
+        assertThat(typed.hashCode()).isEqualTo(plain.hashCode());
+
+        ColumnDetail detail = typed.getColumnDetail();
+        assertThat(detail.getTransformationType()).contains(AGGREGATION);
+        assertThat(detail.getCatalog()).isEqualTo("c");
+        assertThat(detail.getColumnName()).isEqualTo("col");
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -81,6 +81,7 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.eventlistener.ColumnDetail;
 import io.trino.spi.eventlistener.ColumnLineageInfo;
+import io.trino.spi.eventlistener.ColumnTransformationType;
 import io.trino.spi.security.Identity;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
@@ -115,6 +116,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -9066,6 +9068,87 @@ public class TestAnalyzer
                     Statement statement = SQL_PARSER.createStatement(query);
                     return analyzer.analyze(statement);
                 });
+    }
+
+    @Test
+    public void testPerSourceColumnTransformationTypes()
+    {
+        // Straight column copy → IDENTITY.
+        Analysis identity = analyze("INSERT INTO t2 (a, b) SELECT a, b FROM t1");
+        assertThat(transformationTypeFor(identity, "a", "a")).contains(ColumnTransformationType.IDENTITY);
+
+        // Non-aggregate expression → TRANSFORMATION for every contributing source column.
+        Analysis transformation = analyze("INSERT INTO t2 (a) SELECT a + b FROM t1");
+        assertThat(transformationTypeFor(transformation, "a", "a")).contains(ColumnTransformationType.TRANSFORMATION);
+        assertThat(transformationTypeFor(transformation, "a", "b")).contains(ColumnTransformationType.TRANSFORMATION);
+
+        // Pure aggregate → AGGREGATION.
+        Analysis aggregation = analyze("INSERT INTO t2 (a) SELECT sum(b) FROM t1");
+        assertThat(transformationTypeFor(aggregation, "a", "b")).contains(ColumnTransformationType.AGGREGATION);
+
+        // Mixed source columns in one output column: free `a` is TRANSFORMATION, aggregated-only `b` is AGGREGATION.
+        Analysis mixed = analyze("INSERT INTO t2 (a) SELECT a + sum(b) FROM t1 GROUP BY a");
+        assertThat(transformationTypeFor(mixed, "a", "a")).contains(ColumnTransformationType.TRANSFORMATION);
+        assertThat(transformationTypeFor(mixed, "a", "b")).contains(ColumnTransformationType.AGGREGATION);
+
+        // Same source column free AND aggregated → kept as lower exposure TRANSFORMATION.
+        Analysis selfMixed = analyze("INSERT INTO t2 (a) SELECT a + sum(a) FROM t1 GROUP BY a");
+        assertThat(transformationTypeFor(selfMixed, "a", "a")).contains(ColumnTransformationType.TRANSFORMATION);
+
+        // Aggregation through a subquery expanded by SELECT * must NOT be relabeled IDENTITY.
+        Analysis throughSubqueryStar = analyze("INSERT INTO t2 (a) SELECT * FROM (SELECT sum(a) AS s FROM t1)");
+        assertThat(transformationTypeFor(throughSubqueryStar, "a", "a")).contains(ColumnTransformationType.AGGREGATION);
+
+        // Transforming an already-aggregated subquery column stays AGGREGATION.
+        Analysis throughSubquery = analyze("INSERT INTO t2 (a) SELECT s + 1 FROM (SELECT sum(a) AS s FROM t1)");
+        assertThat(transformationTypeFor(throughSubquery, "a", "a")).contains(ColumnTransformationType.AGGREGATION);
+
+        // Non-aggregate scalar subquery in the projection: the raw value survives, so it must NOT be labeled AGGREGATION.
+        Analysis scalarSubquery = analyze("INSERT INTO t2 (a) SELECT (SELECT a FROM t1 LIMIT 1) FROM t1");
+        assertThat(transformationTypeFor(scalarSubquery, "a", "a")).contains(ColumnTransformationType.TRANSFORMATION);
+
+        // Aggregate scalar subquery: the aggregation happened upstream (inside the subquery) so kept as AGGREGATION.
+        Analysis aggregateScalarSubquery = analyze("INSERT INTO t2 (a) SELECT (SELECT sum(a) FROM t1) FROM t1");
+        assertThat(transformationTypeFor(aggregateScalarSubquery, "a", "a")).contains(ColumnTransformationType.AGGREGATION);
+
+        // UNION where one branch copies the source column and the other aggregates it: the copy still exposes the raw value, so the output stays IDENTITY.
+        Analysis union = analyze("INSERT INTO t2 (a) SELECT a FROM t1 UNION ALL SELECT sum(a) FROM t1");
+        assertThat(transformationTypeFor(union, "a", "a")).contains(ColumnTransformationType.IDENTITY);
+
+        // CTE aggregates a, then the outer query passes the aggregated column through unchanged: no raw value of a survives, so it stays AGGREGATION.
+        Analysis cte = analyze("INSERT INTO t2 (a) WITH v AS (SELECT sum(a) AS s FROM t1) SELECT s FROM v");
+        assertThat(transformationTypeFor(cte, "a", "a")).contains(ColumnTransformationType.AGGREGATION);
+
+        // FILTER on a plain aggregate: the function still aggregates its argument away → AGGREGATION.
+        Analysis filteredAggregate = analyze("INSERT INTO t2 (a) SELECT sum(a) FILTER (WHERE b > 0) FROM t1");
+        assertThat(transformationTypeFor(filteredAggregate, "a", "a")).contains(ColumnTransformationType.AGGREGATION);
+
+        // Plain ordered-set aggregate (function-level ORDER BY, no OVER): still an aggregate → AGGREGATION.
+        Analysis orderedAggregate = analyze("INSERT INTO t2 (a) SELECT cardinality(array_agg(a ORDER BY b)) FROM t1");
+        assertThat(transformationTypeFor(orderedAggregate, "a", "a")).contains(ColumnTransformationType.AGGREGATION);
+
+        // Windowed aggregate (sum(a) OVER ...): a per-row value, not a real aggregation, so the raw input survives → TRANSFORMATION.
+        Analysis windowedAggregate = analyze("INSERT INTO t2 (a) SELECT sum(a) OVER (PARTITION BY b) FROM t1");
+        assertThat(transformationTypeFor(windowedAggregate, "a", "a")).contains(ColumnTransformationType.TRANSFORMATION);
+    }
+
+    private static Optional<ColumnTransformationType> transformationTypeFor(Analysis analysis, String outputColumnName, String sourceColumnName)
+    {
+        return sourceColumnsFor(analysis, outputColumnName).stream()
+                .filter(sourceColumn -> sourceColumn.getColumnName().equals(sourceColumnName))
+                .findFirst()
+                .flatMap(Analysis.SourceColumn::getTransformationType);
+    }
+
+    private static Set<Analysis.SourceColumn> sourceColumnsFor(Analysis analysis, String outputColumnName)
+    {
+        Output target = analysis.getTarget().orElseThrow(() -> new AssertionError("analysis has no update target"));
+        List<OutputColumn> columns = target.getColumns().orElseThrow(() -> new AssertionError("update target has no columns"));
+        return columns.stream()
+                .filter(column -> column.getColumn().name().equals(outputColumnName))
+                .map(OutputColumn::getSourceColumns)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no output column named " + outputColumnName));
     }
 
     private TrinoExceptionAssert assertFails(@Language("SQL") String query)

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -9075,69 +9075,86 @@ public class TestAnalyzer
     {
         // Straight column copy → IDENTITY.
         Analysis identity = analyze("INSERT INTO t2 (a, b) SELECT a, b FROM t1");
-        assertThat(transformationTypeFor(identity, "a", "a")).contains(ColumnTransformationType.IDENTITY);
+        assertThat(transformationTypesFor(identity, "a", "a")).containsExactly(ColumnTransformationType.IDENTITY);
 
         // Non-aggregate expression → TRANSFORMATION for every contributing source column.
         Analysis transformation = analyze("INSERT INTO t2 (a) SELECT a + b FROM t1");
-        assertThat(transformationTypeFor(transformation, "a", "a")).contains(ColumnTransformationType.TRANSFORMATION);
-        assertThat(transformationTypeFor(transformation, "a", "b")).contains(ColumnTransformationType.TRANSFORMATION);
+        assertThat(transformationTypesFor(transformation, "a", "a")).containsExactly(ColumnTransformationType.TRANSFORMATION);
+        assertThat(transformationTypesFor(transformation, "a", "b")).containsExactly(ColumnTransformationType.TRANSFORMATION);
 
         // Pure aggregate → AGGREGATION.
         Analysis aggregation = analyze("INSERT INTO t2 (a) SELECT sum(b) FROM t1");
-        assertThat(transformationTypeFor(aggregation, "a", "b")).contains(ColumnTransformationType.AGGREGATION);
+        assertThat(transformationTypesFor(aggregation, "a", "b")).containsExactly(ColumnTransformationType.AGGREGATION);
 
         // Mixed source columns in one output column: free `a` is TRANSFORMATION, aggregated-only `b` is AGGREGATION.
         Analysis mixed = analyze("INSERT INTO t2 (a) SELECT a + sum(b) FROM t1 GROUP BY a");
-        assertThat(transformationTypeFor(mixed, "a", "a")).contains(ColumnTransformationType.TRANSFORMATION);
-        assertThat(transformationTypeFor(mixed, "a", "b")).contains(ColumnTransformationType.AGGREGATION);
+        assertThat(transformationTypesFor(mixed, "a", "a")).containsExactly(ColumnTransformationType.TRANSFORMATION);
+        assertThat(transformationTypesFor(mixed, "a", "b")).containsExactly(ColumnTransformationType.AGGREGATION);
 
-        // Same source column free AND aggregated → kept as lower exposure TRANSFORMATION.
+        // Same source column free AND aggregated in one expression resolves to a single field whose free use dominates → TRANSFORMATION.
         Analysis selfMixed = analyze("INSERT INTO t2 (a) SELECT a + sum(a) FROM t1 GROUP BY a");
-        assertThat(transformationTypeFor(selfMixed, "a", "a")).contains(ColumnTransformationType.TRANSFORMATION);
+        assertThat(transformationTypesFor(selfMixed, "a", "a")).containsExactly(ColumnTransformationType.TRANSFORMATION);
 
         // Aggregation through a subquery expanded by SELECT * must NOT be relabeled IDENTITY.
         Analysis throughSubqueryStar = analyze("INSERT INTO t2 (a) SELECT * FROM (SELECT sum(a) AS s FROM t1)");
-        assertThat(transformationTypeFor(throughSubqueryStar, "a", "a")).contains(ColumnTransformationType.AGGREGATION);
+        assertThat(transformationTypesFor(throughSubqueryStar, "a", "a")).containsExactly(ColumnTransformationType.AGGREGATION);
 
         // Transforming an already-aggregated subquery column stays AGGREGATION.
         Analysis throughSubquery = analyze("INSERT INTO t2 (a) SELECT s + 1 FROM (SELECT sum(a) AS s FROM t1)");
-        assertThat(transformationTypeFor(throughSubquery, "a", "a")).contains(ColumnTransformationType.AGGREGATION);
+        assertThat(transformationTypesFor(throughSubquery, "a", "a")).containsExactly(ColumnTransformationType.AGGREGATION);
 
-        // Non-aggregate scalar subquery in the projection: the raw value survives, so it must NOT be labeled AGGREGATION.
+        // Bare non-aggregate scalar subquery: a straight copy of the inner column, so its IDENTITY subtype passes through unchanged.
         Analysis scalarSubquery = analyze("INSERT INTO t2 (a) SELECT (SELECT a FROM t1 LIMIT 1) FROM t1");
-        assertThat(transformationTypeFor(scalarSubquery, "a", "a")).contains(ColumnTransformationType.TRANSFORMATION);
+        assertThat(transformationTypesFor(scalarSubquery, "a", "a")).containsExactly(ColumnTransformationType.IDENTITY);
 
         // Aggregate scalar subquery: the aggregation happened upstream (inside the subquery) so kept as AGGREGATION.
         Analysis aggregateScalarSubquery = analyze("INSERT INTO t2 (a) SELECT (SELECT sum(a) FROM t1) FROM t1");
-        assertThat(transformationTypeFor(aggregateScalarSubquery, "a", "a")).contains(ColumnTransformationType.AGGREGATION);
+        assertThat(transformationTypesFor(aggregateScalarSubquery, "a", "a")).containsExactly(ColumnTransformationType.AGGREGATION);
 
-        // UNION where one branch copies the source column and the other aggregates it: the copy still exposes the raw value, so the output stays IDENTITY.
+        // Scalar subquery embedded in a larger expression is NOT a bare pass-through: the (+ 1) transforms the copied value → TRANSFORMATION.
+        Analysis scalarSubqueryExpression = analyze("INSERT INTO t2 (a) SELECT (SELECT a FROM t1 LIMIT 1) + 1 FROM t1");
+        assertThat(transformationTypesFor(scalarSubqueryExpression, "a", "a")).containsExactly(ColumnTransformationType.TRANSFORMATION);
+
+        // Aggregate scalar subquery embedded in a larger expression stays AGGREGATION (aggregation sticks along the path).
+        Analysis aggregateScalarSubqueryExpression = analyze("INSERT INTO t2 (a) SELECT (SELECT sum(a) FROM t1) + 1 FROM t1");
+        assertThat(transformationTypesFor(aggregateScalarSubqueryExpression, "a", "a")).containsExactly(ColumnTransformationType.AGGREGATION);
+
+        // Deeply nested bare scalar subqueries: the IDENTITY pass-through composes at every level → IDENTITY.
+        Analysis nestedScalarSubquery = analyze("INSERT INTO t2 (a) SELECT (SELECT (SELECT a FROM t1 LIMIT 1) FROM t1 LIMIT 1) FROM t1");
+        assertThat(transformationTypesFor(nestedScalarSubquery, "a", "a")).containsExactly(ColumnTransformationType.IDENTITY);
+
+        // Deeply nested scalar subquery wrapping an aggregate: AGGREGATION survives the nesting.
+        Analysis nestedAggregateSubquery = analyze("INSERT INTO t2 (a) SELECT (SELECT (SELECT sum(a) FROM t1) FROM t1 LIMIT 1) FROM t1");
+        assertThat(transformationTypesFor(nestedAggregateSubquery, "a", "a")).containsExactly(ColumnTransformationType.AGGREGATION);
+
+        // UNION where one branch copies the source column and the other aggregates it
         Analysis union = analyze("INSERT INTO t2 (a) SELECT a FROM t1 UNION ALL SELECT sum(a) FROM t1");
-        assertThat(transformationTypeFor(union, "a", "a")).contains(ColumnTransformationType.IDENTITY);
+        assertThat(transformationTypesFor(union, "a", "a")).containsExactlyInAnyOrder(ColumnTransformationType.IDENTITY, ColumnTransformationType.AGGREGATION);
 
         // CTE aggregates a, then the outer query passes the aggregated column through unchanged: no raw value of a survives, so it stays AGGREGATION.
         Analysis cte = analyze("INSERT INTO t2 (a) WITH v AS (SELECT sum(a) AS s FROM t1) SELECT s FROM v");
-        assertThat(transformationTypeFor(cte, "a", "a")).contains(ColumnTransformationType.AGGREGATION);
+        assertThat(transformationTypesFor(cte, "a", "a")).containsExactly(ColumnTransformationType.AGGREGATION);
 
         // FILTER on a plain aggregate: the function still aggregates its argument away → AGGREGATION.
         Analysis filteredAggregate = analyze("INSERT INTO t2 (a) SELECT sum(a) FILTER (WHERE b > 0) FROM t1");
-        assertThat(transformationTypeFor(filteredAggregate, "a", "a")).contains(ColumnTransformationType.AGGREGATION);
+        assertThat(transformationTypesFor(filteredAggregate, "a", "a")).containsExactly(ColumnTransformationType.AGGREGATION);
 
         // Plain ordered-set aggregate (function-level ORDER BY, no OVER): still an aggregate → AGGREGATION.
         Analysis orderedAggregate = analyze("INSERT INTO t2 (a) SELECT cardinality(array_agg(a ORDER BY b)) FROM t1");
-        assertThat(transformationTypeFor(orderedAggregate, "a", "a")).contains(ColumnTransformationType.AGGREGATION);
+        assertThat(transformationTypesFor(orderedAggregate, "a", "a")).containsExactly(ColumnTransformationType.AGGREGATION);
 
-        // Windowed aggregate (sum(a) OVER ...): a per-row value, not a real aggregation, so the raw input survives → TRANSFORMATION.
+        // Windowed aggregate (sum(a) OVER ...): a per-row value, not a real aggregation, so the raw input could survive → TRANSFORMATION.
         Analysis windowedAggregate = analyze("INSERT INTO t2 (a) SELECT sum(a) OVER (PARTITION BY b) FROM t1");
-        assertThat(transformationTypeFor(windowedAggregate, "a", "a")).contains(ColumnTransformationType.TRANSFORMATION);
+        assertThat(transformationTypesFor(windowedAggregate, "a", "a")).containsExactly(ColumnTransformationType.TRANSFORMATION);
     }
 
-    private static Optional<ColumnTransformationType> transformationTypeFor(Analysis analysis, String outputColumnName, String sourceColumnName)
+    private static Set<ColumnTransformationType> transformationTypesFor(Analysis analysis, String outputColumnName, String sourceColumnName)
     {
         return sourceColumnsFor(analysis, outputColumnName).stream()
                 .filter(sourceColumn -> sourceColumn.getColumnName().equals(sourceColumnName))
                 .findFirst()
-                .flatMap(Analysis.SourceColumn::getTransformationType);
+                .map(Analysis.SourceColumn::getTransformationTypes)
+                .orElse(Set.of());
     }
 
     private static Set<Analysis.SourceColumn> sourceColumnsFor(Analysis analysis, String outputColumnName)

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestOutput.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestOutput.java
@@ -19,11 +19,13 @@ import io.airlift.json.JsonCodec;
 import io.trino.execution.Column;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.spi.connector.CatalogVersion;
+import io.trino.spi.eventlistener.ColumnTransformationType;
 import io.trino.sql.analyzer.Analysis.SourceColumn;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,12 +46,15 @@ public class TestOutput
                                 new OutputColumn(
                                         new Column("column", "type"),
                                         ImmutableSet.of(
-                                                new SourceColumn(QualifiedObjectName.valueOf("catalog.schema.table"), "column"))))));
+                                                new SourceColumn(QualifiedObjectName.valueOf("catalog.schema.table"), "column")
+                                                        .withTransformationType(ColumnTransformationType.TRANSFORMATION))))));
 
         String json = codec.toJson(expected);
         Output actual = codec.fromJson(json);
 
         assertThat(actual).isEqualTo(expected);
+        SourceColumn roundTripped = getOnlyElement(actual.getColumns().orElseThrow().get(0).getSourceColumns());
+        assertThat(roundTripped.getTransformationType()).contains(ColumnTransformationType.TRANSFORMATION);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestOutput.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestOutput.java
@@ -24,6 +24,7 @@ import io.trino.sql.analyzer.Analysis.SourceColumn;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.json.JsonCodec.jsonCodec;
@@ -47,14 +48,14 @@ public class TestOutput
                                         new Column("column", "type"),
                                         ImmutableSet.of(
                                                 new SourceColumn(QualifiedObjectName.valueOf("catalog.schema.table"), "column")
-                                                        .withTransformationType(ColumnTransformationType.TRANSFORMATION))))));
+                                                        .withTransformationTypes(Set.of(ColumnTransformationType.TRANSFORMATION)))))));
 
         String json = codec.toJson(expected);
         Output actual = codec.fromJson(json);
 
         assertThat(actual).isEqualTo(expected);
         SourceColumn roundTripped = getOnlyElement(actual.getColumns().orElseThrow().get(0).getSourceColumns());
-        assertThat(roundTripped.getTransformationType()).contains(ColumnTransformationType.TRANSFORMATION);
+        assertThat(roundTripped.getTransformationTypes()).containsExactly(ColumnTransformationType.TRANSFORMATION);
     }
 
     @Test

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -235,6 +235,14 @@
                                     </old>
                                 </item>
                                 <!-- Backwards incompatible changes since the previous release -->
+                                <!-- @JsonCreator moved to the 5-arg constructor when the optional transformationType field was added to ColumnDetail -->
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.annotation.removed</code>
+                                    <old>method void io.trino.spi.eventlistener.ColumnDetail::&lt;init&gt;(java.lang.String, java.lang.String, java.lang.String, java.lang.String)</old>
+                                    <new>method void io.trino.spi.eventlistener.ColumnDetail::&lt;init&gt;(java.lang.String, java.lang.String, java.lang.String, java.lang.String)</new>
+                                    <annotation>@com.fasterxml.jackson.annotation.JsonCreator</annotation>
+                                </item>
                                 <item>
                                     <code>java.method.returnTypeChanged</code>
                                     <old>method io.trino.spi.block.DictionaryBlock io.trino.spi.block.DictionaryBlock::compact()</old>

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnDetail.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnDetail.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.Unstable;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -30,15 +31,23 @@ public class ColumnDetail
     private final String schema;
     private final String table;
     private final String columnName;
+    private final Optional<ColumnTransformationType> transformationType;
+
+    @Unstable
+    public ColumnDetail(String catalog, String schema, String table, String columnName)
+    {
+        this(catalog, schema, table, columnName, Optional.empty());
+    }
 
     @JsonCreator
     @Unstable
-    public ColumnDetail(String catalog, String schema, String table, String columnName)
+    public ColumnDetail(String catalog, String schema, String table, String columnName, Optional<ColumnTransformationType> transformationType)
     {
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
         this.columnName = requireNonNull(columnName, "columnName is null");
+        this.transformationType = requireNonNull(transformationType, "transformationType is null");
     }
 
     @JsonProperty
@@ -65,6 +74,13 @@ public class ColumnDetail
         return columnName;
     }
 
+    @JsonProperty
+    public Optional<ColumnTransformationType> getTransformationType()
+    {
+        return transformationType;
+    }
+
+    // transformationType is excluded from equals/hashCode: it is advisory derivation metadata, not identity.
     @Override
     public int hashCode()
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnDetail.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnDetail.java
@@ -14,13 +14,17 @@
 package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.Unstable;
 
+import java.util.LinkedHashSet;
 import java.util.Objects;
-import java.util.Optional;
+import java.util.Set;
 
+import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 /**
  * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
@@ -31,23 +35,23 @@ public class ColumnDetail
     private final String schema;
     private final String table;
     private final String columnName;
-    private final Optional<ColumnTransformationType> transformationType;
+    private final Set<ColumnTransformationType> transformationTypes;
 
     @Unstable
     public ColumnDetail(String catalog, String schema, String table, String columnName)
     {
-        this(catalog, schema, table, columnName, Optional.empty());
+        this(catalog, schema, table, columnName, Set.of());
     }
 
     @JsonCreator
     @Unstable
-    public ColumnDetail(String catalog, String schema, String table, String columnName, Optional<ColumnTransformationType> transformationType)
+    public ColumnDetail(String catalog, String schema, String table, String columnName, Set<ColumnTransformationType> transformationTypes)
     {
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
         this.columnName = requireNonNull(columnName, "columnName is null");
-        this.transformationType = requireNonNull(transformationType, "transformationType is null");
+        this.transformationTypes = unmodifiableSet(new LinkedHashSet<>(requireNonNullElse(transformationTypes, Set.of())));
     }
 
     @JsonProperty
@@ -75,12 +79,13 @@ public class ColumnDetail
     }
 
     @JsonProperty
-    public Optional<ColumnTransformationType> getTransformationType()
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Set<ColumnTransformationType> getTransformationTypes()
     {
-        return transformationType;
+        return transformationTypes;
     }
 
-    // transformationType is excluded from equals/hashCode: it is advisory derivation metadata, not identity.
+    // transformationTypes is excluded from equals/hashCode: it is advisory derivation metadata, not identity.
     @Override
     public int hashCode()
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnTransformationType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnTransformationType.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.spi.eventlistener;
+
+/**
+ * How an output column's value is derived from its source columns.
+ * <p>
+ * These correspond to the subtypes of a {@code DIRECT} transformation in the
+ * <a href="https://openlineage.io/docs/spec/facets/dataset-facets/column_lineage_facet">OpenLineage column lineage facet</a>.
+ * Trino only tracks {@code DIRECT} lineage (a source column contributes to an output column); it does not track
+ * {@code INDIRECT} transformations (join, filter, group-by, sort), so those subtypes are not represented here.
+ * <p>
+ * Classification is per source-column→output-column edge and conservative: an edge is reported as {@link #AGGREGATION}
+ * only when no raw value of that source column survives into the output by any path. Subtypes propagate through
+ * subqueries, common table expressions, views and set operations. When Trino cannot determine an edge's derivation,
+ * no subtype is reported.
+ */
+public enum ColumnTransformationType
+{
+    /**
+     * The output column is a straight copy of a source column, for example {@code SELECT a}.
+     */
+    IDENTITY(0),
+    /**
+     * The output column is derived from its source columns via a non-aggregate expression, for example
+     * {@code SELECT a + b} or {@code SELECT concat(a, b)}.
+     */
+    TRANSFORMATION(1),
+    /**
+     * Every source column reaches the output column only through an aggregate function, for example
+     * {@code SELECT sum(a)} or {@code SELECT count(*)}. Note that some aggregate functions such as
+     * {@code min}, {@code max} and {@code first_value} still return an unmodified source value.
+     */
+    AGGREGATION(2);
+
+    private final int derivationRank;
+
+    ColumnTransformationType(int derivationRank)
+    {
+        this.derivationRank = derivationRank;
+    }
+
+    public int getDerivationRank()
+    {
+        return derivationRank;
+    }
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/eventlistener/TestColumnDetail.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/eventlistener/TestColumnDetail.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.eventlistener;
+
+import io.airlift.json.JsonCodec;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestColumnDetail
+{
+    private final JsonCodec<ColumnDetail> codec = jsonCodec(ColumnDetail.class);
+
+    @Test
+    public void testConvenienceConstructorHasEmptySubtype()
+    {
+        ColumnDetail detail = new ColumnDetail("c", "s", "t", "col");
+        assertThat(detail.getTransformationType()).isEmpty();
+    }
+
+    @Test
+    public void testDeserializesOldPayloadWithoutTransformationType()
+    {
+        // A ColumnDetail emitted before transformationType existed has no such key; it must deserialize to
+        // Optional.empty() rather than fail, preserving backward compatibility for existing event consumers.
+        ColumnDetail detail = codec.fromJson("{\"catalog\":\"c\",\"schema\":\"s\",\"table\":\"t\",\"columnName\":\"col\"}");
+        assertThat(detail.getTransformationType()).isEmpty();
+        assertThat(detail).isEqualTo(new ColumnDetail("c", "s", "t", "col"));
+    }
+
+    @Test
+    public void testJsonRoundTripPreservesTransformationType()
+    {
+        ColumnDetail detail = new ColumnDetail("c", "s", "t", "col", Optional.of(ColumnTransformationType.AGGREGATION));
+        assertThat(codec.fromJson(codec.toJson(detail)).getTransformationType()).contains(ColumnTransformationType.AGGREGATION);
+    }
+
+    @Test
+    public void testSubtypeExcludedFromEqualsAndHashCode()
+    {
+        ColumnDetail withIdentity = new ColumnDetail("c", "s", "t", "col", Optional.of(ColumnTransformationType.IDENTITY));
+        ColumnDetail withAggregation = new ColumnDetail("c", "s", "t", "col", Optional.of(ColumnTransformationType.AGGREGATION));
+        assertThat(withIdentity).isEqualTo(withAggregation);
+        assertThat(withIdentity.hashCode()).isEqualTo(withAggregation.hashCode());
+        assertThat(withAggregation.getTransformationType()).contains(ColumnTransformationType.AGGREGATION);
+    }
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/eventlistener/TestColumnDetail.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/eventlistener/TestColumnDetail.java
@@ -16,7 +16,7 @@ package io.trino.spi.eventlistener;
 import io.airlift.json.JsonCodec;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
+import java.util.Set;
 
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,36 +26,54 @@ public class TestColumnDetail
     private final JsonCodec<ColumnDetail> codec = jsonCodec(ColumnDetail.class);
 
     @Test
-    public void testConvenienceConstructorHasEmptySubtype()
+    public void testConvenienceConstructorHasEmptySubtypes()
     {
         ColumnDetail detail = new ColumnDetail("c", "s", "t", "col");
-        assertThat(detail.getTransformationType()).isEmpty();
+        assertThat(detail.getTransformationTypes()).isEmpty();
     }
 
     @Test
-    public void testDeserializesOldPayloadWithoutTransformationType()
+    public void testDeserializesOldPayloadWithoutTransformationTypes()
     {
-        // A ColumnDetail emitted before transformationType existed has no such key; it must deserialize to
-        // Optional.empty() rather than fail, preserving backward compatibility for existing event consumers.
+        // A ColumnDetail emitted before transformationTypes existed has no such key; it must deserialize to
+        // an empty set rather than fail, preserving backward compatibility for existing event consumers.
         ColumnDetail detail = codec.fromJson("{\"catalog\":\"c\",\"schema\":\"s\",\"table\":\"t\",\"columnName\":\"col\"}");
-        assertThat(detail.getTransformationType()).isEmpty();
+        assertThat(detail.getTransformationTypes()).isEmpty();
         assertThat(detail).isEqualTo(new ColumnDetail("c", "s", "t", "col"));
     }
 
     @Test
-    public void testJsonRoundTripPreservesTransformationType()
+    public void testJsonRoundTripPreservesTransformationTypes()
     {
-        ColumnDetail detail = new ColumnDetail("c", "s", "t", "col", Optional.of(ColumnTransformationType.AGGREGATION));
-        assertThat(codec.fromJson(codec.toJson(detail)).getTransformationType()).contains(ColumnTransformationType.AGGREGATION);
+        ColumnDetail detail = new ColumnDetail("c", "s", "t", "col", Set.of(ColumnTransformationType.AGGREGATION));
+        assertThat(codec.fromJson(codec.toJson(detail)).getTransformationTypes()).containsExactly(ColumnTransformationType.AGGREGATION);
     }
 
     @Test
-    public void testSubtypeExcludedFromEqualsAndHashCode()
+    public void testJsonRoundTripPreservesMultipleTransformationTypes()
     {
-        ColumnDetail withIdentity = new ColumnDetail("c", "s", "t", "col", Optional.of(ColumnTransformationType.IDENTITY));
-        ColumnDetail withAggregation = new ColumnDetail("c", "s", "t", "col", Optional.of(ColumnTransformationType.AGGREGATION));
+        // A source column can reach an output through several paths (for example the branches of a UNION),
+        // so every distinct subtype must survive the round trip.
+        ColumnDetail detail = new ColumnDetail("c", "s", "t", "col", Set.of(ColumnTransformationType.IDENTITY, ColumnTransformationType.AGGREGATION));
+        assertThat(codec.fromJson(codec.toJson(detail)).getTransformationTypes())
+                .containsExactlyInAnyOrder(ColumnTransformationType.IDENTITY, ColumnTransformationType.AGGREGATION);
+    }
+
+    @Test
+    public void testEmptySubtypesOmittedFromJson()
+    {
+        // Most columns carry no subtype; the key must be omitted so events stay lean and match pre-feature payloads.
+        ColumnDetail detail = new ColumnDetail("c", "s", "t", "col");
+        assertThat(codec.toJson(detail)).doesNotContain("transformationTypes");
+    }
+
+    @Test
+    public void testSubtypesExcludedFromEqualsAndHashCode()
+    {
+        ColumnDetail withIdentity = new ColumnDetail("c", "s", "t", "col", Set.of(ColumnTransformationType.IDENTITY));
+        ColumnDetail withAggregation = new ColumnDetail("c", "s", "t", "col", Set.of(ColumnTransformationType.AGGREGATION));
         assertThat(withIdentity).isEqualTo(withAggregation);
         assertThat(withIdentity.hashCode()).isEqualTo(withAggregation.hashCode());
-        assertThat(withAggregation.getTransformationType()).contains(ColumnTransformationType.AGGREGATION);
+        assertThat(withAggregation.getTransformationTypes()).containsExactly(ColumnTransformationType.AGGREGATION);
     }
 }

--- a/docs/src/main/sphinx/admin/event-listeners-openlineage.md
+++ b/docs/src/main/sphinx/admin/event-listeners-openlineage.md
@@ -92,7 +92,10 @@ If you want to disable this facet, add `trino_query_statistics` to
 For queries that write a table (`CREATE TABLE ... AS SELECT`, `INSERT`, and
 `REFRESH MATERIALIZED VIEW`), the output dataset carries a standard OpenLineage
 `columnLineage` dataset facet. Each output column lists the input fields it was
-derived from, and each input field carries its own `transformations` entry:
+derived from, and each input field carries a `transformations` list. Because a
+source column can reach an output column through several paths (for example the
+branches of a `UNION`), the list can hold more than one entry: every distinct
+subtype is reported rather than collapsing to one. Each entry has:
 
 - `type` - always `DIRECT`. Trino tracks direct value dependencies; it does not
   currently emit `INDIRECT` transformations (join, filter, group-by or sort
@@ -108,13 +111,16 @@ derived from, and each input field carries its own `transformations` entry:
     `SELECT count(*)`.
 
 Each source→output edge is classified independently, so a single output column
-can mix subtypes: in `SELECT a + sum(b) ... GROUP BY a` the edge from `a` is
-`TRANSFORMATION` (its raw value survives) while the edge from `b` is
-`AGGREGATION`. Subtypes propagate through subqueries, common table expressions,
-views and set operations: once a value is aggregated upstream its edge stays
-`AGGREGATION` even if a later layer transforms it, and if any path exposes the
-raw value the edge is not reported as `AGGREGATION`. When Trino cannot determine
-an edge's derivation, the `transformations` entry is omitted and consumers should
+can mix subtypes across its input fields: in `SELECT a + sum(b) ... GROUP BY a`
+the edge from `a` is `TRANSFORMATION` (its raw value survives) while the edge from
+`b` is `AGGREGATION`. A single source→output edge can itself carry several
+subtypes when the column reaches the output through more than one path: in
+`SELECT a FROM t UNION ALL SELECT sum(a) FROM t` the edge from `a` reports both
+`IDENTITY` (the copy branch) and `AGGREGATION` (the aggregate branch). Along any
+one path, once a value is aggregated upstream its subtype stays `AGGREGATION` even
+if a later layer transforms it. Subtypes propagate through subqueries, common
+table expressions, views and set operations. When Trino cannot determine an
+edge's derivation, the `transformations` list is omitted and consumers should
 assume a raw source value may survive.
 
 :::{note}

--- a/docs/src/main/sphinx/admin/event-listeners-openlineage.md
+++ b/docs/src/main/sphinx/admin/event-listeners-openlineage.md
@@ -85,6 +85,47 @@ in OpenLineage `Complete/Fail` events.
 If you want to disable this facet, add `trino_query_statistics` to
 `openlineage-event-listener.disabled-facets`.
 
+(openlineage-event-listener-column-lineage)=
+
+### Column lineage
+
+For queries that write a table (`CREATE TABLE ... AS SELECT`, `INSERT`, and
+`REFRESH MATERIALIZED VIEW`), the output dataset carries a standard OpenLineage
+`columnLineage` dataset facet. Each output column lists the input fields it was
+derived from, and each input field carries its own `transformations` entry:
+
+- `type` - always `DIRECT`. Trino tracks direct value dependencies; it does not
+  currently emit `INDIRECT` transformations (join, filter, group-by or sort
+  dependencies).
+- `subtype` - how the output column derives from *that* source column:
+  - `IDENTITY` - the output column is a straight copy of the source column, for
+    example `SELECT a`.
+  - `TRANSFORMATION` - the output column is derived through a non-aggregate
+    expression in which the raw source value can survive, for example
+    `SELECT a + b` or `SELECT concat(a, b)`.
+  - `AGGREGATION` - the source column reaches the output only through an aggregate
+    expression, so no raw value survives, for example `SELECT sum(a)` or
+    `SELECT count(*)`.
+
+Each source→output edge is classified independently, so a single output column
+can mix subtypes: in `SELECT a + sum(b) ... GROUP BY a` the edge from `a` is
+`TRANSFORMATION` (its raw value survives) while the edge from `b` is
+`AGGREGATION`. Subtypes propagate through subqueries, common table expressions,
+views and set operations: once a value is aggregated upstream its edge stays
+`AGGREGATION` even if a later layer transforms it, and if any path exposes the
+raw value the edge is not reported as `AGGREGATION`. When Trino cannot determine
+an edge's derivation, the `transformations` entry is omitted and consumers should
+assume a raw source value may survive.
+
+:::{note}
+The OpenLineage `AGGREGATION` subtype also covers aggregates such as `min`,
+`max` and `first_value`, which return an actual source value (for example
+`max(ssn)` is a real value from the `ssn` column). Consumers making
+retention or masking decisions based on the subtype should therefore not treat
+`AGGREGATION` as blanket-safe; the decision must account for the specific
+aggregate function.
+:::
+
 (openlineage-event-listener-requirements)=
 
 ## Requirements

--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListener.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListener.java
@@ -342,18 +342,26 @@ public class OpenLineageListener
             List<OutputColumnMetadata> outputColumns = outputMetadata.getColumns().orElse(List.of());
 
             OpenLineage.ColumnLineageDatasetFacetFieldsBuilder columnLineageDatasetFacetFieldsBuilder = openLineage.newColumnLineageDatasetFacetFieldsBuilder();
-            outputColumns.forEach(column ->
-                    columnLineageDatasetFacetFieldsBuilder.put(column.getColumnName(),
-                            openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                                    .inputFields(column
-                                            .getSourceColumns()
-                                            .stream()
-                                            .map(inputColumn -> openLineage.newInputFieldBuilder()
-                                                    .field(inputColumn.getColumnName())
-                                                    .namespace(this.datasetNamespace)
-                                                    .name(getDatasetName(inputColumn.getCatalog(), inputColumn.getSchema(), inputColumn.getTable()))
-                                                    .build())
-                                            .toList()).build()));
+            outputColumns.forEach(column -> columnLineageDatasetFacetFieldsBuilder.put(column.getColumnName(),
+                    openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
+                            .inputFields(column
+                                    .getSourceColumns()
+                                    .stream()
+                                    .map(inputColumn -> {
+                                        OpenLineage.InputFieldBuilder inputField = openLineage.newInputFieldBuilder()
+                                                .field(inputColumn.getColumnName())
+                                                .namespace(this.datasetNamespace)
+                                                .name(getDatasetName(inputColumn.getCatalog(), inputColumn.getSchema(), inputColumn.getTable()));
+                                        // Trino only tracks DIRECT lineage; attach this edge's subtype when known.
+                                        inputColumn.getTransformationType().ifPresent(subtype -> inputField.transformations(List.of(
+                                                openLineage.newInputFieldTransformationsBuilder()
+                                                        .type("DIRECT")
+                                                        .subtype(subtype.name())
+                                                        .build())));
+                                        return inputField.build();
+                                    })
+                                    .toList())
+                            .build()));
 
             ImmutableList.Builder<OpenLineage.InputField> inputFields = ImmutableList.builder();
             ioMetadata.getInputs().forEach(input -> {

--- a/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListener.java
+++ b/plugin/trino-openlineage/src/main/java/io/trino/plugin/openlineage/OpenLineageListener.java
@@ -352,12 +352,16 @@ public class OpenLineageListener
                                                 .field(inputColumn.getColumnName())
                                                 .namespace(this.datasetNamespace)
                                                 .name(getDatasetName(inputColumn.getCatalog(), inputColumn.getSchema(), inputColumn.getTable()));
-                                        // Trino only tracks DIRECT lineage; attach this edge's subtype when known.
-                                        inputColumn.getTransformationType().ifPresent(subtype -> inputField.transformations(List.of(
-                                                openLineage.newInputFieldTransformationsBuilder()
-                                                        .type("DIRECT")
-                                                        .subtype(subtype.name())
-                                                        .build())));
+
+                                        // Trino only tracks DIRECT lineage; attach one transformation per known subtype of this edge.
+                                        if (!inputColumn.getTransformationTypes().isEmpty()) {
+                                            inputField.transformations(inputColumn.getTransformationTypes().stream()
+                                                    .map(subtype -> openLineage.newInputFieldTransformationsBuilder()
+                                                            .type("DIRECT")
+                                                            .subtype(subtype.name())
+                                                            .build())
+                                                    .toList());
+                                        }
                                         return inputField.build();
                                     })
                                     .toList())

--- a/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TestOpenLineageEventsFromQueries.java
+++ b/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TestOpenLineageEventsFromQueries.java
@@ -97,32 +97,16 @@ public class TestOpenLineageEventsFromQueries
                 .hasSize(1);
         Map<String, ColumnLineageDatasetFacetFieldsAdditional> expectedColumnLineage = ImmutableMap.of(
                 "nationkey", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.nation")
-                                .field("nationkey")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.nation", "nationkey", "IDENTITY")))
                         .build(),
                 "name", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.nation")
-                                .field("name")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.nation", "name", "IDENTITY")))
                         .build(),
                 "regionkey", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.nation")
-                                .field("regionkey")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.nation", "regionkey", "IDENTITY")))
                         .build(),
                 "comment", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.nation")
-                                .field("comment")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.nation", "comment", "IDENTITY")))
                         .build());
         List<InputField> expectedColumnLineageDataset = ImmutableList.of(
                 openLineage.newInputField(OPEN_LINEAGE_NAMESPACE, "tpch.tiny.nation", "nationkey", null),
@@ -194,32 +178,16 @@ public class TestOpenLineageEventsFromQueries
                 .hasSize(1);
         Map<String, ColumnLineageDatasetFacetFieldsAdditional> expectedColumnLineage = ImmutableMap.of(
                 "nationkey", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name(format("marquez.default.%s", viewName))
-                                .field("nationkey")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField(format("marquez.default.%s", viewName), "nationkey", "IDENTITY")))
                         .build(),
                 "name", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name(format("marquez.default.%s", viewName))
-                                .field("name")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField(format("marquez.default.%s", viewName), "name", "IDENTITY")))
                         .build(),
                 "regionkey", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name(format("marquez.default.%s", viewName))
-                                .field("regionkey")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField(format("marquez.default.%s", viewName), "regionkey", "IDENTITY")))
                         .build(),
                 "comment", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name(format("marquez.default.%s", viewName))
-                                .field("comment")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField(format("marquez.default.%s", viewName), "comment", "IDENTITY")))
                         .build());
         List<InputField> expectedColumnLineageDataset = ImmutableList.of(
                 openLineage.newInputField(OPEN_LINEAGE_NAMESPACE, "tpch.tiny.nation", "nationkey", null),
@@ -288,28 +256,16 @@ public class TestOpenLineageEventsFromQueries
                 .hasSize(1);
         Map<String, ColumnLineageDatasetFacetFieldsAdditional> expectedColumnLineage = ImmutableMap.of(
                 "nation", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.nation")
-                                .field("name")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.nation", "name", "IDENTITY")))
                         .build(),
                 "order_count", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
                         .inputFields(ImmutableList.of())
                         .build(),
                 "total_revenue", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.orders")
-                                .field("totalprice")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.orders", "totalprice", "AGGREGATION")))
                         .build(),
                 "avg_order_value", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.orders")
-                                .field("totalprice")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.orders", "totalprice", "AGGREGATION")))
                         .build());
         List<InputField> expectedColumnLineageDataset = ImmutableList.of(
                 openLineage.newInputField(OPEN_LINEAGE_NAMESPACE, "tpch.sf1.customer", "custkey", null),
@@ -380,63 +336,27 @@ public class TestOpenLineageEventsFromQueries
                 .hasSize(1);
         Map<String, ColumnLineageDatasetFacetFieldsAdditional> expectedColumnLineage = ImmutableMap.of(
                 "d_year", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpcds.tiny.date_dim")
-                                .field("d_year")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpcds.tiny.date_dim", "d_year", "IDENTITY")))
                         .build(),
                 "d_moy", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpcds.tiny.date_dim")
-                                .field("d_moy")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpcds.tiny.date_dim", "d_moy", "IDENTITY")))
                         .build(),
                 "year_month", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
                         .inputFields(ImmutableList.of(
-                                openLineage.newInputFieldBuilder()
-                                        .namespace(OPEN_LINEAGE_NAMESPACE)
-                                        .name("tpcds.tiny.date_dim")
-                                        .field("d_year")
-                                        .build(),
-                                openLineage.newInputFieldBuilder()
-                                        .namespace(OPEN_LINEAGE_NAMESPACE)
-                                        .name("tpcds.tiny.date_dim")
-                                        .field("d_moy")
-                                        .build()))
+                                columnLineageInputField("tpcds.tiny.date_dim", "d_year", "TRANSFORMATION"),
+                                columnLineageInputField("tpcds.tiny.date_dim", "d_moy", "TRANSFORMATION")))
                         .build(),
                 "s_store_name", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpcds.tiny.store")
-                                .field("s_store_name")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpcds.tiny.store", "s_store_name", "IDENTITY")))
                         .build(),
                 "monthly_total", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpcds.tiny.store_sales")
-                                .field("ss_sales_price")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpcds.tiny.store_sales", "ss_sales_price", "AGGREGATION")))
                         .build(),
                 "store_rank", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
                         .inputFields(ImmutableList.of(
-                                openLineage.newInputFieldBuilder()
-                                        .namespace(OPEN_LINEAGE_NAMESPACE)
-                                        .name("tpcds.tiny.date_dim")
-                                        .field("d_year")
-                                        .build(),
-                                openLineage.newInputFieldBuilder()
-                                        .namespace(OPEN_LINEAGE_NAMESPACE)
-                                        .name("tpcds.tiny.date_dim")
-                                        .field("d_moy")
-                                        .build(),
-                                openLineage.newInputFieldBuilder()
-                                        .namespace(OPEN_LINEAGE_NAMESPACE)
-                                        .name("tpcds.tiny.store_sales")
-                                        .field("ss_sales_price")
-                                        .build()))
+                                columnLineageInputField("tpcds.tiny.date_dim", "d_year", "TRANSFORMATION"),
+                                columnLineageInputField("tpcds.tiny.date_dim", "d_moy", "TRANSFORMATION"),
+                                columnLineageInputField("tpcds.tiny.store_sales", "ss_sales_price", "AGGREGATION")))
                         .build());
         List<InputField> expectedColumnLineageDataset = ImmutableList.of(
                 openLineage.newInputField(OPEN_LINEAGE_NAMESPACE, "tpcds.sf0.01.store_sales", "ss_sales_price", null),
@@ -518,39 +438,19 @@ public class TestOpenLineageEventsFromQueries
                 .hasSize(1);
         Map<String, ColumnLineageDatasetFacetFieldsAdditional> expectedColumnLineage = ImmutableMap.of(
                 "suppkey", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.supplier")
-                                .field("suppkey")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.supplier", "suppkey", "IDENTITY")))
                         .build(),
                 "name", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.supplier")
-                                .field("name")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.supplier", "name", "IDENTITY")))
                         .build(),
                 "address", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.supplier")
-                                .field("address")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.supplier", "address", "IDENTITY")))
                         .build(),
                 "phone", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.supplier")
-                                .field("phone")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.supplier", "phone", "IDENTITY")))
                         .build(),
                 "nation_name", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.nation")
-                                .field("name")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.nation", "name", "IDENTITY")))
                         .build());
         List<InputField> expectedColumnLineageDataset = ImmutableList.of(
                 openLineage.newInputField(OPEN_LINEAGE_NAMESPACE, "tpch.tiny.supplier", "address", null),
@@ -635,29 +535,13 @@ public class TestOpenLineageEventsFromQueries
                         .build(),
                 "total_value", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
                         .inputFields(ImmutableList.of(
-                                openLineage.newInputFieldBuilder()
-                                        .namespace(OPEN_LINEAGE_NAMESPACE)
-                                        .name("tpch.tiny.orders")
-                                        .field("totalprice")
-                                        .build(),
-                                openLineage.newInputFieldBuilder()
-                                        .namespace(OPEN_LINEAGE_NAMESPACE)
-                                        .name("tpcds.tiny.store_sales")
-                                        .field("ss_sales_price")
-                                        .build()))
+                                columnLineageInputField("tpch.tiny.orders", "totalprice", "AGGREGATION"),
+                                columnLineageInputField("tpcds.tiny.store_sales", "ss_sales_price", "AGGREGATION")))
                         .build(),
                 "avg_value", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
                         .inputFields(ImmutableList.of(
-                                openLineage.newInputFieldBuilder()
-                                        .namespace(OPEN_LINEAGE_NAMESPACE)
-                                        .name("tpch.tiny.orders")
-                                        .field("totalprice")
-                                        .build(),
-                                openLineage.newInputFieldBuilder()
-                                        .namespace(OPEN_LINEAGE_NAMESPACE)
-                                        .name("tpcds.tiny.store_sales")
-                                        .field("ss_sales_price")
-                                        .build()))
+                                columnLineageInputField("tpch.tiny.orders", "totalprice", "AGGREGATION"),
+                                columnLineageInputField("tpcds.tiny.store_sales", "ss_sales_price", "AGGREGATION")))
                         .build());
         List<InputField> expectedColumnLineageDataset = ImmutableList.of(
                 openLineage.newInputField(OPEN_LINEAGE_NAMESPACE, "tpch.tiny.orders", "totalprice", null),
@@ -726,32 +610,16 @@ public class TestOpenLineageEventsFromQueries
                 .hasSize(1);
         Map<String, ColumnLineageDatasetFacetFieldsAdditional> expectedCreateTableColumnLineage = ImmutableMap.of(
                 "nationkey", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.nation")
-                                .field("nationkey")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.nation", "nationkey", "IDENTITY")))
                         .build(),
                 "name", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.nation")
-                                .field("name")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.nation", "name", "IDENTITY")))
                         .build(),
                 "regionkey", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.nation")
-                                .field("regionkey")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.nation", "regionkey", "IDENTITY")))
                         .build(),
                 "comment", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.nation")
-                                .field("comment")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.nation", "comment", "IDENTITY")))
                         .build());
         List<InputField> expectedCreateTableColumnLineageDataset = ImmutableList.of(
                 openLineage.newInputField(OPEN_LINEAGE_NAMESPACE, "tpch.tiny.nation", "nationkey", null),
@@ -790,32 +658,16 @@ public class TestOpenLineageEventsFromQueries
                 .hasSize(1);
         Map<String, ColumnLineageDatasetFacetFieldsAdditional> expectedInsertIntoTableColumnLineage = ImmutableMap.of(
                 "nationkey", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.nation")
-                                .field("nationkey")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.nation", "nationkey", "IDENTITY")))
                         .build(),
                 "name", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.nation")
-                                .field("name")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.nation", "name", "IDENTITY")))
                         .build(),
                 "regionkey", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.nation")
-                                .field("regionkey")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.nation", "regionkey", "IDENTITY")))
                         .build(),
                 "comment", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.nation")
-                                .field("comment")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.nation", "comment", "IDENTITY")))
                         .build());
         List<InputField> expectedInsertIntoTableColumnLineageDataset = ImmutableList.of(
                 openLineage.newInputField(OPEN_LINEAGE_NAMESPACE, "tpch.tiny.nation", "nationkey", null),
@@ -891,32 +743,16 @@ public class TestOpenLineageEventsFromQueries
                 .hasSize(1);
         Map<String, ColumnLineageDatasetFacetFieldsAdditional> expectedCreateTableColumnLineage = ImmutableMap.of(
                 "custkey", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.customer")
-                                .field("custkey")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.customer", "custkey", "IDENTITY")))
                         .build(),
                 "name", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.customer")
-                                .field("name")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.customer", "name", "IDENTITY")))
                         .build(),
                 "mktsegment", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.customer")
-                                .field("mktsegment")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.customer", "mktsegment", "IDENTITY")))
                         .build(),
                 "nationkey", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.customer")
-                                .field("nationkey")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.customer", "nationkey", "IDENTITY")))
                         .build());
         List<InputField> expectedCreateTableColumnLineageDataset = ImmutableList.of(
                 openLineage.newInputField(OPEN_LINEAGE_NAMESPACE, "tpch.tiny.customer", "mktsegment", null),
@@ -1020,32 +856,16 @@ public class TestOpenLineageEventsFromQueries
                 .hasSize(1);
         Map<String, ColumnLineageDatasetFacetFieldsAdditional> expectedCreateTableColumnLineage = ImmutableMap.of(
                 "custkey", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.customer")
-                                .field("custkey")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.customer", "custkey", "IDENTITY")))
                         .build(),
                 "name", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.customer")
-                                .field("name")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.customer", "name", "IDENTITY")))
                         .build(),
                 "mktsegment", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.customer")
-                                .field("mktsegment")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.customer", "mktsegment", "IDENTITY")))
                         .build(),
                 "nationkey", openLineage.newColumnLineageDatasetFacetFieldsAdditionalBuilder()
-                        .inputFields(ImmutableList.of(openLineage.newInputFieldBuilder()
-                                .namespace(OPEN_LINEAGE_NAMESPACE)
-                                .name("tpch.tiny.customer")
-                                .field("nationkey")
-                                .build()))
+                        .inputFields(ImmutableList.of(columnLineageInputField("tpch.tiny.customer", "nationkey", "IDENTITY")))
                         .build());
         List<InputField> expectedCreateTableColumnLineageDataset = ImmutableList.of(
                 openLineage.newInputField(OPEN_LINEAGE_NAMESPACE, "tpch.tiny.customer", "mktsegment", null),
@@ -1103,6 +923,20 @@ public class TestOpenLineageEventsFromQueries
                 expectedMergeIntoTableColumnLineage,
                 expectedMergeIntoTableColumnLineageDataset,
                 expectedMergeIntoTableSchemaFields);
+    }
+
+    private InputField columnLineageInputField(String name, String field, String subtype)
+    {
+        // Column-level lineage carries the analyzer's DIRECT transformation subtype for each source column.
+        return openLineage.newInputFieldBuilder()
+                .namespace(OPEN_LINEAGE_NAMESPACE)
+                .name(name)
+                .field(field)
+                .transformations(ImmutableList.of(openLineage.newInputFieldTransformationsBuilder()
+                        .type("DIRECT")
+                        .subtype(subtype)
+                        .build()))
+                .build();
     }
 
     private void assertCompletedEventOutput(

--- a/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TestOpenLineageListener.java
+++ b/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TestOpenLineageListener.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.openlineage;
 
 import com.google.common.collect.ImmutableMap;
+import io.openlineage.client.OpenLineage.ColumnLineageDatasetFacetFieldsAdditional;
 import io.openlineage.client.OpenLineage.Job;
 import io.openlineage.client.OpenLineage.Run;
 import io.openlineage.client.OpenLineage.RunEvent;
@@ -190,6 +191,43 @@ final class TestOpenLineageListener
                 .extracting(RunEvent::getJob)
                 .extracting(Job::getName)
                 .isEqualTo("queryId-user-some-trino-client-127.0.0.1-abc123");
+    }
+
+    @Test
+    void testColumnLineageTransformationSubtypes()
+    {
+        OpenLineageListener listener = (OpenLineageListener) createEventListener(Map.of(
+                "openlineage-event-listener.transport.type", "CONSOLE",
+                "openlineage-event-listener.trino.uri", "http://testhost"));
+
+        RunEvent result = listener.getCompletedEvent(TrinoEventData.queryCompleteEventWithColumnLineage);
+
+        assertThat(result.getOutputs())
+                .hasSize(1)
+                .satisfiesExactly(output -> {
+                    assertThat(output.getName()).isEqualTo("marquez.default.target");
+                    Map<String, ColumnLineageDatasetFacetFieldsAdditional> fields =
+                            output.getFacets().getColumnLineage().getFields().getAdditionalProperties();
+                    assertThat(fields).containsOnlyKeys("identity_col", "transformation_col", "aggregation_col");
+                    assertDirectSubtype(fields, "identity_col", "a", "IDENTITY");
+                    assertDirectSubtype(fields, "transformation_col", "c", "TRANSFORMATION");
+                    assertDirectSubtype(fields, "aggregation_col", "b", "AGGREGATION");
+                });
+    }
+
+    private static void assertDirectSubtype(Map<String, ColumnLineageDatasetFacetFieldsAdditional> fields, String outputColumn, String sourceField, String expectedSubtype)
+    {
+        assertThat(fields.get(outputColumn).getInputFields())
+                .satisfiesExactly(input -> {
+                    assertThat(input.getNamespace()).isEqualTo("trino://testhost");
+                    assertThat(input.getName()).isEqualTo("marquez.default.base_table");
+                    assertThat(input.getField()).isEqualTo(sourceField);
+                    assertThat(input.getTransformations())
+                            .satisfiesExactly(transformation -> {
+                                assertThat(transformation.getType()).isEqualTo("DIRECT");
+                                assertThat(transformation.getSubtype()).isEqualTo(expectedSubtype);
+                            });
+                });
     }
 
     private static EventListener createEventListener(Map<String, String> config)

--- a/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TrinoEventData.java
+++ b/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TrinoEventData.java
@@ -194,11 +194,12 @@ public class TrinoEventData
                 "default",
                 "target",
                 Optional.of(List.of(
-                        new OutputColumnMetadata("identity_col", "bigint", Set.of(new ColumnDetail("marquez", "default", "base_table", "a", Optional.of(ColumnTransformationType.IDENTITY)))),
-                        new OutputColumnMetadata("transformation_col", "bigint", Set.of(new ColumnDetail("marquez", "default", "base_table", "c", Optional.of(ColumnTransformationType.TRANSFORMATION)))),
-                        new OutputColumnMetadata("aggregation_col", "bigint", Set.of(new ColumnDetail("marquez", "default", "base_table", "b", Optional.of(ColumnTransformationType.AGGREGATION)))))),
+                        new OutputColumnMetadata("identity_col", "bigint", Set.of(new ColumnDetail("marquez", "default", "base_table", "a", Set.of(ColumnTransformationType.IDENTITY)))),
+                        new OutputColumnMetadata("transformation_col", "bigint", Set.of(new ColumnDetail("marquez", "default", "base_table", "c", Set.of(ColumnTransformationType.TRANSFORMATION)))),
+                        new OutputColumnMetadata("aggregation_col", "bigint", Set.of(new ColumnDetail("marquez", "default", "base_table", "b", Set.of(ColumnTransformationType.AGGREGATION)))))),
                 Optional.empty(),
                 Optional.empty());
+
         queryCompleteEventWithColumnLineage = new QueryCompletedEvent(
                 queryMetadata,
                 queryStatistics,

--- a/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TrinoEventData.java
+++ b/plugin/trino-openlineage/src/test/java/io/trino/plugin/openlineage/TrinoEventData.java
@@ -15,13 +15,20 @@ package io.trino.plugin.openlineage;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.operator.RetryPolicy;
+import io.trino.spi.connector.CatalogVersion;
+import io.trino.spi.eventlistener.ColumnDetail;
+import io.trino.spi.eventlistener.ColumnTransformationType;
+import io.trino.spi.eventlistener.OutputColumnMetadata;
 import io.trino.spi.eventlistener.QueryCompletedEvent;
 import io.trino.spi.eventlistener.QueryContext;
 import io.trino.spi.eventlistener.QueryCreatedEvent;
 import io.trino.spi.eventlistener.QueryIOMetadata;
+import io.trino.spi.eventlistener.QueryInputMetadata;
 import io.trino.spi.eventlistener.QueryMetadata;
+import io.trino.spi.eventlistener.QueryOutputMetadata;
 import io.trino.spi.eventlistener.QueryStatistics;
 import io.trino.spi.eventlistener.StageOutputBufferUtilization;
+import io.trino.spi.metrics.Metrics;
 import io.trino.spi.resourcegroups.QueryType;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.spi.session.ResourceEstimates;
@@ -33,6 +40,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
@@ -46,6 +54,7 @@ public class TrinoEventData
     public static final QueryStatistics queryStatistics;
     public static final QueryCompletedEvent queryCompleteEvent;
     public static final QueryCreatedEvent queryCreatedEvent;
+    public static final QueryCompletedEvent queryCompleteEventWithColumnLineage;
 
     private TrinoEventData()
     {
@@ -161,5 +170,45 @@ public class TrinoEventData
                 Instant.parse("2025-04-28T11:23:55.384424Z"),
                 queryContext,
                 queryMetadata);
+
+        // CREATE TABLE marquez.default.target AS
+        //   SELECT a AS identity_col, c + 1 AS transformation_col, sum(b) AS aggregation_col FROM base_table GROUP BY a, c
+        // Each output column carries its source columns with the transformation subtype the analyzer classified.
+        QueryInputMetadata columnLineageInput = new QueryInputMetadata(
+                Optional.of("marquez"),
+                "marquez",
+                new CatalogVersion("default"),
+                "default",
+                "base_table",
+                List.of(
+                        new QueryInputMetadata.Column("a", "bigint"),
+                        new QueryInputMetadata.Column("b", "bigint"),
+                        new QueryInputMetadata.Column("c", "bigint")),
+                Optional.empty(),
+                Metrics.EMPTY,
+                OptionalLong.empty(),
+                OptionalLong.empty());
+        QueryOutputMetadata columnLineageOutput = new QueryOutputMetadata(
+                "marquez",
+                new CatalogVersion("default"),
+                "default",
+                "target",
+                Optional.of(List.of(
+                        new OutputColumnMetadata("identity_col", "bigint", Set.of(new ColumnDetail("marquez", "default", "base_table", "a", Optional.of(ColumnTransformationType.IDENTITY)))),
+                        new OutputColumnMetadata("transformation_col", "bigint", Set.of(new ColumnDetail("marquez", "default", "base_table", "c", Optional.of(ColumnTransformationType.TRANSFORMATION)))),
+                        new OutputColumnMetadata("aggregation_col", "bigint", Set.of(new ColumnDetail("marquez", "default", "base_table", "b", Optional.of(ColumnTransformationType.AGGREGATION)))))),
+                Optional.empty(),
+                Optional.empty());
+        queryCompleteEventWithColumnLineage = new QueryCompletedEvent(
+                queryMetadata,
+                queryStatistics,
+                queryContext,
+                new QueryIOMetadata(List.of(columnLineageInput), Optional.of(columnLineageOutput)),
+                Optional.empty(),
+                Optional.empty(),
+                Collections.emptyList(),
+                Instant.parse("2025-04-28T11:23:55.384424Z"),
+                Instant.parse("2025-04-28T11:24:16.256207Z"),
+                Instant.parse("2025-04-28T11:24:26.993340Z"));
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -44,6 +44,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.eventlistener.ColumnDetail;
 import io.trino.spi.eventlistener.ColumnInfo;
 import io.trino.spi.eventlistener.ColumnLineageInfo;
+import io.trino.spi.eventlistener.ColumnTransformationType;
 import io.trino.spi.eventlistener.OutputColumnMetadata;
 import io.trino.spi.eventlistener.QueryCompletedEvent;
 import io.trino.spi.eventlistener.QueryCreatedEvent;
@@ -1218,6 +1219,46 @@ public class TestEventListenerBasic
                 ImmutableSet.of("tpch.tiny.orders"),
                 new OutputColumnMetadata("test_varchar", VARCHAR_TYPE, ImmutableSet.of(new ColumnDetail("tpch", "tiny", "orders", "clerk"))),
                 new OutputColumnMetadata("test_bigint", BIGINT_TYPE, ImmutableSet.of()));
+    }
+
+    @Test
+    public void testOutputColumnTransformationTypes()
+            throws Exception
+    {
+        QueryCompletedEvent event = runQueryAndWaitForEvents(
+                "CREATE TABLE mock.default.create_new_table AS " +
+                        "SELECT orderkey AS identity_col, orderkey + 1 AS transformation_col, sum(totalprice) AS aggregation_col FROM orders GROUP BY orderkey")
+                .getQueryEvents().getQueryCompletedEvent();
+        assertThat(transformationTypeFor(event, "identity_col", "orderkey")).contains(ColumnTransformationType.IDENTITY);
+        assertThat(transformationTypeFor(event, "transformation_col", "orderkey")).contains(ColumnTransformationType.TRANSFORMATION);
+        assertThat(transformationTypeFor(event, "aggregation_col", "totalprice")).contains(ColumnTransformationType.AGGREGATION);
+    }
+
+    @Test
+    public void testOutputColumnTransformationTypeMixedAggregateAndGroupingKey()
+            throws Exception
+    {
+        // A grouping key combined with an aggregate exposes the raw key → the key's transformation type stays TRANSFORMATION, never AGGREGATION.
+        QueryCompletedEvent event = runQueryAndWaitForEvents(
+                "CREATE TABLE mock.default.create_new_table AS " +
+                        "SELECT orderkey AS key_col, orderkey + count(*) AS mixed_col FROM orders GROUP BY orderkey")
+                .getQueryEvents().getQueryCompletedEvent();
+        assertThat(transformationTypeFor(event, "key_col", "orderkey")).contains(ColumnTransformationType.IDENTITY);
+        assertThat(transformationTypeFor(event, "mixed_col", "orderkey")).contains(ColumnTransformationType.TRANSFORMATION);
+    }
+
+    private static Optional<ColumnTransformationType> transformationTypeFor(QueryCompletedEvent event, String outputColumn, String sourceColumn)
+    {
+        for (OutputColumnMetadata column : event.getIoMetadata().getOutput().get().getColumns().get()) {
+            if (column.getColumnName().equals(outputColumn)) {
+                for (ColumnDetail source : column.getSourceColumns()) {
+                    if (source.getColumnName().equals(sourceColumn)) {
+                        return source.getTransformationType();
+                    }
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -1229,9 +1229,9 @@ public class TestEventListenerBasic
                 "CREATE TABLE mock.default.create_new_table AS " +
                         "SELECT orderkey AS identity_col, orderkey + 1 AS transformation_col, sum(totalprice) AS aggregation_col FROM orders GROUP BY orderkey")
                 .getQueryEvents().getQueryCompletedEvent();
-        assertThat(transformationTypeFor(event, "identity_col", "orderkey")).contains(ColumnTransformationType.IDENTITY);
-        assertThat(transformationTypeFor(event, "transformation_col", "orderkey")).contains(ColumnTransformationType.TRANSFORMATION);
-        assertThat(transformationTypeFor(event, "aggregation_col", "totalprice")).contains(ColumnTransformationType.AGGREGATION);
+        assertThat(transformationTypesFor(event, "identity_col", "orderkey")).containsExactly(ColumnTransformationType.IDENTITY);
+        assertThat(transformationTypesFor(event, "transformation_col", "orderkey")).containsExactly(ColumnTransformationType.TRANSFORMATION);
+        assertThat(transformationTypesFor(event, "aggregation_col", "totalprice")).containsExactly(ColumnTransformationType.AGGREGATION);
     }
 
     @Test
@@ -1243,22 +1243,22 @@ public class TestEventListenerBasic
                 "CREATE TABLE mock.default.create_new_table AS " +
                         "SELECT orderkey AS key_col, orderkey + count(*) AS mixed_col FROM orders GROUP BY orderkey")
                 .getQueryEvents().getQueryCompletedEvent();
-        assertThat(transformationTypeFor(event, "key_col", "orderkey")).contains(ColumnTransformationType.IDENTITY);
-        assertThat(transformationTypeFor(event, "mixed_col", "orderkey")).contains(ColumnTransformationType.TRANSFORMATION);
+        assertThat(transformationTypesFor(event, "key_col", "orderkey")).containsExactly(ColumnTransformationType.IDENTITY);
+        assertThat(transformationTypesFor(event, "mixed_col", "orderkey")).containsExactly(ColumnTransformationType.TRANSFORMATION);
     }
 
-    private static Optional<ColumnTransformationType> transformationTypeFor(QueryCompletedEvent event, String outputColumn, String sourceColumn)
+    private static Set<ColumnTransformationType> transformationTypesFor(QueryCompletedEvent event, String outputColumn, String sourceColumn)
     {
         for (OutputColumnMetadata column : event.getIoMetadata().getOutput().get().getColumns().get()) {
             if (column.getColumnName().equals(outputColumn)) {
                 for (ColumnDetail source : column.getSourceColumns()) {
                     if (source.getColumnName().equals(sourceColumn)) {
-                        return source.getTransformationType();
+                        return source.getTransformationTypes();
                     }
                 }
             }
         }
-        return Optional.empty();
+        return Set.of();
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information
at https://trino.io/development/process.html,
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

Trino's OpenLineage event listener already emits a columnLineage facet listing the source columns each output column is derived from, but Trino's column lineage tracking does not output transformations.

This PR classifies how each source column feeds an output column and emits it as an OpenLineage DIRECT transformation subtype, so consumers (e.g. PII data-lineage / retention enforcement) can make per-subtype decisions:

- IDENTITY — output column is a straight copy of the source column (`SELECT a`)
- TRANSFORMATION — derived through a non-aggregate expression in which the raw value can survive (`SELECT a + b`, `concat(a, b)`)
- AGGREGATION — the source column reaches the output only through an aggregate, so no raw value survives (`SELECT sum(a)`, `count(*)`)

<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Partial implementation for https://github.com/trinodb/trino/issues/25568

### Functionality
- Classifies how each source column feeds an output column and emits it per source→output edge in the `columnLineage` facet's `transformations` list as `{ type: "DIRECT", subtype }`.
- Subtypes propagate through subqueries, CTEs, views and set operations.
- `transformations` is a list, so one edge can carry several subtypes when a column reaches the output through more than one path — e.g. `SELECT a FROM t UNION ALL SELECT sum(a) FROM t` reports both `IDENTITY` and `AGGREGATION`.
- Conservative for enforcement: any path that preserves a raw value keeps its `IDENTITY`/`TRANSFORMATION` subtype on the edge, so a raw value is never hidden behind a lone `AGGREGATION`; when the derivation can't be determined the entry is omitted (consumer should assume a raw value may survive).

### Scope & limits
- Only `type = DIRECT`; Trino tracks no `INDIRECT` (join/filter/group-by/sort) lineage.
- Applies to statements that produce output columns: `CREATE TABLE ... AS SELECT`, `INSERT`, and `REFRESH MATERIALIZED VIEW`.
- When a source column appears more than once within a single expression (e.g. `sum(a) + a`), Trino emits one subtype for that edge rather than the full set, and the most-exposing subtype is emitted. This reflects how Trino traverses the expression and may classify differently from Spark.
- `AGGREGATION` can cover value-returning aggregates such as `min`/`max`/`first_value`, so it is not blanket-safe for relaxing retention — see the docs note. OpenLineage [masking](https://openlineage.io/docs/spec/facets/dataset-facets/column_lineage_facet/#masking) is not implemented 

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Section
* Add transformation subtypes to DIRECT types in column lineage facet  (https://github.com/trinodb/trino/issues/25568)
```
