### PR TITLE
Reject zero GRACE PERIOD with WHEN STALE FAIL on untrackable sources

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
@@ -14,6 +14,7 @@
 package io.trino.execution;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
 import io.trino.Session;
@@ -24,9 +25,11 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.MaterializedViewDefinition;
 import io.trino.metadata.MaterializedViewPropertyManager;
 import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.TableHandle;
 import io.trino.metadata.ViewColumn;
 import io.trino.security.AccessControl;
 import io.trino.spi.TrinoException;
+import io.trino.spi.catalog.CatalogName;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition.WhenStaleBehavior;
 import io.trino.spi.type.Type;
 import io.trino.sql.PlannerContext;
@@ -44,6 +47,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -60,10 +64,12 @@ import static io.trino.spi.connector.ConnectorCapabilities.MATERIALIZED_VIEW_GRA
 import static io.trino.spi.connector.ConnectorCapabilities.MATERIALIZED_VIEW_WHEN_STALE_BEHAVIOR;
 import static io.trino.sql.SqlFormatterUtil.getFormattedSql;
 import static io.trino.sql.analyzer.ConstantEvaluator.evaluateConstant;
+import static io.trino.sql.analyzer.DeterminismEvaluator.containsCurrentTimeFunctions;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static io.trino.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 
 public class CreateMaterializedViewTask
         implements DataDefinitionTask<CreateMaterializedView>
@@ -164,6 +170,7 @@ public class CreateMaterializedViewTask
         if (!isWhenStaleBehaviorSupported(session, whenStale, catalogHandle)) {
             throw semanticException(NOT_SUPPORTED, statement, "Catalog '%s' does not support WHEN STALE", catalogName);
         }
+        validateSourcesCanBeTrackedForFreshness(statement, analysis, catalogHandle, gracePeriod, whenStale);
 
         MaterializedViewDefinition definition = new MaterializedViewDefinition(
                 sql,
@@ -191,6 +198,62 @@ public class CreateMaterializedViewTask
         accessControl.checkCanCreateMaterializedView(session.toSecurityContext(), name, explicitlySetProperties);
         plannerContext.getMetadata().createMaterializedView(session, name, definition, properties, statement.isReplace(), statement.isNotExists());
         return analysis;
+    }
+
+    /// A zero grace period means no staleness is accepted, so the view is read from its storage
+    /// table only while it is fresh. Several kinds of source, validated in this method, cannot be tracked for freshness at all.
+    /// Reject the combination at creation time instead of failing at every read.
+    private static void validateSourcesCanBeTrackedForFreshness(
+            CreateMaterializedView statement,
+            Analysis analysis,
+            CatalogHandle catalogHandle,
+            Optional<Duration> gracePeriod,
+            WhenStaleBehavior whenStale)
+    {
+        if (whenStale != WhenStaleBehavior.FAIL || !gracePeriod.map(Duration::isZero).orElse(false)) {
+            return;
+        }
+
+        ImmutableList.Builder<String> untrackedSources = ImmutableList.builder();
+        Set<CatalogName> foreignCatalogs = analysis.getTables().stream()
+                .map(TableHandle::catalogHandle)
+                .filter(sourceCatalogHandle -> !sourceCatalogHandle.equals(catalogHandle))
+                .map(CatalogHandle::getCatalogName)
+                .collect(toImmutableSet());
+        if (!foreignCatalogs.isEmpty()) {
+            untrackedSources.add("another catalog " + formatNames(foreignCatalogs.stream().map(CatalogName::toString)));
+        }
+        Set<String> tableFunctions = analysis.getPolymorphicTableFunctions().stream()
+                .map(tableFunction -> tableFunction.getNode().getName().toString())
+                .collect(toImmutableSet());
+        if (!tableFunctions.isEmpty()) {
+            untrackedSources.add("a table function " + formatNames(tableFunctions.stream()));
+        }
+        Set<String> nonDeterministicFunctions = analysis.getResolvedFunctions().stream()
+                .filter(function -> !function.deterministic())
+                .map(function -> function.name().functionName())
+                .collect(toImmutableSet());
+        if (!nonDeterministicFunctions.isEmpty()) {
+            untrackedSources.add("a non-deterministic function " + formatNames(nonDeterministicFunctions.stream()));
+        }
+        if (containsCurrentTimeFunctions(statement.getQuery())) {
+            untrackedSources.add("a current time function");
+        }
+
+        List<String> sources = untrackedSources.build();
+        if (sources.isEmpty()) {
+            return;
+        }
+        throw semanticException(
+                NOT_SUPPORTED,
+                statement,
+                "Materialized view with a zero GRACE PERIOD and WHEN STALE FAIL cannot depend on %s, because such a source cannot be tracked for freshness and the view is never fresh. Use a non-zero GRACE PERIOD, or WHEN STALE INLINE.",
+                String.join(" and ", sources));
+    }
+
+    private static String formatNames(Stream<String> names)
+    {
+        return names.sorted().collect(joining(", ", "[", "]"));
     }
 
     private boolean isWhenStaleBehaviorSupported(Session session, WhenStaleBehavior whenStale, CatalogHandle catalogHandle)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2407,7 +2407,8 @@ class StatementAnalyzer
             if (optionalMaterializedView.isPresent()) {
                 MaterializedViewDefinition materializedViewDefinition = optionalMaterializedView.get();
                 analysis.addEmptyColumnReferencesForTable(accessControl, session.getIdentity(), name, getBranchName(table));
-                if (isMaterializedViewSufficientlyFresh(session, name, materializedViewDefinition)) {
+                FreshnessCheck freshnessCheck = checkMaterializedViewFreshness(session, name, materializedViewDefinition);
+                if (freshnessCheck.sufficientlyFresh()) {
                     // If materialized view is sufficiently fresh with respect to its grace period, answer the query using the storage table
                     QualifiedName storageName = getMaterializedViewStorageTableName(materializedViewDefinition)
                             .orElseThrow(() -> semanticException(INVALID_VIEW, table, "Materialized view '%s' is fresh but does not have storage table name", name));
@@ -2418,6 +2419,15 @@ class StatementAnalyzer
                     return createScopeForMaterializedView(table, name, scope, materializedViewDefinition, Optional.of(tableHandle));
                 }
                 else if (shouldFailWhenStale(materializedViewDefinition)) {
+                    if (freshnessCheck.canNeverBeFresh()) {
+                        throw semanticException(
+                                VIEW_IS_STALE,
+                                table,
+                                "Materialized view '%s' is stale and can never be fresh, because its freshness cannot be determined and its GRACE PERIOD is zero. " +
+                                        "This happens when it depends on a table in another catalog, a table function, or a non-deterministic function. " +
+                                        "Use a non-zero GRACE PERIOD, or WHEN STALE INLINE.",
+                                name);
+                    }
                     throw semanticException(VIEW_IS_STALE, table, "Materialized view '%s' is stale", name);
                 }
                 // This is a stale materialized view and should be expanded like a logical view
@@ -2494,7 +2504,12 @@ class StatementAnalyzer
             return tableScope;
         }
 
-        private boolean isMaterializedViewSufficientlyFresh(Session session, QualifiedObjectName name, MaterializedViewDefinition materializedViewDefinition)
+        /// A materialized view whose freshness cannot be determined ({@link MaterializedViewFreshness.Freshness#UNKNOWN},
+        /// reported when a source cannot be tracked) and whose grace period is zero can never be
+        /// considered sufficiently fresh, no matter how often it is refreshed.
+        private record FreshnessCheck(boolean sufficientlyFresh, boolean canNeverBeFresh) {}
+
+        private FreshnessCheck checkMaterializedViewFreshness(Session session, QualifiedObjectName name, MaterializedViewDefinition materializedViewDefinition)
         {
             boolean gracePeriodZero = materializedViewDefinition.getGracePeriod()
                     .map(Duration::isZero)
@@ -2506,28 +2521,31 @@ class StatementAnalyzer
             MaterializedViewFreshness materializedViewFreshness = metadata.getMaterializedViewFreshness(session, name, considerGracePeriod);
             MaterializedViewFreshness.Freshness freshness = materializedViewFreshness.getFreshness();
 
+            // A view whose freshness cannot be determined is never reported as fresh, so a zero grace period rules out every read of it.
+            boolean canNeverBeFresh = gracePeriodZero && freshness == MaterializedViewFreshness.Freshness.UNKNOWN;
+
             if (freshness == FRESH || freshness == FRESH_WITHIN_GRACE_PERIOD) {
-                return true;
+                return new FreshnessCheck(true, false);
             }
             Optional<Instant> lastKnownFreshTime = materializedViewFreshness.getLastKnownFreshTime();
             if (lastKnownFreshTime.isEmpty()) {
                 // E.g. never refreshed, or connector not updated to report fresh time
-                return false;
+                return new FreshnessCheck(false, canNeverBeFresh);
             }
             if (materializedViewDefinition.getGracePeriod().isEmpty()) {
                 // Unlimited grace period
-                return true;
+                return new FreshnessCheck(true, false);
             }
             if (gracePeriodZero) {
                 // Consider 0 as a special value meaning "do not accept any staleness". This makes 0 more reliable, and more likely what user wanted,
                 // regardless of lastKnownFreshTime, query time or rounding.
-                return false;
+                return new FreshnessCheck(false, canNeverBeFresh);
             }
 
             Duration gracePeriod = materializedViewDefinition.getGracePeriod().get();
             // Can be negative
             Duration staleness = Duration.between(lastKnownFreshTime.get(), session.getStart());
-            return staleness.compareTo(gracePeriod) <= 0;
+            return new FreshnessCheck(staleness.compareTo(gracePeriod) <= 0, false);
         }
 
         private static boolean shouldFailWhenStale(MaterializedViewDefinition materializedViewDefinition)

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
@@ -15,6 +15,7 @@ package io.trino.execution;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Key;
 import io.trino.Session;
 import io.trino.connector.MockConnectorFactory;
@@ -35,10 +36,15 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.sql.tree.AllColumns;
 import io.trino.sql.tree.CreateMaterializedView;
+import io.trino.sql.tree.CreateMaterializedView.WhenStaleBehavior;
 import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.IntervalField;
+import io.trino.sql.tree.IntervalLiteral;
+import io.trino.sql.tree.IntervalLiteral.Sign;
 import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.Property;
 import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.SimpleIntervalQualifier;
 import io.trino.sql.tree.Statement;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.testing.QueryRunner;
@@ -52,13 +58,17 @@ import org.junit.jupiter.api.TestInstance;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
 import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.INVALID_MATERIALIZED_VIEW_PROPERTY;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.PERMISSION_DENIED;
+import static io.trino.spi.connector.ConnectorCapabilities.MATERIALIZED_VIEW_GRACE_PERIOD;
+import static io.trino.spi.connector.ConnectorCapabilities.MATERIALIZED_VIEW_WHEN_STALE_BEHAVIOR;
 import static io.trino.spi.session.PropertyMetadata.integerProperty;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -66,6 +76,8 @@ import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.sql.QueryUtil.selectList;
 import static io.trino.sql.QueryUtil.simpleQuery;
 import static io.trino.sql.QueryUtil.table;
+import static io.trino.sql.tree.CreateMaterializedView.WhenStaleBehavior.FAIL;
+import static io.trino.sql.tree.CreateMaterializedView.WhenStaleBehavior.INLINE;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.CREATE_MATERIALIZED_VIEW;
 import static io.trino.testing.TestingAccessControlManager.privilege;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
@@ -85,6 +97,18 @@ class TestCreateMaterializedViewTask
             List.of(new ColumnMetadata("a", SMALLINT), new ColumnMetadata("b", BIGINT)),
             ImmutableMap.of("baz", "property_value"));
 
+    private static final String OTHER_CATALOG_NAME = "other_catalog";
+    private static final IntervalLiteral ZERO_GRACE_PERIOD = new IntervalLiteral(
+            new NodeLocation(1, 1),
+            "0",
+            Sign.POSITIVE,
+            new SimpleIntervalQualifier(new NodeLocation(1, 1), OptionalInt.empty(), new IntervalField.Second(OptionalInt.empty())));
+    private static final IntervalLiteral ONE_HOUR_GRACE_PERIOD = new IntervalLiteral(
+            new NodeLocation(1, 1),
+            "1",
+            Sign.POSITIVE,
+            new SimpleIntervalQualifier(new NodeLocation(1, 1), OptionalInt.empty(), new IntervalField.Hour()));
+
     private QueryRunner queryRunner;
     private MockMetadata metadata;
     private CreateMaterializedViewTask task;
@@ -102,8 +126,10 @@ class TestCreateMaterializedViewTask
                         .add(stringProperty("foo", "test materialized view property", DEFAULT_MATERIALIZED_VIEW_FOO_PROPERTY_VALUE, false))
                         .add(integerProperty("bar", "test materialized view property", DEFAULT_MATERIALIZED_VIEW_BAR_PROPERTY_VALUE, false))
                         .build())
+                .withCapabilities(() -> ImmutableSet.of(MATERIALIZED_VIEW_GRACE_PERIOD, MATERIALIZED_VIEW_WHEN_STALE_BEHAVIOR))
                 .build()));
         queryRunner.createCatalog(TEST_CATALOG_NAME, "mock", ImmutableMap.of());
+        queryRunner.createCatalog(OTHER_CATALOG_NAME, "mock", ImmutableMap.of());
         Map<Class<? extends Statement>, DataDefinitionTask<?>> tasks = queryRunner.getCoordinator().getInstance(new Key<>() {});
         task = (CreateMaterializedViewTask) tasks.get(CreateMaterializedView.class);
         this.queryRunner = queryRunner;
@@ -232,6 +258,119 @@ class TestCreateMaterializedViewTask
                     .hasMessageContaining("Cannot create materialized view test_catalog.schema.test_mv");
             return null;
         });
+    }
+
+    @Test
+    void testCreateMaterializedViewWithZeroGracePeriodOnForeignSource()
+    {
+        // Such a view is never fresh, so WHEN STALE FAIL would reject every read of it.
+        CreateMaterializedView statement = createMaterializedViewStatement(
+                OTHER_CATALOG_NAME,
+                Optional.of(ZERO_GRACE_PERIOD),
+                Optional.of(FAIL));
+
+        queryRunner.inTransaction(transactionSession -> {
+            assertTrinoExceptionThrownBy(() -> createMaterializedView(transactionSession, statement))
+                    .hasErrorCode(NOT_SUPPORTED)
+                    .hasMessageContaining("cannot depend on another catalog")
+                    .hasMessageContaining("[other_catalog]");
+            return null;
+        });
+        assertThat(metadata.getCreateMaterializedViewCallCount()).isEqualTo(0);
+    }
+
+    @Test
+    void testCreateMaterializedViewIfNotExistsWithZeroGracePeriodOnForeignSource()
+    {
+        // The validation runs before the connector's existence check, so IF NOT EXISTS does not
+        // suppress it for a view that already exists. The GRACE PERIOD and WHEN STALE capability
+        // checks in this task behave the same way.
+        queryRunner.inTransaction(transactionSession -> {
+            createMaterializedView(transactionSession, createMaterializedViewStatement(
+                    OTHER_CATALOG_NAME,
+                    Optional.of(ONE_HOUR_GRACE_PERIOD),
+                    Optional.of(FAIL)));
+            return null;
+        });
+        assertThat(metadata.getCreateMaterializedViewCallCount()).isEqualTo(1);
+
+        CreateMaterializedView statement = createMaterializedViewStatement(
+                OTHER_CATALOG_NAME,
+                Optional.of(ZERO_GRACE_PERIOD),
+                Optional.of(FAIL));
+        assertThat(statement.isNotExists()).isTrue();
+
+        queryRunner.inTransaction(transactionSession -> {
+            assertTrinoExceptionThrownBy(() -> createMaterializedView(transactionSession, statement))
+                    .hasErrorCode(NOT_SUPPORTED)
+                    .hasMessageContaining("cannot depend on another catalog");
+            return null;
+        });
+    }
+
+    @Test
+    void testCreateMaterializedViewWithZeroGracePeriodOnLocalSource()
+    {
+        // Freshness of a source in the view's own catalog is tracked, so this combination works.
+        CreateMaterializedView statement = createMaterializedViewStatement(
+                TEST_CATALOG_NAME,
+                Optional.of(ZERO_GRACE_PERIOD),
+                Optional.of(FAIL));
+
+        queryRunner.inTransaction(transactionSession -> {
+            createMaterializedView(transactionSession, statement);
+            assertThat(metadata.getCreateMaterializedViewCallCount()).isEqualTo(1);
+            return null;
+        });
+    }
+
+    @Test
+    void testCreateMaterializedViewWithNonZeroGracePeriodOnForeignSource()
+    {
+        // A non-zero grace period accepts a view that cannot be proven fresh, so reads work.
+        CreateMaterializedView statement = createMaterializedViewStatement(
+                OTHER_CATALOG_NAME,
+                Optional.of(ONE_HOUR_GRACE_PERIOD),
+                Optional.of(FAIL));
+
+        queryRunner.inTransaction(transactionSession -> {
+            createMaterializedView(transactionSession, statement);
+            assertThat(metadata.getCreateMaterializedViewCallCount()).isEqualTo(1);
+            return null;
+        });
+    }
+
+    @Test
+    void testCreateMaterializedViewWithZeroGracePeriodAndInlineOnForeignSource()
+    {
+        // WHEN STALE INLINE answers the read from the source query instead of failing.
+        CreateMaterializedView statement = createMaterializedViewStatement(
+                OTHER_CATALOG_NAME,
+                Optional.of(ZERO_GRACE_PERIOD),
+                Optional.of(INLINE));
+
+        queryRunner.inTransaction(transactionSession -> {
+            createMaterializedView(transactionSession, statement);
+            assertThat(metadata.getCreateMaterializedViewCallCount()).isEqualTo(1);
+            return null;
+        });
+    }
+
+    private static CreateMaterializedView createMaterializedViewStatement(
+            String sourceCatalog,
+            Optional<IntervalLiteral> gracePeriod,
+            Optional<WhenStaleBehavior> whenStaleBehavior)
+    {
+        return new CreateMaterializedView(
+                new NodeLocation(1, 1),
+                QualifiedName.of("test_mv_freshness"),
+                simpleQuery(selectList(new AllColumns()), table(QualifiedName.of(sourceCatalog, "schema", "mock_table"))),
+                false,
+                true,
+                gracePeriod,
+                whenStaleBehavior,
+                ImmutableList.of(),
+                Optional.empty());
     }
 
     private void createMaterializedView(Session transactionSession, CreateMaterializedView statement)

--- a/docs/src/main/sphinx/sql/create-materialized-view.md
+++ b/docs/src/main/sphinx/sql/create-materialized-view.md
@@ -65,6 +65,20 @@ Note that the `WHEN STALE` clause requires connector support. If a connector
 does not support this feature, using `WHEN STALE` with any value other than 
 `INLINE` results in an error.
 
+Note that a zero `GRACE PERIOD` accepts no staleness at all, and therefore
+requires the freshness of the materialized view to be known. It is rejected in
+combination with `WHEN STALE FAIL` if the `query` reads from a source whose
+freshness cannot be tracked:
+
+* a table in a catalog other than the catalog of the materialized view,
+* a table function,
+* a non-deterministic function, such as `random()`, or a function returning the
+  current time, such as `current_timestamp`.
+
+Such a materialized view is never known to be fresh, and is therefore always
+considered stale, so every query accessing it fails, even directly after a
+refresh. Use a non-zero grace period or `WHEN STALE INLINE` instead.
+
 The optional `COMMENT` clause causes a `string` comment to be stored with
 the metadata about the materialized view. The comment is displayed with the
 {doc}`show-create-materialized-view` statement and is available in the table

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
@@ -157,4 +157,39 @@ public class TestIcebergMaterializedView
         assertUpdate(defaultIceberg, "DROP TABLE common_base_table");
         assertUpdate("DROP MATERIALIZED VIEW mv_on_iceberg2");
     }
+
+    @Test
+    public void testForeignSourceWithZeroGracePeriodAndWhenStaleFail()
+    {
+        Session defaultIceberg = getSession();
+        assertUpdate(secondIceberg, "CREATE TABLE zero_grace_base_table AS SELECT 10 value", 1);
+
+        assertUpdate(defaultIceberg,
+                """
+                CREATE MATERIALIZED VIEW iceberg.tpch.mv_zero_grace_on_iceberg2
+                GRACE PERIOD INTERVAL '0' SECOND
+                WHEN STALE FAIL
+                AS SELECT sum(value) AS s FROM iceberg2.tpch.zero_grace_base_table
+                """);
+
+        assertUpdate(defaultIceberg, "REFRESH MATERIALIZED VIEW mv_zero_grace_on_iceberg2", 1);
+
+        // Changes to a table in another catalog cannot be tracked, so the view is never reported as fresh,
+        // not even directly after a successful refresh. A zero grace period accepts no staleness, so
+        // WHEN STALE FAIL rejects every read of the view and refreshing again does not help.
+        assertThat(getFreshness("mv_zero_grace_on_iceberg2")).isEqualTo("UNKNOWN");
+        assertQueryFails("TABLE mv_zero_grace_on_iceberg2", "line 1:1: Materialized view 'iceberg.tpch.mv_zero_grace_on_iceberg2' is stale");
+        assertUpdate(defaultIceberg, "REFRESH MATERIALIZED VIEW mv_zero_grace_on_iceberg2", 1);
+        assertQueryFails("TABLE mv_zero_grace_on_iceberg2", "line 1:1: Materialized view 'iceberg.tpch.mv_zero_grace_on_iceberg2' is stale");
+
+        assertUpdate(secondIceberg, "DROP TABLE zero_grace_base_table");
+        assertUpdate("DROP MATERIALIZED VIEW mv_zero_grace_on_iceberg2");
+    }
+
+    private String getFreshness(String viewName)
+    {
+        return (String) computeScalar(
+                "SELECT freshness FROM system.metadata.materialized_views " +
+                        "WHERE catalog_name = CURRENT_CATALOG AND schema_name = CURRENT_SCHEMA AND name = '" + viewName + "'");
+    }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
@@ -161,35 +161,72 @@ public class TestIcebergMaterializedView
     @Test
     public void testForeignSourceWithZeroGracePeriodAndWhenStaleFail()
     {
-        Session defaultIceberg = getSession();
         assertUpdate(secondIceberg, "CREATE TABLE zero_grace_base_table AS SELECT 10 value", 1);
 
-        assertUpdate(defaultIceberg,
+        // Changes to a table in another catalog cannot be tracked, so such a view would never be reported
+        // as fresh, not even directly after a successful refresh. A zero grace period accepts no staleness,
+        // so WHEN STALE FAIL would reject every read of it. Creating it is rejected up front instead.
+        assertQueryFails(
                 """
                 CREATE MATERIALIZED VIEW iceberg.tpch.mv_zero_grace_on_iceberg2
                 GRACE PERIOD INTERVAL '0' SECOND
                 WHEN STALE FAIL
                 AS SELECT sum(value) AS s FROM iceberg2.tpch.zero_grace_base_table
-                """);
-
-        assertUpdate(defaultIceberg, "REFRESH MATERIALIZED VIEW mv_zero_grace_on_iceberg2", 1);
-
-        // Changes to a table in another catalog cannot be tracked, so the view is never reported as fresh,
-        // not even directly after a successful refresh. A zero grace period accepts no staleness, so
-        // WHEN STALE FAIL rejects every read of the view and refreshing again does not help.
-        assertThat(getFreshness("mv_zero_grace_on_iceberg2")).isEqualTo("UNKNOWN");
-        assertQueryFails("TABLE mv_zero_grace_on_iceberg2", "line 1:1: Materialized view 'iceberg.tpch.mv_zero_grace_on_iceberg2' is stale");
-        assertUpdate(defaultIceberg, "REFRESH MATERIALIZED VIEW mv_zero_grace_on_iceberg2", 1);
-        assertQueryFails("TABLE mv_zero_grace_on_iceberg2", "line 1:1: Materialized view 'iceberg.tpch.mv_zero_grace_on_iceberg2' is stale");
+                """,
+                "line 1:1: Materialized view with a zero GRACE PERIOD and WHEN STALE FAIL cannot depend on another catalog \\[iceberg2], " +
+                        "because such a source cannot be tracked for freshness and the view is never fresh\\. " +
+                        "Use a non-zero GRACE PERIOD, or WHEN STALE INLINE\\.");
 
         assertUpdate(secondIceberg, "DROP TABLE zero_grace_base_table");
-        assertUpdate("DROP MATERIALIZED VIEW mv_zero_grace_on_iceberg2");
     }
 
-    private String getFreshness(String viewName)
+    @Test
+    public void testTableFunctionSourceWithZeroGracePeriodAndWhenStaleFail()
     {
-        return (String) computeScalar(
-                "SELECT freshness FROM system.metadata.materialized_views " +
-                        "WHERE catalog_name = CURRENT_CATALOG AND schema_name = CURRENT_SCHEMA AND name = '" + viewName + "'");
+        // A table function result cannot be tracked either, so such a view would never be fresh
+        // and WHEN STALE FAIL would reject every read of it.
+        assertQueryFails(
+                """
+                CREATE MATERIALIZED VIEW iceberg.tpch.mv_zero_grace_on_ptf
+                GRACE PERIOD INTERVAL '0' SECOND
+                WHEN STALE FAIL
+                AS SELECT * FROM TABLE(mock.system.sequence_function())
+                """,
+                "line 1:1: Materialized view with a zero GRACE PERIOD and WHEN STALE FAIL cannot depend on a table function \\[mock.system.sequence_function], " +
+                        "because such a source cannot be tracked for freshness and the view is never fresh\\. " +
+                        "Use a non-zero GRACE PERIOD, or WHEN STALE INLINE\\.");
+    }
+
+    @Test
+    public void testNonDeterministicSourceWithZeroGracePeriodAndWhenStaleFail()
+    {
+        assertUpdate("CREATE TABLE zero_grace_nondeterministic_base_table AS SELECT 10 value", 1);
+
+        // A non-deterministic function changes value without any source changing, so such a view
+        // would never be fresh and WHEN STALE FAIL would reject every read of it.
+        assertQueryFails(
+                """
+                CREATE MATERIALIZED VIEW iceberg.tpch.mv_zero_grace_on_random
+                GRACE PERIOD INTERVAL '0' SECOND
+                WHEN STALE FAIL
+                AS SELECT value, random() r FROM zero_grace_nondeterministic_base_table
+                """,
+                "line 1:1: Materialized view with a zero GRACE PERIOD and WHEN STALE FAIL cannot depend on a non-deterministic function \\[random], " +
+                        "because such a source cannot be tracked for freshness and the view is never fresh\\. " +
+                        "Use a non-zero GRACE PERIOD, or WHEN STALE INLINE\\.");
+
+        // current_timestamp is not a resolved function, so it is detected separately.
+        assertQueryFails(
+                """
+                CREATE MATERIALIZED VIEW iceberg.tpch.mv_zero_grace_on_current_timestamp
+                GRACE PERIOD INTERVAL '0' SECOND
+                WHEN STALE FAIL
+                AS SELECT value, current_timestamp ts FROM zero_grace_nondeterministic_base_table
+                """,
+                "line 1:1: Materialized view with a zero GRACE PERIOD and WHEN STALE FAIL cannot depend on a current time function, " +
+                        "because such a source cannot be tracked for freshness and the view is never fresh\\. " +
+                        "Use a non-zero GRACE PERIOD, or WHEN STALE INLINE\\.");
+
+        assertUpdate("DROP TABLE zero_grace_nondeterministic_base_table");
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
@@ -229,4 +229,53 @@ public class TestIcebergMaterializedView
 
         assertUpdate("DROP TABLE zero_grace_nondeterministic_base_table");
     }
+
+    @Test
+    public void testZeroGracePeriodViewSwappedToForeignSourceExplainsPermanentStaleness()
+    {
+        // The combination is rejected at creation time, but a source view can be repointed at another
+        // catalog afterwards, which leaves a materialized view that can never be read again. The read
+        // failure says so, rather than suggesting a refresh that cannot help.
+        assertUpdate("CREATE TABLE swap_local_base_table AS SELECT 10 value", 1);
+        assertUpdate(secondIceberg, "CREATE TABLE swap_foreign_base_table AS SELECT 7 value", 1);
+        assertUpdate("CREATE VIEW swap_source_view AS SELECT value FROM swap_local_base_table");
+
+        assertUpdate(
+                """
+                CREATE MATERIALIZED VIEW iceberg.tpch.mv_on_swapped_view
+                GRACE PERIOD INTERVAL '0' SECOND
+                WHEN STALE FAIL
+                AS SELECT sum(value) AS s FROM swap_source_view
+                """);
+        assertUpdate("REFRESH MATERIALIZED VIEW mv_on_swapped_view", 1);
+        assertThat(getFreshness("mv_on_swapped_view")).isEqualTo("FRESH");
+        assertThat(query("TABLE mv_on_swapped_view")).matches("VALUES BIGINT '10'");
+
+        // The source view now reads from another catalog, which cannot be tracked for freshness.
+        assertUpdate("CREATE OR REPLACE VIEW swap_source_view AS SELECT value FROM iceberg2.tpch.swap_foreign_base_table");
+        // The recorded dependency is still the local table, so the view stays fresh until that table
+        // changes and the next refresh actually runs.
+        assertThat(getFreshness("mv_on_swapped_view")).isEqualTo("FRESH");
+        assertUpdate("INSERT INTO swap_local_base_table VALUES 5", 1);
+        assertUpdate("REFRESH MATERIALIZED VIEW mv_on_swapped_view", 1);
+        assertThat(getFreshness("mv_on_swapped_view")).isEqualTo("UNKNOWN");
+        assertQueryFails(
+                "TABLE mv_on_swapped_view",
+                "line 1:1: Materialized view 'iceberg.tpch.mv_on_swapped_view' is stale and can never be fresh, " +
+                        "because its freshness cannot be determined and its GRACE PERIOD is zero\\. " +
+                        "This happens when it depends on a table in another catalog, a table function, or a non-deterministic function\\. " +
+                        "Use a non-zero GRACE PERIOD, or WHEN STALE INLINE\\.");
+
+        assertUpdate("DROP MATERIALIZED VIEW mv_on_swapped_view");
+        assertUpdate("DROP VIEW swap_source_view");
+        assertUpdate("DROP TABLE swap_local_base_table");
+        assertUpdate(secondIceberg, "DROP TABLE swap_foreign_base_table");
+    }
+
+    private String getFreshness(String viewName)
+    {
+        return (String) computeScalar(
+                "SELECT freshness FROM system.metadata.materialized_views " +
+                        "WHERE catalog_name = CURRENT_CATALOG AND schema_name = CURRENT_SCHEMA AND name = '" + viewName + "'");
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description

### Why

A materialized view is answered from its storage table only while it is reported as
fresh. Some sources can never be tracked for freshness, so the connector reports
`UNKNOWN` permanently, no matter how often the view is refreshed:

* a table in another catalog
* a table function
* a non-deterministic or current time function

A zero `GRACE PERIOD` when combined with `WHEN STALE FAIL`,
every read of it fails with `Materialized view '...' is stale` — including a read issued
directly after a successful `REFRESH`. The view can be created and refreshed, but never
queried, and the error points the user at a refresh that cannot help.

### What

Three commits:

1. A test documenting the behavior and docs changes
2. Rejecting the combination at creation time
3. Explaining the state at read time

## Additional context and related issues

`CREATE OR REPLACE MATERIALIZED VIEW` is the same statement node and task, so the
validation covers it. `ALTER MATERIALIZED VIEW ... SET PROPERTIES` cannot reach the
state: the grace period and when-stale behavior are fields on `MaterializedViewDefinition`,
not connector properties, and the clauses exist only in the `CREATE` grammar. Rename,
`SET AUTHORIZATION`, and `COMMENT ON` leave both fields intact.

Two ways to be in this state remain, which is why the third commit improves the read
failure rather than only guarding creation:

* a source *view* can be repointed at another catalog after the materialized view is
  created, leaving its definition untouched;
* a definition may have been written by an older version or another engine.

One behavior change worth noting for review: validation runs before the connector's
existence check, so `CREATE MATERIALIZED VIEW IF NOT EXISTS` with this combination now
fails even when the view already exists. The pre-existing `GRACE PERIOD` and `WHEN STALE`
capability checks in the same task behave the same way.

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
## General
* Reject creating a materialized view with a zero `GRACE PERIOD` and `WHEN STALE FAIL`
  when its freshness cannot be tracked, because such a view can never be read.
```
