### PR TITLE
Fix SQL generated for legacy IDENTICAL join pushdown

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/JoinCondition.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/JoinCondition.java
@@ -46,7 +46,7 @@ public final class JoinCondition
         LESS_THAN_OR_EQUAL("<=", StandardFunctions.LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME),
         GREATER_THAN(">", StandardFunctions.GREATER_THAN_OPERATOR_FUNCTION_NAME),
         GREATER_THAN_OR_EQUAL(">=", StandardFunctions.GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME),
-        IDENTICAL("≡", StandardFunctions.IDENTICAL_OPERATOR_FUNCTION_NAME),
+        IDENTICAL("IS NOT DISTINCT FROM", StandardFunctions.IDENTICAL_OPERATOR_FUNCTION_NAME),
         /**/;
 
         private static final Map<FunctionName, Operator> byFunctionName = Stream.of(values())

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1189,9 +1189,9 @@ public abstract class BaseJdbcConnectorTest
 
                 List<String> nonEqualities = Stream.concat(
                                 Stream.of(JoinCondition.Operator.values())
-                                        .filter(operator -> operator != JoinCondition.Operator.EQUAL && operator != JoinCondition.Operator.IDENTICAL)
+                                        .filter(operator -> operator != JoinCondition.Operator.EQUAL)
                                         .map(JoinCondition.Operator::getValue),
-                                Stream.of("IS DISTINCT FROM", "IS NOT DISTINCT FROM"))
+                                Stream.of("IS DISTINCT FROM"))
                         .collect(toImmutableList());
 
                 // basic case
@@ -1413,9 +1413,6 @@ public abstract class BaseJdbcConnectorTest
 
     private JoinCondition.Operator toJoinConditionOperator(String operator)
     {
-        if (operator.equals("IS NOT DISTINCT FROM")) {
-            return JoinCondition.Operator.IDENTICAL;
-        }
         return Stream.of(JoinCondition.Operator.values())
                 .filter(joinOperator -> joinOperator.getValue().equals(operator))
                 .collect(toOptional())

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
@@ -544,6 +544,13 @@ public class TestDefaultJdbcQueryBuilder
     public void testBuildJoinSqlLegacy()
             throws SQLException
     {
+        testBuildJoinSqlLegacy(JoinCondition.Operator.EQUAL, "=");
+        testBuildJoinSqlLegacy(JoinCondition.Operator.IDENTICAL, "IS NOT DISTINCT FROM");
+    }
+
+    private void testBuildJoinSqlLegacy(JoinCondition.Operator joinOperator, String sqlOperator)
+            throws SQLException
+    {
         Connection connection = database.getConnection();
 
         PreparedQuery preparedQuery = queryBuilder.legacyPrepareJoinQuery(
@@ -553,7 +560,7 @@ public class TestDefaultJdbcQueryBuilder
                 JoinType.INNER,
                 new PreparedQuery("SELECT * FROM \"test_table\"", List.of()),
                 new PreparedQuery("SELECT * FROM \"test_table\"", List.of()),
-                List.of(new JdbcJoinCondition(columns.get(7), JoinCondition.Operator.EQUAL, columns.get(8))),
+                List.of(new JdbcJoinCondition(columns.get(7), joinOperator, columns.get(8))),
                 Map.of(columns.get(2), "name1"),
                 Map.of(columns.get(3), "name2"));
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery, Optional.empty())) {
@@ -562,7 +569,7 @@ public class TestDefaultJdbcQueryBuilder
                     "(SELECT * FROM \"test_table\") l " +
                     "INNER JOIN " +
                     "(SELECT * FROM \"test_table\") r " +
-                    "ON l.\"col_7\" = r.\"col_8\"");
+                    "ON l.\"col_7\" " + sqlOperator + " r.\"col_8\"");
             long count = 0;
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
                 while (resultSet.next()) {

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -61,6 +61,7 @@ import java.util.stream.Stream;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.jdbc.JdbcMetadataSessionProperties.COMPLEX_JOIN_PUSHDOWN_ENABLED;
 import static io.trino.plugin.postgresql.PostgreSqlConfig.ArrayMapping.AS_ARRAY;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -618,9 +619,9 @@ public class TestPostgreSqlConnectorTest
 
         List<String> nonEqualities = Stream.concat(
                         Stream.of(JoinCondition.Operator.values())
-                                .filter(operator -> operator != JoinCondition.Operator.EQUAL && operator != JoinCondition.Operator.IDENTICAL)
+                                .filter(operator -> operator != JoinCondition.Operator.EQUAL)
                                 .map(JoinCondition.Operator::getValue),
-                        Stream.of("IS DISTINCT FROM", "IS NOT DISTINCT FROM"))
+                        Stream.of("IS DISTINCT FROM"))
                 .collect(toImmutableList());
 
         try (TestTable nationLowercaseTable = newTrinoTable(
@@ -745,6 +746,17 @@ public class TestPostgreSqlConnectorTest
             assertThat(query(session, "SELECT * FROM nation n, region r, customer c WHERE n.regionkey = r.regionkey AND r.regionkey = c.custkey"))
                     .isFullyPushedDown();
         }
+    }
+
+    @Test
+    public void testLegacyJoinPushdownWithIdenticalCondition()
+    {
+        Session session = Session.builder(joinPushdownEnabled(getSession()))
+                .setCatalogSessionProperty("postgresql", COMPLEX_JOIN_PUSHDOWN_ENABLED, "false")
+                .build();
+
+        assertThat(query(session, "SELECT n1.name FROM nation n1 JOIN nation n2 ON n1.nationkey = n2.nationkey AND n1.regionkey IS NOT DISTINCT FROM n2.regionkey"))
+                .isFullyPushedDown();
     }
 
     @Test


### PR DESCRIPTION
85feebc20d3 replaced JoinCondition.Operator.IS_DISTINCT_FROM with IDENTICAL and gave it the IR's display symbol "≡" as its value. DefaultQueryBuilder.formatJoinCondition splices that value straight into the generated SQL, so an IS NOT DISTINCT FROM join pushed into a connector that accepts it (PostgreSQL, Ignite) produced `l."x" ≡ r."y"` and failed with a remote syntax error. The path is reached whenever complex_join_pushdown_enabled is off.

With the value fixed, the test-side workarounds that skipped IDENTICAL and spelled the operator out by hand are no longer needed.

- fixes https://github.com/trinodb/trino/issues/31097