### PR TITLE
Cleanup StageInfo Constructor

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/StageInfo.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageInfo.java
@@ -48,6 +48,7 @@ public record StageInfo(
         requireNonNull(subStages, "subStages is null");
         requireNonNull(tables, "tables is null");
         tasks = ImmutableList.copyOf(tasks);
+        subStages = ImmutableList.copyOf(subStages);
         tables = ImmutableMap.copyOf(tables);
     }
 


### PR DESCRIPTION
## Description
Wraps the `StageInfo.subStages` constructor parameter with an `ImmutableList#copyOf` similar to the tasks and tables fields.


<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: