### PR TITLE
Simplify supported type checks in CSV and raw decoders

### DIFF
--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/csv/CsvColumnDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/csv/CsvColumnDecoder.java
@@ -73,10 +73,7 @@ public class CsvColumnDecoder
         if (type instanceof VarcharType) {
             return true;
         }
-        if (ImmutableList.of(BIGINT, INTEGER, SMALLINT, TINYINT, BOOLEAN, DOUBLE).contains(type)) {
-            return true;
-        }
-        return false;
+        return ImmutableList.of(BIGINT, INTEGER, SMALLINT, TINYINT, BOOLEAN, DOUBLE).contains(type);
     }
 
     public FieldValueProvider decodeField(String[] tokens)

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/raw/RawColumnDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/raw/RawColumnDecoder.java
@@ -164,10 +164,7 @@ public class RawColumnDecoder
         if (type instanceof VarcharType) {
             return true;
         }
-        if (ImmutableList.of(BIGINT, INTEGER, SMALLINT, TINYINT, BOOLEAN, DOUBLE).contains(type)) {
-            return true;
-        }
-        return false;
+        return ImmutableList.of(BIGINT, INTEGER, SMALLINT, TINYINT, BOOLEAN, DOUBLE).contains(type);
     }
 
     private void checkFieldTypeOneOf(FieldType declaredFieldType, String columnName, FieldType... allowedFieldTypes)


### PR DESCRIPTION
## Description

Simplify supported type checks in the CSV and raw column decoders by returning the existing collection membership result directly. This removes redundant boolean branches while preserving the accepted types and evaluation order.

## Additional context and related issues

Validation:
- Maven Airstyle and Checkstyle passed for `lib/trino-record-decoder`.
- `git diff --check` passed.
- Focused `TestCsvDecoder` and `TestRawDecoder` tests and module `validate` were attempted in offline mode but could not complete because required dependencies were missing from the local Maven cache. The initial reactor test run also stopped because a prerequisite module had no matching tests.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
