### PR TITLE
Fix width_bucket arithmetic overflow

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
@@ -1555,7 +1555,20 @@ public final class MathFunctions
             }
         }
         else {
-            result = (long) ((double) bucketCount * (operand - lower) / (upper - lower) + 1);
+            double range = upper - lower;
+            double position = operand - lower;
+            double scaledPosition = bucketCount * position;
+            if (Double.isFinite(range) && Double.isFinite(scaledPosition)) {
+                result = (long) (scaledPosition / range + 1);
+            }
+            else {
+                if (Double.isInfinite(range)) {
+                    // Scale before subtracting to avoid overflowing the width of a finite range.
+                    range = upper / 2 - lower / 2;
+                    position = operand / 2 - lower / 2;
+                }
+                result = Math.min(bucketCount, (long) (bucketCount * (position / range) + 1));
+            }
         }
 
         if (bound1 > bound2) {

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
@@ -3790,6 +3790,40 @@ public class TestMathFunctions
     }
 
     @Test
+    public void testWidthBucketLargeBounds()
+    {
+        // Preserve boundary rounding when the original arithmetic does not overflow.
+        assertThat(assertions.function("width_bucket", "15E0", "0E0", "22E0", "22"))
+                .isEqualTo(16L);
+        assertThat(assertions.function("width_bucket", "15E0", "22E0", "0E0", "22"))
+                .isEqualTo(7L);
+        assertThat(assertions.function("width_bucket", "0E0", "-1E308", "1E308", "10"))
+                .isEqualTo(6L);
+        assertThat(assertions.function("width_bucket", "5E307", "0E0", "1E308", "10"))
+                .isEqualTo(6L);
+        assertThat(assertions.function("width_bucket", "-5E307", "-1E308", "0E0", "10"))
+                .isEqualTo(6L);
+        assertThat(assertions.function("width_bucket", "-5E307", "-1E308", "1E308", "10"))
+                .isEqualTo(3L);
+        assertThat(assertions.function("width_bucket", "5E307", "-1E308", "1E308", "10"))
+                .isEqualTo(8L);
+        assertThat(assertions.function("width_bucket", "-5E307", "1E308", "-1E308", "10"))
+                .isEqualTo(8L);
+        assertThat(assertions.function("width_bucket", "5E307", "1E308", "-1E308", "10"))
+                .isEqualTo(3L);
+        assertThat(assertions.function("width_bucket", "-1E308", "-1E308", "1E308", "10"))
+                .isEqualTo(1L);
+        assertThat(assertions.function("width_bucket", "1E308", "-1E308", "1E308", "10"))
+                .isEqualTo(11L);
+        assertThat(assertions.function("width_bucket", "-1.5E308", "-1E308", "1E308", "10"))
+                .isEqualTo(0L);
+        assertThat(assertions.function("width_bucket", "1.5E308", "-1E308", "1E308", "10"))
+                .isEqualTo(11L);
+        assertThat(assertions.function("width_bucket", "1E-310", "0E0", "2E-310", "10"))
+                .isEqualTo(6L);
+    }
+
+    @Test
     public void testWidthBucketOverflowAscending()
     {
         assertTrinoExceptionThrownBy(assertions.function("width_bucket", "infinity()", "0", "4", Long.toString(Long.MAX_VALUE))::evaluate)


### PR DESCRIPTION
## Description

Prevent intermediate overflow from producing invalid bucket IDs for finite operands and bounds. For example, `width_bucket(0e0, -1e308, 1e308, 10)` now returns `6` instead of `0`.

Preserve the existing arithmetic when its intermediates are finite to retain exact-boundary rounding behavior. When an intermediate overflows, normalize before multiplying and scale overflowing ranges before subtraction. Add regression coverage for large bounds, descending bounds, endpoints, tiny ranges, and ordinary exact boundaries.

Validation: all 94 tests in `TestMathFunctions`, `TestVarbinaryFunctions`, and `TestUrlFunctions` pass against the combined fixes; Maven validation passes with no Checkstyle violations. Regression tests were also run against the original code and reproduced the failures.

## Additional context and related issues

- Fixes #31107

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix incorrect results from {func}`width_bucket` with large finite bounds. ({issue}`31112`)
```
