### PR TITLE
Fix binary substring length overflow

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
@@ -404,11 +404,7 @@ public final class VarbinaryFunctions
             if (indexStart >= slice.length()) {
                 return EMPTY_SLICE;
             }
-            int indexEnd = indexStart + byteLength;
-            if (indexEnd > slice.length()) {
-                indexEnd = slice.length();
-            }
-            return slice.slice(indexStart, indexEnd - indexStart);
+            return slice.slice(indexStart, Math.min(byteLength, slice.length() - indexStart));
         }
 
         // negative start is relative to end of string
@@ -419,13 +415,7 @@ public final class VarbinaryFunctions
             return EMPTY_SLICE;
         }
 
-        int indexStart = startByte;
-        int indexEnd = indexStart + byteLength;
-        if (indexEnd > slice.length()) {
-            indexEnd = slice.length();
-        }
-
-        return slice.slice(indexStart, indexEnd - indexStart);
+        return slice.slice(startByte, Math.min(byteLength, slice.length() - startByte));
     }
 
     private static Slice pad(Slice inputSlice, long targetLength, Slice padSlice, int paddingOffset)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestVarbinaryFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestVarbinaryFunctions.java
@@ -923,6 +923,23 @@ public class TestVarbinaryFunctions
     }
 
     @Test
+    public void testVarbinarySubstringLargeLength()
+    {
+        for (String length : new String[] {"2147483647", "9223372036854775807"}) {
+            assertThat(assertions.function("substr", "X'010203'", "2", length))
+                    .isEqualTo(sqlVarbinary(0x02, 0x03));
+            assertThat(assertions.function("substr", "X'010203'", "-1", length))
+                    .isEqualTo(sqlVarbinary(0x03));
+            assertThat(assertions.function("substr", "X'010203'", "1", length))
+                    .isEqualTo(sqlVarbinary(0x01, 0x02, 0x03));
+            assertThat(assertions.function("substr", "X'010203'", "4", length))
+                    .isEqualTo(sqlVarbinary(""));
+            assertThat(assertions.function("substr", "X'010203'", "-4", length))
+                    .isEqualTo(sqlVarbinary(""));
+        }
+    }
+
+    @Test
     public void testHmacMd5()
     {
         assertThat(assertions.function("hmac_md5", "CAST('' AS VARBINARY)", "CAST('key' AS VARBINARY)"))


### PR DESCRIPTION
## Description

Clamp binary substring length to the available suffix before calculating the slice. For example, `substr(X'010203', 2, 2147483647)` now returns `X'0203'` instead of failing after its end index overflows.

Cover maximum INTEGER and BIGINT lengths with positive, negative, and out-of-range start positions.

Validation: all 94 tests in `TestMathFunctions`, `TestVarbinaryFunctions`, and `TestUrlFunctions` pass against the combined fixes; Maven validation passes with no Checkstyle violations. Regression tests were also run against the original code and reproduced the failures.

## Additional context and related issues

- Fixes #31108

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix failures of binary {func}`substr` and {func}`substring` with large lengths. ({issue}`31113`)
```
