### PR TITLE
Decode URL parameter names before matching

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/UrlFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/UrlFunctions.java
@@ -131,7 +131,7 @@ public final class UrlFunctions
 
         for (String queryArg : queryArgs) {
             Iterator<String> arg = ARG_SPLITTER.split(queryArg).iterator();
-            if (arg.next().equals(parameter)) {
+            if (decodeUrl(arg.next()).toStringUtf8().equals(parameter)) {
                 if (arg.hasNext()) {
                     return decodeUrl(arg.next());
                 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestUrlFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestUrlFunctions.java
@@ -102,6 +102,31 @@ public class TestUrlFunctions
     }
 
     @Test
+    public void testUrlExtractEncodedParameterName()
+    {
+        assertThat(assertions.function("url_extract_parameter", "'http://example.com/?a%20b=first&a+b=second'", "'a b'"))
+                .isEqualTo("first");
+        assertThat(assertions.function("url_extract_parameter", "'http://example.com/?a+b=first&a%20b=second'", "'a b'"))
+                .isEqualTo("first");
+        assertThat(assertions.function("url_extract_parameter", "'http://example.com/?%61=first&a=second'", "'a'"))
+                .isEqualTo("first");
+        assertThat(assertions.function("url_extract_parameter", "'http://example.com/?a%26b%3Dc=value'", "'a&b=c'"))
+                .isEqualTo("value");
+        assertThat(assertions.function("url_extract_parameter", "'http://example.com/?a%2Bb=value'", "'a+b'"))
+                .isEqualTo("value");
+        assertThat(assertions.function("url_extract_parameter", "'http://example.com/?%E3%83%86=value'", "'テ'"))
+                .isEqualTo("value");
+        assertThat(assertions.function("url_extract_parameter", "'http://example.com/?%61&a=second'", "'a'"))
+                .isEqualTo("");
+        assertThat(assertions.function("url_extract_parameter", "'http://example.com/?%61=&a=second'", "'a'"))
+                .isEqualTo("");
+        assertThat(assertions.function("url_extract_parameter", "'http://example.com/?%2561=value'", "'%61'"))
+                .isEqualTo("value");
+        assertThat(assertions.expression("url_extract_parameter('http://example.com/?' || url_encode('a b') || '=ok', 'a b')"))
+                .isEqualTo("ok");
+    }
+
+    @Test
     public void testUrlEncode()
     {
         String[][] outputInputPairs = {


### PR DESCRIPTION
## Description

Decode query parameter names before comparing them with the requested name. For example, `url_extract_parameter('https://example.com/?first%20name=Ada', 'first name')` now returns `Ada`.

Split the raw query string before decoding so encoded separators remain part of names and values. Cover percent encoding, plus signs, Unicode, valueless parameters, single decoding, and a `url_encode` round trip.

Validation: all 94 tests in `TestMathFunctions`, `TestVarbinaryFunctions`, and `TestUrlFunctions` pass against the combined fixes; Maven validation passes with no Checkstyle violations. Regression tests were also run against the original code and reproduced the failures.

## Additional context and related issues

- Fixes #31109

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## General
* Fix matching encoded parameter names in {func}`url_extract_parameter`. ({issue}`31114`)
```
