### PR TITLE
Stop Web UI polling after route navigation

### DIFF
--- a/core/trino-web-ui/src/main/resources/webapp/bun.lock
+++ b/core/trino-web-ui/src/main/resources/webapp/bun.lock
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.5",
+        "@happy-dom/global-registrator": "20.14.5",
         "@types/lodash": "^4.17.25",
         "@types/lodash.merge": "^4.6.9",
         "@types/react": "^19.2.18",
@@ -147,6 +148,8 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
 
     "@fontsource/roboto": ["@fontsource/roboto@5.3.0", "", {}, "sha512-BapRJOWYP+LZ21zp+wBQjfpPYKRoxc4LspJ/RLuI+HSMBD5u/X4O+ESDrSvEqDSy0rAl7GwBJ+09mdc16cVQ1Q=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.14.5", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.14.5" } }, "sha512-B05ID9DhSwLs6mlm1fzlkAtTIvB3duCvjJjfr19LBrlTK7VZtRjDqoTRIVv13GuYuNdhByu8LSZgThwV3Rkj7g=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
@@ -310,6 +313,8 @@
 
     "@types/lodash.merge": ["@types/lodash.merge@4.6.9", "", { "dependencies": { "@types/lodash": "*" } }, "sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ=="],
 
+    "@types/node": ["@types/node@22.20.2", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw=="],
+
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
 
     "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
@@ -321,6 +326,10 @@
     "@types/react-transition-group": ["@types/react-transition-group@4.4.12", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.69.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.69.0", "@typescript-eslint/type-utils": "8.69.0", "@typescript-eslint/utils": "8.69.0", "@typescript-eslint/visitor-keys": "8.69.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.69.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA=="],
 
@@ -395,6 +404,8 @@
     "brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
 
     "browserslist": ["browserslist@4.28.8", "", { "dependencies": { "baseline-browser-mapping": "^2.11.12", "caniuse-lite": "^1.0.30001809", "electron-to-chromium": "^1.5.402", "node-releases": "^2.0.53", "update-browserslist-db": "^1.3.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
 
@@ -500,6 +511,8 @@
 
     "element-resize-detector": ["element-resize-detector@1.2.4", "", { "dependencies": { "batch-processor": "1.0.0" } }, "sha512-Fl5Ftk6WwXE0wqCgNoseKWndjzZlDCwuPTcoVZfCP9R3EHQF8qUtr3YUPNETegRBOKqQKPW3n4kiIWngGi8tKg=="],
 
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "es-abstract": ["es-abstract@1.24.2", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg=="],
@@ -597,6 +610,8 @@
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "happy-dom": ["happy-dom@20.14.5", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-x/RzkpWO40bTjIoT30iQtt64FLLmH/iRcUCN2X//bLx7H3ifkdfPXyqsro/OYtqzIAhiLMMA7mmiOR9C3NOKjQ=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -934,6 +949,8 @@
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.3.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
@@ -941,6 +958,8 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "vite": ["rolldown-vite@7.3.1", "", { "dependencies": { "@oxc-project/runtime": "0.101.0", "fdir": "^6.5.0", "lightningcss": "^1.30.2", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rolldown": "1.0.0-beta.53", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-LYzdNAjRHhF2yA4JUQm/QyARyi216N2rpJ0lJZb8E9FU2y5v6Vk+xq/U4XBOxMefpWixT5H3TslmAHm1rqIq2w=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -953,6 +972,8 @@
     "which-typed-array": ["which-typed-array@1.1.22", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.9", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/core/trino-web-ui/src/main/resources/webapp/eslint.config.js
+++ b/core/trino-web-ui/src/main/resources/webapp/eslint.config.js
@@ -21,6 +21,12 @@ import reactRefreshPlugin from 'eslint-plugin-react-refresh';
 export default [
   js.configs.recommended,
   {
+    files: ['src/test/**/*.js'],
+    languageOptions: {
+      globals: globals.browser,
+    },
+  },
+  {
     files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parser: tsParser,

--- a/core/trino-web-ui/src/main/resources/webapp/package.json
+++ b/core/trino-web-ui/src/main/resources/webapp/package.json
@@ -10,11 +10,12 @@
     "package": "bun install && bun run build",
     "package:clean": "bun install --frozen-lockfile && bun run build",
     "preview": "bun --bun vite preview",
-    "prettier:format": "bun --bun prettier --write \"./src/**/*.{ts,tsx}\"",
-    "prettier:check": "bun --bun prettier --check \"./src/**/*.{ts,tsx}\"",
-    "check": "bun install && bun run typecheck && bun run lint && bun run prettier:check && bun run check:licenses",
-    "check:clean": "bun install --frozen-lockfile && bun run typecheck && bun run lint && bun run prettier:check && bun run check:licenses",
-    "check:licenses": "USED_LICENSES=$(mktemp); find node_modules -name package.json -exec jq 'if (.license | type) == \"string\" then .license else empty end' {} + | sort -u > \"$USED_LICENSES\"; if DIFFERENCES=$(grep -Fvxf ../allowed-licenses.txt \"$USED_LICENSES\"); then echo '\\033[0;31mLicense found in node_modules that is not in allowed-licenses.txt' >&2; echo \"$DIFFERENCES\"; exit 1; fi"
+    "prettier:format": "bun --bun prettier --write \"./src/**/*.{js,ts,tsx}\"",
+    "prettier:check": "bun --bun prettier --check \"./src/**/*.{js,ts,tsx}\"",
+    "check": "bun install && bun run typecheck && bun run lint && bun run prettier:check && bun run test && bun run check:licenses",
+    "check:clean": "bun install --frozen-lockfile && bun run typecheck && bun run lint && bun run prettier:check && bun run test && bun run check:licenses",
+    "check:licenses": "USED_LICENSES=$(mktemp); find node_modules -name package.json -exec jq 'if (.license | type) == \"string\" then .license else empty end' {} + | sort -u > \"$USED_LICENSES\"; if DIFFERENCES=$(grep -Fvxf ../allowed-licenses.txt \"$USED_LICENSES\"); then echo '\\033[0;31mLicense found in node_modules that is not in allowed-licenses.txt' >&2; echo \"$DIFFERENCES\"; exit 1; fi",
+    "test": "bun test --preload ./src/test/setup.js"
   },
   "dependencies": {
     "@dagrejs/dagre": "^1.1.8",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.5",
+    "@happy-dom/global-registrator": "20.14.5",
     "@types/lodash": "^4.17.25",
     "@types/lodash.merge": "^4.6.9",
     "@types/react": "^19.2.18",

--- a/core/trino-web-ui/src/main/resources/webapp/src/components/Dashboard.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/Dashboard.tsx
@@ -70,11 +70,18 @@ export const Dashboard = () => {
     const [error, setError] = useState<string | null>(null)
 
     useEffect(() => {
+        let cancelled = false
+        let timeoutId: number
         const runLoop = () => {
-            getClusterStats()
-            setTimeout(runLoop, 1000)
+            getClusterStats(() => cancelled)
+            timeoutId = setTimeout(runLoop, 1000)
         }
         runLoop()
+
+        return () => {
+            cancelled = true
+            clearTimeout(timeoutId)
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
@@ -84,9 +91,12 @@ export const Dashboard = () => {
         }
     }, [error, showSnackbar])
 
-    const getClusterStats = () => {
+    const getClusterStats = (isCancelled: () => boolean) => {
         setError(null)
         statsApi().then((apiResponse: ApiResponse<Stats>) => {
+            if (isCancelled()) {
+                return
+            }
             if (apiResponse.status === 200 && apiResponse.data) {
                 const newClusterStats: Stats = apiResponse.data
                 setClusterStats((prevClusterStats) => {

--- a/core/trino-web-ui/src/main/resources/webapp/src/components/WorkerStatus.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/WorkerStatus.tsx
@@ -52,24 +52,34 @@ export const WorkerStatus = () => {
     const { nodeId } = useParams()
     const theme = useTheme()
     const initialFilledHistory = Array(MAX_HISTORY).fill(0)
-    const [workerStatus, setWorkerStatus] = useState<IWorkerStatus>({
+    const initialWorkerStatus: IWorkerStatus = {
         info: null,
         processCpuLoad: initialFilledHistory,
         systemCpuLoad: initialFilledHistory,
         heapPercentUsed: initialFilledHistory,
         nonHeapUsed: initialFilledHistory,
         lastRefresh: null,
-    })
+    }
+    const [workerStatus, setWorkerStatus] = useState<IWorkerStatus>(initialWorkerStatus)
     const [loading, setLoading] = useState<boolean>(true)
     const [error, setError] = useState<string | null>(null)
     useEffect(() => {
+        setWorkerStatus(initialWorkerStatus)
+        setLoading(true)
+        let cancelled = false
+        let timeoutId: number
         const runLoop = () => {
-            getWorkerStatus()
-            setTimeout(runLoop, 1000)
+            getWorkerStatus(() => cancelled)
+            timeoutId = setTimeout(runLoop, 1000)
         }
         runLoop()
+
+        return () => {
+            cancelled = true
+            clearTimeout(timeoutId)
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
+    }, [nodeId])
 
     useEffect(() => {
         if (error) {
@@ -77,10 +87,13 @@ export const WorkerStatus = () => {
         }
     }, [error, showSnackbar])
 
-    const getWorkerStatus = () => {
+    const getWorkerStatus = (isCancelled: () => boolean) => {
         setError(null)
         if (nodeId) {
             workerStatusApi(nodeId).then((apiResponse: ApiResponse<WorkerStatusInfo>) => {
+                if (isCancelled()) {
+                    return
+                }
                 setLoading(false)
                 if (apiResponse.status === 200 && apiResponse.data) {
                     const newWorkerStatusInfo: WorkerStatusInfo = apiResponse.data
@@ -407,7 +420,7 @@ export const WorkerStatus = () => {
                         </Grid>
                         <Grid size={{ sm: 12 }}>{renderPoolQueries(workerStatus.info.memoryInfo.pool)}</Grid>
                     </Grid>
-                    {nodeId && <WorkerThreadSnapshot nodeId={nodeId} />}
+                    {nodeId && <WorkerThreadSnapshot key={nodeId} nodeId={nodeId} />}
                 </>
             )}
         </>

--- a/core/trino-web-ui/src/main/resources/webapp/src/components/WorkersList.tsx
+++ b/core/trino-web-ui/src/main/resources/webapp/src/components/WorkersList.tsx
@@ -44,11 +44,18 @@ export const WorkersList = () => {
     const [error, setError] = useState<string | null>(null)
 
     useEffect(() => {
+        let cancelled = false
+        let timeoutId: number
         const runLoop = () => {
-            getWorkersList()
-            setTimeout(runLoop, 1000)
+            getWorkersList(() => cancelled)
+            timeoutId = setTimeout(runLoop, 1000)
         }
         runLoop()
+
+        return () => {
+            cancelled = true
+            clearTimeout(timeoutId)
+        }
     }, [])
 
     useEffect(() => {
@@ -57,9 +64,12 @@ export const WorkersList = () => {
         }
     }, [error, showSnackbar])
 
-    const getWorkersList = () => {
+    const getWorkersList = (isCancelled: () => boolean) => {
         setError(null)
         workerApi().then((apiResponse: ApiResponse<Worker[]>) => {
+            if (isCancelled()) {
+                return
+            }
             if (apiResponse.status === 200 && apiResponse.data) {
                 if (apiResponse.data) {
                     const sortedWorkers: Worker[] = apiResponse.data.sort((workerA, workerB) =>

--- a/core/trino-web-ui/src/main/resources/webapp/src/test/Polling.test.js
+++ b/core/trino-web-ui/src/main/resources/webapp/src/test/Polling.test.js
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterEach, beforeEach, expect, jest, test } from 'bun:test'
+import { act, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { api } from '../api/base.ts'
+import { Dashboard } from '../components/Dashboard.tsx'
+import { WorkersList } from '../components/WorkersList.tsx'
+import { WorkerStatus } from '../components/WorkerStatus.tsx'
+import { SnackbarContext } from '../components/SnackbarContext.ts'
+
+let root
+let container
+let router
+let requests
+let originalAdapter
+let notifications
+
+beforeEach(() => {
+    jest.useFakeTimers()
+    requests = []
+    notifications = []
+    originalAdapter = api.axiosInstance.defaults.adapter
+    api.axiosInstance.defaults.adapter = async (config) => {
+        requests.push(config.url)
+        let data = []
+        if (config.url === '/ui/api/stats') {
+            data = {
+                runningQueries: 0,
+                queuedQueries: 0,
+                blockedQueries: 0,
+                activeWorkers: 1,
+                runningDrivers: 0,
+                reservedMemory: 0,
+                totalInputRows: 0,
+                totalInputBytes: 0,
+                totalCpuTimeSecs: 0,
+            }
+        }
+        // A missing worker still exercises the polling lifecycle without chart layout.
+        return { data, status: config.url.endsWith('/status') ? 404 : 200, statusText: 'OK', headers: {}, config }
+    }
+    localStorage.clear()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    router = createMemoryRouter([
+        { path: '/', element: createElement('div', null, 'Home') },
+        { path: '/dashboard', element: createElement(Dashboard) },
+        { path: '/workers', element: createElement(WorkersList) },
+        { path: '/workers/:nodeId', element: createElement(WorkerStatus) },
+    ])
+})
+
+afterEach(async () => {
+    await act(async () => root.unmount())
+    router.dispose()
+    container.remove()
+    api.axiosInstance.defaults.adapter = originalAdapter
+    localStorage.clear()
+    jest.useRealTimers()
+})
+
+async function render() {
+    await act(async () =>
+        root.render(
+            createElement(
+                SnackbarContext.Provider,
+                { value: { showSnackbar: (message) => notifications.push(message) } },
+                createElement(RouterProvider, { router })
+            )
+        )
+    )
+}
+
+async function navigate(path) {
+    await act(async () => router.navigate(path))
+}
+
+async function tick() {
+    await act(async () => jest.advanceTimersByTime(1000))
+}
+
+for (const [path, endpoint] of [
+    ['/dashboard', '/ui/api/stats'],
+    ['/workers', '/ui/api/worker'],
+    ['/workers/worker_a', '/ui/api/worker/worker_a/status'],
+]) {
+    test(`${path} stops polling on navigation and starts one loop on return`, async () => {
+        await render()
+        await navigate(path)
+        await tick()
+        await navigate('/')
+        const count = requests.filter((url) => url === endpoint).length
+        await tick()
+        await tick()
+        expect(requests.filter((url) => url === endpoint)).toHaveLength(count)
+        await navigate(path)
+        await tick()
+        expect(requests.filter((url) => url === endpoint)).toHaveLength(count + 2)
+    })
+}
+
+test('changing worker ID stops polling the previous worker', async () => {
+    await render()
+    await navigate('/workers/worker_a')
+    await tick()
+    const count = requests.filter((url) => url.includes('worker_a')).length
+    await navigate('/workers/worker_b')
+    await tick()
+    expect(requests.filter((url) => url.includes('worker_a'))).toHaveLength(count)
+    expect(requests.filter((url) => url.includes('worker_b'))).toHaveLength(2)
+})
+
+test('a response arriving after navigation does not restart polling', async () => {
+    let respond
+    api.axiosInstance.defaults.adapter = (config) => {
+        requests.push(config.url)
+        return new Promise((resolve) => {
+            respond = () => resolve({ data: [], status: 200, statusText: 'OK', headers: {}, config })
+        })
+    }
+    await render()
+    await navigate('/workers')
+    await navigate('/')
+    await act(async () => respond())
+    await tick()
+    expect(requests).toHaveLength(1)
+})
+
+test('a late response from the previous worker cannot replace the current error', async () => {
+    let respond
+    api.axiosInstance.defaults.adapter = (config) => {
+        requests.push(config.url)
+        if (config.url.includes('worker_a')) {
+            return new Promise((resolve) => {
+                respond = () => resolve({ data: {}, status: 503, statusText: 'obsolete worker', headers: {}, config })
+            })
+        }
+        return Promise.resolve({ data: {}, status: 503, statusText: 'current worker', headers: {}, config })
+    }
+    await render()
+    await navigate('/workers/worker_a')
+    await navigate('/workers/worker_b')
+    expect(notifications).toHaveLength(1)
+    expect(notifications[0]).toContain('current worker')
+    await act(async () => respond())
+    expect(notifications).toHaveLength(1)
+    expect(notifications[0]).toContain('current worker')
+})

--- a/core/trino-web-ui/src/main/resources/webapp/src/test/setup.js
+++ b/core/trino-web-ui/src/main/resources/webapp/src/test/setup.js
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GlobalRegistrator } from '@happy-dom/global-registrator'
+
+GlobalRegistrator.register()
+globalThis.IS_REACT_ACT_ENVIRONMENT = true


### PR DESCRIPTION
## Description

Clear polling timers when Dashboard, WorkersList, and WorkerStatus unmount, and ignore responses from obsolete effects. Navigating away from Workers now stops `/ui/api/worker` requests; returning starts one polling loop.

When the worker ID changes, reset its status and thread snapshot and replace the polling lifecycle. Add rendered-component tests for navigation/remounting, worker-ID changes, and late responses that must not replace the current worker error.

Introduce Bun component tests using Happy DOM and include them in the existing frontend checks.

Validation: `bun run check:clean` (types, lint, formatting, regression tests, and licenses) and production build pass on this independent branch. The regression tests failed against the original code. Chromium verification against a production build with controlled API responses confirms zero Workers polling requests after navigation.

## Additional context and related issues

- Fixes #31111

The component-test setup is shared with the fix for #31110. Each PR includes the same setup and can be tested and merged independently.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
## Web UI
* Fix continued polling after navigating away from dashboard and worker pages. ({issue}`31115`)
```
